### PR TITLE
Local time stepping (time steppers)

### DIFF
--- a/src/DataStructures/GeneralIndexIterator.hpp
+++ b/src/DataStructures/GeneralIndexIterator.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <type_traits>
+#include <vector>
+
+#include "Utilities/Gsl.hpp"
+
+/// Iterate over a generic "block" of coordinates.  The constructor
+/// takes a container of pairs defining the range (inclusive start,
+/// exclusive end) of each coordinate.  The utility function
+/// make_general_index_iterator() is provided for easier construction.
+template <typename Container>
+class GeneralIndexIterator {
+ public:
+  using value_type = typename Container::value_type::first_type;
+  using iterator_type = typename std::vector<value_type>::const_iterator;
+
+  explicit GeneralIndexIterator(Container ranges) noexcept
+      : ranges_(std::move(ranges)) {
+    current_.reserve(ranges_.size());
+    for (const auto& range : ranges_) {
+      if (range.first == range.second) {
+        done_ = true;
+        return;
+      }
+      current_.push_back(range.first);
+    }
+  }
+
+  /// Access the given coordinate of the current value.
+  const value_type& operator[](size_t i) const noexcept { return current_[i]; }
+
+  /// Check whether the iterator is complete.  Calling any of the
+  /// other methods on a completed iterator is undefined behavior.
+  explicit operator bool() const noexcept { return not done_; }
+
+  void operator++() noexcept {
+    for (size_t index = 0; index < current_.size(); ++index) {
+      ++current_[index];
+      if (current_[index] != gsl::at(ranges_, index).second) { return; }
+      current_[index] = gsl::at(ranges_, index).first;
+    }
+    done_ = true;
+  }
+
+  /// Iterate over the coordinates of the current value.
+  //@{
+  iterator_type cbegin() const noexcept { return current_.cbegin(); }
+  iterator_type cend() const noexcept { return current_.cend(); }
+  iterator_type begin() const noexcept { return cbegin(); }
+  iterator_type end() const noexcept { return cend(); }
+  //@}
+
+ private:
+  Container ranges_;
+  std::vector<value_type> current_{};
+  bool done_{false};
+};
+
+/// Construct a GeneralIndexIterator
+template <typename Container>
+GeneralIndexIterator<std::decay_t<Container>> make_general_index_iterator(
+    Container&& ranges) noexcept {
+  return GeneralIndexIterator<std::decay_t<Container>>(
+      std::forward<Container>(ranges));
+}

--- a/src/Numerical/Interpolation/LagrangePolynomial.hpp
+++ b/src/Numerical/Interpolation/LagrangePolynomial.hpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines functions lagrange_polynomial
+
+#pragma once
+
+#include <iterator>
+
+#include "ErrorHandling/Assert.hpp"
+
+/// Evaluate the jth Lagrange interpolating polynomial with the given
+/// control points where j is the index of index_point.
+template <typename Iterator>
+double lagrange_polynomial(const Iterator& index_point,
+                           double x,
+                           const Iterator& control_points_begin,
+                           const Iterator& control_points_end) {
+  ASSERT(control_points_begin != control_points_end, "No control points");
+
+  const double x_j = *index_point;
+  double result = 1.;
+  for (auto m_it = control_points_begin; m_it != control_points_end; ++m_it) {
+    if (m_it == index_point) { continue; }
+    const double x_m = *m_it;
+    result *= (x_m - x) / (x_m - x_j);
+  }
+  return result;
+}
+
+/// Evaluate the jth (zero-indexed) Lagrange interpolating polynomial
+/// with the given control points.
+template <typename Iterator>
+double lagrange_polynomial(size_t j, double x,
+                           const Iterator& control_points_begin,
+                           const Iterator& control_points_end) {
+  ASSERT(j < static_cast<size_t>(std::distance(control_points_begin,
+                                               control_points_end)),
+         "Polynomial number out of range " << j << " > "
+         << (std::distance(control_points_begin, control_points_end) - 1));
+  return lagrange_polynomial(std::next(control_points_begin,
+                                       static_cast<ssize_t>(j)),
+                             x, control_points_begin, control_points_end);
+}

--- a/src/Time/Time.hpp
+++ b/src/Time/Time.hpp
@@ -200,7 +200,8 @@ inline Time operator+(const TimeDelta& a, Time b) noexcept {
 }
 
 inline Time operator-(Time a, const TimeDelta& b) noexcept {
-  a -= b;
+  // clang-tidy misfeature: warns about boost internals here
+  a -= b;  // NOLINT
   return a;
 }
 
