### PR TITLE
Explicitly instantiate Domain default argument

### DIFF
--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -56,6 +56,10 @@ template class Domain<1, Frame::Inertial>;
 template class Domain<2, Frame::Inertial>;
 template class Domain<3, Frame::Inertial>;
 
+// Some compilers (clang 3.9.1) don't instantiate the default argument
+// to the second Domain constructor.
+template class std::vector<PairOfFaces>;
+
 template std::ostream& operator<<(std::ostream& os,
                                   const Domain<1, Frame::Grid>& block);
 template std::ostream& operator<<(std::ostream& os,

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -19,8 +19,8 @@
 /// identifying the two faces with each other.
 /// \requires The pair of faces must belong to a single block.
 struct PairOfFaces {
-  const std::vector<size_t> first;
-  const std::vector<size_t> second;
+  std::vector<size_t> first;
+  std::vector<size_t> second;
 };
 
 /// \ingroup ComputationalDomain


### PR DESCRIPTION
It seems clang 3.9.1 doesn't implicitly instantiate it, either when
the class is instantiated or when the constructor is called without
specifying the argument.  (Explicitly passing the default value
worked.)