### PR TITLE
Add inverse for Tensor

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/Determinant.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Determinant.hpp
@@ -45,8 +45,8 @@ struct DeterminantImpl<Symmetry<2, 1>, Index, Requires<Index::dim == 3>> {
     const auto& t20 = tensor.template get<2, 0>();
     const auto& t21 = tensor.template get<2, 1>();
     const auto& t22 = tensor.template get<2, 2>();
-    return t00 * (t11 * t22 - t21 * t12) - t01 * (t10 * t22 - t20 * t12) +
-           t02 * (t10 * t21 - t20 * t11);
+    return t00 * (t11 * t22 - t12 * t21) - t01 * (t10 * t22 - t12 * t20) +
+           t02 * (t10 * t21 - t11 * t20);
   }
 };
 
@@ -55,13 +55,13 @@ struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 3>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
     const auto& t00 = tensor.template get<0, 0>();
-    const auto& t10 = tensor.template get<1, 0>();
+    const auto& t01 = tensor.template get<0, 1>();
+    const auto& t02 = tensor.template get<0, 2>();
     const auto& t11 = tensor.template get<1, 1>();
-    const auto& t20 = tensor.template get<2, 0>();
-    const auto& t21 = tensor.template get<2, 1>();
+    const auto& t12 = tensor.template get<1, 2>();
     const auto& t22 = tensor.template get<2, 2>();
-    return t00 * (t11 * t22 - t21 * t21) - t10 * (t10 * t22 - 2 * t20 * t21) -
-           t11 * t20 * t20;
+    return t00 * (t11 * t22 - t12 * t12) - t01 * (t01 * t22 - t12 * t02) +
+           t02 * (t01 * t12 - t11 * t02);
   }
 };
 
@@ -85,16 +85,16 @@ struct DeterminantImpl<Symmetry<2, 1>, Index, Requires<Index::dim == 4>> {
     const auto& t31 = tensor.template get<3, 1>();
     const auto& t32 = tensor.template get<3, 2>();
     const auto& t33 = tensor.template get<3, 3>();
-    const auto tmp1 = t22 * t33 - t32 * t23;
-    const auto tmp2 = t21 * t33 - t31 * t23;
-    const auto tmp3 = t21 * t32 - t31 * t22;
-    const auto tmp4 = t02 * t13 - t12 * t03;
-    const auto tmp5 = t01 * t13 - t11 * t03;
-    const auto tmp6 = t01 * t12 - t02 * t11;
-    return t00 * (t11 * tmp1 - t12 * tmp2 + t13 * tmp3) -
-           t10 * (t01 * tmp1 - t02 * tmp2 + t03 * tmp3) +
-           t20 * (t31 * tmp4 - t32 * tmp5 + t33 * tmp6) -
-           t30 * (t21 * tmp4 - t22 * tmp5 + t23 * tmp6);
+    const auto minor1 = t22 * t33 - t23 * t32;
+    const auto minor2 = t21 * t33 - t23 * t31;
+    const auto minor3 = t20 * t33 - t23 * t30;
+    const auto minor4 = t21 * t32 - t22 * t31;
+    const auto minor5 = t20 * t32 - t22 * t30;
+    const auto minor6 = t20 * t31 - t21 * t30;
+    return t00 * (t11 * minor1 - t12 * minor2 + t13 * minor4) -
+           t01 * (t10 * minor1 - t12 * minor3 + t13 * minor5) +
+           t02 * (t10 * minor2 - t11 * minor3 + t13 * minor6) -
+           t03 * (t10 * minor4 - t11 * minor5 + t12 * minor6);
   }
 };
 
@@ -103,25 +103,25 @@ struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 4>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
     const auto& t00 = tensor.template get<0, 0>();
-    const auto& t10 = tensor.template get<1, 0>();
+    const auto& t01 = tensor.template get<0, 1>();
+    const auto& t02 = tensor.template get<0, 2>();
+    const auto& t03 = tensor.template get<0, 3>();
     const auto& t11 = tensor.template get<1, 1>();
-    const auto& t20 = tensor.template get<2, 0>();
-    const auto& t21 = tensor.template get<2, 1>();
+    const auto& t12 = tensor.template get<1, 2>();
+    const auto& t13 = tensor.template get<1, 3>();
     const auto& t22 = tensor.template get<2, 2>();
-    const auto& t30 = tensor.template get<3, 0>();
-    const auto& t31 = tensor.template get<3, 1>();
-    const auto& t32 = tensor.template get<3, 2>();
+    const auto& t23 = tensor.template get<2, 3>();
     const auto& t33 = tensor.template get<3, 3>();
-    const auto tmp1 = t22 * t33 - t32 * t32;
-    const auto tmp2 = t21 * t33 - t31 * t32;
-    const auto tmp3 = t21 * t32 - t31 * t22;
-    const auto tmp4 = t20 * t31 - t21 * t30;
-    const auto tmp5 = t10 * t31 - t11 * t30;
-    const auto tmp6 = t10 * t21 - t20 * t11;
-    return t00 * (t11 * tmp1 - t21 * tmp2 + t31 * tmp3) -
-           t10 * (t10 * tmp1 - t20 * tmp2 + t30 * tmp3) +
-           t20 * (t31 * tmp4 - t32 * tmp5 + t33 * tmp6) -
-           t30 * (t21 * tmp4 - t22 * tmp5 + t32 * tmp6);
+    const auto minor1 = t22 * t33 - t23 * t23;
+    const auto minor2 = t12 * t33 - t23 * t13;
+    const auto minor3 = t02 * t33 - t23 * t03;
+    const auto minor4 = t12 * t23 - t22 * t13;
+    const auto minor5 = t02 * t23 - t22 * t03;
+    const auto minor6 = t02 * t13 - t12 * t03;
+    return t00 * (t11 * minor1 - t12 * minor2 + t13 * minor4) -
+           t01 * (t01 * minor1 - t12 * minor3 + t13 * minor5) +
+           t02 * (t01 * minor2 - t11 * minor3 + t13 * minor6) -
+           t03 * (t01 * minor4 - t11 * minor5 + t12 * minor6);
   }
 };
 }  // namespace detail

