### PR TITLE
Add a Requires alias to improve SFINAE errors

### DIFF
--- a/src/DataStructures/DataBoxHelpers.hpp
+++ b/src/DataStructures/DataBoxHelpers.hpp
@@ -16,12 +16,12 @@ class Tensor;
 class DataVector;
 /// \endcond
 
-template <typename Tag, typename = void>
+template <typename Tag, typename = std::nullptr_t>
 struct get_item_from_variant_databox;
 
 template <typename Tag>
 struct get_item_from_variant_databox<
-    Tag, std::enable_if_t<std::is_base_of<db::DataBoxTag, Tag>::value>>
+    Tag, Requires<std::is_base_of<db::DataBoxTag, Tag>::value>>
     : boost::static_visitor<db::item_type<Tag>> {
   template <typename DataBox_t>
   constexpr db::item_type<Tag> operator()(DataBox_t& box) const {
@@ -31,8 +31,7 @@ struct get_item_from_variant_databox<
 
 template <typename TagType>
 struct get_item_from_variant_databox<
-    TagType,
-    std::enable_if_t<not std::is_base_of<db::DataBoxTag, TagType>::value>>
+    TagType, Requires<not std::is_base_of<db::DataBoxTag, TagType>::value>>
     : boost::static_visitor<TagType> {
   explicit get_item_from_variant_databox(std::string name)
       : var_name(std::move(name)) {}
@@ -47,7 +46,7 @@ struct get_item_from_variant_databox<
 
 namespace DataBoxHelpers_detail {
 template <typename Tags, typename TagLs,
-          std::enable_if_t<(tmpl::size<Tags>::value == 1)>* = nullptr>
+          Requires<(tmpl::size<Tags>::value == 1)> = nullptr>
 auto get_tensor_from_box(const db::DataBox<TagLs>& box,
                          const std::string& tag_name) {
   using tag = tmpl::front<Tags>;
@@ -58,7 +57,7 @@ auto get_tensor_from_box(const db::DataBox<TagLs>& box,
 }
 
 template <typename Tags, typename TagLs,
-          std::enable_if_t<(tmpl::size<Tags>::value > 1)>* = nullptr>
+          Requires<(tmpl::size<Tags>::value > 1)> = nullptr>
 auto get_tensor_from_box(const db::DataBox<TagLs>& box,
                          const std::string& tag_name) {
   using tag = tmpl::front<Tags>;
@@ -82,7 +81,7 @@ auto get_tensor_from_box(const db::DataBox<TagsLs>& box,
 
 // namespace DataBoxHelpers_detail {
 // template <typename Tags, typename TagsLs,
-//          std::enable_if_t<(tmpl::size<Tags>::value == 1)>* = nullptr>
+//          Requires<(tmpl::size<Tags>::value == 1)> = nullptr>
 // auto get_tensor_norm_from_box(
 //    const db::DataBox<TagsLs>& box,
 //    const std::pair<std::string, TypeOfNorm>& tag_name) {
@@ -95,7 +94,7 @@ auto get_tensor_from_box(const db::DataBox<TagsLs>& box,
 //}
 //
 // template <typename Tags, typename TagsLs,
-//          std::enable_if_t<(tmpl::size<Tags>::value > 1)>* = nullptr>
+//          Requires<(tmpl::size<Tags>::value > 1)> = nullptr>
 // auto get_tensor_norm_from_box(
 //    const db::DataBox<TagsLs>& box,
 //    const std::pair<std::string, TypeOfNorm>& tag_name) {

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -17,6 +17,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/PointerVector.hpp"
+#include "Utilities/Requires.hpp"
 
 /// \cond HIDDEN_SYMBOLS
 namespace PUP {
@@ -392,15 +393,14 @@ DataVector& DataVector::operator=(const blaze::Vector<VT, VF>& expression) {
 
 namespace ConstantExpressions_details {
 template <>
-struct pow<DataVector, 0, void> {
+struct pow<DataVector, 0, std::nullptr_t> {
   SPECTRE_ALWAYS_INLINE static constexpr double apply(const DataVector& /*t*/) {
     return 1.0;
   }
 };
 template <typename BlazeVector>
-struct pow<
-    BlazeVector, 0,
-    std::enable_if_t<std::is_base_of<blaze::Expression, BlazeVector>::value>> {
+struct pow<BlazeVector, 0,
+           Requires<std::is_base_of<blaze::Expression, BlazeVector>::value>> {
   SPECTRE_ALWAYS_INLINE static constexpr double apply(
       const BlazeVector& /*t*/) {
     return 1.0;
@@ -408,7 +408,7 @@ struct pow<
 };
 
 template <int N>
-struct pow<DataVector, N, typename std::enable_if<(N < 0)>::type> {
+struct pow<DataVector, N, Requires<(N < 0)>> {
   static_assert(N > 0,
                 "Cannot use pow on DataVectorStructures with a negative "
                 "exponent. You must "

--- a/src/DataStructures/Index.hpp
+++ b/src/DataStructures/Index.hpp
@@ -16,6 +16,7 @@
 #include "Parallel/PupStlCpp11.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
 
@@ -31,7 +32,7 @@ class Index {
       : indices_(make_array<Dim>(i0)) {}
 
   /// Construct specifying value in each dimension
-  template <typename... I, std::enable_if_t<(sizeof...(I) > 1)>* = nullptr>
+  template <typename... I, Requires<(sizeof...(I) > 1)> = nullptr>
   explicit Index(I... i) : indices_(make_array(static_cast<size_t>(i)...)) {
     static_assert(cpp17::conjunction_v<tt::is_integer<I>...>,
                   "You must pass in a set of size_t's to Index.");
@@ -61,13 +62,13 @@ class Index {
 
   /// The product of the indices.
   /// If Dim = 0, the product is defined as 1.
-  template <int N = Dim, std::enable_if_t<(N > 0)>* = nullptr>
+  template <int N = Dim, Requires<(N > 0)> = nullptr>
   constexpr size_t product() const noexcept {
     return indices_[N - 1] * product<N - 1>();
   }
   /// \cond
   // Specialization for N = 0 to stop recursion
-  template <int N = Dim, std::enable_if_t<(N == 0)>* = nullptr>
+  template <int N = Dim, Requires<(N == 0)> = nullptr>
   constexpr size_t product() const noexcept {
     return 1;
   }
@@ -76,7 +77,7 @@ class Index {
   /// Return a smaller Index with the d-th elmenent removed.
   ///
   /// \param d the element to remove.
-  template <size_t N = Dim, std::enable_if_t<(N > 0)>* = nullptr>
+  template <size_t N = Dim, Requires<(N > 0)> = nullptr>
   Index<Dim - 1> slice_away(const size_t d) const {
     std::array<size_t, Dim - 1> t{};
     for (size_t i = 0; i < Dim; ++i) {

--- a/src/DataStructures/Tensor/EagerMath/Determinant.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Determinant.hpp
@@ -9,11 +9,11 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 
 namespace detail {
-template <typename Symm, typename Index, typename = void>
+template <typename Symm, typename Index, typename = std::nullptr_t>
 struct DeterminantImpl;
 
 template <typename Symm, typename Index>
-struct DeterminantImpl<Symm, Index, std::enable_if_t<Index::dim == 1>> {
+struct DeterminantImpl<Symm, Index, Requires<Index::dim == 1>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
     return tensor.template get<0, 0>();
@@ -21,7 +21,7 @@ struct DeterminantImpl<Symm, Index, std::enable_if_t<Index::dim == 1>> {
 };
 
 template <typename Symm, typename Index>
-struct DeterminantImpl<Symm, Index, std::enable_if_t<Index::dim == 2>> {
+struct DeterminantImpl<Symm, Index, Requires<Index::dim == 2>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
     const auto& t00 = tensor.template get<0, 0>();
@@ -33,8 +33,7 @@ struct DeterminantImpl<Symm, Index, std::enable_if_t<Index::dim == 2>> {
 };
 
 template <typename Index>
-struct DeterminantImpl<Symmetry<2, 1>, Index,
-                       std::enable_if_t<Index::dim == 3>> {
+struct DeterminantImpl<Symmetry<2, 1>, Index, Requires<Index::dim == 3>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
     const auto& t00 = tensor.template get<0, 0>();
@@ -52,8 +51,7 @@ struct DeterminantImpl<Symmetry<2, 1>, Index,
 };
 
 template <typename Index>
-struct DeterminantImpl<Symmetry<1, 1>, Index,
-                       std::enable_if_t<Index::dim == 3>> {
+struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 3>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
     const auto& t00 = tensor.template get<0, 0>();
@@ -68,8 +66,7 @@ struct DeterminantImpl<Symmetry<1, 1>, Index,
 };
 
 template <typename Index>
-struct DeterminantImpl<Symmetry<2, 1>, Index,
-                       std::enable_if_t<Index::dim == 4>> {
+struct DeterminantImpl<Symmetry<2, 1>, Index, Requires<Index::dim == 4>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
     const auto& t00 = tensor.template get<0, 0>();
@@ -102,8 +99,7 @@ struct DeterminantImpl<Symmetry<2, 1>, Index,
 };
 
 template <typename Index>
-struct DeterminantImpl<Symmetry<1, 1>, Index,
-                       std::enable_if_t<Index::dim == 4>> {
+struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 4>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
     const auto& t00 = tensor.template get<0, 0>();

--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "Utilities/Requires.hpp"
 
 namespace TensorExpressions {
 
@@ -64,7 +65,7 @@ struct AddSub<T1, T2, ArgsLs1<Args1...>, ArgsLs2<Args2...>, Sign>
   AddSub(T1 t1, T2 t2) : t1_(std::move(t1)), t2_(std::move(t2)) {}
 
   template <typename... LhsIndices, typename T, int U = Sign,
-            std::enable_if_t<U == 1>* = nullptr>
+            Requires<U == 1> = nullptr>
   SPECTRE_ALWAYS_INLINE type
   get(const std::array<T, num_tensor_indices>& tensor_index) const {
     return t1_.template get<LhsIndices...>(tensor_index) +
@@ -72,19 +73,19 @@ struct AddSub<T1, T2, ArgsLs1<Args1...>, ArgsLs2<Args2...>, Sign>
   }
 
   template <typename... LhsIndices, typename T, int U = Sign,
-            std::enable_if_t<U == -1>* = nullptr>
+            Requires<U == -1> = nullptr>
   SPECTRE_ALWAYS_INLINE type
   get(const std::array<T, num_tensor_indices>& tensor_index) const {
     return t1_.template get<LhsIndices...>(tensor_index) -
            t2_.template get<LhsIndices...>(tensor_index);
   }
 
-  template <int U = Sign, std::enable_if_t<U == 1>* = nullptr>
+  template <int U = Sign, Requires<U == 1> = nullptr>
   SPECTRE_ALWAYS_INLINE typename T1::type operator[](size_t i) const {
     return t1_[i] + t2_[i];
   }
 
-  template <int U = Sign, std::enable_if_t<U == -1>* = nullptr>
+  template <int U = Sign, Requires<U == -1> = nullptr>
   SPECTRE_ALWAYS_INLINE typename T1::type operator[](size_t i) const {
     return t1_[i] - t2_[i];
   }

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -9,6 +9,7 @@
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
+#include "Utilities/Requires.hpp"
 
 /*!
  * \ingroup TensorExpressions
@@ -102,8 +103,7 @@ struct TensorContract
       const TensorExpression<T, X, Symm, IndexLs, ArgsLs>& t)
       : t_(~t) {}
 
-  template <size_t I, size_t Rank,
-            std::enable_if_t<(I <= Index1::value)>* = nullptr>
+  template <size_t I, size_t Rank, Requires<(I <= Index1::value)> = nullptr>
   SPECTRE_ALWAYS_INLINE void fill_contracting_tensor_index(
       std::array<int, Rank>& tensor_index_in,
       const std::array<int, num_tensor_indices>& tensor_index) const {
@@ -113,8 +113,8 @@ struct TensorContract
   }
 
   template <size_t I, size_t Rank,
-            std::enable_if_t<(I > Index1::value and I <= Index2::value and
-                              I < Rank - 1)>* = nullptr>
+            Requires<(I > Index1::value and I <= Index2::value and
+                      I < Rank - 1)> = nullptr>
   SPECTRE_ALWAYS_INLINE void fill_contracting_tensor_index(
       std::array<int, Rank>& tensor_index_in,
       const std::array<int, Rank - 2>& tensor_index) const {
@@ -125,7 +125,7 @@ struct TensorContract
   }
 
   template <size_t I, size_t Rank,
-            std::enable_if_t<(I > Index2::value and I < Rank - 1)>* = nullptr>
+            Requires<(I > Index2::value and I < Rank - 1)> = nullptr>
   SPECTRE_ALWAYS_INLINE void fill_contracting_tensor_index(
       std::array<int, Rank>& tensor_index_in,
       const std::array<int, Rank - 2>& tensor_index) const {
@@ -134,7 +134,7 @@ struct TensorContract
     fill_contracting_tensor_index<I + 1>(tensor_index_in, tensor_index);
   }
 
-  template <size_t I, size_t Rank, std::enable_if_t<(I == Rank - 1)>* = nullptr>
+  template <size_t I, size_t Rank, Requires<(I == Rank - 1)> = nullptr>
   SPECTRE_ALWAYS_INLINE void fill_contracting_tensor_index(
       std::array<int, Rank>& tensor_index_in,
       const std::array<int, num_tensor_indices>& tensor_index) const {

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Requires.hpp"
 
 namespace TensorExpressions {
 
@@ -21,8 +22,7 @@ namespace TensorExpressions {
  * T::index_list>
  */
 template <typename... LhsIndices, typename T,
-          typename std::enable_if<
-              std::is_base_of<Expression, T>::value>::type* = nullptr>
+          Requires<std::is_base_of<Expression, T>::value> = nullptr>
 auto evaluate(const T& te) {
   static_assert(
       sizeof...(LhsIndices) == tmpl::size<typename T::args_list>::value,

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "ErrorHandling/Assert.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 
@@ -300,9 +301,8 @@ struct TensorExpression<Derived, DataType, Symm, IndexLs, ArgsLs<Args...>> {
   // @{
   /// Cast down to the derived class. This is enabled by the
   /// [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern)
-  template <
-      typename V = Derived,
-      typename std::enable_if<not tt::is_a<Tensor, V>::value>::type* = nullptr>
+  template <typename V = Derived,
+            Requires<not tt::is_a<Tensor, V>::value> = nullptr>
   SPECTRE_ALWAYS_INLINE const Derived& operator~() const {
     return static_cast<const Derived&>(*this);
   }
@@ -319,9 +319,8 @@ struct TensorExpression<Derived, DataType, Symm, IndexLs, ArgsLs<Args...>> {
   /// expression.
   /// \returns const TensorExpression<Derived, DataType, Symm, IndexLs,
   /// ArgsLs<Args...>>&
-  template <
-      typename V = Derived,
-      typename std::enable_if<tt::is_a<Tensor, V>::value>::type* = nullptr>
+  template <typename V = Derived,
+            Requires<tt::is_a<Tensor, V>::value> = nullptr>
   SPECTRE_ALWAYS_INLINE auto operator~() const {
     return static_cast<const TensorExpression<Derived, DataType, Symm, IndexLs,
                                               ArgsLs<Args...>>&>(*this);
@@ -400,9 +399,9 @@ struct TensorExpression<Derived, DataType, Symm, IndexLs, ArgsLs<Args...>> {
   /// \tparam V used for SFINAE
   /// \param tensor_index the tensor component to retrieve
   /// \return the value of the DataType of component `tensor_index`
-  template <
-      typename... LhsIndices, typename ArrayValueType, typename V = Derived,
-      typename std::enable_if<tt::is_a<Tensor, V>::value>::type* = nullptr>
+  template <typename... LhsIndices, typename ArrayValueType,
+            typename V = Derived,
+            Requires<tt::is_a<Tensor, V>::value> = nullptr>
   SPECTRE_ALWAYS_INLINE type
   get(const std::array<ArrayValueType, num_tensor_indices>& tensor_index)
       const {
@@ -430,9 +429,9 @@ struct TensorExpression<Derived, DataType, Symm, IndexLs, ArgsLs<Args...>> {
   /// \tparam V used for SFINAE
   /// \param tensor_index the tensor component to retrieve
   /// \return the value of the DataType of component `tensor_index`
-  template <
-      typename... LhsIndices, typename ArrayValueType, typename V = Derived,
-      typename std::enable_if<not tt::is_a<Tensor, V>::value>::type* = nullptr>
+  template <typename... LhsIndices, typename ArrayValueType,
+            typename V = Derived,
+            Requires<not tt::is_a<Tensor, V>::value> = nullptr>
   SPECTRE_ALWAYS_INLINE type
   get(const std::array<ArrayValueType, num_tensor_indices>& tensor_index)
       const {
@@ -444,9 +443,8 @@ struct TensorExpression<Derived, DataType, Symm, IndexLs, ArgsLs<Args...>> {
   }
 
   /// Retrieve the i'th entry of the Tensor being held
-  template <
-      typename V = Derived,
-      typename std::enable_if<tt::is_a<Tensor, V>::value>::type* = nullptr>
+  template <typename V = Derived,
+            Requires<tt::is_a<Tensor, V>::value> = nullptr>
   SPECTRE_ALWAYS_INLINE type operator[](const size_t i) const {
     return t_->operator[](i);
   }
@@ -455,9 +453,8 @@ struct TensorExpression<Derived, DataType, Symm, IndexLs, ArgsLs<Args...>> {
   ///
   /// In this case we do not need to store a pointer to the TensorExpression
   /// since we can cast back to the derived class using operator~.
-  template <
-      typename V = Derived,
-      typename std::enable_if<not tt::is_a<Tensor, V>::value>::type* = nullptr>
+  template <typename V = Derived,
+            Requires<not tt::is_a<Tensor, V>::value> = nullptr>
   TensorExpression() {}  // NOLINT
 
   /// \brief Construct a TensorExpression from a Tensor.

--- a/src/DataStructures/Tensor/IntelDetails.hpp
+++ b/src/DataStructures/Tensor/IntelDetails.hpp
@@ -9,6 +9,7 @@
 #ifdef __INTEL_COMPILER
 
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Requires.hpp"
 
 // This is needed because the Intel compiler is not good enough at templates...
 namespace Tensor_detail {
@@ -24,7 +25,7 @@ void increment_tensor_index(std::array<T, Size>& tensor_index,
 }
 
 template <size_t I, typename T, typename S, size_t Size,
-          typename std::enable_if_t<(I == Size - 1)>* = nullptr>
+          Requires<(I == Size - 1)> = nullptr>
 constexpr std::array<T, Size> increment_tensor_index_impl(
     const std::array<T, Size>& tensor_index, const std::array<S, Size>& dims) {
   return tensor_index[I] + 1 < static_cast<T>(dims[I])
@@ -33,7 +34,7 @@ constexpr std::array<T, Size> increment_tensor_index_impl(
 }
 
 template <size_t I, typename T, typename S, size_t Size,
-          typename std::enable_if_t<(I < Size - 1)>* = nullptr>
+          Requires<(I < Size - 1)> = nullptr>
 constexpr std::array<T, Size> increment_tensor_index_impl(
     const std::array<T, Size>& tensor_index, const std::array<S, Size>& dims) {
   return tensor_index[I] + 1 < static_cast<T>(dims[I])
@@ -63,9 +64,8 @@ T canonicalize_tensor_index(T arr) {
   return arr;
 }
 
-template <
-    typename Symm, typename IndexLs, typename NumComps,
-    typename std::enable_if_t<(tmpl::size<IndexLs>::value > 0)>* = nullptr>
+template <typename Symm, typename IndexLs, typename NumComps,
+          Requires<(tmpl::size<IndexLs>::value > 0)> = nullptr>
 std::array<int, NumComps::value> compute_collapsed_to_storage() {
   static constexpr auto dims = ::make_array_from_list<IndexLs>();
   static constexpr auto rank = tmpl::size<IndexLs>::value;
@@ -95,17 +95,14 @@ std::array<int, NumComps::value> compute_collapsed_to_storage() {
   return collapsed_to_storage;
 }
 
-template <
-    typename Symm, typename IndexLs, typename NumComps,
-    typename std::enable_if_t<(tmpl::size<IndexLs>::value == 0)>* = nullptr>
+template <typename Symm, typename IndexLs, typename NumComps,
+          Requires<(tmpl::size<IndexLs>::value == 0)> = nullptr>
 std::array<int, 1> compute_collapsed_to_storage() {
   return std::array<int, 1>{{0}};
 }
 
-template <
-    typename Symm, typename IndexLs, typename NumIndComps, typename T,
-    size_t NumComps,
-    typename std::enable_if_t<(tmpl::size<IndexLs>::value > 0)>* = nullptr>
+template <typename Symm, typename IndexLs, typename NumIndComps, typename T,
+          size_t NumComps, Requires<(tmpl::size<IndexLs>::value > 0)> = nullptr>
 std::array<std::array<int, tmpl::size<IndexLs>::value>, NumIndComps::value>
 compute_storage_to_tensor(const std::array<T, NumComps>& collapsed_to_storage) {
   static constexpr auto dims = ::make_array_from_list<IndexLs>();
@@ -121,10 +118,9 @@ compute_storage_to_tensor(const std::array<T, NumComps>& collapsed_to_storage) {
   return storage_to_tensor;
 }
 
-template <
-    typename Symm, typename IndexLs, typename NumIndComps, typename T,
-    size_t NumComps,
-    typename std::enable_if_t<(tmpl::size<IndexLs>::value == 0)>* = nullptr>
+template <typename Symm, typename IndexLs, typename NumIndComps, typename T,
+          size_t NumComps,
+          Requires<(tmpl::size<IndexLs>::value == 0)> = nullptr>
 std::array<std::array<int, 1>, NumIndComps::value> compute_storage_to_tensor(
     const std::array<T, NumComps>& /*collapsed_to_storage*/) {
   return std::array<std::array<int, 1>, 1>{{std::array<int, 1>{{0}}}};

--- a/src/DataStructures/Tensor/Metafunctions.hpp
+++ b/src/DataStructures/Tensor/Metafunctions.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 template <typename X, typename Symm, typename IndexLs>
@@ -22,7 +23,7 @@ namespace detail {
  * \tparam Symmetry_t Symmetry of the Tensor
  * \tparam Indices_t typelist of the TensorIndex's of the Tensor
  */
-template <typename Symmetry_t, typename Indices_t, typename = void>
+template <typename Symmetry_t, typename Indices_t, typename = std::nullptr_t>
 struct number_of_independent_components_impl;
 
 /*!
@@ -44,7 +45,7 @@ struct number_of_independent_components_impl<tmpl::list<>, tmpl::list<>> {
 
 template <typename SymmetryValue, typename Index>
 struct number_of_independent_components_impl<typelist<SymmetryValue>,
-                                             typelist<Index>, void> {
+                                             typelist<Index>, std::nullptr_t> {
   using number_of_independent_components = tmpl::size_t<Index::dim>;
   using component_number = tmpl::size_t<1>;
   using number_of_components = tmpl::size_t<Index::dim>;
@@ -74,8 +75,7 @@ template <typename FirstSymm, typename... SymmetryValues, typename FirstIndex,
           typename... Indices>
 struct number_of_independent_components_impl<
     typelist<FirstSymm, SymmetryValues...>, typelist<FirstIndex, Indices...>,
-    std::enable_if_t<(sizeof...(SymmetryValues) > 0 and
-                      sizeof...(Indices) > 0)>> {
+    Requires<(sizeof...(SymmetryValues) > 0 and sizeof...(Indices) > 0)>> {
   static_assert(
       sizeof...(SymmetryValues) == sizeof...(Indices),
       "Number of components in Symmetry_t and Indices_t must be the same.");

--- a/src/DataStructures/Tensor/Structure.hpp
+++ b/src/DataStructures/Tensor/Structure.hpp
@@ -17,6 +17,7 @@
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \ingroup Tensor
@@ -130,10 +131,10 @@ inline constexpr std::size_t compute_collapsed_index(
                   : 0;
 }
 
-template <typename IndexLs, typename... I>
-SPECTRE_ALWAYS_INLINE constexpr std::enable_if_t<
-    cpp17::conjunction_v<tt::is_integer<I>...>, std::size_t>
-compute_collapsed_index(I... i) noexcept {
+template <typename IndexLs, typename... I,
+          Requires<cpp17::conjunction_v<tt::is_integer<I>...>> = nullptr>
+SPECTRE_ALWAYS_INLINE constexpr size_t compute_collapsed_index(
+    I... i) noexcept {
   static_assert(sizeof...(I) == tmpl::size<IndexLs>::value,
                 "The number of tensor indices passed to "
                 "compute_collapsed_index does not match the rank of the "
@@ -310,7 +311,7 @@ struct Structure {
                    compute_collapsed_index(tensor_index, Structure::dims()));
   }
 
-  template <int... N, std::enable_if_t<(sizeof...(N) > 0)>* = nullptr>
+  template <int... N, Requires<(sizeof...(N) > 0)> = nullptr>
   SPECTRE_ALWAYS_INLINE static constexpr std::size_t
   get_storage_index() noexcept {
     static_assert(sizeof...(Indices) == sizeof...(N),

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -231,9 +232,9 @@ class Variables<tmpl::list<Tags...>> {
             "cannot be used in a meaningful way.");
   }
 
-  template <typename TagToAdd, typename... Rest,
-            std::enable_if_t<
-                tt::is_a<Tensor, typename TagToAdd::type>::value>* = nullptr>
+  template <
+      typename TagToAdd, typename... Rest,
+      Requires<tt::is_a<Tensor, typename TagToAdd::type>::value> = nullptr>
   void add_reference_variable_data(typelist<TagToAdd, Rest...> /*unused*/,
                                    size_t variable_offset = 0);
 
@@ -342,8 +343,7 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
 /// \cond HIDDEN_SYMBOLS
 template <typename... Tags>
 template <typename TagToAdd, typename... Rest,
-          typename std::enable_if_t<
-              tt::is_a<Tensor, typename TagToAdd::type>::value>*>
+          Requires<tt::is_a<Tensor, typename TagToAdd::type>::value>>
 void Variables<tmpl::list<Tags...>>::add_reference_variable_data(
     typelist<TagToAdd, Rest...> /*unused*/, const size_t variable_offset) {
   CASSERT(size_ > (variable_offset + TagToAdd::type::size() - 1) *

--- a/src/Parallel/Printf.hpp
+++ b/src/Parallel/Printf.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <type_traits>
 
+#include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 namespace Parallel {
@@ -20,11 +21,10 @@ namespace detail {
  * to a std::string necessary.
  */
 template <typename T,
-          typename std::enable_if_t<
-              std::is_fundamental<std::decay_t<
-                  std::remove_pointer_t<std::decay_t<T>>>>::value or
-              std::is_pointer<T>::value or
-              std::is_pointer<std::decay_t<T>>::value>* = nullptr>
+          Requires<std::is_fundamental<std::decay_t<
+                       std::remove_pointer_t<std::decay_t<T>>>>::value or
+                   std::is_pointer<T>::value or
+                   std::is_pointer<std::decay_t<T>>::value> = nullptr>
 inline constexpr T stream_object_to_string(T&& t) {
   return t;
 }
@@ -35,9 +35,7 @@ inline constexpr T stream_object_to_string(T&& t) {
  * We need a 2-phase call so that the std::string doesn't go out of scope before
  * the C-style string is passed to printf.
  */
-template <
-    typename T,
-    typename std::enable_if_t<std::is_class<std::decay_t<T>>::value>* = nullptr>
+template <typename T, Requires<std::is_class<std::decay_t<T>>::value> = nullptr>
 inline std::string stream_object_to_string(T&& t) {
   static_assert(tt::is_streamable<std::stringstream, T>::value,
                 "Cannot stream type and therefore it cannot be printed. Please "
@@ -51,8 +49,8 @@ inline std::string stream_object_to_string(T&& t) {
  * Fundamentals are already printable, so nothing to do.
  */
 template <typename T,
-          typename std::enable_if_t<std::is_fundamental<std::decay_t<
-              std::remove_pointer_t<std::decay_t<T>>>>::value>* = nullptr>
+          Requires<std::is_fundamental<std::decay_t<
+              std::remove_pointer_t<std::decay_t<T>>>>::value> = nullptr>
 inline constexpr T get_printable_type(T&& t) {
   return t;
 }

--- a/src/Parallel/PupStlCpp11.hpp
+++ b/src/Parallel/PupStlCpp11.hpp
@@ -14,20 +14,21 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "Utilities/Requires.hpp"
+
 namespace PUP {
 
 // @{
 /// \ingroup Parallel
 /// Serialization of std::array for Charm++
-template <
-    typename T, std::size_t N,
-    typename std::enable_if_t<not std::is_arithmetic<T>::value>* = nullptr>
+template <typename T, std::size_t N,
+          Requires<not std::is_arithmetic<T>::value> = nullptr>
 inline void pup(PUP::er& p, std::array<T, N>& a) {  // NOLINT
   std::for_each(a.begin(), a.end(), [&p](auto& t) { p | t; });
 }
 
 template <typename T, std::size_t N,
-          typename std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
+          Requires<std::is_arithmetic<T>::value> = nullptr>
 inline void pup(PUP::er& p, std::array<T, N>& a) {  // NOLINT
   PUParray(p, a.data(), N);
 }
@@ -101,24 +102,24 @@ inline void operator|(er& p, std::unordered_set<T>& s) {  // NOLINT
 /// Serialization of enum for Charm++
 ///
 /// \note This requires a change to Charm++ to work
-template <typename T, std::enable_if_t<std::is_enum<T>::value>* = nullptr>
+template <typename T, Requires<std::is_enum<T>::value> = nullptr>
 inline void operator|(PUP::er& p, T& s) {  // NOLINT
   pup_bytes(&p, static_cast<void*>(&s), sizeof(T));
 }
 
 template <size_t N = 0, typename... Args,
-          std::enable_if_t<0 == sizeof...(Args)>* = nullptr>
+          Requires<0 == sizeof...(Args)> = nullptr>
 void pup_tuple_impl(PUP::er& /* p */, std::tuple<Args...>& /* t */) {  // NOLINT
 }
 
 template <size_t N = 0, typename... Args,
-          std::enable_if_t<(0 < sizeof...(Args) and 0 == N)>* = nullptr>
+          Requires<(0 < sizeof...(Args) and 0 == N)> = nullptr>
 void pup_tuple_impl(PUP::er& p, std::tuple<Args...>& t) {  // NOLINT
   p | std::get<N>(t);
 }
 
 template <size_t N, typename... Args,
-          std::enable_if_t<(sizeof...(Args) > 0 and N > 0)>* = nullptr>
+          Requires<(sizeof...(Args) > 0 and N > 0)> = nullptr>
 void pup_tuple_impl(PUP::er& p, std::tuple<Args...>& t) {  // NOLINT
   p | std::get<N>(t);
   pup_tuple_impl<N - 1>(p, t);
@@ -145,7 +146,7 @@ inline void operator|(PUP::er& p, std::tuple<Args...>& t) {  // NOLINT
 /// \ingroup Parallel
 /// Serialization of a unique_ptr for Charm++
 template <typename T,
-          std::enable_if_t<not std::is_base_of<PUP::able, T>::value>* = nullptr>
+          Requires<not std::is_base_of<PUP::able, T>::value> = nullptr>
 inline void pup(PUP::er& p, std::unique_ptr<T>& t) {  // NOLINT
   bool is_nullptr = nullptr == t;
   p | is_nullptr;
@@ -163,8 +164,7 @@ inline void pup(PUP::er& p, std::unique_ptr<T>& t) {  // NOLINT
   }
 }
 
-template <typename T,
-          std::enable_if_t<std::is_base_of<PUP::able, T>::value>* = nullptr>
+template <typename T, Requires<std::is_base_of<PUP::able, T>::value> = nullptr>
 inline void pup(PUP::er& p, std::unique_ptr<T>& t) {  // NOLINT
   T* t1 = nullptr;
   if (p.isUnpacking()) {

--- a/src/Utilities/Digraph.hpp
+++ b/src/Utilities/Digraph.hpp
@@ -5,6 +5,7 @@
 
 #include <type_traits>
 
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace brigand {
@@ -54,18 +55,17 @@ struct add_unique_vertex<State, edge<Source, Destination, Weight>> {
   using type = append<State, source, destination>;
 };
 
-template <class E, class S, class = void>
+template <class E, class S, class = std::nullptr_t>
 struct has_source : std::false_type {};
 template <class E, class S>
-struct has_source<E, S, typename std::enable_if<
-                            std::is_same<typename E::source, S>::value>::type>
+struct has_source<E, S, Requires<std::is_same<typename E::source, S>::value>>
     : std::true_type {};
 
 template <class E, class D, class = void>
 struct has_destination : std::false_type {};
 template <class E, class D>
-struct has_destination<E, D, typename std::enable_if<std::is_same<
-                                 typename E::destination, D>::value>::type>
+struct has_destination<
+    E, D, Requires<std::is_same<typename E::destination, D>::value>>
     : std::true_type {};
 
 template <class E, class S, class D>

--- a/src/Utilities/Gsl.hpp
+++ b/src/Utilities/Gsl.hpp
@@ -32,6 +32,7 @@
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/Requires.hpp"
 
 #if defined(__clang__) || defined(__GNUC__)
 
@@ -151,14 +152,12 @@ class not_null {
   static_assert(std::is_assignable<T&, std::nullptr_t>::value,
                 "T cannot be assigned nullptr.");
 
-  template <typename U,
-            typename Dummy = std::enable_if_t<std::is_convertible<U, T>::value>>
+  template <typename U, Requires<std::is_convertible<U, T>::value> = nullptr>
   constexpr not_null(U&& u) : ptr_(std::forward<U>(u)) {
     Expects(ptr_ != nullptr);
   }
 
-  template <typename U,
-            typename Dummy = std::enable_if_t<std::is_convertible<U, T>::value>>
+  template <typename U, Requires<std::is_convertible<U, T>::value> = nullptr>
   constexpr not_null(const not_null<U>& other) : not_null(other.get()) {}
 
   not_null(const not_null& other) = default;

--- a/src/Utilities/MakeArray.hpp
+++ b/src/Utilities/MakeArray.hpp
@@ -9,6 +9,7 @@
 #include <array>
 
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 // Much of this is taken from
@@ -70,8 +71,7 @@ SPECTRE_ALWAYS_INLINE constexpr std::array<std::decay_t<T>, size> make_array(
  * \brief Helper function to initialize a std::array with varying number of
  * arguments
  */
-template <typename T, typename... V,
-          typename std::enable_if_t<(sizeof...(V) > 0)>* = nullptr>
+template <typename T, typename... V, Requires<(sizeof...(V) > 0)> = nullptr>
 SPECTRE_ALWAYS_INLINE constexpr std::array<typename std::decay_t<T>,
                                            sizeof...(V) + 1>
 make_array(T&& t, V&&... values) {

--- a/src/Utilities/PrettyType.hpp
+++ b/src/Utilities/PrettyType.hpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <string>
 
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 
@@ -185,13 +186,13 @@ std::string add_qualifiers() {
  * \tparam KT the struct holding the template alias template_list which is a
  * list of known specializations of construct_name for those containers
  */
-template <typename T, typename M, typename KT, typename U = void>
+template <typename T, typename M, typename KT, typename = std::nullptr_t>
 struct construct_name;
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<
-        tmpl::has_key<M, std::decay_t<std::remove_pointer_t<T>>>::value == 1>> {
+    Requires<tmpl::has_key<M, std::decay_t<std::remove_pointer_t<T>>>::value ==
+             1>> {
   static std::string get() {
     constexpr str_const t =
         tmpl::at<M, std::decay_t<std::remove_pointer_t<T>>>::type_name;
@@ -204,7 +205,7 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<
+    Requires<
         tmpl::has_key<M, std::decay_t<std::remove_reference_t<
                              std::remove_pointer_t<T>>>>::value == 0 and
         std::is_same<
@@ -227,9 +228,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
-        std::vector,
-        std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::vector, std::decay_t<std::remove_reference_t<
+                                         std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_pointer_t<T>>;
   static std::string get() {
     std::stringstream ss;
@@ -245,7 +245,7 @@ struct construct_name<
 
 template <typename T, typename M, typename KT>
 struct construct_name<
-    T, M, KT, std::enable_if_t<tt::is_std_array_v<std::decay_t<
+    T, M, KT, Requires<tt::is_std_array_v<std::decay_t<
                   std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
   static std::string get() {
@@ -264,9 +264,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
-        std::deque,
-        std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::deque, std::decay_t<std::remove_reference_t<
+                                        std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_pointer_t<T>>;
   static std::string get() {
     std::stringstream ss;
@@ -283,9 +282,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
-        std::forward_list,
-        std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::forward_list, std::decay_t<std::remove_reference_t<
+                                               std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_pointer_t<T>>;
   static std::string get() {
     std::stringstream ss;
@@ -302,8 +300,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<std::list, std::decay_t<std::remove_reference_t<
-                                               std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::list, std::decay_t<std::remove_reference_t<
+                                       std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_pointer_t<T>>;
   static std::string get() {
     std::stringstream ss;
@@ -321,8 +319,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<std::map, std::decay_t<std::remove_reference_t<
-                                              std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::map, std::decay_t<std::remove_reference_t<
+                                      std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
   static std::string get() {
     std::stringstream ss;
@@ -343,9 +341,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
-        std::multimap,
-        std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::multimap, std::decay_t<std::remove_reference_t<
+                                           std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
   static std::string get() {
     std::stringstream ss;
@@ -366,9 +363,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
-        std::multiset,
-        std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::multiset, std::decay_t<std::remove_reference_t<
+                                           std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
   static std::string get() {
     std::stringstream ss;
@@ -385,8 +381,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<std::set, std::decay_t<std::remove_reference_t<
-                                              std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::set, std::decay_t<std::remove_reference_t<
+                                      std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
   static std::string get() {
     std::stringstream ss;
@@ -405,7 +401,7 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
+    Requires<tt::is_a_v<
         std::unordered_map,
         std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
@@ -428,7 +424,7 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
+    Requires<tt::is_a_v<
         std::unordered_multimap,
         std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
@@ -451,7 +447,7 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
+    Requires<tt::is_a_v<
         std::unordered_multiset,
         std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
@@ -470,7 +466,7 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
+    Requires<tt::is_a_v<
         std::unordered_set,
         std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
@@ -490,7 +486,7 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
+    Requires<tt::is_a_v<
         std::priority_queue,
         std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
@@ -513,9 +509,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
-        std::queue,
-        std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::queue, std::decay_t<std::remove_reference_t<
+                                        std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
   static std::string get() {
     std::stringstream ss;
@@ -536,9 +531,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
-        std::stack,
-        std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::stack, std::decay_t<std::remove_reference_t<
+                                        std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
   static std::string get() {
     std::stringstream ss;
@@ -560,9 +554,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
-        std::unique_ptr,
-        std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::unique_ptr, std::decay_t<std::remove_reference_t<
+                                             std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
   static std::string get() {
     std::stringstream ss;
@@ -581,9 +574,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
-        std::shared_ptr,
-        std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::shared_ptr, std::decay_t<std::remove_reference_t<
+                                             std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
   static std::string get() {
     std::stringstream ss;
@@ -602,9 +594,8 @@ struct construct_name<
 template <typename T, typename M, typename KT>
 struct construct_name<
     T, M, KT,
-    std::enable_if_t<tt::is_a_v<
-        std::weak_ptr,
-        std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>>>> {
+    Requires<tt::is_a_v<std::weak_ptr, std::decay_t<std::remove_reference_t<
+                                           std::remove_pointer_t<T>>>>>> {
   using type = std::decay_t<std::remove_reference_t<std::remove_pointer_t<T>>>;
   using element_type = typename type::element_type;
   static std::string get() {

--- a/src/Utilities/Requires.hpp
+++ b/src/Utilities/Requires.hpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// \file
+/// Defines the type alias Requires
+
+#include <cstddef>
+
+namespace Requires_detail {
+template <bool B>
+struct requires_impl {
+  using template_error_types_failed_to_meet_requirements_on_template_parameters =
+      std::nullptr_t;
+};
+
+template <>
+struct requires_impl<false> {};
+}  // namespace Requires_detail
+
+/*!
+ * \ingroup Utilities
+ * \brief Express requirements on the template parameters of a function or
+ * class, replaces `std::enable_if_t`
+ *
+ * Replacement for `std::enable_if_t` and Concepts for expressing requirements
+ * on template parameters. This does not require merging of the Concepts
+ * TS (whose merit is debatable) and provides an "error message" if substitution
+ * of a template parameter failed. Specifically, the compiler error will contain
+ * "template_error_types_failed_to_meet_requirements_on_template_parameters",
+ * aiding the user of a function or class in tracking down the list of
+ * requirements on the deduced type.
+ *
+ * For example, if a function `foo` is defined as:
+ * \snippet Utilities/Test_Requires.cpp foo_definition
+ * then calling the function with a list, `foo(std::list<double>{});` results in
+ * the following compilation error from clang:
+ * \code
+ * ./tests/Unit/Utilities/Test_Requires.cpp:29:3: error: no matching function
+ *    for call to 'foo'
+ *   foo(std::list<double>{});
+ *   ^~~
+ * ./tests/Unit/Utilities/Test_Requires.cpp:15:13: note: candidate
+ *     template ignored: substitution failure [with T = std::__1::list<double,
+ *     std::__1::allocator<double> >]: no type named
+ *     'template_error_types_failed_to_meet_requirements_on_template_parameters'
+ *     in 'Requires_detail::requires_impl<false>'
+ * std::string foo(const T&) {
+ *             ^
+ * 1 error generated.
+ * \endcode
+ *
+ * Here is an example of how write function overloads using `Requires` or to
+ * express constraints on the template parameters:
+ * \snippet Utilities/Test_Requires.cpp function_definitions
+ *
+ * \note
+ * Using `Requires` is safer than using `std::enable_if_t` because the
+ * nested type alias is of type `std::nullptr_t` and so usage is always:
+ * \code
+ * template <typename T, Requires<(bool depending on T)> = nullptr>
+ * \endcode
+ */
+template <bool B>
+using Requires = typename Requires_detail::requires_impl<
+    B>::template_error_types_failed_to_meet_requirements_on_template_parameters;

--- a/src/Utilities/StdHelpers.hpp
+++ b/src/Utilities/StdHelpers.hpp
@@ -21,6 +21,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "Utilities/Requires.hpp"
 #include "Utilities/StlStreamDeclarations.hpp"
 #include "Utilities/TypeTraits.hpp"
 
@@ -129,7 +130,7 @@ inline std::ostream& operator<<(std::ostream& os,
  * \ingroup Utilities
  * \brief Output all the key, value pairs of a map
  */
-template <typename Map, typename std::enable_if_t<tt::is_maplike<Map>::value>*>
+template <typename Map, Requires<tt::is_maplike<Map>::value>>
 inline std::ostream& operator<<(std::ostream& os, const Map& m) {
   StdHelpers_detail::print_helper(
       os, begin(m), end(m),
@@ -164,8 +165,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::set<T>& v) {
  * \ingroup Utilities
  * \brief Stream operator for std::unique_ptr
  */
-template <typename T,
-          typename std::enable_if_t<tt::is_streamable<std::ostream, T>::value>*>
+template <typename T, Requires<tt::is_streamable<std::ostream, T>::value>>
 inline std::ostream& operator<<(std::ostream& os, const std::unique_ptr<T>& t) {
   return os << *t;
 }
@@ -174,8 +174,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::unique_ptr<T>& t) {
  * \ingroup Utilities
  * \brief Stream operator for std::shared_ptr
  */
-template <typename T,
-          typename std::enable_if_t<tt::is_streamable<std::ostream, T>::value>*>
+template <typename T, Requires<tt::is_streamable<std::ostream, T>::value>>
 inline std::ostream& operator<<(std::ostream& os, const std::shared_ptr<T>& t) {
   return os << *t;
 }
@@ -193,8 +192,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::pair<T, U>& t) {
  * \ingroup Utilities
  * \brief Construct a string containing the keys of a map
  */
-template <typename Map,
-          typename std::enable_if_t<tt::is_maplike<Map>::value>* = nullptr>
+template <typename Map, Requires<tt::is_maplike_v<Map>> = nullptr>
 inline std::string keys_of(const Map& m) {
   std::ostringstream os;
   StdHelpers_detail::print_helper(

--- a/src/Utilities/StlStreamDeclarations.hpp
+++ b/src/Utilities/StlStreamDeclarations.hpp
@@ -23,6 +23,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "Utilities/Requires.hpp"
+
 namespace tt {
 template <typename S, typename T, typename>
 struct is_streamable;
@@ -43,9 +45,7 @@ std::ostream& operator<<(std::ostream& os, const std::array<T, N>& a);
 template <typename... Args>
 std::ostream& operator<<(std::ostream& os, const std::tuple<Args...>& t);
 
-template <
-    typename Map,
-    typename std::enable_if_t<tt::is_maplike<Map, void>::value>* = nullptr>
+template <typename Map, Requires<tt::is_maplike<Map, void>::value> = nullptr>
 std::ostream& operator<<(std::ostream& os, const Map& m);
 
 template <typename T>
@@ -55,13 +55,11 @@ template <typename T>
 inline std::ostream& operator<<(std::ostream& os, const std::set<T>& v);
 
 template <typename T,
-          typename std::enable_if_t<
-              tt::is_streamable<std::ostream, T, void>::value>* = nullptr>
+          Requires<tt::is_streamable<std::ostream, T, void>::value> = nullptr>
 std::ostream& operator<<(std::ostream& os, const std::unique_ptr<T>& t);
 
 template <typename T,
-          typename std::enable_if_t<
-              tt::is_streamable<std::ostream, T, void>::value>* = nullptr>
+          Requires<tt::is_streamable<std::ostream, T, void>::value> = nullptr>
 std::ostream& operator<<(std::ostream& os, const std::shared_ptr<T>& t);
 
 template <typename T, typename U>

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -25,6 +25,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "Utilities/Requires.hpp"
 #include "Utilities/StlStreamDeclarations.hpp"
 
 /// \ingroup TypeTraits
@@ -691,7 +692,7 @@ struct is_maplike<T,
                   cpp17::void_t<typename T::key_type, typename T::mapped_type,
                                 decltype(std::declval<T&>()[std::declval<
                                     const typename T::key_type&>()]),
-                                std::enable_if_t<tt::is_iterable_v<T>>>>
+                                Requires<tt::is_iterable_v<T>>>>
     : std::true_type {};
 /// \endcond
 /// \see is_maplike
@@ -742,7 +743,7 @@ template <typename S, typename T>
 struct is_streamable<
     S, T, cpp17::void_t<decltype(std::declval<std::add_lvalue_reference_t<S>>()
                                  << std::declval<T>()),
-                        std::enable_if_t<not std::is_same<S, T>::value>>>
+                        Requires<not std::is_same<S, T>::value>>>
     : std::true_type {};
 /// \endcond
 /// \see is_streamable
@@ -786,15 +787,15 @@ using is_streamable_t = typename is_streamable<S, T>::type;
 /// \snippet Utilities/Test_TypeTraits.cpp is_string_like_example
 /// \see std::string std::is_same
 /// \tparam T the type to check
-template <typename T, typename = cpp17::void_t<>>
+template <typename T, typename = std::nullptr_t>
 struct is_string_like : std::false_type {};
 /// \cond HIDDEN_SYMBOLS
 template <typename T>
 struct is_string_like<
-    T, std::enable_if_t<
-           std::is_same<std::decay_t<T>, std::string>::value or
-           std::is_same<std::decay_t<std::remove_pointer_t<std::decay_t<T>>>,
-                        char>::value>> : std::true_type {};
+    T,
+    Requires<std::is_same<std::decay_t<T>, std::string>::value or
+             std::is_same<std::decay_t<std::remove_pointer_t<std::decay_t<T>>>,
+                          char>::value>> : std::true_type {};
 /// \endcond
 /// \see is_string_like
 template <typename T>
@@ -837,7 +838,7 @@ using is_string_like_t = typename is_string_like<T>::type;
 /// \snippet Utilities/Test_TypeTraits.cpp has_get_clone_example
 /// \see has_clone
 /// \tparam T the type to check
-template <typename T, typename = cpp17::void_t<>, typename = void>
+template <typename T, typename = cpp17::void_t<>, typename = std::nullptr_t>
 struct has_get_clone : std::false_type {};
 /// \cond HIDDEN_SYMBOLS
 // The ugliness with two void template parameters is because clang does not
@@ -846,15 +847,14 @@ template <typename T>
 struct has_get_clone<
     T, cpp17::void_t<decltype(
            std::declval<std::remove_pointer_t<std::decay_t<T>>>().get_clone())>,
-    std::enable_if_t<not tt::is_a_v<std::unique_ptr, std::decay_t<T>> and
-                     not tt::is_a_v<std::shared_ptr, std::decay_t<T>>>>
+    Requires<not tt::is_a_v<std::unique_ptr, std::decay_t<T>> and
+             not tt::is_a_v<std::shared_ptr, std::decay_t<T>>>>
     : std::true_type {};
 template <typename T>
-struct has_get_clone<
-    T, cpp17::void_t<std::enable_if_t<tt::is_a_v<std::unique_ptr, T>>,
-                     decltype(std::declval<T>()->get_clone())>,
-    std::enable_if_t<tt::is_a_v<std::unique_ptr, std::decay_t<T>> or
-                     tt::is_a_v<std::shared_ptr, std::decay_t<T>>>>
+struct has_get_clone<T, cpp17::void_t<Requires<tt::is_a_v<std::unique_ptr, T>>,
+                                      decltype(std::declval<T>()->get_clone())>,
+                     Requires<tt::is_a_v<std::unique_ptr, std::decay_t<T>> or
+                              tt::is_a_v<std::shared_ptr, std::decay_t<T>>>>
     : std::true_type {};
 /// \endcond
 /// \see has_get_clone
@@ -897,20 +897,18 @@ using has_get_clone_t = typename has_get_clone<T>::type;
 /// \snippet Utilities/Test_TypeTraits.cpp has_clone_example
 /// \see has_get_clone
 /// \tparam T the type to check
-template <typename T, typename = cpp17::void_t<>, typename = void>
+template <typename T, typename = cpp17::void_t<>, typename = std::nullptr_t>
 struct has_clone : std::false_type {};
 /// \cond HIDDEN_SYMBOLS
 template <typename T>
-struct has_clone<
-    T, cpp17::void_t<decltype(std::declval<T>().clone())>,
-    std::enable_if_t<not tt::is_a_v<std::unique_ptr, std::decay_t<T>> and
-                     not tt::is_a_v<std::shared_ptr, std::decay_t<T>>>>
+struct has_clone<T, cpp17::void_t<decltype(std::declval<T>().clone())>,
+                 Requires<not tt::is_a_v<std::unique_ptr, std::decay_t<T>> and
+                          not tt::is_a_v<std::shared_ptr, std::decay_t<T>>>>
     : std::true_type {};
 template <typename T>
-struct has_clone<
-    T, cpp17::void_t<decltype(std::declval<T>()->clone())>,
-    std::enable_if_t<tt::is_a_v<std::unique_ptr, std::decay_t<T>> or
-                     tt::is_a_v<std::shared_ptr, std::decay_t<T>>>>
+struct has_clone<T, cpp17::void_t<decltype(std::declval<T>()->clone())>,
+                 Requires<tt::is_a_v<std::unique_ptr, std::decay_t<T>> or
+                          tt::is_a_v<std::shared_ptr, std::decay_t<T>>>>
     : std::true_type {};
 /// \endcond
 /// \see has_clone

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -97,8 +97,7 @@ T serialize_and_deserialize(const T& t) {
 }
 
 /// Test for copy semantics assuming operator== is implement correctly
-template <typename T,
-          typename std::enable_if<tt::has_equivalence<T>::value, int>::type = 0>
+template <typename T, Requires<tt::has_equivalence<T>::value> = nullptr>
 void test_copy_semantics(const T& a) {
   static_assert(std::is_copy_assignable<T>::value,
                 "Class is not copy assignable.");
@@ -120,8 +119,7 @@ void test_copy_semantics(const T& a) {
 
 /// Test for move semantics assuming operator== is implement correctly
 /// \requires `std::is_rvalue_reference<decltype(a)>::%value` is true
-template <typename T,
-          typename std::enable_if<tt::has_equivalence<T>::value, int>::type = 0>
+template <typename T, Requires<tt::has_equivalence<T>::value> = nullptr>
 void test_move_semantics(T&& a, const T& comparison) {
   static_assert(std::is_rvalue_reference<decltype(a)>::value,
                 "Must move into test_move_semantics");

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -12,6 +12,7 @@ set(UTILITIES_TESTS
     Utilities/Test_MakeArray.cpp
     Utilities/Test_Math.cpp
     Utilities/Test_PrettyType.cpp
+    Utilities/Test_Requires.cpp
     Utilities/Test_StdHelpers.cpp
     Utilities/Test_TaggedTuple.cpp
     Utilities/Test_TypeTraits.cpp

--- a/tests/Unit/Utilities/Test_Requires.cpp
+++ b/tests/Unit/Utilities/Test_Requires.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+#include <list>
+#include <vector>
+
+#include "Utilities/Requires.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+/// [function_definitions]
+/// [foo_definition]
+template <typename T, Requires<tt::is_a_v<std::vector, T>> = nullptr>
+std::string foo(const T& /*unused*/) {
+  return "vector";
+}
+/// [foo_definition]
+
+template <typename T, Requires<tt::is_a_v<std::list, T>> = nullptr>
+std::string foo(const T& /*unused*/) {
+  return "list";
+}
+/// [function_definitions]
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Utilities.Requires", "[Unit][Utilities]") {
+  CHECK("vector" == foo(std::vector<double>{}));
+  CHECK("list" == foo(std::list<double>{}));
+}


### PR DESCRIPTION
I was reading the proposal [here](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0726r0.html) which echos a feeling I've developed of Concepts since seeing how power constexpr-if statements are. However, it got me thinking that `enable_if` gives rather unhelpful errors to someone not trained, and is also not the best name, I think. So I implemented a `Requires` type alias that produces as helpful of an error message (of course welcome to changes) as possible, while not breaking SFINAE (a `static_assert` is not SFINAE friendly). Here is a small sample program and the output:

```cpp
template <typename T, Requires<is_a_v<std::vector, T>> = nullptr>
void foo(const T&) {
  std::cout << "vector\n";
}

int main() {
  foo(std::vector<double>{});
  foo(std::list<double>{});
}
```

which fails to compile because there is no `foo` defined whose requirements `list` could satisfy. The error message with clang is:
```
clang++ -std=c++14 -stdlib=libc++ ./part-05-concepts.cpp 
./part-05-concepts.cpp:60:3: error: no matching function for call to 'foo'
  foo(std::list<double>{});
  ^~~
./part-05-concepts.cpp:54:6: note: candidate template ignored: substitution failure [with T = std::__1::list<double,
      std::__1::allocator<double> >]: no type named 'Requires_not_satisfied_see_functions_or_classes_Requires_parameters' in
      'Requires_detail::requires_impl<false>'
void foo(const T&) {
     ^
1 error generated.
```

and with GCC:

```
g++ -std=c++14 ./part-05-concepts.cpp 
./part-05-concepts.cpp: In function ‘int main()’:
./part-05-concepts.cpp:60:26: error: no matching function for call to ‘foo(std::__cxx11::list<double>)’
   foo(std::list<double>{});
                          ^
./part-05-concepts.cpp:54:6: note: candidate: template<class T, typename Requires_detail::requires_impl<is_a_v<std::vector, T> >::Requires_not_satisfied_see_functions_or_classes_Requires_parameters <anonymous> > void foo(const T&)
 void foo(const T&) {
      ^~~
./part-05-concepts.cpp:54:6: note:   template argument deduction/substitution failed:
./part-05-concepts.cpp:53:58: error: no type named ‘Requires_not_satisfied_see_functions_or_classes_Requires_parameters’ in ‘struct Requires_detail::requires_impl<false>’
 template <typename T, Requires<is_a_v<std::vector, T>> = nullptr>
                                                          ^~~~~~~
./part-05-concepts.cpp:53:58: note: invalid template non-type parameter
```

The other difference to `enable_if` is that you always must write `Requires<..> = nullptr` because the alias is to a `std::nullptr_t`. In this sense it's more limited than `enable_if`, but I think also easier to understand.

I've changed `DataBox` to use `Requires` (note it must be capitalized because `requires` is a C++20 keyword), but before changing everything I wanted to see if people think this is a good idea.