@@ -252,7 +253,8 @@ inline Time& Time::operator+=(const TimeDelta& delta) noexcept {
 
 inline Time& Time::operator-=(const TimeDelta& delta) noexcept {
   *this = this->with_slab(delta.slab_);
-  fraction_ -= delta.fraction_;
+  // clang-tidy misfeature: warns about boost internals here
+  fraction_ -= delta.fraction_;  // NOLINT
   range_check();
   return *this;
 }

--- a/src/Time/Time.hpp
+++ b/src/Time/Time.hpp
@@ -57,6 +57,26 @@ class Time {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  /// A comparison operator that compares Times structurally, i.e.,
+  /// just looking at the class members.  This is only intended for
+  /// use as the comparator in a map.  The returned ordering does not
+  /// match the time ordering and opposite sides of slab boundaries do
+  /// not compare equal.  It is, however, much faster to compute than
+  /// the temporal ordering, so it is useful when an ordering is
+  /// required, but the ordering does not have to be physically
+  /// meaningful.
+  struct StructuralCompare {
+    bool operator()(const Time& a, const Time& b) const {
+      if (a.fraction().numerator() != b.fraction().numerator()) {
+        return a.fraction().numerator() < b.fraction().numerator();
+      }
+      if (a.fraction().denominator() != b.fraction().denominator()) {
+        return a.fraction().denominator() < b.fraction().denominator();
+      }
+      return a.slab() < b.slab();
+    }
+  };
+
  private:
   Slab slab_;
   rational_t fraction_;

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -169,6 +169,11 @@ class AdamsBashforthN : public TimeStepper::Inherit {
           history,
       const TimeDelta& time_step) const noexcept;
 
+  template <typename Vars, typename DerivVars>
+  typename std::deque<std::tuple<Time, Vars, DerivVars>>::const_iterator
+  needed_history(const std::deque<std::tuple<Time, Vars, DerivVars>>& history)
+      const noexcept;
+
   size_t number_of_substeps() const noexcept override;
 
   size_t number_of_past_steps() const noexcept override;
@@ -534,6 +539,18 @@ BoundaryVars AdamsBashforthN::compute_boundary_delta(
   }  // for coupling_evaluation
 
   return accumulated_change;
+}
+
+template <typename Vars, typename DerivVars>
+typename std::deque<std::tuple<Time, Vars, DerivVars>>::const_iterator
+AdamsBashforthN::needed_history(
+    const std::deque<std::tuple<Time, Vars, DerivVars>>& history) const
+    noexcept {
+ if (history.size() >= target_order_) {
+   return history.end() - static_cast<ssize_t>(target_order_ - 1);
+ } else {
+   return history.begin();
+ }
 }
 
 template <typename Iterator>

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -65,6 +65,15 @@ class AdamsBashforthN : public TimeStepper::Inherit {
       const std::deque<std::tuple<Time, Vars, DerivVars>>& history,
       const TimeDelta& time_step) const noexcept;
 
+  template <typename BoundaryVars, typename FluxVars, typename Coupling>
+  BoundaryVars compute_boundary_delta(
+      const Coupling& coupling,
+      const std::vector<std::deque<std::tuple<Time, BoundaryVars, FluxVars>>>&
+          history,
+      const TimeDelta& time_step) const noexcept {
+    ERROR("Unimpemented");
+  }
+
   size_t number_of_substeps() const noexcept override;
 
   size_t number_of_past_steps() const noexcept override;

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -9,17 +9,22 @@
 #include <array>
 #include <boost/iterator/transform_iterator.hpp>
 #include <deque>
+#include <functional>
 #include <iterator>
 #include <memory>
 #include <string>
 #include <tuple>
 #include <vector>
 
+#include "DataStructures/GeneralIndexIterator.hpp"
+#include "DataStructures/MakeWithValue.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/Error.hpp"
+#include "Numerical/Interpolation/LagrangePolynomial.hpp"
 #include "Options/Options.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/CachedFunction.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace TimeSteppers {
@@ -65,14 +70,104 @@ class AdamsBashforthN : public TimeStepper::Inherit {
       const std::deque<std::tuple<Time, Vars, DerivVars>>& history,
       const TimeDelta& time_step) const noexcept;
 
+  /*!
+   * An explanation of the computation being performed by this
+   * function:
+   *
+   * We number the sides \f$1\f$ through \f$S\f$, and let the
+   * evaluation times on side \f$s\f$ be \f$\ldots, t^s_{-1}, t^s_0,
+   * t^s_1, \ldots\f$, with the starting location of the numbering
+   * arbitrary.  The union of all these sets of times produces the
+   * sequence \f$\ldots, \tilde{t}_{-1}, \tilde{t}_0, \tilde{t}_1,
+   * \ldots\f$, again numbered arbitrarily.  For example, one possible
+   * sequence of times for a two-sided boundary is:
+   * \f{equation}
+   *   \begin{aligned}
+   *     \text{Side 1:} \\ \text{Union times:} \\ \text{Side 2:}
+   *   \end{aligned}
+   *   \cdots
+   *   \begin{gathered}
+   *     t^1_4 \\ \tilde{t}_8 \\ t^2_1
+   *   \end{gathered}
+   *   \leftarrow \Delta \tilde{t}_8 \rightarrow
+   *   \begin{gathered}
+   *    \, \\ \tilde{t}_9 \\ t^2_2
+   *   \end{gathered}
+   *   \leftarrow \Delta \tilde{t}_9 \rightarrow
+   *   \begin{gathered}
+   *     t^1_5 \\ \tilde{t}_{10} \\ \,
+   *   \end{gathered}
+   *   \cdots
+   * \f}
+   *
+   * We call the indices of the start and end times in the union time
+   * set \f$n_S\f$ and \f$n_E\f$, respectively, so for the above
+   * example, if we wish to compute the step on side 1 from
+   * \f$t^1_4\f$ to \f$t^1_5\f$, we would have \f$n_S = 8\f$ and
+   * \f$n_E = 10\f$.  The indices of steps on each side containing or
+   * starting with union time number \f$n\f$ are denoted
+   * \f$\vec{m}_n\f$, so in the above example \f$\vec{m}_9 = (4,
+   * 2)\f$.  The union indices corresponding to the start of a set of
+   * side step indices \f$\vec{m}\f$ are denoted
+   * \f$\vec{n}_{\vec{m}}\f$, so in the example \f$\vec{n}_{(4, 2)} =
+   * (8, 9)\f$.  In the below equations, addition, subtraction, min,
+   * and max operations applied to vectors operate on each component
+   * individually, i.e., \f$\vec{q} + k = (q^1 + k, \ldots, q^S +
+   * k)\f$.
+   *
+   * Let \f$k\f$ be the order of the integrator.  For a sequence of
+   * times \f$t^s_{j_s - (k-1)}, \ldots, t^s_{j_s}\f$ on each side
+   * \f$s\f$, we can write the cardinal functions on those times as
+   * \f{equation}{
+   *   \newcommand\of[1]{\!\!\left(#1\right)}
+   *   C_{a_1, \ldots, a_S}(t_1, \ldots, t_S; j_1, \ldots, j_S) =
+   *   \prod_{s=1}^S \ell_{a_s}\of{t_s; t^s_{j_s - (k-1)}, \ldots, t^s_{j_s}},
+   * \f}
+   * with \f$\ell_a(t; x_1, \ldots, x_k)\f$ the Lagrange interpolating
+   * polynomials.  (Note that we take the indices \f$a\f$ to run from
+   * \f$1\f$ to \f$k\f$ here, but from \f$0\f$ to \f$k-1\f$ in the
+   * code.)  The cardinal function satisfies
+   * \f$ C_{a_1, \ldots, a_S}(t^1_{i_1}, \ldots, t^S_{i_S}; j_1, \ldots, j_S) =
+   *   \prod_{s=1}^S \delta_{i_s, j_s + a_s - k} \f$.
+   * We write the integral of a cardinal function using an
+   * Adams-Bashforth step based on the union times along the diagonal
+   * \f$t_1 = t_2 = \cdots = t_S\f$ from \f$\tilde{t}_n\f$ to
+   * \f$\tilde{t}_{n+1}\f$ as
+   * \f{equation}{
+   *   \newcommand\of[1]{\!\!\left(#1\right)}
+   *   I_{n,\vec{q}} =
+   *   \Delta \tilde{t}_n
+   *   \sum_{j = 0}^{k-1}
+   *   \tilde{\alpha}_{nj}
+   *   C_{\vec{q}-\vec{m}_n+k}
+   *     \of{\tilde{t}_{n - j}, \ldots, \tilde{t}_{n - j}; \vec{m}_n},
+   * \f}
+   * where \f$\tilde{\alpha}_{nj}\f$ are the Adams-Bashforth
+   * coefficients derived from the union times and \f$\vec{q}\f$ is a
+   * vector specifying the cardinal function indices.  The boundary
+   * delta for the step is then
+   * \f{equation}{
+   *   \newcommand\mat{\mathbf}
+   *   \mat{F}_{n_S, n_E} =
+   *   \mspace{-7mu}
+   *   \sum_{\vec{q} = \vec{m}_{n_s}-(k-1)}^{\vec{m}_{n_E-1}}
+   *   \mspace{-4mu}
+   *   \mat{D}_{\vec{q}}
+   *   \mspace{-4mu}
+   *   \sum_{n = \max\left\{n_S, \vec{n}_{\vec{q}} \right\}}
+   *       ^{\min\left\{n_E, \vec{n}_{\vec{q} + k}\right\} - 1}
+   *   \mspace{-7mu}
+   *   I_{n,\vec{q}},
+   * \f}
+   * where \f$\mat{D}_{\vec{q}}\f$ is the coupling function evaluated
+   * at the side values at side step indices \f$\vec{q}\f$.
+   */
   template <typename BoundaryVars, typename FluxVars, typename Coupling>
   BoundaryVars compute_boundary_delta(
       const Coupling& coupling,
       const std::vector<std::deque<std::tuple<Time, BoundaryVars, FluxVars>>>&
           history,
-      const TimeDelta& time_step) const noexcept {
-    ERROR("Unimpemented");
-  }
+      const TimeDelta& time_step) const noexcept;
 
   size_t number_of_substeps() const noexcept override;
 
