### PR TITLE
Compile time hash type

### DIFF
--- a/src/DataStructures/DataBox.hpp
+++ b/src/DataStructures/DataBox.hpp
@@ -592,15 +592,6 @@ class DataBox<TagsList<Tags...>> {
       tmpl2::flat_all_v<cpp17::is_base_of_v<db::DataBoxTag, Tags>...>,
       "All structs used to Tag (compute) items in a DataBox must derive off of "
       "db::DataBoxTag");
-  static_assert(
-      tmpl2::flat_all_v<detail::tag_has_label<Tags>::value...>,
-      "Missing a label on a Tag. All Tags must have a static "
-      "constexpr db::DataBoxString_t member variable named 'label' with "
-      "the name of the Tag.");
-  static_assert(
-      tmpl2::flat_all_v<detail::tag_label_correct_type<Tags>::value...>,
-      "One of the labels of the Tags in a DataBox has the incorrect "
-      "type. It should be a DataBoxString_t.");
 
  public:
   /*!
@@ -728,15 +719,6 @@ class DataBox<TagsList<Tags...>> {
                     typelist<NewTags...> /*meta*/,
                     typelist<NewComputeItems...> /*meta*/,
                     ComputeItemsToKeep /*meta*/, Args&&... args);
-
-  SPECTRE_ALWAYS_INLINE void check_tags() const {
-#ifdef SPECTRE_DEBUG
-    ASSERT(tmpl::size<tags_list>::value == 0 or
-               tmpl::for_each<tags_list>(detail::check_tag_labels{}).value,
-           "Could not match one of the Tag labels with the Tag type. That is, "
-           "the label of a Tag must be the same as the Tag.");
-#endif
-  }
 
   databox_detail::TaggedDeferredTuple<Tags...> data_;
 };
