### PR TITLE
Datavector fabs

### DIFF
--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -27,6 +27,10 @@
 namespace PUP {
 class er;
 }  // namespace PUP
+
+// clang-tidy: no using declarations in header files
+//             We want the std::abs to be used
+using std::abs;  // NOLINT
 /// \endcond
 
 /*!

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -328,6 +328,11 @@ class DataVector {
     return abs(t.data_);
   }
 
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) fabs(
+      const DataVector& t) noexcept {
+    return abs(t.data_);
+  }
+
   SPECTRE_ALWAYS_INLINE friend decltype(auto) sqrt(
       const DataVector& t) noexcept {
     return sqrt(t.data_);

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -240,6 +240,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   CHECK(-14 == min(val));
   CHECK(12 == max(val));
   check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, abs(val));
+  check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, fabs(val));
 
   check_vectors(DataVector(num_pts, 81.0), nine * nine);
   check_vectors(DataVector(num_pts, 81.0), nine * (nine * one));


### PR DESCRIPTION
## Proposed changes

Add `fabs` function to DataVector.
Add `using std::abs` to `DataVector.hpp`

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."

