### PR TITLE
Add travis target to search for fixup commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,9 @@ matrix:
     osx_image: xcode8.3
     env: BUILD_TYPE=Release
     compiler: clang
+  - os: linux
+    env: CHECK_COMMITS=true
+    compiler: clang
 
 
 # Travis allows caching of data between builds to reduce build times or perform
@@ -178,10 +181,17 @@ before_install:
 # macOS:
 # The variable ${TRAVIS_BUILD_DIR} points to the cloned repository, not what
 # we would normally call the build dir, but actually the source dir.
+#
+# What's the deal with all the &&?
+# TravisCI only sees the return code of the last command executed inside the
+# if block so a && between all the commands to execute returns the and of all
+# the results. Thus, if any individual step fails, the build is failed.
 script:
 - ENCRYPTED_KEY_VAR="encrypted_${ENCRYPTION_LABEL}_key"
 - ENCRYPTED_IV_VAR="encrypted_${ENCRYPTION_LABEL}_iv"
-- if [ ${TRAVIS_OS_NAME} = linux ]; then
+- if [ ${CHECK_COMMITS} = true ]; then
+    ./tools/CheckCommits.sh;
+  elif [ ${TRAVIS_OS_NAME} = linux ]; then
     cp -vr containers ${HOME}/docker
     && cd ${HOME}
     && mv -v ${TRAVIS_BUILD_DIR} ${HOME}/docker/spectre

--- a/tools/CheckCommits.sh
+++ b/tools/CheckCommits.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Set \n as the only separator for lists since commit messages might
+# have spaces in them
+IFS=$'\n'
+
+# Get the last 300 commits and check those for bad messages. TravisCI doesn't
+# allow us to get develop (at least not easily) so we can't just find and check
+# the added commits.
+COMMIT_LINES=`git log -n 300 --oneline`
+
+# For all commit messages, check if they start with one of the key words
+for commit_msg in $COMMIT_LINES
+do
+    if grep "^[0-9a-f]\{6,40\} [Ff][Ii][Xx][Uu][Pp]" <<< $commit_msg\
+    > /dev/null; then
+        printf "\n\n\nError: Fixup commit found: %s\n\n\n" "$commit_msg" 2>&1
+        exit 1
+    elif grep "^[0-9a-f]\{6,40\} [Ww][Ii][Pp]" <<< $commit_msg > /dev/null; then
+        printf "\n\n\nError: WIP commit found: %s\n\n\n" "$commit_msg" 2>&1
+        exit 1
+    elif grep "^[0-9a-f]\{6,40\} [Ff][Ii][Xx][Mm][Ee]" <<< $commit_msg\
+    > /dev/null; then
+        printf "\n\n\nError: FixMe commit found: %s\n\n\n" "$commit_msg" 2>&1
+        exit 1
+    elif grep "^[0-9a-f]\{6,40\} [Dd][Ee][Ll][Ee][Tt][Ee][Mm][Ee]" <<< \
+    $commit_msg > /dev/null; then
+        printf "\n\n\nError: DeleteMe commit found: %s\n\n\n" "$commit_msg" 2>&1
+        exit 1
+    elif grep "^[0-9a-f]\{6,40\} [Rr][Ee][Bb][Aa][Ss][Ee][Mm][Ee]" <<< \
+    $commit_msg > /dev/null; then
+        printf "\n\n\nError: RebaseMe commit found: %s\n\n\n" "$commit_msg" 2>&1
+        exit 1
+    elif grep "^[0-9a-f]\{6,40\} [Tt][Ee][Ss][Tt][Ii][Nn][Gg]" <<< $commit_msg\
+     > /dev/null; then
+        printf "\n\n\nError: Testing commit found: %s\n\n\n" "$commit_msg" 2>&1
+        exit 1
+    elif grep "^[0-9a-f]\{6,40\} [Rr][Ee][Bb][Aa][Ss][Ee]" <<< $commit_msg\
+     > /dev/null; then
+        printf "\n\n\nError: Rebase commit found: %s\n\n\n" "$commit_msg" 2>&1
+        exit 1
+    fi
+done
+
+exit 0


### PR DESCRIPTION
This will have a single travis build fail if any commit message starts with any capitalization of `fixup`, `wip`, `rebase`, `rebaseme`, `deleteme`, `testing`, or `fixme` commits are found. The usual tests will still run and pass or fail depending on their correctness.