### PR TITLE
Add make_vector helper function

### DIFF
--- a/src/Utilities/MakeVector.hpp
+++ b/src/Utilities/MakeVector.hpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <vector>
+
+#include "Utilities/TMPL.hpp"
+
+namespace MakeVectorImpl {
+/// \cond NEVER
+template <class T>
+struct tag {
+  using type = T;
+};
+template <class T, size_t n>
+struct get_tag : get_tag<typename T::type, n - 1> {};
+template <class T>
+struct get_tag<T, 0> : tag<T> {};
+
+template <class Tag, size_t n = 1>
+using type_t = typename get_tag<Tag, n>::type;
+/// \endcond
+
+// build the return type:
+template <class T0, class... Ts>
+using vector_types =
+    type_t<std::conditional<std::is_same<T0, void>::value,
+                            tmpl::front<tmpl::list<typename std::decay<Ts>...>>,
+                            tag<T0>>,
+           2>;
+template <class T0, class... Ts>
+using vector_return_type = std::vector<vector_types<T0, Ts...>>;
+}  // namespace MakeVectorImpl
+
+/*!
+ * \brief Constructs a `std::vector` containing each of the arguments in 'ts'.
+ *
+ * This is useful as it allows in place construction of a vector of non-copyable
+ * objects.
+ *
+ * \example
+ * \snippet Utilities/Test_MakeVector.cpp make_vector_example
+ */
+template <class ValueType = void, class Arg1, class... Args>
+auto make_vector(Arg1&& arg_1, Args&&... remaining_args) {
+  std::vector<
+      std::conditional_t<cpp17::is_same_v<ValueType, void>, Arg1, ValueType>>
+      return_vector;
+  return_vector.reserve(sizeof...(Args) + 1);
+  return_vector.emplace_back(std::forward<Arg1>(arg_1));
+  (void)std::initializer_list<int>{
+      (((void)retval.emplace_back(std::forward<Ts>(ts))), 0)...};
+  return retval;
+}
+
+template <class T>
+std::vector<T> make_vector() {
+  return {};
+}

--- a/src/Utilities/MakeVector.hpp
+++ b/src/Utilities/MakeVector.hpp
@@ -6,37 +6,12 @@
 #include <vector>
 
 #include "Utilities/TMPL.hpp"
