### PR TITLE
Fix Git hooks and have Travis check formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -182,7 +182,8 @@ script:
 - ENCRYPTED_KEY_VAR="encrypted_${ENCRYPTION_LABEL}_key"
 - ENCRYPTED_IV_VAR="encrypted_${ENCRYPTION_LABEL}_iv"
 - if [ ${CHECK_COMMITS} = true ]; then
-    ./tools/CheckCommits.sh;
+    ./tools/CheckCommits.sh
+    && ./tools/CheckFiles.sh;
   elif [ ${TRAVIS_OS_NAME} = linux ]; then
     cp -vr containers ${HOME}/docker
     && cd ${HOME}

--- a/cmake/SpectreAddCatchTests.cmake
+++ b/cmake/SpectreAddCatchTests.cmake
@@ -99,13 +99,13 @@ function(spectre_parse_file SOURCE_FILE TEST_TARGET)
         string(REGEX MATCH "(CATCH_)?(TEST_CASE_METHOD|SCENARIO|TEST_CASE)"
                TEST_TYPE "${TEST_NAME}")
 
-        string(REPLACE "${TEST_TYPE}(" "" 
+        string(REPLACE "${TEST_TYPE}(" ""
                TEST_FIXTURE "${TEST_TYPE_AND_FIXTURE}")
 
         # Get string parts of test definition
         string(REGEX MATCHALL "\"[^\"]+\"" TEST_STRINGS "${TEST_NAME}")
 
-        # Strip wrapping quotation marks of each element of the list 
+        # Strip wrapping quotation marks of each element of the list
         # TEST_STRINGS
         string(REGEX REPLACE "^\"(.*)\"$" "\\1" TEST_STRINGS "${TEST_STRINGS}")
         string(REPLACE "\";\"" ";" TEST_STRINGS "${TEST_STRINGS}")

--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+###############################################################################
+# Add grep colors if available
+color_option=''
+if grep --help 2>&1 | grep -q -e --color
+then
+  color_option='--color=auto'
+fi
+
+###############################################################################
+# Check for lines longer than 80 characters
+found_long_lines=`
+find ./ -type f -name '*.[ch]pp' \
+    | xargs grep --with-filename -n '.\{81,\}'`
+if [[ $found_long_lines != "" ]]; then
+    echo "This script can be run locally from the root source dir using:"
+    echo "./.travis/CheckFiles.sh"
+    echo "Found lines over 80 characters:"
+    echo "$found_long_lines"
+    exit 1
+fi
+
+###############################################################################
+# Find lines that have tabs in them and block them from being committed
+found_tabs_files=`
+find ./ -type f               \
+     ! -name "*.patch"        \
+     ! -path "./docs/*"       \
+     ! -path "./.git/*"       \
+    | xargs grep -E '^.*'$'\t'`
+if [[ $found_tabs_files != "" ]]; then
+    echo "This script can be run locally from the root source dir using:"
+    echo "./.travis/CheckFiles.sh"
+    echo "Found tabs in the following  files:"
+    echo "$found_tabs_files" | GREP_COLOR='1;37;41' grep -F $'\t' $color_option
+    exit 1
+fi
+
+###############################################################################
+# Find files that have white space at the end of a line and block them
+found_spaces_files=`
+find ./ -type f             \
+     ! -name "*.patch"      \
+     ! -path "./docs/*"     \
+     ! -path "./.git/*"     \
+    | xargs grep -E '^.* +$'`
+echo
+if [[ $found_spaces_files != "" ]]; then
+    echo "This script can be run locally from the root source dir using:"
+    echo "./.travis/CheckFiles.sh"
+    echo "Found white space at end of line in the following files:"
+    echo "$found_spaces_files" | \
+        GREP_COLOR='1;37;41' grep -E ' +$' $color_option
+    exit 1
+fi
+
+###############################################################################
+# Check for carriage returns
+found_carriage_return_files=`
+find ./ -type f                 \
+     ! -path "*.git*"           \
+    | xargs grep -E '^\+.*'$'\r'`
+if [[ $found_carriage_return_files != "" ]]; then
+    echo "This script can be run locally from the root source dir using:"
+    echo "./.travis/CheckFiles.sh"
+    echo "Found carriage returns in the following files:"
+    echo "$found_carriage_return_files" | \
+        GREP_COLOR='1;37;41' grep -E '\r+$' $color_option
+    exit 1
+fi
+
+###############################################################################
+# Check for license file. We need to ignore a few files that shouldn't have
+# the license
+files_without_license=`
+find ./ -type f                                                              \
+     ! -path "*cmake/FindLIBCXX.cmake"                                       \
+     ! -path "*cmake/FindPAPI.cmake"                                         \
+     ! -path "*cmake/CodeCoverageDetection.cmake"                            \
+     ! -path "*cmake/CodeCoverage.cmake"                                     \
+     ! -path "*cmake/Findcppcheck.cmake"                                     \
+     ! -path "*cmake/Findcppcheck.cpp"                                       \
+     ! -path "*cmake/FindCatch.cmake"                                        \
+     ! -path "*cmake/FindPythonModule.cmake"                                 \
+     ! -path "./src/Utilities/Gsl.hpp"                                       \
+     ! -path "*.git/*"                                                       \
+     ! -path "*.idea/*"                                                      \
+     ! -path "*docs/config/*"                                                \
+     ! -path "*.travis/deploy_key*"                                          \
+     ! -name "*.patch"                                                       \
+     ! -name "*LICENSE.*"                                                    \
+     ! -name "*.clang-format"                                                \
+    | xargs grep -L "^.*Distributed under the MIT License"`
+if [[ $files_without_license != "" ]]; then
+    echo "This script can be run locally from the root source dir using:"
+    echo "./.travis/CheckFiles.sh"
+    echo "Did not find a license in these files:"
+    echo "$files_without_license"
+    exit 1
+fi

--- a/tools/Hooks/pre-commit.sh
+++ b/tools/Hooks/pre-commit.sh
@@ -22,6 +22,13 @@ do
     fi
 done
 
+# If no files were added or modified we do not run any of the hooks. If we did
+# then rewording commits, and making empty commits would result in the hooks
+# searching the entire repository, which is not what we want in general.
+if [ -z "$commit_files" ]; then
+    exit 0
+fi
+
 ###############################################################################
 # Check the file size
 @PYTHON_EXECUTABLE@ @CMAKE_SOURCE_DIR@/.git/hooks/CheckFileSize.py
@@ -85,12 +92,6 @@ fi
 ###############################################################################
 # Make sure all files have the license header in them.
 no_license_found=`grep -L "^.*Distributed under the MIT License" $commit_files`
-# If commit_files is empty, then no_license_found searches standard input,
-# which does not contain the license and is a false positive. This occurs when
-# rewording a commit message during interactive rebase.
-if [[ $commit_files = "" ]]; then
-    no_license_found=""
-fi
 if [[ $no_license_found != "" ]]; then
     echo "Did not find the license header in these files:"
     echo "$no_license_found"


### PR DESCRIPTION
- Git hooks are no longer run erroneously on all files if no files were modified or added.
- Travis checks basic formatting on the entire repository.

fix #63 