### PR TITLE
Move generic part of FakeVirtual to free function

### DIFF
--- a/src/Utilities/FakeVirtual.hpp
+++ b/src/Utilities/FakeVirtual.hpp
@@ -10,6 +10,7 @@
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 /// \ingroup Utilities
 /// \brief Define a function that acts similarly to a virtual
@@ -44,45 +45,71 @@
 ///
 /// \example
 /// \snippet Test_FakeVirtual.cpp fake_virtual_example
-#define DEFINE_FAKE_VIRTUAL(function)                                      \
-  /* This struct is only needed for producing an error if the function */  \
-  /* is not overridden in the derived class. */                            \
-  template <typename Base>                                                 \
-  struct FakeVirtualInherit_##function : public Base {                     \
-    using Base::Base;                                                      \
-    /* clang-tidy: I think "= delete" was overlooked in the guideline */   \
-    void function(...) const = delete;  /* NOLINT */                       \
-  };                                                                       \
-                                                                           \
-  template <typename Classes, typename... TArgs, typename Base,            \
-            typename... Args,                                              \
-            Requires<(tmpl::size<Classes>::value == 0)> = nullptr>         \
-  [[noreturn]] auto fake_virtual_##function(Base* obj, Args&&... args)     \
-      /* clang-tidy: macro arg in parentheses */                           \
-      ->decltype(obj->template function<TArgs...>(args...)) {  /* NOLINT */\
-    ERROR("Class " << pretty_type::get_runtime_type_name(*obj)             \
-                   << " is not registered with "                           \
-                   << pretty_type::get_name<std::remove_const_t<Base>>()); \
-  }                                                                        \
-                                                                           \
-  template <typename Classes, typename... TArgs, typename Base,            \
-            typename... Args,                                              \
-            Requires<(tmpl::size<Classes>::value != 0)> = nullptr>         \
-  decltype(auto) fake_virtual_##function(Base* obj, Args&&... args) {      \
-    using derived = tmpl::front<Classes>;                                  \
-    static_assert(std::is_base_of<typename Base::Inherit, derived>::value, \
-                  "Derived class does not inherit from Base::Inherit");    \
-    using derived_p = std::conditional_t<std::is_const<Base>::value,       \
-                                         derived const*, derived*>;        \
-    /* If we want to allow creatable classses to return objects of */      \
-    /* types derived from themselves then this will have to be changed */  \
-    /* to a dynamic_cast, but we probably won't want that and this */      \
-    /* form is significantly faster. */                                    \
-    return typeid(*obj) == typeid(derived)                                 \
-        ? static_cast<derived_p>(obj)                                      \
-        /* clang-tidy: macro arg in parentheses */                         \
-              ->template function<TArgs...>(/* NOLINT */                   \
-                                            std::forward<Args>(args)...)   \
-        : fake_virtual_##function<tmpl::pop_front<Classes>, TArgs...>(     \
-            obj, std::forward<Args>(args)...);                             \
+///
+/// \see call_with_dynamic_type
+#define DEFINE_FAKE_VIRTUAL(function)                                          \
+  /* This struct is only needed for producing an error if the function */      \
+  /* is not overridden in the derived class. */                                \
+  template <typename Base>                                                     \
+  struct FakeVirtualInherit_##function : public Base {                         \
+    using Base::Base;                                                          \
+    /* clang-tidy: I think "= delete" was overlooked in the guideline */       \
+    void function(...) const = delete; /* NOLINT */                            \
+  };                                                                           \
+                                                                               \
+  template <typename Classes, typename... TArgs, typename Base,                \
+            typename... Args>                                                  \
+  decltype(auto) fake_virtual_##function(Base* obj, Args&&... args) noexcept { \
+    /* clang-tidy: macro arg in parentheses */                                 \
+    return call_with_dynamic_type<                                             \
+        decltype(obj->template function<TArgs...>(args...)), /* NOLINT */      \
+        Classes>(                                                              \
+        obj, [&args...](auto* const dynamic_obj) noexcept -> decltype(auto) {  \
+          static_assert(                                                       \
+              cpp17::is_base_of_v<typename Base::Inherit,                      \
+                                  std::decay_t<decltype(*dynamic_obj)>>,       \
+              "Derived class does not inherit from Base::Inherit");            \
+          /* clang-tidy: macro arg in parentheses */                           \
+          return dynamic_obj->template function<TArgs...>(/* NOLINT */         \
+                                                          std::forward<Args>(  \
+                                                              args)...);       \
+        });                                                                    \
   }
