### PR TITLE
Enable tests that fail to be caught be CMake and passed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,9 @@ before_install:
       brew install hdf5;
 
       git clone https://github.com/philsquared/Catch.git;
+      cd Catch;
+      git checkout v1.6.1;
+      cd ../;
 
       git clone https://github.com/edouarda/brigand.git;
 

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -1,6 +1,16 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+# If you change this file please push a new image to DockerHub so that the
+# new image is used for testing. To build a new image run:
+# docker build  -t sxscollaboration/spectrebuildenv:latest
+#               -f ./Dockerfile.buildenv .
+# and then to push to DockerHub:
+# docker push sxscollaboration/spectrebuildenv
+# If you do not have permission to push to DockerHub please coordinate with
+# someone who does. Since changes to this image effect our testing
+# infrastructure it is important all changes be carefully reviewed.
+
 FROM ubuntu:17.04
 
 ARG CHARM_GIT_TAG=v6.7.1
@@ -64,7 +74,7 @@ RUN printf "\n  openssl:\n    paths:\n      openssl@1.0.2g: /usr\n\
 RUN echo "export PATH=\$PATH:/work/spack/bin" >> /root/.bashrc
 RUN echo '. /work/spack/share/spack/setup-env.sh' >> /root/.bashrc
 RUN export PATH=$PATH:/work/spack/bin
-RUN /work/spack/bin/spack install catch
+RUN /work/spack/bin/spack install catch@1.6.1
 RUN /work/spack/bin/spack install brigand@master
 RUN /work/spack/bin/spack install blaze
 

--- a/docs/MainSite/Installation.md
+++ b/docs/MainSite/Installation.md
@@ -14,7 +14,7 @@ See LICENSE.txt for details.
 * BLAS
 * [Boost](http://www.boost.org/)
 * [Brigand](https://github.com/edouarda/brigand)
-* [Catch](https://github.com/philsquared/Catch)
+* [Catch](https://github.com/philsquared/Catch) (v1.6.1 or older)
 * [HDF5](https://support.hdfgroup.org/HDF5/) (non-mpi version on macOS)
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp)
 

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 set(executable RunTests)
 
-set(SPECTRE_TESTS "")
+set(SPECTRE_TESTS "TestFramework.cpp")
 
 add_subdirectory(Utilities)
 

--- a/tests/Unit/TestFramework.cpp
+++ b/tests/Unit/TestFramework.cpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+#include <charm++.h>
+
+// [[OutputRegex, I failed]]
+TEST_CASE("TestFramework.Abort", "[Unit]") { CkAbort("I failed"); }


### PR DESCRIPTION
Also adds a TestFramework file where we will verify that the testing
framework properly handles ASSERT, ERROR, etc.