@@ -944,7 +926,6 @@ constexpr DataBox<TagsList<Tags...>>::DataBox(
     typelist<TagsInArgsOrder...> /*meta*/, typelist<FullItems...> /*meta*/,
     typelist<ComputeItemTags...> /*meta*/,
     typelist<FullComputeItems...> /*meta*/, Args&&... args) {
-  check_tags();
   static_assert(
       sizeof...(Tags) == sizeof...(FullItems) + sizeof...(FullComputeItems),
       "Must pass in as many (compute) items as there are Tags.");
@@ -985,7 +966,6 @@ constexpr DataBox<TagsList<Tags...>>::DataBox(
                                                          tmpl::_state>>;
   using DependencyGraph = tmpl::digraph<edge_list>;
 
-  check_tags();
   // Merge old tags, including all ComputeItems even though they might be
   // reset.
   databox_detail::merge_old_box(old_box, data_, typelist<KeepTags...>{});
@@ -1209,7 +1189,9 @@ const Type& get_item_from_box(const DataBox<TagList>& box,
   if (result == nullptr) {
     std::stringstream tags_in_box;
     tmpl::for_each<TagList>([&tags_in_box](auto temp) {
-      tags_in_box << "  " << decltype(temp)::type::label << "\n";
+      tags_in_box << "  "
+                  << get_tag_name<std::decay_t<typename decltype(temp)::type>>()
+                  << "\n";
     });
     ERROR("Could not find the tag named \""
           << tag_name << "\" in the DataBox. Available tags are:\n"
@@ -1221,21 +1203,21 @@ const Type& get_item_from_box(const DataBox<TagList>& box,
 
 /*!
  * \ingroup DataBoxGroup
- * \brief Retrieve an item from the DataBox that has a tag with label `tag_name`
+ * \brief Retrieve an item from the DataBox that has a tag named `tag_name`
  * and type `Type`
  *
  * \details
  * The type that the tag represents must be of the type `Type`, and the tag must
- * have the label `tag_name`. The function iterates over all tags in the DataBox
- * `box` that have the type `Type` searching linearly for one whose `label`
+ * have the name `tag_name`. The function iterates over all tags in the DataBox
+ * `box` that have the type `Type` searching linearly for one whose name
  * matches `tag_name`.
  *
  * \example
  * \snippet Test_DataBox.cpp get_item_from_box
  *
- * \tparam Type the type of the tag with the `label` `tag_name`
+ * \tparam Type the type of the tag with the name `tag_name`
  * \param box the DataBox through which to search
- * \param tag_name the `label` of the tag to retrieve
+ * \param tag_name the name of the tag to retrieve
  */
 template <typename Type, typename TagList>
 constexpr const Type& get_item_from_box(const DataBox<TagList>& box,

--- a/src/DataStructures/DataBoxTag.hpp
+++ b/src/DataStructures/DataBoxTag.hpp
@@ -28,13 +28,6 @@ struct Variables;
 /// \endcond
 
 namespace db {
-
-/*!
- * \ingroup DataBoxGroup
- * \brief The string used to give a runtime name to a DataBoxTag
- */
-using DataBoxString_t = const char* const;
-
 /*!
  * \ingroup DataBoxGroup
  * \brief Tags for the DataBox inherit from this type
@@ -45,8 +38,6 @@ using DataBoxString_t = const char* const;
  *
  * \derivedrequires
  * - type alias `type` of the type this DataBoxTag represents
- * - `static constexpr DataBoxString_t` that is the same as the type name
- *    and named `label`
  *
  * \example
  * \snippet Test_DataBox.cpp databox_tag_example
@@ -60,17 +51,15 @@ struct DataBoxTag {};
  * \brief Marks an item as being a prefix to another tag
  *
  * \details
- * Used to mark a type as being a DataBoxTag where the `label` is a prefix to
- * the DataBoxTag that is a member type alias `tag`. A prefix tag must contain a
+ * Used to mark a type as being a DataBoxTag whose name should be prepended to
+ * the DataBoxTag's name. That is, "PrefixTag::Tag". A prefix tag must contain a
  * type alias named `type` with the type of the Tag it is a prefix to, as well
  * as a type alias `tag` that is the type of the Tag that this prefix tag is
- * a prefix for. A prefix tag must also have a `label` equal to the name of
- * the struct (tag).
+ * a prefix for.
  *
  * \derivedrequires
  * - type alias `tag` of the DataBoxTag that this tag is a prefix to
  * - type alias `type` that is the type that this DataBoxPrefix holds
- * - DataBoxString_t `label` that is the prefix to the `tag`
  *
  * \example
  * A DataBoxPrefix tag has the structure:
@@ -91,10 +80,9 @@ struct DataBoxPrefix : DataBoxTag {};
  * \details
  * A compute item tag contains a member named `function` that is either a
  * function pointer, or a static constexpr function. The compute item tag
- * must also have a `label`, same as the DataBox tags, and a type alias
- * `argument_tags` that is a typelist of the tags that will
- * be retrieved from the DataBox and whose data will be passed to the function
- * (pointer).
+ * must also have type alias `argument_tags` that is a typelist of the tags that
+ * will be retrieved from the DataBox and whose data will be passed to the
+ * function (pointer).
  *
  * \example
  * Most compute item tags will look similar to:
@@ -109,79 +97,6 @@ struct DataBoxPrefix : DataBoxTag {};
  * \see DataBox DataBoxTag DataBoxString_t get_tag_name DataBoxPrefix
  */
 struct ComputeItemTag : DataBoxTag {};
-
-namespace detail {
-// @{
-/*!
- * \ingroup DataBoxGroup
- * \brief Check if a Tag has a label
- *
- * \details
- * Check if a type `T` has a static member variable named `label`.
- *
- * \usage
- * For any type `T`
- * \code
- * using result = db::detail::tag_has_label<T>;
- * \endcode
- * \metareturns
- * cpp17::bool_constant
- *
- * \see tag_label_correct_type
- * \tparam T the type to check
- */
-template <typename T, typename = void>
-struct tag_has_label : std::false_type {};
-/// \cond HIDDEN_SYMBOLS
-template <typename T>
-struct tag_has_label<T, cpp17::void_t<decltype(T::label)>> : std::true_type {};
-/// \endcond
-// @}
-
-// @{
-/*!
- * \ingroup DataBoxGroup
- * \brief Check if a Tag label has type DataBoxString_t
- *
- * \details
- * For a type `T`, check that the static member variable named `label` has type
- * DataBoxString_t
- *
- * \usage
- * For any type `T`
- * \code
- * using result = db::tag_label_correct_type<T>;
- * \endcode
- * \metareturns
- * cpp17::bool_constant
- *
- * \tparam T the type to check
- */
-template <typename T, typename = std::nullptr_t>
-struct tag_label_correct_type : std::false_type {};
-/// \cond HIDDEN_SYMBOLS
-template <typename T>
-struct tag_label_correct_type<
-    T, Requires<std::is_same<DataBoxString_t, decltype(T::label)>::value>>
-    : std::true_type {};
-/// \endcond
-// @}
-
-struct check_tag_labels {
-  using value_type = bool;
-  value_type value{false};
-  template <typename T>
-  void operator()(tmpl::type_<T> /*meta*/) {
-    bool correct = pretty_type::get_name<T>().find(std::string(T::label)) !=
-                   std::string::npos;
-    value |= correct;
-    ASSERT(correct,
-           "Failed to match the Tag label " << std::string(T::label)
-                                            << " with its type name "
-                                            << pretty_type::get_name<T>());
-  }
-};
-}  // namespace detail
 
 // @{
 /*!
@@ -198,77 +113,32 @@ struct check_tag_labels {
 template <typename Tag,
           Requires<not std::is_base_of<DataBoxPrefix, Tag>::value> = nullptr>
 std::string get_tag_name() {
-  return std::string(Tag::label);
+  return pretty_type::short_name<Tag>();
 }
 /// \cond HIDDEN_SYMBOLS
 template <typename Tag,
           Requires<std::is_base_of<DataBoxPrefix, Tag>::value> = nullptr>
 std::string get_tag_name() {
-  return std::string(Tag::label) + get_tag_name<typename Tag::tag>();
+  return pretty_type::short_name<Tag>() + get_tag_name<typename Tag::tag>();
 }
 /// \endcond
 // @}
 
 namespace detail {
-// @{
-/*!
- * \ingroup DataBoxGroup
- * \brief Compute a hash of the `label` of a DataBoxTag
- *
- * \details
- * Given a DataBoxTag returns a `value` of type `value_type` which is the hash
- * of the label of the DataBoxTag, including any prefix. The hashing algorithm
- * is based on what is used for std::typeinfo in libcxx v3.9.0.
- *
- * \tparam Tag the DataBoxTag whose name to get
- * \metareturns
- * value member of type `value_type` representing the hash of the DataBoxTag
- */
-template <typename Tag, typename = std::nullptr_t>
-struct hash_databox_tag {
-  using value_type = size_t;
-  static constexpr value_type value = cstring_hash(Tag::label);
-  using type = std::integral_constant<value_type, value>;
-};
-/// \cond HIDDEN_SYMBOLS
-template <typename Tag>
-struct hash_databox_tag<Tag,
-                        Requires<std::is_base_of<DataBoxPrefix, Tag>::value>> {
-  using value_type = size_t;
-  static constexpr value_type value =
-      cstring_hash(Tag::label) * hash_databox_tag<typename Tag::tag>::value;
-  using type = std::integral_constant<value_type, value>;
-};
-
-template <typename Tag>
-struct hash_databox_tag<Tag,
-                        Requires<tt::is_a<::Tags::Variables, Tag>::value>> {
-  using value_type = size_t;
-  using reduced_hash = tmpl::fold<
-      typename Tag::type::tags_list, tmpl::size_t<0>,
-      tmpl::bind<tmpl::plus, tmpl::_state, hash_databox_tag<tmpl::_element>>>;
-  static constexpr value_type value =
-      cstring_hash(Tag::label) * reduced_hash::value;
-  using type = std::integral_constant<value_type, value>;
-};
-/// \endcond
-// @}
-
 /*!
  * \ingroup DataBoxGroup
  *
  * \details
  * Predicate that inherits from std::true_type if
- * `hash_databox_tag<DataBoxTag1>::value <
- * hash_databox_tag<DataBoxTag2>::value` otherwise inherits from
- * std::false_type.
+ * `hash_type_name<DataBoxTag1>() < hash_type_name<DataBoxTag2>())`
+ * otherwise inherits from std::false_type.
  *
  * \tparam DataBoxTag1 the left operand
  * \tparam DataBoxTag2 the right operand
  */
 template <typename DataBoxTag1, typename DataBoxTag2>
-struct databox_tag_less : tmpl::bool_<(hash_databox_tag<DataBoxTag1>::value <
-                                       hash_databox_tag<DataBoxTag2>::value)> {
+struct databox_tag_less : tmpl::bool_<(hash_type_name<DataBoxTag1>() <
+                                       hash_type_name<DataBoxTag2>())> {
 };
 }  // namespace detail
 

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -29,7 +29,6 @@ struct Variables : db::DataBoxTag {
                 "The TagsList passed to Tags::Variables is not a typelist");
   using tags_list = TagsList;
   using type = ::Variables<TagsList>;
-  static constexpr db::DataBoxString_t label = "Variables";
 };
 }  // namespace Tags
 

--- a/src/Utilities/ConstantExpressions.hpp
+++ b/src/Utilities/ConstantExpressions.hpp
@@ -239,6 +239,33 @@ SPECTRE_ALWAYS_INLINE constexpr size_t cstring_hash(const char* str) noexcept {
              : 5381;
 }
 
+#ifdef __clang__
+#define HASH_TYPE_NAME_DETAIL_NAME_LENGTH \
+  sizeof("const char *const get_pretty_function_array() [T = ") - 1
+#else
+#define HASH_TYPE_NAME_DETAIL_NAME_LENGTH                                     \
+  sizeof(                                                                     \
+      "constexpr const char *const get_pretty_function_array() [with T = ") - \
+      1
+#endif
+
+namespace ConstantExpression_detail {
+template <class T>
+constexpr const char* get_pretty_function_array() {
+  return __PRETTY_FUNCTION__;
+}
+}  // namespace ConstantExpression_detail
+
+/// \ingroup ConstantExpressions
+/// \brief Hash a type name, including namespaces, at compile time. The hash
+/// used is that of typeid in libcxx.
+template <class T>
+constexpr size_t hash_type_name() noexcept {
+  return cstring_hash(
+      ConstantExpression_detail::get_pretty_function_array<T>() +
+      HASH_TYPE_NAME_DETAIL_NAME_LENGTH);
+}
+
 namespace ConstantExpression_detail {
 template <typename T, size_t Size, size_t... I, size_t... J>
 inline constexpr std::array<std::decay_t<T>, Size> replace_at_helper(

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -25,44 +25,36 @@ namespace test_databox_tags {
 /// [databox_tag_example]
 struct Tag0 : db::DataBoxTag {
   using type = double;
-  static constexpr db::DataBoxString_t label = "Tag0";
 };
 /// [databox_tag_example]
 struct Tag1 : db::DataBoxTag {
   using type = std::vector<double>;
-  static constexpr db::DataBoxString_t label = "Tag1";
 };
 struct Tag2 : db::DataBoxTag {
   using type = std::string;
-  static constexpr db::DataBoxString_t label = "Tag2";
 };
 struct Tag3 : db::DataBoxTag {
   using type = std::string;
-  static constexpr db::DataBoxString_t label = "Tag3";
 };
 
 /// [databox_compute_item_tag_example]
 struct ComputeTag0 : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "ComputeTag0";
   static constexpr auto function = multiply_by_two;
   using argument_tags = typelist<Tag0>;
 };
 /// [databox_compute_item_tag_example]
 struct ComputeTag1 : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "ComputeTag1";
   static constexpr auto function = append_word;
   using argument_tags = typelist<Tag2, ComputeTag0>;
 };
 
 struct TagTensor : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "TagTensor";
   static constexpr auto function = get_tensor;
   using argument_tags = typelist<>;
 };
 
 /// [compute_item_tag_function]
 struct ComputeLambda0 : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "ComputeLambda0";
   static constexpr double function(const double a) { return 3.0 * a; }
   using argument_tags = typelist<Tag0>;
 };
@@ -70,7 +62,6 @@ struct ComputeLambda0 : db::ComputeItemTag {
 
 /// [compute_item_tag_no_tags]
 struct ComputeLambda1 : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "ComputeLambda1";
   static constexpr double function() { return 7.0; }
   using argument_tags = typelist<>;
 };
@@ -81,7 +72,6 @@ template <typename Tag>
 struct TagPrefix : db::DataBoxPrefix {
   using type = typename Tag::type;
   using tag = Tag;
-  static constexpr db::DataBoxString_t label = "TagPrefix";
 };
 /// [databox_prefix_tag_example]
 }  // namespace test_databox_tags
@@ -132,12 +122,15 @@ static_assert(
 static_assert(std::is_same<decltype(db::create_from<db::RemoveTags<>>(Box_t{})),
                            Box_t>::value,
               "Failed testing no-op create_from");
-
-static_assert(db::detail::tag_has_label<test_databox_tags::Tag0>::value,
-              "Failed testing db::tag_has_label");
-static_assert(db::detail::tag_has_label<test_databox_tags::TagTensor>::value,
-              "Failed testing db::tag_has_label");
 }  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.get_tag_name",
+                  "[Unit][DataStructures]") {
+  CHECK(db::get_tag_name<test_databox_tags::TagTensor>() == "TagTensor");
+  CHECK(db::get_tag_name<
+            test_databox_tags::TagPrefix<test_databox_tags::Tag2>>() ==
+        "TagPrefixTag2");
+}
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   /// [create_databox]
@@ -164,8 +157,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   // Check retrieving chained compute item result
   CHECK(db::get<test_databox_tags::ComputeTag1>(original_box) ==
         "My Sample String6.28"s);
-  CHECK(db::get<test_databox_tags::ComputeLambda0>(original_box) ==
-        3.0 * 3.14);
+  CHECK(db::get<test_databox_tags::ComputeLambda0>(original_box) == 3.0 * 3.14);
   CHECK(db::get<test_databox_tags::ComputeLambda1>(original_box) == 7.0);
   // No removal
   {
@@ -224,8 +216,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
         db::RemoveTags<>, db::AddTags<test_databox_tags::Tag3>,
         db::AddComputeItemsTags<test_databox_tags::ComputeTag0>>(
         simple_box, "Yet another test string"s);
-    CHECK(db::get<test_databox_tags::Tag3>(box) ==
-          "Yet another test string"s);
+    CHECK(db::get<test_databox_tags::Tag3>(box) == "Yet another test string"s);
     CHECK(db::get<test_databox_tags::Tag2>(box) == "My Sample String"s);
     // Check retrieving compute item result
     CHECK(db::get<test_databox_tags::ComputeTag0>(box) == 6.28);
@@ -240,8 +231,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
         db::AddTags<test_databox_tags::Tag3>,
         db::AddComputeItemsTags<test_databox_tags::ComputeTag0>>(
         simple_box, "Yet another test string"s);
-    CHECK(db::get<test_databox_tags::Tag3>(box) ==
-          "Yet another test string"s);
+    CHECK(db::get<test_databox_tags::Tag3>(box) == "Yet another test string"s);
     CHECK(db::get<test_databox_tags::Tag2>(box) == "My Sample String"s);
     // Check retrieving compute item result
     CHECK(6.28 == db::get<test_databox_tags::ComputeTag0>(box));

--- a/tests/Unit/Utilities/Test_ConstantExpressions.cpp
+++ b/tests/Unit/Utilities/Test_ConstantExpressions.cpp
@@ -126,6 +126,19 @@ static_assert(cstring_hash(dummy_string1) == cstring_hash(dummy_string2),
 static_assert(cstring_hash(dummy_string1) != cstring_hash(dummy_string3),
               "Failed testing cstring_hash");
 
+/// Test hashing types
+namespace {
+struct SomeType {};
+}  // namespace
+static_assert(hash_type_name<int>() == hash_type_name<int>(),
+              "Failed testing hash_type_name");
+static_assert(hash_type_name<int>() != hash_type_name<double>(),
+              "Failed testing hash_type_name");
+static_assert(hash_type_name<int>() != hash_type_name<SomeType>(),
+              "Failed testing hash_type_name");
+static_assert(hash_type_name<SomeType>() == hash_type_name<SomeType>(),
+              "Failed testing hash_type_name");
+
 // Test array_equal and replace_at
 constexpr std::array<double, 3> array1{{1.2, 3, 4}};
 constexpr std::array<double, 3> array1_copy{{1.2, 3, 4}};


### PR DESCRIPTION
Provide a compile-time hash of type names to allow simplifications to DataBox.

DataBox uses the compile-time hash of type names to sort the typelist on, instead of relying on a member variable inside the tags.