### PR TITLE
Improve parsing backtraces in factory

### DIFF
--- a/src/Options/Factory.hpp
+++ b/src/Options/Factory.hpp
@@ -100,14 +100,13 @@ std::unique_ptr<BaseClass> create(const Option& options) {
     id = node.begin()->first.as<std::string>();
     derived_opts.set_node(node.begin()->second);
   } else if (node.IsNull()) {
-    PARSE_ERROR(options.context(),
+    PARSE_ERROR(derived_opts.context(),
                 "Expected a class to create:\n" << help_derived<BaseClass>());
   } else {
     PARSE_ERROR(derived_opts.context(),
                 "Expected a class or a class with options, got:\n"
                 << node);
   }
-  derived_opts.append_context("While creating type " + id);
   auto derived =
       create_derived<BaseClass, typename BaseClass::creatable_classes>(
           id, derived_opts);


### PR DESCRIPTION
* Fix missing class name in factory error.
* Remove redundant backtrace line.

### Types of changes:

- [X] Bugfix
- [ ] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
