### PR TITLE
Add make_coordinate_map_base

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -396,6 +396,18 @@ make_coordinate_map(Maps&&... maps) {
       std::forward<Maps>(maps)...);
 }
 
+/// \ingroup ComputationalDomain
+/// \brief Creates a std::unique_ptr<CoordinateMapBase> of `maps...`
+template <typename SourceFrame, typename TargetFrame, typename... Maps>
+std::unique_ptr<CoordinateMapBase<
+    SourceFrame, TargetFrame,
+    CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>::dim>>
+make_coordinate_map_base(Maps&&... maps) noexcept {
+  return std::make_unique<
+      CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>>(
+      std::forward<Maps>(maps)...);
+}
+
 /// \cond
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 PUP::able::PUP_ID


### PR DESCRIPTION
## Proposed changes

Adds make_coordinate_map_base function.

Fixes #300

### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sxs-collaboration/spectre/332)
<!-- Reviewable:end -->