@@ -98,6 +193,45 @@ class AdamsBashforthN : public TimeStepper::Inherit {
 
   static std::vector<double> constant_coefficients(size_t order) noexcept;
 
+  /// Comparator for ordering by "simulation time"
+  class SimulationLess {
+   public:
+    explicit SimulationLess(const bool forward_in_time) noexcept
+        : forward_in_time_(forward_in_time) {}
+
+    bool operator()(const Time& a, const Time& b) const noexcept {
+      return forward_in_time_ ? a < b : b < a;
+    }
+
+   private:
+    bool forward_in_time_;
+  };
+
+  /// Convert an iterator over history entries to an iterator over
+  /// their times.
+  template <typename Iterator>
+  static auto time_iter(const Iterator& it) noexcept {
+    // Cast the overloaded get function to a function pointer taking a
+    // history entry to a time reference.  This is needed to prevent the
+    // boost::make_transform_iterator calls from being ambiguous.
+    const Time& (*const get_time)(const typename Iterator::value_type&) =
+        std::get<0>;
+    return boost::make_transform_iterator(it, get_time);
+  }
+
+  /// Find the step on a given side containing the given time.  Steps
+  /// contain their start time but not their end time.
+  template <typename SideHistory, typename Compare>
+  static typename SideHistory::const_iterator step_containing_time(
+      const SideHistory& side_hist,
+      const Time& time,
+      const Compare& comparator) noexcept {
+    return std::upper_bound(time_iter(side_hist.begin()),
+                            time_iter(side_hist.end()),
+                            time, comparator)
+               .base() - 1;
+  }
+
   size_t target_order_ = 3;
   bool is_self_starting_ = true;
 };
@@ -114,13 +248,9 @@ TimeDelta AdamsBashforthN::update_u(
          "Length of history (" << history.size() << ") "
          << "should not exceed target order (" << target_order_ << ")");
 
