### PR TITLE
Add Sphere and test

### DIFF
--- a/src/Domain/DomainCreators/CMakeLists.txt
+++ b/src/Domain/DomainCreators/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Rectangle.cpp
   RegisterDerivedWithCharm.cpp
   Shell.cpp
+  Sphere.cpp
   )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Domain/DomainCreators/DomainCreator.hpp
+++ b/src/Domain/DomainCreators/DomainCreator.hpp
@@ -34,6 +34,8 @@ template <typename TargetFrame>
 class Rectangle;
 template <typename TargetFrame>
 class Shell;
+template <typename TargetFrame>
+class Sphere;
 }  // namespace DomainCreators
 
 namespace DomainCreators_detail {
@@ -55,7 +57,8 @@ template <>
 struct domain_creators<3> {
   template <typename Frame>
   using creators =
-      typelist<DomainCreators::Brick<Frame>, DomainCreators::Shell<Frame>>;
+      typelist<DomainCreators::Brick<Frame>, DomainCreators::Shell<Frame>,
+               DomainCreators::Sphere<Frame>>;
 };
 }  // namespace DomainCreators_detail
 
@@ -91,3 +94,4 @@ class DomainCreator {
 #include "Domain/DomainCreators/Interval.hpp"
 #include "Domain/DomainCreators/Rectangle.hpp"
 #include "Domain/DomainCreators/Shell.hpp"
+#include "Domain/DomainCreators/Sphere.hpp"

--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -42,6 +42,13 @@ void register_with_charm<3>() {
                       CoordinateMaps::ProductOf3Maps<
                           CoordinateMaps::AffineMap, CoordinateMaps::AffineMap,
                           CoordinateMaps::AffineMap>>));
+  PUPable_reg(
+      SINGLE_ARG(::CoordinateMap<
+                 Frame::Logical, Frame::Inertial,
+                 CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
+                                                CoordinateMaps::Equiangular,
+                                                CoordinateMaps::Equiangular>>));
+
   PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Wedge3D>));
 }

