### PR TITLE
Add step_function to DataVector

### DIFF
--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -468,6 +468,12 @@ class DataVector {
   }
   // @}
 
+  /// If less than zero returns zero, otherwise returns one
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) step_function(
+      const DataVector& t) noexcept {
+    return step_function(t.data_);
+  }
+
  private:
   /// \cond HIDDEN_SYMBOLS
   size_t size_ = 0;

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -40,6 +40,41 @@ using std::abs;  // NOLINT
  * A Data holds an array of contiguous data and can be either owning (the array
  * is deleted when the Data goes out of scope) or non-owning, meaning it just
  * has a pointer to an array.
+ *
+ * A variety of mathematical operations are supported with DataVectors. In
+ * addition to the addition, subtraction, multiplication, division, etc. there
+ * are the following element-wise operations:
+ *
+ * - abs
+ * - acos
+ * - acosh
+ * - asin
+ * - asinh
+ * - atan
+ * - atan2
+ * - atanh
+ * - cbrt
+ * - cos
+ * - cosh
+ * - erf
+ * - erfc
+ * - exp
+ * - exp2
+ * - exp10
+ * - fabs
+ * - invsqrt
+ * - log
+ * - log2
+ * - log10
+ * - max
+ * - min
+ * - pow
+ * - sin
+ * - sinh
+ * - sqrt
+ * - step_function: if less than zero returns zero, otherwise returns one
+ * - tan
+ * - tanh
  */
 class DataVector {
   /// \cond HIDDEN_SYMBOLS

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -242,6 +242,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, abs(val));
   check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, fabs(val));
 
+  check_vectors(step_function(DataVector{-12.3, 2.0, -4.0, 0.0, 7.0, -8.0}),
+                DataVector{0.0, 1.0, 0.0, 1.0, 1.0, 0.0});
+
   check_vectors(DataVector(num_pts, 81.0), nine * nine);
   check_vectors(DataVector(num_pts, 81.0), nine * (nine * one));
   check_vectors(DataVector(num_pts, 81.0), (nine * nine) * one);


### PR DESCRIPTION
## Proposed changes

Add `step_function` to DataVector. This is needed by SpEC and since I wrote it already I figured it is better just to get it into the code than weit.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."

