### PR TITLE
ERROR and ASSERT print triggering function

### DIFF
--- a/src/ErrorHandling/AbortWithErrorMessage.cpp
+++ b/src/ErrorHandling/AbortWithErrorMessage.cpp
@@ -9,7 +9,8 @@
 #include "Parallel/Info.hpp"
 
 void abort_with_error_message(const char* expression, const char* file,
-                              const int line, const std::string& message) {
+                              const int line, const char* pretty_function,
+                              const std::string& message) {
   std::ostringstream os;
   os << "\n"
      << "############ ASSERT FAILED ############\n"
@@ -17,6 +18,7 @@ void abort_with_error_message(const char* expression, const char* file,
      << "\n"
      << "Line: " << line << " of " << file << "\n"
      << "'" << expression << "' violated!\n"
+     << "Function: " << pretty_function << "\n"
      << message << "\n"
      << "############ ASSERT FAILED ############\n"
      << "\n";
@@ -24,6 +26,7 @@ void abort_with_error_message(const char* expression, const char* file,
 }
 
 void abort_with_error_message(const char* file, const int line,
+                              const char* pretty_function,
                               const std::string& message) {
   std::ostringstream os;
   os << "\n"
@@ -31,6 +34,7 @@ void abort_with_error_message(const char* file, const int line,
      << "Node: " << Parallel::my_node() << " Proc: " << Parallel::my_proc()
      << "\n"
      << "Line: " << line << " of " << file << "\n"
+     << "Function: " << pretty_function << "\n"
      << message << "\n"
      << "############ ERROR ############\n"
      << "\n";

--- a/src/ErrorHandling/AbortWithErrorMessage.hpp
+++ b/src/ErrorHandling/AbortWithErrorMessage.hpp
@@ -12,9 +12,11 @@
 /// Compose an error message with an expression and abort the program.
 [[noreturn]] void abort_with_error_message(const char* expression,
                                            const char* file, int line,
+                                           const char* pretty_function,
                                            const std::string& message);
 
 /// \ingroup ErrorHandling
 /// Compose an error message and abort the program.
 [[noreturn]] void abort_with_error_message(const char* file, int line,
+                                           const char* pretty_function,
                                            const std::string& message);

--- a/src/ErrorHandling/Assert.hpp
+++ b/src/ErrorHandling/Assert.hpp
@@ -34,15 +34,15 @@
 // 20160415) can't figure out that the else branch and everything
 // after it is unreachable, causing warnings (and possibly suboptimal
 // code generation).
-#define ASSERT(a, m)                                                \
-  do {                                                              \
-    if (!(a)) {                                                     \
-      std::ostringstream avoid_name_collisions_ASSERT;              \
-      /* clang-tidy: macro arg in parentheses */                    \
-      avoid_name_collisions_ASSERT << m; /* NOLINT */               \
-      abort_with_error_message(#a, __FILE__, __LINE__,              \
-                               avoid_name_collisions_ASSERT.str()); \
-    }                                                               \
+#define ASSERT(a, m)                                                        \
+  do {                                                                      \
+    if (!(a)) {                                                             \
+      std::ostringstream avoid_name_collisions_ASSERT;                      \
+      /* clang-tidy: macro arg in parentheses */                            \
+      avoid_name_collisions_ASSERT << m; /* NOLINT */                       \
+      abort_with_error_message(#a, __FILE__, __LINE__, __PRETTY_FUNCTION__, \
+                               avoid_name_collisions_ASSERT.str());         \
+    }                                                                       \
   } while (false)
 #else
 #define ASSERT(a, m)                                   \

--- a/src/ErrorHandling/Error.hpp
+++ b/src/ErrorHandling/Error.hpp
@@ -32,13 +32,13 @@
 // 20160415) can't figure out that the else branch and everything
 // after it is unreachable, causing warnings (and possibly suboptimal
 // code generation).
-#define ERROR(m)                                                 \
-  do {                                                           \
-    std::ostringstream avoid_name_collisions_ERROR;              \
-    /* clang-tidy: macro arg in parentheses */                   \
-    avoid_name_collisions_ERROR << m; /* NOLINT */               \
-    abort_with_error_message(__FILE__, __LINE__,                 \
-                             avoid_name_collisions_ERROR.str()); \
+#define ERROR(m)                                                      \
+  do {                                                                \
+    std::ostringstream avoid_name_collisions_ERROR;                   \
+    /* clang-tidy: macro arg in parentheses */                        \
+    avoid_name_collisions_ERROR << m; /* NOLINT */                    \
+    abort_with_error_message(__FILE__, __LINE__, __PRETTY_FUNCTION__, \
+                             avoid_name_collisions_ERROR.str());      \
   } while (false)
 
 /*!

--- a/src/IO/H5/File.hpp
+++ b/src/IO/H5/File.hpp
@@ -99,7 +99,7 @@ class H5File {
    */
   template <
       typename ObjectType, typename... Args,
-      typename std::enable_if_t<(sizeof(ObjectType),
+      typename std::enable_if_t<((void)sizeof(ObjectType),
                                  Access_t == AccessType::ReadWrite)>* = nullptr>
   ObjectType& get(const std::string& path, Args&&... args);
 
@@ -134,7 +134,7 @@ class H5File {
  private:
   /// \cond HIDDEN_SYMBOLS
   template <typename ObjectType,
-            std::enable_if_t<(sizeof(ObjectType),
+            std::enable_if_t<((void)sizeof(ObjectType),
                               Access_t == AccessType::ReadWrite)>* = nullptr>
   ObjectType& convert_to_derived(
       std::unique_ptr<h5::Object>& current_object);  // NOLINT
@@ -161,7 +161,7 @@ class H5File {
 
 template <AccessType Access_t>
 template <typename ObjectType, typename... Args,
-          typename std::enable_if_t<(sizeof(ObjectType),
+          typename std::enable_if_t<((void)sizeof(ObjectType),
                                      Access_t == AccessType::ReadWrite)>*>
 ObjectType& H5File<Access_t>::get(const std::string& path, Args&&... args) {
   // Ensure we call the const version of the get function to avoid infinite
@@ -242,7 +242,7 @@ ObjectType& H5File<Access_t>::insert(const std::string& path,
 /// \cond HIDDEN_SYMBOLS
 template <AccessType Access_t>
 template <typename ObjectType,
-          typename std::enable_if_t<(sizeof(ObjectType),
+          typename std::enable_if_t<((void)sizeof(ObjectType),
                                      Access_t == AccessType::ReadWrite)>*>
 ObjectType& H5File<Access_t>::convert_to_derived(
     std::unique_ptr<h5::Object>& current_object) {

--- a/tests/Unit/ErrorHandling/Test_AbortWithErrorMessage.cpp
+++ b/tests/Unit/ErrorHandling/Test_AbortWithErrorMessage.cpp
@@ -11,12 +11,16 @@
     "Unit.ErrorHandling.AbortWithErrorMessage.Assert",
     "[Unit][ErrorHandling]") {
   ERROR_TEST();
-  abort_with_error_message("a == b", __FILE__, __LINE__, "Test Error");
+  abort_with_error_message("a == b", __FILE__, __LINE__,
+                           static_cast<const char*>(__PRETTY_FUNCTION__),
+                           "Test Error");
 }
 
 // [[OutputRegex, ############ ERROR]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.ErrorHandling.AbortWithErrorMessage.Error",
                                "[Unit][ErrorHandling]") {
   ERROR_TEST();
-  abort_with_error_message(__FILE__, __LINE__, "Test Error");
+  abort_with_error_message(__FILE__, __LINE__,
+                           static_cast<const char*>(__PRETTY_FUNCTION__),
+                           "Test Error");
 }


### PR DESCRIPTION
## Proposed changes

Have ERROR and ASSERT print out the function they were triggered in. closes #358 

Sample output:

```
############ ERROR ############
Node: 0 Proc: 0
Line: 13 of /home/nils/SpECTRE/spectre/tests/Unit/DataStructures/Test_DataVector.cpp
Function: void foobar() [T = double]
oh no
```

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [x] Code has documentation and unit tests
- [x] Private member variables have a trailing underscore
- [x] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [x] File lists in CMake are alphabetical
- [x] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [x] Mark objects `const` whenever possible
- [x] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [x] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [x] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
