### PR TITLE
Ignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .idea
 .dir-locals.el
 .vscode
+compile_commands.json
 
 # TeX products
 *.aux


### PR DESCRIPTION
Some autocomplete systems require this file be in the source directory.