### PR TITLE
Add Block and test

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Block.hpp"
+
+#include <ostream>
+
+#include "Utilities/StdHelpers.hpp"
+
+template <size_t VolumeDim>
+Block<VolumeDim>::Block(
+    const EmbeddingMap<VolumeDim, VolumeDim>& embedding_map, const size_t id,
+    std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>&&
+        neighbors)
+    : embedding_map_(embedding_map.get_clone()),
+      id_(id),
+      neighbors_(std::move(neighbors)) {
+  // Loop over Directions to search which Directions were not set to neighbors_,
+  // set these Directions to external_boundaries_.
+  for (const auto& direction : Direction<VolumeDim>::all_directions()) {
+    if (neighbors_.find(direction) == neighbors_.end()) {
+      external_boundaries_.emplace(std::move(direction));
+    }
+  }
+}
+
+template <size_t VolumeDim>
+void Block<VolumeDim>::pup(PUP::er& p) {
+  p | embedding_map_;
+  p | id_;
+  p | neighbors_;
+  p | external_boundaries_;
+}
+
+template <size_t VolumeDim>
+std::ostream& operator<<(std::ostream& os, const Block<VolumeDim>& block) {
+  os << "Block " << block.id() << ":\n";
+  os << "Neighbors:\n";
+  for (const auto& direction_to_neighbors : block.neighbors()) {
+    os << direction_to_neighbors.first << ": " << direction_to_neighbors.second
+       << "\n";
+  }
+  os << "External boundaries: " << block.external_boundaries() << "\n";
+  return os;
+}
+
+template <size_t VolumeDim>
+bool operator==(const Block<VolumeDim>& lhs,
+                const Block<VolumeDim>& rhs) noexcept {
+  return (lhs.id() == rhs.id() and lhs.neighbors() == rhs.neighbors() and
+          lhs.external_boundaries() == rhs.external_boundaries());
+}
+
+template <size_t VolumeDim>
+bool operator!=(const Block<VolumeDim>& lhs,
+                const Block<VolumeDim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+template class Block<1>;
+template class Block<2>;
+template class Block<3>;
+
+template std::ostream& operator<<(std::ostream&, const Block<1>&);
+template std::ostream& operator<<(std::ostream&, const Block<2>&);
+template std::ostream& operator<<(std::ostream&, const Block<3>&);
+
+template bool operator==(const Block<1>&, const Block<1>&);
+template bool operator==(const Block<2>&, const Block<2>&);
+template bool operator==(const Block<3>&, const Block<3>&);
+
+template bool operator!=(const Block<1>&, const Block<1>&);
+template bool operator!=(const Block<2>&, const Block<2>&);
+template bool operator!=(const Block<3>&, const Block<3>&);

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -1,0 +1,91 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines class template Block.
+
+#pragma once
+
+#include <iosfwd>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "Domain/BlockNeighbor.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/EmbeddingMaps/EmbeddingMap.hpp"
+
+/// \ingroup ComputationalDomain
+/// A Block<VolumeDim> is a region of a VolumeDim-dimensional computational
+/// domain that defines the root node of a tree which is used to construct the
+/// Elements that cover a region of the computational domain.
+///
+/// Each codimension 1 boundary of a Block<VolumeDim> is either an external
+/// boundary or identical to a boundary of one other Block.
+///
+/// A Block has logical coordinates that go from -1 to +1 in each
+/// dimension.  The global coordinates are obtained from the logical
+/// coordinates from the EmbeddingMap:  EmbeddingMap::operator() takes
+/// Points in the Logical Frame (i.e., logical coordinates) and
+/// returns Points in the Grid Frame (i.e., global coordinates).
+///
+/// \tparam VolumeDim the dimension of the Block (i.e. the volume dimension).
+template <size_t VolumeDim>
+class Block {
+ public:
+  /// \param embedding_map the EmbeddingMap.
+  /// \param id a unique ID.
+  /// \param neighbors info about the Blocks that share a codimension 1
+  /// boundary with this Block.
+  Block(const EmbeddingMap<VolumeDim, VolumeDim>& embedding_map, size_t id,
+        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>&&
+            neighbors);
+
+  Block() = default;
+  ~Block() = default;
+  Block(const Block<VolumeDim>&) = delete;
+  Block(Block<VolumeDim>&&) = default;  // NOLINT
+  Block<VolumeDim>& operator=(const Block<VolumeDim>&) = delete;
+  Block<VolumeDim>& operator=(Block<VolumeDim>&&) = default;  // NOLINT
+
+  const EmbeddingMap<VolumeDim, VolumeDim>& embedding_map() const noexcept {
+    return *embedding_map_;
+  }
+
+  /// A unique identifier for the Block that is in the range
+  /// [0, number_of_blocks -1] where number_of_blocks is the number
+  /// of Blocks that cover the computational domain.
+  size_t id() const noexcept { return id_; }
+
+  /// Information about the neighboring Blocks.
+  const std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>&
+  neighbors() const noexcept {
+    return neighbors_;
+  }
+
+  /// The directions of the faces of the Block that are external boundaries.
+  const std::unordered_set<Direction<VolumeDim>>& external_boundaries() const
+      noexcept {
+    return external_boundaries_;
+  }
+
+  /// Serialization for Charm++
+  void pup(PUP::er& p);  // NOLINT
+
+ private:
+  std::unique_ptr<EmbeddingMap<VolumeDim, VolumeDim>> embedding_map_;
+  size_t id_;
+  std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>> neighbors_;
+  std::unordered_set<Direction<VolumeDim>> external_boundaries_;
+};
+
+template <size_t VolumeDim>
+std::ostream& operator<<(std::ostream& os, const Block<VolumeDim>& block);
+
+template <size_t VolumeDim>
+bool operator==(const Block<VolumeDim>& lhs,
+                const Block<VolumeDim>& rhs) noexcept;
+
+template <size_t VolumeDim>
+bool operator!=(const Block<VolumeDim>& lhs,
+                const Block<VolumeDim>& rhs) noexcept;

--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(EmbeddingMaps)
 set(LIBRARY Domain)
 
 set(LIBRARY_SOURCES
+    Block.cpp
     BlockNeighbor.cpp
     Direction.cpp
     ElementId.cpp

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 set(DOMAIN_TESTS
+    Domain/Test_Block.cpp
     Domain/Test_BlockNeighbor.cpp
     Domain/Test_Direction.cpp
     Domain/Test_EmbeddingMaps.cpp

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "Domain/Block.cpp"
+#include "Domain/EmbeddingMaps/Identity.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+template <size_t Dim>
+void test_block() {
+  const EmbeddingMaps::Identity<Dim> identity_map{};
+  Block<Dim> block(identity_map, 7, {});
+
+  // Test external boundaries:
+  CHECK((block.external_boundaries().size()) == 2 * Dim);
+
+  // Test neighbors:
+  CHECK((block.neighbors().size()) == 0);
+
+  // Test id:
+  CHECK((block.id()) == 7);
+
+  // Test that the block's embedding_map is Identity:
+  const auto& map = block.embedding_map();
+  const Point<Dim, Frame::Logical> xi(1.0);
+  const Point<Dim, Frame::Grid> x(1.0);
+  CHECK(map(xi) == x);
+  CHECK(map.inverse(x) == xi);
+
+  // Test PUP
+  // CHECK(block == serialize_and_deserialize(block));
+
+  // Test move semantics:
+  const Block<Dim> block_copy(identity_map, 7, {});
+  test_move_semantics(std::move(block), block_copy);
+}
+
+TEST_CASE("Unit.Domain.Block.Identity", "[Domain][Unit]") {
+  test_block<1>();
+  test_block<2>();
+  // test_identity<3>();
+}
+
+TEST_CASE("Unit.Domain.Block.Neighbors", "[Domain][Unit]") {
+  // Create std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>
+
+  // Each BlockNeighbor is an id and an Orientation:
+  const BlockNeighbor<2> block_neighbor1(
+      1, Orientation<2>(std::array<Direction<2>, 2>{
+             {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}));
+  const BlockNeighbor<2> block_neighbor2(
+      2, Orientation<2>(std::array<Direction<2>, 2>{
+             {Direction<2>::lower_xi(), Direction<2>::upper_eta()}}));
+  std::unordered_map<Direction<2>, BlockNeighbor<2>> neighbors = {
+      {Direction<2>::upper_xi(), block_neighbor1},
+      {Direction<2>::lower_eta(), block_neighbor2}};
+  const EmbeddingMaps::Identity<2> identity_map{};
+  const Block<2> block(identity_map, 3, std::move(neighbors));
+
+  // Test external boundaries:
+  CHECK((block.external_boundaries().size()) == 2);
+
+  // Test neighbors:
+  CHECK((block.neighbors().size()) == 2);
+
+  // Test id:
+  CHECK((block.id()) == 3);
+
+  // Test output:
+  CHECK(get_output(block) ==
+        "Block 3:\n"
+        "Neighbors:\n"
+        "-1: Id = 2; orientation = (-0, +1)\n"
+        "+0: Id = 1; orientation = (+0, +1)\n"
+        "External boundaries: (+1,-0)\n");
+
+  // Test comparison:
+  const Block<2> neighborless_block(identity_map, 7, {});
+  CHECK(block == block);
+  CHECK(block != neighborless_block);
+  CHECK(neighborless_block == neighborless_block);
+}

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -89,6 +89,10 @@
  */
 template <typename T>
 T serialize_and_deserialize(const T& t) {
+  static_assert(
+      std::is_default_constructible<T>::value,
+      "Cannot use serialize_and_deserialize if a class is not default "
+      "constructible.");
   return deserialize<T>(serialize<T>(t).data());
 }
 


### PR DESCRIPTION
Notable: Block construction now only takes Neighbors and no longer takes ExternalBoundaries - the ExternalBoundaries are deduced from the Neighbors during construction.