-
-namespace MakeVectorImpl {
-/// \cond NEVER
-template <class T>
-struct tag {
-  using type = T;
-};
-template <class T, size_t n>
-struct get_tag : get_tag<typename T::type, n - 1> {};
-template <class T>
-struct get_tag<T, 0> : tag<T> {};
-
-template <class Tag, size_t n = 1>
-using type_t = typename get_tag<Tag, n>::type;
-/// \endcond
-
-// build the return type:
-template <class T0, class... Ts>
-using vector_types =
-    type_t<std::conditional<std::is_same<T0, void>::value,
-                            tmpl::front<tmpl::list<typename std::decay<Ts>...>>,
-                            tag<T0>>,
-           2>;
-template <class T0, class... Ts>
-using vector_return_type = std::vector<vector_types<T0, Ts...>>;
-}  // namespace MakeVectorImpl
+#include "Utilities/TypeTraits.hpp"
 
 /*!
- * \brief Constructs a `std::vector` containing each of the arguments in 'ts'.
+ * \brief Constructs a `std::vector` containing arguments passed in.
  *
- * This is useful as it allows in place construction of a vector of non-copyable
+ * This is useful as it allows in-place construction of a vector of non-copyable
  * objects.
  *
  * \example
@@ -50,8 +25,9 @@ auto make_vector(Arg1&& arg_1, Args&&... remaining_args) {
   return_vector.reserve(sizeof...(Args) + 1);
   return_vector.emplace_back(std::forward<Arg1>(arg_1));
   (void)std::initializer_list<int>{
-      (((void)retval.emplace_back(std::forward<Ts>(ts))), 0)...};
-  return retval;
+      (((void)return_vector.emplace_back(std::forward<Args>(remaining_args))),
+       0)...};
+  return return_vector;
 }
 
 template <class T>

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -346,3 +346,31 @@ std::unique_ptr<BaseClass> test_factory_creation(
   options.parse("Opt:\n" + construction_string);
   return options.template get<TestHelpers_detail::Opt<BaseClass>>();
 }
+
+struct NonCopyable {
+  constexpr NonCopyable() = default;
+  constexpr NonCopyable(const NonCopyable&) = delete;
+  constexpr NonCopyable& operator=(const NonCopyable&) = delete;
+  constexpr NonCopyable(NonCopyable&&) = default;
+  NonCopyable& operator=(NonCopyable&&) = default;
+  ~NonCopyable() = default;
+};
+
+class DoesNotThrow {
+ public:
+  DoesNotThrow() noexcept = default;
+  DoesNotThrow(const DoesNotThrow&) noexcept = default;
+  DoesNotThrow& operator=(const DoesNotThrow&) noexcept = default;
+  DoesNotThrow(DoesNotThrow&&) noexcept = default;
+  DoesNotThrow& operator=(DoesNotThrow&&) noexcept = default;
+  ~DoesNotThrow() = default;
+};
+class DoesThrow {
+ public:
+  DoesThrow() noexcept(false);
+  DoesThrow(const DoesThrow&) noexcept(false);
+  DoesThrow& operator=(const DoesThrow&) noexcept(false);
+  DoesThrow(DoesThrow&&) noexcept(false);
+  DoesThrow& operator=(DoesThrow&&) noexcept(false);
+  ~DoesThrow() = default;
+};

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -11,6 +11,7 @@ set(UTILITIES_TESTS
     Utilities/Test_FractionUtilities.cpp
     Utilities/Test_Gsl.cpp
     Utilities/Test_MakeArray.cpp
+    Utilities/Test_MakeVector.cpp
     Utilities/Test_Math.cpp
     Utilities/Test_Overloader.cpp
     Utilities/Test_PrettyType.cpp

--- a/tests/Unit/Utilities/Test_MakeArray.cpp
+++ b/tests/Unit/Utilities/Test_MakeArray.cpp
@@ -6,36 +6,6 @@
 #include "Utilities/MakeArray.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-namespace {
-struct NonCopyable {
-  constexpr NonCopyable() = default;
-  constexpr NonCopyable(const NonCopyable&) = delete;
-  constexpr NonCopyable& operator=(const NonCopyable&) = delete;
-  constexpr NonCopyable(NonCopyable&&) = default;
-  NonCopyable& operator=(NonCopyable&&) = default;
-  ~NonCopyable() = default;
-};
-}  // namespace
-
-class DoesNotThrow {
- public:
-  DoesNotThrow() noexcept = default;
-  DoesNotThrow(const DoesNotThrow&) noexcept = default;
-  DoesNotThrow& operator=(const DoesNotThrow&) noexcept = default;
-  DoesNotThrow(DoesNotThrow&&) noexcept = default;
-  DoesNotThrow& operator=(DoesNotThrow&&) noexcept = default;
-  ~DoesNotThrow() = default;
-};
-class DoesThrow {
- public:
-  DoesThrow() noexcept(false);
-  DoesThrow(const DoesThrow&) noexcept(false);
-  DoesThrow& operator=(const DoesThrow&) noexcept(false);
-  DoesThrow(DoesThrow&&) noexcept(false);
-  DoesThrow& operator=(DoesThrow&&) noexcept(false);
-  ~DoesThrow() = default;
-};
-
 static_assert(noexcept(make_array<2>(0)),
               "Failed Unit.Utilities.MakeArray testing noexcept calculation of "
               "make_array.");

--- a/tests/Unit/Utilities/Test_MakeVector.cpp
+++ b/tests/Unit/Utilities/Test_MakeVector.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "Utilities/MakeVector.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+struct NonCopyable {
+  constexpr NonCopyable() = default;
+  constexpr NonCopyable(const NonCopyable&) = delete;
+  constexpr NonCopyable& operator=(const NonCopyable&) = delete;
+  constexpr NonCopyable(NonCopyable&&) = default;
+  NonCopyable& operator=(NonCopyable&&) = default;
+  ~NonCopyable() = default;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Utilities.MakeVector", "[Unit][Utilities]") {
+  auto varying_vector = make_vector(3.2, 4.3, 5.4, 6.5, 7.8);
+  CHECK((varying_vector == std::vector<double>{{3.2, 4.3, 5.4, 6.5, 7.8}}));
+
+  auto vector_n = make_vector(5, 5, 5, 5, 5, 5);
+  static_assert(
+      std::is_same<typename std::decay<decltype(vector_n)>::type::value_type,
+                   int>::value,
+      "Unit Test Failure: Incorrect type from make_vector.");
+
+  CHECK(vector_n.size() == 6);
+  for (const auto& p : vector_n) {
+    CHECK(5 == p);
+  }
+
+  /// [make_vector_example]
+  auto vector_non_copyable = make_vector(NonCopyable{}, NonCopyable{});
+  CHECK(vector_non_copyable.size() == 2);
+
+  auto vector_empty = make_vector<int>();
+  CHECK(vector_empty.empty());
+
+  auto my_vector = make_vector(1, 3, 4, 8, 9);
+  CHECK(my_vector.size() == 5);
+
+  auto vector_explicit_type = make_vector<double>(1, 2, 3);
+  CHECK(vector_explicit_type == (std::vector<double>{1.,2.,3.}));
+  /// [make_vector_example]
+}

--- a/tests/Unit/Utilities/Test_MakeVector.cpp
+++ b/tests/Unit/Utilities/Test_MakeVector.cpp
@@ -6,41 +6,25 @@
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-namespace {
-struct NonCopyable {
-  constexpr NonCopyable() = default;
-  constexpr NonCopyable(const NonCopyable&) = delete;
-  constexpr NonCopyable& operator=(const NonCopyable&) = delete;
-  constexpr NonCopyable(NonCopyable&&) = default;
-  NonCopyable& operator=(NonCopyable&&) = default;
-  ~NonCopyable() = default;
-};
-}  // namespace
-
 SPECTRE_TEST_CASE("Unit.Utilities.MakeVector", "[Unit][Utilities]") {
-  auto varying_vector = make_vector(3.2, 4.3, 5.4, 6.5, 7.8);
-  CHECK((varying_vector == std::vector<double>{{3.2, 4.3, 5.4, 6.5, 7.8}}));
-
-  auto vector_n = make_vector(5, 5, 5, 5, 5, 5);
   static_assert(
-      std::is_same<typename std::decay<decltype(vector_n)>::type::value_type,
-                   int>::value,
+      std::is_same<
+          typename std::decay<decltype(make_vector(0., 0.))>::type::value_type,
+          double>::value,
       "Unit Test Failure: Incorrect type from make_vector.");
 
-  CHECK(vector_n.size() == 6);
-  for (const auto& p : vector_n) {
-    CHECK(5 == p);
-  }
-
   /// [make_vector_example]
+  auto vector = make_vector(3.2, 4.3, 5.4, 6.5, 7.8);
+  CHECK(vector == (std::vector<double>{{3.2, 4.3, 5.4, 6.5, 7.8}}));
+
   auto vector_non_copyable = make_vector(NonCopyable{}, NonCopyable{});
   CHECK(vector_non_copyable.size() == 2);
 
   auto vector_empty = make_vector<int>();
   CHECK(vector_empty.empty());
 
-  auto my_vector = make_vector(1, 3, 4, 8, 9);
-  CHECK(my_vector.size() == 5);
+  auto vector_size_one = make_vector(3);
+  CHECK(vector_size_one == std::vector<int>{3});
 
   auto vector_explicit_type = make_vector<double>(1, 2, 3);
   CHECK(vector_explicit_type == (std::vector<double>{1.,2.,3.}));


### PR DESCRIPTION
Adds make vector function which makes it easier to construct a std::vector of noncopyable objects.