### PR TITLE
Prevent cmake from mangling hook scripts

### DIFF
--- a/cmake/SetupGitHooks.cmake
+++ b/cmake/SetupGitHooks.cmake
@@ -17,15 +17,18 @@ if(NOT CHECK_SOURCE_DIR_WRITABLE_RESULT)
   configure_file(
       ${CMAKE_SOURCE_DIR}/tools/Hooks/pre-commit.sh
       ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit
+      @ONLY
   )
 
   configure_file(
       ${CMAKE_SOURCE_DIR}/tools/Hooks/ClangFormat.py
       ${CMAKE_SOURCE_DIR}/.git/hooks/ClangFormat.py
+      @ONLY
   )
 
   configure_file(
       ${CMAKE_SOURCE_DIR}/tools/Hooks/CheckFileSize.py
       ${CMAKE_SOURCE_DIR}/.git/hooks/CheckFileSize.py
+      @ONLY
   )
 endif()


### PR DESCRIPTION
Unless @ONLY is given ${foo} is treated as a cmake substitution.  This
is rather bad for bash scripts.  In this case it caused the pre-commit
hook to only check the last file alphabetically.