-  // Cast the overloaded get function to a function pointer taking a
-  // history entry to a time reference.  This is needed to prevent the
-  // boost::make_transform_iterator calls from being ambiguous.
-  const Time& (*const get_time)(const decltype(history[0])&) = std::get<0>;
-  const auto& coefficients = get_coefficients(
-      boost::make_transform_iterator(history.cbegin(), get_time),
-      boost::make_transform_iterator(history.cend(), get_time), time_step);
+  const auto& coefficients = get_coefficients(time_iter(history.cbegin()),
+                                              time_iter(history.cend()),
+                                              time_step);
 
   switch (history.size()) {
     case 1: {
@@ -186,6 +316,224 @@ TimeDelta AdamsBashforthN::update_u(
     default:
       ERROR("Bad amount of history data: " << history.size());
   }
+}
+
+template <typename BoundaryVars, typename FluxVars, typename Coupling>
+BoundaryVars AdamsBashforthN::compute_boundary_delta(
+    const Coupling& coupling,
+    const std::vector<std::deque<std::tuple<Time, BoundaryVars, FluxVars>>>&
+        history,
+    const TimeDelta& time_step) const noexcept {
+  ASSERT(not is_self_starting_, "Unimplemented");
+
+  using HistoryEntry = decltype(history[0][0]);
+  using HistoryIterator = decltype(history[0].cbegin());
+
+  // Avoid billions of casts
+  const auto target_order_s = static_cast<ssize_t>(target_order_);
+
+  const SimulationLess simulation_less(time_step.is_positive());
+
+  // Cast the overloaded get function to a function pointer taking a
+  // history entry to a time reference.  This is needed to prevent the
+  // boost::make_transform_iterator calls from being ambiguous.
+  const Time& (*const get_time)(const HistoryEntry&) = std::get<0>;
+
+  // Time::value is fairly slow, so cache values.
+  auto time_value =
+      make_cached_function<Time, std::map, Time::StructuralCompare>(
+          [](const Time& t) noexcept { return t.value(); });
+
+  const size_t num_sides = history.size();
+
+  // Evaluate the cardinal function for a grid of points at a point on
+  // the diagonal.
+  const auto grid_cardinal_function =
+      [target_order_s, &time_value, &get_time](
+          const double evaluation_time,
+          const auto& function_index,
+          const auto& grid_times) noexcept {
+    double result = 1.;
+    for (size_t side = 0; side < grid_times.size(); ++side) {
+      // Stop calculating things if we're just going to multiply
+      // them by zero.
+      if (result == 0.) { break; }
+
+      // Makes an iterator with a map to give time as a double.
+      const auto make_lagrange_iterator =
+          [&time_value, &get_time](const HistoryIterator& it) noexcept {
+        return boost::make_transform_iterator(
+            it, [&time_value, &get_time](const HistoryEntry& h) noexcept {
+              return time_value(get_time(h));
+            });
+      };
+      result *= lagrange_polynomial(
+          make_lagrange_iterator(function_index[side]),
+          evaluation_time,
+          make_lagrange_iterator(grid_times[side] - (target_order_s - 1)),
+          make_lagrange_iterator(grid_times[side] + 1));
+    }
+    return result;
+  };
+
+  for (const auto& side_hist : history) {
+    ASSERT(not side_hist.empty(), "No data");
+    ASSERT(std::is_sorted(time_iter(side_hist.begin()),
+                          time_iter(side_hist.end()),
+                          simulation_less),
+           "History not in order");
+  }
+
+  // Start and end of the step we are trying to take
+  const Time start_time = get_time(history[0].back());
+  const Time end_time = start_time + time_step;
+
+  // Union of times of all step boundaries on any side.
+  const auto union_times =
+      [&end_time, &get_time, &history, &simulation_less]() noexcept {
+    std::set<Time, decltype(simulation_less)> ret({end_time}, simulation_less);
+    for (const auto& side_hist : history) {
+      ret.insert(time_iter(side_hist.cbegin()), time_iter(side_hist.cend()));
+      ASSERT(simulation_less(get_time(side_hist.back()), end_time),
+             "Please supply only older data: " << get_time(side_hist.back())
+             << " is not before " << end_time);
+    }
+    return ret;
+  }();
+
+  // Calculating the Adams-Bashforth coefficients is somewhat
+  // expensive, so we cache them.  ab_coefs(it) returns the
+  // coefficients used to step from *it to *(it + 1).
+  auto ab_coefs = [target_order_s, &union_times]() noexcept {
+    using Iter = decltype(union_times.cbegin());
+    auto compare = [](const Iter& a, const Iter& b) noexcept {
+      return Time::StructuralCompare{}(*a, *b);
+    };
+    return make_cached_function<Iter, std::map, decltype(compare)>(
+        [target_order = target_order_s](const Iter& last_time) noexcept {
+          const auto times_end = std::next(last_time);
+          const auto times_begin = std::prev(last_time, target_order - 1);
+          return get_coefficients(times_begin, times_end,
+                                  *times_end - *last_time);
+        },
+        std::move(compare));
+  }();
+
+  // Result variable.
+  auto accumulated_change =
+      make_with_value<BoundaryVars>(std::get<1>(history[0].back()), 0.);
+
+  // Ranges of values where we evaluate the coupling function.
+  std::vector<std::pair<HistoryIterator, HistoryIterator>>
+      coupling_evaluation_ranges;
+  for (size_t side = 0; side < num_sides; ++side) {
+    const auto& side_hist = history[side];
+    const auto current_step_on_side =
+        step_containing_time(side_hist, start_time, simulation_less);
+    ASSERT(std::distance(side_hist.begin(), current_step_on_side) >=
+           target_order_s - 1,
+           "Not enough data on side " << side << ": "
+           << std::distance(side_hist.begin(), current_step_on_side)
+           << " (" << get_time(side_hist.front()) << " to "
+           << get_time(*current_step_on_side) << ")");
+    coupling_evaluation_ranges.emplace_back(
+        current_step_on_side - (target_order_s - 1), side_hist.end());
+  }
+  for (auto coupling_evaluation =
+           make_general_index_iterator(std::move(coupling_evaluation_ranges));
+       coupling_evaluation;
+       ++coupling_evaluation) {
+    double deriv_coef = 0.;
+
+    // Prepare to loop over the union times relevant for the current
+    // coupling evaluation.
+
+    // Latest of start of current step (otherwise was computed in a
+    // previous call) and the times of the side data being coupled
+    // (since segments can't depend on later data).
+    Time coupling_start_time = start_time;
+    // Earliest of the end of the current step (since the step can't
+    // depend on later data), and target_order steps after the
+    // evaluation on each side (since AB only uses data for that
+    // long).
+    Time coupling_end_time = end_time;
+    for (size_t side = 0; side < num_sides; ++side) {
+      const auto& evaluation_side = coupling_evaluation[side];
+      if (simulation_less(coupling_start_time, get_time(*evaluation_side))) {
+        coupling_start_time = get_time(*evaluation_side);
+      }
+      if (history[side].end() - evaluation_side > target_order_s and
+          simulation_less(get_time(*(evaluation_side + target_order_s)),
+                          coupling_end_time)) {
+        coupling_end_time = get_time(*(evaluation_side + target_order_s));
+      }
+    }
+    const auto union_times_for_coupling_begin =
+        std::lower_bound(union_times.cbegin(), union_times.cend(),
+                         coupling_start_time, simulation_less);
+    const auto union_times_for_coupling_end =
+        std::lower_bound(union_times_for_coupling_begin, union_times.cend(),
+                         coupling_end_time, simulation_less);
+
+    // Iterators to the time on each side containing the union time we are
+    // currently considering.
+    std::vector<HistoryIterator> side_indices;
+    for (const auto& side_hist : history) {
+      side_indices.push_back(step_containing_time(
+          side_hist, *union_times_for_coupling_begin, simulation_less));
+    }
+
+    // This loop computes the coefficient of the coupling evaluation,
+    // i.e., the sum over the I_{n,q}, as deriv_coef.
+    for (auto union_time = union_times_for_coupling_begin;
+         union_time != union_times_for_coupling_end;
+         ++union_time) {
+      // Advance the step of any side where we've moved into the next
+      // step.
+      for (size_t side = 0; side < num_sides; ++side) {
+        const auto next_index = side_indices[side] + 1;
+        if (next_index != history[side].end() and
+            not simulation_less(*union_time, get_time(*next_index))) {
+          side_indices[side] = next_index;
+        }
+      }
+
+      // Perform a single step Adams-Bashforth integration of a grid
+      // cardinal function.  This computes the quantity called I_{n,q}
+      // in the documentation as integrated_cardinal_function.
+      const std::vector<double>& method_coefs = ab_coefs(union_time);
+      // This produces a reversed iterator pointing to the same entry
+      // as union_time.
+      auto recent_time = std::make_reverse_iterator(std::next(union_time));
+      auto method_it = method_coefs.begin();
+      double integrated_cardinal_function = 0.;
+      for (; method_it != method_coefs.end(); ++method_it, ++recent_time) {
+        integrated_cardinal_function +=
+            *method_it * grid_cardinal_function(time_value(*recent_time),
+                                                coupling_evaluation,
+                                                side_indices);
+      }
+      integrated_cardinal_function *=
+          (*std::next(union_time) - *union_time).value();
+
+      deriv_coef += integrated_cardinal_function;
+    }  // for union_time
+
+    if (deriv_coef != 0.) {
+      // We sometimes get exact zeros from the Lagrange polynomials.
+      // Skip the (potentially expensive) coupling calculation in that
+      // case.
+
+      std::vector<std::reference_wrapper<const FluxVars>> args;
+      for (size_t side = 0; side < num_sides; ++side) {
+        args.push_back(std::cref(std::get<2>(*coupling_evaluation[side])));
+      }
+
+      accumulated_change += deriv_coef * coupling(args);
+    }
+  }  // for coupling_evaluation
+
+  return accumulated_change;
 }
 
 template <typename Iterator>

--- a/src/Time/TimeSteppers/RungeKutta3.hpp
+++ b/src/Time/TimeSteppers/RungeKutta3.hpp
@@ -6,10 +6,15 @@
 
 #pragma once
 
+#include <algorithm>
 #include <deque>
+#include <functional>
+#include <iterator>
 #include <string>
 #include <tuple>
+#include <vector>
 
+#include "DataStructures/MakeWithValue.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Options/Options.hpp"
 #include "Time/Time.hpp"
@@ -43,6 +48,13 @@ class RungeKutta3 : public TimeStepper::Inherit {
       const std::deque<std::tuple<Time, Vars, DerivVars>>& history,
       const TimeDelta& time_step) const noexcept;
 
+  template <typename BoundaryVars, typename FluxVars, typename Coupling>
+  BoundaryVars compute_boundary_delta(
+      const Coupling& coupling,
+      const std::vector<std::deque<std::tuple<Time, BoundaryVars, FluxVars>>>&
+          history,
+      const TimeDelta& time_step) const noexcept;
+
   size_t number_of_substeps() const noexcept override;
 
   size_t number_of_past_steps() const noexcept override;
@@ -50,6 +62,14 @@ class RungeKutta3 : public TimeStepper::Inherit {
   bool is_self_starting() const noexcept override;
 
   double stable_step() const noexcept override;
+
+ private:
+  template <typename Vars, typename UnusedData, typename DerivVars>
+  TimeDelta step_work(
+    gsl::not_null<Vars*> u,
+    const std::deque<std::tuple<Time, Vars, UnusedData>>& history,
+    const TimeDelta& time_step,
+    const DerivVars& dt_vars) const noexcept;
 };
 
 template <typename Vars, typename DerivVars>
@@ -57,9 +77,35 @@ TimeDelta RungeKutta3::update_u(
     const gsl::not_null<Vars*> u,
     const std::deque<std::tuple<Time, Vars, DerivVars>>& history,
     const TimeDelta& time_step) const noexcept {
+  return step_work(u, history, time_step, std::get<2>(history.back()));
+}
+
+template <typename BoundaryVars, typename FluxVars, typename Coupling>
+BoundaryVars RungeKutta3::compute_boundary_delta(
+    const Coupling& coupling,
+    const std::vector<std::deque<std::tuple<Time, BoundaryVars, FluxVars>>>&
+        history,
+    const TimeDelta& time_step) const noexcept {
+  std::vector<std::reference_wrapper<const FluxVars>> coupling_args;
+  std::transform(history.begin(), history.end(),
+                 std::inserter(coupling_args, coupling_args.begin()),
+                 [](const auto& side) {
+                   return std::cref(std::get<2>(side.back()));
+                 });
+
+  auto u = make_with_value<BoundaryVars>(std::get<1>(history[0][0]), 0.);
+  step_work(make_not_null(&u), history[0], time_step, coupling(coupling_args));
+  return u;
+}
+
+template <typename Vars, typename UnusedData, typename DerivVars>
+TimeDelta RungeKutta3::step_work(
+    const gsl::not_null<Vars*> u,
+    const std::deque<std::tuple<Time, Vars, UnusedData>>& history,
+    const TimeDelta& time_step,
+    const DerivVars& dt_vars) const noexcept {
   const size_t substep = history.size() - 1;
   const auto& vars = std::get<1>(history.back());
-  const auto& dt_vars = std::get<2>(history.back());
   const auto& U0 = std::get<1>(history[0]);
 
   switch (substep) {

--- a/src/Time/TimeSteppers/RungeKutta3.hpp
+++ b/src/Time/TimeSteppers/RungeKutta3.hpp
@@ -55,6 +55,11 @@ class RungeKutta3 : public TimeStepper::Inherit {
           history,
       const TimeDelta& time_step) const noexcept;
 
+  template <typename Vars, typename DerivVars>
+  typename std::deque<std::tuple<Time, Vars, DerivVars>>::const_iterator
+  needed_history(const std::deque<std::tuple<Time, Vars, DerivVars>>& history)
+      const noexcept;
+
   size_t number_of_substeps() const noexcept override;
 
   size_t number_of_past_steps() const noexcept override;
@@ -139,6 +144,15 @@ TimeDelta RungeKutta3::step_work(
     default:
       ERROR("Bad substep value in RK3: " << substep);
   }
+}
+
+template <typename Vars, typename DerivVars>
+typename std::deque<std::tuple<Time, Vars, DerivVars>>::const_iterator
+RungeKutta3::needed_history(
+    const std::deque<std::tuple<Time, Vars, DerivVars>>& history) const
+    noexcept {
+  const bool at_step_end = history.size() == number_of_substeps();
+  return at_step_end ? history.end() : history.begin();
 }
 
 }  // namespace TimeSteppers

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -53,7 +53,7 @@ class TimeStepper : public Factory<TimeStepper> {
   template <typename Vars, typename DerivVars>
   TimeDelta update_u(
       const gsl::not_null<Vars*> u,
-      const std::deque<std::tuple<Vars, DerivVars, TimeDelta>>& history,
+      const std::deque<std::tuple<Time, Vars, DerivVars>>& history,
       const TimeDelta& time_step) const noexcept {
     return TimeStepper_detail::fake_virtual_update_u<creatable_classes>(
         this, u, history, time_step);

--- a/src/Utilities/CachedFunction.hpp
+++ b/src/Utilities/CachedFunction.hpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines class CachedFunction
+
+#pragma once
+
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+/// A function wrapper that caches function values.
+template <typename Function, typename Map>
+class CachedFunction {
+ public:
+  using input = typename Map::key_type;
+  using output = typename Map::mapped_type;
+
+  template <typename... MapArgs>
+  explicit CachedFunction(Function function, MapArgs... map_args) noexcept
+      : function_(std::move(function)),
+        cache_(std::forward<MapArgs>(map_args)...) {}
+
+  /// Obtain the function result
+  const output& operator()(
+      const input& x) noexcept(noexcept(std::declval<Function>()(x))) {
+    auto it = cache_.find(x);
+    if (it == cache_.end()) {
+      it = cache_.emplace(x, function_(x)).first;
+    }
+    return it->second;
+  }
+
+  /// Clear the cache entries
+  void clear() noexcept { cache_.clear(); }
+ private:
+  Function function_;
+  Map cache_;
+};
+
+/// Construct a CachedFunction wrapping the given function
+///
+/// \example
+/// \snippet Test_CachedFunction.cpp make_cached_function_example
+///
+/// \tparam Input function argument type
+/// \tparam Map class template to use as the map holding the cache
+/// \param function the function
+/// \param map_args arguments to pass to the map constructor
+template <typename Input, template <typename...> class Map = std::unordered_map,
+          typename... MapArgs, typename Function, typename... PassedMapArgs>
+auto make_cached_function(Function function,
+                          PassedMapArgs... map_args) noexcept {
+  using output = std::result_of_t<Function&(const Input&)>;
+  return CachedFunction<Function, Map<std::decay_t<Input>,
+                                      std::decay_t<output>,
+                                      MapArgs...>>(
+      std::move(function), std::forward<PassedMapArgs>(map_args)...);
+}

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(DATA_STRUCTURES_TESTS
     DataStructures/Test_DataBox.cpp
     DataStructures/Test_DataVector.cpp
+    DataStructures/Test_GeneralIndexIterator.cpp
     DataStructures/Test_Index.cpp
     DataStructures/Test_IndexIterator.cpp
     DataStructures/Test_MakeWithValue.cpp

--- a/tests/Unit/DataStructures/Test_GeneralIndexIterator.cpp
+++ b/tests/Unit/DataStructures/Test_GeneralIndexIterator.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <catch.hpp>
+
+#include "DataStructures/GeneralIndexIterator.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.GeneralIndexIterator",
+                  "[Unit][DataStructures]") {
+  // Test constructing from const value
+  const std::array<std::pair<int, int>, 3> ranges{{{0, 2}, {1, 2}, {1, 3}}};
+  auto coordinates = make_general_index_iterator(ranges);
+
+  auto check_values = [&](std::array<int, 3> expected) {
+    CHECK(coordinates);
+    auto it = coordinates.begin();
+    for(size_t i = 0; i < expected.size(); ++i, ++it) {
+      CHECK(coordinates[i] == gsl::at(expected, i));
+      CHECK(*it == gsl::at(expected, i));
+    }
+    CHECK(it == coordinates.end());
+  };
+  check_values({{0, 1, 1}});
+  ++coordinates;
+  check_values({{1, 1, 1}});
+  ++coordinates;
+  check_values({{0, 1, 2}});
+  ++coordinates;
+  check_values({{1, 1, 2}});
+  ++coordinates;
+  CHECK_FALSE(coordinates);
+
+  // Test constructing from temporary
+  auto zero_dimensional_coordinates = make_general_index_iterator(
+      std::array<std::pair<int, int>, 0>{});
+  CHECK(zero_dimensional_coordinates);
+  CHECK(zero_dimensional_coordinates.begin() ==
+        zero_dimensional_coordinates.end());
+  ++zero_dimensional_coordinates;
+  CHECK_FALSE(zero_dimensional_coordinates);
+
+  auto degenerate_coordinates = make_general_index_iterator(
+      std::array<std::pair<int, int>, 1>{{{2, 2}}});
+  CHECK_FALSE(degenerate_coordinates);
+}

--- a/tests/Unit/Numerical/CMakeLists.txt
+++ b/tests/Unit/Numerical/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(SPECTRE_UNIT_NUMERICAL_TESTS)
 
+add_subdirectory(Interpolation)
 add_subdirectory(LinearOperators)
 add_subdirectory(RootFinding)
 add_subdirectory(Spectral)

--- a/tests/Unit/Numerical/Interpolation/CMakeLists.txt
+++ b/tests/Unit/Numerical/Interpolation/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(SPECTRE_UNIT_INTERPOLATION_TESTS
+    Numerical/Interpolation/Test_LagrangePolynomial.cpp
+    )
+
+set(SPECTRE_UNIT_NUMERICAL_TESTS
+    "${SPECTRE_UNIT_NUMERICAL_TESTS};${SPECTRE_UNIT_INTERPOLATION_TESTS}"
+    PARENT_SCOPE)

--- a/tests/Unit/Numerical/Interpolation/Test_LagrangePolynomial.cpp
+++ b/tests/Unit/Numerical/Interpolation/Test_LagrangePolynomial.cpp
@@ -1,0 +1,38 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <catch.hpp>
+
+#include "Numerical/Interpolation/LagrangePolynomial.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.LagrangePolynomial",
+                  "[Unit][Numerical]") {
+  std::array<double, 4> control{{-1., 0., 1.5, 6.}};
+
+  for (size_t i = 0; i < control.size(); ++i) {
+    for (size_t j = 0; j < control.size(); ++j) {
+      CHECK(lagrange_polynomial(j, gsl::at(control, i),
+                                control.begin(), control.end())
+            == approx(i == j ? 1. : 0.));
+      CHECK(lagrange_polynomial(control.begin() + static_cast<ssize_t>(j),
+                                gsl::at(control, i),
+                                control.begin(),
+                                control.end()) ==
+            approx(i == j ? 1. : 0.));
+    }
+  }
+
+  // Check interpolating a cubic
+  const auto func =
+      [](double x) { return 1.2 + x * (2.3 + x * (3.4 + x * 4.5)); };
+  const double test_point = 2.7;
+  double interpolated = 0.;
+  for (auto it = control.begin(); it != control.end(); ++it) {
+    interpolated +=
+        func(*it) * lagrange_polynomial(it, test_point, control.begin(),
+                                        control.end());
+  }
+  CHECK(interpolated == approx(func(test_point)));
+}

--- a/tests/Unit/Time/Test_Time.cpp
+++ b/tests/Unit/Time/Test_Time.cpp
@@ -104,6 +104,20 @@ SPECTRE_TEST_CASE("Unit.Time.Time", "[Unit][Time]") {
   CHECK(get_output(Time(slab, 0)) == slab_str + ":0/1");
   CHECK(get_output(Time(slab, 1)) == slab_str + ":1/1");
   CHECK(get_output(Time(slab, rational_t(3, 5))) == slab_str + ":3/5");
+
+  const auto check_structural_compare =
+      [](const Time& a, const Time& b) noexcept {
+    Time::StructuralCompare sc;
+    CHECK_FALSE(sc(a, a));
+    CHECK_FALSE(sc(b, b));
+    CHECK(sc(a, b) != sc(b, a));
+  };
+  check_structural_compare(Time(slab, rational_t(1, 3)),
+                           Time(slab, rational_t(2, 3)));
+  check_structural_compare(Time(slab, rational_t(1, 3)),
+                           Time(slab, rational_t(1, 2)));
+  check_structural_compare(Time(slab, rational_t(0, 1)),
+                           Time(slab.advance(), rational_t(0, 1)));
 }
 
 SPECTRE_TEST_CASE("Unit.Time.Time_slab_comparison", "[Unit][Time]") {

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -1,10 +1,16 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <catch.hpp>
 #include <cmath>
+#include <deque>
 
+#include "DataStructures/MakeWithValue.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
 #include "Options/Options.hpp"
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"
+#include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp"
 
@@ -73,4 +79,294 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Factory",
                   "[Unit][Time]") {
   test_factory_creation<TimeStepper>("  AdamsBashforthN:\n"
                                      "    TargetOrder: 3");
+}
+
+SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.Equal",
+                  "[Unit][Time]") {
+  for (size_t order = 1; order < 9; ++order) {
+    INFO(order);
+    const double epsilon = std::max(std::pow(1e-3, order), 1e-14);
+    TimeStepperTestUtils::equal_rate_boundary(
+        TimeSteppers::AdamsBashforthN(order, false), epsilon, true);
+  }
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.Equal.Backwards",
+    "[Unit][Time]") {
+  for (size_t order = 1; order < 9; ++order) {
+    INFO(order);
+    const double epsilon = std::max(std::pow(1e-3, order), 1e-14);
+    TimeStepperTestUtils::equal_rate_boundary(
+        TimeSteppers::AdamsBashforthN(order, false), epsilon, false);
+  }
+}
+
+namespace {
+// Non-copyable double to verify that the boundary code is not making
+// internal copies.
+class NCd {
+ public:
+  explicit NCd(double x) : x_(x) {}
+  NCd(const NCd&) = delete;
+  NCd(NCd&&) = default;
+  NCd& operator=(const NCd&) = delete;
+  NCd& operator=(NCd&&) = default;
+  ~NCd() = default;
+
+  double operator()() const { return x_; }
+
+ private:
+  double x_;
+};
+
+NCd operator*(double a, NCd&& b) { return NCd(a * b()); }
+NCd& operator+=(NCd& a, NCd&& b) { return a = NCd(a() + b()); }
+
+// Random numbers
+constexpr double c10 = 0.949716728952811;
+constexpr double c11 = 0.190663110072823;
+constexpr double c20 = 0.932407227651314;
+constexpr double c21 = 0.805454101952822;
+constexpr double c22 = 0.825876851406978;
+
+// Test coupling for integrating using two drivers (multiplied together)
+NCd quartic_coupling(const std::vector<std::reference_wrapper<const NCd>>& v) {
+  CHECK(v.size() == 3);
+  return NCd(v[1]() * v[2]());
+}
+
+// Test functions for integrating a quartic using the above coupling.
+// The derivative of quartic_answer is the product of the other two.
+double quartic_side1(double x) { return c10 + x * c11; }
+double quartic_side2(double x) { return c20 + x * (c21 + x * c22); }
+double quartic_answer(double x) {
+  return x * (c10 * c20
+              + x * ((c10 * c21 + c11 * c20) / 2
+                     + x * ((c10 * c22 + c11 * c21) / 3
+                            + x * (c11 * c22 / 4))));
+}
+
+// Analytic solutions
+const std::array<double (*const)(double), 3> side_solutions{{
+    quartic_answer, quartic_side1, quartic_side2}};
+
+// Value to assign to points during a simulation
+double simulation_value(const size_t side, const Time& t, const double y) {
+  switch (side) {
+    case 0: return y;
+    case 1: return quartic_side1(t.value());
+    case 2: return quartic_side2(t.value());
+    default: ERROR("");
+  };
+}
+}  // namespace
+
+namespace MakeWithValueImpls {
+template <>
+SPECTRE_ALWAYS_INLINE NCd MakeWithValueImpl<NCd, NCd>::apply(
+    const NCd& /*unused*/, double value) {
+  return NCd(value);
+}
+}  // namespace MakeWithValueImpls
+
+SPECTRE_TEST_CASE(
+    "Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.MultipleSides",
+    "[Unit][Time]") {
+  constexpr double unused = 4444.;
+
+  const Slab slab(0., 1.);
+
+  Time t = slab.start();
+  const TimeDelta dt = slab.duration() / 4;
+
+  TimeSteppers::AdamsBashforthN ab4(4, false);
+
+  std::vector<std::deque<std::tuple<Time, NCd, NCd>>> history(3);
+
+  {
+    const Slab init_slab = slab.retreat();
+    const TimeDelta init_dt = dt.with_slab(init_slab);
+
+    for (ssize_t step = 1; step <= 3; ++step) {
+      const Time now = t - step * init_dt;
+      for (size_t side = 0; side < 3; ++side) {
+        history[side].emplace_front(
+            now, NCd(unused), NCd(gsl::at(side_solutions, side)(now.value())));
+      }
+    }
+  }
+
+  double y = 0.;
+  while (t < slab.end()) {
+    for (size_t side = 0; side < 3; ++side) {
+      history[side].emplace_back(t, NCd(unused),
+                                 NCd(simulation_value(side, t, y)));
+    }
+
+    t += dt;
+    y += ab4.compute_boundary_delta(quartic_coupling, history, dt)();
+    CHECK(y == approx(quartic_answer(t.value())));
+  }
+}
+
+namespace {
+void do_lts_test(const std::array<TimeDelta, 3>& dt) noexcept {
+  constexpr double unused = 4444.;
+
+  const bool forward_in_time = dt[0].is_positive();
+  const auto simulation_less =
+      [forward_in_time](const Time& a, const Time& b) noexcept {
+    return forward_in_time ? a < b : b < a;
+  };
+
+  const Slab slab = dt[0].slab();
+  Time t = forward_in_time ? slab.start() : slab.end();
+
+  TimeSteppers::AdamsBashforthN ab4(4, false);
+
+  std::vector<std::deque<std::tuple<Time, NCd, NCd>>> history(3);
+  {
+    const Slab init_slab = slab.advance_towards(-dt[0]);
+
+    for (ssize_t step = 1; step <= 3; ++step) {
+      for (size_t side = 0; side < 3; ++side) {
+        const Time now = t - step * gsl::at(dt, side).with_slab(init_slab);
+        history[side].emplace_front(
+            now, NCd(unused), NCd(gsl::at(side_solutions, side)(now.value())));
+      }
+    }
+  }
+
+  double y = quartic_answer(t.value());
+  Time next_check = t + dt[0];
+  std::array<Time, 3> next{{t, t, t}};
+  for (;;) {
+    const auto side = static_cast<size_t>(
+        std::min_element(next.cbegin(), next.cend(), simulation_less)
+        - next.cbegin());
+
+    history[side].emplace_back(t, NCd(unused),
+                               NCd(simulation_value(side, t, y)));
+
+    gsl::at(next, side) += gsl::at(dt, side);
+
+    t = *std::min_element(next.cbegin(), next.cend(), simulation_less);
+
+    ASSERT(not simulation_less(next_check, t), "Screwed up arithmetic");
+    if (t == next_check) {
+      y += ab4.compute_boundary_delta(quartic_coupling, history, dt[0])();
+      CHECK(y == approx(quartic_answer(t.value())));
+      if (t.is_at_slab_boundary()) {
+        break;
+      }
+      next_check += dt[0];
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.LocalStepping",
+    "[Unit][Time]") {
+  const Slab slab(0., 1.);
+  const TimeDelta full = slab.duration();
+  do_lts_test({{full / 4, full / 4, full / 4}});
+  do_lts_test({{full / 4, full / 8, full / 8}});
+  do_lts_test({{full / 4, full / 8, full / 4}});
+  do_lts_test({{full / 8, full / 4, full / 4}});
+  do_lts_test({{full / 8, full / 4, full / 8}});
+  do_lts_test({{full / 4, full / 8, full / 16}});
+  do_lts_test({{full / 16, full / 4, full / 8}});
+  do_lts_test({{full / 8, full / 16, full / 4}});
+
+  // Non-nesting cases
+  do_lts_test({{full / 4, full / 6, full / 8}});
+  do_lts_test({{full / 6, full / 8, full / 4}});
+  do_lts_test({{full / 8, full / 4, full / 6}});
+  do_lts_test({{full / 5, full / 7, full / 13}});
+  do_lts_test({{full / 7, full / 13, full / 5}});
+  do_lts_test({{full / 13, full / 5, full / 7}});
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.LocalSteppingBackward",
+    "[Unit][Time]") {
+  const Slab slab(0., 1.);
+  const TimeDelta full = -slab.duration();
+  do_lts_test({{full / 4, full / 4, full / 4}});
+  do_lts_test({{full / 4, full / 8, full / 8}});
+  do_lts_test({{full / 4, full / 8, full / 4}});
+  do_lts_test({{full / 8, full / 4, full / 4}});
+  do_lts_test({{full / 8, full / 4, full / 8}});
+  do_lts_test({{full / 4, full / 8, full / 16}});
+  do_lts_test({{full / 16, full / 4, full / 8}});
+  do_lts_test({{full / 8, full / 16, full / 4}});
+
+  // Non-nesting cases
+  do_lts_test({{full / 4, full / 6, full / 8}});
+  do_lts_test({{full / 6, full / 8, full / 4}});
+  do_lts_test({{full / 8, full / 4, full / 6}});
+  do_lts_test({{full / 5, full / 7, full / 13}});
+  do_lts_test({{full / 7, full / 13, full / 5}});
+  do_lts_test({{full / 13, full / 5, full / 7}});
+}
+
+SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.Variable",
+                  "[Unit][Time]") {
+  constexpr double unused = 4444.;
+
+  const Slab slab(0., 1.);
+
+  Time t = slab.start();
+
+  TimeSteppers::AdamsBashforthN ab4(4, false);
+
+  std::vector<std::deque<std::tuple<Time, NCd, NCd>>> history(3);
+  {
+    const Slab init_slab = slab.retreat();
+    const TimeDelta init_dt = init_slab.duration() / 4;
+
+    for (ssize_t step = 1; step <= 3; ++step) {
+      const Time now = t - step * init_dt;
+      for (size_t side = 0; side < 3; ++side) {
+        history[side].emplace_front(
+            now, NCd(unused), NCd(gsl::at(side_solutions, side)(now.value())));
+      }
+    }
+  }
+
+  std::array<std::deque<TimeDelta>, 3> dt{{
+      {slab.duration() / 4, slab.duration() / 2, slab.duration() / 4},
+      {slab.duration() / 3, slab.duration() / 3, slab.duration() / 3},
+      {slab.duration() / 6, slab.duration() / 6, slab.duration() * 2 / 9,
+            slab.duration() * 4 / 9}}};
+
+  double y = quartic_answer(t.value());
+  Time next_check = t + dt[0][0];
+  std::array<Time, 3> next{{t, t, t}};
+  for (;;) {
+    const auto side = static_cast<size_t>(
+        std::min_element(next.cbegin(), next.cend()) - next.cbegin());
+
+    history[side].emplace_back(gsl::at(next, side), NCd(unused),
+                               NCd(simulation_value(side, gsl::at(next, side),
+                                                    y)));
+
+    const TimeDelta this_dt = gsl::at(dt, side).front();
+    gsl::at(dt, side).pop_front();
+
+    gsl::at(next, side) += this_dt;
+
+    if (*std::min_element(next.cbegin(), next.cend()) == next_check) {
+      y += ab4.compute_boundary_delta(quartic_coupling, history,
+                                      next_check - t)();
+      CHECK(y == approx(quartic_answer(next_check.value())));
+      if (next_check.is_at_slab_boundary()) {
+        break;
+      }
+      t = next_check;
+      next_check += dt[0].front();
+    }
+  }
 }

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -12,17 +12,17 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
   for (size_t order = 1; order < 9; ++order) {
     INFO(order);
     const TimeSteppers::AdamsBashforthN stepper(order, false);
-    check_multistep_properties(stepper);
+    TimeStepperTestUtils::check_multistep_properties(stepper);
     const double epsilon = std::max(std::pow(1e-3, order), 1e-14);
-    integrate_test(stepper, 1., epsilon);
+    TimeStepperTestUtils::integrate_test(stepper, 1., epsilon);
   }
 
   for (size_t order = 1; order < 9; ++order) {
     INFO(order);
     const TimeSteppers::AdamsBashforthN stepper(order, true);
-    check_multistep_properties(stepper);
+    TimeStepperTestUtils::check_multistep_properties(stepper);
     // Accuracy limited by first step
-    integrate_test(stepper, 1., 1e-3);
+    TimeStepperTestUtils::integrate_test(stepper, 1., 1e-3);
   }
 }
 
@@ -31,14 +31,15 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Variable",
   for (size_t order = 1; order < 9; ++order) {
     INFO(order);
     const double epsilon = std::max(std::pow(1e-3, order), 1e-14);
-    integrate_variable_test(TimeSteppers::AdamsBashforthN(order, false),
-                            epsilon);
+    TimeStepperTestUtils::integrate_variable_test(
+        TimeSteppers::AdamsBashforthN(order, false), epsilon);
   }
 
   for (size_t order = 1; order < 9; ++order) {
     INFO(order);
     // Accuracy limited by first step
-    integrate_variable_test(TimeSteppers::AdamsBashforthN(order, true), 1e-3);
+    TimeStepperTestUtils::integrate_variable_test(
+        TimeSteppers::AdamsBashforthN(order, true), 1e-3);
   }
 }
 
@@ -47,13 +48,15 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Backwards",
   for (size_t order = 1; order < 9; ++order) {
     INFO(order);
     const double epsilon = std::max(std::pow(1e-3, order), 1e-14);
-    integrate_test(TimeSteppers::AdamsBashforthN(order, false), -1., epsilon);
+    TimeStepperTestUtils::integrate_test(
+        TimeSteppers::AdamsBashforthN(order, false), -1., epsilon);
   }
 
   for (size_t order = 1; order < 9; ++order) {
     INFO(order);
     // Accuracy limited by first step
-    integrate_test(TimeSteppers::AdamsBashforthN(order, true), -1., 1e-3);
+    TimeStepperTestUtils::integrate_test(
+        TimeSteppers::AdamsBashforthN(order, true), -1., 1e-3);
   }
 }
 
