### PR TITLE
Add compute inverse spacetime metric, derivs of metric and christoffel. 

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY GeneralRelativity)
 
 set(LIBRARY_SOURCES
+    Christoffel.cpp
     ComputeSpacetimeQuantities.cpp
     )
 

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+tnsr::abb<DataType, SpatialDim, Frame, Index> compute_christoffel_first_kind(
+    const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric) {
+  tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel{};
+  constexpr auto dimensionality =
+      tnsr::abb<DataType, SpatialDim, Frame, Index>::template index_dim<0>();
+  for (size_t k = 0; k < dimensionality; ++k) {
+    for (size_t i = 0; i < dimensionality; ++i) {
+      for (size_t j = i; j < dimensionality; ++j) {
+        christoffel.get(k, i, j) =
+            0.5 * (d_metric.get(i, j, k) + d_metric.get(j, i, k) -
+                   d_metric.get(k, i, j));
+      }
+    }
+  }
+  return christoffel;
+}
+
+// Explicit Instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define INDEXTYPE(data) BOOST_PP_TUPLE_ELEM(3, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template tnsr::abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>   \
+  compute_christoffel_first_kind(                                            \
+      const tnsr::abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>& \
+          d_metric);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial),
+                        (IndexType::Spatial, IndexType::Spacetime))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INDEXTYPE
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+///\file
+/// Defines functions to calculate Christoffel symbols
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes Christoffel symbol of the first kind from derivative of
+ * metric
+ *
+ * \details Computes Christoffel symbol \f$\Gamma_{abc}\f$ as:
+ * \f$ \Gamma_{cab} = 1/2 ( \partial_a g_{bc} + \partial_b g_{ac} -  \partial_c
+ *    g_{ab}) \f$
+ * where \f$g_{bc}\f$ is either a spatial or spacetime metric
+ */
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+tnsr::abb<DataType, SpatialDim, Frame, Index> compute_christoffel_first_kind(
+    const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric);

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -63,24 +63,99 @@ tnsr::AA<DataType, Dim, Frame> compute_inverse_spacetime_metric(
   return inverse_spacetime_metric;
 }
 
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::abb<DataType, Dim, Frame> compute_derivatives_of_spacetime_metric(
+    const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+    const tnsr::i<DataType, Dim, Frame>& deriv_lapse,
+    const tnsr::I<DataType, Dim, Frame>& shift,
+    const tnsr::I<DataType, Dim, Frame>& dt_shift,
+    const tnsr::iJ<DataType, Dim, Frame>& deriv_shift,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
+    const tnsr::ii<DataType, Dim, Frame>& dt_spatial_metric,
+    const tnsr::ijj<DataType, Dim, Frame>& deriv_spatial_metric) noexcept {
+  tnsr::abb<DataType, Dim, Frame> spacetime_deriv_spacetime_metric{
+      make_with_value<DataType>(lapse.get(), 0.)};
+
+  get<0, 0, 0>(spacetime_deriv_spacetime_metric) =
+      -2.0 * lapse.get() * dt_lapse.get();
+
+  for (size_t m = 0; m < Dim; ++m) {
+    for (size_t n = 0; n < Dim; ++n) {
+      get<0, 0, 0>(spacetime_deriv_spacetime_metric) +=
+          dt_spatial_metric.get(m, n) * shift.get(m) * shift.get(n) +
+          2.0 * spatial_metric.get(m, n) * shift.get(m) * dt_shift.get(n);
+    }
+  }
+
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t m = 0; m < Dim; ++m) {
+      spacetime_deriv_spacetime_metric.get(0, 0, i + 1) +=
+          dt_spatial_metric.get(m, i) * shift.get(m) +
+          spatial_metric.get(m, i) * dt_shift.get(m);
+    }
+    for (size_t j = i; j < Dim; ++j) {
+      spacetime_deriv_spacetime_metric.get(0, i + 1, j + 1) =
+          dt_spatial_metric.get(i, j);
+    }
+  }
+
+  for (size_t k = 0; k < Dim; ++k) {
+    spacetime_deriv_spacetime_metric.get(k + 1, 0, 0) =
+        -2.0 * lapse.get() * deriv_lapse.get(k);
+    for (size_t m = 0; m < Dim; ++m) {
+      for (size_t n = 0; n < Dim; ++n) {
+        spacetime_deriv_spacetime_metric.get(k + 1, 0, 0) +=
+            deriv_spatial_metric.get(k, m, n) * shift.get(m) * shift.get(n) +
+            2.0 * spatial_metric.get(m, n) * shift.get(m) *
+                deriv_shift.get(k, n);
+      }
+    }
+
+    for (size_t i = 0; i < Dim; ++i) {
+      for (size_t m = 0; m < Dim; ++m) {
+        spacetime_deriv_spacetime_metric.get(k + 1, 0, i + 1) +=
+            deriv_spatial_metric.get(k, m, i) * shift.get(m) +
+            spatial_metric.get(m, i) * deriv_shift.get(k, m);
+      }
+      for (size_t j = i; j < Dim; ++j) {
+        spacetime_deriv_spacetime_metric.get(k + 1, i + 1, j + 1) =
+            deriv_spatial_metric.get(k, i, j);
+      }
+    }
+  }
+
+  return spacetime_deriv_spacetime_metric;
+}
+
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define INSTANTIATE(_, data)                                     \
-  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>         \
-  compute_spacetime_metric(                                      \
-      const Scalar<DTYPE(data)>& lapse,                          \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift, \
-      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&       \
-          spatial_metric) noexcept;                              \
-  template tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>         \
-  compute_inverse_spacetime_metric(                              \
-      const Scalar<DTYPE(data)>& lapse,                          \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift, \
-      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&       \
-          inverse_spatial_metric) noexcept;
+#define INSTANTIATE(_, data)                                                  \
+  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>                      \
+  compute_spacetime_metric(                                                   \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spatial_metric) noexcept;                                           \
+  template tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>                      \
+  compute_inverse_spacetime_metric(                                           \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric) noexcept;                                   \
+  template tnsr::abb<DTYPE(data), DIM(data), FRAME(data)>                     \
+  compute_derivatives_of_spacetime_metric(                                    \
+      const Scalar<DTYPE(data)>& lapse, const Scalar<DTYPE(data)>& dt_lapse,  \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& deriv_lapse,        \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& dt_shift,           \
+      const tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>& deriv_shift,       \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          deriv_spatial_metric) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Inertial))

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -8,11 +8,11 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
-template <size_t Dim, typename Fr, typename DataType>
-tnsr::aa<DataType, Dim, Fr> compute_spacetime_metric(
-    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift,
-    const tnsr::ii<DataType, Dim, Fr>& spatial_metric) noexcept {
-  tnsr::aa<DataType, Dim, Fr> spacetime_metric{
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::aa<DataType, Dim, Frame> compute_spacetime_metric(
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Frame>& shift,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric) noexcept {
+  tnsr::aa<DataType, Dim, Frame> spacetime_metric{
       make_with_value<DataType>(lapse.get(), 0.)};
 
   get<0, 0>(spacetime_metric) = -lapse.get() * lapse.get();

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -37,18 +37,50 @@ tnsr::aa<DataType, Dim, Frame> compute_spacetime_metric(
   return spacetime_metric;
 }
 
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::AA<DataType, Dim, Frame> compute_inverse_spacetime_metric(
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Frame>& shift,
+    const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric) noexcept {
+  tnsr::AA<DataType, Dim, Frame> inverse_spacetime_metric{};
+
+  get<0, 0>(inverse_spacetime_metric) =
+      -1.0 / (lapse.get() * lapse.get());
+
+  const auto& minus_one_over_lapse_sqrd = get<0, 0>(inverse_spacetime_metric);
+
+  for (size_t i = 0; i < Dim; ++i) {
+    inverse_spacetime_metric.get(0, i + 1) = -
+        shift.get(i) * minus_one_over_lapse_sqrd;
+  }
+
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = i; j < Dim; ++j) {
+      inverse_spacetime_metric.get(i + 1, j + 1) =
+          inverse_spatial_metric.get(i, j) +
+          shift.get(i) * shift.get(j) * minus_one_over_lapse_sqrd;
+    }
+  }
+  return inverse_spacetime_metric;
+}
+
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
-#define INSTANTIATE(_, data)                                            \
-  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>                \
-  compute_spacetime_metric(                                             \
-      const Scalar<DTYPE(data)>& lapse,                                 \
-      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,        \
-      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&              \
-          spatial_metric) noexcept;
+#define INSTANTIATE(_, data)                                     \
+  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>         \
+  compute_spacetime_metric(                                      \
+      const Scalar<DTYPE(data)>& lapse,                          \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift, \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&       \
+          spatial_metric) noexcept;                              \
+  template tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>         \
+  compute_inverse_spacetime_metric(                              \
+      const Scalar<DTYPE(data)>& lapse,                          \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift, \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&       \
+          inverse_spatial_metric) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Inertial))

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -26,3 +26,24 @@ tnsr::aa<DataType, SpatialDim, Frame> compute_spacetime_metric(
     const Scalar<DataType>& lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute inverse spacetime metric from inverse spatial metric, lapse
+ * and shift
+ *
+ * \details The inverse spacetime metric \f$ \psi^{ab} \f$ is calculated as
+ * \f{align}
+ *    \psi^{tt} &=& -  1/N^2 \\
+ *    \psi^{ti} &=& N^i / N^2 \\
+ *    \psi^{ij} &=& g^{ij} - N^i N^j / N^2
+ * \f}
+ * where \f$ N, N^i\f$ and \f$ g^{ij}\f$ are the lapse, shift and inverse
+ * spatial metric respectively
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::AA<DataType, SpatialDim, Frame> compute_inverse_spacetime_metric(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::II<DataType, SpatialDim, Frame>&
+        inverse_spatial_metric) noexcept;

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -21,7 +21,8 @@
 * where \f$ N, N^i\f$ and \f$ g_{ij}\f$ are the lapse, shift and spatial metric
 * respectively
 */
