### PR TITLE
Add tmpl::list_contains metafunction

### DIFF
--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -545,3 +545,13 @@ constexpr bool flat_any_v = flat_any<Bs...>::value;
  */
 template <typename... Ts>
 constexpr void swallow(Ts&&...) noexcept {}
+
+namespace brigand {
+/// Check if a typelist contains an item.
+template <typename Sequence, typename Item>
+using list_contains =
+    tmpl::found<Sequence, std::is_same<tmpl::_1, tmpl::pin<Item>>>;
+
+template <typename Sequence, typename Item>
+constexpr const bool list_contains_v = list_contains<Sequence, Item>::value;
+}  // namespace brigand

--- a/tests/Unit/Utilities/Test_TMPL.cpp
+++ b/tests/Unit/Utilities/Test_TMPL.cpp
@@ -31,3 +31,18 @@ SPECTRE_TEST_CASE("Unit.Utilities.swallow", "[Utilities][Unit]") {
   CHECK(std::get<2>(my_tupull_output) == 16.4f);
 }
 /// [swallow_example]
+
+namespace {
+template <typename>
+struct Templated {};
+}  // namespace
+
+static_assert(tmpl::list_contains_v<tmpl::list<Templated<int>,
+                                               Templated<double>>,
+                                    Templated<double>>,
+              "Failed testing list_contains");
+
+static_assert(not tmpl::list_contains_v<tmpl::list<Templated<int>,
+                                                   Templated<double>>,
+                                        double>,
+              "Failed testing list_contains");


### PR DESCRIPTION
## Proposed changes

Ad d a metafunction to check if a typelist contains an item.

### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
