### PR TITLE
Improve handling of default tolerance in Approx

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -247,6 +247,35 @@
  * a regex to match the test name using `ctest -R Unit.Blah`, or run all
  * tests with a certain tag using `ctest -L tag`.
  *
+ * ### Comparing double-precision results
+ *
+ * To compare two floating-point numbers that may differ by round-off, use the
+ * helper object `approx`. This is an instance of Catch's comparison class
+ * `Approx` in which the relative tolerance for comparisons is set to roughly
+ * \f$10^{-14}\f$ (i.e. `std\:\:numeric_limits<double>\:\:epsilon()*100`).
+ * When possible, we recommend using `approx` for fuzzy comparisons as follows:
+ * \example
+ * \snippet TestFramework.cpp approx_default
+ *
+ * For checks that need more control over the precision (e.g. an algorithm in
+ * which round-off errors accumulate to a higher level), we recommend using
+ * the `approx` helper with a one-time tolerance adjustment. A comment
+ * should explain the reason for the adjustment:
+ * \example
+ * \snippet TestFramework.cpp approx_single_custom
+ *
+ * For tests in which the same precision adjustment is re-used many times, a new
+ * helper object can be created from Catch's `Approx` with a custom precision:
+ * \example
+ * \snippet TestFramework.cpp approx_new_custom
+ *
+ * Note: We provide the `approx` object because Catch's `Approx` defaults to a
+ * very loose tolerance (`std\:\:numeric_limits<float>\:\:epsilon()*100`, or
+ * roughly \f$10^{-5}\f$ relative error), and so is poorly-suited to checking
+ * many numerical algorithms that rely on double-precision accuracy. By
+ * providing a tighter tolerance with `approx`, we avoid having to redefine the
+ * tolerance in every test.
+ *
  * ### Attributes
  *
  * Attributes allow you to modify properties of the test. Attributes are

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Determinant.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Determinant.cpp
@@ -9,8 +9,6 @@
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
                   "[DataStructures][Unit]") {
-  Approx approx = Approx::custom().epsilon(1e-15);
-
   // Test determinant function on general (no symmetry) matrices:
   // * use rank-2 Tensor in 1-4 dimensions, i.e. 1x1, 2x2, 3x3, 4x4 matrices.
   // * use Tensor<double, ...>, i.e. data at single spatial point.

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -146,7 +146,7 @@ template <typename T1, typename T2>
 void check_vectors(const T1& t1, const T2& t2) {
   CHECK(t1.size() == t2.size());
   for (size_t i = 0; i < t1.size(); ++i) {
-    CHECK(t1[i] == Approx(t2[i]).epsilon(1e-12));
+    CHECK(t1[i] == approx(t2[i]));
   }
 }
 }  // namespace

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -168,7 +168,7 @@ void check_vectors(const Variables<T1>& t1, const blaze::Vector<VT, VF>& t2) {
     // We've removed the subscript operator so people don't try to use that
     // and as a result we need to use the data() member function
     // clang-tidy: do not use pointer arithmetic
-    CHECK(t1.data()[i] == Approx((~t2)[i]).epsilon(1e-14));  // NOLINT
+    CHECK(t1.data()[i] == approx((~t2)[i]));  // NOLINT
   }
 }
 
