### PR TITLE
Refactor data_on_slice to use tmpl::for_each

### DIFF
--- a/src/DataStructures/VariablesHelpers.hpp
+++ b/src/DataStructures/VariablesHelpers.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <boost/range/combine.hpp>
 #include <cstddef>
 
 #include "DataStructures/Index.hpp"
@@ -28,18 +29,22 @@ Variables<TagsList> data_on_slice(const Variables<TagsList>& vars,
   const size_t interface_grid_points =
       element_extents.slice_away(sliced_dim).product();
   const size_t volume_grid_points = vars.number_of_grid_points();
-  const size_t number_of_independent_components =
-      vars.number_of_independent_components;
   Variables<TagsList> interface_vars(interface_grid_points);
-  const double* vars_data = vars.data();
-  double* interface_vars_data = interface_vars.data();
-  for (SliceIterator si(element_extents, sliced_dim, slice_point); si; ++si) {
-    for (size_t i = 0; i < number_of_independent_components; ++i) {
-      // clang-tidy: do not use pointer arithmetic
-      interface_vars_data[si.slice_offset() +                      // NOLINT
-                          i * interface_grid_points] =             // NOLINT
-          vars_data[si.volume_offset() + i * volume_grid_points];  // NOLINT
-    }
+  for (SliceIterator slice_it(element_extents, sliced_dim, slice_point);
+       slice_it; ++slice_it) {
+    tmpl::for_each<TagsList>([&vars, &interface_vars, &slice_it](auto tag) {
+      using Tag = tmpl::type_from<decltype(tag)>;
+      const auto& variable_in_volume = vars.template get<Tag>();
+      auto& variable_on_interface = interface_vars.template get<Tag>();
+      for (auto&& interface_and_volume_variable :
+           boost::combine(variable_on_interface, variable_in_volume)) {
+        auto& interface_var = interface_and_volume_variable.template get<0>();
+        const auto& volume_var =
+            interface_and_volume_variable.template get<1>();
+        interface_var[slice_it.slice_offset()] =
+            volume_var[slice_it.volume_offset()];
+      }
+    });
   }
   return interface_vars;
 }


### PR DESCRIPTION
`data_on_slice` currently uses pointer arithmetic on a Variables class which isn't desirable. I seem to remember there being an issue from the BitBucket repo for which data_on_slice was a bottleneck due to non-optimal ordering of loops. Even though this might no longer be an issue in a real simulation, I decided to figure out how to do some premature, rudimentary benchmarking on this using google benchmark on my machine. 

For a Variables with the same structure as the 3D GH variables, the pointer arithmetic method is always ~5-10% faster than this when checked with 10-12 grid points per dimension and slicing in each dimension. For an MHD with dynamical GR structure, the pointer method can become ~40% faster when using 12 grid points per dimension. 

I'm not suggesting we do anything with these benchmarks (they're kind of crude anyway), but it'll be something to keep in mind if we find this function takes a significant amount of time on a real simulation. 