### PR TITLE
Fix linker warnings on MacBook Pro using AppleClang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -280,7 +280,7 @@ script:
              -D CATCH_ROOT=$HOME/Catch
              -D LIBXSMM_ROOT=$HOME/libxsmm/build
              -D YAMLCPP_ROOT=$HOME/yaml-cpp/
-             -D CMAKE_EXE_LINKER_FLAGS="${SPECTRE_MIN_MACOS}"
+             -D MACOSX_MIN=10.11
              ${TRAVIS_BUILD_DIR}
     && make -j2
     && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ include(SetupCppCheck)
 include(SetupCxxFlags)
 include(SetupSanitizers)
 include(SetupListTargets)
+include(SetupMacOsx)
 include(SetupDoxygen)
 include(CodeCoverageDetection)
 

--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -39,3 +39,8 @@ check_and_add_cxx_flag("-Wwrite-strings")
 # GCC 7.1ish and newer warn about noexcept changing mangled names,
 # but we don't care
 check_and_add_cxx_flag("-Wno-noexcept-type")
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
+    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+  set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -Qunused-arguments")
+endif()

--- a/cmake/SetupGsl.cmake
+++ b/cmake/SetupGsl.cmake
@@ -8,7 +8,7 @@ list(APPEND SPECTRE_LIBRARIES ${GSL_LIBRARIES})
 # Extract the path where the shared libraries are and point the linker to
 # that directory
 list(GET GSL_LIBRARIES 0 FIRST_GSL_LIBRARY)
-string(REGEX REPLACE "libgsl[cblas]*.so" ""
+string(REGEX REPLACE "libgsl(cblas)?.(a|so|dylib)" ""
     GSL_LIBRARY_PATH ${FIRST_GSL_LIBRARY})
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L${GSL_LIBRARY_PATH}")
 list(APPEND SPECTRE_LIBRARIES "-lgsl")

--- a/cmake/SetupMacOsx.cmake
+++ b/cmake/SetupMacOsx.cmake
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+if(APPLE)
+  set(SPECTRE_MACOSX_MIN "10.7")
+  if(DEFINED MACOSX_MIN)
+    set(SPECTRE_MACOSX_MIN "${MACOSX_MIN}")
+  endif()
+  set(CMAKE_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS} -mmacosx-version-min=${SPECTRE_MACOSX_MIN}")
+endif()


### PR DESCRIPTION
## Proposed changes

Fixes to get rid of warnings on my MacBook Pro 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
