### PR TITLE
Interface items

### DIFF
--- a/src/DataStructures/DataVector.cpp
+++ b/src/DataStructures/DataVector.cpp
@@ -45,7 +45,8 @@ DataVector& DataVector::operator=(const DataVector& rhs) {
     }
     data_ = decltype(data_){owned_data_.data(), size_};
   } else {
-    ASSERT(rhs.size() == size(), "Must copy into same size");
+    ASSERT(rhs.size() == size(), "Must copy into same size, not "
+                                     << rhs.size() << " into " << size());
     std::copy(rhs.begin(), rhs.end(), begin());
   }
   return *this;
@@ -76,7 +77,8 @@ DataVector& DataVector::operator=(DataVector&& rhs) noexcept {
     data_ = std::move(rhs.data_);  // NOLINT
     owning_ = rhs.owning_;
   } else {
-    ASSERT(rhs.size() == size(), "Must copy into same size");
+    ASSERT(rhs.size() == size(), "Must copy into same size, not "
+                                     << rhs.size() << " into " << size());
     std::copy(rhs.begin(), rhs.end(), begin());
   }
   rhs.owning_ = true;

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -661,9 +661,9 @@ struct Subitems<Tag, Requires<tt::is_a_v<Variables, item_type<Tag>>>> {
       const gsl::not_null<item_type<Tag>*> parent_value,
       const gsl::not_null<item_type<Subtag>*> sub_value) noexcept {
     auto& vars = get<Subtag>(*parent_value);
-    for (auto vars_it = vars.begin(), var_it = sub_value->begin();
-         vars_it != vars.end(); ++vars_it, ++var_it) {
-      var_it->set_data_ref(&*vars_it);
+    for (auto vars_it = vars.begin(), sub_var_it = sub_value->begin();
+         vars_it != vars.end(); ++vars_it, ++sub_var_it) {
+      sub_var_it->set_data_ref(&*vars_it);
     }
   }
 

--- a/src/Domain/Direction.hpp
+++ b/src/Domain/Direction.hpp
@@ -18,6 +18,8 @@
 template <size_t VolumeDim>
 class Direction {
  public:
+  static constexpr const size_t volume_dim = VolumeDim;
+
   /// The logical-coordinate names of each dimension
   enum class Axis;
 

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Index.hpp"
@@ -20,6 +21,8 @@
 #include "Domain/FaceNormal.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 class DataVector;
 template <size_t Dim>
@@ -142,4 +145,193 @@ struct UnnormalizedFaceNormal : db::ComputeItemTag {
   using argument_tags = tmpl::list<Extents<VolumeDim>, ElementMap<VolumeDim>>;
 };
 
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// The set of directions to neighboring Elements
+template <size_t VolumeDim>
+struct InternalDirections : db::ComputeItemTag {
+  static constexpr db::DataBoxString label = "InternalDirections";
+  using argument_tags = tmpl::list<Element<VolumeDim>>;
+  static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
+    std::unordered_set<::Direction<VolumeDim>> result;
+    for (const auto& direction_neighbors : element.neighbors()) {
+      result.insert(direction_neighbors.first);
+    }
+    return result;
+  }
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// Base type for the Interface tag.  Exposed so that specializations
+/// can reuse the implementation.
+/// \tparam DirectionsTag the item of directions
+/// \tparam NameTag the tag labeling the item
+/// \tparam FunctionTag the tag to call to compute the result
+template <typename DirectionsTag, typename NameTag, typename FunctionTag>
+struct InterfaceBase;
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// \brief Prefix for an object on interfaces.
+///
+/// The contained object will be a map from ::Direction to the item
+/// type of `Tag`, with the set of directions being those produced by
+/// `DirectionsTag`.  If `Tag` is a compute item, its function will be
+/// applied separately to the data on each interface.  If some of the
+/// compute item's inputs should be taken from the volume even when
+/// applied on a slice, it may indicate them using a `volume_tags`
+/// typelist in the tag struct.
+///
+/// \tparam DirectionsTag the item of directions
+/// \tparam Tag the tag labeling the item
+template <typename DirectionsTag, typename Tag>
+struct Interface : InterfaceBase<DirectionsTag, Tag, Tag> {};
+
+namespace Interface_detail {
+// Pull volume_tags from BaseComputeItem, defaulting to an empty list.
+template <typename BaseComputeItem, typename = cpp17::void_t<>>
+struct volume_tags {
+  using type = tmpl::list<>;
+};
+
+template <typename BaseComputeItem>
+struct volume_tags<BaseComputeItem,
+                   cpp17::void_t<typename BaseComputeItem::volume_tags>> {
+  using type = typename BaseComputeItem::volume_tags;
+};
+
+// Add an Interface wrapper to a tag if it is not listed as being
+// taken from the volume.
+template <typename DirectionsTag, typename Tag, typename VolumeTags>
+struct interface_compute_item_argument_tag {
+  using type = tmpl::conditional_t<tmpl::list_contains_v<VolumeTags, Tag>, Tag,
+                                   Interface<DirectionsTag, Tag>>;
+};
+
+// Compute the argument tags for the interface version of a compute item.
+template <typename DirectionsTag, typename BaseComputeItem>
+using interface_compute_item_argument_tags = tmpl::transform<
+    typename BaseComputeItem::argument_tags,
+    interface_compute_item_argument_tag<
+        tmpl::pin<DirectionsTag>, tmpl::_1,
+        tmpl::pin<typename volume_tags<BaseComputeItem>::type>>>;
+
+// Pull the direction's entry from interface arguments, passing volume
+// arguments through unchanged.
+template <bool IsVolumeTag>
+struct unmap_interface_args;
+
+template <>
+struct unmap_interface_args<true> {
+  template <size_t VolumeDim, typename T>
+  static constexpr decltype(auto) apply(
+      const ::Direction<VolumeDim>& /*direction*/, const T& arg) noexcept {
+    return arg;
+  }
+};
+
+template <>
+struct unmap_interface_args<false> {
+  template <size_t VolumeDim, typename T>
+  static constexpr decltype(auto) apply(const ::Direction<VolumeDim>& direction,
+                                        const T& arg) noexcept {
+    return arg.at(direction);
+  }
+};
+
+template <typename DirectionsTag, typename BaseComputeItem,
+          typename ArgumentTags>
+struct evaluate_compute_item;
+
+template <typename DirectionsTag, typename BaseComputeItem,
+          typename... ArgumentTags>
+struct evaluate_compute_item<DirectionsTag, BaseComputeItem,
+                             tmpl::list<ArgumentTags...>> {
+  using volume_tags = typename volume_tags<BaseComputeItem>::type;
+  static_assert(
+      tmpl::size<tmpl::list_difference<
+          volume_tags, typename BaseComputeItem::argument_tags>>::value == 0,
+      "volume_tags contains tags not in argument_tags");
+
+  static constexpr auto apply(
+      const db::item_type<DirectionsTag>& directions,
+      const db::item_type<ArgumentTags>&... args) noexcept {
+    std::unordered_map<
+        typename db::item_type<DirectionsTag>::value_type,
+        std::decay_t<decltype(BaseComputeItem::function(
+            unmap_interface_args<tmpl::list_contains_v<
+                volume_tags, ArgumentTags>>::apply(*directions.begin(),
+                                                   args)...))>>
+        result;
+    for (const auto& direction : directions) {
+      result[direction] = BaseComputeItem::function(
+          unmap_interface_args<tmpl::list_contains_v<
+              volume_tags, ArgumentTags>>::apply(direction, args)...);
+    }
+    return result;
+  }
+};
+
+template <bool IsComputeItem, typename DirectionsTag, typename NameTag,
+          typename FunctionTag>
+struct InterfaceImpl;
+
+template <typename DirectionsTag, typename NameTag, typename FunctionTag>
+struct InterfaceImpl<false, DirectionsTag, NameTag, FunctionTag> {
+  static_assert(cpp17::is_same_v<NameTag, FunctionTag>,
+                "Can't specify a function for a simple item tag");
+  using tag = NameTag;
+  using type =
+      std::unordered_map<typename db::item_type<DirectionsTag>::value_type,
+                         db::item_type<NameTag>>;
+};
+
+template <typename DirectionsTag, typename NameTag, typename FunctionTag>
+struct InterfaceImpl<true, DirectionsTag, NameTag, FunctionTag>
+    : db::ComputeItemTag {
+  using tag = NameTag;
+  using forwarded_argument_tags =
+      interface_compute_item_argument_tags<DirectionsTag, FunctionTag>;
+  using argument_tags =
+      tmpl::push_front<forwarded_argument_tags, DirectionsTag>;
+  static constexpr auto function = evaluate_compute_item<
+    DirectionsTag, FunctionTag, forwarded_argument_tags>::apply;
+};
+}  // namespace Interface_detail
+
+template <typename DirectionsTag, typename NameTag, typename FunctionTag>
+struct InterfaceBase
+    : db::DataBoxPrefix,
+      Interface_detail::InterfaceImpl<db::is_compute_item_v<FunctionTag>,
+                                      DirectionsTag, NameTag, FunctionTag> {
+  static constexpr db::DataBoxString label = "Interface";
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// ::Direction to an interface
+template <size_t VolumeDim>
+struct Direction : db::DataBoxTag {
+  static constexpr db::DataBoxString label = "Direction";
+  using type = ::Direction<VolumeDim>;
+};
+
+/// \cond
+template <typename DirectionsTag, size_t VolumeDim>
+struct Interface<DirectionsTag, Direction<VolumeDim>>
+    : db::DataBoxPrefix, db::ComputeItemTag {
+  static constexpr db::DataBoxString label = "Interface";
+  using tag = Direction<VolumeDim>;
+  static constexpr auto function(
+      const std::unordered_set<::Direction<VolumeDim>>& directions) noexcept {
+    std::unordered_map<::Direction<VolumeDim>, ::Direction<VolumeDim>> result;
+    for (const auto& d : directions) {
+      result.emplace(d, d);
+    }
+    return result;
+  }
+  using argument_tags = tmpl::list<DirectionsTag>;
+};
+/// \endcond
 }  // namespace Tags

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -480,6 +480,19 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.SliceVariables",
   CHECK(data_on_slice(vars, extents, 0, x_offset) == expected_vars_sliced_in_x);
   CHECK(data_on_slice(vars, extents, 1, y_offset) == expected_vars_sliced_in_y);
   CHECK(data_on_slice(vars, extents, 2, z_offset) == expected_vars_sliced_in_z);
+
+  CHECK(
+      data_on_slice<VariablesTestTags_detail::vector>(
+          extents, 0, x_offset, get<VariablesTestTags_detail::vector>(vars)) ==
+      expected_vars_sliced_in_x);
+  CHECK(
+      data_on_slice<VariablesTestTags_detail::vector>(
+          extents, 1, y_offset, get<VariablesTestTags_detail::vector>(vars)) ==
+      expected_vars_sliced_in_y);
+  CHECK(
+      data_on_slice<VariablesTestTags_detail::vector>(
+          extents, 2, z_offset, get<VariablesTestTags_detail::vector>(vars)) ==
+      expected_vars_sliced_in_z);
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Variables.add_slice_to_data",

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SPECTRE_UNIT_DOMAIN
   Domain/Test_ElementMap.cpp
   Domain/Test_FaceNormal.cpp
   Domain/Test_InitialElementIds.cpp
+  Domain/Test_InterfaceItems.cpp
   Domain/Test_LogicalCoordinates.cpp
   Domain/Test_Neighbors.cpp
   Domain/Test_OrientationMap.cpp

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -1,0 +1,165 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+template <size_t N>
+struct NoCopy {
+  NoCopy() = default;
+  NoCopy(const NoCopy&) = delete;
+  NoCopy(NoCopy&&) = default;
+  NoCopy& operator=(const NoCopy&) = delete;
+  NoCopy& operator=(NoCopy&&) = default;
+  ~NoCopy() = default;
+};
+
+namespace TestTags {
+struct Int : db::DataBoxTag {
+  static constexpr db::DataBoxString label = "Int";
+  using type = int;
+};
+
+struct Double : db::DataBoxTag {
+  static constexpr db::DataBoxString label = "Double";
+  using type = double;
+};
+
+template <size_t N>
+struct NoCopy : db::DataBoxTag {
+  static constexpr db::DataBoxString label = "NoCopy";
+  using type = ::NoCopy<N>;
+};
+
+template <typename Tag>
+struct Negate : db::DataBoxPrefix, db::ComputeItemTag {
+  static constexpr db::DataBoxString label = "Negate";
+  using tag = Tag;
+  static constexpr auto function(const db::item_type<Tag>& x) noexcept {
+    return -x;
+  }
+  using argument_tags = tmpl::list<Tag>;
+};
+
+struct AddThree : db::ComputeItemTag {
+  static constexpr db::DataBoxString label = "AddThree";
+  static constexpr auto function(const int x) noexcept { return x + 3; }
+  using argument_tags = tmpl::list<Int>;
+  using volume_tags = tmpl::list<Int>;
+};
+
+template <size_t VolumeDim>
+struct ComplexComputeItem : db::ComputeItemTag {
+  static constexpr db::DataBoxString label = "ComplexComputeItem";
+  static constexpr auto function(const int i, const double d,
+                                 const ::NoCopy<1>& /*unused*/,
+                                 const ::NoCopy<2>& /*unused*/) noexcept {
+    return std::make_pair(i, d);
+  }
+  using argument_tags = tmpl::list<Int, Double, NoCopy<1>, NoCopy<2>>;
+  using volume_tags = tmpl::list<Int, NoCopy<1>>;
+};
+
+template <typename>
+struct TemplatedDirections : db::DataBoxTag {
+  static constexpr db::DataBoxString label = "TemplatedDirections";
+  using type = std::unordered_set<Direction<3>>;
+};
+}  // namespace TestTags
+}  // namespace
+
+namespace Tags {
+template <typename DirectionsTag>
+struct Interface<DirectionsTag, TestTags::Int>
+    : InterfaceBase<DirectionsTag, TestTags::Int, TestTags::AddThree> {};
+}  // namespace Tags
+
+SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
+  constexpr size_t dim = 3;
+  using internal_directions = Tags::InternalDirections<dim>;
+  using templated_directions = TestTags::TemplatedDirections<int>;
+
+  Element<dim> element{ElementId<3>(0),
+                       {{Direction<dim>::lower_xi(), {}},
+                        {Direction<dim>::upper_xi(), {}},
+                        {Direction<dim>::upper_zeta(), {}}}};
+
+  std::unordered_map<Direction<dim>, NoCopy<2>> nocopy_map_item;
+  nocopy_map_item.emplace(Direction<dim>::lower_xi(), NoCopy<2>{});
+  nocopy_map_item.emplace(Direction<dim>::upper_xi(), NoCopy<2>{});
+  nocopy_map_item.emplace(Direction<dim>::upper_zeta(), NoCopy<2>{});
+  const auto box = db::create<
+      db::AddTags<Tags::Element<dim>,
+                  TestTags::Int,
+                  Tags::Interface<internal_directions, TestTags::Double>,
+                  TestTags::NoCopy<1>,
+                  Tags::Interface<internal_directions, TestTags::NoCopy<2>>,
+                  templated_directions,
+                  Tags::Interface<templated_directions, TestTags::Double>>,
+      db::AddComputeItemsTags<
+          internal_directions,
+          Tags::Interface<internal_directions, Tags::Direction<dim>>,
+          TestTags::Negate<TestTags::Int>,
+          Tags::Interface<internal_directions, TestTags::Int>,
+          Tags::Interface<internal_directions,
+                          TestTags::Negate<TestTags::Double>>,
+          Tags::Interface<internal_directions,
+                          TestTags::ComplexComputeItem<dim>>,
+          Tags::Interface<templated_directions, Tags::Direction<dim>>,
+          Tags::Interface<templated_directions,
+                          TestTags::Negate<TestTags::Double>>>>(
+      std::move(element), 5,
+      std::unordered_map<Direction<dim>, double>{
+          {Direction<dim>::lower_xi(), 1.5},
+          {Direction<dim>::upper_xi(), 2.5},
+          {Direction<dim>::upper_zeta(), 3.5}},
+      NoCopy<1>{}, std::move(nocopy_map_item),
+      std::unordered_set<Direction<dim>>{Direction<dim>::upper_xi()},
+      std::unordered_map<Direction<dim>, double>{
+          {Direction<dim>::upper_xi(), 4.5}});
+
+  CHECK(
+      (get<Tags::Interface<internal_directions, Tags::Direction<dim>>>(box)) ==
+      (std::unordered_map<Direction<dim>, Direction<dim>>{
+          {Direction<dim>::lower_xi(), Direction<dim>::lower_xi()},
+          {Direction<dim>::upper_xi(), Direction<dim>::upper_xi()},
+          {Direction<dim>::upper_zeta(), Direction<dim>::upper_zeta()}}));
+
+  CHECK(get<TestTags::Negate<TestTags::Int>>(box) == -5);
+  CHECK((get<Tags::Interface<internal_directions,
+                             TestTags::Negate<TestTags::Double>>>(box)) ==
+        (std::unordered_map<Direction<dim>, double>{
+            {Direction<dim>::lower_xi(), -1.5},
+            {Direction<dim>::upper_xi(), -2.5},
+            {Direction<dim>::upper_zeta(), -3.5}}));
+
+  CHECK((get<Tags::Interface<internal_directions, TestTags::Int>>(box)) ==
+        (std::unordered_map<Direction<dim>, int>{
+            {Direction<dim>::lower_xi(), 8},
+            {Direction<dim>::upper_xi(), 8},
+            {Direction<dim>::upper_zeta(), 8}}));
+
+  CHECK((get<Tags::Interface<internal_directions,
+                             TestTags::ComplexComputeItem<dim>>>(box)) ==
+        (std::unordered_map<Direction<dim>, std::pair<int, double>>{
+            {Direction<dim>::lower_xi(), {5, 1.5}},
+            {Direction<dim>::upper_xi(), {5, 2.5}},
+            {Direction<dim>::upper_zeta(), {5, 3.5}}}));
+
+  CHECK((get<Tags::Interface<templated_directions,
+                             TestTags::Negate<TestTags::Double>>>(box)) ==
+        (std::unordered_map<Direction<dim>, double>{
+            {Direction<dim>::upper_xi(), -4.5}}));
+}


### PR DESCRIPTION
## Proposed changes

Adds infrastructure for handling items and compute items for boundary data more ergonomically and uses them in the flux communication actions.  This fixes the recomputation of the magnitude of the grid normal that we were doing before.

As minor other benefits, it moves the specification of the magnitude function to the system so we're not assuming flat space anymore and adds a missing pin to DataBox.

### Types of changes:

- [X] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

The interface for slicing variables is suboptimal.  It would be best if the sliced version of `VarTag` were `Interface<VarTag>` (where I am eliding unimportant parameters), but I can't think of a way for the code to know whether to compute `Interface<VarTag>` by slicing or by computing it directly on the boundary (as is needed for the magnitude of the grid normal).  Instead it is presented as `Interface<Slice<VarTag>>`, which won't work in general compute items expecting a plain `VarTag` (the non-Euclidean magnitude function fetching the metric will hit this).

I think some tag has to be specialized to deal with this.  We could remove the `Slice` wrapper if we specialized the `Interface` tag (or set a flag of some kind) for each type of variables we wanted sliced, which would have to be done for each system.  Alternatively, we could specialize the compute items using them to act differently on slices.  I am leaning towards the former solution.