### PR TITLE
Stop setting _GLIBCXX_DEBUG macro

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -3,7 +3,7 @@
 
 set(
     CMAKE_CXX_FLAGS_DEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} -DSPECTRE_DEBUG -D_GLIBCXX_DEBUG"
+    "${CMAKE_CXX_FLAGS_DEBUG} -DSPECTRE_DEBUG"
 )
 
 # Always build with -g so we can view backtraces, etc. when production code


### PR DESCRIPTION
It changes the memory layout of standard library types, so any
compilation units that exchange such types have to be compiled with
the same value.  This includes units in any system libraries for with
we use an interface involving standard library types, such as
yaml-cpp.