### PR TITLE
Remove CASSERT

### DIFF
--- a/src/DataStructures/Tensor/Structure.hpp
+++ b/src/DataStructures/Tensor/Structure.hpp
@@ -292,11 +292,7 @@ struct Structure {
   template <size_t Rank = sizeof...(Indices),
             std::enable_if_t<Rank == 0>* = nullptr>
   SPECTRE_ALWAYS_INLINE static constexpr std::array<size_t, 0>
-  get_canonical_tensor_index(const size_t storage_index) noexcept {
-    static_cast<void>(storage_index);
-    CASSERT(0 == storage_index,
-            "For a scalar the 0th storage index should be retrieved for "
-            "consistency.");
+  get_canonical_tensor_index(const size_t /*storage_index*/) noexcept {
     return std::array<size_t, 0>{};
   }
 

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -219,12 +219,12 @@ class Variables<tmpl::list<Tags...>> {
   }
   //@}
 
-  static SPECTRE_ALWAYS_INLINE void constexpr add_reference_variable_data(
+  static SPECTRE_ALWAYS_INLINE void add_reference_variable_data(
       typelist<> /*unused*/, const size_t /*variable_offset*/ = 0) {
-    CASSERT(sizeof...(Tags) > 0,
-            "This ASSERT is triggered if you try to construct a Variables "
-            "with no Tags. A Variables with no Tags is a valid type, but "
-            "cannot be used in a meaningful way.");
+    ASSERT(sizeof...(Tags) > 0,
+           "This ASSERT is triggered if you try to construct a Variables "
+           "with no Tags. A Variables with no Tags is a valid type, but "
+           "cannot be used in a meaningful way.");
   }
 
   template <
@@ -358,12 +358,12 @@ template <typename TagToAdd, typename... Rest,
           Requires<tt::is_a<Tensor, typename TagToAdd::type>::value>>
 void Variables<tmpl::list<Tags...>>::add_reference_variable_data(
     typelist<TagToAdd, Rest...> /*unused*/, const size_t variable_offset) {
-  CASSERT(size_ > (variable_offset + TagToAdd::type::size() - 1) *
-                      number_of_grid_points_,
-          "This ASSERT is typically triggered because a Variables class was "
-          "default constructed. The only reason the Variables class has a "
-          "default constructor is because Charm++ uses it, you are not "
-          "supposed to use it otherwise.");
+  ASSERT(size_ > (variable_offset + TagToAdd::type::size() - 1) *
+                     number_of_grid_points_,
+         "This ASSERT is typically triggered because a Variables class was "
+         "default constructed. The only reason the Variables class has a "
+         "default constructor is because Charm++ uses it, you are not "
+         "supposed to use it otherwise.");
   typename TagToAdd::type& var =
       tuples::get<TagToAdd>(reference_variable_data_);
   for (size_t i = 0; i < TagToAdd::type::size(); ++i) {

--- a/src/Domain/SegmentId.hpp
+++ b/src/Domain/SegmentId.hpp
@@ -77,8 +77,8 @@ bool operator!=(const SegmentId& lhs, const SegmentId& rhs) noexcept;
 //##############################################################################
 
 inline SegmentId SegmentId::id_of_parent() const noexcept {
-  CASSERT(0 != refinement_level_,
-          "Cannot call id_of_parent() on root refinement level!");
+  ASSERT(0 != refinement_level_,
+         "Cannot call id_of_parent() on root refinement level!");
   // The parent has half as many segments as the child.
   return {refinement_level_ - 1, index_ / 2};
 }

--- a/src/ErrorHandling/Assert.hpp
+++ b/src/ErrorHandling/Assert.hpp
@@ -56,32 +56,3 @@
     }                                                  \
   } while (false)
 #endif
-
-// If SPECTRE_DEBUG is not defined, a void cast is used to avoid an unused
-// variable compiler warning when a passed parameter is only used in an ASSERT.
-// This is inside an if(false) statement so that the code never actually gets
-// executed and only placates the compiler.
-
-/*!
- * \ingroup ErrorHandling
- * \brief Assert that an expression should be true.
- *
- * Just like ASSERT and so the same guidelines apply. However, because
- * it does not use std::stringstream it can be used in some constexpr
- * functions where ASSERT cannot be.
- * \param a the expression that must be satisfied
- * \param m a std::string holding the error message
- */
-#ifdef SPECTRE_DEBUG
-#define CASSERT(a, m)                                                         \
-  do {                                                                        \
-    if (!(a)) {                                                               \
-      Parallel::abort("\n############ ASSERT FAILED ############\nLine: "s +  \
-                      std::to_string(__LINE__) + " of file '"s + __FILE__ +   \
-                      "'\n"s + "Condition: "s + #a + "\n"s + m + /* NOLINT */ \
-                      "\n#######################################\n"s);        \
-    }                                                                         \
-  } while (false)
-#else
-#define CASSERT(a, m)
-#endif

--- a/src/Utilities/ConstantExpressions.hpp
+++ b/src/Utilities/ConstantExpressions.hpp
@@ -25,7 +25,6 @@
 template <typename T,
           Requires<tt::is_integer_v<T> and cpp17::is_unsigned_v<T>> = nullptr>
 SPECTRE_ALWAYS_INLINE constexpr T two_to_the(T n) {
-  CASSERT(n < 8 * sizeof(T), "two_to_the is overflowing!");
   return T(1) << n;
 }
 

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -708,19 +708,6 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
 #endif
 }
 
-// [[OutputRegex, For a scalar the 0th storage index should be retrieved for
-// consistency.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.DataStructures.Tensor.const_out_of_bounds_get_tensor_index_scalar",
-    "[DataStructures][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  Scalar<double> tensor(1_st);
-  const auto& t = tensor.get_tensor_index(1000);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
 // [[OutputRegex, Expects violated: index >= 0 and index < narrow_cast<Size>]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.DataStructures.Tensor.const_out_of_bounds_get_tensor_index_vector",

--- a/tests/Unit/Utilities/Test_ConstantExpressions.cpp
+++ b/tests/Unit/Utilities/Test_ConstantExpressions.cpp
@@ -35,18 +35,6 @@ template struct TestTwoToThe<unsigned short>;
 template struct TestTwoToThe<unsigned long>;
 template struct TestTwoToThe<unsigned long long>;
 
-// [[OutputRegex, two_to_the is overflowing!]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.ConstantExpressions.TwoToThe",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const size_t n = 8 * sizeof(size_t);
-  // clang-tidy: value stored ... never used
-  const size_t two_to_the_n = two_to_the(n);  // NOLINT
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
 static_assert(square(2) == 4, "Failed test Unit.Utilities.ConstantExpressions");
 
 static_assert(cube(2) == 8, "Failed test Unit.Utilities.ConstantExpressions");

--- a/tests/Unit/Utilities/Test_MakeArray.cpp
+++ b/tests/Unit/Utilities/Test_MakeArray.cpp
@@ -53,19 +53,10 @@ SPECTRE_TEST_CASE("Unit.Utilities.MakeArray", "[Unit][Utilities]") {
   CHECK((my_array[0] == 1 and my_array[1] == 3 and my_array[2] == 4 and
          my_array[3] == 8 and my_array[4] == 9));
 
-  CHECK((std::array<int, 3>{{2, 8, 6}}) ==
-        (make_array<int, 3>(std::vector<int>{2, 8, 6})));
-  CHECK((std::array<int, 3>{{2, 8, 6}}) ==
-        (make_array<int, 3>(std::vector<int>{2, 8, 6, 9, 7})));
-}
-
-// [[OutputRegex, The sequence size must be at least as large as the array being
-// created from it.]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.MakeArraySeqTooSmall",
-                               "[Unit][Utilities]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  static_cast<void>(make_array<int, 3>(std::vector<int>{2, 8}));
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
+  constexpr const auto array_from_sequence =
+      make_array<int, 3>(std::initializer_list<int>{2, 8, 6});
+  CHECK((std::array<int, 3>{{2, 8, 6}}) == array_from_sequence);
+  constexpr const auto array_from_truncated_sequence =
+      make_array<int, 3>(std::initializer_list<int>{2, 8, 6, 9, 7});
+  CHECK((std::array<int, 3>{{2, 8, 6}}) == array_from_truncated_sequence);
 }


### PR DESCRIPTION
CASSERT does not work with GCC 5.  Compilation fails if any function
containing it is used in a constexpr context, so such functions are
effectively not constexpr and their CASSERTs can be replaced with
plain ASSERTs.

I have tried to judge in each case that used CASSERT whether it is
more important to have the function constexpr or to have the
assertion and made the appropriate change.

### Types of changes:

- [X] Bugfix
- [ ] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
