### PR TITLE
Make test_move_semantics harder to misuse

### DIFF
--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Unit.DataStructures.DataVector", "[DataStructures][Unit]") {
   test_copy_semantics(t);
   auto t_copy = t;
   CHECK(t_copy.is_owning());
-  test_move_semantics(t, t_copy);
+  test_move_semantics(std::move(t), t_copy);
   DataVector t_move_assignment = std::move(t_copy);
   CHECK(t_move_assignment.is_owning());
   DataVector t_move_constructor = std::move(t_move_assignment);
@@ -71,7 +71,7 @@ TEST_CASE("Unit.DataStructures.DataVector_Ref", "[DataStructures][Unit]") {
   test_copy_semantics(t);
   DataVector t_copy;
   t_copy.set_data_ref(t);
-  test_move_semantics(t, t_copy);
+  test_move_semantics(std::move(t), t_copy);
   DataVector t_move_assignment = std::move(t_copy);
   CHECK(not t_move_assignment.is_owning());
   DataVector t_move_constructor = std::move(t_move_assignment);

--- a/tests/Unit/DataStructures/Test_Index.cpp
+++ b/tests/Unit/DataStructures/Test_Index.cpp
@@ -49,5 +49,5 @@ TEST_CASE("Unit.DataStructures.Index", "[DataStructures][Unit]") {
 
   test_copy_semantics(index_3d);
   auto index_3d_copy = index_3d;
-  test_move_semantics(index_3d, index_3d_copy);
+  test_move_semantics(std::move(index_3d), index_3d_copy);
 }

--- a/tests/Unit/DataStructures/Test_Matrix.cpp
+++ b/tests/Unit/DataStructures/Test_Matrix.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Unit.DataStructures.Matrix", "[DataStructures][Unit]") {
 
   test_copy_semantics(matrix);
   auto matrix_copy = matrix;
-  test_move_semantics(matrix, matrix_copy);
+  test_move_semantics(std::move(matrix), matrix_copy);
 }
 
 TEST_CASE("Unit.Serialization.Matrix",

--- a/tests/Unit/Domain/Test_Orientations.cpp
+++ b/tests/Unit/Domain/Test_Orientations.cpp
@@ -39,7 +39,7 @@ void test_1d() {
   // Test semantics:
   const auto custom_copy = custom1;
   test_copy_semantics(custom2);
-  test_move_semantics(custom1, custom_copy);
+  test_move_semantics(std::move(custom1), custom_copy);
 
   // Test serialization:
   serialize_and_deserialize(custom2);
@@ -143,7 +143,7 @@ void test_2d() {
   // Test semantics:
   const auto rotated_copy = rotated2d_neg_eta_pos_xi;
   test_copy_semantics(rotated2d_pos_eta_neg_xi);
-  test_move_semantics(rotated2d_neg_eta_pos_xi, rotated_copy);
+  test_move_semantics(std::move(rotated2d_neg_eta_pos_xi), rotated_copy);
 
   // Test serialization:
   serialize_and_deserialize(rotated_copy);
@@ -199,7 +199,7 @@ void test_3d() {
   // Test semantics:
   const auto custom_copy = custom_orientation;
   test_copy_semantics(aligned_orientation);
-  test_move_semantics(custom_orientation, custom_copy);
+  test_move_semantics(std::move(custom_orientation), custom_copy);
 
   // Test serialzation:
   serialize_and_deserialize(custom2);

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -115,10 +115,10 @@ void test_copy_semantics(const T& a) {
 template <typename T,
           typename std::enable_if<tt::has_equivalence<T>::value, int>::type = 0>
 void test_move_semantics(T&& a, const T& comparison) {
-  static_assert(std::is_move_assignable<T>::value,
-                "Class is not move assignable.");
-  static_assert(std::is_move_constructible<T>::value,
-                "Class is not move constructible.");
+  static_assert(std::is_nothrow_move_assignable<T>::value,
+                "Class is not nothrow move assignable.");
+  static_assert(std::is_nothrow_move_constructible<T>::value,
+                "Class is not nothrow move constructible.");
   static_assert(std::is_default_constructible<T>::value,
                 "Cannot use test_move_semantics if a class is not default "
                 "constructible.");

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -114,7 +114,7 @@ void test_copy_semantics(const T& a) {
 /// Test for move semantics assuming operator== is implement correctly
 template <typename T,
           typename std::enable_if<tt::has_equivalence<T>::value, int>::type = 0>
-void test_move_semantics(T& a, const T& comparison) {
+void test_move_semantics(T&& a, const T& comparison) {
   static_assert(std::is_move_assignable<T>::value,
                 "Class is not move assignable.");
   static_assert(std::is_move_constructible<T>::value,


### PR DESCRIPTION
This addresses #111, but instead of changing the argument to by-value changes it to by-rvalue-reference.  This avoids the problem of requiring a move constructor before the compiler considers the function body while still making it clear to callers that the argument will be invalidated.

Also tightened the static assertions to require nothrow, as discussed in the bug.