### PR TITLE
Clean up variables in Wedge3D, make tan map optional

### DIFF
--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -17,7 +17,7 @@
 namespace CoordinateMaps {
 
 /*!
- * \ingroup CoordinateMaps
+ * \ingroup CoordinateMapsGroup
  *
  * \brief Three dimensional map from the cube to a wedge.
  *
@@ -28,7 +28,146 @@ namespace CoordinateMaps {
  *  0) and spherical (a sphericity of 1).
  *
  *  The first two logical coordinates correspond to the two angular coordinates,
- *  and the third to the radial coordinate
+ *  and the third to the radial coordinate.
+ *
+ *  The Wedge3D map is constructed by linearly interpolating between a bulged
+ *  face of radius `radius_of_other_surface` to a spherical face of
+ *  radius `radius_of_spherical_surface`, where the radius of the bulged face
+ *  is defined to be the radius of the sphere circumscribing the bulge.
+ *
+ *  We make a choice here as to whether we wish to use the logical coordinates
+ *  parameterizing these surface as they are, in which case we have the
+ *  equidistant choice of coordinates, or whether to apply a tangent map to them
+ *  which leads us to the equiangular choice of coordinates. In terms of the
+ *  logical coordinates, the equiangular coordinates are:
+ *
+ *  \f[\textrm{equiangular xi} : \Xi(\xi) = \textrm{tan}(\xi\pi/4)\f]
+ *
+ *  \f[\textrm{equiangular eta}  : \mathrm{H}(\eta) = \textrm{tan}(\eta\pi/4)\f]
+ *
+ *  With derivatives:
+ *
+ *  \f[\Xi'(\xi) = \frac{\pi}{4}(1+\Xi^2)\f]
+ *
+ *  \f[\mathrm{H}'(\eta) = \frac{\pi}{4}(1+\mathrm{H}^2)\f]
+ *
+ *  The equidistant coordinates are:
+ *
+ *  \f[ \textrm{equidistant xi}  : \Xi = \xi\f]
+ *
+ *  \f[ \textrm{equidistant eta}  : \mathrm{H} = \eta\f]
+ *
+ *  with derivatives:
+ *
+ *  <center>\f$\Xi'(\xi) = 1\f$, and \f$\mathrm{H}'(\eta) = 1\f$</center>
+ *
+ *  We also define the variable \f$\rho\f$, given by:
+ *
+ *  \f[\textrm{rho} : \rho = \sqrt{1+\Xi^2+\mathrm{H}^2}\f]
+ *
+ *  ### The Spherical Face Map
+ *  The surface map for the spherical face of radius \f$R\f$ lying in the
+ * \f$+z\f$
+ *  direction in either choice of coordinates is then given by:
+ *
+ *  \f[\sigma_{spherical}: \vec{\xi} \rightarrow \vec{x}(\vec{\xi})\f]
+ *  Where
+ *  \f[
+ *  \vec{x}(\xi,\eta) =
+ *  \begin{bmatrix}
+ *  x(\xi,\eta)\\
+ *  y(\xi,\eta)\\
+ *  z(\xi,\eta)\\
+ *  \end{bmatrix}  = R
+ *  \begin{bmatrix}
+ *  \Xi/\rho\\
+ *  \mathrm{H}/\rho\\
+ *  1/\rho\\
+ *  \end{bmatrix}\f]
+ *
+ *  ### The Bulged Face Map
+ *  The bulged surface is itself constructed by linearly interpolating between
+ *  a cubical face and a spherical face. The surface map for the cubical face
+ *  of side length \f$2L\f$ lying in the \f$+z\f$ direction is given by:
+ *
+ *  \f[\vec{\sigma}_{cubical}: \vec{\xi} \rightarrow \vec{x}(\vec{\xi})\f]
+ *  Where
+ *  \f[
+ *  \vec{x}(\xi,\eta) =
+ *  \begin{bmatrix}
+ *  x(\xi,\eta)\\
+ *  y(\xi,\eta)\\
+ *  L\\
+ *  \end{bmatrix}  = L
+ *  \begin{bmatrix}
+ *  \Xi\\
+ *  \mathrm{H}\\
+ *  1\\
+ *  \end{bmatrix}\f]
+ *
+ *  To construct the bulged map we interpolate between this cubical face map
+ *  and a spherical face map of radius `radius_of_other_surface`, with the
+ *  interpolation parameter being \f$s\f$, the `sphericity_of_other_surface`.
+ *  The surface map for the bulged face lying in the \f$+z\f$ direction is then
+ *  given by:
+ *
+ *  \f[\vec{\sigma}_{other}(\xi,\eta) = {(1-s)L + \frac{sR_{other}}{\rho}}
+ *  \begin{bmatrix}
+ *  \Xi\\
+ *  \mathrm{H}\\
+ *  1\\
+ *  \end{bmatrix}\f]
+ *
+ *  We constrain L by demanding that the spherical face circumscribe the cube.
+ *  With this condition, we have \f$L = R_{other}/\sqrt3\f$.
+ *
+ *  ### The Full Volume Map
+ *  The final map for the wedge which lies along the \f$+z\f$ is obtained by
+ *  interpolating between the spherical and bulged surfaces with the
+ *  interpolation parameter being the logical coordinate \f$\zeta\f$. This
+ *  results in:
+ *
+ *  \f[\vec{x}(\xi,\eta,\zeta) = \frac{1}{2}\big\{(1-\zeta)(1-s)L
+ *   + (1-\zeta)s\frac{R_{other}}{\rho} +
+ *  (1+\zeta)\frac{R_{spherical}}{\rho}\big\}\begin{bmatrix}
+ *  \Xi\\
+ *  \mathrm{H}\\
+ *  1\\
+ *  \end{bmatrix}\f]
+ *
+ *  We will define the variables \f$b_{f1}\f$ and \f$b_{f2}\f$, the first and
+ *  second *blending factors*:
+ *
+ *  \f[b_{f1} = \frac{1}{2}\big\{(1-\zeta)(1-s)L\big\}\f]
+ *
+ *  \f[b_{f2} = \frac{1}{2}\big\{(1-\zeta)sR_{other} + (1+\zeta)R_{spherical}
+ *  \big\}\f]
+ *
+ *  We also define their zeta-derivatives, the *blending rates*:
+ *
+ *  \f[b_{r1} = \frac{\mathrm{d}b_{f1}}{\mathrm{d}\zeta} =
+ *  \frac{1}{2}(s-1)L\f]
+ *
+ *  \f[b_{r2} = \frac{\mathrm{d}b_{f2}}{\mathrm{d}\zeta} =
+ *  \frac{1}{2}\big\{-sR_{other} + R_{spherical}\big\}\f]
+ *
+ *  The Jacobian then is: \f[J =
+ *  \begin{bmatrix}
+ *  b_{f1}\Xi' & 0 &b_{r1}\Xi\\
+ *  0 & b_{f1}\mathrm{H}' &b_{r1}\mathrm{H}\\
+ *  0 & 0 &b_{r1}\\
+ *  \end{bmatrix} + \begin{bmatrix}
+ *  b_{f2}\Xi'(1+\mathrm{H}^2)/{\rho^3} & -b_{f2}\mathrm{H}'\Xi\mathrm{H}/\rho^3
+ * &
+ *  b_{r2}\Xi/\rho\\
+ *  -b_{f2}\Xi'\Xi\mathrm{H}/\rho^3 & b_{f2}\mathrm{H}'(1+\Xi^2)/\rho^3 &
+ *  b_{r2}\mathrm{H}/\rho\\
+ *  -b_{f2}\Xi'\Xi/\rho^3 & -b_{f2}\mathrm{H}'\mathrm{H}/\rho^3 & b_{r2}/\rho\\
+ *  \end{bmatrix}
+ *  \f]
+ *
+ *  \note This differs from the choice in SpEC where it is demanded that the
+ *  surfaces touch at the center, which leads to \f$L = R_{other}\f$.
  */
 class Wedge3D {
  public:
@@ -45,10 +184,12 @@ class Wedge3D {
    * \param sphericity_of_other_surface Value between 0 and 1 which determines
    * whether the other surface is flat (value of 0), spherical (value of 1) or
    * somewhere in between
+   * \param with_equiangular_map Determines whether to apply a tangent function
+   * mapping to the logical coordinates (for 'true') or not (for 'false').
    */
   Wedge3D(double radius_of_other_surface, double radius_of_spherical_surface,
-          Direction<3> direction_of_wedge,
-          double sphericity_of_other_surface) noexcept;
+          Direction<3> direction_of_wedge, double sphericity_of_other_surface,
+          bool with_equiangular_map) noexcept;
 
   Wedge3D() = default;
   ~Wedge3D() = default;
@@ -63,8 +204,8 @@ class Wedge3D {
 
   // Currently unimplemented, hence the noreturn attribute
   template <typename T>
-  [[noreturn]] std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3>
-  inverse(const std::array<T, 3>& x) const noexcept;
+  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> inverse(
+      const std::array<T, 3>& x) const noexcept;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
@@ -92,6 +233,7 @@ class Wedge3D {
   Direction<3> direction_of_wedge_{};
   double sphericity_of_other_surface_{
       std::numeric_limits<double>::signaling_NaN()};
+  bool with_equiangular_map_ = false;
 };
 bool operator!=(const Wedge3D& lhs, const Wedge3D& rhs) noexcept;
 }  // namespace CoordinateMaps

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -195,3 +195,13 @@ void test_coordinate_map_argument_types(
                           make_tensor_data_vector(expected));
   }
 }
