### PR TITLE
Add GSL library path to EXE_LINKER_FLAGS

### DIFF
--- a/cmake/SetupGsl.cmake
+++ b/cmake/SetupGsl.cmake
@@ -5,6 +5,14 @@ find_package(GSL REQUIRED)
 
 include_directories(SYSTEM ${GSL_INCLUDE_DIR})
 list(APPEND SPECTRE_LIBRARIES ${GSL_LIBRARIES})
+# Extract the path where the shared libraries are and point the linker to
+# that directory
+list(GET GSL_LIBRARIES 0 FIRST_GSL_LIBRARY)
+string(REGEX REPLACE "libgsl[cblas]*.so" ""
+    GSL_LIBRARY_PATH ${FIRST_GSL_LIBRARY})
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L${GSL_LIBRARY_PATH}")
+list(APPEND SPECTRE_LIBRARIES "-lgsl")
+list(APPEND SPECTRE_LIBRARIES "-lgslcblas")
 
 message(STATUS "GSL libs: ${GSL_LIBRARIES}")
 message(STATUS "GSL incl: ${GSL_INCLUDE_DIR}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,6 @@ add_subdirectory(ErrorHandling)
 add_subdirectory(Executables)
 add_subdirectory(Numerical)
 
-# Propagate core labraries up to global scope. GSL needs to be added explicitly here due
-# to strange linking errors with GCC
+# Propagate core labraries up to global scope.
 set(SPECTRE_LIBRARIES
-    "${SPECTRE_CORE_LIBRARIES};${SPECTRE_LIBRARIES};-lgsl -lgslcblas" PARENT_SCOPE)
+    "${SPECTRE_CORE_LIBRARIES};${SPECTRE_LIBRARIES}" PARENT_SCOPE)


### PR DESCRIPTION
Add GSL library path to EXE_LINKER_FLAGS for compilation support on more platforms