--- a/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
@@ -1,0 +1,365 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines function computing the determinant and inverse of a tensor.
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/MakeArithmeticValue.hpp"
+#include "Utilities/Requires.hpp"
+
+namespace determinant_and_inverse_detail {
+// Helps to shorten some repeated code:
+template <typename Index0, typename Index1>
+using inverse_indices =
+    typelist<change_index_up_lo<Index1>, change_index_up_lo<Index0>>;
+template <typename T, typename Symm, typename Index0, typename Index1>
+using determinant_inverse_pair =
+    std::pair<Scalar<T>, Tensor<T, Symm, inverse_indices<Index0, Index1>>>;
+
+template <typename Symm, typename Index0, typename Index1,
+          typename = std::nullptr_t>
+struct DetAndInverseImpl;
+
+template <typename Symm, typename Index0, typename Index1>
+struct DetAndInverseImpl<Symm, Index0, Index1, Requires<Index0::dim == 1>> {
+  template <typename T>
+  static determinant_inverse_pair<T, Symm, Index0, Index1> apply(
+      const Tensor<T, Symm, typelist<Index0, Index1>>& tensor) {
+    const T& t00 = tensor.template get<0, 0>();
+    // inv is non-const so that it can be moved into the std::pair:
+    Tensor<T, Symm, inverse_indices<Index0, Index1>> inv{
+        make_arithmetic_value(t00, 1.0) / t00};
+    return std::make_pair(Scalar<T>{t00}, std::move(inv));
+  }
+};
+
+// The inverse of a 2x2 tensor is computed from Cramer's rule.
+template <typename Index0, typename Index1>
+struct DetAndInverseImpl<Symmetry<2, 1>, Index0, Index1,
+                         Requires<Index0::dim == 2>> {
+  template <typename T>
+  static determinant_inverse_pair<T, Symmetry<2, 1>, Index0, Index1> apply(
+      const Tensor<T, Symmetry<2, 1>, typelist<Index0, Index1>>& tensor) {
+    const T& t00 = tensor.template get<0, 0>();
+    const T& t01 = tensor.template get<0, 1>();
+    const T& t10 = tensor.template get<1, 0>();
+    const T& t11 = tensor.template get<1, 1>();
+    // det is non-const so that it can be moved into the std::pair:
+    Scalar<T> det{t00 * t11 - t01 * t10};
+    const T one_over_det = make_arithmetic_value(det.get(), 1.0) / det.get();
+    Tensor<T, Symmetry<2, 1>, inverse_indices<Index0, Index1>> inv{};
+    inv.template get<0, 0>() = t11 * one_over_det;
+    inv.template get<0, 1>() = -t01 * one_over_det;
+    inv.template get<1, 0>() = -t10 * one_over_det;
+    inv.template get<1, 1>() = t00 * one_over_det;
+    return std::make_pair(std::move(det), std::move(inv));
+  }
+};
+
+template <typename Index0>
+struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
+                         Requires<Index0::dim == 2>> {
+  template <typename T>
+  static determinant_inverse_pair<T, Symmetry<1, 1>, Index0, Index0> apply(
+      const Tensor<T, Symmetry<1, 1>, typelist<Index0, Index0>>& tensor) {
+    const T& t00 = tensor.template get<0, 0>();
+    const T& t01 = tensor.template get<0, 1>();
+    const T& t11 = tensor.template get<1, 1>();
+    // det is non-const so that it can be moved into the std::pair:
+    Scalar<T> det{t00 * t11 - t01 * t01};
+    const T one_over_det = make_arithmetic_value(det.get(), 1.0) / det.get();
+    Tensor<T, Symmetry<1, 1>, inverse_indices<Index0, Index0>> inv{};
+    inv.template get<0, 0>() = t11 * one_over_det;
+    inv.template get<0, 1>() = -t01 * one_over_det;
+    inv.template get<1, 1>() = t00 * one_over_det;
+    return std::make_pair(std::move(det), std::move(inv));
+  }
+};
+
+// The inverse of a 3x3 tensor is computed from Cramer's rule. By reusing some
+// terms, the determinant is computed efficiently at the same time.
+template <typename Index0, typename Index1>
+struct DetAndInverseImpl<Symmetry<2, 1>, Index0, Index1,
+                         Requires<Index0::dim == 3>> {
+  template <typename T>
+  static determinant_inverse_pair<T, Symmetry<2, 1>, Index0, Index1> apply(
+      const Tensor<T, Symmetry<2, 1>, typelist<Index0, Index1>>& tensor) {
+    const T& t00 = tensor.template get<0, 0>();
+    const T& t01 = tensor.template get<0, 1>();
+    const T& t02 = tensor.template get<0, 2>();
+    const T& t10 = tensor.template get<1, 0>();
+    const T& t11 = tensor.template get<1, 1>();
+    const T& t12 = tensor.template get<1, 2>();
+    const T& t20 = tensor.template get<2, 0>();
+    const T& t21 = tensor.template get<2, 1>();
+    const T& t22 = tensor.template get<2, 2>();
+    const T a = t11 * t22 - t12 * t21;
+    const T b = t12 * t20 - t10 * t22;
+    const T c = t10 * t21 - t11 * t20;
+    // det is non-const so that it can be moved into the std::pair:
+    Scalar<T> det{t00 * a + t01 * b + t02 * c};
+    const T one_over_det = make_arithmetic_value(det.get(), 1.0) / det.get();
+    Tensor<T, Symmetry<2, 1>, inverse_indices<Index0, Index1>> inv{};
+    inv.template get<0, 0>() = a * one_over_det;
+    inv.template get<0, 1>() = (t21 * t02 - t22 * t01) * one_over_det;
+    inv.template get<0, 2>() = (t01 * t12 - t02 * t11) * one_over_det;
+    inv.template get<1, 0>() = b * one_over_det;
+    inv.template get<1, 1>() = (t22 * t00 - t20 * t02) * one_over_det;
+    inv.template get<1, 2>() = (t02 * t10 - t00 * t12) * one_over_det;
+    inv.template get<2, 0>() = c * one_over_det;
+    inv.template get<2, 1>() = (t20 * t01 - t21 * t00) * one_over_det;
+    inv.template get<2, 2>() = (t00 * t11 - t01 * t10) * one_over_det;
+    return std::make_pair(std::move(det), std::move(inv));
+  }
+};
+
+template <typename Index0>
+struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
+                         Requires<Index0::dim == 3>> {
+  template <typename T>
+  static determinant_inverse_pair<T, Symmetry<1, 1>, Index0, Index0> apply(
+      const Tensor<T, Symmetry<1, 1>, typelist<Index0, Index0>>& tensor) {
+    const T& t00 = tensor.template get<0, 0>();
+    const T& t01 = tensor.template get<0, 1>();
+    const T& t02 = tensor.template get<0, 2>();
+    const T& t11 = tensor.template get<1, 1>();
+    const T& t12 = tensor.template get<1, 2>();
+    const T& t22 = tensor.template get<2, 2>();
+    const T a = t11 * t22 - t12 * t12;
+    const T b = t12 * t02 - t01 * t22;
+    const T c = t01 * t12 - t11 * t02;
+    // det is non-const so that it can be moved into the std::pair:
+    Scalar<T> det{t00 * a + t01 * b + t02 * c};
+    const T one_over_det = make_arithmetic_value(det.get(), 1.0) / det.get();
+    Tensor<T, Symmetry<1, 1>, inverse_indices<Index0, Index0>> inv{};
+    inv.template get<0, 0>() = (t11 * t22 - t12 * t12) * one_over_det;
+    inv.template get<0, 1>() = (t12 * t02 - t22 * t01) * one_over_det;
+    inv.template get<0, 2>() = (t01 * t12 - t02 * t11) * one_over_det;
+    inv.template get<1, 1>() = (t22 * t00 - t02 * t02) * one_over_det;
+    inv.template get<1, 2>() = (t02 * t01 - t00 * t12) * one_over_det;
+    inv.template get<2, 2>() = (t00 * t11 - t01 * t01) * one_over_det;
+    return std::make_pair(std::move(det), std::move(inv));
+  }
+};
+
+// The 4x4 tensor inverse is implemented using the formula for inverting a
+// partitioned matrix (here, partitioned into 2x2 blocks). This is more
+// efficient than Cramer's rule for matrices larger than 3x3.
+//
+// In this algorithm, the 4x4 input matrix is partitioned into the 2x2 blocks:
+//   P Q
+//   R S
+// The 4x4 inverse matrix is partitioned into the 2x2 blocks:
+//   U V
+//   W X
+// Each inverse block is obtained from the blocks {P,Q,R,S} of the input matrix
+// as follows:
+//   X = inv[S - R inv(P) Q] (i.e. inv(X) is the Schur complement of P)
+//   W = - X R inv(P)
+//   V = - inv(P) Q X
+//   U = inv(P) + inv(P) Q X R inv(P) = inv(P) - inv(P) Q W
+template <typename Index0, typename Index1>
+struct DetAndInverseImpl<Symmetry<2, 1>, Index0, Index1,
+                         Requires<Index0::dim == 4>> {
+  template <typename T>
+  static determinant_inverse_pair<T, Symmetry<2, 1>, Index0, Index1> apply(
+      const Tensor<T, Symmetry<2, 1>, typelist<Index0, Index1>>& tensor) {
+    const T& p00 = tensor.template get<0, 0>();
+    const T& p01 = tensor.template get<0, 1>();
+    const T& p10 = tensor.template get<1, 0>();
+    const T& p11 = tensor.template get<1, 1>();
+    const T& q00 = tensor.template get<0, 2>();
+    const T& q01 = tensor.template get<0, 3>();
+    const T& q10 = tensor.template get<1, 2>();
+    const T& q11 = tensor.template get<1, 3>();
+    const T& r00 = tensor.template get<2, 0>();
+    const T& r01 = tensor.template get<2, 1>();
+    const T& r10 = tensor.template get<3, 0>();
+    const T& r11 = tensor.template get<3, 1>();
+    const T& s00 = tensor.template get<2, 2>();
+    const T& s01 = tensor.template get<2, 3>();
+    const T& s10 = tensor.template get<3, 2>();
+    const T& s11 = tensor.template get<3, 3>();
+
+    Tensor<T, Symmetry<2, 1>, inverse_indices<Index0, Index1>> inv{};
+    T& u00 = inv.template get<0, 0>();
+    T& u01 = inv.template get<0, 1>();
+    T& u10 = inv.template get<1, 0>();
+    T& u11 = inv.template get<1, 1>();
+    T& v00 = inv.template get<0, 2>();
+    T& v01 = inv.template get<0, 3>();
+    T& v10 = inv.template get<1, 2>();
+    T& v11 = inv.template get<1, 3>();
+    T& w00 = inv.template get<2, 0>();
+    T& w01 = inv.template get<2, 1>();
+    T& w10 = inv.template get<3, 0>();
+    T& w11 = inv.template get<3, 1>();
+    T& x00 = inv.template get<2, 2>();
+    T& x01 = inv.template get<2, 3>();
+    T& x10 = inv.template get<3, 2>();
+    T& x11 = inv.template get<3, 3>();
+
+    const T det_p = p00 * p11 - p01 * p10;
+    const T one_over_det_p = make_arithmetic_value(det_p, 1.0) / det_p;
+    const T inv_p00 = p11 * one_over_det_p;
+    const T inv_p01 = -p01 * one_over_det_p;
+    const T inv_p10 = -p10 * one_over_det_p;
+    const T inv_p11 = p00 * one_over_det_p;
+
+    const T r_inv_p00 = r00 * inv_p00 + r01 * inv_p10;
+    const T r_inv_p01 = r00 * inv_p01 + r01 * inv_p11;
+    const T r_inv_p10 = r10 * inv_p00 + r11 * inv_p10;
+    const T r_inv_p11 = r10 * inv_p01 + r11 * inv_p11;
+
+    const T inv_p_q00 = inv_p00 * q00 + inv_p01 * q10;
+    const T inv_p_q01 = inv_p00 * q01 + inv_p01 * q11;
+    const T inv_p_q10 = inv_p10 * q00 + inv_p11 * q10;
+    const T inv_p_q11 = inv_p10 * q01 + inv_p11 * q11;
+
+    const T inv_x00 = s00 - (r_inv_p00 * q00 + r_inv_p01 * q10);
+    const T inv_x01 = s01 - (r_inv_p00 * q01 + r_inv_p01 * q11);
+    const T inv_x10 = s10 - (r_inv_p10 * q00 + r_inv_p11 * q10);
+    const T inv_x11 = s11 - (r_inv_p10 * q01 + r_inv_p11 * q11);
+
+    const T det_inv_x = inv_x00 * inv_x11 - inv_x01 * inv_x10;
+    const T one_over_det_inv_x =
+        make_arithmetic_value(det_inv_x, 1.0) / det_inv_x;
+    x00 = inv_x11 * one_over_det_inv_x;
+    x01 = -inv_x01 * one_over_det_inv_x;
+    x10 = -inv_x10 * one_over_det_inv_x;
+    x11 = inv_x00 * one_over_det_inv_x;
+
+    w00 = -x00 * r_inv_p00 - x01 * r_inv_p10;
+    w01 = -x00 * r_inv_p01 - x01 * r_inv_p11;
+    w10 = -x10 * r_inv_p00 - x11 * r_inv_p10;
+    w11 = -x10 * r_inv_p01 - x11 * r_inv_p11;
+
+    v00 = -inv_p_q00 * x00 - inv_p_q01 * x10;
+    v01 = -inv_p_q00 * x01 - inv_p_q01 * x11;
+    v10 = -inv_p_q10 * x00 - inv_p_q11 * x10;
+    v11 = -inv_p_q10 * x01 - inv_p_q11 * x11;
+
+    u00 = inv_p00 - (inv_p_q00 * w00 + inv_p_q01 * w10);
+    u01 = inv_p01 - (inv_p_q00 * w01 + inv_p_q01 * w11);
+    u10 = inv_p10 - (inv_p_q10 * w00 + inv_p_q11 * w10);
+    u11 = inv_p11 - (inv_p_q10 * w01 + inv_p_q11 * w11);
+
+    // det is non-const so that it can be moved into the std::pair:
+    Scalar<T> det{det_p * det_inv_x};
+    return std::make_pair(std::move(det), std::move(inv));
+  }
+};
+
+template <typename Index0>
+struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
+                         Requires<Index0::dim == 4>> {
+  template <typename T>
+  static determinant_inverse_pair<T, Symmetry<1, 1>, Index0, Index0> apply(
+      const Tensor<T, Symmetry<1, 1>, typelist<Index0, Index0>>& tensor) {
+    const T& p00 = tensor.template get<0, 0>();
+    const T& p01 = tensor.template get<0, 1>();
+    const T& p11 = tensor.template get<1, 1>();
+    const T& q00 = tensor.template get<0, 2>();
+    const T& q01 = tensor.template get<0, 3>();
+    const T& q10 = tensor.template get<1, 2>();
+    const T& q11 = tensor.template get<1, 3>();
+    const T& s00 = tensor.template get<2, 2>();
+    const T& s01 = tensor.template get<2, 3>();
+    const T& s11 = tensor.template get<3, 3>();
+
+    Tensor<T, Symmetry<1, 1>, inverse_indices<Index0, Index0>> inv{};
+    T& u00 = inv.template get<0, 0>();
+    T& u01 = inv.template get<0, 1>();
+    T& u11 = inv.template get<1, 1>();
+    T& v00 = inv.template get<0, 2>();
+    T& v01 = inv.template get<0, 3>();
+    T& v10 = inv.template get<1, 2>();
+    T& v11 = inv.template get<1, 3>();
+    T& x00 = inv.template get<2, 2>();
+    T& x01 = inv.template get<2, 3>();
+    T& x11 = inv.template get<3, 3>();
+
+    const T det_p = p00 * p11 - p01 * p01;
+    const T one_over_det_p = make_arithmetic_value(det_p, 1.0) / det_p;
+    const T inv_p00 = p11 * one_over_det_p;
+    const T inv_p01 = -p01 * one_over_det_p;
+    const T inv_p11 = p00 * one_over_det_p;
+
+    const T r_inv_p00 = q00 * inv_p00 + q10 * inv_p01;
+    const T r_inv_p01 = q00 * inv_p01 + q10 * inv_p11;
+    const T r_inv_p10 = q01 * inv_p00 + q11 * inv_p01;
+    const T r_inv_p11 = q01 * inv_p01 + q11 * inv_p11;
+
+    const T inv_x00 = s00 - (r_inv_p00 * q00 + r_inv_p01 * q10);
+    const T inv_x01 = s01 - (r_inv_p00 * q01 + r_inv_p01 * q11);
+    const T inv_x11 = s11 - (r_inv_p10 * q01 + r_inv_p11 * q11);
+
+    const T det_inv_x = inv_x00 * inv_x11 - inv_x01 * inv_x01;
+    const T one_over_det_inv_x =
+        make_arithmetic_value(det_inv_x, 1.0) / det_inv_x;
+    x00 = inv_x11 * one_over_det_inv_x;
+    x01 = -inv_x01 * one_over_det_inv_x;
+    x11 = inv_x00 * one_over_det_inv_x;
+
+    v00 = -x00 * r_inv_p00 - x01 * r_inv_p10;
+    v10 = -x00 * r_inv_p01 - x01 * r_inv_p11;
+    v01 = -x01 * r_inv_p00 - x11 * r_inv_p10;
+    v11 = -x01 * r_inv_p01 - x11 * r_inv_p11;
+
+    u00 = inv_p00 - (r_inv_p00 * v00 + r_inv_p10 * v01);
+    u01 = inv_p01 - (r_inv_p00 * v10 + r_inv_p10 * v11);
+    u11 = inv_p11 - (r_inv_p01 * v10 + r_inv_p11 * v11);
+
+    // det is non-const so that it can be moved into the std::pair:
+    Scalar<T> det{det_p * det_inv_x};
+    return std::make_pair(std::move(det), std::move(inv));
+  }
+};
+}  // namespace determinant_and_inverse_detail
+
+/*!
+ * \ingroup Tensor
+ * \brief Computes the determinant and inverse of a rank-2 Tensor.
+ *
+ * Computes the determinant and inverse together, because this leads to fewer
+ * operations compared to computing the determinant independently.
+ *
+ * \param tensor the input rank-2 Tensor.
+ * \return a std::pair that holds the determinant (in `pair.first`) and inverse
+ * (in `pair.second`) of the input tensor.
+ *
+ * \details
+ * Treats the input rank-2 tensor as a matrix. The first (second) index of the
+ * tensor corresponds to the rows (columns) of the matrix. The determinant is a
+ * scalar tensor. The inverse is a rank-2 tensor whose indices are reversed and
+ * of opposite valence relative to the input tensor, i.e. given \f$T_a^b\f$
+ * returns \f$(Tinv)_b^a\f$.
+ *
+ * \note
+ * When inverting a 4x4 spacetime metric, it is typically more efficient to use
+ * the 3+1 decomposition of the 4-metric in terms of lapse, shift, and spatial
+ * 3-metric, in which only the spatial 3-metric needs to be inverted.
+ */
+template <typename T, typename Symm, typename Index0, typename Index1>
+std::pair<Scalar<T>, Tensor<T, Symm, typelist<change_index_up_lo<Index1>,
+                                              change_index_up_lo<Index0>>>>
+determinant_and_inverse(
+    const Tensor<T, Symm, typelist<Index0, Index1>>& tensor) {
+  static_assert(Index0::dim == Index1::dim,
+                "Cannot take the inverse of a Tensor whose Indices are not "
+                "of the same dimensionality.");
+  static_assert(Index0::index_type == Index1::index_type,
+                "Taking the inverse of a mixed Spatial and Spacetime index "
+                "Tensor is not allowed since it's not clear what that means.");
+  static_assert(not std::is_integral<T>::value, "Can't invert a Tensor<int>.");
+  return determinant_and_inverse_detail::DetAndInverseImpl<
+      Symm, Index0, Index1>::apply(tensor);
+}

