### PR TITLE
Add support for dividing doubles by Datavectors

### DIFF
--- a/src/DataStructures/DataVector.cpp
+++ b/src/DataStructures/DataVector.cpp
@@ -67,14 +67,7 @@ DataVector& DataVector::operator=(DataVector&& rhs) noexcept {
 }
 /// \endcond
 
-void DataVector::set_data_ref(double* start, size_t size) {
-  size_ = size;
-  owned_data_ = decltype(owned_data_){};
-  data_ = decltype(data_){start, size_};
-  owning_ = false;
-}
-
-void DataVector::pup(PUP::er& p) {  // NOLINT
+void DataVector::pup(PUP::er& p) noexcept {  // NOLINT
   p | size_;
   if (p.isUnpacking()) {
     owning_ = true;

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <blaze/math/typetraits/IsVector.h>
 #include <cstddef>
 #include <initializer_list>
 #include <iosfwd>
@@ -485,8 +486,7 @@ struct pow<DataVector, 0, std::nullptr_t> {
   }
 };
 template <typename BlazeVector>
-struct pow<BlazeVector, 0,
-           Requires<std::is_base_of<blaze::Expression, BlazeVector>::value>> {
+struct pow<BlazeVector, 0, Requires<blaze::IsVector<BlazeVector>::value>> {
   SPECTRE_ALWAYS_INLINE static constexpr double apply(
       const BlazeVector& /*t*/) {
     return 1.0;

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -272,6 +272,10 @@ class DataVector {
     return lhs.data_ * ~rhs;
   }
 
+  friend decltype(auto) operator/(const double& lhs, const DataVector& rhs) {
+    return lhs / rhs.data_;
+  }
+
   friend decltype(auto) operator/(const DataVector& lhs, const double& rhs) {
     return lhs.data_ / rhs;
   }

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -413,7 +413,7 @@ BoundaryVars AdamsBashforthN::compute_boundary_delta(
   // Calculating the Adams-Bashforth coefficients is somewhat
   // expensive, so we cache them.  ab_coefs(it) returns the
   // coefficients used to step from *it to *(it + 1).
-  auto ab_coefs = [target_order_s, &union_times]() noexcept {
+  auto ab_coefs = [target_order_s]() noexcept {
     using Iter = decltype(union_times.cbegin());
     auto compare = [](const Iter& a, const Iter& b) noexcept {
       return Time::StructuralCompare{}(*a, *b);

--- a/src/Utilities/ConstantExpressions.hpp
+++ b/src/Utilities/ConstantExpressions.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <algorithm>
+#include <blaze/math/typetraits/IsVector.h>
 #include <type_traits>
 
 #include "Utilities/ForceInline.hpp"
@@ -14,10 +15,6 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
-
-namespace blaze {
-struct Expression;
-}  // namespace blaze
 
 /// \ingroup ConstantExpressions
 /// Compute 2 to the n for integral types.
@@ -77,7 +74,7 @@ struct pow<T, N, Requires<(N < 0)>> {
 };
 
 template <typename T>
-struct pow<T, 0, Requires<not std::is_base_of<blaze::Expression, T>::value>> {
+struct pow<T, 0, Requires<not blaze::IsVector<T>::value>> {
   SPECTRE_ALWAYS_INLINE static constexpr T apply(const T& /*t*/) {
     return static_cast<T>(1);
   }

--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -18,6 +18,38 @@
 
 namespace blaze {
 template <typename ST>
+struct DivideScalarByVector {
+ public:
+  explicit inline DivideScalarByVector(ST scalar) : scalar_(scalar) {}
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) operator()(const T& a) const {
+    return scalar_ / a;
+  }
+
+  template <typename T>
+  static constexpr bool simdEnabled() {
+    return blaze::HasSIMDDiv<T, ST>::value;
+  }
+
+  template <typename T>
+  BLAZE_ALWAYS_INLINE decltype(auto) load(const T& a) const {
+    BLAZE_CONSTRAINT_MUST_BE_SIMD_PACK(T);
+    return set(scalar_) / a;
+  }
+
+ private:
+  ST scalar_;
+};
+
+template <typename Scalar, typename VT, bool TF,
+          typename = blaze::EnableIf_<blaze::IsNumeric<Scalar>>>
+BLAZE_ALWAYS_INLINE decltype(auto) operator/(
+    Scalar scalar, const blaze::DenseVector<VT, TF>& vec) {
+  return forEach(~vec, DivideScalarByVector<Scalar>(scalar));
+}
+
+template <typename ST>
 struct AddScalar {
  public:
   explicit inline AddScalar(ST scalar) : scalar_(scalar) {}

--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -298,37 +298,32 @@ struct PointerVector
  private:
   template <typename VT>
   using VectorizedAssign = std::integral_constant<
-      bool,
-      blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
-          blaze::IsSIMDCombinable<Type, blaze::ElementType_<VT>>::value>;
+      bool, blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
+                blaze::IsSIMDCombinable<Type, blaze::ElementType_<VT>>::value>;
 
   template <typename VT>
   using VectorizedAddAssign = std::integral_constant<
-      bool,
-      blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
-          blaze::IsSIMDCombinable<Type, blaze::ElementType_<VT>>::value &&
-          blaze::HasSIMDAdd<Type, blaze::ElementType_<VT>>::value>;
+      bool, blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
+                blaze::IsSIMDCombinable<Type, blaze::ElementType_<VT>>::value &&
+                blaze::HasSIMDAdd<Type, blaze::ElementType_<VT>>::value>;
 
   template <typename VT>
   using VectorizedSubAssign = std::integral_constant<
-      bool,
-      blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
-          blaze::IsSIMDCombinable<Type, blaze::ElementType_<VT>>::value &&
-          blaze::HasSIMDSub<Type, blaze::ElementType_<VT>>::value>;
+      bool, blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
+                blaze::IsSIMDCombinable<Type, blaze::ElementType_<VT>>::value &&
+                blaze::HasSIMDSub<Type, blaze::ElementType_<VT>>::value>;
 
   template <typename VT>
   using VectorizedMultAssign = std::integral_constant<
-      bool,
-      blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
-          blaze::IsSIMDCombinable<Type, blaze::ElementType_<VT>>::value &&
-          blaze::HasSIMDMult<Type, blaze::ElementType_<VT>>::value>;
+      bool, blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
+                blaze::IsSIMDCombinable<Type, blaze::ElementType_<VT>>::value &&
+                blaze::HasSIMDMult<Type, blaze::ElementType_<VT>>::value>;
 
   template <typename VT>
   using VectorizedDivAssign = std::integral_constant<
-      bool,
-      blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
-          blaze::IsSIMDCombinable<Type, blaze::ElementType_<VT>>::value &&
-          blaze::HasSIMDDiv<Type, blaze::ElementType_<VT>>::value>;
+      bool, blaze::useOptimizedKernels && simdEnabled && VT::simdEnabled &&
+                blaze::IsSIMDCombinable<Type, blaze::ElementType_<VT>>::value &&
+                blaze::HasSIMDDiv<Type, blaze::ElementType_<VT>>::value>;
 
   //! The number of elements packed within a single SIMD element.
   enum : size_t { SIMDSIZE = blaze::SIMDTrait<ElementType>::size };

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -176,6 +176,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   check_vectors(DataVector(num_pts, -1.0 / 9.0), -one / nine);
   check_vectors(DataVector(num_pts, -8.0 / 9.0), -(nine - one) / nine);
   check_vectors(DataVector(num_pts, 18.0), (one / 0.5) * nine);
+  check_vectors(DataVector(num_pts, 1.0), 9.0 / nine);
+  check_vectors(DataVector(num_pts, 1.0), (one * 9.0) / nine);
 
   CHECK(-14 == min(val));
   CHECK(12 == max(val));


### PR DESCRIPTION
- Fixes warning in clang
- Adds support for Blaze v3.2
- Enables dividing doubles by DataVectors (closes #122 )

To fix #144 it will be easiest to move to requiring Blaze 3.2, I'll put in a separate PR for that.