### PR TITLE
Add Determinant and associated test

### DIFF
--- a/src/Numerical/CMakeLists.txt
+++ b/src/Numerical/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY NumericalAlgorithms)
 
 set(LIBRARY_SOURCES)
 
+add_subdirectory(LinearAlgebra)
 add_subdirectory(RootFinding)
 add_subdirectory(Spectral)
 

--- a/src/Numerical/LinearAlgebra/CMakeLists.txt
+++ b/src/Numerical/LinearAlgebra/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(MY_LIBRARY_SOURCES
+   )
+
+set(LIBRARY_SOURCES "${LIBRARY_SOURCES};${MY_LIBRARY_SOURCES}" PARENT_SCOPE)

--- a/src/Numerical/LinearAlgebra/Determinant.hpp
+++ b/src/Numerical/LinearAlgebra/Determinant.hpp
@@ -1,0 +1,150 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines function for taking the determinant of a rank-2 tensor
+
+#pragma once
+
+#include "DataStructures/Tensor/Tensor.hpp"
+
+namespace detail {
+template <typename Symm, typename Index, typename = void>
+struct DeterminantImpl;
+
+template <typename Symm, typename Index>
+struct DeterminantImpl<Symm, Index, std::enable_if_t<Index::dim == 1>> {
+  template <typename T>
+  static typename T::type apply(const T& tensor) {
+    return tensor.template get<0, 0>();
+  }
+};
+
+template <typename Symm, typename Index>
+struct DeterminantImpl<Symm, Index, std::enable_if_t<Index::dim == 2>> {
+  template <typename T>
+  static typename T::type apply(const T& tensor) {
+    const auto& t00 = tensor.template get<0, 0>();
+    const auto& t01 = tensor.template get<0, 1>();
+    const auto& t10 = tensor.template get<1, 0>();
+    const auto& t11 = tensor.template get<1, 1>();
+    return t00 * t11 - t01 * t10;
+  }
+};
+
+template <typename Index>
+struct DeterminantImpl<Symmetry<2, 1>, Index,
+                       std::enable_if_t<Index::dim == 3>> {
+  template <typename T>
+  static typename T::type apply(const T& tensor) {
+    const auto& t00 = tensor.template get<0, 0>();
+    const auto& t01 = tensor.template get<0, 1>();
+    const auto& t02 = tensor.template get<0, 2>();
+    const auto& t10 = tensor.template get<1, 0>();
+    const auto& t11 = tensor.template get<1, 1>();
+    const auto& t12 = tensor.template get<1, 2>();
+    const auto& t20 = tensor.template get<2, 0>();
+    const auto& t21 = tensor.template get<2, 1>();
+    const auto& t22 = tensor.template get<2, 2>();
+    return t00 * (t11 * t22 - t21 * t12) - t01 * (t10 * t22 - t20 * t12) +
+           t02 * (t10 * t21 - t20 * t11);
+  }
+};
+
+template <typename Index>
+struct DeterminantImpl<Symmetry<1, 1>, Index,
+                       std::enable_if_t<Index::dim == 3>> {
+  template <typename T>
+  static typename T::type apply(const T& tensor) {
+    const auto& t00 = tensor.template get<0, 0>();
+    const auto& t10 = tensor.template get<1, 0>();
+    const auto& t11 = tensor.template get<1, 1>();
+    const auto& t20 = tensor.template get<2, 0>();
+    const auto& t21 = tensor.template get<2, 1>();
+    const auto& t22 = tensor.template get<2, 2>();
+    return t00 * (t11 * t22 - t21 * t21) - t10 * (t10 * t22 - 2 * t20 * t21) -
+           t11 * t20 * t20;
+  }
+};
+
+template <typename Index>
+struct DeterminantImpl<Symmetry<2, 1>, Index,
+                       std::enable_if_t<Index::dim == 4>> {
+  template <typename T>
+  static typename T::type apply(const T& tensor) {
+    const auto& t00 = tensor.template get<0, 0>();
+    const auto& t01 = tensor.template get<0, 1>();
+    const auto& t02 = tensor.template get<0, 2>();
+    const auto& t03 = tensor.template get<0, 3>();
+    const auto& t10 = tensor.template get<1, 0>();
+    const auto& t11 = tensor.template get<1, 1>();
+    const auto& t12 = tensor.template get<1, 2>();
+    const auto& t13 = tensor.template get<1, 3>();
+    const auto& t20 = tensor.template get<2, 0>();
+    const auto& t21 = tensor.template get<2, 1>();
+    const auto& t22 = tensor.template get<2, 2>();
+    const auto& t23 = tensor.template get<2, 3>();
+    const auto& t30 = tensor.template get<3, 0>();
+    const auto& t31 = tensor.template get<3, 1>();
+    const auto& t32 = tensor.template get<3, 2>();
+    const auto& t33 = tensor.template get<3, 3>();
+    const auto tmp1 = t22 * t33 - t32 * t23;
+    const auto tmp2 = t21 * t33 - t31 * t23;
+    const auto tmp3 = t21 * t32 - t31 * t22;
+    const auto tmp4 = t02 * t13 - t12 * t03;
+    const auto tmp5 = t01 * t13 - t11 * t03;
+    const auto tmp6 = t01 * t12 - t02 * t11;
+    return t00 * (t11 * tmp1 - t12 * tmp2 + t13 * tmp3) -
+           t10 * (t01 * tmp1 - t02 * tmp2 + t03 * tmp3) +
+           t20 * (t31 * tmp4 - t32 * tmp5 + t33 * tmp6) -
+           t30 * (t21 * tmp4 - t22 * tmp5 + t23 * tmp6);
+  }
+};
+
+template <typename Index>
+struct DeterminantImpl<Symmetry<1, 1>, Index,
+                       std::enable_if_t<Index::dim == 4>> {
+  template <typename T>
+  static typename T::type apply(const T& tensor) {
+    const auto& t00 = tensor.template get<0, 0>();
+    const auto& t10 = tensor.template get<1, 0>();
+    const auto& t11 = tensor.template get<1, 1>();
+    const auto& t20 = tensor.template get<2, 0>();
+    const auto& t21 = tensor.template get<2, 1>();
+    const auto& t22 = tensor.template get<2, 2>();
+    const auto& t30 = tensor.template get<3, 0>();
+    const auto& t31 = tensor.template get<3, 1>();
+    const auto& t32 = tensor.template get<3, 2>();
+    const auto& t33 = tensor.template get<3, 3>();
+    const auto tmp1 = t22 * t33 - t32 * t32;
+    const auto tmp2 = t21 * t33 - t31 * t32;
+    const auto tmp3 = t21 * t32 - t31 * t22;
+    const auto tmp4 = t20 * t31 - t21 * t30;
+    const auto tmp5 = t10 * t31 - t11 * t30;
+    const auto tmp6 = t10 * t21 - t20 * t11;
+    return t00 * (t11 * tmp1 - t21 * tmp2 + t31 * tmp3) -
+           t10 * (t10 * tmp1 - t20 * tmp2 + t30 * tmp3) +
+           t20 * (t31 * tmp4 - t32 * tmp5 + t33 * tmp6) -
+           t30 * (t21 * tmp4 - t22 * tmp5 + t32 * tmp6);
+  }
+};
+}  // namespace detail
+
+/*! \ingroup Functors
+ * \brief Computes the determinant of a rank-2 Tensor `tensor`.
+ *
+ * \returns The determinant of `tensor`.
+ * \requires That `tensor` be a rank-2 Tensor, with both indices sharing the
+ *           same dimension and type.
+ */
+template <typename T, typename Symm, typename Index0, typename Index1>
+Scalar<T> determinant(
+    const Tensor<T, Symm, index_list<Index0, Index1>>& tensor) {
+  static_assert(Index0::dim == Index1::dim,
+                "Cannot take the determinant of a Tensor whose Indices are not "
+                "of the same dimensionality.");
+  static_assert(Index0::index_type == Index1::index_type,
+                "Taking the determinant of a mixed Spatial and Spacetime index "
+                "Tensor is not allowed since it's not clear what that means.");
+  return Scalar<T>{detail::DeterminantImpl<Symm, Index0>::apply(tensor)};
+}