--- a/src/Domain/DomainCreators/Sphere.cpp
+++ b/src/Domain/DomainCreators/Sphere.cpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/DomainCreators/Sphere.hpp"
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/BlockNeighbor.hpp"
+#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Equiangular.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/Wedge3D.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Domain.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace DomainCreators {
+
+template <typename TargetFrame>
+Sphere<TargetFrame>::Sphere(
+    typename InnerRadius::type inner_radius,
+    typename OuterRadius::type outer_radius,
+    typename InitialRefinement::type initial_refinement,
+    typename InitialGridPoints::type initial_number_of_grid_points,
+    typename UseEquiangularMap::type use_equiangular_map) noexcept
+    // clang-tidy: trivially copyable
+    : inner_radius_(std::move(inner_radius)),                  // NOLINT
+      outer_radius_(std::move(outer_radius)),                  // NOLINT
+      initial_refinement_(                                     // NOLINT
+          std::move(initial_refinement)),                      // NOLINT
+      initial_number_of_grid_points_(                          // NOLINT
+          std::move(initial_number_of_grid_points)),           // NOLINT
+      use_equiangular_map_(std::move(use_equiangular_map)) {}  // NOLINT
+
+template <typename TargetFrame>
+Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
+  using Wedge3DMap = CoordinateMaps::Wedge3D;
+  using AffineMap = CoordinateMaps::AffineMap;
+  using AffineMap3D =
+      CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+  using Equiangular = CoordinateMaps::Equiangular;
+  using Equiangular3D =
+      CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
+
+  std::vector<std::array<size_t, 8>> corners{
+      {{7, 5, 8, 6, 15, 13, 16, 14}},  // Upper z
+      {{4, 2, 3, 1, 12, 10, 11, 9}},   // Lower z
+      {{4, 8, 2, 6, 12, 16, 10, 14}},  // Upper y
+      {{7, 3, 5, 1, 15, 11, 13, 9}},   // Lower y
+      {{1, 2, 5, 6, 9, 10, 13, 14}},   // Upper x
+      {{4, 3, 8, 7, 12, 11, 16, 15}},  // Lower x
+      {{3, 1, 4, 2, 7, 5, 8, 6}}};     // center cube
+
+  auto coord_maps =
+      make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
+          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::upper_zeta(),
+                     0.0, use_equiangular_map_},
+          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::lower_zeta(),
+                     0.0, use_equiangular_map_},
+          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::upper_eta(),
+                     0.0, use_equiangular_map_},
+          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::lower_eta(),
+                     0.0, use_equiangular_map_},
+          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::upper_xi(),
+                     0.0, use_equiangular_map_},
+          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::lower_xi(),
+                     0.0, use_equiangular_map_});
+  if (use_equiangular_map_) {
+    coord_maps.emplace_back(
+        make_coordinate_map_base<Frame::Logical, TargetFrame>(Equiangular3D{
+            Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                        inner_radius_ / sqrt(3.0)),
+            Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                        inner_radius_ / sqrt(3.0)),
+            Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                        inner_radius_ / sqrt(3.0))}));
+  } else {
+    coord_maps.emplace_back(
+        make_coordinate_map_base<Frame::Logical, TargetFrame>(
+            AffineMap3D{AffineMap(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                                  inner_radius_ / sqrt(3.0)),
+                        AffineMap(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                                  inner_radius_ / sqrt(3.0)),
+                        AffineMap(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                                  inner_radius_ / sqrt(3.0))}));
+  }
+  return Domain<3, TargetFrame>(std::move(coord_maps), corners);
+}
+
+template <typename TargetFrame>
+std::vector<std::array<size_t, 3>> Sphere<TargetFrame>::initial_extents() const
+    noexcept {
+  std::vector<std::array<size_t, 3>> extents{
+      6,
+      {{initial_number_of_grid_points_[1], initial_number_of_grid_points_[1],
+        initial_number_of_grid_points_[0]}}};
+  extents.push_back(
+      {{initial_number_of_grid_points_[1], initial_number_of_grid_points_[1],
+        initial_number_of_grid_points_[1]}});
+  return extents;
+}
+template <typename TargetFrame>
+std::vector<std::array<size_t, 3>>
+Sphere<TargetFrame>::initial_refinement_levels() const noexcept {
+  return {7, make_array<3>(initial_refinement_)};
+}
+}  // namespace DomainCreators
+
+template class DomainCreators::Sphere<Frame::Grid>;
+template class DomainCreators::Sphere<Frame::Inertial>;