--- a/tests/Unit/DataStructures/TensorEagerMath/CMakeLists.txt
+++ b/tests/Unit/DataStructures/TensorEagerMath/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(TENSOR_EAGER_MATH_TESTS
     DataStructures/TensorEagerMath/Test_Determinant.cpp
+    DataStructures/TensorEagerMath/Test_DeterminantAndInverse.cpp
     DataStructures/TensorEagerMath/Test_DivideBy.cpp
     DataStructures/TensorEagerMath/Test_Magnitude.cpp
     )

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Determinant.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Determinant.cpp
@@ -22,8 +22,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
     {
       tnsr::ij<double, 2, Frame::Grid> matrix{};
       matrix.get<0, 0>() = 2.1;
-      matrix.get<1, 0>() = 4.5;
-      matrix.get<0, 1>() = -18.3;
+      matrix.get<0, 1>() = 4.5;
+      matrix.get<1, 0>() = -18.3;
       matrix.get<1, 1>() = -10.9;
       const auto det = determinant(matrix);
       CHECK(59.46 == approx(det.get()));
@@ -32,13 +32,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
     {
       tnsr::ij<double, 3, Frame::Grid> matrix{};
       matrix.get<0, 0>() = 1.1;
-      matrix.get<1, 0>() = -10.4;
-      matrix.get<2, 0>() = -4.5;
-      matrix.get<0, 1>() = 3.2;
+      matrix.get<0, 1>() = -10.4;
+      matrix.get<0, 2>() = -4.5;
+      matrix.get<1, 0>() = 3.2;
       matrix.get<1, 1>() = 15.4;
-      matrix.get<2, 1>() = -19.2;
-      matrix.get<0, 2>() = 4.3;
-      matrix.get<1, 2>() = 16.8;
+      matrix.get<1, 2>() = -19.2;
+      matrix.get<2, 0>() = 4.3;
+      matrix.get<2, 1>() = 16.8;
       matrix.get<2, 2>() = 2.0;
       const auto det = determinant(matrix);
       CHECK(1369.95 == approx(det.get()));
@@ -47,20 +47,20 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
     {
       tnsr::ij<double, 4, Frame::Grid> matrix{};
       matrix.get<0, 0>() = 1.1;
-      matrix.get<1, 0>() = -10.4;
-      matrix.get<2, 0>() = -4.5;
-      matrix.get<3, 0>() = 3.2;
-      matrix.get<0, 1>() = 15.4;
+      matrix.get<0, 1>() = -10.4;
+      matrix.get<0, 2>() = -4.5;
+      matrix.get<0, 3>() = 3.2;
+      matrix.get<1, 0>() = 15.4;
       matrix.get<1, 1>() = -19.2;
-      matrix.get<2, 1>() = 4.3;
-      matrix.get<3, 1>() = 16.8;
-      matrix.get<0, 2>() = 2.0;
-      matrix.get<1, 2>() = 3.1;
+      matrix.get<1, 2>() = 4.3;
+      matrix.get<1, 3>() = 16.8;
+      matrix.get<2, 0>() = 2.0;
+      matrix.get<2, 1>() = 3.1;
       matrix.get<2, 2>() = 4.2;
-      matrix.get<3, 2>() = -0.2;
-      matrix.get<0, 3>() = -3.2;
-      matrix.get<1, 3>() = 2.6;
-      matrix.get<2, 3>() = 1.5;
+      matrix.get<2, 3>() = -0.2;
+      matrix.get<3, 0>() = -3.2;
+      matrix.get<3, 1>() = 2.6;
+      matrix.get<3, 2>() = 1.5;
       matrix.get<3, 3>() = 2.8;
       const auto det = determinant(matrix);
       CHECK(1049.7072 == approx(det.get()));
@@ -74,7 +74,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
     {
       tnsr::ii<double, 2, Frame::Grid> matrix{};
       matrix.get<0, 0>() = 2.1;
-      matrix.get<1, 0>() = 4.5;
+      matrix.get<0, 1>() = 4.5;
       matrix.get<1, 1>() = -10.9;
       const auto det = determinant(matrix);
       CHECK(-43.14 == approx(det.get()));
@@ -83,10 +83,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
     {
       tnsr::ii<double, 3, Frame::Grid> matrix{};
       matrix.get<0, 0>() = 1.1;
-      matrix.get<1, 0>() = -10.4;
-      matrix.get<2, 0>() = -4.5;
+      matrix.get<0, 1>() = -10.4;
+      matrix.get<0, 2>() = -4.5;
       matrix.get<1, 1>() = 3.2;
-      matrix.get<2, 1>() = 15.4;
+      matrix.get<1, 2>() = 15.4;
       matrix.get<2, 2>() = -19.2;
       const auto det = determinant(matrix);
       CHECK(3124.852 == approx(det.get()));
@@ -95,14 +95,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
     {
       tnsr::ii<double, 4, Frame::Grid> matrix{};
       matrix.get<0, 0>() = 1.1;
-      matrix.get<1, 0>() = -10.4;
-      matrix.get<2, 0>() = -4.5;
-      matrix.get<3, 0>() = 3.2;
+      matrix.get<0, 1>() = -10.4;
+      matrix.get<0, 2>() = -4.5;
+      matrix.get<0, 3>() = 3.2;
       matrix.get<1, 1>() = 15.4;
-      matrix.get<2, 1>() = -19.2;
-      matrix.get<3, 1>() = 4.3;
+      matrix.get<1, 2>() = -19.2;
+      matrix.get<1, 3>() = 4.3;
       matrix.get<2, 2>() = 16.8;
-      matrix.get<3, 2>() = 2.0;
+      matrix.get<2, 3>() = 2.0;
       matrix.get<3, 3>() = 3.1;
       const auto det = determinant(matrix);
       CHECK(-22819.6093 == approx(det.get()));
@@ -116,8 +116,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
     {
       tnsr::ij<int, 2, Frame::Grid> matrix{};
       matrix.get<0, 0>() = 9;
-      matrix.get<1, 0>() = 1;
-      matrix.get<0, 1>() = -3;
+      matrix.get<0, 1>() = 1;
+      matrix.get<1, 0>() = -3;
       matrix.get<1, 1>() = -4;
       const auto det = determinant(matrix);
       CHECK(-33 == det.get());
@@ -126,8 +126,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
     {
       tnsr::ij<DataVector, 2, Frame::Grid> matrix{};
       matrix.get<0, 0>() = DataVector({6.0, 5.9, 9.8, 6.4});
-      matrix.get<1, 0>() = DataVector({6.1, 0.3, 2.4, 5.7});
-      matrix.get<0, 1>() = DataVector({4.2, 7.1, 1.1, 6.5});
+      matrix.get<0, 1>() = DataVector({6.1, 0.3, 2.4, 5.7});
+      matrix.get<1, 0>() = DataVector({4.2, 7.1, 1.1, 6.5});
       matrix.get<1, 1>() = DataVector({7.2, 8.4, 6.1, 3.7});
       const auto det = determinant(matrix);
       CHECK(17.58 == approx(det.get()[0]));

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_DeterminantAndInverse.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_DeterminantAndInverse.cpp
@@ -1,0 +1,249 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Determinant.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+// In the spirit of the Tensor type aliases, but for a rank-2 Tensor with each
+// index in a different frame. If Fr1 == Fr2, then this reduces to tnsr::iJ.
+template <typename DataType, size_t Dim, typename Fr1, typename Fr2>
+using tnsr_iJ = Tensor<DataType, tmpl::integral_list<int32_t, 2, 1>,
+                       index_list<SpatialIndex<Dim, UpLo::Lo, Fr1>,
+                                  SpatialIndex<Dim, UpLo::Up, Fr2>>>;
+
+template <typename TensorType>
+void verify_det_and_inv_1d() {
+  TensorType t{};
+  t.template get<0, 0>() = 2.0;
+  const auto det_inv = determinant_and_inverse(t);
+  CHECK(det_inv.first.get() == 2.0);
+  CHECK((det_inv.second.template get<0, 0>()) == 0.5);
+}
+
+template <typename TensorType>
+void verify_det_and_inv_generic_2d() {
+  TensorType t{};
+  t.template get<0, 0>() = 2.0;
+  t.template get<0, 1>() = 3.0;
+  t.template get<1, 0>() = 4.0;
+  t.template get<1, 1>() = 5.0;
+  const auto det_inv = determinant_and_inverse(t);
+  CHECK(det_inv.first.get() == -2.0);
+  CHECK((det_inv.second.template get<0, 0>()) == -2.5);
+  CHECK((det_inv.second.template get<0, 1>()) == 1.5);
+  CHECK((det_inv.second.template get<1, 0>()) == 2.0);
+  CHECK((det_inv.second.template get<1, 1>()) == -1.0);
+}
+
+template <typename TensorType>
+void verify_det_and_inv_generic_3d() {
+  TensorType t{};
+  t.template get<0, 0>() = 2.0;
+  t.template get<0, 1>() = 3.0;
+  t.template get<0, 2>() = 6.0;
+  t.template get<1, 0>() = 4.0;
+  t.template get<1, 1>() = 5.0;
+  t.template get<1, 2>() = 7.0;
+  t.template get<2, 0>() = 8.0;
+  t.template get<2, 1>() = 9.0;
+  t.template get<2, 2>() = 10.0;
+  const auto det_inv = determinant_and_inverse(t);
+  CHECK(det_inv.first.get() == -2.0);
+  CHECK((det_inv.second.template get<0, 0>()) == 6.5);
+  CHECK((det_inv.second.template get<0, 1>()) == -12.0);
+  CHECK((det_inv.second.template get<0, 2>()) == 4.5);
+  CHECK((det_inv.second.template get<1, 0>()) == -8.0);
+  CHECK((det_inv.second.template get<1, 1>()) == 14.0);
+  CHECK((det_inv.second.template get<1, 2>()) == -5.0);
+  CHECK((det_inv.second.template get<2, 0>()) == 2.0);
+  CHECK((det_inv.second.template get<2, 1>()) == -3.0);
+  CHECK((det_inv.second.template get<2, 2>()) == 1.0);
+}
+
+template <typename TensorType>
+void verify_det_and_inv_generic_4d() {
+  TensorType t{};
+  t.template get<0, 0>() = 2.0;
+  t.template get<0, 1>() = 3.0;
+  t.template get<0, 2>() = 6.0;
+  t.template get<0, 3>() = 11.0;
+  t.template get<1, 0>() = 4.0;
+  t.template get<1, 1>() = 5.0;
+  t.template get<1, 2>() = 7.0;
+  t.template get<1, 3>() = 12.0;
+  t.template get<2, 0>() = 8.0;
+  t.template get<2, 1>() = 9.0;
+  t.template get<2, 2>() = 10.0;
+  t.template get<2, 3>() = 13.0;
+  t.template get<3, 0>() = 14.0;
+  t.template get<3, 1>() = 15.0;
+  t.template get<3, 2>() = 16.0;
+  t.template get<3, 3>() = 17.0;
+  const auto det_inv = determinant_and_inverse(t);
+  CHECK(det_inv.first.get() == -8.0);
+  CHECK((det_inv.second.template get<0, 0>()) == -4.0);
+  CHECK((det_inv.second.template get<0, 1>()) == 9.0);
+  CHECK((det_inv.second.template get<0, 2>()) == -9.5);
+  CHECK((det_inv.second.template get<0, 3>()) == 3.5);
+  CHECK((det_inv.second.template get<1, 0>()) == 3.25);
+  CHECK((det_inv.second.template get<1, 1>()) == -8.5);
+  CHECK((det_inv.second.template get<1, 2>()) == 10.0);
+  CHECK((det_inv.second.template get<1, 3>()) == -3.75);
+  CHECK((det_inv.second.template get<2, 0>()) == 1.25);
+  CHECK((det_inv.second.template get<2, 1>()) == -1.5);
+  CHECK((det_inv.second.template get<2, 2>()) == 0.0);
+  CHECK((det_inv.second.template get<2, 3>()) == 0.25);
+  CHECK((det_inv.second.template get<3, 0>()) == -0.75);
+  CHECK((det_inv.second.template get<3, 1>()) == 1.5);
+  CHECK((det_inv.second.template get<3, 2>()) == -1.0);
+  CHECK((det_inv.second.template get<3, 3>()) == 0.25);
+}
+
+template <typename TensorType>
+void verify_det_and_inv_symmetric_2d() {
+  TensorType t{};
+  t.template get<0, 0>() = 2.0;
+  t.template get<0, 1>() = 3.0;
+  t.template get<1, 1>() = 5.0;
+  const auto det_inv = determinant_and_inverse(t);
+  CHECK(det_inv.first.get() == 1.0);
+  CHECK((det_inv.second.template get<0, 0>()) == 5.0);
+  CHECK((det_inv.second.template get<0, 1>()) == -3.0);
+  CHECK((det_inv.second.template get<1, 0>()) == -3.0);
+  CHECK((det_inv.second.template get<1, 1>()) == 2.0);
+}
+
+template <typename TensorType>
+void verify_det_and_inv_symmetric_3d() {
+  TensorType t{};
+  t.template get<0, 0>() = 2.0;
+  t.template get<0, 1>() = 3.0;
+  t.template get<0, 2>() = 6.0;
+  t.template get<1, 1>() = 5.0;
+  t.template get<1, 2>() = 7.0;
+  t.template get<2, 2>() = 10.0;
+  const auto det_inv = determinant_and_inverse(t);
+  CHECK(det_inv.first.get() == -16.0);
+  CHECK((det_inv.second.template get<0, 0>()) == -0.0625);
+  CHECK((det_inv.second.template get<0, 1>()) == -0.75);
+  CHECK((det_inv.second.template get<0, 2>()) == 0.5625);
+  CHECK((det_inv.second.template get<1, 0>()) == -0.75);
+  CHECK((det_inv.second.template get<1, 1>()) == 1.0);
+  CHECK((det_inv.second.template get<1, 2>()) == -0.25);
+  CHECK((det_inv.second.template get<2, 0>()) == 0.5625);
+  CHECK((det_inv.second.template get<2, 1>()) == -0.25);
+  CHECK((det_inv.second.template get<2, 2>()) == -0.0625);
+}
+
+template <typename TensorType>
+void verify_det_and_inv_symmetric_4d() {
+  TensorType t{};
+  t.template get<0, 0>() = 2.0;
+  t.template get<0, 1>() = 3.0;
+  t.template get<0, 2>() = 6.0;
+  t.template get<0, 3>() = 11.0;
+  t.template get<1, 1>() = 5.0;
+  t.template get<1, 2>() = 7.0;
+  t.template get<1, 3>() = 12.0;
+  t.template get<2, 2>() = 10.0;
+  t.template get<2, 3>() = 13.0;
+  t.template get<3, 3>() = 17.0;
+  const auto det_inv = determinant_and_inverse(t);
+  CHECK(det_inv.first.get() == -100.0);
+  CHECK((det_inv.second.template get<0, 0>()) == approx(0.84));
+  CHECK((det_inv.second.template get<0, 1>()) == approx(-0.94));
+  CHECK((det_inv.second.template get<0, 2>()) == approx(-0.34));
+  CHECK((det_inv.second.template get<0, 3>()) == approx(0.38));
+  CHECK((det_inv.second.template get<1, 0>()) == approx(-0.94));
+  CHECK((det_inv.second.template get<1, 1>()) == approx(1.04));
+  CHECK((det_inv.second.template get<1, 2>()) == approx(-0.06));
+  CHECK((det_inv.second.template get<1, 3>()) == approx(-0.08));
+  CHECK((det_inv.second.template get<2, 0>()) == approx(-0.34));
+  CHECK((det_inv.second.template get<2, 1>()) == approx(-0.06));
+  CHECK((det_inv.second.template get<2, 2>()) == approx(0.84));
+  CHECK((det_inv.second.template get<2, 3>()) == approx(-0.38));
+  CHECK((det_inv.second.template get<3, 0>()) == approx(0.38));
+  CHECK((det_inv.second.template get<3, 1>()) == approx(-0.08));
+  CHECK((det_inv.second.template get<3, 2>()) == approx(-0.38));
+  CHECK((det_inv.second.template get<3, 3>()) == approx(0.16));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DeterminantAndInverse",
+                  "[DataStructures][Unit]") {
+  // Check that the inverse tensor has the expected index structure -- for an
+  // input Tensor of type T^a_b, the inverse should have type T^b_a.
+  {
+    static_assert(
+        cpp17::is_same_v<
+            Tensor<double, tmpl::integral_list<int32_t, 2, 1>,
+                   index_list<SpatialIndex<2, UpLo::Up, Frame::Inertial>,
+                              SpatialIndex<2, UpLo::Lo, Frame::Grid>>>,
+            decltype(determinant_and_inverse(
+                std::declval<
+                    Tensor<double, tmpl::integral_list<int32_t, 2, 1>,
+                           index_list<SpatialIndex<2, UpLo::Up, Frame::Grid>,
+                                      SpatialIndex<2, UpLo::Lo,
+                                                   Frame::Inertial>>>>()))::
+                second_type>,
+        "Inverse tensor has incorrect index structure.");
+  }
+
+  // Check paired determinant and inverse for 1x1 through 4x4 tensors, both
+  // generic and symmetric, with both spatial and spacetime indices.
+  {
+    verify_det_and_inv_1d<tnsr::ii<double, 1, Frame::Grid>>();
+    verify_det_and_inv_1d<tnsr::ij<double, 1, Frame::Grid>>();
+    verify_det_and_inv_1d<tnsr_iJ<double, 1, Frame::Grid, Frame::Inertial>>();
+
+    verify_det_and_inv_symmetric_2d<tnsr::ii<double, 2, Frame::Grid>>();
+    verify_det_and_inv_generic_2d<tnsr::ij<double, 2, Frame::Grid>>();
+    verify_det_and_inv_generic_2d<
+        tnsr_iJ<double, 2, Frame::Grid, Frame::Inertial>>();
+
+    verify_det_and_inv_symmetric_3d<tnsr::ii<double, 3, Frame::Grid>>();
+    verify_det_and_inv_generic_3d<tnsr::ij<double, 3, Frame::Grid>>();
+    verify_det_and_inv_generic_3d<
+        tnsr_iJ<double, 3, Frame::Grid, Frame::Inertial>>();
+
+    verify_det_and_inv_symmetric_4d<tnsr::ii<double, 4, Frame::Grid>>();
+    verify_det_and_inv_generic_4d<tnsr::ij<double, 4, Frame::Grid>>();
+    verify_det_and_inv_generic_4d<
+        tnsr_iJ<double, 4, Frame::Grid, Frame::Inertial>>();
+
+    verify_det_and_inv_symmetric_2d<tnsr::aa<double, 1, Frame::Grid>>();
+    verify_det_and_inv_generic_2d<tnsr::ab<double, 1, Frame::Grid>>();
+
+    verify_det_and_inv_symmetric_3d<tnsr::aa<double, 2, Frame::Grid>>();
+    verify_det_and_inv_generic_3d<tnsr::ab<double, 2, Frame::Grid>>();
+
+    verify_det_and_inv_symmetric_4d<tnsr::aa<double, 3, Frame::Grid>>();
+    verify_det_and_inv_generic_4d<tnsr::ab<double, 3, Frame::Grid>>();
+  }
+
+  // Check paired determinant and inverse for a Tensor<DataVector>.
+  {
+    tnsr::ij<DataVector, 2, Frame::Grid> t{};
+    t.template get<0, 0>() = DataVector({2.0, 3.0, 5.0, 1.0});
+    t.template get<0, 1>() = DataVector({3.0, 5.0, 4.0, -1.0});
+    t.template get<1, 0>() = DataVector({4.0, 2.0, 2.0, 1.0});
+    t.template get<1, 1>() = DataVector({5.0, 3.0, 2.0, 1.0});
+    const auto det_inv = determinant_and_inverse(t);
+    CHECK(det_inv.first.get() == DataVector({-2.0, -1.0, 2.0, 2.0}));
+    CHECK((det_inv.second.template get<0, 0>()) ==
+          DataVector({-2.5, -3.0, 1.0, 0.5}));
+    CHECK((det_inv.second.template get<0, 1>()) ==
+          DataVector({1.5, 5.0, -2.0, 0.5}));
+    CHECK((det_inv.second.template get<1, 0>()) ==
+          DataVector({2.0, 2.0, -1.0, -0.5}));
+    CHECK((det_inv.second.template get<1, 1>()) ==
+          DataVector({-1.0, -3.0, 2.5, 0.5}));
+  }
+}


### PR DESCRIPTION
Questions:

1. In the code call we leaned towards only implementing 3x3. Do we still agree? My concern is that we may find a good reason to use a 4x4 inverse in the future but forget how to do it correctly. Should we include Saul's efficient 4x4 algorithm somewhere in the repo for this case?

2. I would like to rename the file `InvertMatrix` to `Inverse` so that it matches the function it defines. However, this does make the name more generic / less descriptive. Opinions?