### PR TITLE
Add ScaleBy and Magnitude functions for tensors. 

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/DivideBy.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DivideBy.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines function divide_by
+
+#pragma once
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+
+/*!
+ * \ingroup Tensor
+ * \brief Divides the components of a tensor by a scalar
+ *
+ * \returns a tensor of the same type as the input tensor
+ */
+template <typename TensorType>
+TensorType divide_by(TensorType tensor, const DataVector& divisor) {
+  ASSERT(tensor.get(0).size() == divisor.size(),
+         "The DataVectors in `tensor` and `divisor` do not have the same size");
+  for (auto& component : tensor) {
+    component /= divisor;
+  }
+  return tensor;
+}

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Assert.hpp"
 
 /*!
  * \ingroup Tensor
@@ -18,7 +19,6 @@
  * \details
  * Computes the square root of the sum of the squares of the components of
  * the rank-1 tensor.
- *
  */
 template <typename Index>
 DataVector magnitude(
@@ -39,7 +39,6 @@ DataVector magnitude(
  * \details
  * Returns the square root of the input tensor contracted twice with the given
  * metric.
- *
  */
 template <typename Index0, typename Index1>
 DataVector magnitude(
@@ -50,9 +49,7 @@ DataVector magnitude(
                 "The indices of the tensor and metric must be the same, "
                 "except for their valence which must be opposite");
   ASSERT(tensor.get(0).size() == metric.get(0, 0).size(),
-         "The size of the DataVector in 'tensor' is not the same as the "
-         "DataVector "
-         "in 'metric'.");
+         "The DataVector in `tensor` and `metric` do not have the same size");
   DataVector magnitude_squared(tensor.template get<0>().size(), 0.);
   for (size_t a = 0; a < Index0::dim; ++a) {
     for (size_t b = 0; b < Index0::dim; ++b) {

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines functions euclidean_magnitude and magnitude
+
+#pragma once
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+
+/*!
+ * \ingroup Tensor
+ * \brief compute the Euclidean magnitude of a rank-1 tensor
+ *
+ * \returns the Euclidean magnitude of the rank-1 tensor
+ *
+ * \details
+ * Computes the square root of the sum of the squares of the components of
+ * the rank-1 tensor.
+ *
+ */
+template <typename Index>
+DataVector magnitude(
+    const Tensor<DataVector, Symmetry<1>, typelist<Index>>& tensor) {
+  DataVector magnitude_squared(tensor.template get<0>().size(), 0.);
+  for (size_t d = 0; d < Index::dim; ++d) {
+    magnitude_squared += square(tensor.get(d));
+  }
+  return sqrt(magnitude_squared);
+}
+
+/*!
+ * \ingroup Tensor
+ * \brief compute the magnitude of a rank-1 tensor
+ *
+ * \returns the magnitude of the rank-1 tensor
+ *
+ * \details
+ * Returns the square root of the input tensor contracted twice with the given
+ * metric.
+ *
+ */
+template <typename Index0, typename Index1>
+DataVector magnitude(
+    const Tensor<DataVector, Symmetry<1>, typelist<Index0>>& tensor,
+    const Tensor<DataVector, Symmetry<1, 1>, typelist<Index1, Index1>>&
+        metric) {
+  static_assert(std::is_same<Index0, change_index_up_lo<Index1>>::value,
+                "The indices of the tensor and metric must be the same, "
+                "except for their valence which must be opposite");
+  ASSERT(tensor.get(0).size() == metric.get(0, 0).size(),
+         "The size of the DataVector in 'tensor' is not the same as the "
+         "DataVector "
+         "in 'metric'.");
+  DataVector magnitude_squared(tensor.template get<0>().size(), 0.);
+  for (size_t a = 0; a < Index0::dim; ++a) {
+    for (size_t b = 0; b < Index0::dim; ++b) {
+      magnitude_squared += tensor.get(a) * tensor.get(b) * metric.get(a, b);
+    }
+  }
+  return sqrt(magnitude_squared);
+}

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(DATA_STRUCTURES_TESTS
     DataStructures/Test_DataBox.cpp
     DataStructures/Test_DataVector.cpp
+    DataStructures/Test_DivideBy.cpp
     DataStructures/Test_Index.cpp
     DataStructures/Test_IndexIterator.cpp
     DataStructures/Test_Matrix.cpp

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -11,6 +11,7 @@ set(DATA_STRUCTURES_TESTS
     DataStructures/Test_StripeIterator.cpp
     DataStructures/Test_Tensor.cpp
     DataStructures/Test_TensorExpressions.cpp
+    DataStructures/Test_TensorMagnitude.cpp
     DataStructures/Test_Variables.cpp
     )
 

--- a/tests/Unit/DataStructures/Test_DivideBy.cpp
+++ b/tests/Unit/DataStructures/Test_DivideBy.cpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "DataStructures/Tensor/EagerMath/DivideBy.hpp"
+
+TEST_CASE("Unit.DataStructures.Tensor.DivideBy", "[Functors][Unit]") {
+  const size_t npts = 2;
+  const DataVector one(npts, 1.0);
+  const DataVector two(npts, 2.0);
+  const DataVector three(npts, 3.0);
+  const DataVector four(npts, 4.0);
+  const DataVector five(npts, 5.0);
+  const DataVector twelve(npts, 12.0);
+  const DataVector thirteen(npts, 13.0);
+
+  const Tensor<DataVector, Symmetry<1>,
+               typelist<SpatialIndex<1, UpLo::Lo, Frame::Grid>>>
+      one_d_covector{{{two}}};
+  const DataVector magnitude_one_d_covector = two;
+  const auto normalized_one_d_covector =
+      divide_by(one_d_covector, magnitude_one_d_covector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(normalized_one_d_covector.get<0>()[s] == 1.0);
+  }
+
+  const Tensor<DataVector, Symmetry<1>,
+               typelist<SpacetimeIndex<1, UpLo::Up, Frame::Grid>>>
+      two_d_vector{{{three, four}}};
+  const DataVector magnitude_two_d_vector = five;
+  const auto normalized_two_d_vector =
+      divide_by(two_d_vector, magnitude_two_d_vector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(normalized_two_d_vector.get<0>()[s] == 0.6);
+    CHECK(normalized_two_d_vector.get<1>()[s] == 0.8);
+  }
+
+  const Tensor<DataVector, Symmetry<1>,
+               typelist<SpatialIndex<2, UpLo::Up, Frame::Grid>>>
+      two_d_spatial_vector{{{five, twelve}}};
+  const DataVector magnitude_two_d_spatial_vector = thirteen;
+  const auto normalized_two_d_spatial_vector =
+      divide_by(two_d_spatial_vector, magnitude_two_d_spatial_vector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(normalized_two_d_spatial_vector.get<0>()[s] == 5.0 / 13.0);
+    CHECK(normalized_two_d_spatial_vector.get<1>()[s] == 12.0 / 13.0);
+  }
+
+  const Tensor<DataVector, Symmetry<1>,
+               typelist<SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+      three_d_covector{{{three, twelve, four}}};
+  const DataVector magnitude_three_d_covector = thirteen;
+  const auto normalized_three_d_covector =
+      divide_by(three_d_covector, magnitude_three_d_covector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(normalized_three_d_covector.get<0>()[s] == 3.0 / 13.0);
+    CHECK(normalized_three_d_covector.get<1>()[s] == 12.0 / 13.0);
+    CHECK(normalized_three_d_covector.get<2>()[s] == 4.0 / 13.0);
+  }
+
+  const Tensor<DataVector, Symmetry<1>,
+               typelist<SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
+      five_d_covector{{{two, twelve, four, one, two}}};
+  const DataVector magnitude_five_d_covector = thirteen;
+  const auto normalized_five_d_covector =
+      divide_by(five_d_covector, magnitude_five_d_covector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(normalized_five_d_covector.get<0>()[s] == 2.0 / 13.0);
+    CHECK(normalized_five_d_covector.get<1>()[s] == 12.0 / 13.0);
+    CHECK(normalized_five_d_covector.get<2>()[s] == 4.0 / 13.0);
+    CHECK(normalized_five_d_covector.get<3>()[s] == 1.0 / 13.0);
+    CHECK(normalized_five_d_covector.get<4>()[s] == 2.0 / 13.0);
+  }
+}

--- a/tests/Unit/DataStructures/Test_TensorMagnitude.cpp
+++ b/tests/Unit/DataStructures/Test_TensorMagnitude.cpp
@@ -7,90 +7,92 @@
 
 TEST_CASE("Unit.DataStructures.Tensor.EuclideanMagnitude",
           "[DataStructures][Unit]") {
-  const size_t npts = 8;
-  DataVector one(npts, 1.0);
-  DataVector two(npts, 2.0);
-  DataVector minus_three(npts, -3.0);
-  DataVector four(npts, 4.0);
-  DataVector minus_five(npts, -5.0);
-  DataVector twelve(npts, 12.0);
-  DataVector thirteen(npts, 13.0);
+  const size_t npts = 2;
+  const DataVector one(npts, 1.0);
+  const DataVector two(npts, 2.0);
+  const DataVector minus_three(npts, -3.0);
+  const DataVector four(npts, 4.0);
+  const DataVector minus_five(npts, -5.0);
+  const DataVector twelve(npts, 12.0);
 
-  tnsr::i<DataVector, 1, Frame::Grid> one_d_covector;
-  one_d_covector.get<0>() = two;
-  DataVector magnitude_one_d_covector = magnitude(one_d_covector);
+  const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector{{{two}}};
+  const DataVector magnitude_one_d_covector = magnitude(one_d_covector);
   for (size_t s = 0; s < npts; ++s) {
     CHECK(magnitude_one_d_covector[s] == 2.0);
   }
 
-  tnsr::A<DataVector, 1, Frame::Grid> one_d_vector;
-  one_d_vector.get<0>() = minus_three;
-  one_d_vector.get<1>() = four;
-  DataVector magnitude_one_d_vector = magnitude(one_d_vector);
+  const tnsr::i<DataVector, 1, Frame::Grid> negative_one_d_covector{
+      {{minus_three}}};
+  const DataVector magnitude_negative_one_d_covector =
+      magnitude(negative_one_d_covector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(magnitude_negative_one_d_covector[s] == 3.0);
+  }
+  const tnsr::A<DataVector, 1, Frame::Grid> one_d_vector{{{minus_three, four}}};
+  const DataVector magnitude_one_d_vector = magnitude(one_d_vector);
   for (size_t s = 0; s < npts; ++s) {
     CHECK(magnitude_one_d_vector[s] == 5.0);
   }
 
-  tnsr::I<DataVector, 2, Frame::Grid> two_d_vector;
-  two_d_vector.get<0>() = minus_five;
-  two_d_vector.get<1>() = twelve;
-  DataVector magnitude_two_d_vector = magnitude(two_d_vector);
+  const tnsr::I<DataVector, 2, Frame::Grid> two_d_vector{
+      {{minus_five, twelve}}};
+  const DataVector magnitude_two_d_vector = magnitude(two_d_vector);
   for (size_t s = 0; s < npts; ++s) {
     CHECK(magnitude_two_d_vector[s] == 13.0);
   }
 
-  tnsr::i<DataVector, 3, Frame::Grid> three_d_covector;
-  three_d_covector.get<0>() = minus_three;
-  three_d_covector.get<1>() = twelve;
-  three_d_covector.get<2>() = four;
-  DataVector magnitude_three_d_covector = magnitude(three_d_covector);
+  const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector{
+      {{minus_three, twelve, four}}};
+  const DataVector magnitude_three_d_covector = magnitude(three_d_covector);
   for (size_t s = 0; s < npts; ++s) {
     CHECK(magnitude_three_d_covector[s] == 13.0);
   }
 
   // 5D example
-  tnsr::a<DataVector, 4, Frame::Grid> five_d_covector;
-  five_d_covector.get<0>() = two;
-  five_d_covector.get<1>() = twelve;
-  five_d_covector.get<2>() = four;
-  five_d_covector.get<3>() = one;
-  five_d_covector.get<4>() = two;
-  DataVector magnitude_five_d_covector = magnitude(five_d_covector);
+  const tnsr::a<DataVector, 4, Frame::Grid> five_d_covector{
+      {{two, twelve, four, one, two}}};
+  const DataVector magnitude_five_d_covector = magnitude(five_d_covector);
   for (size_t s = 0; s < npts; ++s) {
     CHECK(magnitude_five_d_covector[s] == 13.0);
   }
 }
 
 TEST_CASE("Unit.DataStructures.Tensor.Magnitude", "[DataStructures][Unit]") {
-  const size_t npts = 8;
-  DataVector one(npts, 1.0);
-  DataVector two(npts, 2.0);
-  DataVector minus_three(npts, -3.0);
-  DataVector four(npts, 4.0);
-  DataVector minus_five(npts, -5.0);
-  DataVector twelve(npts, 12.0);
-  DataVector thirteen(npts, 13.0);
+  const size_t npts = 2;
+  const DataVector one(npts, 1.0);
+  const DataVector two(npts, 2.0);
+  const DataVector minus_three(npts, -3.0);
+  const DataVector four(npts, 4.0);
+  const DataVector minus_five(npts, -5.0);
+  const DataVector twelve(npts, 12.0);
+  const DataVector thirteen(npts, 13.0);
 
-  tnsr::i<DataVector, 1, Frame::Grid> one_d_covector;
-  tnsr::II<DataVector, 1, Frame::Grid> inv_h;
-  one_d_covector.get<0>() = two;
-  inv_h.get<0, 0>() = four;
-  DataVector magnitude_a = magnitude(one_d_covector, inv_h);
+  const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector{{{two}}};
+  const tnsr::II<DataVector, 1, Frame::Grid> inv_h = [&four]() {
+    tnsr::II<DataVector, 1, Frame::Grid> tensor;
+    tensor.template get<0, 0>() = four;
+    return tensor;
+  }();
+
+  const DataVector magnitude_a = magnitude(one_d_covector, inv_h);
   for (size_t s = 0; s < npts; ++s) {
     CHECK(magnitude_a[s] == 4.0);
   }
-  tnsr::i<DataVector, 3, Frame::Grid> three_d_covector;
-  tnsr::II<DataVector, 3, Frame::Grid> inv_g;
-  three_d_covector.get<0>() = minus_three;
-  three_d_covector.get<1>() = twelve;
-  three_d_covector.get<2>() = four;
-  inv_g.get<0, 0>() = two;
-  inv_g.get<0, 1>() = minus_three;
-  inv_g.get<0, 2>() = four;
-  inv_g.get<1, 1>() = minus_five;
-  inv_g.get<1, 2>() = twelve;
-  inv_g.get<2, 2>() = thirteen;
-  DataVector magnitude_three_d_covector = magnitude(three_d_covector, inv_g);
+  const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector{
+      {{minus_three, twelve, four}}};
+  const tnsr::II<DataVector, 3, Frame::Grid> inv_g =
+      [&two, &minus_three, &four, &minus_five, &twelve, &thirteen]() {
+        tnsr::II<DataVector, 3, Frame::Grid> tensor;
+        tensor.get<0, 0>() = two;
+        tensor.get<0, 1>() = minus_three;
+        tensor.get<0, 2>() = four;
+        tensor.get<1, 1>() = minus_five;
+        tensor.get<1, 2>() = twelve;
+        tensor.get<2, 2>() = thirteen;
+        return tensor;
+      }();
+  const DataVector magnitude_three_d_covector =
+      magnitude(three_d_covector, inv_g);
   for (size_t s = 0; s < npts; ++s) {
     CHECK(magnitude_three_d_covector[s] == sqrt(778.0));
   }

--- a/tests/Unit/DataStructures/Test_TensorMagnitude.cpp
+++ b/tests/Unit/DataStructures/Test_TensorMagnitude.cpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+
+TEST_CASE("Unit.DataStructures.Tensor.EuclideanMagnitude",
+          "[DataStructures][Unit]") {
+  const size_t npts = 8;
+  DataVector one(npts, 1.0);
+  DataVector two(npts, 2.0);
+  DataVector minus_three(npts, -3.0);
+  DataVector four(npts, 4.0);
+  DataVector minus_five(npts, -5.0);
+  DataVector twelve(npts, 12.0);
+  DataVector thirteen(npts, 13.0);
+
+  tnsr::i<DataVector, 1, Frame::Grid> one_d_covector;
+  one_d_covector.get<0>() = two;
+  DataVector magnitude_one_d_covector = magnitude(one_d_covector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(magnitude_one_d_covector[s] == 2.0);
+  }
+
+  tnsr::A<DataVector, 1, Frame::Grid> one_d_vector;
+  one_d_vector.get<0>() = minus_three;
+  one_d_vector.get<1>() = four;
+  DataVector magnitude_one_d_vector = magnitude(one_d_vector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(magnitude_one_d_vector[s] == 5.0);
+  }
+
+  tnsr::I<DataVector, 2, Frame::Grid> two_d_vector;
+  two_d_vector.get<0>() = minus_five;
+  two_d_vector.get<1>() = twelve;
+  DataVector magnitude_two_d_vector = magnitude(two_d_vector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(magnitude_two_d_vector[s] == 13.0);
+  }
+
+  tnsr::i<DataVector, 3, Frame::Grid> three_d_covector;
+  three_d_covector.get<0>() = minus_three;
+  three_d_covector.get<1>() = twelve;
+  three_d_covector.get<2>() = four;
+  DataVector magnitude_three_d_covector = magnitude(three_d_covector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(magnitude_three_d_covector[s] == 13.0);
+  }
+
+  // 5D example
+  tnsr::a<DataVector, 4, Frame::Grid> five_d_covector;
+  five_d_covector.get<0>() = two;
+  five_d_covector.get<1>() = twelve;
+  five_d_covector.get<2>() = four;
+  five_d_covector.get<3>() = one;
+  five_d_covector.get<4>() = two;
+  DataVector magnitude_five_d_covector = magnitude(five_d_covector);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(magnitude_five_d_covector[s] == 13.0);
+  }
+}
+
+TEST_CASE("Unit.DataStructures.Tensor.Magnitude", "[DataStructures][Unit]") {
+  const size_t npts = 8;
+  DataVector one(npts, 1.0);
+  DataVector two(npts, 2.0);
+  DataVector minus_three(npts, -3.0);
+  DataVector four(npts, 4.0);
+  DataVector minus_five(npts, -5.0);
+  DataVector twelve(npts, 12.0);
+  DataVector thirteen(npts, 13.0);
+
+  tnsr::i<DataVector, 1, Frame::Grid> one_d_covector;
+  tnsr::II<DataVector, 1, Frame::Grid> inv_h;
+  one_d_covector.get<0>() = two;
+  inv_h.get<0, 0>() = four;
+  DataVector magnitude_a = magnitude(one_d_covector, inv_h);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(magnitude_a[s] == 4.0);
+  }
+  tnsr::i<DataVector, 3, Frame::Grid> three_d_covector;
+  tnsr::II<DataVector, 3, Frame::Grid> inv_g;
+  three_d_covector.get<0>() = minus_three;
+  three_d_covector.get<1>() = twelve;
+  three_d_covector.get<2>() = four;
+  inv_g.get<0, 0>() = two;
+  inv_g.get<0, 1>() = minus_three;
+  inv_g.get<0, 2>() = four;
+  inv_g.get<1, 1>() = minus_five;
+  inv_g.get<1, 2>() = twelve;
+  inv_g.get<2, 2>() = thirteen;
+  DataVector magnitude_three_d_covector = magnitude(three_d_covector, inv_g);
+  for (size_t s = 0; s < npts; ++s) {
+    CHECK(magnitude_three_d_covector[s] == sqrt(778.0));
+  }
+}


### PR DESCRIPTION
Since Normalize is unused I removed the commits which added it. 