### PR TITLE
Fix Test_DomainCreators bug

### DIFF
--- a/tests/Unit/Domain/Test_DomainCreators.cpp
+++ b/tests/Unit/Domain/Test_DomainCreators.cpp
@@ -52,7 +52,9 @@ class FaceCornerIterator {
       corner_[i] = 2 * static_cast<int>(get_nth_bit(index_, i)) - 1;
     }
   }
-  explicit operator bool() noexcept { return index_ < two_to_the(VolumeDim); }
+  explicit operator bool() noexcept {
+    return face_index_ < two_to_the(VolumeDim - 1);
+  }
   tnsr::I<double, VolumeDim, Frame::Logical> operator()() noexcept {
     return corner_;
   }
@@ -166,13 +168,15 @@ double physical_separation(
     const Block<VolumeDim, TargetFrame>& block2) noexcept {
   double max_separation = 0;
   // Find Direction to block2:
-  const auto& direction = find_direction_to_neighbor(block1, block2);
+  const auto direction = find_direction_to_neighbor(block1, block2);
   // Find Orientation relative to block2:
-  const auto& orientation = find_neighbor_orientation(block1, block2);
+  const auto orientation = find_neighbor_orientation(block1, block2);
   // Construct shared Points, in frame of block1:
-  std::array<tnsr::I<double, VolumeDim, Frame::Logical>, VolumeDim>
+  std::array<tnsr::I<double, VolumeDim, Frame::Logical>,
+             two_to_the(VolumeDim - 1)>
       shared_points1;
-  std::array<tnsr::I<double, VolumeDim, Frame::Logical>, VolumeDim>
+  std::array<tnsr::I<double, VolumeDim, Frame::Logical>,
+             two_to_the(VolumeDim - 1)>
       shared_points2;
   for (FaceCornerIterator<VolumeDim> fci(direction); fci; ++fci) {
     shared_points1[fci.face_index()] = fci();


### PR DESCRIPTION
## Proposed changes

The array holding the shared corners should be of size 2^(dim-1), not dim.
This was not caught when Disk was the base on which this was tested
because Disk has dim=2.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
