### PR TITLE
Require at least version 1.8 of Catch

### DIFF
--- a/cmake/FindCatch.cmake
+++ b/cmake/FindCatch.cmake
@@ -3,17 +3,42 @@
 
 # SpECTRE modifications:
 # - add PATH_SUFFIXES to find_path
+# - call function _get_catch_version (taken from another source)
+# - pass version to find_package_handle_standard_args
+
+# This function is from: https://github.com/pybind/pybind11
+# Extract the version number from catch.hpp
+function(_get_catch_version)
+  file(
+    STRINGS "${CATCH_INCLUDE_DIR}/catch.hpp"
+    version_line REGEX "Catch v.*" LIMIT_COUNT 1
+    )
+  if(version_line MATCHES "Catch v([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+    set(
+      CATCH_VERSION
+      "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}" PARENT_SCOPE
+      )
+  endif()
+endfunction()
 
 find_path(
-    CATCH_INCLUDE_DIR
-    PATH_SUFFIXES single_include include catch
-    NAMES catch.hpp
-    HINTS ${CATCH_ROOT}
-    DOC "catch include dir"
-)
+  CATCH_INCLUDE_DIR
+  PATH_SUFFIXES single_include include catch
+  NAMES catch.hpp
+  HINTS ${CATCH_ROOT}
+  DOC "catch include dir"
+  )
+
+if(CATCH_INCLUDE_DIR)
+  _get_catch_version()
+endif()
 
 set(CATCH_INCLUDE_DIRS ${CATCH_INCLUDE_DIR})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Catch DEFAULT_MSG CATCH_INCLUDE_DIR)
+find_package_handle_standard_args(
+  Catch REQUIRED_VARS CATCH_INCLUDE_DIR VERSION_VAR CATCH_VERSION
+  )
+
 mark_as_advanced(CATCH_INCLUDE_DIR)
+mark_as_advanced(CATCH_VERSION)

--- a/cmake/SetupCatch.cmake
+++ b/cmake/SetupCatch.cmake
@@ -1,7 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(Catch REQUIRED)
+find_package(Catch 1.8 REQUIRED)
 
 include_directories(SYSTEM "${CATCH_INCLUDE_DIR}")
 message(STATUS "Catch include: ${CATCH_INCLUDE_DIR}")
+message(STATUS "Catch version: ${CATCH_VERSION}")

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -128,8 +128,6 @@ void test_copy_semantics(const T& a) {
   static_assert(std::is_copy_constructible<T>::value,
                 "Class is not copy constructible.");
   T b = a;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wparentheses"
   CHECK(b == a);
   // clang-tidy: intentionally not a reference to force invocation of copy
   // constructor
@@ -138,7 +136,6 @@ void test_copy_semantics(const T& a) {
   // clang-tidy: self-assignment
   b = b;  // NOLINT
   CHECK(b == a);
-#pragma GCC diagnostic pop
 }
 
 /// Test for move semantics assuming operator== is implement correctly
@@ -163,12 +160,9 @@ void test_move_semantics(T&& a, const T& comparison) {
   T b;
   // clang-tidy: use std::forward instead of std::move
   b = std::move(a);  // NOLINT
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wparentheses"
   CHECK(b == comparison);
   T c(std::move(b));
   CHECK(c == comparison);
-#pragma GCC diagnostic pop
 }
 
 // Test for iterators


### PR DESCRIPTION
Fix #110  

Also removed some ignores of Wparentheses which should not be needed
for the required versions of Catch.