### PR TITLE
Add compute_spacetime_metric

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -111,6 +111,11 @@
  */
 
 /*!
+ * \defgroup GeneralRelavitiyGroup General Relativity
+ * \brief Contains functions used in General Relativistic simulations
+ */
+
+/*!
  * \defgroup GlobalCache Global Cache
  * How to access and utilize the global cache
  */

--- a/src/PointwiseFunctions/CMakeLists.txt
+++ b/src/PointwiseFunctions/CMakeLists.txt
@@ -2,4 +2,5 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(AnalyticSolutions)
+add_subdirectory(GeneralRelativity)
 add_subdirectory(MathFunctions)

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY GeneralRelativity)
+
+set(LIBRARY_SOURCES
+    ComputeSpacetimeQuantities.cpp
+    )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/MakeWithValue.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+template <size_t Dim, typename Fr, typename DataType>
+tnsr::aa<DataType, Dim, Fr> compute_spacetime_metric(
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift,
+    const tnsr::ii<DataType, Dim, Fr>& spatial_metric) noexcept {
+  tnsr::aa<DataType, Dim, Fr> spacetime_metric{
+      make_with_value<DataType>(lapse.get(), 0.)};
+
+  spacetime_metric.template get<0, 0>() = -lapse.get() * lapse.get();
+
+  for (size_t m = 0; m < Dim; ++m) {
+    spacetime_metric.template get<0, 0>() +=
+        spatial_metric.get(m, m) * shift.get(m) * shift.get(m);
+    for (size_t n = 0; n < m; ++n) {
+      spacetime_metric.template get<0, 0>() +=
+          2 * spatial_metric.get(m, n) * shift.get(m) * shift.get(n);
+    }
+  }
+
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t m = 0; m < Dim; ++m) {
+      spacetime_metric.get(0, i + 1) += spatial_metric.get(m, i) * shift.get(m);
+    }
+    for (size_t j = i; j < Dim; ++j) {
+      spacetime_metric.get(i + 1, j + 1) = spatial_metric.get(i, j);
+    }
+  }
+  return spacetime_metric;
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>                \
+  compute_spacetime_metric(                                             \
+      const Scalar<DTYPE(data)>& lapse,                                 \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,        \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&              \
+          spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+///\file
+/// Defines Functions for calculating spacetime tensors from 3+1 quantities
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/*!
+* \ingroup GeneralRelativityGroup
+* \brief Computes the spacetime metric from the spatial metric, lapse, and
+* shift.
+* \details The spacetime metric \f$ \psi_{ab} \f$ is calculated as
+* \f{align}{
+*   \psi_{tt} &=& - N^2 + N^m N^n g_{mn} \\
+*   \psi_{ti} &=& g_{mi} N^m  \\
+*   \psi_{ij} &=& g_{ij}
+* \f}
+* where \f$ N, N^i\f$ and \f$ g_{ij}\f$ are the lapse, shift and spatial metric
+* respectively
+*/
+template <size_t Dim, typename Fr, typename DataType>
+tnsr::aa<DataType, Dim, Fr> compute_spacetime_metric(
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift,
+    const tnsr::ii<DataType, Dim, Fr>& spatial_metric) noexcept;

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(
   DomainCreators
   EinsteinSolutions
   GeneralizedHarmonic
+  GeneralRelativity
   IO
   NumericalAlgorithms
   Time

--- a/tests/Unit/PointwiseFunctions/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(SPECTRE_UNIT_POINTWISE_FUNCTIONS)
 
 add_subdirectory(AnalyticSolutions)
+add_subdirectory(GeneralRelativity)
 add_subdirectory(MathFunctions)
 
 set(SPECTRE_TESTS "${SPECTRE_TESTS};${SPECTRE_UNIT_POINTWISE_FUNCTIONS}"

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(SPECTRE_UNIT_GENERAL_RELATIVITY
+    PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+    )
+
+set(SPECTRE_UNIT_POINTWISE_FUNCTIONS
+  "${SPECTRE_UNIT_POINTWISE_FUNCTIONS};${SPECTRE_UNIT_GENERAL_RELATIVITY}"
+  PARENT_SCOPE)

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/range/combine.hpp>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+template <typename Symmetry, typename IndexList>
+void check_tensor_doubles_equals_tensor_datavectors(
+    const Tensor<DataVector, Symmetry, IndexList>& tensor_dv,
+    const Tensor<double, Symmetry, IndexList>& tensor_double) {
+  const size_t n_pts = tensor_dv.begin()->size();
+  for (decltype(auto) datavector_and_double_components :
+       boost::combine(tensor_dv, tensor_double)) {
+    for (size_t s = 0; s < n_pts; ++s) {
+      CHECK(boost::get<0>(datavector_and_double_components)[s] ==
+            boost::get<1>(datavector_and_double_components));
+    }
+  }
+}
+
+template <typename DataType>
+auto make_lapse(const DataType& structure) {
+  return Scalar<DataType>{make_with_value<DataType>(structure, 3.)};
+}
+
+template <typename DataType>
+auto make_shift(const DataType& structure) {
+  tnsr::I<DataType, 3> shift{};
+  for (size_t i = 0; i < 3; ++i) {
+    shift.get(i) = make_with_value<DataType>(structure, i);
+  }
+  return shift;
+}
+
+template <typename DataType>
+auto make_spatial_metric(const DataType& structure) {
+  tnsr::ii<DataType, 3> metric{};
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      metric.get(i, j) =
+          make_with_value<DataType>(structure, (i + 1.) * (j + 1.));
+    }
+  }
+  return metric;
+}
+
+void test_compute_spacetime_metric(const DataVector& structure) {
+  const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift(0.),
+                                            make_spatial_metric(0.));
+  CHECK(psi.get(0, 0) == approx(55.));
+  CHECK(psi.get(0, 1) == approx(8.));
+  CHECK(psi.get(0, 2) == approx(16.));
+  CHECK(psi.get(0, 3) == approx(24.));
+  CHECK(psi.get(1, 1) == approx(1.));
+  CHECK(psi.get(1, 2) == approx(2.));
+  CHECK(psi.get(1, 3) == approx(3.));
+  CHECK(psi.get(2, 2) == approx(4.));
+  CHECK(psi.get(2, 3) == approx(6.));
+  CHECK(psi.get(3, 3) == approx(9.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_spacetime_metric(make_lapse(structure),
+                               make_shift(structure),
+                               make_spatial_metric(structure)),
+      psi);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GrFunctions.SpacetimeDecomp",
+                  "[PointwiseFunctions][Unit]") {
+  const DataVector dv(2);
+  test_compute_spacetime_metric(dv);
+}


### PR DESCRIPTION
We need a lot of these functions which calculate GR quantities. This PR is just to add one such function so that we can decide on directory placement and things like that. I'll add the rest after we've settled on this one.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
