### PR TITLE
Change error message when assertion tests fail

### DIFF
--- a/docs/DevGuide/WritingTests.md
+++ b/docs/DevGuide/WritingTests.md
@@ -11,7 +11,8 @@ before the `SPECTRE_TEST_CASE` macro will force ctest to only pass the particula
 if the regular expression is found. This can be used to test error handling.
 When testing `ASSERT`s you must mark the `SPECTRE_TEST_CASE` as `[[noreturn]]`,
 add the macro `ASSERTION_TEST();` to the beginning of the test, and also have
-the test call `ERROR("Bad test end");` at the end of the test body.
+the test call `ERROR("Failed to trigger ASSERT in an assertion test");` at the
+end of the test body.
 For example,
 
 ```cpp
@@ -25,7 +26,7 @@ For example,
   data_ref.set_data_ref(data);
   DataVector data2{1.43, 2.83, 3.94};
   data_ref = data2;
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 ```

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -122,7 +122,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector_Ref",
   data_ref.set_data_ref(data);
   DataVector data2{1.43, 2.83, 3.94};
   data_ref = data2;
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -137,7 +137,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector_Ref",
   data_ref.set_data_ref(data);
   DataVector data2{1.43, 2.83, 3.94};
   data_ref = std::move(data2);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -326,6 +326,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   DataVector one_ref(one.data(), one.size());
   DataVector one_b(2, 1.0);
   one_ref = (one_b * one_b);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -669,7 +669,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
 #ifdef SPECTRE_DEBUG
   tnsr::Abb<double, 3, Frame::Grid> tensor(1_st);
   auto& t = tensor[1000];
