### PR TITLE
Travis Static Analysers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,11 @@ compiler:
 
 # macOS is easiest to add specific targets for. We target 10.11 Debug and 10.12
 # Release builds.
+#
+# We also have separate targets for running shell scripts that enforce what
+# would normally be done as pre-push hooks, CHECK_COMMITS and CHECK_FILES
+#
+# We run two static analyzers, cppcheck and clang-tidy.
 matrix:
   fast_finish: true
   include:
@@ -89,6 +94,14 @@ matrix:
   - os: linux
     dist: trusty
     env: CHECK_FILES=true
+    compiler: clang
+  - os: linux
+    dist: trusty
+    env: RUN_CLANG_TIDY=true
+    compiler: clang
+  - os: linux
+    dist: trusty
+    env: RUN_CPPCHECK=true
     compiler: clang
 
 
@@ -186,9 +199,13 @@ before_install:
 script:
 - ENCRYPTED_KEY_VAR="encrypted_${ENCRYPTION_LABEL}_key"
 - ENCRYPTED_IV_VAR="encrypted_${ENCRYPTION_LABEL}_iv"
-- if [ ${CHECK_COMMITS} = true ]; then
-    ./tools/CheckCommits.sh
-  elif [ ${CHECK_FILES} = true ]; then
+- export UPSTREAM_REPO="https://github.com/sxs-collaboration/spectre.git"
+- export UPSTREAM_BRANCH="develop"
+- export GH_PAGES_REPO="git@github.com:sxs-collaboration/spectre.git"
+- export GH_PAGES_SOURCE_BRANCH="develop"
+- if [ "${CHECK_COMMITS}" == "true" ]; then
+    ./tools/CheckCommits.sh;
+  elif [ "${CHECK_FILES}" ==  "true" ]; then
     ./tools/CheckFiles.sh;
   elif [ ${TRAVIS_OS_NAME} = linux ]; then
     cp -vr containers ${HOME}/docker
@@ -216,9 +233,13 @@ script:
         --build-arg ENCRYPTED_IV=${!ENCRYPTED_IV_VAR}
         --build-arg SONAR_TOKEN=${SONAR_TOKEN}
         --build-arg SONARQUBE=${SONARQUBE}
-        --build-arg GH_PAGES_REPO="git@github.com:sxs-collaboration/spectre.git"
-        --build-arg GH_PAGES_SOURCE_BRANCH="develop"
+        --build-arg GH_PAGES_REPO=${GH_PAGES_REPO}
+        --build-arg GH_PAGES_SOURCE_BRANCH=${GH_PAGES_SOURCE_BRANCH}
         --build-arg COVERALLS_TOKEN=${COVERALLS_TOKEN}
+        --build-arg RUN_CLANG_TIDY=${RUN_CLANG_TIDY}
+        --build-arg RUN_CPPCHECK=${RUN_CPPCHECK}
+        --build-arg UPSTREAM_REPO=${UPSTREAM_REPO}
+        --build-arg UPSTREAM_BRANCH=${UPSTREAM_BRANCH}
         --build-arg CHARM_PATCH=${CHARM_PATCH}
         -t ${TRAVIS_REPO_SLUG}
         -f ${HOME}/docker/Dockerfile.travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,12 @@ matrix:
     env: BUILD_TYPE=Release
     compiler: clang
   - os: linux
+    dist: trusty
     env: CHECK_COMMITS=true
+    compiler: clang
+  - os: linux
+    dist: trusty
+    env: CHECK_FILES=true
     compiler: clang
 
 
@@ -183,7 +188,8 @@ script:
 - ENCRYPTED_IV_VAR="encrypted_${ENCRYPTION_LABEL}_iv"
 - if [ ${CHECK_COMMITS} = true ]; then
     ./tools/CheckCommits.sh
-    && ./tools/CheckFiles.sh;
+  elif [ ${CHECK_FILES} = true ]; then
+    ./tools/CheckFiles.sh;
   elif [ ${TRAVIS_OS_NAME} = linux ]; then
     cp -vr containers ${HOME}/docker
     && cd ${HOME}