--- a/tests/Unit/Numerical/CMakeLists.txt
+++ b/tests/Unit/Numerical/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(SPECTRE_UNIT_NUMERICAL_TESTS)
 
+add_subdirectory(LinearAlgebra)
 add_subdirectory(RootFinding)
 add_subdirectory(Spectral)
 

--- a/tests/Unit/Numerical/LinearAlgebra/CMakeLists.txt
+++ b/tests/Unit/Numerical/LinearAlgebra/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(SPECTRE_UNIT_LINEAR_ALGEBRA_TESTS
+    Numerical/LinearAlgebra/Test_Determinant.cpp
+   )
+
+set(SPECTRE_UNIT_NUMERICAL_TESTS
+   "${SPECTRE_UNIT_NUMERICAL_TESTS};${SPECTRE_UNIT_LINEAR_ALGEBRA_TESTS}"
+   PARENT_SCOPE)

--- a/tests/Unit/Numerical/LinearAlgebra/Test_Determinant.cpp
+++ b/tests/Unit/Numerical/LinearAlgebra/Test_Determinant.cpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "DataStructures/DataVector.hpp"
+#include "Numerical/LinearAlgebra/Determinant.hpp"
+
+TEST_CASE("Unit.Numerical.LinearAlgebra.Determinant",
+          "[LinearAlgebra][Numerical][Unit]") {
+  Approx approx = Approx::custom().epsilon(1e-15);
+
+  // Test determinant function on general (no symmetry) matrices:
+  // * use rank-2 Tensor in 1-4 dimensions, i.e. 1x1, 2x2, 3x3, 4x4 matrices.
+  // * use Tensor<double, ...>, i.e. data at single spatial point.
+  SECTION("Test general Tensor<double,...> matrices") {
+    {
+      const tnsr::ij<double, 1, Frame::Grid> matrix(1.3);
+      const auto det = determinant(matrix);
+      CHECK(1.3 == approx(det.get()));
+    }
+
+    {
+      tnsr::ij<double, 2, Frame::Grid> matrix;
+      matrix.get<0, 0>() = 2.1;
+      matrix.get<1, 0>() = 4.5;
+      matrix.get<0, 1>() = -18.3;
+      matrix.get<1, 1>() = -10.9;
+      const auto det = determinant(matrix);
+      CHECK(59.46 == approx(det.get()));
+    }
+
+    {
+      tnsr::ij<double, 3, Frame::Grid> matrix;
+      matrix.get<0, 0>() = 1.1;
+      matrix.get<1, 0>() = -10.4;
+      matrix.get<2, 0>() = -4.5;
+      matrix.get<0, 1>() = 3.2;
+      matrix.get<1, 1>() = 15.4;
+      matrix.get<2, 1>() = -19.2;
+      matrix.get<0, 2>() = 4.3;
+      matrix.get<1, 2>() = 16.8;
+      matrix.get<2, 2>() = 2.0;
+      const auto det = determinant(matrix);
+      CHECK(1369.95 == approx(det.get()));
+    }
+
+    {
+      tnsr::ij<double, 4, Frame::Grid> matrix;
+      matrix.get<0, 0>() = 1.1;
+      matrix.get<1, 0>() = -10.4;
+      matrix.get<2, 0>() = -4.5;
+      matrix.get<3, 0>() = 3.2;
+      matrix.get<0, 1>() = 15.4;
+      matrix.get<1, 1>() = -19.2;
+      matrix.get<2, 1>() = 4.3;
+      matrix.get<3, 1>() = 16.8;
+      matrix.get<0, 2>() = 2.0;
+      matrix.get<1, 2>() = 3.1;
+      matrix.get<2, 2>() = 4.2;
+      matrix.get<3, 2>() = -0.2;
+      matrix.get<0, 3>() = -3.2;
+      matrix.get<1, 3>() = 2.6;
+      matrix.get<2, 3>() = 1.5;
+      matrix.get<3, 3>() = 2.8;
+      const auto det = determinant(matrix);
+      CHECK(1049.7072 == approx(det.get()));
+    }
+  }
+
+  // Test determinant function on symmetric matrices:
+  // * use rank-2 Tensor in 2-4 dimensions (symmetry meaningless for dim==1).
+  // * use Tensor<double, ...>, i.e. data at single spatial point.
+  SECTION("Test symmetric Tensor<double,...> matrices") {
+    {
+      tnsr::ii<double, 2, Frame::Grid> matrix;
+      matrix.get<0, 0>() = 2.1;
+      matrix.get<1, 0>() = 4.5;
+      matrix.get<1, 1>() = -10.9;
+      const auto det = determinant(matrix);
+      CHECK(-43.14 == approx(det.get()));
+    }
+
+    {
+      tnsr::ii<double, 3, Frame::Grid> matrix;
+      matrix.get<0, 0>() = 1.1;
+      matrix.get<1, 0>() = -10.4;
+      matrix.get<2, 0>() = -4.5;
+      matrix.get<1, 1>() = 3.2;
+      matrix.get<2, 1>() = 15.4;
+      matrix.get<2, 2>() = -19.2;
+      const auto det = determinant(matrix);
+      CHECK(3124.852 == approx(det.get()));
+    }
+
+    {
+      tnsr::ii<double, 4, Frame::Grid> matrix;
+      matrix.get<0, 0>() = 1.1;
+      matrix.get<1, 0>() = -10.4;
+      matrix.get<2, 0>() = -4.5;
+      matrix.get<3, 0>() = 3.2;
+      matrix.get<1, 1>() = 15.4;
+      matrix.get<2, 1>() = -19.2;
+      matrix.get<3, 1>() = 4.3;
+      matrix.get<2, 2>() = 16.8;
+      matrix.get<3, 2>() = 2.0;
+      matrix.get<3, 3>() = 3.1;
+      const auto det = determinant(matrix);
+      CHECK(-22819.6093 == approx(det.get()));
+    }
+  }
+
+  // Test determinant function for Tensors of different (not double) types:
+  // * use rank-2 Tensor in 2 dimensions, i.e. a 2x2 matrix.
+  // * use Tensor<T,...> for T in {int, DataVector}.
+  SECTION("Test Tensors of different types") {
+    {
+      tnsr::ij<int, 2, Frame::Grid> matrix;
+      matrix.get<0, 0>() = 9;
+      matrix.get<1, 0>() = 1;
+      matrix.get<0, 1>() = -3;
+      matrix.get<1, 1>() = -4;
+      const auto det = determinant(matrix);
+      CHECK(-33 == det.get());
+    }
+
+    {
+      tnsr::ij<DataVector, 2, Frame::Grid> matrix;
+      matrix.get<0, 0>() = DataVector({6.0, 5.9, 9.8, 6.4});
+      matrix.get<1, 0>() = DataVector({6.1, 0.3, 2.4, 5.7});
+      matrix.get<0, 1>() = DataVector({4.2, 7.1, 1.1, 6.5});
+      matrix.get<1, 1>() = DataVector({7.2, 8.4, 6.1, 3.7});
+      const auto det = determinant(matrix);
+      CHECK(17.58 == approx(det.get()[0]));
+      CHECK(47.43 == approx(det.get()[1]));
+      CHECK(57.14 == approx(det.get()[2]));
+      CHECK(-13.37 == approx(det.get()[3]));
+    }
+  }
+}


### PR DESCRIPTION
Two things:
1. This code computes the determinant pointwise by looping over points. It is not obvious that this is better than doing math with DataVectors. Has this been benchmarked? Should it be?
2. The original test was also testing the determinant computation on "reference" DataVectors. I removed this, because it should not be the responsibility of Determinant to check that DataVectors are correctly implemented. But we currently do not have a "math" test with reference DataVectors. Should I add one?