+
+/// \cond
+template <typename Result, typename Classes, typename Base, typename Callable,
+          Requires<(tmpl::size<Classes>::value == 0)> = nullptr>
+[[noreturn]] Result call_with_dynamic_type(Base* const obj,
+                                           Callable&& /*f*/) noexcept {
+  ERROR("Class " << pretty_type::get_runtime_type_name(*obj)
+        << " is not registered with "
+        << pretty_type::get_name<std::remove_const_t<Base>>());
+}
+/// \endcond
+
+/// \ingroup Utilities
+/// \brief Call a functor with the derived type of a base class pointer.
+///
+/// \details Calls functor with obj cast to type `T*` where T is the
+/// dynamic type of `*obj`.  The decay type of `T` must be in the
+/// provided list of classes.
+///
+/// \see DEFINE_FAKE_VIRTUAL
+///
+/// \tparam Result the return type
+/// \tparam Classes the typelist of derived classes
+template <typename Result, typename Classes, typename Base, typename Callable,
+          Requires<(tmpl::size<Classes>::value != 0)> = nullptr>
+Result call_with_dynamic_type(Base* const obj, Callable&& f) noexcept {
+  using Derived = tmpl::front<Classes>;
+  using DerivedPointer =
+      std::conditional_t<std::is_const<Base>::value, Derived const*, Derived*>;
+  // If we want to allow creatable classses to return objects of
+  // types derived from themselves then this will have to be changed
+  // to a dynamic_cast, but we probably won't want that and this
+  // form is significantly faster.
+  return typeid(*obj) == typeid(Derived)
+             ? std::forward<Callable>(f)(static_cast<DerivedPointer>(obj))
+             : call_with_dynamic_type<Result, tmpl::pop_front<Classes>>(
+                   obj, std::forward<Callable>(f));
+}

--- a/tests/Unit/Utilities/Test_FakeVirtual.cpp
+++ b/tests/Unit/Utilities/Test_FakeVirtual.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/FakeVirtual.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
@@ -205,4 +206,48 @@ SPECTRE_TEST_CASE("Unit.Utilities.FakeVirtual.Unregistered",
   const std::unique_ptr<MultipleBase> c = std::make_unique<C>();
 
   c->deduced(1);
+}
+
+SPECTRE_TEST_CASE("Unit.Utilities.call_with_dynamic_type",
+                  "[Unit][Utilities]") {
+  struct B {
+    B() = default;
+    B(const B&) = delete;
+    B(B&&) = delete;
+    B& operator=(const B&) = delete;
+    B& operator=(B&&) = delete;
+    virtual ~B() = default;
+  };
+  struct D1 : B {
+    int mutable_func() { return 1; }
+    int const_func() const { return 11; }
+  };
+  struct D2 : B {
+    int mutable_func() { return 2; }
+    int const_func() const { return 12; }
+  };
+  std::unique_ptr<B> d1 = std::make_unique<D1>();
+  std::unique_ptr<B> d2 = std::make_unique<D2>();
+
+  CHECK(1 ==
+        (call_with_dynamic_type<int, tmpl::list<D1, D2>>(
+             d1.get(), [](auto* const p) { return p->mutable_func(); })));
+  CHECK(2 ==
+        (call_with_dynamic_type<int, tmpl::list<D1, D2>>(
+             d2.get(), [](auto* const p) { return p->mutable_func(); })));
+
+  CHECK(11 ==
+        (call_with_dynamic_type<int, tmpl::list<D1, D2>>(
+             &as_const(*d1),
+             [](const auto* const p) { return p->const_func(); })));
+  CHECK(12 ==
+        (call_with_dynamic_type<int, tmpl::list<D1, D2>>(
+             &as_const(*d2),
+             [](const auto* const p) { return p->const_func(); })));
+
+  // Test void return type
+  int result = 0;
+  call_with_dynamic_type<void, tmpl::list<D1, D2>>(
+      d2.get(), [&result](auto* const p) { result = p->mutable_func(); });
+  CHECK(2 == result);
 }


### PR DESCRIPTION
### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