@@ -61,7 +64,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Stability",
                   "[Unit][Time]") {
   for (size_t order = 1; order < 9; ++order) {
     INFO(order);
-    stability_test(TimeSteppers::AdamsBashforthN(order, false));
+    TimeStepperTestUtils::stability_test(
+        TimeSteppers::AdamsBashforthN(order, false));
   }
 }
 

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -331,8 +331,10 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.Variable",
     const Slab init_slab = slab.retreat();
     const TimeDelta init_dt = init_slab.duration() / 4;
 
-    for (ssize_t step = 1; step <= 3; ++step) {
-      const Time now = t - step * init_dt;
+    // clang-tidy misfeature: warns about boost internals here
+    for (ssize_t step = 1; step <= 3; ++step) {  // NOLINT
+      // clang-tidy misfeature: warns about boost internals here
+      const Time now = t - step * init_dt;  // NOLINT
       for (size_t side = 0; side < 3; ++side) {
         history[side].emplace_front(
             now, NCd(unused), NCd(gsl::at(side_solutions, side)(now.value())));

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -206,6 +206,8 @@ SPECTRE_TEST_CASE(
 
     t += dt;
     y += ab4.compute_boundary_delta(quartic_coupling, history, dt)();
+    TimeStepperTestUtils::erase_boundary_history(
+        ab4, make_not_null(&history), dt);
     CHECK(y == approx(quartic_answer(t.value())));
   }
 }
@@ -256,6 +258,8 @@ void do_lts_test(const std::array<TimeDelta, 3>& dt) noexcept {
     ASSERT(not simulation_less(next_check, t), "Screwed up arithmetic");
     if (t == next_check) {
       y += ab4.compute_boundary_delta(quartic_coupling, history, dt[0])();
+      TimeStepperTestUtils::erase_boundary_history(
+          ab4, make_not_null(&history), dt[0]);
       CHECK(y == approx(quartic_answer(t.value())));
       if (t.is_at_slab_boundary()) {
         break;
@@ -361,6 +365,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.Variable",
     if (*std::min_element(next.cbegin(), next.cend()) == next_check) {
       y += ab4.compute_boundary_delta(quartic_coupling, history,
                                       next_check - t)();
+      TimeStepperTestUtils::erase_boundary_history(
+          ab4, make_not_null(&history), next_check - t);
       CHECK(y == approx(quartic_answer(next_check.value())));
       if (next_check.is_at_slab_boundary()) {
         break;

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -32,3 +32,15 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Factory",
                   "[Unit][Time]") {
   test_factory_creation<TimeStepper>("  RungeKutta3");
 }
+
+SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Boundary.Equal",
+                  "[Unit][Time]") {
+  TimeStepperTestUtils::equal_rate_boundary(
+      TimeSteppers::RungeKutta3{}, 1e-9, true);
+}
+
+SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Boundary.Equal.Backwards",
+                  "[Unit][Time]") {
+  TimeStepperTestUtils::equal_rate_boundary(
+      TimeSteppers::RungeKutta3{}, 1e-9, false);
+}

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -7,25 +7,25 @@
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3", "[Unit][Time]") {
   const TimeSteppers::RungeKutta3 stepper{};
-  check_substep_properties(stepper);
-  integrate_test(stepper, 1., 1e-9);
+  TimeStepperTestUtils::check_substep_properties(stepper);
+  TimeStepperTestUtils::integrate_test(stepper, 1., 1e-9);
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Variable",
                   "[Unit][Time]") {
   const TimeSteppers::RungeKutta3 stepper{};
-  integrate_variable_test(stepper, 1e-9);
+  TimeStepperTestUtils::integrate_variable_test(stepper, 1e-9);
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Backwards",
                   "[Unit][Time]") {
   const TimeSteppers::RungeKutta3 stepper{};
-  integrate_test(stepper, -1., 1e-9);
+  TimeStepperTestUtils::integrate_test(stepper, -1., 1e-9);
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Stability",
                   "[Unit][Time]") {
-  stability_test(TimeSteppers::RungeKutta3{});
+  TimeStepperTestUtils::stability_test(TimeSteppers::RungeKutta3{});
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Factory",

--- a/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -14,6 +14,8 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 
+namespace TimeStepperTestUtils {
+
 template <typename Stepper, typename F>
 void take_step(
     const gsl::not_null<Time*> time,
@@ -182,3 +184,5 @@ void stability_test(const Stepper& stepper) noexcept {
     CHECK(false);
   }
 }
+
+}  // namespace TimeStepperTestUtils

--- a/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -30,11 +30,9 @@ void take_step(
     const TimeDelta substep_dt = stepper.update_u(y, *history, step_size);
     accumulated_step_dt += substep_dt;
     *time += substep_dt;
+    history->erase(history->begin(), stepper.needed_history(*history));
   }
   CHECK(accumulated_step_dt == step_size);
-  while (history->size() > stepper.number_of_past_steps()) {
-    history->pop_front();
-  }
 }
 
 template <typename Stepper, typename F1, typename F2>
@@ -97,6 +95,11 @@ void integrate_test(const Stepper& stepper, const double integration_time,
     // This check needs a looser tolerance for lower-order time steppers.
     CHECK(y == approx(analytic(time.value())).epsilon(epsilon));
   }
+  // Make sure history is being cleaned up.  The limit of 20 is
+  // arbitrary, but much larger than the order of any integrators we
+  // care about and much smaller than the number of time steps in the
+  // test.
+  CHECK(history.size() < 20);
 }
 
 template <typename Stepper>

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(UTILITIES_TESTS
     Utilities/Test_Blas.cpp
     Utilities/Test_BoostHelpers.cpp
+    Utilities/Test_CachedFunction.cpp
     Utilities/Test_ConstantExpressions.cpp
     Utilities/Test_Deferred.cpp
     Utilities/Test_FakeVirtual.cpp

--- a/tests/Unit/Utilities/Test_CachedFunction.cpp
+++ b/tests/Unit/Utilities/Test_CachedFunction.cpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+#include <map>
+#include <string>
+
+#include "Utilities/CachedFunction.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.CachedFunction", "[Unit][Utilities]") {
+  size_t call_count = 0;
+  // Use types that cannot be implicitly converted
+  const auto func = [&call_count](const std::string& s) noexcept {
+    ++call_count;
+    return s.size();
+  };
+
+  bool comparator_used = false;
+  // Unused capture to silence clang-tidy warning in the example below.
+  auto comparator = [&comparator_used, not_trivially_copyable=std::string{}](
+      const std::string& a, const std::string& b) noexcept {
+    comparator_used = true;
+    return a < b;
+  };
+
+  /// [make_cached_function_example]
+  auto cached = make_cached_function<const std::string&>(func);
+
+  // Specifying all the arguments
+  auto cached2 =
+      make_cached_function<const std::string&, std::map, decltype(comparator)>(
+          func, std::move(comparator));
+  /// [make_cached_function_example]
+
+  static_assert(cpp17::is_same_v<decltype(cached)::input, std::string>,
+                "Wrong input type");
+  static_assert(cpp17::is_same_v<decltype(cached)::output, size_t>,
+                "Wrong output type");
+
+  static_assert(cpp17::is_same_v<decltype(cached2)::input, std::string>,
+                "Wrong input type");
+  static_assert(cpp17::is_same_v<decltype(cached2)::output, size_t>,
+                "Wrong output type");
+
+  CHECK(call_count == 0);
+  CHECK(cached("x") == 1);
+  CHECK(call_count == 1);
+  CHECK(cached("xx") == 2);
+  CHECK(call_count == 2);
+  CHECK(cached("x") == 1);
+  CHECK(call_count == 2);
+  cached.clear();
+  CHECK(cached("x") == 1);
+  CHECK(call_count == 3);
+
+  CHECK(not comparator_used);
+  CHECK(cached2("x") == 1);
+  CHECK(cached2("xx") == 2);
+  CHECK(comparator_used);
+}


### PR DESCRIPTION
This adds support to the AdamsBashforthN TimeStepper for local time stepping.  RungeKutta3 continues to only work with global time stepping, but implements the same interface.  This does not cover the driver and communication routines because we don't have the infrastructure for those in place yet.