--- a/.travis/RunClangTidy.sh
+++ b/.travis/RunClangTidy.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+BUILD_DIR=`pwd`
+git clone ${UPSTREAM_REPO} /work/spectre_upstream
+cd /work/spectre_upstream
+git checkout ${UPSTREAM_BRANCH}
+COMMITS_ON_UPSTREAM=`git rev-list HEAD`
+cd /work/spectre
+
+# For each upstream commit we check if the commit is on this branch, once we
+# find a match we save that hash and exit. This allows us to check only files
+# currently being committed.
+UPSTREAM_COMMIT_HASH=''
+
+for HASH in ${COMMITS_ON_UPSTREAM}
+do
+    if git cat-file -e $HASH^{commit} 2> /dev/null
+    then
+       UPSTREAM_COMMIT_HASH=$HASH
+       break
+    fi
+done
+
+if [ -z $UPSTREAM_COMMIT_HASH ];
+then
+   echo "The branch is not branched from ${UPSTREAM_REPO}/${UPSTREAM_BRANCH}"
+   exit 1
+fi
+
+echo "Using upstream commit hash: ${UPSTREAM_COMMIT_HASH}"
+
+###############################################################################
+# Get list of non-deleted files
+MODIFIED_FILES=''
+
+for FILENAME in `git diff --name-only ${UPSTREAM_COMMIT_HASH} HEAD`
+do
+    if [ -f $FILENAME ]; then
+        MODIFIED_FILES="${MODIFIED_FILES} $FILENAME"
+    fi
+done
+
+# Go to build directory and then run clang-tidy, writing output to file
+cd ${BUILD_DIR}
+CLANG_TIDY_OUTPUT="./.clang_tidy_check_output"
+rm -f ${CLANG_TIDY_OUTPUT}
+
+printf "\nRunning clang-tidy on:\n"
+echo $MODIFIED_FILES
+echo ''
+
+for FILENAME in $MODIFIED_FILES
+do
+    make clang-tidy FILE=/work/spectre/${FILENAME} 2>&1 >> ${CLANG_TIDY_OUTPUT}
+done
+
+if [ -f "${CLANG_TIDY_OUTPUT}" ]; then
+    sed -i'.bak' "s^warning: /usr/bin/clang++: 'linker' input unused.*^^g" ${CLANG_TIDY_OUTPUT}
+fi
+
+if [ -f "${CLANG_TIDY_OUTPUT}" ] \
+       && ( grep 'warning:' ${CLANG_TIDY_OUTPUT} > /dev/null ||
+                grep 'error:' ${CLANG_TIDY_OUTPUT} > /dev/null )
+then
+    printf "\nclang-tidy found problems! Output:\n\n"
+    more ${CLANG_TIDY_OUTPUT}
+    exit 1
+fi
+
+exit 0

--- a/cmake/PrintUsefulCMakeInfo.cmake
+++ b/cmake/PrintUsefulCMakeInfo.cmake
@@ -36,8 +36,8 @@ if (PYTHONINTERP_FOUND)
 else()
   message(STATUS "Python: Not found")
 endif()
-if(CMAKE_CXX_CLANG_TIDY)
-  message(STATUS "Found clang-tidy: ${CMAKE_CXX_CLANG_TIDY}")
+if(CLANG_TIDY_BIN)
+  message(STATUS "Found clang-tidy: ${CLANG_TIDY_BIN}")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   message(
       STATUS

--- a/cmake/SetupClangTidy.cmake
+++ b/cmake/SetupClangTidy.cmake
@@ -10,7 +10,9 @@ if(NOT CMAKE_CXX_CLANG_TIDY AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       CLANG_TIDY_BIN
       NAMES "clang-tidy-${LLVM_VERSION}" "clang-tidy"
       HINTS ${COMPILER_PATH}
-  )
+      )
+elseif(CMAKE_CXX_CLANG_TIDY)
+  set(CLANG_TIDY_BIN "${CMAKE_CXX_CLANG_TIDY}")
 endif()
 
 # Remove the checks because:
@@ -23,6 +25,7 @@ if (CLANG_TIDY_BIN)
       ${CLANG_TIDY_BIN}
       -header-filter=${CMAKE_SOURCE_DIR}
       -checks=*,-llvm-header-guard,-google-runtime-int