--- a/src/Domain/DomainCreators/Sphere.hpp
+++ b/src/Domain/DomainCreators/Sphere.hpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "Domain/DomainCreators/DomainCreator.hpp"
+#include "Options/Options.hpp"
+
+namespace DomainCreators {
+
+/// \ingroup DomainCreatorsGroup
+/// Create a 3D Domain in the shape of a sphere consisting of six wedges
+/// and a central cube.
+template <typename TargetFrame>
+class Sphere : public DomainCreator<3, TargetFrame> {
+ public:
+  struct InnerRadius {
+    using type = double;
+    static constexpr OptionString help = {
+        "Radius of the sphere circumscribing the inner cube."};
+  };
+
+  struct OuterRadius {
+    using type = double;
+    static constexpr OptionString help = {"Radius of the Sphere."};
+  };
+
+  struct InitialRefinement {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Initial refinement level in each dimension."};
+  };
+
+  struct InitialGridPoints {
+    using type = std::array<size_t, 2>;
+    static constexpr OptionString help = {
+        "Initial number of grid points in [r,angular]."};
+  };
+
+  struct UseEquiangularMap {
+    using type = bool;
+    static constexpr OptionString help = {
+        "Use equiangular instead of equidistant coordinates."};
+  };
+  using options = tmpl::list<InnerRadius, OuterRadius, InitialRefinement,
+                             InitialGridPoints, UseEquiangularMap>;
+
+  static constexpr OptionString help{
+      "Creates a 3D Sphere with seven Blocks.\n"
+      "Only one refinement level for all dimensions is currently supported.\n"
+      "The number of gridpoints in the radial direction can be set\n"
+      "independently of the number of gridpoints in the angular directions.\n"
+      "The number of gridpoints along the dimensions of the cube is equal\n"
+      "to the number of gridpoints along the angular dimensions of the "
+      "wedges.\n"
+      "Equiangular coordinates give better gridpoint spacings in the angular\n"
+      "directions, while equidistant coordinates give better gridpoint\n"
+      "spacings in the center block."};
+
+  Sphere(typename InnerRadius::type inner_radius,
+         typename OuterRadius::type outer_radius,
+         typename InitialRefinement::type initial_refinement,
+         typename InitialGridPoints::type initial_number_of_grid_points,
+         typename UseEquiangularMap::type use_equiangular_map) noexcept;
+
+  Sphere() = default;
+  Sphere(const Sphere&) = delete;
+  Sphere(Sphere&&) noexcept = default;
+  Sphere& operator=(const Sphere&) = delete;
+  Sphere& operator=(Sphere&&) noexcept = default;
+  ~Sphere() noexcept override = default;
+
+  Domain<3, TargetFrame> create_domain() const noexcept override;
+
+  std::vector<std::array<size_t, 3>> initial_extents() const noexcept override;
+
+  std::vector<std::array<size_t, 3>> initial_refinement_levels() const
+      noexcept override;
+
+ private:
+  typename InnerRadius::type inner_radius_{};
+  typename OuterRadius::type outer_radius_{};
+  typename InitialRefinement::type initial_refinement_{};
+  typename InitialGridPoints::type initial_number_of_grid_points_{};
+  typename UseEquiangularMap::type use_equiangular_map_ = false;
+};
+}  // namespace DomainCreators

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -15,6 +15,7 @@ set(DOMAIN_TESTS
     Domain/DomainCreators/Test_Interval.cpp
     Domain/DomainCreators/Test_Rectangle.cpp
     Domain/DomainCreators/Test_Shell.cpp
+    Domain/DomainCreators/Test_Sphere.cpp
     Domain/DomainTestHelpers.cpp
     Domain/Test_Block.cpp
     Domain/Test_BlockNeighbor.cpp

--- a/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
@@ -1,0 +1,239 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <algorithm>
+#include <array>
+#include <catch.hpp>
+#include <vector>
+
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Equiangular.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/Wedge3D.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/Sphere.hpp"
+#include "Domain/DomainHelpers.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/MakeVector.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "tests/Unit/Domain/DomainTestHelpers.hpp"
+#include "tests/Unit/TestFactoryCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+void test_sphere_construction(
+    const DomainCreators::Sphere<Frame::Inertial>& sphere,
+    const double inner_radius, const double outer_radius,
+    const bool use_equiangular_map,
+    const std::array<size_t, 2>& expected_sphere_extents,
+    const std::vector<std::array<size_t, 3>>& expected_refinement_level) {
+  const auto domain = sphere.create_domain();
+  const auto& blocks = domain.blocks();
+  const OrientationMap<3> aligned_orientation{};
+  const OrientationMap<3> quarter_turn_ccw_about_zeta(
+      std::array<Direction<3>, 3>{{Direction<3>::lower_eta(),
+                                   Direction<3>::upper_xi(),
+                                   Direction<3>::upper_zeta()}});
+  const OrientationMap<3> half_turn_about_zeta(std::array<Direction<3>, 3>{
+      {Direction<3>::lower_xi(), Direction<3>::lower_eta(),
+       Direction<3>::upper_zeta()}});
+  const OrientationMap<3> quarter_turn_cw_about_zeta(
+      std::array<Direction<3>, 3>{{Direction<3>::upper_eta(),
+                                   Direction<3>::lower_xi(),
+                                   Direction<3>::upper_zeta()}});
+  const OrientationMap<3> center_relative_to_minus_z(
+      std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                   Direction<3>::lower_eta(),
+                                   Direction<3>::lower_zeta()}});
+  const OrientationMap<3> center_relative_to_plus_y(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+       Direction<3>::upper_eta()}});
+  const OrientationMap<3> center_relative_to_minus_y(
+      std::array<Direction<3>, 3>{{Direction<3>::lower_zeta(),
+                                   Direction<3>::upper_xi(),
+                                   Direction<3>::lower_eta()}});
+  const OrientationMap<3> center_relative_to_plus_x(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
+       Direction<3>::upper_xi()}});
+  const OrientationMap<3> center_relative_to_minus_x(
+      std::array<Direction<3>, 3>{{Direction<3>::lower_eta(),
+                                   Direction<3>::upper_zeta(),
+                                   Direction<3>::lower_xi()}});
+
+  const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
+      expected_block_neighbors{
+          {{Direction<3>::upper_xi(), {4, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::upper_eta(), {2, quarter_turn_cw_about_zeta}},
+           {Direction<3>::lower_xi(), {5, quarter_turn_cw_about_zeta}},
+           {Direction<3>::lower_eta(), {3, quarter_turn_cw_about_zeta}},
+           {Direction<3>::lower_zeta(), {6, aligned_orientation}}},
+          {{Direction<3>::upper_xi(), {4, quarter_turn_cw_about_zeta}},
+           {Direction<3>::upper_eta(), {3, quarter_turn_cw_about_zeta}},
+           {Direction<3>::lower_xi(), {5, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::lower_eta(), {2, quarter_turn_cw_about_zeta}},
+           {Direction<3>::lower_zeta(), {6, center_relative_to_minus_z}}},
+          {{Direction<3>::upper_xi(), {0, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::upper_eta(), {4, quarter_turn_cw_about_zeta}},
+           {Direction<3>::lower_xi(), {1, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::lower_eta(), {5, quarter_turn_cw_about_zeta}},
+           {Direction<3>::lower_zeta(), {6, center_relative_to_plus_y}}},
+          {{Direction<3>::upper_xi(), {1, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::upper_eta(), {4, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::lower_xi(), {0, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::lower_eta(), {5, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::lower_zeta(), {6, center_relative_to_minus_y}}},
+          {{Direction<3>::upper_xi(), {2, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::upper_eta(), {0, quarter_turn_cw_about_zeta}},
+           {Direction<3>::lower_xi(), {3, quarter_turn_cw_about_zeta}},
+           {Direction<3>::lower_eta(), {1, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::lower_zeta(), {6, center_relative_to_plus_x}}},
+          {{Direction<3>::upper_xi(), {3, quarter_turn_cw_about_zeta}},
+           {Direction<3>::upper_eta(), {0, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::lower_xi(), {2, quarter_turn_ccw_about_zeta}},
+           {Direction<3>::lower_eta(), {1, quarter_turn_cw_about_zeta}},
+           {Direction<3>::lower_zeta(), {6, center_relative_to_minus_x}}},
+          {{Direction<3>::upper_zeta(), {0, aligned_orientation}},
+           {Direction<3>::lower_zeta(),
+            {1, center_relative_to_minus_z.inverse_map()}},
+           {Direction<3>::upper_eta(),
+            {2, center_relative_to_plus_y.inverse_map()}},
+           {Direction<3>::lower_eta(),
+            {3, center_relative_to_minus_y.inverse_map()}},
+           {Direction<3>::upper_xi(),
+            {4, center_relative_to_plus_x.inverse_map()}},
+           {Direction<3>::lower_xi(),
+            {5, center_relative_to_minus_x.inverse_map()}}}};
+
+  const std::vector<std::unordered_set<Direction<3>>>
+      expected_external_boundaries{{{Direction<3>::upper_zeta()}},
+                                   {{Direction<3>::upper_zeta()}},
+                                   {{Direction<3>::upper_zeta()}},
+                                   {{Direction<3>::upper_zeta()}},
+                                   {{Direction<3>::upper_zeta()}},
+                                   {{Direction<3>::upper_zeta()}},
+                                   {}};
+
+  std::vector<std::array<size_t, 3>> expected_extents{
+      6,
+      {{expected_sphere_extents[1], expected_sphere_extents[1],
+        expected_sphere_extents[0]}}};
+  expected_extents.push_back(
+      {{expected_sphere_extents[1], expected_sphere_extents[1],
+        expected_sphere_extents[1]}});
+
+  CHECK(sphere.initial_extents() == expected_extents);
+  CHECK(sphere.initial_refinement_levels() == expected_refinement_level);
+  using Wedge3DMap = CoordinateMaps::Wedge3D;
+  using AffineMap = CoordinateMaps::AffineMap;
+  using AffineMap3D =
+      CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+  using Equiangular = CoordinateMaps::Equiangular;
+  using Equiangular3D =
+      CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
+
+  auto coord_maps =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge3DMap{inner_radius, outer_radius, Direction<3>::upper_zeta(),
+                     0.0, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius, Direction<3>::lower_zeta(),
+                     0.0, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius, Direction<3>::upper_eta(), 0.0,
+                     use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius, Direction<3>::lower_eta(), 0.0,
+                     use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius, Direction<3>::upper_xi(), 0.0,
+                     use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius, Direction<3>::lower_xi(), 0.0,
+                     use_equiangular_map});
+  if (use_equiangular_map) {
+    coord_maps.emplace_back(
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(Equiangular3D{
+            Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                        inner_radius / sqrt(3.0)),
+            Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                        inner_radius / sqrt(3.0)),
+            Equiangular(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                        inner_radius / sqrt(3.0))}));
+  } else {
+    coord_maps.emplace_back(
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            AffineMap3D{AffineMap(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                                  inner_radius / sqrt(3.0)),
+                        AffineMap(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                                  inner_radius / sqrt(3.0)),
+                        AffineMap(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                                  inner_radius / sqrt(3.0))}));
+  }
+  test_domain_construction(domain, expected_block_neighbors,
+                           expected_external_boundaries, coord_maps);
+  test_initial_domain(domain, sphere.initial_refinement_levels());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Sphere.Boundaries.Equiangular",
+                  "[Domain][Unit]") {
+  const double inner_radius = 1.0, outer_radius = 2.0;
+  const size_t refinement = 2;
+  const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
+
+  const DomainCreators::Sphere<Frame::Inertial> sphere{
+      inner_radius, outer_radius, refinement, grid_points_r_angular, true};
+  test_physical_separation(sphere.create_domain().blocks());
+
+  test_sphere_construction(sphere, inner_radius, outer_radius, true,
+                           grid_points_r_angular,
+                           {7, make_array<3>(refinement)});
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Sphere.Factory.Equiangular",
+                  "[Domain][Unit]") {
+  const auto sphere = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+      "  Sphere:\n"
+      "    InnerRadius: 1\n"
+      "    OuterRadius: 3\n"
+      "    InitialRefinement: 2\n"
+      "    InitialGridPoints: [2,3]\n"
+      "    UseEquiangularMap: true\n");
+  const double inner_radius = 1.0, outer_radius = 3.0;
+  const size_t refinement_level = 2;
+  const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
+  test_sphere_construction(
+      dynamic_cast<const DomainCreators::Sphere<Frame::Inertial>&>(*sphere),
+      inner_radius, outer_radius, true, grid_points_r_angular,
+      {7, make_array<3>(refinement_level)});
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Sphere.Boundaries.Equidistant",
+                  "[Domain][Unit]") {
+  const double inner_radius = 1.0, outer_radius = 2.0;
+  const size_t refinement = 2;
+  const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
+
+  const DomainCreators::Sphere<Frame::Inertial> sphere{
+      inner_radius, outer_radius, refinement, grid_points_r_angular, false};
+  test_physical_separation(sphere.create_domain().blocks());
+
+  test_sphere_construction(sphere, inner_radius, outer_radius, false,
+                           grid_points_r_angular,
+                           {7, make_array<3>(refinement)});
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Sphere.Factory.Equidistant",
+                  "[Domain][Unit]") {
+  const auto sphere = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+      "  Sphere:\n"
+      "    InnerRadius: 1\n"
+      "    OuterRadius: 3\n"
+      "    InitialRefinement: 2\n"
+      "    InitialGridPoints: [2,3]\n"
+      "    UseEquiangularMap: false\n");
+  const double inner_radius = 1.0, outer_radius = 3.0;
+  const size_t refinement_level = 2;
+  const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
+  test_sphere_construction(
+      dynamic_cast<const DomainCreators::Sphere<Frame::Inertial>&>(*sphere),
+      inner_radius, outer_radius, false, grid_points_r_angular,
+      {7, make_array<3>(refinement_level)});
+}


### PR DESCRIPTION
## Proposed changes

A DomainCreator for the cubed sphere constructed from six wedges and and cube.
Allows for equiangular/equidistant coordinates
The sphericity cannot be changed yet (until the SpheredCube coordinatemap for the center cube is added later on)

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
