### PR TITLE
Overload db::get to allow retrieving DataBox

### DIFF
--- a/src/DataStructures/DataBoxTag.hpp
+++ b/src/DataStructures/DataBoxTag.hpp
@@ -27,6 +27,24 @@ struct Variables;
 }  // namespace Tags
 /// \endcond
 
+namespace Tags {
+/*!
+ * \ingroup DataBoxTags
+ * \brief Tag used to retrieve the DataBox from the `db::get` function
+ *
+ * The main use of this tag is to allow fetching the DataBox from itself. The
+ * primary use case is to allow an invokable to take a DataBox as an argument
+ * when called through `db::apply`.
+ *
+ * \snippet Test_DataBox.cpp databox_self_tag_example
+ */
+struct DataBox {
+  // Trick to get friend function declaration to compile but a const void& is
+  // rather useless
+  using type = void;
+};
+}  // namespace Tags
+
 namespace db {
 
 /*!


### PR DESCRIPTION
## Proposed changes

Allows "retrieving" the DataBox from itself by calling db::get<Tags::DataBox>(box).

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."