+      -p ${CMAKE_BINARY_DIR}
       \${FILE}
   )
   set_target_properties(

--- a/cmake/SetupCppCheck.cmake
+++ b/cmake/SetupCppCheck.cmake
@@ -6,6 +6,8 @@ if(NOT CPPCHECK_FOUND AND NOT CPPCHECK_EXECUTABLE)
 endif()
 
 if(CPPCHECK_EXECUTABLE)
+  # We run cppcheck on 2 cores since this is the maximum on TravisCI
+  # and modern machines all have 2 cores.
   add_custom_target(
       cppcheck
       COMMAND
@@ -15,6 +17,7 @@ if(CPPCHECK_EXECUTABLE)
       --enable=warning,performance,portability,information,missingInclude
       --project=${CMAKE_BINARY_DIR}/compile_commands.json
       --suppressions-list=${CMAKE_SOURCE_DIR}/tools/SuppressionsCppCheck.txt
+      -j2
 
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
   )

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -20,7 +20,7 @@ ARG PARALLEL_MAKE_ARG=-j2
 RUN apt-get update -y
 RUN apt-get install -y gcc g++ gfortran git cmake
 RUN apt-get install -y libopenblas-dev liblapack-dev libhdf5-dev libgsl0-dev
-RUN apt-get install -y clang clang-format iwyu lcov
+RUN apt-get install -y clang clang-format clang-tidy iwyu lcov cppcheck
 RUN apt-get install -y libboost-all-dev libyaml-cpp-dev
 
 # Update is needed to get libc++ correctly

--- a/containers/Dockerfile.travis
+++ b/containers/Dockerfile.travis
@@ -41,6 +41,10 @@ ARG SONARQUBE
 ARG GH_PAGES_REPO
 ARG GH_PAGES_SOURCE_BRANCH
 ARG COVERALLS_TOKEN
+ARG RUN_CLANG_TIDY
+ARG RUN_CPPCHECK
+ARG UPSTREAM_REPO
+ARG UPSTREAM_BRANCH
 ARG CHARM_PATCH
 
 # Copy the spectre repo from the TravisCI disk into the Docker image /work
@@ -87,28 +91,48 @@ RUN bash -c ". /etc/profile.d/lmod.sh; \
           -D COVERAGE=${COVERAGE} \
           ../spectre/"
 
+RUN if [ ${RUN_CPPCHECK} ]; then \
+      make cppcheck; \
+    fi
+
+RUN if [ ${RUN_CLANG_TIDY} ]; then \
+      /work/spectre/.travis/RunClangTidy.sh; \
+    fi
+
 # TravisCI currently has 2 cores for a job, so we build on 2.
 RUN if [ ${SONARQUBE} ] \
+    && [ -z "${RUN_CPPCHECK}" ] \
+    && [ -z "${RUN_CLANG_TIDY}" ] \
     && [ ${TRAVIS_SECURE_ENV_VARS} = true ] \
     && [ ${TRAVIS_EVENT_TYPE} = cron ] \
     && [ ${CC} = gcc ]; then \
       /work/sonarqube/build-wrapper-linux-x86/build-wrapper-linux-x86-64 \
         --out-dir sonar-output make -j2; \
-    else \
+    elif [ -z "${RUN_CPPCHECK}" ] \
+    && [ -z "${RUN_CLANG_TIDY}" ]; then \
       make -j2; \
     fi
 RUN ccache -s
 
-RUN ctest --output-on-failure
+RUN if [ -z "${RUN_CPPCHECK}" ] \
+    && [ -z "${RUN_CLANG_TIDY}" ]; then \
+      ctest --output-on-failure; \
+    fi
 
 # Check documentation output for warnings write to stdout and to file so we
 # can search the file for warnings
-RUN if [ "${CC}" = "gcc" ] && [ $BUILD_TYPE = Debug ]; then \
+RUN if [ "${CC}" = "gcc" ] \
+    && [ $BUILD_TYPE = Debug ] \
+    && [ -z "${RUN_CPPCHECK}" ] \
+    && [ -z "${RUN_CLANG_TIDY}" ]; then \
       make doc | tee doxygen.log; \
       ! grep 'warning' ./doxygen.log; \
     fi
 
-RUN if [ "${CC}" = "gcc" ] && [ ${COVERAGE} = ON ]; then \
+RUN if [ "${CC}" = "gcc" ] \
+    && [ -z "${RUN_CPPCHECK}" ] \
+    && [ -z "${RUN_CLANG_TIDY}" ] \
+    && [ ${COVERAGE} = ON ]; then \
       make unit-test-coverage; \
       if [ ${TRAVIS_SECURE_ENV_VARS} = true ]; then \
         cd /work/spectre; \
@@ -124,6 +148,8 @@ RUN if [ "${CC}" = "gcc" ] && [ ${COVERAGE} = ON ]; then \
 # for one job but let the others run tests, i.e.
 # we add documentation only for one specific build matrix entry.
 RUN if [ ${CC} = gcc ] \
+    && [ -z "${RUN_CPPCHECK}" ] \
+    && [ -z "${RUN_CLANG_TIDY}" ] \
     && [ ${TRAVIS_EVENT_TYPE} = cron ] \
     && [ ${TRAVIS_SECURE_ENV_VARS} = true ] \
     && [ ${COVERAGE} ] \
@@ -173,4 +199,9 @@ RUN if [ ${CC} = gcc ] \
       cd /work; \
       git clone "$GH_PAGES_REPO" gh-pages; \
     fi
-RUN /work/spectre/.travis/TravisPushDocumentation.sh
+
+# push documentation to GitHub pages
+RUN if  [ -z "${RUN_CPPCHECK}" ] \
+    && [ -z "${RUN_CLANG_TIDY}" ]; then \
+      /work/spectre/.travis/TravisPushDocumentation.sh; \
+    fi

--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -17,10 +17,23 @@ found_long_lines=`
 find ./ -type f -name '*.[ch]pp' \
     | xargs grep --with-filename -n '.\{81,\}'`
 if [[ $found_long_lines != "" ]]; then
-    echo "This script can be run locally from the root source dir using:"
-    echo "./.travis/CheckFiles.sh"
+    echo "This script can be run locally from any source dir using:"
+    echo "SPECTRE_ROOT/tools/CheckFiles.sh"
     echo "Found lines over 80 characters:"
     echo "$found_long_lines"
+    exit 1
+fi
+
+###############################################################################
+# Check for iostream header
+found_iostream=`
+find ./ -type f -name '*.[ch]pp' \
+    | xargs grep --with-filename -n '#include <iostream>'`
+if [[ $found_iostream != "" ]]; then
+    echo "This script can be run locally from any source dir using:"
+    echo "SPECTRE_ROOT/tools/CheckFiles.sh"
+    echo "Found iostream header in files:"
+    echo "$found_iostream"
     exit 1
 fi
 
@@ -33,8 +46,8 @@ find ./ -type f               \
      ! -path "./.git/*"       \
     | xargs grep -E '^.*'$'\t'`
 if [[ $found_tabs_files != "" ]]; then
-    echo "This script can be run locally from the root source dir using:"
-    echo "./.travis/CheckFiles.sh"
+    echo "This script can be run locally from any source dir using:"
+    echo "SPECTRE_ROOT/tools/CheckFiles.sh"
     echo "Found tabs in the following  files:"
     echo "$found_tabs_files" | GREP_COLOR='1;37;41' grep -F $'\t' $color_option
     exit 1
@@ -50,8 +63,8 @@ find ./ -type f             \
     | xargs grep -E '^.* +$'`
 echo
 if [[ $found_spaces_files != "" ]]; then
-    echo "This script can be run locally from the root source dir using:"
-    echo "./.travis/CheckFiles.sh"
+    echo "This script can be run locally from any source dir using:"
+    echo "SPECTRE_ROOT/tools/CheckFiles.sh"
     echo "Found white space at end of line in the following files:"
     echo "$found_spaces_files" | \
         GREP_COLOR='1;37;41' grep -E ' +$' $color_option
@@ -65,8 +78,8 @@ find ./ -type f                 \
      ! -path "*.git*"           \
     | xargs grep -E '^\+.*'$'\r'`
 if [[ $found_carriage_return_files != "" ]]; then
-    echo "This script can be run locally from the root source dir using:"
-    echo "./.travis/CheckFiles.sh"
+    echo "This script can be run locally from any source dir using:"
+    echo "SPECTRE_ROOT/tools/CheckFiles.sh"
     echo "Found carriage returns in the following files:"
     echo "$found_carriage_return_files" | \
         GREP_COLOR='1;37;41' grep -E '\r+$' $color_option
@@ -96,8 +109,8 @@ find ./ -type f                                                              \
      ! -name "*.clang-format"                                                \
     | xargs grep -L "^.*Distributed under the MIT License"`
 if [[ $files_without_license != "" ]]; then
-    echo "This script can be run locally from the root source dir using:"
-    echo "./.travis/CheckFiles.sh"
+    echo "This script can be run locally from any source dir using:"
+    echo "SPECTRE_ROOT/tools/CheckFiles.sh"
     echo "Did not find a license in these files:"
     echo "$files_without_license"
     exit 1


### PR DESCRIPTION
Add the clang-tidy and cppcheck static analysis tools as targets on Travis. Also, split the checking of commit messages from checking "push hooks" on files.