+
+/*!
+ * \ingroup TestingFramework
+ * \brief Given a Map `map`, checks that the inverse map gives expected results
+ */
+template <typename Map>
+void test_inverse_map(const Map& map,
+                      const std::array<double, Map::dim>& test_point) {
+  CHECK_ITERABLE_APPROX(test_point, map.inverse(map(test_point)));
+}

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -11,41 +11,91 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Sphere",
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Sphere.Equiangular",
                   "[Domain][Unit]") {
   const std::array<double, 3> lower_corner{{1.0, 1.0, -1.0}};
   const std::array<double, 3> upper_corner{{1.0, 1.0, 1.0}};
-  const CoordinateMaps::Wedge3D map(sqrt(3.0), 2.0 * sqrt(3.0),
-                                    Direction<3>::upper_zeta(), 1);
+  const std::array<double, 3> test_point1{{-0.1, 0.3, 0.1}};
+  const std::array<double, 3> test_point2{{0.5, 0.7, -0.5}};
+  const std::array<double, 3> test_point3{{0.9, -1.0, 0.4}};
 
-  CHECK(map(lower_corner)[0] == approx(1.0));
-  CHECK(map(lower_corner)[1] == approx(1.0));
-  CHECK(map(lower_corner)[2] == approx(1.0));
-  CHECK(map(upper_corner)[0] == approx(2.0));
-  CHECK(map(upper_corner)[1] == approx(2.0));
-  CHECK(map(upper_corner)[2] == approx(2.0));
+  for (const auto& direction : Direction<3>::all_directions()) {
+    const CoordinateMaps::Wedge3D map(sqrt(3.0), 2.0 * sqrt(3.0), direction, 1,
+                                      true);
+    test_jacobian(map, test_point1);
+    test_jacobian(map, test_point2);
+    test_jacobian(map, test_point3);
 
-  const std::array<double, 3> test_point1{{-1.0, 0.25, 0.0}};
-  const std::array<double, 3> test_point2{{1.0, 1.0, -0.5}};
-  const std::array<double, 3> test_point3{{0.7, -0.2, 0.4}};
+    test_inv_jacobian(map, test_point1);
+    test_inv_jacobian(map, test_point2);
+    test_inv_jacobian(map, test_point3);
 
-  test_jacobian(map, test_point1);
-  test_jacobian(map, test_point2);
-  test_jacobian(map, test_point3);
+    test_inverse_map(map, test_point1);
+    test_inverse_map(map, test_point2);
+    test_inverse_map(map, test_point3);
+  }
 
-  test_inv_jacobian(map, test_point1);
-  test_inv_jacobian(map, test_point2);
-  test_inv_jacobian(map, test_point3);
+  const CoordinateMaps::Wedge3D map_upper_zeta(
+      sqrt(3.0), 2.0 * sqrt(3.0), Direction<3>::upper_zeta(), 1, true);
 
-  test_coordinate_map_implementation<CoordinateMaps::Wedge3D>(map);
+  CHECK(map_upper_zeta(lower_corner)[0] == approx(1.0));
+  CHECK(map_upper_zeta(lower_corner)[1] == approx(1.0));
+  CHECK(map_upper_zeta(lower_corner)[2] == approx(1.0));
+  CHECK(map_upper_zeta(upper_corner)[0] == approx(2.0));
+  CHECK(map_upper_zeta(upper_corner)[1] == approx(2.0));
+  CHECK(map_upper_zeta(upper_corner)[2] == approx(2.0));
 
-  CHECK(serialize_and_deserialize(map) == map);
-  CHECK_FALSE(serialize_and_deserialize(map) != map);
+  test_coordinate_map_implementation<CoordinateMaps::Wedge3D>(map_upper_zeta);
 
-  test_coordinate_map_argument_types<false>(map, test_point1);
+  CHECK(serialize_and_deserialize(map_upper_zeta) == map_upper_zeta);
+  CHECK_FALSE(serialize_and_deserialize(map_upper_zeta) != map_upper_zeta);
+
+  test_coordinate_map_argument_types(map_upper_zeta, test_point1);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Alignment",
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Sphere.Equidistant",
+                  "[Domain][Unit]") {
+  const std::array<double, 3> lower_corner{{1.0, 1.0, -1.0}};
+  const std::array<double, 3> upper_corner{{1.0, 1.0, 1.0}};
+  const std::array<double, 3> test_point1{{-0.1, 0.3, 0.1}};
+  const std::array<double, 3> test_point2{{0.5, 0.7, -0.5}};
+  const std::array<double, 3> test_point3{{0.9, -1.0, 0.4}};
+
+  for (const auto& direction : Direction<3>::all_directions()) {
+    const CoordinateMaps::Wedge3D map(sqrt(3.0), 2.0 * sqrt(3.0), direction, 1,
+                                      false);
+    test_jacobian(map, test_point1);
+    test_jacobian(map, test_point2);
+    test_jacobian(map, test_point3);
+
+    test_inv_jacobian(map, test_point1);
+    test_inv_jacobian(map, test_point2);
+    test_inv_jacobian(map, test_point3);
+
+    test_inverse_map(map, test_point1);
+    test_inverse_map(map, test_point2);
+    test_inverse_map(map, test_point3);
+  }
+
+  const CoordinateMaps::Wedge3D map_upper_zeta(
+      sqrt(3.0), 2.0 * sqrt(3.0), Direction<3>::upper_zeta(), 1, false);
+
+  CHECK(map_upper_zeta(lower_corner)[0] == approx(1.0));
+  CHECK(map_upper_zeta(lower_corner)[1] == approx(1.0));
+  CHECK(map_upper_zeta(lower_corner)[2] == approx(1.0));
+  CHECK(map_upper_zeta(upper_corner)[0] == approx(2.0));
+  CHECK(map_upper_zeta(upper_corner)[1] == approx(2.0));
+  CHECK(map_upper_zeta(upper_corner)[2] == approx(2.0));
+
+  test_coordinate_map_implementation<CoordinateMaps::Wedge3D>(map_upper_zeta);
+
+  CHECK(serialize_and_deserialize(map_upper_zeta) == map_upper_zeta);
+  CHECK_FALSE(serialize_and_deserialize(map_upper_zeta) != map_upper_zeta);
+
+  test_coordinate_map_argument_types(map_upper_zeta, test_point1);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Alignment.Equiangular",
                   "[Domain][Unit]") {
   // Test that the logical axes point along the expected directions in
   // physical space
@@ -53,61 +103,147 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Alignment",
   const double inner_r = sqrt(3.0);
   const double outer_r = 2.0 * sqrt(3.0);
 
-  const CoordinateMaps::Wedge3D map_upper_zeta(inner_r, outer_r,
-                                               Direction<3>::upper_zeta(),
-                                               0);  // Upper Z wedge
-  const CoordinateMaps::Wedge3D map_upper_eta(inner_r, outer_r,
-                                              Direction<3>::upper_eta(),
-                                              0);  // Upper Y wedge
-  const CoordinateMaps::Wedge3D map_upper_xi(inner_r, outer_r,
-                                             Direction<3>::upper_xi(),
-                                             0);  // Upper X Wedge
-  const CoordinateMaps::Wedge3D map_lower_zeta(inner_r, outer_r,
-                                               Direction<3>::lower_zeta(),
-                                               0);  // Lower Z wedge
-  const CoordinateMaps::Wedge3D map_lower_eta(inner_r, outer_r,
-                                              Direction<3>::lower_eta(),
-                                              0);  // Lower Y wedge
-  const CoordinateMaps::Wedge3D map_lower_xi(inner_r, outer_r,
-                                             Direction<3>::lower_xi(),
-                                             0);  // Lower X wedge
+  const CoordinateMaps::Wedge3D map_upper_zeta(
+      inner_r, outer_r, Direction<3>::upper_zeta(), 0, true);  // Upper Z wedge
+  const CoordinateMaps::Wedge3D map_upper_eta(
+      inner_r, outer_r, Direction<3>::upper_eta(), 0, true);  // Upper Y wedge
+  const CoordinateMaps::Wedge3D map_upper_xi(
+      inner_r, outer_r, Direction<3>::upper_xi(), 0, true);  // Upper X Wedge
+  const CoordinateMaps::Wedge3D map_lower_zeta(
+      inner_r, outer_r, Direction<3>::lower_zeta(), 0, true);  // Lower Z wedge
+  const CoordinateMaps::Wedge3D map_lower_eta(
+      inner_r, outer_r, Direction<3>::lower_eta(), 0, true);  // Lower Y wedge
+  const CoordinateMaps::Wedge3D map_lower_xi(
+      inner_r, outer_r, Direction<3>::lower_xi(), 0, true);  // Lower X wedge
   const std::array<double, 3> lowest_corner{{-1.0, -1.0, -1.0}};
   const std::array<double, 3> along_xi{{1.0, -1.0, -1.0}};
   const std::array<double, 3> along_eta{{-1.0, 1.0, -1.0}};
   const std::array<double, 3> along_zeta{{-1.0, -1.0, 1.0}};
 
   // Test that this map's logical axes point along +X, +Y, +Z:
-  CHECK(map_upper_zeta(along_xi)[0] > map_upper_zeta(lowest_corner)[0]);
-  CHECK(map_upper_zeta(along_eta)[1] > map_upper_zeta(lowest_corner)[1]);
-  CHECK(map_upper_zeta(along_zeta)[2] > map_upper_zeta(lowest_corner)[2]);
+  CHECK(map_upper_zeta(along_xi)[0] == approx(1.0));
+  CHECK(map_upper_zeta(lowest_corner)[0] == approx(-1.0));
+  CHECK(map_upper_zeta(along_eta)[1] == approx(1.0));
+  CHECK(map_upper_zeta(lowest_corner)[1] == approx(-1.0));
+  CHECK(map_upper_zeta(along_zeta)[2] == approx(2.0));
+  CHECK(map_upper_zeta(lowest_corner)[2] == approx(1.0));
 
   // Test that this map's logical axes point along +Z, +X, +Y:
-  CHECK(map_upper_eta(along_xi)[2] > map_upper_eta(lowest_corner)[2]);
-  CHECK(map_upper_eta(along_eta)[0] > map_upper_eta(lowest_corner)[0]);
-  CHECK(map_upper_eta(along_zeta)[1] > map_upper_eta(lowest_corner)[1]);
+  CHECK(map_upper_eta(along_xi)[2] == approx(1.0));
+  CHECK(map_upper_eta(lowest_corner)[2] == approx(-1.0));
+  CHECK(map_upper_eta(along_eta)[0] == approx(1.0));
+  CHECK(map_upper_eta(lowest_corner)[0] == approx(-1.0));
+  CHECK(map_upper_eta(along_zeta)[1] == approx(2.0));
+  CHECK(map_upper_eta(lowest_corner)[1] == approx(1.0));
 
   // Test that this map's logical axes point along +Y, +Z, +X:
-  CHECK(map_upper_xi(along_xi)[1] > map_upper_xi(lowest_corner)[1]);
-  CHECK(map_upper_xi(along_eta)[2] > map_upper_xi(lowest_corner)[2]);
-  CHECK(map_upper_xi(along_zeta)[0] > map_upper_xi(lowest_corner)[0]);
+  CHECK(map_upper_xi(along_xi)[1] == approx(1.0));
+  CHECK(map_upper_xi(lowest_corner)[1] == approx(-1.0));
+  CHECK(map_upper_xi(along_eta)[2] == approx(1.0));
+  CHECK(map_upper_xi(lowest_corner)[2] == approx(-1.0));
+  CHECK(map_upper_xi(along_zeta)[0] == approx(2.0));
+  CHECK(map_upper_xi(lowest_corner)[0] == approx(1.0));
 
   // Test that this map's logical axes point along +X, -Y, -Z:
-  CHECK(map_lower_zeta(along_xi)[0] > map_lower_zeta(lowest_corner)[0]);
-  CHECK(map_lower_zeta(along_eta)[1] < map_lower_zeta(lowest_corner)[1]);
-  CHECK(map_lower_zeta(along_zeta)[2] < map_lower_zeta(lowest_corner)[2]);
+  CHECK(map_lower_zeta(along_xi)[0] == approx(1.0));
+  CHECK(map_lower_zeta(lowest_corner)[0] == approx(-1.0));
+  CHECK(map_lower_zeta(along_eta)[1] == approx(-1.0));
+  CHECK(map_lower_zeta(lowest_corner)[1] == approx(1.0));
+  CHECK(map_lower_zeta(along_zeta)[2] == approx(-2.0));
+  CHECK(map_lower_zeta(lowest_corner)[2] == approx(-1.0));
 
   // Test that this map's logical axes point along -Z, +X, -Y:
-  CHECK(map_lower_eta(along_xi)[2] < map_lower_eta(lowest_corner)[2]);
-  CHECK(map_lower_eta(along_eta)[0] > map_lower_eta(lowest_corner)[0]);
-  CHECK(map_lower_eta(along_zeta)[1] < map_lower_eta(lowest_corner)[1]);
+  CHECK(map_lower_eta(along_xi)[2] == approx(-1.0));
+  CHECK(map_lower_eta(lowest_corner)[2] == approx(1.0));
+  CHECK(map_lower_eta(along_eta)[0] == approx(1.0));
+  CHECK(map_lower_eta(lowest_corner)[0] == approx(-1.0));
+  CHECK(map_lower_eta(along_zeta)[1] == approx(-2.0));
+  CHECK(map_lower_eta(lowest_corner)[1] == approx(-1.0));
 
   // Test that this map's logical axes point along -Y, +Z, -X:
-  CHECK(map_lower_xi(along_xi)[1] < map_lower_xi(lowest_corner)[1]);
-  CHECK(map_lower_xi(along_eta)[2] > map_lower_xi(lowest_corner)[2]);
-  CHECK(map_lower_xi(along_zeta)[0] < map_lower_xi(lowest_corner)[0]);
+  CHECK(map_lower_xi(along_xi)[1] == approx(-1.0));
+  CHECK(map_lower_xi(lowest_corner)[1] == approx(1.0));
+  CHECK(map_lower_xi(along_eta)[2] == approx(1.0));
+  CHECK(map_lower_xi(lowest_corner)[2] == approx(-1.0));
+  CHECK(map_lower_xi(along_zeta)[0] == approx(-2.0));
+  CHECK(map_lower_xi(lowest_corner)[0] == approx(-1.0));
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.RandomRadii",
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Alignment.Equidistant",
+                  "[Domain][Unit]") {
+  // Test that the logical axes point along the expected directions in
+  // physical space
+
+  const double inner_r = sqrt(3.0);
+  const double outer_r = 2.0 * sqrt(3.0);
+
+  const CoordinateMaps::Wedge3D map_upper_zeta(
+      inner_r, outer_r, Direction<3>::upper_zeta(), 0, true);  // Upper Z wedge
+  const CoordinateMaps::Wedge3D map_upper_eta(
+      inner_r, outer_r, Direction<3>::upper_eta(), 0, true);  // Upper Y wedge
+  const CoordinateMaps::Wedge3D map_upper_xi(
+      inner_r, outer_r, Direction<3>::upper_xi(), 0, true);  // Upper X Wedge
+  const CoordinateMaps::Wedge3D map_lower_zeta(
+      inner_r, outer_r, Direction<3>::lower_zeta(), 0, true);  // Lower Z wedge
+  const CoordinateMaps::Wedge3D map_lower_eta(
+      inner_r, outer_r, Direction<3>::lower_eta(), 0, true);  // Lower Y wedge
+  const CoordinateMaps::Wedge3D map_lower_xi(
+      inner_r, outer_r, Direction<3>::lower_xi(), 0, true);  // Lower X wedge
+  const std::array<double, 3> lowest_corner{{-1.0, -1.0, -1.0}};
+  const std::array<double, 3> along_xi{{1.0, -1.0, -1.0}};
+  const std::array<double, 3> along_eta{{-1.0, 1.0, -1.0}};
+  const std::array<double, 3> along_zeta{{-1.0, -1.0, 1.0}};
+
+  // Test that this map's logical axes point along +X, +Y, +Z:
+  CHECK(map_upper_zeta(along_xi)[0] == approx(1.0));
+  CHECK(map_upper_zeta(lowest_corner)[0] == approx(-1.0));
+  CHECK(map_upper_zeta(along_eta)[1] == approx(1.0));
+  CHECK(map_upper_zeta(lowest_corner)[1] == approx(-1.0));
+  CHECK(map_upper_zeta(along_zeta)[2] == approx(2.0));
+  CHECK(map_upper_zeta(lowest_corner)[2] == approx(1.0));
+
+  // Test that this map's logical axes point along +Z, +X, +Y:
+  CHECK(map_upper_eta(along_xi)[2] == approx(1.0));
+  CHECK(map_upper_eta(lowest_corner)[2] == approx(-1.0));
+  CHECK(map_upper_eta(along_eta)[0] == approx(1.0));
+  CHECK(map_upper_eta(lowest_corner)[0] == approx(-1.0));
+  CHECK(map_upper_eta(along_zeta)[1] == approx(2.0));
+  CHECK(map_upper_eta(lowest_corner)[1] == approx(1.0));
+
+  // Test that this map's logical axes point along +Y, +Z, +X:
+  CHECK(map_upper_xi(along_xi)[1] == approx(1.0));
+  CHECK(map_upper_xi(lowest_corner)[1] == approx(-1.0));
+  CHECK(map_upper_xi(along_eta)[2] == approx(1.0));
+  CHECK(map_upper_xi(lowest_corner)[2] == approx(-1.0));
+  CHECK(map_upper_xi(along_zeta)[0] == approx(2.0));
+  CHECK(map_upper_xi(lowest_corner)[0] == approx(1.0));
+
+  // Test that this map's logical axes point along +X, -Y, -Z:
+  CHECK(map_lower_zeta(along_xi)[0] == approx(1.0));
+  CHECK(map_lower_zeta(lowest_corner)[0] == approx(-1.0));
+  CHECK(map_lower_zeta(along_eta)[1] == approx(-1.0));
+  CHECK(map_lower_zeta(lowest_corner)[1] == approx(1.0));
+  CHECK(map_lower_zeta(along_zeta)[2] == approx(-2.0));
+  CHECK(map_lower_zeta(lowest_corner)[2] == approx(-1.0));
+
+  // Test that this map's logical axes point along -Z, +X, -Y:
+  CHECK(map_lower_eta(along_xi)[2] == approx(-1.0));
+  CHECK(map_lower_eta(lowest_corner)[2] == approx(1.0));
+  CHECK(map_lower_eta(along_eta)[0] == approx(1.0));
+  CHECK(map_lower_eta(lowest_corner)[0] == approx(-1.0));
+  CHECK(map_lower_eta(along_zeta)[1] == approx(-2.0));
+  CHECK(map_lower_eta(lowest_corner)[1] == approx(-1.0));
+
+  // Test that this map's logical axes point along -Y, +Z, -X:
+  CHECK(map_lower_xi(along_xi)[1] == approx(-1.0));
+  CHECK(map_lower_xi(lowest_corner)[1] == approx(1.0));
+  CHECK(map_lower_xi(along_eta)[2] == approx(1.0));
+  CHECK(map_lower_xi(lowest_corner)[2] == approx(-1.0));
+  CHECK(map_lower_xi(along_zeta)[0] == approx(-2.0));
+  CHECK(map_lower_xi(lowest_corner)[0] == approx(-1.0));
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.RandomRadii.Equiangular",
                   "[Domain][Unit]") {
   // Set up random number generator:
   std::random_device rd;
@@ -148,22 +284,22 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.RandomRadii",
 
   const CoordinateMaps::Wedge3D map_lower_xi(random_inner_radius_lower_xi,
                                              random_outer_radius_lower_xi,
-                                             Direction<3>::lower_xi(), 0);
-  const CoordinateMaps::Wedge3D map_lower_eta(random_inner_radius_lower_eta,
-                                              random_outer_radius_lower_eta,
-                                              Direction<3>::lower_eta(), 0);
-  const CoordinateMaps::Wedge3D map_lower_zeta(random_inner_radius_lower_zeta,
-                                               random_outer_radius_lower_zeta,
-                                               Direction<3>::lower_zeta(), 0);
+                                             Direction<3>::lower_xi(), 0, true);
+  const CoordinateMaps::Wedge3D map_lower_eta(
+      random_inner_radius_lower_eta, random_outer_radius_lower_eta,
+      Direction<3>::lower_eta(), 0, true);
+  const CoordinateMaps::Wedge3D map_lower_zeta(
+      random_inner_radius_lower_zeta, random_outer_radius_lower_zeta,
+      Direction<3>::lower_zeta(), 0, true);
   const CoordinateMaps::Wedge3D map_upper_xi(random_inner_radius_upper_xi,
                                              random_outer_radius_upper_xi,
-                                             Direction<3>::upper_xi(), 0);
-  const CoordinateMaps::Wedge3D map_upper_eta(random_inner_radius_upper_eta,
-                                              random_outer_radius_upper_eta,
-                                              Direction<3>::upper_eta(), 0);
-  const CoordinateMaps::Wedge3D map_upper_zeta(random_inner_radius_upper_zeta,
-                                               random_outer_radius_upper_zeta,
-                                               Direction<3>::upper_zeta(), 0);
+                                             Direction<3>::upper_xi(), 0, true);
+  const CoordinateMaps::Wedge3D map_upper_eta(
+      random_inner_radius_upper_eta, random_outer_radius_upper_eta,
+      Direction<3>::upper_eta(), 0, true);
+  const CoordinateMaps::Wedge3D map_upper_zeta(
+      random_inner_radius_upper_zeta, random_outer_radius_upper_zeta,
+      Direction<3>::upper_zeta(), 0, true);
   CHECK(map_lower_xi(outer_corner)[0] ==
         approx(-random_outer_radius_lower_xi / sqrt(3.0)));
   CHECK(map_lower_eta(outer_corner)[1] ==
@@ -210,8 +346,110 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.RandomRadii",
         approx(random_outer_radius_upper_zeta));
 }
 
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.RandomRadii.Equidistant",
+                  "[Domain][Unit]") {
+  // Set up random number generator:
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> real_dis(-1, 1);
+  std::uniform_real_distribution<> inner_dis(1, 3);
+  std::uniform_real_distribution<> outer_dis(4, 7);
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Jacobian",
+  // Check that points on the corners of the reference cube map to the correct
+  // corners of the wedge.
+  const std::array<double, 3> inner_corner{{-1.0, -1.0, -1.0}};
+  const std::array<double, 3> outer_corner{{1.0, 1.0, 1.0}};
+  const double random_inner_radius_lower_xi = inner_dis(gen);
+  CAPTURE_PRECISE(random_inner_radius_lower_xi);
+  const double random_inner_radius_lower_eta = inner_dis(gen);
+  CAPTURE_PRECISE(random_inner_radius_lower_eta);
+  const double random_inner_radius_lower_zeta = inner_dis(gen);
+  CAPTURE_PRECISE(random_inner_radius_lower_zeta);
+  const double random_inner_radius_upper_xi = inner_dis(gen);
+  CAPTURE_PRECISE(random_inner_radius_upper_xi);
+  const double random_inner_radius_upper_eta = inner_dis(gen);
+  CAPTURE_PRECISE(random_inner_radius_upper_eta);
+  const double random_inner_radius_upper_zeta = inner_dis(gen);
+  CAPTURE_PRECISE(random_inner_radius_upper_zeta);
+
+  const double random_outer_radius_lower_xi = outer_dis(gen);
+  CAPTURE_PRECISE(random_outer_radius_lower_xi);
+  const double random_outer_radius_lower_eta = outer_dis(gen);
+  CAPTURE_PRECISE(random_outer_radius_lower_eta);
+  const double random_outer_radius_lower_zeta = outer_dis(gen);
+  CAPTURE_PRECISE(random_outer_radius_lower_zeta);
+  const double random_outer_radius_upper_xi = outer_dis(gen);
+  CAPTURE_PRECISE(random_outer_radius_upper_xi);
+  const double random_outer_radius_upper_eta = outer_dis(gen);
+  CAPTURE_PRECISE(random_outer_radius_upper_eta);
+  const double random_outer_radius_upper_zeta = outer_dis(gen);
+  CAPTURE_PRECISE(random_outer_radius_upper_zeta);
+
+  const CoordinateMaps::Wedge3D map_lower_xi(
+      random_inner_radius_lower_xi, random_outer_radius_lower_xi,
+      Direction<3>::lower_xi(), 0, false);
+  const CoordinateMaps::Wedge3D map_lower_eta(
+      random_inner_radius_lower_eta, random_outer_radius_lower_eta,
+      Direction<3>::lower_eta(), 0, false);
+  const CoordinateMaps::Wedge3D map_lower_zeta(
+      random_inner_radius_lower_zeta, random_outer_radius_lower_zeta,
+      Direction<3>::lower_zeta(), 0, false);
+  const CoordinateMaps::Wedge3D map_upper_xi(
+      random_inner_radius_upper_xi, random_outer_radius_upper_xi,
+      Direction<3>::upper_xi(), 0, false);
+  const CoordinateMaps::Wedge3D map_upper_eta(
+      random_inner_radius_upper_eta, random_outer_radius_upper_eta,
+      Direction<3>::upper_eta(), 0, false);
+  const CoordinateMaps::Wedge3D map_upper_zeta(
+      random_inner_radius_upper_zeta, random_outer_radius_upper_zeta,
+      Direction<3>::upper_zeta(), 0, false);
+  CHECK(map_lower_xi(outer_corner)[0] ==
+        approx(-random_outer_radius_lower_xi / sqrt(3.0)));
+  CHECK(map_lower_eta(outer_corner)[1] ==
+        approx(-random_outer_radius_lower_eta / sqrt(3.0)));
+  CHECK(map_lower_zeta(outer_corner)[2] ==
+        approx(-random_outer_radius_lower_zeta / sqrt(3.0)));
+  CHECK(map_upper_xi(inner_corner)[0] ==
+        approx(random_inner_radius_upper_xi / sqrt(3.0)));
+  CHECK(map_upper_eta(inner_corner)[1] ==
+        approx(random_inner_radius_upper_eta / sqrt(3.0)));
+  CHECK(map_upper_zeta(inner_corner)[2] ==
+        approx(random_inner_radius_upper_zeta / sqrt(3.0)));
+
+  // Check that random points on the edges of the reference cube map to the
+  // correct edges of the wedge.
+  const std::array<double, 3> random_outer_face{
+      {real_dis(gen), real_dis(gen), 1.0}};
+  const std::array<double, 3> random_inner_face{
+      {real_dis(gen), real_dis(gen), -1.0}};
+  for (size_t i = 0; i < 3; ++i) {
+    CAPTURE_PRECISE(gsl::at(random_outer_face, i));
+    CAPTURE_PRECISE(gsl::at(random_inner_face, i));
+  }
+
+  CHECK(magnitude(map_lower_xi(random_outer_face)) ==
+        approx(random_outer_radius_lower_xi));
+  CHECK(map_lower_xi(random_inner_face)[0] ==
+        approx(-random_inner_radius_lower_xi / sqrt(3.0)));
+  CHECK(magnitude(map_lower_eta(random_outer_face)) ==
+        approx(random_outer_radius_lower_eta));
+  CHECK(map_lower_eta(random_inner_face)[1] ==
+        approx(-random_inner_radius_lower_eta / sqrt(3.0)));
+  CHECK(magnitude(map_upper_xi(random_outer_face)) ==
+        approx(random_outer_radius_upper_xi));
+  CHECK(map_upper_xi(random_inner_face)[0] ==
+        approx(random_inner_radius_upper_xi / sqrt(3.0)));
+  CHECK(magnitude(map_upper_eta(random_outer_face)) ==
+        approx(random_outer_radius_upper_eta));
+  CHECK(map_upper_eta(random_inner_face)[1] ==
+        approx(random_inner_radius_upper_eta / sqrt(3.0)));
+  CHECK(magnitude(map_lower_zeta(random_outer_face)) ==
+        approx(random_outer_radius_lower_zeta));
+  CHECK(magnitude(map_upper_zeta(random_outer_face)) ==
+        approx(random_outer_radius_upper_zeta));
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Jacobian.Equiangular",
                   "[Domain][Unit]") {
   // Set up random number generator
   std::random_device rd;
@@ -236,9 +474,46 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Jacobian",
 
   for (const auto direction : Direction<3>::all_directions()) {
     const CoordinateMaps::Wedge3D map{inner_radius, outer_radius, direction,
-                                      sphericity};
+                                      sphericity, true};
     const CoordinateMaps::Wedge3D map_spheres{inner_radius, outer_radius,
-                                             direction, 1};
+                                              direction, 1, true};
+
+    const std::array<double, 3> test_point{{xi, eta, zeta}};
+    test_jacobian(map, test_point);
+    test_inv_jacobian(map, test_point);
+    test_jacobian(map_spheres, test_point);
+    test_inv_jacobian(map_spheres, test_point);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Jacobian.Equidistant",
+                  "[Domain][Unit]") {
+  // Set up random number generator
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> real_dis(-1, 1);
+  std::uniform_real_distribution<> unit_dis(0, 1);
+  std::uniform_real_distribution<> inner_dis(1, 3);
+  std::uniform_real_distribution<> outer_dis(4, 7);
+
+  const double xi = real_dis(gen);
+  CAPTURE_PRECISE(xi);
+  const double eta = real_dis(gen);
+  CAPTURE_PRECISE(eta);
+  const double zeta = real_dis(gen);
+  CAPTURE_PRECISE(zeta);
+  const double inner_radius = inner_dis(gen);
+  CAPTURE_PRECISE(inner_radius);
+  const double outer_radius = outer_dis(gen);
+  CAPTURE_PRECISE(outer_radius);
+  const double sphericity = unit_dis(gen);
+  CAPTURE_PRECISE(sphericity);
+
+  for (const auto direction : Direction<3>::all_directions()) {
+    const CoordinateMaps::Wedge3D map{inner_radius, outer_radius, direction,
+                                      sphericity, false};
+    const CoordinateMaps::Wedge3D map_spheres{inner_radius, outer_radius,
+                                              direction, 1, false};
 
     const std::array<double, 3> test_point{{xi, eta, zeta}};
     test_jacobian(map, test_point);


### PR DESCRIPTION
Allows for use of either equiangular or equidistant variables in this coordinate map
Closes Issue #330 