@@ -179,7 +179,7 @@ void check_vectors(const Variables<T1>& t1, const Variables<T2>& t2) {
     // We've removed the subscript operator so people don't try to use that
     // and as a result we need to use the data() member function
     // clang-tidy: do not use pointer arithmetic
-    CHECK(t1.data()[i] == Approx(t2.data()[i]).epsilon(1e-14));  // NOLINT
+    CHECK(t1.data()[i] == approx(t2.data()[i]));  // NOLINT
   }
 }
 }  // namespace

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -116,7 +116,6 @@ void test_coordinate_map_with_affine_map() {
       CoordinateMaps::ProductOf3Maps<affine_map, affine_map, affine_map>;
 
   constexpr size_t number_of_points_checked = 10;
-  Approx approx = Approx::custom().epsilon(1.0e-14);
 
   // Test 1D
   const auto map = make_coordinate_map<Frame::Logical, Frame::Grid>(

--- a/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
@@ -9,7 +9,6 @@
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Rotation<2>", "[Domain][Unit]") {
   CoordinateMaps::Rotation<2> half_pi_rotation_map(M_PI_2);
-  Approx approx = Approx::custom().epsilon(1e-15);
 
   const auto xi0 = make_array<2>(0.0);
   const auto x0 = make_array<2>(0.0);
@@ -61,8 +60,6 @@ void test_rotation_3(const CoordinateMaps::Rotation<3>& three_dim_rotation_map,
                      const std::array<T, 3>& xi_hat,
                      const std::array<T, 3>& eta_hat,
                      const std::array<T, 3>& zeta_hat) {
-  Approx approx = Approx::custom().epsilon(1e-15);
-
   const std::array<T, 3> zero_logical{{0.0, 0.0, 0.0}};
   const std::array<T, 3> zero_grid{{0.0, 0.0, 0.0}};
   const std::array<T, 3> xi{{1.0, 0.0, 0.0}};

--- a/tests/Unit/Domain/Test_Neighbors.cpp
+++ b/tests/Unit/Domain/Test_Neighbors.cpp
@@ -6,7 +6,7 @@
 #include "Domain/Neighbors.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-TEST_CASE("Unit.Domain.Neighbors.1d", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Neighbors.1d", "[Domain][Unit]") {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
   Neighbors<1> test_neighbors;
@@ -62,7 +62,7 @@ TEST_CASE("Unit.Domain.Neighbors.1d", "[Domain][Unit]") {
   test_iterators(custom_neighbors);
 }
 
-TEST_CASE("Unit.Domain.Neighbors.2d", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Neighbors.2d", "[Domain][Unit]") {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
   Neighbors<2> test_neighbors;
@@ -123,7 +123,7 @@ TEST_CASE("Unit.Domain.Neighbors.2d", "[Domain][Unit]") {
   test_move_semantics(std::move(custom_neighbors), custom_copy);
 }
 
-TEST_CASE("Unit.Domain.Neighbors.3d", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Neighbors.3d", "[Domain][Unit]") {
   // Test default constructor, only used for Charm++ serialization so no CHECK
   // calls:
   Neighbors<3> test_neighbors;

--- a/tests/Unit/Numerical/RootFinding/Test_QuadraticEquation.cpp
+++ b/tests/Unit/Numerical/RootFinding/Test_QuadraticEquation.cpp
@@ -41,11 +41,11 @@
 
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.OnePositiveRoot",
                   "[Numerical][RootFinding][Unit]") {
-  CHECK(Approx(6.31662479035539985) == positive_root(1.0, -6.0, -2.0));
+  CHECK(approx(6.31662479035539985) == positive_root(1.0, -6.0, -2.0));
 }
 
 SPECTRE_TEST_CASE("Unit.Functors.RealRoots", "[Numerical][RootFinding][Unit]") {
   auto roots = real_roots(2.0, -11.0, 5.0);
-  CHECK(Approx(0.5) == roots[0]);
-  CHECK(Approx(5.0) == roots[1]);
+  CHECK(approx(0.5) == roots[0]);
+  CHECK(approx(5.0) == roots[1]);
 }

--- a/tests/Unit/Numerical/Spectral/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/Numerical/Spectral/Test_DefiniteIntegral.cpp
@@ -15,7 +15,6 @@
 
 namespace {
 void test_definite_integral_1d(const Index<1>& index_1d) {
-  Approx approx = Approx::custom().epsilon(1e-15);
   const size_t num_pts_in_x = index_1d[0];
   const DataVector& x = Basis::lgl::collocation_points(num_pts_in_x);
   Scalar<DataVector> integrand(num_pts_in_x);
@@ -33,7 +32,6 @@ void test_definite_integral_1d(const Index<1>& index_1d) {
 }
 
 void test_definite_integral_2d(const Index<2>& index_2d) {
-  Approx approx = Approx::custom().epsilon(1e-15);
   Mesh<2> extents(index_2d);
   const size_t num_pts_in_x = index_2d[0];
   const size_t num_pts_in_y = index_2d[1];
@@ -58,7 +56,6 @@ void test_definite_integral_2d(const Index<2>& index_2d) {
 }
 
 void test_definite_integral_3d(const Index<3>& index_3d) {
-  Approx approx = Approx::custom().epsilon(1e-15);
   Mesh<3> extents(index_3d);
   const size_t num_pts_in_x = index_3d[0];
   const size_t num_pts_in_y = index_3d[1];

--- a/tests/Unit/Numerical/Spectral/Test_LegendreGaussLobatto.cpp
+++ b/tests/Unit/Numerical/Spectral/Test_LegendreGaussLobatto.cpp
@@ -35,8 +35,6 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.Points",
        .5349928640318858, .6637764022903113, .7753682609520557,
        .8668779780899503, .9359344988126655, .9807437048939139}};
 
-  Approx approx = Approx::custom().epsilon(1e-12);
-
   // cppcheck-suppress preprocessorErrorDirective
   SECTION("Check 2 points") {
     const DataVector& collocation_pts = Basis::lgl::collocation_points(2);
@@ -160,7 +158,6 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.DiffMatrix",
   //
   // Command to generate differentation matrix with the Matlab code:
   // DN = Dmatrix1D(N, JacobiGL(0,0,N), Vandermonde1D(N, JacobiGL(0,0,N)))
-  Approx approx = Approx::custom().epsilon(1e-12);
 
   SECTION("Check 2 points") {
     const Matrix diff_matrix_expected = []() {
@@ -321,7 +318,6 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.DiffMatrix",
 SPECTRE_TEST_CASE(
     "Unit.Numerical.Spectral.LegendreGaussLobatto.LinearFilterMatrix",
     "[Numerical][Spectral][Unit]") {
-  Approx approx = Approx::custom().epsilon(1e-12);
   for (size_t n = 2; n < 10; ++n) {
     const Matrix& filter_matrix = Basis::lgl::linear_filter_matrix(n);
     const Matrix& grid_points_to_spectral_matrix =
@@ -347,7 +343,6 @@ SPECTRE_TEST_CASE(
     "Unit.Numerical.Spectral.LegendreGaussLobatto.InterpolationMatrix",
     "[Numerical][Spectral][Unit]") {
   auto check_interp = [](const size_t num_pts, auto func) {
-    Approx approx = Approx::custom().epsilon(1e-14);
     const DataVector& collocation_points =
         Basis::lgl::collocation_points(num_pts);
     DataVector u(num_pts);

--- a/tests/Unit/TestFramework.cpp
+++ b/tests/Unit/TestFramework.cpp
@@ -6,6 +6,33 @@
 
 #include "tests/Unit/TestHelpers.hpp"
 
+SPECTRE_TEST_CASE("TestFramework.Approx", "[Unit]") {
+  /// [approx_test]
+  CHECK(1.0 == approx(1.0 + 1e-15));
+  CHECK(1.0 != approx(1.0 + 1e-13));
+  /// [approx_test]
+  // also check numbers that are not order unity, but do not include in example
+  CHECK(1e-10 == approx(1e-10 + 1e-25).scale(1e-10));
+  CHECK(1e-10 == approx(1e-10 + 1e-23));
+  CHECK(1e-10 != approx(1e-10 + 1e-23).scale(1e-10));
+  CHECK(1e+10 == approx(1e+10 + 1e-5));
+  CHECK(1e+10 != approx(1e+10 + 1e-3));
+
+  /// [approx_default]
+  CHECK(sin(M_PI / 4.0) == approx(cos(M_PI / 4.0)));
+  /// [approx_default]
+  /// [approx_single_custom]
+  // This check needs tolerance 1e-12 for X reason.
+  CHECK(1.0 == approx(1.0 + 5e-13).epsilon(1e-12));
+  /// [approx_single_custom]
+  /// [approx_new_custom]
+  // The checks in this test need tolerance 1d-12 for X reason.
+  Approx my_approx = Approx::custom().epsilon(1e-12);
+  CHECK(1.0 == my_approx(1.0 + 5e-13));
+  CHECK(1.0 != my_approx(1.0 + 5e-12));
+  /// [approx_new_custom]
+}
+
 /// [error_test]
 // [[OutputRegex, I failed]]
 SPECTRE_TEST_CASE("TestFramework.Abort", "[Unit]") {

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -9,6 +9,7 @@
 #include <catch.hpp>
 #include <charm++.h>
 #include <csignal>
+#include <limits>
 #include <pup.h>
 
 #include "ErrorHandling/Error.hpp"
@@ -17,6 +18,24 @@
 #include "Utilities/TypeTraits.hpp"
 
 #define SPECTRE_TEST_CASE(m, n) TEST_CASE(m, n)  // NOLINT
+
+/*!
+ * \ingroup TestingFramework
+ * \brief Set a default tolerance for floating-point number comparison
+ *
+ * \details
+ * Catch's default (relative) tolerance for comparing floating-point numbers is
+ * `std\:\:numeric_limits<float>\:\:epsilon() * 100`, or roughly \f$10^{-5}\f$.
+ * This tolerance is too loose for checking many scientific algorithms that
+ * rely on double precision floating-point accuracy, so we provide a tighter
+ * tighter tolerance through the `approx` static object.
+ *
+ * \example
+ * \snippet TestFramework.cpp approx_test
+ */
+// clang-tidy: static object creation may throw exception
+static Approx approx = Approx::custom().epsilon(    // NOLINT
+    std::numeric_limits<double>::epsilon() * 100);  // NOLINT
 
 /// \cond HIDDEN_SYMBOLS
 [[noreturn]] inline void spectre_testing_signal_handler(int /*signal*/) {

--- a/tests/Unit/Time/Test_Slab.cpp
+++ b/tests/Unit/Time/Test_Slab.cpp
@@ -9,9 +9,6 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.Slab", "[Unit][Time]") {
-  Approx approx =
-      Approx::custom().epsilon(5 * std::numeric_limits<double>::epsilon());
-
   const double tstart_d = 0.68138945475734402635;
   const double tend_d = 76.34481744714527451379;
   // Make sure we're using values that will trigger rounding errors.

--- a/tests/Unit/Time/Test_Time.cpp
+++ b/tests/Unit/Time/Test_Time.cpp
@@ -11,9 +11,6 @@
 SPECTRE_TEST_CASE("Unit.Time.Time", "[Unit][Time]") {
   using rational_t = Time::rational_t;
 
-  Approx approx =
-      Approx::custom().epsilon(5 * std::numeric_limits<double>::epsilon());
-
   const double tstart_d = 0.68138945475734402635;
   const double tend_d = 76.34481744714527451379;
   // Make sure we're using values that will trigger rounding errors.
@@ -186,9 +183,6 @@ SPECTRE_TEST_CASE("Unit.Time.Time.serialization",
 
 SPECTRE_TEST_CASE("Unit.Time.TimeDelta", "[Unit][Time]") {
   using rational_t = TimeDelta::rational_t;
-
-  Approx approx =
-      Approx::custom().epsilon(5 * std::numeric_limits<double>::epsilon());
 
   const double tstart_d = 0.68138945475734402635;
   const double tend_d = 76.34481744714527451379;

--- a/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -73,8 +73,6 @@ void integrate_test(const Stepper& stepper, const double integration_time,
   auto analytic = [](double t) { return sin(t); };
   auto rhs = [](double v) { return sqrt(1. - square(v)); };
 
-  Approx approx = Approx::custom().epsilon(epsilon);
-
   const size_t num_steps = 800;
   const Slab slab = integration_time > 0
       ? Slab::with_duration_from_start(0., integration_time)
@@ -93,7 +91,8 @@ void integrate_test(const Stepper& stepper, const double integration_time,
 
   for (size_t i = 0; i < num_steps; ++i) {
     take_step(time, y, history, stepper, rhs, step_size);
-    CHECK(y == approx(analytic(time.value())));
+    // This check needs a looser tolerance for lower-order time steppers.
+    CHECK(y == approx(analytic(time.value())).epsilon(epsilon));
   }
 }
 
@@ -102,8 +101,6 @@ void integrate_variable_test(const Stepper& stepper,
                              const double epsilon) noexcept {
   auto analytic = [](double t) { return sin(t); };
   auto rhs = [](double v) { return sqrt(1. - square(v)); };
-
-  Approx approx = Approx::custom().epsilon(epsilon);
 
   const size_t num_steps = 800;
   const double average_step = 1. / num_steps;
@@ -122,7 +119,8 @@ void integrate_variable_test(const Stepper& stepper,
         (1. + 0.5 * sin(i)) * average_step);
 
     take_step(time, y, history, stepper, rhs, slab.duration());
-    CHECK(y == approx(analytic(time.value())));
+    // This check needs a looser tolerance for lower-order time steppers.
+    CHECK(y == approx(analytic(time.value())).epsilon(epsilon));
   }
 }
 

--- a/tests/Unit/Utilities/Test_Tuple.cpp
+++ b/tests/Unit/Utilities/Test_Tuple.cpp
@@ -21,7 +21,6 @@ struct tuple_fold_plus {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.tuple_fold", "[Utilities][Unit]") {
-  Approx approx = Approx::custom().epsilon(1e-14);
   {
     /// [tuple_fold_lambda]
     const auto my_tupull = std::make_tuple(2, 7, -3.8, 20.9);
@@ -203,7 +202,6 @@ struct negate_if_sum_less {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.tuple_transform", "[Utilities][Unit]") {
-  Approx approx = Approx::custom().epsilon(1e-14);
   /// [tuple_transform]
   const auto my_tupull = std::make_tuple(2, 7, -3.8, 20.9);
   std::decay_t<decltype(my_tupull)> out_tupull;


### PR DESCRIPTION
**This is a PR for discussion.**

The problem:

Catch's `Approx` allows fuzzy comparison between floating-point numbers, but the default tolerance of ~ 1e-5 is too lax. The tolerance _can_ be customized, but we do not want to do this separately in each test, as it will lead to inconsistencies.

The code in my branch tries to address this by:

1. providing an instantiation of Catch's`Approx`, called `spectre_approx`, with tolerance  set to `std::numeric_limits<double>::epsilon()*100` i.e. ~ 1e-14.
2. replacing the use of `Approx` (with tolerances varying between ~ `1e-5` (default) to `1e-15`) with this new default.

**Issue to discuss:**

`spectre_approx` is not `const`, because Catch's `Approx` cannot be `const` (let alone `constexpr`). ~~This means improper use of `spectre_approx` in one test can change the default used in subsequent tests.~~ (edit: this claim was incorrect, see discussion below) Some options:
* find a better way to provide a default using Catch's `Approx`
* provide a default `const double spectre_eps = blah;` and let each test create its local `Approx approx = Approx::custom()::epsilon(spectre_eps);`
* write our own approx class, that can be `const`.

Other, more minor, issues:
1. `spectre_approx` is an unwieldy name.
2. `Test_DefiniteIntegral` previously had a `1e-15` tolerance. Now it is the default ~ `1e-14`. Should it be special-cased back to the tighter value?
3. Broken Doxygen comments.
