### PR TITLE
Use libstdc++ with Docker

### DIFF
--- a/.travis/TravisPushDocumentation.sh
+++ b/.travis/TravisPushDocumentation.sh
@@ -18,7 +18,7 @@ spack load blaze
 spack load brigand
 spack load catch
 spack load libxsmm
-spack load yaml-cpp%${CC}
+spack load yaml-cpp
 
 # We use cron jobs to deploy to gh-pages. Since this still runs all jobs we
 # only actually build documentation for one job but let the others run tests.

--- a/cmake/SetupLIBCXX.cmake
+++ b/cmake/SetupLIBCXX.cmake
@@ -1,39 +1,46 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  include(CheckCXXCompilerFlag)
-  unset(CXX_FLAG_WORKS CACHE)
-  set(CMAKE_REQUIRED_QUIET 1)
-  check_cxx_compiler_flag("-stdlib=libc++" CXX_FLAG_WORKS)
-  unset(CMAKE_REQUIRED_QUIET)
-  # If we cannot use the -stdlib=libc++ flag directly we must find libc++
-  # explicity by searching on the file system
-  if (CXX_FLAG_WORKS AND NOT LIBCXX_ROOT)
-    message(STATUS "libc++: Compiler supports -stdlib=libc++, no need to find "
+  if (NOT USE_LIBCXX)
+    option(USE_LIBCXX "Use libc++ as standard library" OFF)
+  endif()
+  if (USE_LIBCXX)
+    include(CheckCXXCompilerFlag)
+    unset(CXX_FLAG_WORKS CACHE)
+    set(CMAKE_REQUIRED_QUIET 1)
+    check_cxx_compiler_flag("-stdlib=libc++" CXX_FLAG_WORKS)
+    unset(CMAKE_REQUIRED_QUIET)
+    # If we cannot use the -stdlib=libc++ flag directly we must find libc++
+    # explicity by searching on the file system
+    if (CXX_FLAG_WORKS AND NOT LIBCXX_ROOT)
+      message(STATUS "libc++: Compiler supports -stdlib=libc++, no need to find "
         "libc++ explicity. Specify `LIBCXX_ROOT` to use a specified version of "
         "libc++. If the specified version is not found we fall back to the "
         "system libc++, if available.")
-  else()
-    find_package(LIBCXX REQUIRED)
-    set(
+    else()
+      find_package(LIBCXX REQUIRED)
+      set(
         CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}\
  -L${LIBCXXABI_LIBRARIES} -L${LIBCXX_LIBRARIES}"
-    )
-    include_directories(${LIBCXX_INCLUDE_DIRS})
-    message(STATUS "libc++ include: ${LIBCXX_INCLUDE_DIRS}")
-    message(STATUS "libc++ libraries: ${LIBCXX_LIBRARIES}")
-  endif()
+        )
+      include_directories(${LIBCXX_INCLUDE_DIRS})
+      message(STATUS "libc++ include: ${LIBCXX_INCLUDE_DIRS}")
+      message(STATUS "libc++ libraries: ${LIBCXX_LIBRARIES}")
+    endif()
 
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
-  set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+    set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 
-  option(
+    option(
       LIBCXX_DEBUG
       "Enable debug mode for libc++ in Debug builds"
       OFF
-  )
-  if(LIBCXX_DEBUG)
-    set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -D_LIBCPP_DEBUG=0")
+      )
+    if(LIBCXX_DEBUG)
+      set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} -D_LIBCPP_DEBUG=0")
+    endif()
   endif()
 endif()

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -86,8 +86,7 @@ RUN /work/spack/bin/spack install gsl%gcc
 RUN /work/spack/bin/spack install libxsmm
 # On 09/03/2017 CMake 3.9.0 failed to build with spack
 RUN /work/spack/bin/spack install cmake@3.8.0
-RUN /work/spack/bin/spack install yaml-cpp@develop%gcc ^cmake@3.8.0
-RUN /work/spack/bin/spack install yaml-cpp@develop%clang ^cmake@3.8.0 cxxflags="-stdlib=libc++" ldflags="-stdlib=libc++" cppflags="-stdlib=libc++"
+RUN /work/spack/bin/spack install yaml-cpp@develop
 
 # Download and build the Charm++ version used by SpECTRE
 # We build both Clang and GCC versions of Charm++ so that all our tests can
@@ -97,7 +96,7 @@ WORKDIR /work/charm
 RUN git checkout ${CHARM_GIT_TAG}
 RUN ./build charm++ multicore-linux64 gcc ${PARALLEL_MAKE_ARG} -g -O0
 RUN ./build charm++ multicore-linux64 clang ${PARALLEL_MAKE_ARG} \
--g -O0 -stdlib=libc++
+-g -O0
 
 WORKDIR /work
 
@@ -107,3 +106,4 @@ RUN echo 'spack load brigand' >> /root/.bashrc
 RUN echo 'spack load blaze' >> /root/.bashrc
 RUN echo 'spack load gsl' >> /root/.bashrc
 RUN echo 'spack load libxsmm' >> /root/.bashrc
+RUN echo 'spack load yaml-cpp' >> /root/.bashrc

--- a/containers/Dockerfile.travis
+++ b/containers/Dockerfile.travis
@@ -82,7 +82,7 @@ RUN bash -c ". /etc/profile.d/lmod.sh; \
     spack load brigand; \
     spack load catch; \
     spack load libxsmm; \
-    spack load yaml-cpp%${CC}; \
+    spack load yaml-cpp; \
     cmake -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
           -D CMAKE_C_COMPILER=${CC} \
           -D CMAKE_CXX_COMPILER=${CXX} \
@@ -125,7 +125,7 @@ RUN if [ -z "${RUN_CPPCHECK}" ] \
                spack load brigand; \
                spack load catch; \
                spack load libxsmm; \
-               spack load yaml-cpp%${CC}; \
+               spack load yaml-cpp; \
                ctest --output-on-failure"; \
     fi
 


### PR DESCRIPTION
With the improved DataBox we no longer need to rely on libc++ with Clang. This will make dealing with yaml-cpp a lot easier since then we can just use libstdc++ on Travis.