### PR TITLE
DataVector initializer_list constructor requires doubles

### DIFF
--- a/src/DataStructures/DataVector.cpp
+++ b/src/DataStructures/DataVector.cpp
@@ -12,8 +12,11 @@ DataVector::DataVector(const size_t size, const double value)
       owned_data_(size_, value),
       data_(owned_data_.data(), size_) {}
 
-DataVector::DataVector(std::initializer_list<double> list)
-    : size_(list.size()), owned_data_(list), data_(owned_data_.data(), size_) {}
+template <class T, Requires<cpp17::is_same_v<T, double>>>
+DataVector::DataVector(std::initializer_list<T> list)
+    : size_(list.size()),
+      owned_data_(std::move(list)),
+      data_(owned_data_.data(), size_) {}
 
 DataVector::DataVector(double* start, size_t size)
     : size_(size), owned_data_(0), data_(start, size_), owning_(false) {}
@@ -117,3 +120,7 @@ bool operator==(const DataVector& lhs, const DataVector& rhs) {
 bool operator!=(const DataVector& lhs, const DataVector& rhs) {
   return not(lhs == rhs);
 }
+
+/// \cond
+template DataVector::DataVector(std::initializer_list<double> list);
+/// \endcond

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -21,6 +21,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/PointerVector.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 /// \cond HIDDEN_SYMBOLS
 namespace PUP {
@@ -71,8 +72,10 @@ class DataVector {
   /// Create a non-owning DataVector that points to `start`
   DataVector(double* start, size_t size);
 
-  /// Create from an initializer list
-  DataVector(std::initializer_list<double> list);
+  /// Create from an initializer list of doubles. All elements in the
+  /// `std::initializer_list` must have decimal points
+  template <class T, Requires<cpp17::is_same_v<T, double>> = nullptr>
+  DataVector(std::initializer_list<T> list);
 
   /// Empty DataVector
   DataVector() = default;

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -9,6 +9,15 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector", "[DataStructures][Unit]") {
+  DataVector a{2};
+  CHECK(a.size() == 2);
+  DataVector b{2, 10.0};
+  CHECK(b.size() == 2);
+  for (size_t i = 0; i < b.size(); ++i) {
+    INFO(i);
+    CHECK(b[i] == 10.0);
+  }
+
   DataVector t(5, 10.0);
   CHECK(t.size() == 5);
   for (size_t i = 0; i < t.size(); ++i) {
@@ -204,7 +213,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.MathAfterMove",
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
                   "[Unit][DataStructures]") {
   constexpr size_t num_pts = 19;
-  DataVector val{1, 2, 3, -4, 8, 12, -14};
+  DataVector val{1., 2., 3., -4., 8., 12., -14.};
   DataVector nine(num_pts, 9.0);
   DataVector one(num_pts, 1.0);
 
@@ -230,7 +239,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
 
   CHECK(-14 == min(val));
   CHECK(12 == max(val));
-  check_vectors(DataVector{1, 2, 3, 4, 8, 12, 14}, abs(val));
+  check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, abs(val));
 
   check_vectors(DataVector(num_pts, 81.0), nine * nine);
   check_vectors(DataVector(num_pts, 81.0), nine * (nine * one));

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -545,7 +545,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeFile1D", "[Unit][IO][H5]") {
       DataVector{0.0, 1.0, 2.0});
   const Index<1> extents{3};
   const std::string element_id{"[0][0]"};
-  const Scalar<DataVector> scalar(DataVector{0, 8, 4});
+  const Scalar<DataVector> scalar(DataVector{0., 8., 4.});
   const tnsr::I<DataVector, 1, Frame::Grid> vector{
       {{DataVector{3.8, 9.7, 2.8}}}};
   std::unordered_map<
@@ -556,7 +556,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeFile1D", "[Unit][IO][H5]") {
   detyped_tensors.emplace(
       "weird_scalar"s,
       std::make_pair(std::vector<std::string>{},
-                     std::vector<DataVector>{DataVector{9, 7, 4}}));
+                     std::vector<DataVector>{DataVector{9., 7., 4.}}));
   {
     vis::VolumeFile my_file(file_name, 2);
     my_file.write_xdmf_time(time);
@@ -573,10 +573,10 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeFile1D", "[Unit][IO][H5]") {
   CHECK(3.8 == h5::get_time(file_id, "/[0][0]"));
   h5::detail::OpenGroup group(file_id, "/[0][0]", h5::AccessType::ReadOnly);
   CHECK(extents == h5::read_extents<1>(group.id(), "Extents"));
-  CHECK((DataVector{0, 1, 2}) == h5::read_data(group.id(), "x-coord"));
-  CHECK((DataVector{0, 8, 4}) == h5::read_data(group.id(), "scalar"));
+  CHECK((DataVector{0., 1., 2.}) == h5::read_data(group.id(), "x-coord"));
+  CHECK((DataVector{0., 8., 4.}) == h5::read_data(group.id(), "scalar"));
   CHECK((DataVector{3.8, 9.7, 2.8}) == h5::read_data(group.id(), "vector_x"));
-  CHECK((DataVector{9, 7, 4}) == h5::read_data(group.id(), "weird_scalar"));
+  CHECK((DataVector{9., 7., 4.}) == h5::read_data(group.id(), "weird_scalar"));
   CHECK_H5(H5Fclose(file_id), "Failed to close file: '" << file_name << "'");
 }
 
@@ -593,7 +593,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeFile2D", "[Unit][IO][H5]") {
   my_file.write_xdmf_time(time);
   my_file.write_element_connectivity_and_coordinates(time, grid_coords, extents,
                                                      element_id);
-  const Scalar<DataVector> scalar(DataVector{0, 8, 4, 7, 5, 2});
+  const Scalar<DataVector> scalar(DataVector{0., 8., 4., 7., 5., 2.});
   const tnsr::I<DataVector, dim, Frame::Grid> vector(
       DataVector{3.8, 9.7, 2.8, 8.9, 2.4, 8.3});
   std::unordered_map<
@@ -636,7 +636,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeFile3D", "[Unit][IO][H5]") {
   my_file.write_element_connectivity_and_coordinates(time, grid_coords, extents,
                                                      element_id);
   const Scalar<DataVector> scalar(
-      DataVector{0, 8, 4, 7, 5, 2, 8.9, 3.8, 39.0, 9.384, 38.2, 7.8});
+      DataVector{0., 8., 4., 7., 5., 2., 8.9, 3.8, 39.0, 9.384, 38.2, 7.8});
   const tnsr::I<DataVector, dim, Frame::Grid> vector(
       DataVector{3.8, 9.7, 2.8, 8.9, 2.4, 8.3, 3.8, 9.7, 2.8, 8.9, 2.4, 8.3});
   std::unordered_map<


### PR DESCRIPTION
## Proposed changes

Because initializer_list construction is overly greedy in C++
DataVector{2} creates a DataVector with a single element with value 2
instead of the expected behavior that it creates a DataVector of size 2. 

closes #356 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