-  ERROR("Bad test end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -681,7 +681,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
 #ifdef SPECTRE_DEBUG
   const tnsr::Abb<double, 3, Frame::Grid> tensor(1_st);
   const auto& t = tensor[1000];
-  ERROR("Bad test end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -693,7 +693,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
 #ifdef SPECTRE_DEBUG
   Scalar<double> tensor(1_st);
   const auto& t = tensor.multiplicity(1000);
-  ERROR("Bad test end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -705,7 +705,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
 #ifdef SPECTRE_DEBUG
   Scalar<double> tensor(1_st);
   const auto& t = tensor.get_tensor_index(1000);
-  ERROR("Bad test end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -130,7 +130,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
       v(1, -3.0);
   auto& vector_in_v = v.get<VariablesTestTags_detail::vector>();
   vector_in_v = tnsr::I<DataVector, 3, Frame::Grid>{10_st, -4.0};
-  ERROR("Bad test end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 

--- a/tests/Unit/Domain/Test_Direction.cpp
+++ b/tests/Unit/Domain/Test_Direction.cpp
@@ -179,7 +179,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Output", "[Domain][Unit]") {
   auto failed_direction = Direction<1>(1, Side::Upper);
   static_cast<void>(failed_direction);
 
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -192,7 +192,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Output", "[Domain][Unit]") {
   auto failed_direction = Direction<2>(2, Side::Upper);
   static_cast<void>(failed_direction);
 
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -205,6 +205,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Output", "[Domain][Unit]") {
   auto failed_direction = Direction<3>(3, Side::Upper);
   static_cast<void>(failed_direction);
 
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }

--- a/tests/Unit/Numerical/RootFinding/Test_QuadraticEquation.cpp
+++ b/tests/Unit/Numerical/RootFinding/Test_QuadraticEquation.cpp
@@ -13,7 +13,7 @@
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   real_roots(1.0, -3.0, 3.0);
-  ERROR("Bad test end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -24,7 +24,7 @@
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   positive_root(1.0, -3.0, 3.0);
-  ERROR("Bad test end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -35,7 +35,7 @@
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   positive_root(1.0, -3.0, 2.0);
-  ERROR("Bad test end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 

--- a/tests/Unit/Time/Test_Slab.cpp
+++ b/tests/Unit/Time/Test_Slab.cpp
@@ -103,7 +103,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(1., 0.);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -112,7 +112,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab::with_duration_from_start(0., -1.);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -121,7 +121,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab::with_duration_to_end(0., -1.);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -131,7 +131,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
 #ifdef SPECTRE_DEBUG
   const Slab slab(0., 1.);
   slab.advance_towards(0 * slab.duration());
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -140,7 +140,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) < Slab(0.1, 0.9);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -149,7 +149,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) < Slab(0.1, 1.1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -158,7 +158,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) < Slab(-0.1, 0.9);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -167,7 +167,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) < Slab(-0.1, 1.1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -176,7 +176,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) > Slab(0.1, 0.9);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -185,7 +185,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) > Slab(0.1, 1.1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -194,7 +194,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) > Slab(-0.1, 0.9);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -203,7 +203,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) > Slab(-0.1, 1.1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -212,7 +212,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) <= Slab(0.1, 0.9);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -221,7 +221,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) <= Slab(0.1, 1.1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -230,7 +230,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) <= Slab(-0.1, 0.9);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -239,7 +239,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) <= Slab(-0.1, 1.1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -249,7 +249,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) >= Slab(0.1, 0.9);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -259,7 +259,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) >= Slab(0.1, 1.1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -269,7 +269,7 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) >= Slab(-0.1, 0.9);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -279,6 +279,6 @@ SPECTRE_TEST_CASE("Unit.Time.Slab.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Slab(0., 1.) >= Slab(-0.1, 1.1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }

--- a/tests/Unit/Time/Test_Time.cpp
+++ b/tests/Unit/Time/Test_Time.cpp
@@ -287,7 +287,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), -1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 /// [example_of_error_test]
@@ -297,7 +297,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 2);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -306,7 +306,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), Time::rational_t(1, 2)).with_slab(Slab(1., 2.));
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -315,7 +315,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), Time::rational_t(1, 2)).with_slab(Slab(-1., 0.));
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -324,7 +324,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), Time::rational_t(1, 2)).with_slab(Slab(0., 2.));
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -333,7 +333,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0).with_slab(Slab(1., 2.));
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -342,7 +342,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0).with_slab(Slab(-1., 1.));
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -351,7 +351,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 1).with_slab(Slab(-1., 0.));
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -360,7 +360,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 1).with_slab(Slab(0., 2.));
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -369,7 +369,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 1) < Time(Slab(0., 2.), 1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -378,7 +378,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) - Time(Slab(2., 3.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -387,7 +387,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 1) - Time(Slab(-1., 0.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -396,7 +396,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(-1., 0.), 0) - Time(Slab(0., 1.), 1);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -405,7 +405,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) + TimeDelta(Slab(0., 1.), 2);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -414,7 +414,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) += TimeDelta(Slab(0., 1.), 2);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -423,7 +423,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) + TimeDelta(Slab(0., 1.), -2);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -432,7 +432,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) += TimeDelta(Slab(0., 1.), -2);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -441,7 +441,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) - TimeDelta(Slab(0., 1.), 2);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -450,7 +450,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) -= TimeDelta(Slab(0., 1.), 2);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -459,7 +459,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) - TimeDelta(Slab(0., 1.), -2);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -468,7 +468,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) -= TimeDelta(Slab(0., 1.), -2);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -477,7 +477,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) + TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -486,7 +486,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) += TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -495,7 +495,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) - TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -504,7 +504,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Time(Slab(0., 1.), 0) -= TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -514,7 +514,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(0., 1.), 0) < TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -524,7 +524,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(0., 1.), 0) > TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -534,7 +534,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(0., 1.), 0) <= TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -544,7 +544,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(0., 1.), 0) >= TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -554,7 +554,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(0., 1.), 2) + Time(Slab(0., 1.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -564,7 +564,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(0., 1.), -2) + Time(Slab(0., 1.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -574,7 +574,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(1., 2.), 0) + Time(Slab(0., 1.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -584,7 +584,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(0., 1.), 0) += TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -594,7 +594,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(0., 1.), 0) + TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -604,7 +604,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(0., 1.), 0) -= TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
@@ -614,6 +614,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeDelta.serialization",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   TimeDelta(Slab(0., 1.), 0) - TimeDelta(Slab(1., 2.), 0);
-  ERROR("Bad end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }

--- a/tests/Unit/Utilities/Test_Deferred.cpp
+++ b/tests/Unit/Utilities/Test_Deferred.cpp
@@ -71,6 +71,6 @@ SPECTRE_TEST_CASE("Unit.Utilities.Deferred", "[Utilities][Unit]") {
 #ifdef SPECTRE_DEBUG
   auto def = make_deferred(func{});
   auto& mutate = def.mutate();
-  ERROR("Bad test end");
+  ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }


### PR DESCRIPTION
@kidder, @wthrowe and I had discussed changing the error message when an `ASSERT` fails to trigger in an assertion test. This implements that discussion.