-template <size_t Dim, typename Fr, typename DataType>
-tnsr::aa<DataType, Dim, Fr> compute_spacetime_metric(
-    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Fr>& shift,
-    const tnsr::ii<DataType, Dim, Fr>& spatial_metric) noexcept;
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::aa<DataType, SpatialDim, Frame> compute_spacetime_metric(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric) noexcept;

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -47,3 +47,32 @@ tnsr::AA<DataType, SpatialDim, Frame> compute_inverse_spacetime_metric(
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes spacetime derivative of spacetime metric from spatial metric,
+ * lapse, shift, and their space and time derivatives.
+ *
+ * \details Computes the derivatives as:
+ * \f{align}
+ *     \partial_\mu \psi_{tt} &=& - 2 N \partial_\mu N
+ *                 + 2 g_{mn} N^m \partial_\mu N^n
+ *                 + N^m N^n \partial_\mu g_{mn} \\
+ *     \partial_\mu \psi_{ti} &=& g_{mi} \partial_\mu N^m
+ *                 + N^m \partial_\mu g_{mi} \\
+ *     \partial_\mu \psi_{ij} &=& \partial_\mu g_{ij}
+ * \f}
+ * where \f$ N, N^i, g \f$ are the lapse, shift, and spatial metric
+ * respectively.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::abb<DataType, SpatialDim, Frame> compute_derivatives_of_spacetime_metric(
+    const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+    const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>&
+        deriv_spatial_metric) noexcept;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 set(SPECTRE_UNIT_GENERAL_RELATIVITY
+    PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
     PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
     )
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(SPECTRE_UNIT_GENERAL_RELATIVITY
     PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
+    PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
     PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
     )
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
@@ -1,0 +1,159 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+template <typename DataType>
+Scalar<DataType> make_lapse(const DataType& used_for_size) {
+  return Scalar<DataType>{make_with_value<DataType>(used_for_size, 3.)};
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::I<DataType, SpatialDim> make_shift(const DataType& used_for_size) {
+  tnsr::I<DataType, SpatialDim> shift{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    shift.get(i) = make_with_value<DataType>(used_for_size, i);
+  }
+  return shift;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::ii<DataType, SpatialDim> make_spatial_metric(
+    const DataType& used_for_size) {
+  tnsr::ii<DataType, SpatialDim> metric{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      metric.get(i, j) =
+          make_with_value<DataType>(used_for_size, (i + 1.) * (j + 1.));
+    }
+  }
+  return metric;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::II<DataType, SpatialDim> make_inverse_spatial_metric(
+    const DataType& used_for_size) {
+  tnsr::II<DataType, SpatialDim> metric{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      metric.get(i, j) =
+          make_with_value<DataType>(used_for_size, (i + 1.) * (j + 1.));
+    }
+  }
+  return metric;
+}
+
+template <typename DataType>
+Scalar<DataType> make_dt_lapse(const DataType& used_for_size) {
+  return Scalar<DataType>{make_with_value<DataType>(used_for_size, 5.)};
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::I<DataType, SpatialDim> make_dt_shift(const DataType& used_for_size) {
+  tnsr::I<DataType, SpatialDim> dt_shift{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    dt_shift.get(i) = make_with_value<DataType>(used_for_size, SpatialDim * i);
+  }
+  return dt_shift;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::ii<DataType, SpatialDim> make_dt_spatial_metric(
+    const DataType& used_for_size) {
+  tnsr::ii<DataType, SpatialDim> metric{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      metric.get(i, j) = make_with_value<DataType>(used_for_size, i + j);
+    }
+  }
+  return metric;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::i<DataType, SpatialDim> make_deriv_lapse(const DataType& used_for_size) {
+  tnsr::i<DataType, SpatialDim> deriv_lapse{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    deriv_lapse.get(i) = make_with_value<DataType>(used_for_size, 2.5 * i);
+  }
+  return deriv_lapse;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::iJ<DataType, SpatialDim> make_deriv_shift(const DataType& used_for_size) {
+  tnsr::iJ<DataType, SpatialDim> deriv_shift{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      deriv_shift.get(i, j) =
+          make_with_value<DataType>(used_for_size, 3. * (j + 1.) - i);
+    }
+  }
+  return deriv_shift;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::ijj<DataType, SpatialDim> make_deriv_spatial_metric(
+    const DataType& used_for_size) {
+  tnsr::ijj<DataType, SpatialDim> deriv_spatial_metric{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      for (size_t k = 0; k < SpatialDim; ++k) {
+        deriv_spatial_metric.get(k, i, j) = make_with_value<DataType>(
+            used_for_size, 3. * (i + 1.) * (j + 1.) + k);
+      }
+    }
+  }
+  return deriv_spatial_metric;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::abb<DataType, SpatialDim> make_spacetime_deriv_spacetime_metric(
+    const DataType& used_for_size) {
+  tnsr::abb<DataType, SpatialDim> d_spacetime_metric{};
+  for (size_t i = 0; i < SpatialDim + 1; i++) {
+    for (size_t j = i; j < SpatialDim + 1; j++) {
+      for (size_t k = 0; k < SpatialDim + 1; k++) {
+        d_spacetime_metric.get(k, i, j) = make_with_value<DataType>(
+            used_for_size, (i + 1.) * (j + 1.) * (k + 3.));
+      }
+    }
+  }
+  return d_spacetime_metric;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template tnsr::I<DTYPE(data), DIM(data)> make_shift(const DTYPE(data) &    \
+                                                      used_for_size);        \
+  template tnsr::ii<DTYPE(data), DIM(data)> make_spatial_metric(             \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::II<DTYPE(data), DIM(data)> make_inverse_spatial_metric(     \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::I<DTYPE(data), DIM(data)> make_dt_shift(const DTYPE(data) & \
+                                                         used_for_size);     \
+  template tnsr::ii<DTYPE(data), DIM(data)> make_dt_spatial_metric(          \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::i<DTYPE(data), DIM(data)> make_deriv_lapse(                 \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::iJ<DTYPE(data), DIM(data)> make_deriv_shift(                \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::ijj<DTYPE(data), DIM(data)> make_deriv_spatial_metric(      \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::abb<DTYPE(data), DIM(data)>                                 \
+  make_spacetime_deriv_spacetime_metric(const DTYPE(data) & used_for_size);
+
+template Scalar<double> make_lapse(const double& used_for_size);
+template Scalar<DataVector> make_lapse(const DataVector& used_for_size);
+template Scalar<double> make_dt_lapse(const double& used_for_size);
+template Scalar<DataVector> make_dt_lapse(const DataVector& used_for_size);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))
+
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines functions useful for testing general relativity
+
+#pragma once
+
+#include <boost/range/combine.hpp>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "tests/TestHelpers.hpp"
+
+template <typename Symmetry, typename IndexList>
+void check_tensor_doubles_equals_tensor_datavectors(
+    const Tensor<DataVector, Symmetry, IndexList>& tensor_dv,
+    const Tensor<double, Symmetry, IndexList>& tensor_double) {
+  const size_t n_pts = tensor_dv.begin()->size();
+  for (decltype(auto) datavector_and_double_components :
+       boost::combine(tensor_dv, tensor_double)) {
+    for (size_t s = 0; s < n_pts; ++s) {
+      CHECK(boost::get<0>(datavector_and_double_components)[s] ==
+            boost::get<1>(datavector_and_double_components));
+    }
+  }
+}
+
+template <typename DataType>
+Scalar<DataType> make_lapse(const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::I<DataType, SpatialDim> make_shift(const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::ii<DataType, SpatialDim> make_spatial_metric(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::II<DataType, SpatialDim> make_inverse_spatial_metric(
+    const DataType& used_for_size);
+
+template <typename DataType>
+Scalar<DataType> make_dt_lapse(const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::I<DataType, SpatialDim> make_dt_shift(const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::ii<DataType, SpatialDim> make_dt_spatial_metric(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::i<DataType, SpatialDim> make_deriv_lapse(const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::iJ<DataType, SpatialDim> make_deriv_shift(const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::ijj<DataType, SpatialDim> make_deriv_spatial_metric(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::abb<DataType, SpatialDim> make_spacetime_deriv_spacetime_metric(
+    const DataType& used_for_size);

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
@@ -10,7 +10,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "tests/TestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 template <typename Symmetry, typename IndexList>
 void check_tensor_doubles_equals_tensor_datavectors(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -1,0 +1,177 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+void test_1d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
+  const size_t spatial_dim = 1;
+  const auto christoffel = compute_christoffel_first_kind(
+      make_deriv_spatial_metric<spatial_dim>(0.));
+  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_christoffel_first_kind(
+          make_deriv_spatial_metric<spatial_dim>(used_for_size)),
+      christoffel);
+}
+
+void test_2d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
+  const size_t spatial_dim = 2;
+  const auto christoffel = compute_christoffel_first_kind(
+      make_deriv_spatial_metric<spatial_dim>(0.));
+  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
+  CHECK(christoffel.get(0, 0, 1) == approx(2.0));
+  CHECK(christoffel.get(0, 1, 1) == approx(1.0));
+  CHECK(christoffel.get(1, 0, 0) == approx(4.0));
+  CHECK(christoffel.get(1, 0, 1) == approx(6.0));
+  CHECK(christoffel.get(1, 1, 1) == approx(6.5));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_christoffel_first_kind(
+          make_deriv_spatial_metric<spatial_dim>(used_for_size)),
+      christoffel);
+}
+
+void test_3d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
+  const size_t spatial_dim = 3;
+  const auto christoffel = compute_christoffel_first_kind(
+      make_deriv_spatial_metric<spatial_dim>(0.));
+  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
+  CHECK(christoffel.get(0, 0, 1) == approx(2.0));
+  CHECK(christoffel.get(0, 0, 2) == approx(2.5));
+  CHECK(christoffel.get(0, 1, 1) == approx(1.0));
+  CHECK(christoffel.get(0, 1, 2) == approx(0.0));
+  CHECK(christoffel.get(0, 2, 2) == approx(-2.5));
+  CHECK(christoffel.get(1, 0, 0) == approx(4.0));
+  CHECK(christoffel.get(1, 0, 1) == approx(6.0));
+  CHECK(christoffel.get(1, 0, 2) == approx(8.0));
+  CHECK(christoffel.get(1, 1, 1) == approx(6.5));
+  CHECK(christoffel.get(1, 1, 2) == approx(7.0));
+  CHECK(christoffel.get(1, 2, 2) == approx(6.0));
+  CHECK(christoffel.get(2, 0, 0) == approx(6.5));
+  CHECK(christoffel.get(2, 0, 1) == approx(10.0));
+  CHECK(christoffel.get(2, 0, 2) == approx(13.5));
+  CHECK(christoffel.get(2, 1, 1) == approx(12.0));
+  CHECK(christoffel.get(2, 1, 2) == approx(14.0));
+  CHECK(christoffel.get(2, 2, 2) == approx(14.5));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_christoffel_first_kind(
+          make_deriv_spatial_metric<spatial_dim>(used_for_size)),
+      christoffel);
+}
+
+void test_1d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
+  const size_t spatial_dim = 1;
+  const auto christoffel = compute_christoffel_first_kind(
+      make_spacetime_deriv_spacetime_metric<spatial_dim>(0.));
+  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
+  CHECK(christoffel.get(0, 0, 1) == approx(2.0));
+  CHECK(christoffel.get(0, 1, 1) == approx(2.0));
+  CHECK(christoffel.get(1, 0, 0) == approx(4.0));
+  CHECK(christoffel.get(1, 0, 1) == approx(6.0));
+  CHECK(christoffel.get(1, 1, 1) == approx(8.0));
+
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_christoffel_first_kind(
+          make_spacetime_deriv_spacetime_metric<spatial_dim>(used_for_size)),
+      christoffel);
+}
+
+void test_2d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
+  const size_t spatial_dim = 2;
+  const auto christoffel = compute_christoffel_first_kind(
+      make_spacetime_deriv_spacetime_metric<spatial_dim>(0.));
+  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
+  CHECK(christoffel.get(0, 0, 1) == approx(2.0));
+  CHECK(christoffel.get(0, 0, 2) == approx(2.5));
+  CHECK(christoffel.get(0, 1, 1) == approx(2.0));
+  CHECK(christoffel.get(0, 1, 2) == approx(2.0));
+  CHECK(christoffel.get(0, 2, 2) == approx(1.5));
+  CHECK(christoffel.get(1, 0, 0) == approx(4.0));
+  CHECK(christoffel.get(1, 0, 1) == approx(6.0));
+  CHECK(christoffel.get(1, 0, 2) == approx(8.0));
+  CHECK(christoffel.get(1, 1, 1) == approx(8.0));
+  CHECK(christoffel.get(1, 1, 2) == approx(10.0));
+  CHECK(christoffel.get(1, 2, 2) == approx(12.0));
+  CHECK(christoffel.get(2, 0, 0) == approx(6.5));
+  CHECK(christoffel.get(2, 0, 1) == approx(10.0));
+  CHECK(christoffel.get(2, 0, 2) == approx(13.5));
+  CHECK(christoffel.get(2, 1, 1) == approx(14.0));
+  CHECK(christoffel.get(2, 1, 2) == approx(18.0));
+  CHECK(christoffel.get(2, 2, 2) == approx(22.5));
+
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_christoffel_first_kind(
+          make_spacetime_deriv_spacetime_metric<spatial_dim>(used_for_size)),
+      christoffel);
+}
+
+void test_3d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
+  const size_t spatial_dim = 3;
+  const auto christoffel = compute_christoffel_first_kind(
+      make_spacetime_deriv_spacetime_metric<spatial_dim>(0.));
+  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
+  CHECK(christoffel.get(0, 0, 1) == approx(2.));
+  CHECK(christoffel.get(0, 0, 2) == approx(2.5));
+  CHECK(christoffel.get(0, 0, 3) == approx(3.));
+  CHECK(christoffel.get(0, 1, 1) == approx(2.));
+  CHECK(christoffel.get(0, 1, 2) == approx(2.));
+  CHECK(christoffel.get(0, 1, 3) == approx(2.));
+  CHECK(christoffel.get(0, 2, 2) == approx(1.5));
+  CHECK(christoffel.get(0, 2, 3) == approx(1.));
+  CHECK(christoffel.get(0, 3, 3) == approx(0.));
+  CHECK(christoffel.get(1, 0, 0) == approx(4.));
+  CHECK(christoffel.get(1, 0, 1) == approx(6.));
+  CHECK(christoffel.get(1, 0, 2) == approx(8.));
+  CHECK(christoffel.get(1, 0, 3) == approx(10.));
+  CHECK(christoffel.get(1, 1, 1) == approx(8.));
+  CHECK(christoffel.get(1, 1, 2) == approx(10.));
+  CHECK(christoffel.get(1, 1, 3) == approx(12.));
+  CHECK(christoffel.get(1, 2, 2) == approx(12.));
+  CHECK(christoffel.get(1, 2, 3) == approx(14.));
+  CHECK(christoffel.get(1, 3, 3) == approx(16.));
+  CHECK(christoffel.get(2, 0, 0) == approx(6.5));
+  CHECK(christoffel.get(2, 0, 1) == approx(10.));
+  CHECK(christoffel.get(2, 0, 2) == approx(13.5));
+  CHECK(christoffel.get(2, 0, 3) == approx(17.));
+  CHECK(christoffel.get(2, 1, 1) == approx(14.));
+  CHECK(christoffel.get(2, 1, 2) == approx(18.));
+  CHECK(christoffel.get(2, 1, 3) == approx(22.));
+  CHECK(christoffel.get(2, 2, 2) == approx(22.5));
+  CHECK(christoffel.get(2, 2, 3) == approx(27.));
+  CHECK(christoffel.get(2, 3, 3) == approx(32.));
+  CHECK(christoffel.get(3, 0, 0) == approx(9.));
+  CHECK(christoffel.get(3, 0, 1) == approx(14.));
+  CHECK(christoffel.get(3, 0, 2) == approx(19.));
+  CHECK(christoffel.get(3, 0, 3) == approx(24.));
+  CHECK(christoffel.get(3, 1, 1) == approx(20.));
+  CHECK(christoffel.get(3, 1, 2) == approx(26.));
+  CHECK(christoffel.get(3, 1, 3) == approx(32.));
+  CHECK(christoffel.get(3, 2, 2) == approx(33.));
+  CHECK(christoffel.get(3, 2, 3) == approx(40.));
+  CHECK(christoffel.get(3, 3, 3) == approx(48.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_christoffel_first_kind(
+          make_spacetime_deriv_spacetime_metric<spatial_dim>(used_for_size)),
+      christoffel);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel.",
+                  "[PointwiseFunctions][Unit]") {
+  const DataVector dv(2);
+  test_1d_spatial_christoffel_first_kind(dv);
+  test_2d_spatial_christoffel_first_kind(dv);
+  test_3d_spatial_christoffel_first_kind(dv);
+  test_1d_spacetime_christoffel_first_kind(dv);
+  test_2d_spacetime_christoffel_first_kind(dv);
+  test_3d_spacetime_christoffel_first_kind(dv);
+}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -6,49 +6,10 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
-template <typename Symmetry, typename IndexList>
-void check_tensor_doubles_equals_tensor_datavectors(
-    const Tensor<DataVector, Symmetry, IndexList>& tensor_dv,
-    const Tensor<double, Symmetry, IndexList>& tensor_double) {
-  const size_t n_pts = tensor_dv.begin()->size();
-  for (decltype(auto) datavector_and_double_components :
-       boost::combine(tensor_dv, tensor_double)) {
-    for (size_t s = 0; s < n_pts; ++s) {
-      CHECK(boost::get<0>(datavector_and_double_components)[s] ==
-            boost::get<1>(datavector_and_double_components));
-    }
-  }
-}
-
-template <typename DataType>
-auto make_lapse(const DataType& structure) {
-  return Scalar<DataType>{make_with_value<DataType>(structure, 3.)};
-}
-
-template <typename DataType>
-auto make_shift(const DataType& structure) {
-  tnsr::I<DataType, 3> shift{};
-  for (size_t i = 0; i < 3; ++i) {
-    shift.get(i) = make_with_value<DataType>(structure, i);
-  }
-  return shift;
-}
-
-template <typename DataType>
-auto make_spatial_metric(const DataType& structure) {
-  tnsr::ii<DataType, 3> metric{};
-  for (size_t i = 0; i < 3; ++i) {
-    for (size_t j = i; j < 3; ++j) {
-      metric.get(i, j) =
-          make_with_value<DataType>(structure, (i + 1.) * (j + 1.));
-    }
-  }
-  return metric;
-}
-
 void test_compute_spacetime_metric(const DataVector& structure) {
   const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift(0.),
                                             make_spatial_metric(0.));

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -10,9 +10,45 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
-void test_compute_spacetime_metric(const DataVector& structure) {
-  const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift(0.),
-                                            make_spatial_metric(0.));
+void test_compute_1d_spacetime_metric(const DataVector &used_for_size) {
+  const size_t dim = 1;
+  const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
+                                            make_spatial_metric<dim>(0.));
+
+  CHECK(psi.get(0, 0) == approx(-9.0));
+  CHECK(psi.get(0, 1) == approx(0.0));
+  CHECK(psi.get(1, 1) == approx(1.0));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_spacetime_metric(make_lapse(used_for_size),
+                               make_shift<dim>(used_for_size),
+                               make_spatial_metric<dim>(used_for_size)),
+      psi);
+}
+
+void test_compute_2d_spacetime_metric(const DataVector &used_for_size) {
+  const size_t dim = 2;
+  const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
+                                            make_spatial_metric<dim>(0.));
+
+  CHECK(psi.get(0, 0) == approx(-5.0));
+  CHECK(psi.get(0, 1) == approx(2.0));
+  CHECK(psi.get(0, 2) == approx(4.0));
+  CHECK(psi.get(1, 1) == approx(1.0));
+  CHECK(psi.get(1, 2) == approx(2.0));
+  CHECK(psi.get(2, 2) == approx(4.0));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_spacetime_metric(make_lapse(used_for_size),
+                               make_shift<dim>(used_for_size),
+                               make_spatial_metric<dim>(used_for_size)),
+      psi);
+}
+
+void test_compute_3d_spacetime_metric(const DataVector &used_for_size) {
+  const size_t dim = 3;
+  const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
+                                            make_spatial_metric<dim>(0.));
   CHECK(psi.get(0, 0) == approx(55.));
   CHECK(psi.get(0, 1) == approx(8.));
   CHECK(psi.get(0, 2) == approx(16.));
@@ -25,9 +61,9 @@ void test_compute_spacetime_metric(const DataVector& structure) {
   CHECK(psi.get(3, 3) == approx(9.));
 
   check_tensor_doubles_equals_tensor_datavectors(
-      compute_spacetime_metric(make_lapse(structure),
-                               make_shift(structure),
-                               make_spatial_metric(structure)),
+      compute_spacetime_metric(make_lapse(used_for_size),
+                               make_shift<dim>(used_for_size),
+                               make_spatial_metric<dim>(used_for_size)),
       psi);
 }
 }  // namespace
@@ -35,5 +71,7 @@ void test_compute_spacetime_metric(const DataVector& structure) {
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GrFunctions.SpacetimeDecomp",
                   "[PointwiseFunctions][Unit]") {
   const DataVector dv(2);
-  test_compute_spacetime_metric(dv);
+  test_compute_1d_spacetime_metric(dv);
+  test_compute_2d_spacetime_metric(dv);
+  test_compute_3d_spacetime_metric(dv);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -66,6 +66,65 @@ void test_compute_3d_spacetime_metric(const DataVector &used_for_size) {
                                make_spatial_metric<dim>(used_for_size)),
       psi);
 }
+
+void test_compute_1d_inverse_spacetime_metric(const DataVector &used_for_size) {
+  const size_t dim = 1;
+  const auto inverse_spacetime_metric =
+      compute_inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
+                                       make_inverse_spatial_metric<dim>(0.));
+  CHECK(inverse_spacetime_metric.get(0, 0) == approx(-1. / 9.));
+  CHECK(inverse_spacetime_metric.get(0, 1) == approx(0.0));
+  CHECK(inverse_spacetime_metric.get(1, 1) == approx(1.0));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_inverse_spacetime_metric(
+          make_lapse(used_for_size), make_shift<dim>(used_for_size),
+          make_inverse_spatial_metric<dim>(used_for_size)),
+      inverse_spacetime_metric);
+}
+
+void test_compute_2d_inverse_spacetime_metric(const DataVector &used_for_size) {
+  const size_t dim = 2;
+  const auto inverse_spacetime_metric =
+      compute_inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
+                                       make_inverse_spatial_metric<dim>(0.));
+  CHECK(inverse_spacetime_metric.get(0, 0) == approx(-1. / 9.));
+  CHECK(inverse_spacetime_metric.get(0, 1) == approx(0.0));
+  CHECK(inverse_spacetime_metric.get(0, 2) == approx(1. / 9.));
+  CHECK(inverse_spacetime_metric.get(1, 1) == approx(1.0));
+  CHECK(inverse_spacetime_metric.get(1, 2) == approx(2.0));
+  CHECK(inverse_spacetime_metric.get(2, 2) == approx(35. / 9.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_inverse_spacetime_metric(
+          make_lapse(used_for_size), make_shift<dim>(used_for_size),
+          make_inverse_spatial_metric<dim>(used_for_size)),
+      inverse_spacetime_metric);
+}
+
+void test_compute_3d_inverse_spacetime_metric(const DataVector &used_for_size) {
+  const size_t dim = 3;
+  const auto inverse_spacetime_metric =
+      compute_inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
+                                       make_inverse_spatial_metric<dim>(0.));
+  CHECK(inverse_spacetime_metric.get(0, 0) == approx(-1. / 9.));
+  CHECK(inverse_spacetime_metric.get(0, 1) == approx(0.));
+  CHECK(inverse_spacetime_metric.get(0, 2) == approx(1. / 9.));
+  CHECK(inverse_spacetime_metric.get(0, 3) == approx(2. / 9.));
+  CHECK(inverse_spacetime_metric.get(1, 1) == approx(1.));
+  CHECK(inverse_spacetime_metric.get(1, 2) == approx(2.));
+  CHECK(inverse_spacetime_metric.get(1, 3) == approx(3.));
+  CHECK(inverse_spacetime_metric.get(2, 2) == approx(35. / 9.));
+  CHECK(inverse_spacetime_metric.get(2, 3) == approx(52. / 9.));
+  CHECK(inverse_spacetime_metric.get(3, 3) == approx(77. / 9.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_inverse_spacetime_metric(
+          make_lapse(used_for_size), make_shift<dim>(used_for_size),
+          make_inverse_spatial_metric<dim>(used_for_size)),
+      inverse_spacetime_metric);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GrFunctions.SpacetimeDecomp",
@@ -74,4 +133,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GrFunctions.SpacetimeDecomp",
   test_compute_1d_spacetime_metric(dv);
   test_compute_2d_spacetime_metric(dv);
   test_compute_3d_spacetime_metric(dv);
+  test_compute_1d_inverse_spacetime_metric(dv);
+  test_compute_2d_inverse_spacetime_metric(dv);
+  test_compute_3d_inverse_spacetime_metric(dv);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -10,7 +10,7 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
-void test_compute_1d_spacetime_metric(const DataVector &used_for_size) {
+void test_compute_1d_spacetime_metric(const DataVector& used_for_size) {
   const size_t dim = 1;
   const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
                                             make_spatial_metric<dim>(0.));
@@ -26,7 +26,7 @@ void test_compute_1d_spacetime_metric(const DataVector &used_for_size) {
       psi);
 }
 
-void test_compute_2d_spacetime_metric(const DataVector &used_for_size) {
+void test_compute_2d_spacetime_metric(const DataVector& used_for_size) {
   const size_t dim = 2;
   const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
                                             make_spatial_metric<dim>(0.));
@@ -45,7 +45,7 @@ void test_compute_2d_spacetime_metric(const DataVector &used_for_size) {
       psi);
 }
 
-void test_compute_3d_spacetime_metric(const DataVector &used_for_size) {
+void test_compute_3d_spacetime_metric(const DataVector& used_for_size) {
   const size_t dim = 3;
   const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
                                             make_spatial_metric<dim>(0.));
@@ -67,7 +67,7 @@ void test_compute_3d_spacetime_metric(const DataVector &used_for_size) {
       psi);
 }
 
-void test_compute_1d_inverse_spacetime_metric(const DataVector &used_for_size) {
+void test_compute_1d_inverse_spacetime_metric(const DataVector& used_for_size) {
   const size_t dim = 1;
   const auto inverse_spacetime_metric =
       compute_inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
@@ -83,7 +83,7 @@ void test_compute_1d_inverse_spacetime_metric(const DataVector &used_for_size) {
       inverse_spacetime_metric);
 }
 
-void test_compute_2d_inverse_spacetime_metric(const DataVector &used_for_size) {
+void test_compute_2d_inverse_spacetime_metric(const DataVector& used_for_size) {
   const size_t dim = 2;
   const auto inverse_spacetime_metric =
       compute_inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
@@ -102,7 +102,7 @@ void test_compute_2d_inverse_spacetime_metric(const DataVector &used_for_size) {
       inverse_spacetime_metric);
 }
 
-void test_compute_3d_inverse_spacetime_metric(const DataVector &used_for_size) {
+void test_compute_3d_inverse_spacetime_metric(const DataVector& used_for_size) {
   const size_t dim = 3;
   const auto inverse_spacetime_metric =
       compute_inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
@@ -125,9 +125,138 @@ void test_compute_3d_inverse_spacetime_metric(const DataVector &used_for_size) {
       inverse_spacetime_metric);
 }
 
+void test_compute_1d_derivatives_spacetime_metric(
+    const DataVector& used_for_size) {
+  const size_t dim = 1;
+  const auto d_spacetime_metric = compute_derivatives_of_spacetime_metric(
+      make_lapse(0.), make_dt_lapse(0.), make_deriv_lapse<dim>(0.),
+      make_shift<dim>(0.), make_dt_shift<dim>(0.), make_deriv_shift<dim>(0.),
+      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
+      make_deriv_spatial_metric<dim>(0.));
+
+  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(-30.0));
+  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(0.0));
+  CHECK(d_spacetime_metric.get(0, 1, 1) == approx(0.0));
+  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(0.0));
+  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(3.0));
+  CHECK(d_spacetime_metric.get(1, 1, 1) == approx(3.0));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_derivatives_of_spacetime_metric(
+          make_lapse(used_for_size), make_dt_lapse(used_for_size),
+          make_deriv_lapse<dim>(used_for_size), make_shift<dim>(used_for_size),
+          make_dt_shift<dim>(used_for_size),
+          make_deriv_shift<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size),
+          make_dt_spatial_metric<dim>(used_for_size),
+          make_deriv_spatial_metric<dim>(used_for_size)),
+      d_spacetime_metric);
+}
+
+void test_compute_2d_derivatives_spacetime_metric(
+    const DataVector& used_for_size) {
+  const size_t dim = 2;
+  const auto d_spacetime_metric = compute_derivatives_of_spacetime_metric(
+      make_lapse(0.), make_dt_lapse(0.), make_deriv_lapse<dim>(0.),
+      make_shift<dim>(0.), make_dt_shift<dim>(0.), make_deriv_shift<dim>(0.),
+      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
+      make_deriv_spatial_metric<dim>(0.));
+
+  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(-12.0));
+  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(5.0));
+  CHECK(d_spacetime_metric.get(0, 0, 2) == approx(10.0));
+  CHECK(d_spacetime_metric.get(0, 1, 1) == approx(0.0));
+  CHECK(d_spacetime_metric.get(0, 1, 2) == approx(1.0));
+  CHECK(d_spacetime_metric.get(0, 2, 2) == approx(2.0));
+  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(72.0));
+  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(21.0));
+  CHECK(d_spacetime_metric.get(1, 0, 2) == approx(42.0));
+  CHECK(d_spacetime_metric.get(1, 1, 1) == approx(3.0));
+  CHECK(d_spacetime_metric.get(1, 1, 2) == approx(6.0));
+  CHECK(d_spacetime_metric.get(1, 2, 2) == approx(12.0));
+  CHECK(d_spacetime_metric.get(2, 0, 0) == approx(46.0));
+  CHECK(d_spacetime_metric.get(2, 0, 1) == approx(19.0));
+  CHECK(d_spacetime_metric.get(2, 0, 2) == approx(37.0));
+  CHECK(d_spacetime_metric.get(2, 1, 1) == approx(4.0));
+  CHECK(d_spacetime_metric.get(2, 1, 2) == approx(7.0));
+  CHECK(d_spacetime_metric.get(2, 2, 2) == approx(13.0));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_derivatives_of_spacetime_metric(
+          make_lapse(used_for_size), make_dt_lapse(used_for_size),
+          make_deriv_lapse<dim>(used_for_size), make_shift<dim>(used_for_size),
+          make_dt_shift<dim>(used_for_size),
+          make_deriv_shift<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size),
+          make_dt_spatial_metric<dim>(used_for_size),
+          make_deriv_spatial_metric<dim>(used_for_size)),
+      d_spacetime_metric);
+}
+
+void test_compute_3d_derivatives_spacetime_metric(
+    const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const auto d_spacetime_metric = compute_derivatives_of_spacetime_metric(
+      make_lapse(0.), make_dt_lapse(0.), make_deriv_lapse<dim>(0.),
+      make_shift<dim>(0.), make_dt_shift<dim>(0.), make_deriv_shift<dim>(0.),
+      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
+      make_deriv_spatial_metric<dim>(0.));
+
+  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(384.));
+  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(29.));
+  CHECK(d_spacetime_metric.get(0, 0, 2) == approx(56.));
+  CHECK(d_spacetime_metric.get(0, 0, 3) == approx(83.));
+  CHECK(d_spacetime_metric.get(0, 1, 1) == approx(0.));
+  CHECK(d_spacetime_metric.get(0, 1, 2) == approx(1.));
+  CHECK(d_spacetime_metric.get(0, 1, 3) == approx(2.));
+  CHECK(d_spacetime_metric.get(0, 2, 2) == approx(2.));
+  CHECK(d_spacetime_metric.get(0, 2, 3) == approx(3.));
+  CHECK(d_spacetime_metric.get(0, 3, 3) == approx(4.));
+  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(864.));
+  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(66.));
+  CHECK(d_spacetime_metric.get(1, 0, 2) == approx(132.));
+  CHECK(d_spacetime_metric.get(1, 0, 3) == approx(198.));
+  CHECK(d_spacetime_metric.get(1, 1, 1) == approx(3.));
+  CHECK(d_spacetime_metric.get(1, 1, 2) == approx(6.));
+  CHECK(d_spacetime_metric.get(1, 1, 3) == approx(9.));
+  CHECK(d_spacetime_metric.get(1, 2, 2) == approx(12));
+  CHECK(d_spacetime_metric.get(1, 2, 3) == approx(18));
+  CHECK(d_spacetime_metric.get(1, 3, 3) == approx(27));
+  CHECK(d_spacetime_metric.get(2, 0, 0) == approx(762.));
+  CHECK(d_spacetime_metric.get(2, 0, 1) == approx(63.));
+  CHECK(d_spacetime_metric.get(2, 0, 2) == approx(123.));
+  CHECK(d_spacetime_metric.get(2, 0, 3) == approx(183.));
+  CHECK(d_spacetime_metric.get(2, 1, 1) == approx(4.));
+  CHECK(d_spacetime_metric.get(2, 1, 2) == approx(7.));
+  CHECK(d_spacetime_metric.get(2, 1, 3) == approx(10));
+  CHECK(d_spacetime_metric.get(2, 2, 2) == approx(13));
+  CHECK(d_spacetime_metric.get(2, 2, 3) == approx(19));
+  CHECK(d_spacetime_metric.get(2, 3, 3) == approx(28));
+  CHECK(d_spacetime_metric.get(3, 0, 0) == approx(660.));
+  CHECK(d_spacetime_metric.get(3, 0, 1) == approx(60.));
+  CHECK(d_spacetime_metric.get(3, 0, 2) == approx(114.));
+  CHECK(d_spacetime_metric.get(3, 0, 3) == approx(168.));
+  CHECK(d_spacetime_metric.get(3, 1, 1) == approx(5.));
+  CHECK(d_spacetime_metric.get(3, 1, 2) == approx(8.));
+  CHECK(d_spacetime_metric.get(3, 1, 3) == approx(11.));
+  CHECK(d_spacetime_metric.get(3, 2, 2) == approx(14.));
+  CHECK(d_spacetime_metric.get(3, 2, 3) == approx(20.));
+  CHECK(d_spacetime_metric.get(3, 3, 3) == approx(29.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_derivatives_of_spacetime_metric(
+          make_lapse(used_for_size), make_dt_lapse(used_for_size),
+          make_deriv_lapse<dim>(used_for_size), make_shift<dim>(used_for_size),
+          make_dt_shift<dim>(used_for_size),
+          make_deriv_shift<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size),
+          make_dt_spatial_metric<dim>(used_for_size),
+          make_deriv_spatial_metric<dim>(used_for_size)),
+      d_spacetime_metric);
+}
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GrFunctions.SpacetimeDecomp",
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
                   "[PointwiseFunctions][Unit]") {
   const DataVector dv(2);
   test_compute_1d_spacetime_metric(dv);
@@ -136,4 +265,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GrFunctions.SpacetimeDecomp",
   test_compute_1d_inverse_spacetime_metric(dv);
   test_compute_2d_inverse_spacetime_metric(dv);
   test_compute_3d_inverse_spacetime_metric(dv);
+  test_compute_1d_derivatives_spacetime_metric(dv);
+  test_compute_2d_derivatives_spacetime_metric(dv);
+  test_compute_3d_derivatives_spacetime_metric(dv);
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
