### PR TITLE
Fixes several open issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,7 @@ At a high level, describe what this PR does.
 - [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
 - [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
 - [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
+- [ ] Prefix commits addressing PR requests with `fixup`
 
 
 ### Further comments

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,19 +72,19 @@ matrix:
     compiler: clang
   - os: linux
     dist: trusty
-    env: RUN_CLANG_TIDY=true BUILD_TYPE=Release
+    env: RUN_CLANG_TIDY=true BUILD_TYPE=Release BUILD_CODE=true
     compiler: clang
   - os: linux
     dist: trusty
-    env: RUN_CLANG_TIDY=true BUILD_TYPE=Debug
+    env: RUN_CLANG_TIDY=true BUILD_TYPE=Debug BUILD_CODE=true
     compiler: clang
   - os: linux
     dist: trusty
-    env: RUN_CPPCHECK=true BUILD_TYPE=Release
+    env: RUN_CPPCHECK=true BUILD_TYPE=Release BUILD_CODE=true
     compiler: clang
   - os: linux
     dist: trusty
-    env: RUN_CPPCHECK=true BUILD_TYPE=Debug
+    env: RUN_CPPCHECK=true BUILD_TYPE=Debug BUILD_CODE=true
     compiler: clang
   - os: linux
     dist: trusty
@@ -94,26 +94,26 @@ matrix:
   - os: linux
     compiler: gcc
     dist: trusty
-    env: BUILD_TYPE=Debug SONARQUBE=ON COVERAGE=ON
+    env: BUILD_TYPE=Debug SONARQUBE=ON COVERAGE=ON BUILD_CODE=true
   - os: linux
     compiler: gcc
     dist: trusty
-    env: BUILD_TYPE=Release
+    env: BUILD_TYPE=Release BUILD_CODE=true
   - os: linux
     compiler: clang
     dist: trusty
-    env: BUILD_TYPE=Debug
+    env: BUILD_TYPE=Debug BUILD_CODE=true
   - os: linux
     compiler: clang
     dist: trusty
-    env: BUILD_TYPE=Release
+    env: BUILD_TYPE=Release BUILD_CODE=true
   - os: osx
-    env: BUILD_TYPE=Debug
+    env: BUILD_TYPE=Debug BUILD_CODE=true
     osx_image: xcode7.3
     compiler: clang
   - os: osx
     osx_image: xcode8.3
-    env: BUILD_TYPE=Release
+    env: BUILD_TYPE=Release BUILD_CODE=true
     compiler: clang
 
 
@@ -226,13 +226,14 @@ script:
 - export UPSTREAM_BRANCH="develop"
 - export GH_PAGES_REPO="git@github.com:sxs-collaboration/spectre.git"
 - export GH_PAGES_SOURCE_BRANCH="develop"
+- printenv
 - if [ "${CHECK_COMMITS}" == "true" ]; then
     ./tools/CheckCommits.sh;
   elif [ "${CHECK_FILES}" ==  "true" ]; then
     ./tools/CheckFiles.sh;
   elif [ "${TEST_CHECK_FILES}" ==  "true" ]; then
     ./tools/CheckFiles.sh --test;
-  elif [ ${TRAVIS_OS_NAME} = linux ]; then
+  elif [ "${TRAVIS_OS_NAME}" == "linux" ] && [ "${BUILD_CODE}" == "true" ]; then
     cp -vr containers ${HOME}/docker
     && cd ${HOME}
     && mv -v ${TRAVIS_BUILD_DIR} ${HOME}/docker/spectre
@@ -275,7 +276,7 @@ script:
     && docker cp ${CON}:/root/.sonar ${HOME}/
     && docker cp ${CON}:/work/build_${BUILD_TYPE}_${CC}/tmp/coverage.info
                  ${HOME}/docker/spectre;
-  else
+  elif [ "${TRAVIS_OS_NAME}" == "osx" ] && [ "${BUILD_CODE}" == "true" ]; then
     cd $HOME
     && mkdir build_${TRAVIS_OS_NAME}_${BUILD_TYPE}
     && cd ./build_${TRAVIS_OS_NAME}_${BUILD_TYPE}
@@ -291,6 +292,9 @@ script:
     && make -j2
     && ctest --output-on-failure
     && ccache -s;
+  else
+    echo "Unknown build environment"
+    && exit -1;
   fi
 
 # After a successful build the results are pushed to codecov.io, which doesn't

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,10 @@ matrix:
     dist: trusty
     env: RUN_CPPCHECK=true BUILD_TYPE=Debug
     compiler: clang
+  - os: linux
+    dist: trusty
+    env: TEST_CHECK_FILES=true
+    compiler: clang
     # Run full builds after static analysis
   - os: linux
     compiler: gcc
@@ -226,6 +230,8 @@ script:
     ./tools/CheckCommits.sh;
   elif [ "${CHECK_FILES}" ==  "true" ]; then
     ./tools/CheckFiles.sh;
+  elif [ "${TEST_CHECK_FILES}" ==  "true" ]; then
+    ./tools/CheckFiles.sh --test;
   elif [ ${TRAVIS_OS_NAME} = linux ]; then
     cp -vr containers ${HOME}/docker
     && cd ${HOME}

--- a/cmake/CheckCompilerVersion.cmake
+++ b/cmake/CheckCompilerVersion.cmake
@@ -2,8 +2,8 @@
 # See LICENSE.txt for details.
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.2)
-    message(FATAL_ERROR "GCC version must be at least 5.2")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.4)
+    message(FATAL_ERROR "GCC version must be at least 5.4")
   endif ()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.5)

--- a/docs/DevGuide/CodeReviewGuide.md
+++ b/docs/DevGuide/CodeReviewGuide.md
@@ -43,6 +43,8 @@ the class by the following line, which contains exactly 64 equal signs
   (<code>// \@{</code> and <code>// \@}</code>).
 * Use the [alternative tokens](http://en.cppreference.com/w/cpp/language/operator_alternative) `or`, `and` and `not` instead of `||`, `&&`, and `!`.
 * Use C-style Doxygen comments (`/*! ... */`) when using multi-line math, otherwise C-style and C++ style comments are accepted.
+* When addressing requests on a PR, the commit message must start with
+  `fixup` followed by a descriptive message.
 
 Code Quality Items:
 
@@ -79,3 +81,9 @@ is not the same as the number of grid points in the determinant."
 * Variable names in macros must avoid name collisions, e.g. inside the `PARSE_ERROR` macro you would write `double variable_name_avoid_name_collisions_PARSE_ERROR = 0.0;`
 * Avoid macros if possible. Prefer `constexpr` functions, constexpr variables,
 and/or template metaprogramming
+* Explicitly specify `double`s, e.g. `sqrt(2.)` or `sqrt(2.0)` instead of
+  `sqrt(2)`.
+* When the index of a `Tensor` is known at compile time, use
+  `get<a, b>(tensor)` instead of the member `get` function.
+* All necessary header files must be included. In header files, prefer
+  forward declarations if class definitions aren't necessary.

--- a/docs/DevGuide/CodeReviewGuide.md
+++ b/docs/DevGuide/CodeReviewGuide.md
@@ -15,17 +15,22 @@ Here we summarize what we view as the more important portions of the guides.
 Stylistic Items:
 
 * Adhere to [Google style](https://google.github.io/styleguide/cppguide.html).
-Can use
-[`clang-format -style=google` (here)](http://clang.llvm.org/docs/ClangFormat.html).
+  [Can use `clang-format -style=google`]
+  (http://clang.llvm.org/docs/ClangFormat.html).
 * CamelCase: class names template parameters, file names, and directory names.
 * snake_case: function, variable, metafunction and metavariable names.
 * SCREAMING_SNAKE_CASE: macros.
-* Functions or classes only used internally in a library should be in a namespace named `LibraryOrFile_detail`. For example, `databox_detail`, `Tensor_detail` or `ConstantExpressions_detail`.
+* Functions or classes only used internally in a library should be in a
+  namespace named `LibraryOrFile_detail`. For example, `databox_detail`,
+  `Tensor_detail` or `ConstantExpressions_detail`.
 * Name unused function parameters `/*parameter_name*/` or `/*meta*/` for TMP
   cases
 * Type aliases that wrap type traits have a trailing `_t` following the STL
-* Private member variables have a [trailing underscore](https://google.github.io/styleguide/cppguide.html#Variable_Names).
-* Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
+* Private member variables have a [trailing underscore]
+  (https://google.github.io/styleguide/cppguide.html#Variable_Names).
+* Do not use
+  [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation),
+  e.g. `double* pd_blah` is bad
 * Header order:
   1. hpp corresponding to cpp (only in cpp files)
   2. Blank line (only in cpp files)
@@ -33,7 +38,7 @@ Can use
   4. Blank line
   5. SpECTRE includes (in alphabetical order)
 * Template definitions in header files are separated from the declaration of
-the class by the following line, which contains exactly 64 equal signs
+  the class by the following line, which contains exactly 64 equal signs
 
 ``` cpp
 // ================================================================
@@ -41,46 +46,58 @@ the class by the following line, which contains exactly 64 equal signs
 
 * No blank lines surrounding Doxygen group comments
   (<code>// \@{</code> and <code>// \@}</code>).
-* Use the [alternative tokens](http://en.cppreference.com/w/cpp/language/operator_alternative) `or`, `and` and `not` instead of `||`, `&&`, and `!`.
-* Use C-style Doxygen comments (`/*! ... */`) when using multi-line math, otherwise C-style and C++ style comments are accepted.
+* Use the [alternative tokens]
+  (http://en.cppreference.com/w/cpp/language/operator_alternative)
+  `or`, `and`, and `not` instead of `||`, `&&`, and `!`.
+* Use C-style Doxygen comments (`/*! ... */`) when using multi-line math,
+  otherwise C-style and C++ style comments are accepted.
 * When addressing requests on a PR, the commit message must start with
   `fixup` followed by a descriptive message.
 
 Code Quality Items:
 
 * All code passes Clang and CppCheck static analyzers. For help
-with these tools see \ref static_analysis_tools "here".
+  with these tools see \ref static_analysis_tools "here".
 * Almost always `auto`, except with expression templates, i.e. `DataVector`
 * All loops and if statements use braces.
 * Order of declaration in classes is `public` before `private` and member
-functions before data. See
-[Google](https://google.github.io/styleguide/cppguide.html#Declaration_Order).
+  functions before data. See
+  [Google](https://google.github.io/styleguide/cppguide.html#Declaration_Order).
 * Prefer return by value over pass-by-mutable-reference except when mutable
-reference provides superior performance (in practice if you need a mutable
-reference use const `gsl::not_null<Type*>` instead of `Type&`). The mutable
-references must be the first arguments passed to the function.
+  reference provides superior performance (in practice if you need a mutable
+  reference use `const gsl::not_null<Type*>` instead of `Type&`). The mutable
+  references must be the first arguments passed to the function.
 * All commits for performance changes provide quantitative evidence and the
-tests used to obtain said evidence.
-* Never include `<iostream>`, use `Parallel::printf` inside `Parallel/Printf.hpp` instead, which is safe to use in parallel.
-* Do not add anything to
-[the `std` namespace](http://en.cppreference.com/w/cpp/language/extending_std).
+  tests used to obtain said evidence.
+* Never include `<iostream>`, use `Parallel::printf` inside
+  `Parallel/Printf.hpp` instead, which is safe to use in parallel.
+* Do not add anything to [the `std` namespace]
+  (http://en.cppreference.com/w/cpp/language/extending_std).
 * Virtual functions are explicitly overridden using the `override` keyword.
 * `pragma once` is to be used for header guards
 * Prefer range-based for loops
 * Use `size_t` for positive integers rather than `int`, specifically when
-looping over containers. This is in compliance with what the STL uses.
+  looping over containers. This is in compliance with what the STL uses.
 * Error messages should be helpful. An example of a bad error message is
-"Size mismatch" which should read "The number of grid points in the matrix 'F'
-is not the same as the number of grid points in the determinant."
+  "Size mismatch" which should read "The number of grid points in the matrix
+  'F' is not the same as the number of grid points in the determinant."
 * Mark immutable objects as `const`
 * Make classes serializable by writing a `pup` function
-* If a class stores an object passed into a constructor the object should be taken by-value and `std::move`d into the member variable.
-* Definitions of function and class templates should be in `.cpp` files with explicit instantiations whenever possible.
-* Explicit instantiations of functions marked as noexcept should be marked as noexcept as well.
-* Functions that do not throw should be marked `noexcept`. If you're unsure and the function does not use an `OptionContext`, mark it `noexcept`.
-* Variable names in macros must avoid name collisions, e.g. inside the `PARSE_ERROR` macro you would write `double variable_name_avoid_name_collisions_PARSE_ERROR = 0.0;`
-* Avoid macros if possible. Prefer `constexpr` functions, constexpr variables,
-and/or template metaprogramming
+* If a class stores an object passed into a constructor the object should
+  be taken by-value and `std::move`d into the member variable.
+* Definitions of function and class templates should be in `.cpp` files with
+  explicit instantiations whenever possible. The macro
+  `GENERATE_EXPLICIT_INSTANTIATIONS` is useful for generating many
+  explicit instantiations.
+* Explicit instantiations of functions marked as noexcept should be marked
+  as noexcept as well.
+* Functions that do not throw should be marked `noexcept`. If you're unsure
+  and the function does not use an `OptionContext`, mark it `noexcept`.
+* Variable names in macros must avoid name collisions, e.g. inside the
+  `PARSE_ERROR` macro you would write
+  `double variable_name_avoid_name_collisions_PARSE_ERROR = 0.0;`
+* Avoid macros if possible. Prefer `constexpr` functions, constexpr
+  variables, and/or template metaprogramming
 * Explicitly specify `double`s, e.g. `sqrt(2.)` or `sqrt(2.0)` instead of
   `sqrt(2)`.
 * When the index of a `Tensor` is known at compile time, use

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -85,9 +85,19 @@ EXCLUDE                =
 
 EXCLUDE_SYMLINKS       = NO
 
-EXCLUDE_PATTERNS = */support/* */cmake/* */README.md @PROJECT_SOURCE_DIR@/tests/*
+EXCLUDE_PATTERNS       = @PROJECT_SOURCE_DIR@/build*                  \
+                         @PROJECT_SOURCE_DIR@/cmake/*                 \
+                         @PROJECT_SOURCE_DIR@/README.md               \
+                         @PROJECT_SOURCE_DIR@/support/*               \
+                         @PROJECT_SOURCE_DIR@/tests/*
 
-EXCLUDE_SYMBOLS = *detail* *brigand* std* PUP* YAML* charm* SPECTRE_TEST_CASE*
+EXCLUDE_SYMBOLS        = *brigand*                                    \
+                         charm*                                       \
+                         *detail*                                     \
+                         PUP*                                         \
+                         SPECTRE_TEST_CASE*                           \
+                         std*                                         \
+                         YAML*
 
 EXAMPLE_PATH           = @PROJECT_SOURCE_DIR@/tests/Unit/
 

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -12,12 +12,12 @@
  */
 
 /*!
- * \defgroup BoundaryConditions Boundary Conditions
+ * \defgroup BoundaryConditionsGroup Boundary Conditions
  * A collection of boundary conditions used for evolutions.
  */
 
 /*!
- * \defgroup ComputationalDomain  Computational Domain
+ * \defgroup ComputationalDomainGroup  Computational Domain
  * \brief The building blocks used to describe the computational domain.
  *
  * ### Description
@@ -30,7 +30,7 @@
  */
 
 /*!
- * \defgroup ConstantExpressions Constant Expressions
+ * \defgroup ConstantExpressionsGroup Constant Expressions
  * \brief Contains an assortment of constexpr functions
  *
  * ### Description
@@ -54,17 +54,17 @@
  */
 
 /*!
- * \defgroup DataBoxTags DataBox Tags
+ * \defgroup DataBoxTagsGroup DataBox Tags
  * \brief Structures and metafunctions for labeling the contents of DataBoxes
  */
 
 /*!
- * \defgroup DataStructures Data Structures
+ * \defgroup DataStructuresGroup Data Structures
  * \brief Various useful data structures used in SpECTRE
  */
 
 /*!
- * \defgroup DiscontinuousGalerkin Discontinuous Galerkin
+ * \defgroup DiscontinuousGalerkinGroup Discontinuous Galerkin
  * \brief Functions and classes specific to the Discontinuous Galerkin
  * algorithm.
  */
@@ -81,17 +81,12 @@
  */
 
 /*!
- * \defgroup ErrorHandling Error Handling
+ * \defgroup ErrorHandlingGroup Error Handling
  * Macros and functions used for handling errors
  */
 
 /*!
- * \defgroup EvolveSystem Evolve System
- * \brief Classes and functions used for starting a simulation
- */
-
-/*!
- * \defgroup Executables Executables
+ * \defgroup ExecutablesGroup Executables
  * \brief A list of executables and how to use them
  *
  * <table class="doxtable">
@@ -106,7 +101,7 @@
  */
 
 /*!
- * \defgroup FileSystem File System
+ * \defgroup FileSystemGroup File System
  * \brief A light-weight file system library.
  */
 
@@ -116,42 +111,27 @@
  */
 
 /*!
- * \defgroup GlobalCache Global Cache
- * How to access and utilize the global cache
- */
-
-/*!
- * \defgroup CacheTags Global Cache Tags
+ * \defgroup CacheTagsGroup Global Cache Tags
  * \brief Tags for common data stored in the GlabalCache
  */
 
 /*!
- * \defgroup HDF5 HDF5
+ * \defgroup HDF5Group HDF5
  * \brief Functions and classes for manipulating HDF5 files
  */
 
 /*!
- * \defgroup InputOptions Input File Options
- * \brief Options for input files for different systems
- */
-
-/*!
- * \defgroup NumericalAlgorithms Numerical Algorithms
+ * \defgroup NumericalAlgorithmsGroup Numerical Algorithms
  * \brief Generic numerical algorithms
  */
 
 /*!
- * \defgroup NumericalFluxes Numerical Fluxes
- * A collection of numerical fluxes used by discontinuous Galerkin methods.
- */
-
-/*!
- * \defgroup OptionParsing Option Parsing
+ * \defgroup OptionParsingGroup Option Parsing
  * Things related to parsing YAML input files.
  */
 
 /*!
- * \defgroup Parallel Parallelization
+ * \defgroup ParallelGroup Parallelization
  * \brief Functions, classes and documentation related to parallelization and
  * Charm++
 
@@ -295,35 +275,22 @@ into two classes:
  */
 
 /*!
- * \defgroup PrettyType Pretty Type
+ * \defgroup PrettyTypeGroup Pretty Type
  * \brief Pretty printing of types
  */
 
 /*!
- * \defgroup Profiling Profiling
- * \brief Functions and variables useful for profiling SpECTRE
- *
- * See the \ref profiling_with_projections "Profiling With Charm++ Projections"
- * section of the dev guide for more details.
- */
-
-/*!
- * \defgroup SlopeLimiters Slope Limiters
- * A collection of slope limiters used for handling shocks.
- */
-
-/*!
- * \defgroup Spectral Spectral
+ * \defgroup SpectralGroup Spectral
  * Things related to spectral transformations.
  */
 
 /*!
- * \defgroup Tensor Tensor
+ * \defgroup TensorGroup Tensor
  * Tensor use documentation.
  */
 
 /*!
- * \defgroup TensorExpressions Tensor Expressions
+ * \defgroup TensorExpressionsGroup Tensor Expressions
  * Tensor Expressions allow writing expressions of
  * tensors in a way similar to what is used with pen and paper.
  *
@@ -337,12 +304,12 @@ into two classes:
  */
 
 /*!
- * \defgroup ParallelComponents ParallelComponents
+ * \defgroup ParallelComponentsGroup ParallelComponents
  * Information about which ParallelComponents are available and how to use them
  */
 
 /*!
- * \defgroup TestingFramework Testing Framework
+ * \defgroup TestingFrameworkGroup Testing Framework
  * \brief Classes, functions, macros, and instructions for developing tests
  *
  * \details
@@ -498,18 +465,12 @@ into two classes:
  */
 
 /*!
- * \defgroup TypeTraits Type Traits
+ * \defgroup TypeTraitsGroup Type Traits
  * A collection of useful type traits, including C++14 and C++17 additions to
  * the standard library.
  */
 
 /*!
- * \defgroup Utilities Utilities
+ * \defgroup UtilitiesGroup Utilities
  * \brief A collection of useful classes, functions and metafunctions.
- */
-
-/*!
- * \defgroup VariableFixers Variable Fixers
- * A collection of methods for correcting conservative variables that have
- * unphysical primitive variables.
  */

--- a/docs/MainSite/Installation.md
+++ b/docs/MainSite/Installation.md
@@ -8,7 +8,7 @@ See LICENSE.txt for details.
 
 #### Required:
 
-* [GCC](https://gcc.gnu.org/) 5.2 or later,
+* [GCC](https://gcc.gnu.org/) 5.4 or later,
 [Clang](https://clang.llvm.org/) 3.6 or later, or AppleClang 6.0 or later
 * [CMake](https://cmake.org/) 3.3.2 or later
 * [Charm++](http://charm.cs.illinois.edu/) 6.8 or newer (must be compiled from source)

--- a/docs/Tutorials/OptionParsing.md
+++ b/docs/Tutorials/OptionParsing.md
@@ -34,7 +34,7 @@ constructible in their declarations.
 
 ## Constructible classes
 
-A class that defines `static constexpr OptionString_t help` and a
+A class that defines `static constexpr OptionString help` and a
 typelist of option structs `options` can be created by the option
 parser.  When the class is requested, the option parser will parse
 each of the options in the `options` list, and then supply them to the

--- a/src/ApparentHorizons/SpherepackIterator.hpp
+++ b/src/ApparentHorizons/SpherepackIterator.hpp
@@ -13,7 +13,7 @@
 #include "ErrorHandling/Assert.hpp"
 
 /*!
- * \ingroup Spectral
+ * \ingroup SpectralGroup
  * \brief
  * Iterates over spectral coefficients stored in SPHEREPACK format.
  *

--- a/src/ApparentHorizons/YlmSpherepack.hpp
+++ b/src/ApparentHorizons/YlmSpherepack.hpp
@@ -11,7 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Blas.hpp"
 
-/// \ingroup Spectral
+/// \ingroup SpectralGroup
 /// \brief C++ interface to SPHEREPACK.
 class YlmSpherepack {
  public:

--- a/src/DataStructures/DataBox.hpp
+++ b/src/DataStructures/DataBox.hpp
@@ -58,7 +58,7 @@ class DataBox;
 
 // @{
 /*!
- * \ingroup TypeTraits DataBox
+ * \ingroup TypeTraitsGroup DataBox
  * \brief Determines if a type `T` is as db::DataBox
  *
  * \effects Inherits from std::true_type if `T` is a specialization of

--- a/src/DataStructures/DataBox.hpp
+++ b/src/DataStructures/DataBox.hpp
@@ -619,12 +619,12 @@ class DataBox<TagsList<Tags...>> {
   static_assert(
       tmpl2::flat_all_v<detail::tag_has_label<Tags>::value...>,
       "Missing a label on a Tag. All Tags must have a static "
-      "constexpr db::DataBoxString_t member variable named 'label' with "
+      "constexpr db::DataBoxString member variable named 'label' with "
       "the name of the Tag.");
   static_assert(
       tmpl2::flat_all_v<detail::tag_label_correct_type<Tags>::value...>,
       "One of the labels of the Tags in a DataBox has the incorrect "
-      "type. It should be a DataBoxString_t.");
+      "type. It should be a DataBoxString.");
 
  public:
   /*!

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -28,7 +28,7 @@ struct d<Tag, VolumeDim, Fr, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Fr>;
   using tag = Tag;
-  static constexpr db::DataBoxString_t label = "d";
+  static constexpr db::DataBoxString label = "d";
 };
 
 template <typename Tag, typename VolumeDim, typename Fr>
@@ -37,14 +37,14 @@ struct d<Tag, VolumeDim, Fr,
     : db::DataBoxPrefix {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString_t label = "d";
+  static constexpr db::DataBoxString label = "d";
 };
 
 /// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a time derivative
 template <typename Tag>
 struct dt : db::DataBoxPrefix {
-  static constexpr db::DataBoxString_t label = "dt";
+  static constexpr db::DataBoxString label = "dt";
   using type = db::item_type<Tag>;
   using tag = Tag;
 };
@@ -63,7 +63,7 @@ struct Flux<Tag, VolumeDim, Fr,
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Up, Fr>;
   using tag = Tag;
-  static constexpr db::DataBoxString_t label = "Flux";
+  static constexpr db::DataBoxString label = "Flux";
 };
 
 template <typename Tag, typename VolumeDim, typename Fr>
@@ -72,7 +72,7 @@ struct Flux<Tag, VolumeDim, Fr,
     : db::DataBoxPrefix {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString_t label = "Flux";
+  static constexpr db::DataBoxString label = "Flux";
 };
 /// \endcond
 
@@ -83,7 +83,7 @@ template <typename Tag>
 struct NormalDotFlux : db::DataBoxPrefix {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString_t label = "NormalDotFlux";
+  static constexpr db::DataBoxString label = "NormalDotFlux";
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -93,6 +93,6 @@ template <typename Tag>
 struct NormalDotNumericalFlux : db::DataBoxPrefix {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString_t label = "NormalDotNumericalFlux";
+  static constexpr db::DataBoxString label = "NormalDotNumericalFlux";
 };
 }  // namespace Tags

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -15,7 +15,7 @@
 #include "Utilities/TypeTraits.hpp"
 
 namespace Tags {
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \brief prefix for a `VolumeDim` spatial derivatives with respect to the `Fr`
 /// coordinate frame.
 template <typename Tag, typename VolumeDim, typename Fr,
@@ -40,7 +40,7 @@ struct d<Tag, VolumeDim, Fr,
   static constexpr db::DataBoxString_t label = "d";
 };
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a time derivative
 template <typename Tag>
 struct dt : db::DataBoxPrefix {
@@ -49,7 +49,7 @@ struct dt : db::DataBoxPrefix {
   using tag = Tag;
 };
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a flux
 template <typename Tag, typename VolumeDim, typename Fr,
           typename = std::nullptr_t>
@@ -76,7 +76,7 @@ struct Flux<Tag, VolumeDim, Fr,
 };
 /// \endcond
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating an unnormalized boundary normal vector
 /// dotted into the flux
 template <typename Tag>
@@ -86,7 +86,7 @@ struct NormalDotFlux : db::DataBoxPrefix {
   static constexpr db::DataBoxString_t label = "NormalDotFlux";
 };
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating an unnormalized boundary normal vector
 /// dotted into the numerical flux
 template <typename Tag>

--- a/src/DataStructures/DataBoxTag.hpp
+++ b/src/DataStructures/DataBoxTag.hpp
@@ -51,7 +51,7 @@ namespace db {
  * \ingroup DataBoxGroup
  * \brief The string used to give a runtime name to a DataBoxTag
  */
-using DataBoxString_t = const char* const;
+using DataBoxString = const char* const;
 
 /*!
  * \ingroup DataBoxGroup
@@ -63,13 +63,13 @@ using DataBoxString_t = const char* const;
  *
  * \derivedrequires
  * - type alias `type` of the type this DataBoxTag represents
- * - `static constexpr DataBoxString_t` that is the same as the type name
+ * - `static constexpr DataBoxString` that is the same as the type name
  *    and named `label`
  *
  * \example
  * \snippet Test_DataBox.cpp databox_tag_example
  *
- * \see DataBox DataBoxPrefix DataBoxString_t get_tag_name
+ * \see DataBox DataBoxPrefix DataBoxString get_tag_name
  */
 struct DataBoxTag {};
 
@@ -88,7 +88,7 @@ struct DataBoxTag {};
  * \derivedrequires
  * - type alias `tag` of the DataBoxTag that this tag is a prefix to
  * - type alias `type` that is the type that this DataBoxPrefix holds
- * - DataBoxString_t `label` that is the prefix to the `tag`
+ * - DataBoxString `label` that is the prefix to the `tag`
  *
  * \example
  * A DataBoxPrefix tag has the structure:
@@ -98,7 +98,7 @@ struct DataBoxTag {};
  * \snippet Test_DataBox.cpp databox_name_prefix
  *
  *
- * \see DataBox DataBoxTag DataBoxString_t get_tag_name ComputeItemTag
+ * \see DataBox DataBoxTag DataBoxString get_tag_name ComputeItemTag
  */
 struct DataBoxPrefix : DataBoxTag {};
 
@@ -124,7 +124,7 @@ struct DataBoxPrefix : DataBoxTag {};
  * which offers a lot of simplicity for very simple compute items.
  * \snippet Test_DataBox.cpp compute_item_tag_function
  *
- * \see DataBox DataBoxTag DataBoxString_t get_tag_name DataBoxPrefix
+ * \see DataBox DataBoxTag DataBoxString get_tag_name DataBoxPrefix
  */
 struct ComputeItemTag : DataBoxTag {};
 
@@ -159,11 +159,11 @@ struct tag_has_label<T, cpp17::void_t<decltype(T::label)>> : std::true_type {};
 // @{
 /*!
  * \ingroup DataBoxGroup
- * \brief Check if a Tag label has type DataBoxString_t
+ * \brief Check if a Tag label has type DataBoxString
  *
  * \details
  * For a type `T`, check that the static member variable named `label` has type
- * DataBoxString_t
+ * DataBoxString
  *
  * \usage
  * For any type `T`
@@ -180,7 +180,7 @@ struct tag_label_correct_type : std::false_type {};
 /// \cond HIDDEN_SYMBOLS
 template <typename T>
 struct tag_label_correct_type<
-    T, Requires<std::is_same<DataBoxString_t, decltype(T::label)>::value>>
+    T, Requires<std::is_same<DataBoxString, decltype(T::label)>::value>>
     : std::true_type {};
 /// \endcond
 // @}

--- a/src/DataStructures/DataBoxTag.hpp
+++ b/src/DataStructures/DataBoxTag.hpp
@@ -29,7 +29,7 @@ struct Variables;
 
 namespace Tags {
 /*!
- * \ingroup DataBoxTags
+ * \ingroup DataBoxTagsGroup
  * \brief Tag used to retrieve the DataBox from the `db::get` function
  *
  * The main use of this tag is to allow fetching the DataBox from itself. The
@@ -378,7 +378,7 @@ struct is_variables_compute_item<
     Requires<is_compute_item<T>::value and tt::is_a_v<Variables, item_type<T>>>>
     : std::true_type {};
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \brief Create a new list of Tags by wrapping each tag in `TagList` using the
 /// `Wrapper`.
 template <template <typename...> class Wrapper, typename TagList,
@@ -424,14 +424,14 @@ struct remove_tag_prefix_impl<
 };
 }  // namespace detail
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// Wrap `Tag` in `Prefix<_, Args...>`, also wrapping variables tags
 /// if `Tag` is a `Tags::Variables`.
 template <template <typename...> class Prefix, typename Tag, typename... Args>
 using add_tag_prefix = typename detail::add_tag_prefix_impl<
     tt::is_a_v<Tags::Variables, Tag>>::template f<Prefix, Tag, Args...>;
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// Remove a prefix from `Tag`, also removing it from the variables
 /// tags if the unwrapped tag is a `Tags::Variables`.
 template <typename Tag>

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -34,7 +34,7 @@ using std::abs;  // NOLINT
 /// \endcond
 
 /*!
- * \ingroup DataStructures
+ * \ingroup DataStructuresGroup
  * \brief A class for storing data on a mesh.
  *
  * A Data holds an array of contiguous data and can be either owning (the array

--- a/src/DataStructures/Index.hpp
+++ b/src/DataStructures/Index.hpp
@@ -20,7 +20,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-/// \ingroup DataStructures
+/// \ingroup DataStructuresGroup
 /// An integer multi-index.
 ///
 /// \tparam Dim the number of integers in the Index.

--- a/src/DataStructures/IndexIterator.hpp
+++ b/src/DataStructures/IndexIterator.hpp
@@ -8,7 +8,7 @@
 
 #include "DataStructures/Index.hpp"
 
-/// \ingroup DataStructures
+/// \ingroup DataStructuresGroup
 /// IndexIterator iterates over a unique set of Index.
 ///
 /// \example

--- a/src/DataStructures/MakeWithValue.hpp
+++ b/src/DataStructures/MakeWithValue.hpp
@@ -8,7 +8,7 @@
 
 #include "Utilities/ForceInline.hpp"
 
-/// \ingroup DataStructures
+/// \ingroup DataStructuresGroup
 /// Implementations of make_with_value.
 namespace MakeWithValueImpls {
 template <typename R, typename T>
@@ -17,7 +17,7 @@ struct MakeWithValueImpl {
 };
 }  // namespace MakeWithValueImpls
 
-/// \ingroup DataStructures
+/// \ingroup DataStructuresGroup
 /// \brief Given an object of type `T`, create an object of type `R` whose
 /// elements are initialized to `value`.
 ///

--- a/src/DataStructures/Matrix.hpp
+++ b/src/DataStructures/Matrix.hpp
@@ -15,7 +15,7 @@ class er;
 }  // namespace PUP
 
 /*!
- * \ingroup DataStructures
+ * \ingroup DataStructuresGroup
  * \brief A dynamically sized matrix.
  *
  * \note The data layout is column-major (0-based)

--- a/src/DataStructures/SliceIterator.hpp
+++ b/src/DataStructures/SliceIterator.hpp
@@ -14,7 +14,7 @@ class er;
 }  // namespace PUP
 
 /*!
- * \ingroup DataStructures
+ * \ingroup DataStructuresGroup
  * \brief Iterate over a (dim-1)-dimensional slice
  */
 class SliceIterator {

--- a/src/DataStructures/StripeIterator.hpp
+++ b/src/DataStructures/StripeIterator.hpp
@@ -13,7 +13,7 @@ class er;
 }  // namespace PUP
 
 /*!
- * \ingroup DataStructures
+ * \ingroup DataStructuresGroup
  * \brief Iterates over the 1-dimensional stripes with info on how to
  * iterate over the current stripe
  */

--- a/src/DataStructures/Tensor/EagerMath/Determinant.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Determinant.hpp
@@ -127,7 +127,7 @@ struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 4>> {
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Computes the determinant of a rank-2 Tensor `tensor`.
  *
  * \returns The determinant of `tensor`.

--- a/src/DataStructures/Tensor/EagerMath/Determinant.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Determinant.hpp
@@ -16,7 +16,7 @@ template <typename Symm, typename Index>
 struct DeterminantImpl<Symm, Index, Requires<Index::dim == 1>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
-    return tensor.template get<0, 0>();
+    return get<0, 0>(tensor);
   }
 };
 
@@ -24,10 +24,10 @@ template <typename Symm, typename Index>
 struct DeterminantImpl<Symm, Index, Requires<Index::dim == 2>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
-    const auto& t00 = tensor.template get<0, 0>();
-    const auto& t01 = tensor.template get<0, 1>();
-    const auto& t10 = tensor.template get<1, 0>();
-    const auto& t11 = tensor.template get<1, 1>();
+    const auto& t00 = get<0, 0>(tensor);
+    const auto& t01 = get<0, 1>(tensor);
+    const auto& t10 = get<1, 0>(tensor);
+    const auto& t11 = get<1, 1>(tensor);
     return t00 * t11 - t01 * t10;
   }
 };
@@ -36,15 +36,15 @@ template <typename Index>
 struct DeterminantImpl<Symmetry<2, 1>, Index, Requires<Index::dim == 3>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
-    const auto& t00 = tensor.template get<0, 0>();
-    const auto& t01 = tensor.template get<0, 1>();
-    const auto& t02 = tensor.template get<0, 2>();
-    const auto& t10 = tensor.template get<1, 0>();
-    const auto& t11 = tensor.template get<1, 1>();
-    const auto& t12 = tensor.template get<1, 2>();
-    const auto& t20 = tensor.template get<2, 0>();
-    const auto& t21 = tensor.template get<2, 1>();
-    const auto& t22 = tensor.template get<2, 2>();
+    const auto& t00 = get<0, 0>(tensor);
+    const auto& t01 = get<0, 1>(tensor);
+    const auto& t02 = get<0, 2>(tensor);
+    const auto& t10 = get<1, 0>(tensor);
+    const auto& t11 = get<1, 1>(tensor);
+    const auto& t12 = get<1, 2>(tensor);
+    const auto& t20 = get<2, 0>(tensor);
+    const auto& t21 = get<2, 1>(tensor);
+    const auto& t22 = get<2, 2>(tensor);
     return t00 * (t11 * t22 - t12 * t21) - t01 * (t10 * t22 - t12 * t20) +
            t02 * (t10 * t21 - t11 * t20);
   }
@@ -54,12 +54,12 @@ template <typename Index>
 struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 3>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
-    const auto& t00 = tensor.template get<0, 0>();
-    const auto& t01 = tensor.template get<0, 1>();
-    const auto& t02 = tensor.template get<0, 2>();
-    const auto& t11 = tensor.template get<1, 1>();
-    const auto& t12 = tensor.template get<1, 2>();
-    const auto& t22 = tensor.template get<2, 2>();
+    const auto& t00 = get<0, 0>(tensor);
+    const auto& t01 = get<0, 1>(tensor);
+    const auto& t02 = get<0, 2>(tensor);
+    const auto& t11 = get<1, 1>(tensor);
+    const auto& t12 = get<1, 2>(tensor);
+    const auto& t22 = get<2, 2>(tensor);
     return t00 * (t11 * t22 - t12 * t12) - t01 * (t01 * t22 - t12 * t02) +
            t02 * (t01 * t12 - t11 * t02);
   }
@@ -69,22 +69,22 @@ template <typename Index>
 struct DeterminantImpl<Symmetry<2, 1>, Index, Requires<Index::dim == 4>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
-    const auto& t00 = tensor.template get<0, 0>();
-    const auto& t01 = tensor.template get<0, 1>();
-    const auto& t02 = tensor.template get<0, 2>();
-    const auto& t03 = tensor.template get<0, 3>();
-    const auto& t10 = tensor.template get<1, 0>();
-    const auto& t11 = tensor.template get<1, 1>();
-    const auto& t12 = tensor.template get<1, 2>();
-    const auto& t13 = tensor.template get<1, 3>();
-    const auto& t20 = tensor.template get<2, 0>();
-    const auto& t21 = tensor.template get<2, 1>();
-    const auto& t22 = tensor.template get<2, 2>();
-    const auto& t23 = tensor.template get<2, 3>();
-    const auto& t30 = tensor.template get<3, 0>();
-    const auto& t31 = tensor.template get<3, 1>();
-    const auto& t32 = tensor.template get<3, 2>();
-    const auto& t33 = tensor.template get<3, 3>();
+    const auto& t00 = get<0, 0>(tensor);
+    const auto& t01 = get<0, 1>(tensor);
+    const auto& t02 = get<0, 2>(tensor);
+    const auto& t03 = get<0, 3>(tensor);
+    const auto& t10 = get<1, 0>(tensor);
+    const auto& t11 = get<1, 1>(tensor);
+    const auto& t12 = get<1, 2>(tensor);
+    const auto& t13 = get<1, 3>(tensor);
+    const auto& t20 = get<2, 0>(tensor);
+    const auto& t21 = get<2, 1>(tensor);
+    const auto& t22 = get<2, 2>(tensor);
+    const auto& t23 = get<2, 3>(tensor);
+    const auto& t30 = get<3, 0>(tensor);
+    const auto& t31 = get<3, 1>(tensor);
+    const auto& t32 = get<3, 2>(tensor);
+    const auto& t33 = get<3, 3>(tensor);
     const auto minor1 = t22 * t33 - t23 * t32;
     const auto minor2 = t21 * t33 - t23 * t31;
     const auto minor3 = t20 * t33 - t23 * t30;
@@ -102,16 +102,16 @@ template <typename Index>
 struct DeterminantImpl<Symmetry<1, 1>, Index, Requires<Index::dim == 4>> {
   template <typename T>
   static typename T::type apply(const T& tensor) {
-    const auto& t00 = tensor.template get<0, 0>();
-    const auto& t01 = tensor.template get<0, 1>();
-    const auto& t02 = tensor.template get<0, 2>();
-    const auto& t03 = tensor.template get<0, 3>();
-    const auto& t11 = tensor.template get<1, 1>();
-    const auto& t12 = tensor.template get<1, 2>();
-    const auto& t13 = tensor.template get<1, 3>();
-    const auto& t22 = tensor.template get<2, 2>();
-    const auto& t23 = tensor.template get<2, 3>();
-    const auto& t33 = tensor.template get<3, 3>();
+    const auto& t00 = get<0, 0>(tensor);
+    const auto& t01 = get<0, 1>(tensor);
+    const auto& t02 = get<0, 2>(tensor);
+    const auto& t03 = get<0, 3>(tensor);
+    const auto& t11 = get<1, 1>(tensor);
+    const auto& t12 = get<1, 2>(tensor);
+    const auto& t13 = get<1, 3>(tensor);
+    const auto& t22 = get<2, 2>(tensor);
+    const auto& t23 = get<2, 3>(tensor);
+    const auto& t33 = get<3, 3>(tensor);
     const auto minor1 = t22 * t33 - t23 * t23;
     const auto minor2 = t12 * t33 - t23 * t13;
     const auto minor3 = t02 * t33 - t23 * t03;

--- a/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
@@ -326,7 +326,7 @@ struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
 }  // namespace determinant_and_inverse_detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Computes the determinant and inverse of a rank-2 Tensor.
  *
  * Computes the determinant and inverse together, because this leads to fewer

--- a/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
@@ -33,7 +33,7 @@ struct DetAndInverseImpl<Symm, Index0, Index1, Requires<Index0::dim == 1>> {
   template <typename T>
   static determinant_inverse_pair<T, Symm, Index0, Index1> apply(
       const Tensor<T, Symm, typelist<Index0, Index1>>& tensor) {
-    const T& t00 = tensor.template get<0, 0>();
+    const T& t00 = get<0, 0>(tensor);
     // inv is non-const so that it can be moved into the std::pair:
     Tensor<T, Symm, inverse_indices<Index0, Index1>> inv{
         make_with_value<T>(t00, 1.0) / t00};
@@ -48,18 +48,18 @@ struct DetAndInverseImpl<Symmetry<2, 1>, Index0, Index1,
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<2, 1>, Index0, Index1> apply(
       const Tensor<T, Symmetry<2, 1>, typelist<Index0, Index1>>& tensor) {
-    const T& t00 = tensor.template get<0, 0>();
-    const T& t01 = tensor.template get<0, 1>();
-    const T& t10 = tensor.template get<1, 0>();
-    const T& t11 = tensor.template get<1, 1>();
+    const T& t00 = get<0, 0>(tensor);
+    const T& t01 = get<0, 1>(tensor);
+    const T& t10 = get<1, 0>(tensor);
+    const T& t11 = get<1, 1>(tensor);
     // det is non-const so that it can be moved into the std::pair:
     Scalar<T> det{t00 * t11 - t01 * t10};
     const T one_over_det = make_with_value<T>(det, 1.0) / det.get();
     Tensor<T, Symmetry<2, 1>, inverse_indices<Index0, Index1>> inv{};
-    inv.template get<0, 0>() = t11 * one_over_det;
-    inv.template get<0, 1>() = -t01 * one_over_det;
-    inv.template get<1, 0>() = -t10 * one_over_det;
-    inv.template get<1, 1>() = t00 * one_over_det;
+    get<0, 0>(inv) = t11 * one_over_det;
+    get<0, 1>(inv) = -t01 * one_over_det;
+    get<1, 0>(inv) = -t10 * one_over_det;
+    get<1, 1>(inv) = t00 * one_over_det;
     return std::make_pair(std::move(det), std::move(inv));
   }
 };
@@ -70,16 +70,16 @@ struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<1, 1>, Index0, Index0> apply(
       const Tensor<T, Symmetry<1, 1>, typelist<Index0, Index0>>& tensor) {
-    const T& t00 = tensor.template get<0, 0>();
-    const T& t01 = tensor.template get<0, 1>();
-    const T& t11 = tensor.template get<1, 1>();
+    const T& t00 = get<0, 0>(tensor);
+    const T& t01 = get<0, 1>(tensor);
+    const T& t11 = get<1, 1>(tensor);
     // det is non-const so that it can be moved into the std::pair:
     Scalar<T> det{t00 * t11 - t01 * t01};
     const T one_over_det = make_with_value<T>(det, 1.0) / det.get();
     Tensor<T, Symmetry<1, 1>, inverse_indices<Index0, Index0>> inv{};
-    inv.template get<0, 0>() = t11 * one_over_det;
-    inv.template get<0, 1>() = -t01 * one_over_det;
-    inv.template get<1, 1>() = t00 * one_over_det;
+    get<0, 0>(inv) = t11 * one_over_det;
+    get<0, 1>(inv) = -t01 * one_over_det;
+    get<1, 1>(inv) = t00 * one_over_det;
     return std::make_pair(std::move(det), std::move(inv));
   }
 };
@@ -92,15 +92,15 @@ struct DetAndInverseImpl<Symmetry<2, 1>, Index0, Index1,
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<2, 1>, Index0, Index1> apply(
       const Tensor<T, Symmetry<2, 1>, typelist<Index0, Index1>>& tensor) {
-    const T& t00 = tensor.template get<0, 0>();
-    const T& t01 = tensor.template get<0, 1>();
-    const T& t02 = tensor.template get<0, 2>();
-    const T& t10 = tensor.template get<1, 0>();
-    const T& t11 = tensor.template get<1, 1>();
-    const T& t12 = tensor.template get<1, 2>();
-    const T& t20 = tensor.template get<2, 0>();
-    const T& t21 = tensor.template get<2, 1>();
-    const T& t22 = tensor.template get<2, 2>();
+    const T& t00 = get<0, 0>(tensor);
+    const T& t01 = get<0, 1>(tensor);
+    const T& t02 = get<0, 2>(tensor);
+    const T& t10 = get<1, 0>(tensor);
+    const T& t11 = get<1, 1>(tensor);
+    const T& t12 = get<1, 2>(tensor);
+    const T& t20 = get<2, 0>(tensor);
+    const T& t21 = get<2, 1>(tensor);
+    const T& t22 = get<2, 2>(tensor);
     const T a = t11 * t22 - t12 * t21;
     const T b = t12 * t20 - t10 * t22;
     const T c = t10 * t21 - t11 * t20;
@@ -108,15 +108,15 @@ struct DetAndInverseImpl<Symmetry<2, 1>, Index0, Index1,
     Scalar<T> det{t00 * a + t01 * b + t02 * c};
     const T one_over_det = make_with_value<T>(det, 1.0) / det.get();
     Tensor<T, Symmetry<2, 1>, inverse_indices<Index0, Index1>> inv{};
-    inv.template get<0, 0>() = a * one_over_det;
-    inv.template get<0, 1>() = (t21 * t02 - t22 * t01) * one_over_det;
-    inv.template get<0, 2>() = (t01 * t12 - t02 * t11) * one_over_det;
-    inv.template get<1, 0>() = b * one_over_det;
-    inv.template get<1, 1>() = (t22 * t00 - t20 * t02) * one_over_det;
-    inv.template get<1, 2>() = (t02 * t10 - t00 * t12) * one_over_det;
-    inv.template get<2, 0>() = c * one_over_det;
-    inv.template get<2, 1>() = (t20 * t01 - t21 * t00) * one_over_det;
-    inv.template get<2, 2>() = (t00 * t11 - t01 * t10) * one_over_det;
+    get<0, 0>(inv) = a * one_over_det;
+    get<0, 1>(inv) = (t21 * t02 - t22 * t01) * one_over_det;
+    get<0, 2>(inv) = (t01 * t12 - t02 * t11) * one_over_det;
+    get<1, 0>(inv) = b * one_over_det;
+    get<1, 1>(inv) = (t22 * t00 - t20 * t02) * one_over_det;
+    get<1, 2>(inv) = (t02 * t10 - t00 * t12) * one_over_det;
+    get<2, 0>(inv) = c * one_over_det;
+    get<2, 1>(inv) = (t20 * t01 - t21 * t00) * one_over_det;
+    get<2, 2>(inv) = (t00 * t11 - t01 * t10) * one_over_det;
     return std::make_pair(std::move(det), std::move(inv));
   }
 };
@@ -127,12 +127,12 @@ struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<1, 1>, Index0, Index0> apply(
       const Tensor<T, Symmetry<1, 1>, typelist<Index0, Index0>>& tensor) {
-    const T& t00 = tensor.template get<0, 0>();
-    const T& t01 = tensor.template get<0, 1>();
-    const T& t02 = tensor.template get<0, 2>();
-    const T& t11 = tensor.template get<1, 1>();
-    const T& t12 = tensor.template get<1, 2>();
-    const T& t22 = tensor.template get<2, 2>();
+    const T& t00 = get<0, 0>(tensor);
+    const T& t01 = get<0, 1>(tensor);
+    const T& t02 = get<0, 2>(tensor);
+    const T& t11 = get<1, 1>(tensor);
+    const T& t12 = get<1, 2>(tensor);
+    const T& t22 = get<2, 2>(tensor);
     const T a = t11 * t22 - t12 * t12;
     const T b = t12 * t02 - t01 * t22;
     const T c = t01 * t12 - t11 * t02;
@@ -140,12 +140,12 @@ struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
     Scalar<T> det{t00 * a + t01 * b + t02 * c};
     const T one_over_det = make_with_value<T>(det, 1.0) / det.get();
     Tensor<T, Symmetry<1, 1>, inverse_indices<Index0, Index0>> inv{};
-    inv.template get<0, 0>() = (t11 * t22 - t12 * t12) * one_over_det;
-    inv.template get<0, 1>() = (t12 * t02 - t22 * t01) * one_over_det;
-    inv.template get<0, 2>() = (t01 * t12 - t02 * t11) * one_over_det;
-    inv.template get<1, 1>() = (t22 * t00 - t02 * t02) * one_over_det;
-    inv.template get<1, 2>() = (t02 * t01 - t00 * t12) * one_over_det;
-    inv.template get<2, 2>() = (t00 * t11 - t01 * t01) * one_over_det;
+    get<0, 0>(inv) = (t11 * t22 - t12 * t12) * one_over_det;
+    get<0, 1>(inv) = (t12 * t02 - t22 * t01) * one_over_det;
+    get<0, 2>(inv) = (t01 * t12 - t02 * t11) * one_over_det;
+    get<1, 1>(inv) = (t22 * t00 - t02 * t02) * one_over_det;
+    get<1, 2>(inv) = (t02 * t01 - t00 * t12) * one_over_det;
+    get<2, 2>(inv) = (t00 * t11 - t01 * t01) * one_over_det;
     return std::make_pair(std::move(det), std::move(inv));
   }
 };
@@ -172,40 +172,40 @@ struct DetAndInverseImpl<Symmetry<2, 1>, Index0, Index1,
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<2, 1>, Index0, Index1> apply(
       const Tensor<T, Symmetry<2, 1>, typelist<Index0, Index1>>& tensor) {
-    const T& p00 = tensor.template get<0, 0>();
-    const T& p01 = tensor.template get<0, 1>();
-    const T& p10 = tensor.template get<1, 0>();
-    const T& p11 = tensor.template get<1, 1>();
-    const T& q00 = tensor.template get<0, 2>();
-    const T& q01 = tensor.template get<0, 3>();
-    const T& q10 = tensor.template get<1, 2>();
-    const T& q11 = tensor.template get<1, 3>();
-    const T& r00 = tensor.template get<2, 0>();
-    const T& r01 = tensor.template get<2, 1>();
-    const T& r10 = tensor.template get<3, 0>();
-    const T& r11 = tensor.template get<3, 1>();
-    const T& s00 = tensor.template get<2, 2>();
-    const T& s01 = tensor.template get<2, 3>();
-    const T& s10 = tensor.template get<3, 2>();
-    const T& s11 = tensor.template get<3, 3>();
+    const T& p00 = get<0, 0>(tensor);
+    const T& p01 = get<0, 1>(tensor);
+    const T& p10 = get<1, 0>(tensor);
+    const T& p11 = get<1, 1>(tensor);
+    const T& q00 = get<0, 2>(tensor);
+    const T& q01 = get<0, 3>(tensor);
+    const T& q10 = get<1, 2>(tensor);
+    const T& q11 = get<1, 3>(tensor);
+    const T& r00 = get<2, 0>(tensor);
+    const T& r01 = get<2, 1>(tensor);
+    const T& r10 = get<3, 0>(tensor);
+    const T& r11 = get<3, 1>(tensor);
+    const T& s00 = get<2, 2>(tensor);
+    const T& s01 = get<2, 3>(tensor);
+    const T& s10 = get<3, 2>(tensor);
+    const T& s11 = get<3, 3>(tensor);
 
     Tensor<T, Symmetry<2, 1>, inverse_indices<Index0, Index1>> inv{};
-    T& u00 = inv.template get<0, 0>();
-    T& u01 = inv.template get<0, 1>();
-    T& u10 = inv.template get<1, 0>();
-    T& u11 = inv.template get<1, 1>();
-    T& v00 = inv.template get<0, 2>();
-    T& v01 = inv.template get<0, 3>();
-    T& v10 = inv.template get<1, 2>();
-    T& v11 = inv.template get<1, 3>();
-    T& w00 = inv.template get<2, 0>();
-    T& w01 = inv.template get<2, 1>();
-    T& w10 = inv.template get<3, 0>();
-    T& w11 = inv.template get<3, 1>();
-    T& x00 = inv.template get<2, 2>();
-    T& x01 = inv.template get<2, 3>();
-    T& x10 = inv.template get<3, 2>();
-    T& x11 = inv.template get<3, 3>();
+    T& u00 = get<0, 0>(inv);
+    T& u01 = get<0, 1>(inv);
+    T& u10 = get<1, 0>(inv);
+    T& u11 = get<1, 1>(inv);
+    T& v00 = get<0, 2>(inv);
+    T& v01 = get<0, 3>(inv);
+    T& v10 = get<1, 2>(inv);
+    T& v11 = get<1, 3>(inv);
+    T& w00 = get<2, 0>(inv);
+    T& w01 = get<2, 1>(inv);
+    T& w10 = get<3, 0>(inv);
+    T& w11 = get<3, 1>(inv);
+    T& x00 = get<2, 2>(inv);
+    T& x01 = get<2, 3>(inv);
+    T& x10 = get<3, 2>(inv);
+    T& x11 = get<3, 3>(inv);
 
     const T det_p = p00 * p11 - p01 * p10;
     const T one_over_det_p = make_with_value<T>(det_p, 1.0) / det_p;
@@ -264,28 +264,28 @@ struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<1, 1>, Index0, Index0> apply(
       const Tensor<T, Symmetry<1, 1>, typelist<Index0, Index0>>& tensor) {
-    const T& p00 = tensor.template get<0, 0>();
-    const T& p01 = tensor.template get<0, 1>();
-    const T& p11 = tensor.template get<1, 1>();
-    const T& q00 = tensor.template get<0, 2>();
-    const T& q01 = tensor.template get<0, 3>();
-    const T& q10 = tensor.template get<1, 2>();
-    const T& q11 = tensor.template get<1, 3>();
-    const T& s00 = tensor.template get<2, 2>();
-    const T& s01 = tensor.template get<2, 3>();
-    const T& s11 = tensor.template get<3, 3>();
+    const T& p00 = get<0, 0>(tensor);
+    const T& p01 = get<0, 1>(tensor);
+    const T& p11 = get<1, 1>(tensor);
+    const T& q00 = get<0, 2>(tensor);
+    const T& q01 = get<0, 3>(tensor);
+    const T& q10 = get<1, 2>(tensor);
+    const T& q11 = get<1, 3>(tensor);
+    const T& s00 = get<2, 2>(tensor);
+    const T& s01 = get<2, 3>(tensor);
+    const T& s11 = get<3, 3>(tensor);
 
     Tensor<T, Symmetry<1, 1>, inverse_indices<Index0, Index0>> inv{};
-    T& u00 = inv.template get<0, 0>();
-    T& u01 = inv.template get<0, 1>();
-    T& u11 = inv.template get<1, 1>();
-    T& v00 = inv.template get<0, 2>();
-    T& v01 = inv.template get<0, 3>();
-    T& v10 = inv.template get<1, 2>();
-    T& v11 = inv.template get<1, 3>();
-    T& x00 = inv.template get<2, 2>();
-    T& x01 = inv.template get<2, 3>();
-    T& x11 = inv.template get<3, 3>();
+    T& u00 = get<0, 0>(inv);
+    T& u01 = get<0, 1>(inv);
+    T& u11 = get<1, 1>(inv);
+    T& v00 = get<0, 2>(inv);
+    T& v01 = get<0, 3>(inv);
+    T& v10 = get<1, 2>(inv);
+    T& v11 = get<1, 3>(inv);
+    T& x00 = get<2, 2>(inv);
+    T& x01 = get<2, 3>(inv);
+    T& x11 = get<3, 3>(inv);
 
     const T det_p = p00 * p11 - p01 * p01;
     const T one_over_det_p = make_with_value<T>(det_p, 1.0) / det_p;

--- a/src/DataStructures/Tensor/EagerMath/DivideBy.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DivideBy.hpp
@@ -10,7 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Divides the components of a tensor by a scalar
  *
  * \returns a tensor of the same type as the input tensor

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -12,7 +12,7 @@
 #include "ErrorHandling/Assert.hpp"
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief compute the Euclidean magnitude of a rank-1 tensor
  *
  * \returns the Euclidean magnitude of the rank-1 tensor
@@ -32,7 +32,7 @@ DataType magnitude(
 }
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief compute the magnitude of a rank-1 tensor
  *
  * \returns the magnitude of the rank-1 tensor

--- a/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
+++ b/src/DataStructures/Tensor/Expressions/AddSubtract.hpp
@@ -99,7 +99,7 @@ struct AddSub<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>, Sign>
 }  // namespace TensorExpressions
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  */
 template <typename T1, typename T2, typename X, typename Symm1, typename Symm2,
           typename IndexList1, typename IndexList2, typename Args1,
@@ -121,7 +121,7 @@ SPECTRE_ALWAYS_INLINE auto operator+(
 }
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  */
 template <typename T1, typename T2, typename X, typename Symm1, typename Symm2,
           typename IndexList1, typename IndexList2, typename Args1,

--- a/src/DataStructures/Tensor/Expressions/Contract.hpp
+++ b/src/DataStructures/Tensor/Expressions/Contract.hpp
@@ -12,7 +12,7 @@
 #include "Utilities/Requires.hpp"
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  * Holds all possible TensorExpressions currently implemented
  */
 namespace TensorExpressions {
@@ -69,7 +69,7 @@ struct ComputeContractionImpl<0, Index1, Index2> {
 }  // namespace detail
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  */
 template <typename Index1, typename Index2, typename T, typename X,
           typename Symm, typename IndexList, typename ArgsList>
@@ -162,7 +162,7 @@ struct TensorContract
 };
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  */
 template <int Index1, int Index2, typename T, typename X, typename Symm,
           typename IndexList, typename Args>
@@ -216,7 +216,7 @@ struct fully_contract_helper<TE, ReplacedArgList,
 }  // namespace detail
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  * \brief Represents a fully contracted Tensor
  */
 template <template <typename> class TE, typename ReplacedArgList, typename I,

--- a/src/DataStructures/Tensor/Expressions/Evaluate.hpp
+++ b/src/DataStructures/Tensor/Expressions/Evaluate.hpp
@@ -13,7 +13,7 @@
 namespace TensorExpressions {
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  * \brief Evaluate a Tensor Expression with LHS indices set in the template
  * parameters
  *

--- a/src/DataStructures/Tensor/Expressions/Product.hpp
+++ b/src/DataStructures/Tensor/Expressions/Product.hpp
@@ -11,7 +11,7 @@
 namespace TensorExpressions {
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  *
  * @tparam T1
  * @tparam T2
@@ -68,7 +68,7 @@ struct Product<T1, T2, ArgsList1<Args1...>, ArgsList2<Args2...>>
 }  // namespace TensorExpressions
 
 /*!
- * @ingroup TensorExpressions
+ * @ingroup TensorExpressionsGroup
  *
  * @tparam T1
  * @tparam T2

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -12,7 +12,7 @@
 #include "Utilities/TypeTraits.hpp"
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  * \brief Represents the indices in a TensorExpression
  *
  * \details
@@ -32,20 +32,20 @@ struct TensorIndex {
   static constexpr value_type value = I;
 };
 
-/// \ingroup TensorExpressions
+/// \ingroup TensorExpressionsGroup
 /// Given an `TensorIndex<size_t>` return `TensorIndex<size_t + 1>`
 /// \tparam T the args to increment
 template <typename T>
 using next_tensor_index = TensorIndex<T::value + 1>;
 
-/// \ingroup TensorExpressions
+/// \ingroup TensorExpressionsGroup
 /// Metafunction to return the sum of two TensorIndex's
 template <typename A, typename B>
 using plus_tensor_index = TensorIndex<A::value + B::value>;
 
 // @{
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  * \brief The available TensorIndex's to use in a TensorExpression
  *
  * Available tensor indices to use in a Tensor Expression.
@@ -98,20 +98,20 @@ using ti_J_t = decltype(ti_J);
 // @}
 
 /// \cond HIDDEN_SYMBOLS
-/// \ingroup TensorExpressions
+/// \ingroup TensorExpressionsGroup
 /// Type alias used when Tensor Expressions manipulate indices. These are used
 /// to denote contracted as opposed to free indices.
 template <int I>
 using ti_contracted_t = TensorIndex<static_cast<size_t>(I + 1000)>;
 
-/// \ingroup TensorExpressions
+/// \ingroup TensorExpressionsGroup
 template <int I>
 TensorIndex<static_cast<size_t>(I + 1000)> ti_contracted();
 /// \endcond
 
 namespace tt {
 /*!
- * \ingroup TypeTraits TensorExpressions
+ * \ingroup TypeTraitsGroup TensorExpressions
  * \brief Check if a type `T` is a TensorIndex used in TensorExpressions
  */
 template <typename T>
@@ -129,7 +129,7 @@ struct rhs_elements_in_lhs_helper {
 };
 }  // namespace detail
 
-/// \ingroup TensorExpressions
+/// \ingroup TensorExpressionsGroup
 /// Returns a list of all the elements in the typelist Rhs that are also in the
 /// typelist Lhs.
 ///
@@ -183,7 +183,7 @@ struct generate_transformation_impl {
 };
 }  // namespace detail
 
-/// \ingroup TensorExpressions
+/// \ingroup TensorExpressionsGroup
 /// \brief Generate transformation to account for index order difference in RHS
 /// and LHS.
 ///
@@ -219,7 +219,7 @@ struct repeated_helper {
 }  // namespace detail
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  * Returns a list of all the types that occurred more than once in List.
  */
 template <typename List>
@@ -250,13 +250,13 @@ struct replace_indices_impl<List, tmpl::list<>, I> {
 }  // namespace detail
 
 /*!
- * \ingroup TensorExpressions
+ * \ingroup TensorExpressionsGroup
  */
 template <typename List, typename ReplaceList>
 using replace_indices =
     typename detail::replace_indices_impl<List, ReplaceList, 0>::type;
 
-/// \ingroup TensorExpressions
+/// \ingroup TensorExpressionsGroup
 /// \brief Marks a class as being a TensorExpression
 ///
 /// \details
@@ -273,7 +273,7 @@ class Tensor;
 /// \endcond
 
 // @{
-/// \ingroup TensorExpressions
+/// \ingroup TensorExpressionsGroup
 /// \brief The base class all tensor expression implementations derive from
 ///
 /// \tparam Derived the derived class needed for
@@ -337,7 +337,7 @@ struct TensorExpression<Derived, DataType, Symm, IndexList, ArgsList<Args...>> {
 
   // @{
   /// \cond HIDDEN_SYMBOLS
-  /// \ingroup TensorExpressions
+  /// \ingroup TensorExpressionsGroup
   /// Helper struct to compute the correct tensor index array from a
   /// typelist of std::integral_constant's indicating the ordering. This is
   /// needed for dealing with expressions such as \f$T_{ab} = F_{ba}\f$ and gets

--- a/src/DataStructures/Tensor/IndexType.hpp
+++ b/src/DataStructures/Tensor/IndexType.hpp
@@ -12,7 +12,7 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Whether a \ref SpacetimeIndex "TensorIndexType" is covariant or
 /// contravariant
 enum class UpLo {
@@ -28,11 +28,11 @@ inline std::ostream& operator<<(std::ostream& os, const UpLo& ul) {
 }
 /// \endcond
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Indicates the ::Frame that a \ref SpacetimeIndex "TensorIndexType"
 /// is in.
 namespace Frame {
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Marks a Frame as being "physical" in the sense that it is meaningful to
 /// evaluate an analytic solution in that frame.
 struct FrameIsPhysical {};
@@ -49,7 +49,7 @@ struct NoFrame {};
 /// for jacobians.
 using ordered_frame_list = typelist<Logical, Grid, Inertial, Distorted>;
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Returns std::true_type if the frame is "physical" in the sense that it is
 /// meaningful to evaluate an analytic solution in that frame.
 /// \example
@@ -59,7 +59,7 @@ using is_frame_physical =
     std::integral_constant<bool,
                            cpp17::is_base_of_v<FrameIsPhysical, CheckFrame>>;
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Returns true if the frame is "physical" in the sense that it is
 /// meaningful to evaluate an analytic solution in that frame.
 /// \example
@@ -90,7 +90,7 @@ inline std::ostream& operator<<(std::ostream& os,
 /// \endcond
 }  // namespace Frame
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Indicates whether the \ref SpacetimeIndex "TensorIndexType" is
 /// Spatial or Spacetime
 enum class IndexType : char {
@@ -107,7 +107,7 @@ inline std::ostream& operator<<(std::ostream& os, const IndexType& index_type) {
 /// \endcond
 
 namespace Tensor_detail {
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// A ::TensorIndexType holds information about what type of index an index of a
 /// Tensor is. It holds the information about the number of spatial dimensions,
 /// whether the index is covariant or contravariant (::UpLo), the ::Frame the
@@ -134,7 +134,7 @@ struct TensorIndexType {
 };
 }  // namespace Tensor_detail
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// A SpatialIndex holds information about the number of spatial
 /// dimensions, whether the index is covariant or contravariant (::UpLo), and
 /// the ::Frame the index is in.
@@ -147,7 +147,7 @@ template <size_t SpatialDim, UpLo Ul, typename Fr>
 using SpatialIndex =
     Tensor_detail::TensorIndexType<SpatialDim, Ul, Fr, IndexType::Spatial>;
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// A SpacetimeIndex holds information about the number of spatial
 /// dimensions, whether the index is covariant or contravariant (::UpLo), and
 /// the ::Frame the index is in.
@@ -163,7 +163,7 @@ using SpacetimeIndex =
 
 namespace tt {
 // @{
-/// \ingroup Tensor TypeTraits
+/// \ingroup TensorGroup TypeTraits
 /// Inherits from std::true_type if T is a \ref SpacetimeIndex
 /// "TensorIndexType"
 /// \tparam T the type to check
@@ -181,7 +181,7 @@ using is_tensor_index_type_t = typename is_tensor_index_type<T>::type;
 // @}
 }  // namespace tt
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Change the \ref SpacetimeIndex "TensorIndexType" to be covariant
 /// if it's contravariant and vice-versa
 ///

--- a/src/DataStructures/Tensor/Metafunctions.hpp
+++ b/src/DataStructures/Tensor/Metafunctions.hpp
@@ -14,12 +14,12 @@ template <typename X, typename Symm, typename IndexList>
 class Tensor;
 /// \endcond
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Contains all metafunctions related to Tensor manipulations
 namespace TensorMetafunctions {
 namespace detail {
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * Compute the number of components and independent components for a given
  * Symmetry and TensorIndex list
  * \tparam Symmetry_t Symmetry of the Tensor
@@ -29,7 +29,7 @@ template <typename Symmetry_t, typename Indices_t, typename = std::nullptr_t>
 struct number_of_independent_components_impl;
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * Case where the Tensor is a scalar
  */
 template <>
@@ -39,7 +39,7 @@ struct number_of_independent_components_impl<tmpl::list<>, tmpl::list<>> {
 };
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * End recursion, only one index left. The component number is 1 (first
  * component) and the number of components and independent components is the
  * dimensionality of the first index
@@ -55,7 +55,7 @@ struct number_of_independent_components_impl<typelist<SymmetryValue>,
 
 /// \cond HIDDEN_SYMBOLS
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  *
  * General case for computing the number of (independent) components. The type
  * alias `next` computes the number of components with one fewer TensorIndex,
@@ -108,7 +108,7 @@ struct number_of_independent_components_impl<
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Compute the number of independent components for a given ::Symmetry
  * and \ref SpacetimeIndex "TensorIndexType" list
  * \tparam Symmetry_t Symmetry of the Tensor
@@ -120,7 +120,7 @@ using independent_components =
         Symmetry_t, Indices_t>::number_of_independent_components;
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Compute the number of components for a given ::Symmetry and \ref
  * SpacetimeIndex "TensorIndexType" list
  * \tparam Symmetry_t Symmetry of the Tensor
@@ -158,7 +158,7 @@ struct increment_tensor_index_impl<true> {
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Increment a tensor index
  *
  * \details
@@ -231,7 +231,7 @@ struct tensor_index_to_swap_impl<false> {
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  */
 template <typename Symm, typename TensorIndex, size_t Rank, size_t I,
           size_t Offset>
@@ -265,7 +265,7 @@ struct canonicalize_tensor_index_impl<true> {
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  */
 template <typename Symm, typename IndexList, typename TensorIndex>
 using canonicalize_tensor_index =
@@ -298,7 +298,7 @@ struct compute_collapsed_index_impl<true> {
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  *
  * \requires `is_a<typelist, IndexList>::%value` is true, `tt::is_a<typelist,
  * TensorIndex>::%value` is true, and `tmpl::all<TensorIndex,
@@ -333,7 +333,7 @@ struct update_collapsed_to_storage_using_canonical_tensor_index_impl<true> {
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \note Cannot use `std::conditional_t` because `typelist<>` will fail
  */
 template <typename IndexList, typename CanonicalTensorIndex,
@@ -347,7 +347,7 @@ using update_collapsed_to_storage_using_canonical_tensor_index =
                           CollapsedToStorageList, I, Count>;
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief given a `TensorIndex` checks if it is the canonical form, if so
  * returns `tmpl::plus<Count, tmpl::size_t<1>>` otherwise returns `Count`
  */
@@ -390,7 +390,7 @@ struct compute_collapsed_to_storage_impl<true> {
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Compute the collapse index to storage index ::typelist
  */
 template <typename IndexList, typename Symm, typename NumComps>
@@ -446,7 +446,7 @@ struct compute_storage_to_tensor_impl<2> {
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Compute a ::typelist holding the tensor index for each storage index
  */
 template <typename Symm, typename IndexList, typename CollapsedToStorageList,
@@ -496,7 +496,7 @@ struct compute_multiplicity_impl<true> {
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Compute ::typelist of the multiplicity of each storage index of a
  * Tensor
  *
@@ -554,7 +554,7 @@ struct check_index_symmetry_impl<2> {
 }  // namespace detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Check that each of symmetric indices is in the same frame and have the
  * same dimensionality.
  */
@@ -567,7 +567,7 @@ constexpr bool check_index_symmetry_v =
     check_index_symmetry<Symm, IndexList>::value;
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Add a spatial index to the from of a Tensor
  *
  * \tparam Tensor_t the tensor type to prepend
@@ -587,7 +587,7 @@ using prepend_spatial_index = Tensor<
                      SpatialIndex<VolumeDim, Ul, Fr>>>;
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Add a spacetime index to the from of a Tensor
  *
  * \tparam Tensor_t the tensor type to prepend

--- a/src/DataStructures/Tensor/Structure.hpp
+++ b/src/DataStructures/Tensor/Structure.hpp
@@ -21,7 +21,7 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Contains details of the implementation of Tensor
 namespace Tensor_detail {
 namespace detail {
@@ -144,7 +144,7 @@ SPECTRE_ALWAYS_INLINE constexpr size_t compute_collapsed_index(
       static_cast<std::size_t>(i)...));
 }
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// A lookup table between each tensor_index and storage_index
 ///
 /// 1. tensor_index: (a, b, c,...). There are Dim^rank tensor_index's

--- a/src/DataStructures/Tensor/Symmetry.hpp
+++ b/src/DataStructures/Tensor/Symmetry.hpp
@@ -12,7 +12,7 @@
 
 namespace detail {
 // @{
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// \brief Metafunction that computes the new sign map
 ///
 /// \details
@@ -45,7 +45,7 @@ struct compute_sign_map_helper<true> {
 // @}
 
 // @{
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Metafunction to compute the new `sign_map` which is a map between indices
 /// and +/-1 depending on whether the index is symmetric (or has no symmetry) or
 /// is anti-symmetric, respectively.
@@ -90,7 +90,7 @@ struct compute_sign_map<false> {
 // @}
 
 // @{
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// A metafunction that, given the current and past SignMap, returns either 1
 /// if the absolute value of index is not in the `PastSignMap` or returns the
 /// signed value in the `CurrentSignMap` if the absolute value of index is in
@@ -121,20 +121,20 @@ struct compute_sign<false> {
 /// \endcond
 // @}
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Metafunction to compute the symmetry typelist. See the Symmetry type alias
 /// for details of how to use.
 template <std::int32_t... T>
 struct symm;
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Scalar tensor case
 template <>
 struct symm<> {
   using type = tmpl::integral_list<std::int32_t>;
 };
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Last index case to end recursion.
 template <std::int32_t index>
 struct symm<index> {
@@ -147,7 +147,7 @@ struct symm<index> {
       tmpl::pair<tmpl::int32_t<index>, tmpl::sign<tmpl::int32_t<index>>>>;
 };
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Metafunction that computes symmetry as a typelist of std::integral_constant.
 /// The `added_map` is a typemap used to keep track of whether or not a
 /// particular index has already been added to the list. If it or its negative
@@ -208,7 +208,7 @@ struct symm<index, T...> {
 };
 }  // namespace detail
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// \brief Computes the canonical symmetry from the integers `T`
 ///
 /// \details

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -228,20 +228,15 @@ class Tensor<X, Symm, IndexList<Indices...>> {
 
   // @{
   /// Retrieve the index `N...` by computing the storage index at compile time
-  template <int... N>
-  SPECTRE_ALWAYS_INLINE constexpr reference get() {
-    static_assert(sizeof...(Indices) == sizeof...(N),
-                  "the number of tensor indices specified must match the rank "
-                  "of the tensor");
-    return gsl::at(data_, structure::template get_storage_index<N...>());
-  }
-  template <int... N>
-  SPECTRE_ALWAYS_INLINE constexpr const_reference get() const {
-    static_assert(sizeof...(Indices) == sizeof...(N),
-                  "the number of tensor indices specified must match the rank "
-                  "of the tensor");
-    return gsl::at(data_, structure::template get_storage_index<N...>());
-  }
+  // clang-tidy: redundant declaration (bug in clang-tidy)
+  template <int... N, typename... Args>
+  friend SPECTRE_ALWAYS_INLINE constexpr typename Tensor<Args...>::reference
+  get(Tensor<Args...>& t) noexcept;  // NOLINT
+  // clang-tidy: redundant declaration (bug in clang-tidy)
+  template <int... N, typename... Args>
+  friend SPECTRE_ALWAYS_INLINE constexpr
+      typename Tensor<Args...>::const_reference
+      get(const Tensor<Args...>& t) noexcept;  // NOLINT
   // @}
 
   // @{
@@ -456,6 +451,26 @@ Tensor<X, Symm, IndexList<Indices...>>::get_vector_of_data() const {
     serialized_tensor[i] = gsl::at(data_, i);
   }
   return std::make_pair(component_names, serialized_tensor);
+}
+
+template <int... N, typename... Args>
+SPECTRE_ALWAYS_INLINE constexpr typename Tensor<Args...>::reference get(
+    Tensor<Args...>& t) noexcept {
+  static_assert(Tensor<Args...>::rank() == sizeof...(N),
+                "the number of tensor indices specified must match the rank "
+                "of the tensor");
+  return gsl::at(
+      t.data_, Tensor<Args...>::structure::template get_storage_index<N...>());
+}
+
+template <int... N, typename... Args>
+SPECTRE_ALWAYS_INLINE constexpr typename Tensor<Args...>::const_reference get(
+    const Tensor<Args...>& t) noexcept {
+  static_assert(Tensor<Args...>::rank() == sizeof...(N),
+                "the number of tensor indices specified must match the rank "
+                "of the tensor");
+  return gsl::at(
+      t.data_, Tensor<Args...>::structure::template get_storage_index<N...>());
 }
 
 template <typename X, typename Symm, template <typename...> class IndexList,

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -40,7 +40,7 @@ struct is_tensor<Tensor<X, Symm, IndexList>> : std::true_type {};
 }  // namespace Tensor_detail
 
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Represents an object with multiple components
  *
  * \details

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -15,15 +15,13 @@ template <typename X, typename Symm, typename IndexList>
 class Tensor;
 /// \endcond
 
-/// \ingroup Tensor
+/// \ingroup TensorGroup
 /// Scalar type
 template <typename T>
 using Scalar = Tensor<T, Symmetry<>, index_list<>>;
 
-
-
 /*!
- * \ingroup Tensor
+ * \ingroup TensorGroup
  * \brief Type aliases to construct common Tensors
  *
  * Lower case letters represent covariant indices and upper case letters

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -31,7 +31,7 @@ struct Variables : db::DataBoxTag {
                 "The TagsList passed to Tags::Variables is not a typelist");
   using tags_list = TagsList;
   using type = ::Variables<TagsList>;
-  static constexpr db::DataBoxString_t label = "Variables";
+  static constexpr db::DataBoxString label = "Variables";
 };
 }  // namespace Tags
 

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -41,7 +41,7 @@ class Variables;
 /// \endcond
 
 /*!
- * \ingroup DataStructures
+ * \ingroup DataStructuresGroup
  * \brief A Variables holds a contiguous memory block with Tensors pointing
  * into it
  */
@@ -297,7 +297,7 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
 
 // {@
 /*!
- * \ingroup DataStructures
+ * \ingroup DataStructuresGroup
  * \brief Return Tag::type pointing into the contiguous array
  *
  * \tparam Tag the variable to return

--- a/src/DataStructures/VariablesHelpers.hpp
+++ b/src/DataStructures/VariablesHelpers.hpp
@@ -18,7 +18,7 @@
 #include "Utilities/Gsl.hpp"
 
 /*!
- * \ingroup DataStructures
+ * \ingroup DataStructuresGroup
  * \brief Slices the data within `vars` to a codimension 1 slice. The
  * slice has a constant logical coordinate in direction `sliced_dim`,
  * slicing the volume at `fixed_index` in that dimension.  For
@@ -55,7 +55,7 @@ Variables<TagsList> data_on_slice(const Variables<TagsList>& vars,
 }
 
 /*!
- * \ingroup DataStructures
+ * \ingroup DataStructuresGroup
  * \brief Adds data on a codimension 1 slice to a volume quantity. The
  * slice has a constant logical coordinate in direction `sliced_dim`,
  * slicing the volume at `fixed_index` in that dimension.  For
@@ -104,7 +104,7 @@ std::vector<size_t> oriented_offset(
     const Orientation<3>& orientation_of_neighbor) noexcept;
 }  // namespace OrientVariablesOnSlice_detail
 
-/// \ingroup DataStructures
+/// \ingroup DataStructuresGroup
 /// Orients variables on a slice to the data-storage order of a neighbor with
 /// the given orientation.
 template <size_t VolumeDim, typename TagsList>

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -16,7 +16,7 @@
 #include "Domain/Direction.hpp"
 #include "Utilities/StdHelpers.hpp"
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// A Block<VolumeDim> is a region of a VolumeDim-dimensional computational
 /// domain that defines the root node of a tree which is used to construct the
 /// Elements that cover a region of the computational domain.

--- a/src/Domain/BlockNeighbor.hpp
+++ b/src/Domain/BlockNeighbor.hpp
@@ -12,7 +12,7 @@
 #include "Domain/Direction.hpp"
 #include "Domain/Orientation.hpp"
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// Information about the neighbor of a Block in a particular direction.
 ///
 /// \tparam VolumeDim the volume dimension.

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -387,7 +387,7 @@ bool operator!=(
   return not(lhs == rhs);
 }
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// \brief Creates a CoordinateMap of `maps...`
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 constexpr CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>
@@ -396,7 +396,7 @@ make_coordinate_map(Maps&&... maps) {
       std::forward<Maps>(maps)...);
 }
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// \brief Creates a std::unique_ptr<CoordinateMapBase> of `maps...`
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 std::unique_ptr<CoordinateMapBase<

--- a/src/Domain/CoordinateMaps/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "DataStructures/MakeWithValue.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Parallel/PupStlCpp11.hpp"
@@ -301,21 +302,12 @@ ProductOf3Maps<Map1, Map2, Map3>::inv_jacobian(
          index_list<SpatialIndex<dim, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<dim, UpLo::Lo, Frame::NoFrame>>>
       inv_jac{make_with_value<UnwrappedT>(dereference_wrapper(xi[0]), 0.0)};
-  inv_jac.template get<0, 0>() =
-      map1_
-          .inv_jacobian(
-              std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[0]}})
-          .template get<0, 0>();
-  inv_jac.template get<1, 1>() =
-      map2_
-          .inv_jacobian(
-              std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[1]}})
-          .template get<0, 0>();
-  inv_jac.template get<2, 2>() =
-      map3_
-          .inv_jacobian(
-              std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[2]}})
-          .template get<0, 0>();
+  get<0, 0>(inv_jac) = get<0, 0>(map1_.inv_jacobian(
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[0]}}));
+  get<1, 1>(inv_jac) = get<0, 0>(map2_.inv_jacobian(
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[1]}}));
+  get<2, 2>(inv_jac) = get<0, 0>(map3_.inv_jacobian(
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[2]}}));
   return inv_jac;
 }
 template <typename Map1, typename Map2, typename Map3>
@@ -332,21 +324,12 @@ ProductOf3Maps<Map1, Map2, Map3>::jacobian(const std::array<T, dim>& xi) const {
          index_list<SpatialIndex<dim, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<dim, UpLo::Lo, Frame::NoFrame>>>
       jac{make_with_value<UnwrappedT>(dereference_wrapper(xi[0]), 0.0)};
-  jac.template get<0, 0>() =
-      map1_
-          .jacobian(
-              std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[0]}})
-          .template get<0, 0>();
-  jac.template get<1, 1>() =
-      map2_
-          .jacobian(
-              std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[1]}})
-          .template get<0, 0>();
-  jac.template get<2, 2>() =
-      map3_
-          .jacobian(
-              std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[2]}})
-          .template get<0, 0>();
+  get<0, 0>(jac) = get<0, 0>(map1_.jacobian(
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[0]}}));
+  get<1, 1>(jac) = get<0, 0>(map2_.jacobian(
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[1]}}));
+  get<2, 2>(jac) = get<0, 0>(map3_.jacobian(
+      std::array<std::reference_wrapper<const UnwrappedT>, 1>{{xi[2]}}));
   return jac;
 }
 template <typename Map1, typename Map2, typename Map3>

--- a/src/Domain/CoordinateMaps/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/Rotation.cpp
@@ -13,28 +13,28 @@ Rotation<2>::Rotation(const double rotation_angle)
       rotation_matrix_(std::numeric_limits<double>::signaling_NaN()) {
   const double cos_alpha = cos(rotation_angle_);
   const double sin_alpha = sin(rotation_angle_);
-  rotation_matrix_.template get<0, 0>() = cos_alpha;
-  rotation_matrix_.template get<0, 1>() = -sin_alpha;
-  rotation_matrix_.template get<1, 0>() = sin_alpha;
-  rotation_matrix_.template get<1, 1>() = cos_alpha;
+  get<0, 0>(rotation_matrix_) = cos_alpha;
+  get<0, 1>(rotation_matrix_) = -sin_alpha;
+  get<1, 0>(rotation_matrix_) = sin_alpha;
+  get<1, 1>(rotation_matrix_) = cos_alpha;
 }
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> Rotation<2>::
 operator()(const std::array<T, 2>& xi) const {
-  return {{xi[0] * rotation_matrix_.template get<0, 0>() +
-               xi[1] * rotation_matrix_.template get<0, 1>(),
-           xi[0] * rotation_matrix_.template get<1, 0>() +
-               xi[1] * rotation_matrix_.template get<1, 1>()}};
+  return {{xi[0] * get<0, 0>(rotation_matrix_) +
+               xi[1] * get<0, 1>(rotation_matrix_),
+           xi[0] * get<1, 0>(rotation_matrix_) +
+               xi[1] * get<1, 1>(rotation_matrix_)}};
 }
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2>
 Rotation<2>::inverse(const std::array<T, 2>& x) const {
-  return {{x[0] * rotation_matrix_.template get<0, 0>() +
-               x[1] * rotation_matrix_.template get<1, 0>(),
-           x[0] * rotation_matrix_.template get<0, 1>() +
-               x[1] * rotation_matrix_.template get<1, 1>()}};
+  return {
+      {x[0] * get<0, 0>(rotation_matrix_) + x[1] * get<1, 0>(rotation_matrix_),
+       x[0] * get<0, 1>(rotation_matrix_) +
+           x[1] * get<1, 1>(rotation_matrix_)}};
 }
 
 template <typename T>
@@ -49,10 +49,10 @@ Rotation<2>::jacobian(const std::array<T, 2>& xi) const {
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
       jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
           dereference_wrapper(xi[0]), 0.0)};
-  jac.template get<0, 0>() = rotation_matrix_.template get<0, 0>();
-  jac.template get<1, 0>() = rotation_matrix_.template get<1, 0>();
-  jac.template get<0, 1>() = rotation_matrix_.template get<0, 1>();
-  jac.template get<1, 1>() = rotation_matrix_.template get<1, 1>();
+  get<0, 0>(jac) = get<0, 0>(rotation_matrix_);
+  get<1, 0>(jac) = get<1, 0>(rotation_matrix_);
+  get<0, 1>(jac) = get<0, 1>(rotation_matrix_);
+  get<1, 1>(jac) = get<1, 1>(rotation_matrix_);
   return jac;
 }
 
@@ -68,10 +68,10 @@ Rotation<2>::inv_jacobian(const std::array<T, 2>& xi) const {
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
       inv_jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
           dereference_wrapper(xi[0]), 0.0)};
-  inv_jac.template get<0, 0>() = rotation_matrix_.template get<0, 0>();
-  inv_jac.template get<1, 0>() = rotation_matrix_.template get<0, 1>();
-  inv_jac.template get<0, 1>() = rotation_matrix_.template get<1, 0>();
-  inv_jac.template get<1, 1>() = rotation_matrix_.template get<1, 1>();
+  get<0, 0>(inv_jac) = get<0, 0>(rotation_matrix_);
+  get<1, 0>(inv_jac) = get<0, 1>(rotation_matrix_);
+  get<0, 1>(inv_jac) = get<1, 0>(rotation_matrix_);
+  get<1, 1>(inv_jac) = get<1, 1>(rotation_matrix_);
   return inv_jac;
 }
 
@@ -101,48 +101,46 @@ Rotation<3>::Rotation(const double rotation_about_z,
   const double sin_beta = sin(rotation_about_rotated_y_);
   const double cos_gamma = cos(rotation_about_rotated_z_);
   const double sin_gamma = sin(rotation_about_rotated_z_);
-  rotation_matrix_.template get<0, 0>() =
+  get<0, 0>(rotation_matrix_) =
       cos_gamma * cos_beta * cos_alpha - sin_gamma * sin_alpha;
-  rotation_matrix_.template get<0, 1>() =
+  get<0, 1>(rotation_matrix_) =
       -sin_gamma * cos_beta * cos_alpha - cos_gamma * sin_alpha;
-  rotation_matrix_.template get<0, 2>() = sin_beta * cos_alpha;
-  rotation_matrix_.template get<1, 0>() =
+  get<0, 2>(rotation_matrix_) = sin_beta * cos_alpha;
+  get<1, 0>(rotation_matrix_) =
       cos_gamma * cos_beta * sin_alpha + sin_gamma * cos_alpha;
-  rotation_matrix_.template get<1, 1>() =
+  get<1, 1>(rotation_matrix_) =
       -sin_gamma * cos_beta * sin_alpha + cos_gamma * cos_alpha;
-  rotation_matrix_.template get<1, 2>() = sin_beta * sin_alpha;
-  rotation_matrix_.template get<2, 0>() = -cos_gamma * sin_beta;
-  rotation_matrix_.template get<2, 1>() = sin_gamma * sin_beta;
-  rotation_matrix_.template get<2, 2>() = cos_beta;
+  get<1, 2>(rotation_matrix_) = sin_beta * sin_alpha;
+  get<2, 0>(rotation_matrix_) = -cos_gamma * sin_beta;
+  get<2, 1>(rotation_matrix_) = sin_gamma * sin_beta;
+  get<2, 2>(rotation_matrix_) = cos_beta;
 }
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> Rotation<3>::
 operator()(const std::array<T, 3>& xi) const {
-  return {{xi[0] * rotation_matrix_.template get<0, 0>() +
-               xi[1] * rotation_matrix_.template get<0, 1>() +
-               xi[2] * rotation_matrix_.template get<0, 2>(),
-           xi[0] * rotation_matrix_.template get<1, 0>() +
-               xi[1] * rotation_matrix_.template get<1, 1>() +
-               xi[2] * rotation_matrix_.template get<1, 2>(),
-           xi[0] * rotation_matrix_.template get<2, 0>() +
-               xi[1] * rotation_matrix_.template get<2, 1>() +
-               xi[2] * rotation_matrix_.template get<2, 2>()}};
+  return {{xi[0] * get<0, 0>(rotation_matrix_) +
+               xi[1] * get<0, 1>(rotation_matrix_) +
+               xi[2] * get<0, 2>(rotation_matrix_),
+           xi[0] * get<1, 0>(rotation_matrix_) +
+               xi[1] * get<1, 1>(rotation_matrix_) +
+               xi[2] * get<1, 2>(rotation_matrix_),
+           xi[0] * get<2, 0>(rotation_matrix_) +
+               xi[1] * get<2, 1>(rotation_matrix_) +
+               xi[2] * get<2, 2>(rotation_matrix_)}};
 }
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3>
 Rotation<3>::inverse(const std::array<T, 3>& x) const {
   // Inverse rotation matrix is the same as the transpose.
-  return {{x[0] * rotation_matrix_.template get<0, 0>() +
-               x[1] * rotation_matrix_.template get<1, 0>() +
-               x[2] * rotation_matrix_.template get<2, 0>(),
-           x[0] * rotation_matrix_.template get<0, 1>() +
-               x[1] * rotation_matrix_.template get<1, 1>() +
-               x[2] * rotation_matrix_.template get<2, 1>(),
-           x[0] * rotation_matrix_.template get<0, 2>() +
-               x[1] * rotation_matrix_.template get<1, 2>() +
-               x[2] * rotation_matrix_.template get<2, 2>()}};
+  return {
+      {x[0] * get<0, 0>(rotation_matrix_) + x[1] * get<1, 0>(rotation_matrix_) +
+           x[2] * get<2, 0>(rotation_matrix_),
+       x[0] * get<0, 1>(rotation_matrix_) + x[1] * get<1, 1>(rotation_matrix_) +
+           x[2] * get<2, 1>(rotation_matrix_),
+       x[0] * get<0, 2>(rotation_matrix_) + x[1] * get<1, 2>(rotation_matrix_) +
+           x[2] * get<2, 2>(rotation_matrix_)}};
 }
 
 template <typename T>
@@ -157,15 +155,15 @@ Rotation<3>::jacobian(const std::array<T, 3>& xi) const {
                     SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
       jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
           dereference_wrapper(xi[0]), 0.0)};
-  jac.template get<0, 0>() = rotation_matrix_.template get<0, 0>();
-  jac.template get<1, 0>() = rotation_matrix_.template get<1, 0>();
-  jac.template get<0, 1>() = rotation_matrix_.template get<0, 1>();
-  jac.template get<1, 1>() = rotation_matrix_.template get<1, 1>();
-  jac.template get<2, 0>() = rotation_matrix_.template get<2, 0>();
-  jac.template get<2, 1>() = rotation_matrix_.template get<2, 1>();
-  jac.template get<0, 2>() = rotation_matrix_.template get<0, 2>();
-  jac.template get<1, 2>() = rotation_matrix_.template get<1, 2>();
-  jac.template get<2, 2>() = rotation_matrix_.template get<2, 2>();
+  get<0, 0>(jac) = get<0, 0>(rotation_matrix_);
+  get<1, 0>(jac) = get<1, 0>(rotation_matrix_);
+  get<0, 1>(jac) = get<0, 1>(rotation_matrix_);
+  get<1, 1>(jac) = get<1, 1>(rotation_matrix_);
+  get<2, 0>(jac) = get<2, 0>(rotation_matrix_);
+  get<2, 1>(jac) = get<2, 1>(rotation_matrix_);
+  get<0, 2>(jac) = get<0, 2>(rotation_matrix_);
+  get<1, 2>(jac) = get<1, 2>(rotation_matrix_);
+  get<2, 2>(jac) = get<2, 2>(rotation_matrix_);
   return jac;
 }
 
@@ -181,15 +179,15 @@ Rotation<3>::inv_jacobian(const std::array<T, 3>& xi) const {
                     SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
       inv_jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
           dereference_wrapper(xi[0]), 0.0)};
-  inv_jac.template get<0, 0>() = rotation_matrix_.template get<0, 0>();
-  inv_jac.template get<1, 0>() = rotation_matrix_.template get<0, 1>();
-  inv_jac.template get<0, 1>() = rotation_matrix_.template get<1, 0>();
-  inv_jac.template get<1, 1>() = rotation_matrix_.template get<1, 1>();
-  inv_jac.template get<2, 0>() = rotation_matrix_.template get<0, 2>();
-  inv_jac.template get<2, 1>() = rotation_matrix_.template get<1, 2>();
-  inv_jac.template get<0, 2>() = rotation_matrix_.template get<2, 0>();
-  inv_jac.template get<1, 2>() = rotation_matrix_.template get<2, 1>();
-  inv_jac.template get<2, 2>() = rotation_matrix_.template get<2, 2>();
+  get<0, 0>(inv_jac) = get<0, 0>(rotation_matrix_);
+  get<1, 0>(inv_jac) = get<0, 1>(rotation_matrix_);
+  get<0, 1>(inv_jac) = get<1, 0>(rotation_matrix_);
+  get<1, 1>(inv_jac) = get<1, 1>(rotation_matrix_);
+  get<2, 0>(inv_jac) = get<0, 2>(rotation_matrix_);
+  get<2, 1>(inv_jac) = get<1, 2>(rotation_matrix_);
+  get<0, 2>(inv_jac) = get<2, 0>(rotation_matrix_);
+  get<1, 2>(inv_jac) = get<2, 1>(rotation_matrix_);
+  get<2, 2>(inv_jac) = get<2, 2>(rotation_matrix_);
   return inv_jac;
 }
 

--- a/src/Domain/CoordinateMaps/Wedge2D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.cpp
@@ -69,10 +69,10 @@ Wedge2D::jacobian(const std::array<T, 2>& xi) const noexcept {
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
       jacobian_matrix{};
 
-  auto &dxdxi = jacobian_matrix.template get<0, 0>(),
-       &dydeta = jacobian_matrix.template get<1, 1>(),
-       &dxdeta = jacobian_matrix.template get<0, 1>(),
-       &dydxi = jacobian_matrix.template get<1, 0>();
+  auto &dxdxi = get<0, 0>(jacobian_matrix),
+       &dydeta = get<1, 1>(jacobian_matrix),
+       &dxdeta = get<0, 1>(jacobian_matrix),
+       &dydxi = get<1, 0>(jacobian_matrix);
 
   dxdxi = -0.5 * inner_radius_ / sqrt(2.0) + 0.5 * outer_radius_ * cos(theta);
   dxdeta = -0.5 * (1 + xi[0]) * outer_radius_ * sin(theta) * M_PI_4;

--- a/src/Domain/CoordinateMaps/Wedge3D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.cpp
@@ -212,15 +212,15 @@ Wedge3D::jacobian(const std::array<T, 3>& x) const noexcept {
                     SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
       jacobian_matrix{};
 
-  auto &dx_dxi = jacobian_matrix.template get<0, 0>(),
-       &dx_deta = jacobian_matrix.template get<0, 1>(),
-       &dx_dzeta = jacobian_matrix.template get<0, 2>(),
-       &dy_dxi = jacobian_matrix.template get<1, 0>(),
-       &dy_deta = jacobian_matrix.template get<1, 1>(),
-       &dy_dzeta = jacobian_matrix.template get<1, 2>(),
-       &dz_dxi = jacobian_matrix.template get<2, 0>(),
-       &dz_deta = jacobian_matrix.template get<2, 1>(),
-       &dz_dzeta = jacobian_matrix.template get<2, 2>();
+  auto &dx_dxi = get<0, 0>(jacobian_matrix),
+       &dx_deta = get<0, 1>(jacobian_matrix),
+       &dx_dzeta = get<0, 2>(jacobian_matrix),
+       &dy_dxi = get<1, 0>(jacobian_matrix),
+       &dy_deta = get<1, 1>(jacobian_matrix),
+       &dy_dzeta = get<1, 2>(jacobian_matrix),
+       &dz_dxi = get<2, 0>(jacobian_matrix),
+       &dz_deta = get<2, 1>(jacobian_matrix),
+       &dz_dzeta = get<2, 2>(jacobian_matrix);
 
   dz_dxi = -second_blending_factor_over_rho_cubed * cap_xi * cap_xi_deriv;
   dz_deta = -second_blending_factor_over_rho_cubed * cap_eta * cap_eta_deriv;

--- a/src/Domain/CreateInitialElement.hpp
+++ b/src/Domain/CreateInitialElement.hpp
@@ -16,7 +16,7 @@ class ElementId;
 /// \endcond
 
 /*!
- * \ingroup ComputationalDomain
+ * \ingroup ComputationalDomainGroup
  * \brief Creates an initial element of a Block.
  */
 template <size_t VolumeDim, typename TargetFrame>

--- a/src/Domain/Direction.hpp
+++ b/src/Domain/Direction.hpp
@@ -13,7 +13,7 @@
 #include "Domain/Side.hpp"
 #include "Parallel/PupStlCpp11.hpp"
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// A particular Side along a particular coordinate Axis.
 template <size_t VolumeDim>
 class Direction {

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -18,7 +18,7 @@ template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
 
 /*!
- *  \ingroup ComputationalDomain
+ *  \ingroup ComputationalDomainGroup
  *  \brief A wrapper around a vector of Blocks that represent the computational
  * domain.
  */

--- a/src/Domain/DomainCreators/Brick.hpp
+++ b/src/Domain/DomainCreators/Brick.hpp
@@ -17,37 +17,37 @@ class Brick : public DomainCreator<3, Frame::Inertial> {
  public:
   struct LowerBound {
     using type = std::array<double, 3>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Sequence of [x,y,z] for lower bounds."};
   };
 
   struct UpperBound {
     using type = std::array<double, 3>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Sequence of [x,y,z] for upper bounds."};
   };
   struct IsPeriodicIn {
     using type = std::array<bool, 3>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Sequence for [x,y,z], true if periodic."};
     static type default_value() { return make_array<3>(false); }
   };
 
   struct InitialRefinement {
     using type = std::array<size_t, 3>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Initial refinement level in [x,y,z]."};
   };
 
   struct InitialGridPoints {
     using type = std::array<size_t, 3>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Initial number of grid points in [x,y,z]."};
   };
   using options = tmpl::list<LowerBound, UpperBound, IsPeriodicIn,
                              InitialRefinement, InitialGridPoints>;
 
-  static constexpr OptionString_t help{"Creates a 3D brick."};
+  static constexpr OptionString help{"Creates a 3D brick."};
 
   Brick(typename LowerBound::type lower_xyz,
         typename UpperBound::type upper_xyz,

--- a/src/Domain/DomainCreators/Interval.hpp
+++ b/src/Domain/DomainCreators/Interval.hpp
@@ -17,34 +17,34 @@ class Interval : public DomainCreator<1, Frame::Inertial> {
  public:
   struct LowerBound {
     using type = std::array<double, 1>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Sequence of [x] for lower bounds."};
   };
   struct UpperBound {
     using type = std::array<double, 1>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Sequence of [x] for upper bounds."};
   };
   struct IsPeriodicIn {
     using type = std::array<bool, 1>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Sequence for [x], true if periodic."};
     static type default_value() { return make_array<1>(false); }
   };
   struct InitialRefinement {
     using type = std::array<size_t, 1>;
-    static constexpr OptionString_t help = {"Initial refinement level in [x]."};
+    static constexpr OptionString help = {"Initial refinement level in [x]."};
   };
   struct InitialGridPoints {
     using type = std::array<size_t, 1>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Initial number of grid points in [x]."};
   };
 
   using options = tmpl::list<LowerBound, UpperBound, IsPeriodicIn,
                              InitialRefinement, InitialGridPoints>;
 
-  static constexpr OptionString_t help = {"Creates a 1D interval."};
+  static constexpr OptionString help = {"Creates a 1D interval."};
 
   Interval(typename LowerBound::type lower_x, typename UpperBound::type upper_x,
            typename IsPeriodicIn::type is_periodic_in_x,

--- a/src/Domain/DomainCreators/Rectangle.hpp
+++ b/src/Domain/DomainCreators/Rectangle.hpp
@@ -17,37 +17,37 @@ class Rectangle : public DomainCreator<2, Frame::Inertial> {
  public:
   struct LowerBound {
     using type = std::array<double, 2>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Sequence of [x,y] for lower bounds."};
   };
 
   struct UpperBound {
     using type = std::array<double, 2>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Sequence of [x,y] for upper bounds."};
   };
   struct IsPeriodicIn {
     using type = std::array<bool, 2>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Sequence for [x,y], true if periodic."};
     static type default_value() { return make_array<2>(false); }
   };
 
   struct InitialRefinement {
     using type = std::array<size_t, 2>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Initial refinement level in [x,y]."};
   };
 
   struct InitialGridPoints {
     using type = std::array<size_t, 2>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Initial number of grid points in [x,y]."};
   };
   using options = tmpl::list<LowerBound, UpperBound, IsPeriodicIn,
                              InitialRefinement, InitialGridPoints>;
 
-  static constexpr OptionString_t help{"Creates a 2D rectangle."};
+  static constexpr OptionString help{"Creates a 2D rectangle."};
 
   Rectangle(
       typename LowerBound::type lower_xy, typename UpperBound::type upper_xy,

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -13,7 +13,7 @@
 #include "Domain/BlockNeighbor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// Each member in `PairOfFaces` holds the global corner ids of a block face.
 /// `PairOfFaces` is used in setting up periodic boundary conditions by
 /// identifying the two faces with each other.
@@ -23,7 +23,7 @@ struct PairOfFaces {
   std::vector<size_t> second;
 };
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// Sets up the BlockNeighbors using the corner numbering scheme
 /// to deduce the correct neighbors and orientations. Does not set
 /// up periodic boundary conditions.
@@ -35,7 +35,7 @@ void set_internal_boundaries(
         std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks);
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// Sets up additional BlockNeighbors corresponding to any
 /// periodic boundary condtions provided by the user. These are
 /// stored in identifications.

--- a/src/Domain/Element.hpp
+++ b/src/Domain/Element.hpp
@@ -17,7 +17,7 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// A spectral element with knowledge of its neighbors.
 ///
 /// \tparam VolumeDim the volume dimension.

--- a/src/Domain/ElementId.hpp
+++ b/src/Domain/ElementId.hpp
@@ -15,7 +15,7 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdHelpers.hpp"
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// An ElementId uniquely labels a Element.
 /// It is constructed from the BlockId of the Block to which the Element belongs
 /// and the VolumeDim SegementIds that label the segments of the Block that the

--- a/src/Domain/ElementIndex.hpp
+++ b/src/Domain/ElementIndex.hpp
@@ -46,7 +46,7 @@ template <size_t VolumeDim>
 std::ostream& operator<<(std::ostream& s,
                          const ElementIndex<VolumeDim>& index) noexcept;
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// A class for indexing a Charm array by Element.
 template <size_t VolumeDim>
 class ElementIndex {

--- a/src/Domain/GridNormal.hpp
+++ b/src/Domain/GridNormal.hpp
@@ -17,7 +17,7 @@ template <size_t>
 class Index;
 
 /*!
- * \ingroup ComputationalDomain
+ * \ingroup ComputationalDomainGroup
  * \brief Compute the outward grid normal on a face of an Element
  *
  * \returns outward grid-frame one-form holding the normal

--- a/src/Domain/InitialElementIds.hpp
+++ b/src/Domain/InitialElementIds.hpp
@@ -9,7 +9,7 @@
 template <size_t VolumeDim>
 class ElementId;
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// \brief Create the ElementIds of the initial computational domain.
 template <size_t VolumeDim>
 std::vector<ElementId<VolumeDim>> initial_element_ids(

--- a/src/Domain/LogicalCoordinates.hpp
+++ b/src/Domain/LogicalCoordinates.hpp
@@ -17,7 +17,7 @@ template<size_t Dim>
 class Direction;
 
 /*!
- * \ingroup ComputationalDomain
+ * \ingroup ComputationalDomainGroup
  * \brief Compute the Legendre-Gauss-Lobatto coordinates in an Element
  *
  * \returns logical-frame vector holding coordinates
@@ -30,7 +30,7 @@ tnsr::I<DataVector, VolumeDim, Frame::Logical> logical_coordinates(
     const Index<VolumeDim>& extents);
 
 /*!
- * \ingroup ComputationalDomain
+ * \ingroup ComputationalDomainGroup
  * \brief Compute the logical coordinates on a face of an Element
  *
  * \returns logical-frame vector holding coordinates

--- a/src/Domain/Neighbors.hpp
+++ b/src/Domain/Neighbors.hpp
@@ -13,7 +13,7 @@
 #include "Domain/ElementId.hpp"
 #include "Domain/Orientation.hpp"
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// Information about the neighbors of an Element in a particular direction.
 ///
 /// \tparam VolumeDim the volume dimension.

--- a/src/Domain/SegmentId.hpp
+++ b/src/Domain/SegmentId.hpp
@@ -14,7 +14,7 @@
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// A SegmentId labels a segment of the interval [-1,1].
 /// A SegmentId is used to (partially) identify an Element.
 /// The segment is the interval [-1 + 2*(N/D), -1 + 2*(N+1)/D]

--- a/src/Domain/Side.hpp
+++ b/src/Domain/Side.hpp
@@ -11,7 +11,7 @@
 
 #include "Parallel/PupStlCpp11.hpp"
 
-/// \ingroup ComputationalDomain
+/// \ingroup ComputationalDomainGroup
 /// A label for the side of a manifold.
 ///
 /// Lower and Upper are with respect to the logical coordinate whose axis is

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -18,8 +18,8 @@
 
 namespace Tags {
 
-/// \ingroup DataBoxTags
-/// \ingroup ComputationalDomain
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
 /// The ::Element associated with the DataBox
 template <size_t VolumeDim>
 struct Element : db::DataBoxTag {
@@ -27,8 +27,8 @@ struct Element : db::DataBoxTag {
   using type = ::Element<VolumeDim>;
 };
 
-/// \ingroup DataBoxTags
-/// \ingroup ComputationalDomain
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
 /// The extents of DataVectors in the DataBox
 template <size_t VolumeDim>
 struct Extents : db::DataBoxTag {
@@ -36,8 +36,8 @@ struct Extents : db::DataBoxTag {
   using type = ::Index<VolumeDim>;
 };
 
-/// \ingroup DataBoxTags
-/// \ingroup ComputationalDomain
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
 /// The coordinate map from logical to grid coordinate
 template <size_t VolumeDim>
 struct ElementMap : db::DataBoxTag {
@@ -63,8 +63,8 @@ auto make_unnormalized_grid_normals(
 }
 }  // namespace detail
 
-/// \ingroup DataBoxTags
-/// \ingroup ComputationalDomain
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
 /// The unnormalized grid normal one form on each side
 template <size_t VolumeDim>
 struct UnnormalizedGridNormal : db::ComputeItemTag {

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -23,7 +23,7 @@ namespace Tags {
 /// The ::Element associated with the DataBox
 template <size_t VolumeDim>
 struct Element : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "Element";
+  static constexpr db::DataBoxString label = "Element";
   using type = ::Element<VolumeDim>;
 };
 
@@ -32,7 +32,7 @@ struct Element : db::DataBoxTag {
 /// The extents of DataVectors in the DataBox
 template <size_t VolumeDim>
 struct Extents : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "Extents";
+  static constexpr db::DataBoxString label = "Extents";
   using type = ::Index<VolumeDim>;
 };
 
@@ -41,7 +41,7 @@ struct Extents : db::DataBoxTag {
 /// The coordinate map from logical to grid coordinate
 template <size_t VolumeDim>
 struct ElementMap : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "ElementMap";
+  static constexpr db::DataBoxString label = "ElementMap";
   using type = std::unique_ptr<::CoordinateMapBase<Frame::Logical, Frame::Grid,
                                                    VolumeDim>>;
 };
@@ -68,7 +68,7 @@ auto make_unnormalized_grid_normals(
 /// The unnormalized grid normal one form on each side
 template <size_t VolumeDim>
 struct UnnormalizedGridNormal : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "UnnormalizedGridNormal";
+  static constexpr db::DataBoxString label = "UnnormalizedGridNormal";
   static constexpr auto function =
       detail::make_unnormalized_grid_normals<VolumeDim>;
   using argument_tags = tmpl::list<Extents<VolumeDim>, ElementMap<VolumeDim>>;

--- a/src/ErrorHandling/AbortWithErrorMessage.hpp
+++ b/src/ErrorHandling/AbortWithErrorMessage.hpp
@@ -8,14 +8,14 @@
 
 #include <string>
 
-/// \ingroup ErrorHandling
+/// \ingroup ErrorHandlingGroup
 /// Compose an error message with an expression and abort the program.
 [[noreturn]] void abort_with_error_message(const char* expression,
                                            const char* file, int line,
                                            const char* pretty_function,
                                            const std::string& message);
 
-/// \ingroup ErrorHandling
+/// \ingroup ErrorHandlingGroup
 /// Compose an error message and abort the program.
 [[noreturn]] void abort_with_error_message(const char* file, int line,
                                            const char* pretty_function,

--- a/src/ErrorHandling/Assert.hpp
+++ b/src/ErrorHandling/Assert.hpp
@@ -14,7 +14,7 @@
 #include "Utilities/Literals.hpp"
 
 /*!
- * \ingroup ErrorHandling
+ * \ingroup ErrorHandlingGroup
  * \brief Assert that an expression should be true.
  *
  * If the preprocessor macro SPECTRE_DEBUG is defined and the expression is

--- a/src/ErrorHandling/Assert.hpp
+++ b/src/ErrorHandling/Assert.hpp
@@ -34,15 +34,16 @@
 // 20160415) can't figure out that the else branch and everything
 // after it is unreachable, causing warnings (and possibly suboptimal
 // code generation).
-#define ASSERT(a, m)                                                        \
-  do {                                                                      \
-    if (!(a)) {                                                             \
-      std::ostringstream avoid_name_collisions_ASSERT;                      \
-      /* clang-tidy: macro arg in parentheses */                            \
-      avoid_name_collisions_ASSERT << m; /* NOLINT */                       \
-      abort_with_error_message(#a, __FILE__, __LINE__, __PRETTY_FUNCTION__, \
-                               avoid_name_collisions_ASSERT.str());         \
-    }                                                                       \
+#define ASSERT(a, m)                                                          \
+  do {                                                                        \
+    if (!(a)) {                                                               \
+      std::ostringstream avoid_name_collisions_ASSERT;                        \
+      /* clang-tidy: macro arg in parentheses */                              \
+      avoid_name_collisions_ASSERT << m; /* NOLINT */                         \
+      abort_with_error_message(#a, __FILE__, __LINE__,                        \
+                               static_cast<const char*>(__PRETTY_FUNCTION__), \
+                               avoid_name_collisions_ASSERT.str());           \
+    }                                                                         \
   } while (false)
 #else
 #define ASSERT(a, m)                                   \

--- a/src/ErrorHandling/Error.hpp
+++ b/src/ErrorHandling/Error.hpp
@@ -32,13 +32,14 @@
 // 20160415) can't figure out that the else branch and everything
 // after it is unreachable, causing warnings (and possibly suboptimal
 // code generation).
-#define ERROR(m)                                                      \
-  do {                                                                \
-    std::ostringstream avoid_name_collisions_ERROR;                   \
-    /* clang-tidy: macro arg in parentheses */                        \
-    avoid_name_collisions_ERROR << m; /* NOLINT */                    \
-    abort_with_error_message(__FILE__, __LINE__, __PRETTY_FUNCTION__, \
-                             avoid_name_collisions_ERROR.str());      \
+#define ERROR(m)                                                            \
+  do {                                                                      \
+    std::ostringstream avoid_name_collisions_ERROR;                         \
+    /* clang-tidy: macro arg in parentheses */                              \
+    avoid_name_collisions_ERROR << m; /* NOLINT */                          \
+    abort_with_error_message(__FILE__, __LINE__,                            \
+                             static_cast<const char*>(__PRETTY_FUNCTION__), \
+                             avoid_name_collisions_ERROR.str());            \
   } while (false)
 
 /*!

--- a/src/ErrorHandling/Error.hpp
+++ b/src/ErrorHandling/Error.hpp
@@ -14,7 +14,7 @@
 #include "Utilities/Literals.hpp"
 
 /*!
- * \ingroup ErrorHandling
+ * \ingroup ErrorHandlingGroup
  * \brief prints an error message to the standard error stream and aborts the
  * program.
  *
@@ -42,7 +42,7 @@
   } while (false)
 
 /*!
- * \ingroup ErrorHandling
+ * \ingroup ErrorHandlingGroup
  * \brief prints an error message to the standard error and aborts the
  * program.
  *

--- a/src/ErrorHandling/ExpectsAndEnsures.hpp
+++ b/src/ErrorHandling/ExpectsAndEnsures.hpp
@@ -17,9 +17,8 @@
 #endif
 #endif
 
-
 /*!
- * \ingroup ErrorHandling
+ * \ingroup ErrorHandlingGroup
  * \brief check expectation of pre-conditions of a function
  *
  * The Expects macro sets the preconditions to a function's arguments, it is a
@@ -42,7 +41,7 @@
 #endif
 
 /*!
- * \ingroup ErrorHandling
+ * \ingroup ErrorHandlingGroup
  * \brief Check that a post-condition of a function is true
  *
  * The Ensures macro sets the postconditions of function, it is a contract

--- a/src/ErrorHandling/FloatingPointExceptions.hpp
+++ b/src/ErrorHandling/FloatingPointExceptions.hpp
@@ -6,12 +6,12 @@
 
 #pragma once
 
-/// \ingroup ErrorHandling
+/// \ingroup ErrorHandlingGroup
 /// After a call to this function, the code will terminate with a floating
 /// point exception on overflow, divide-by-zero, and invalid operations.
 void enable_floating_point_exceptions();
 
-/// \ingroup ErrorHandling
+/// \ingroup ErrorHandlingGroup
 /// After a call to this function, the code will NOT terminate with a floating
 /// point exception on overflow, divide-by-zero, and invalid operations.
 void disable_floating_point_exceptions();

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.cpp
@@ -10,6 +10,7 @@
 
 namespace GeneralizedHarmonic {
 
+/// \cond
 template <size_t Dim>
 void ComputeDuDt<Dim>::apply(
     const gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,
@@ -244,6 +245,7 @@ void ComputeDuDt<Dim>::apply(
     }
   }
 }
+/// \endcond
 }  // namespace GeneralizedHarmonic
 
 template struct GeneralizedHarmonic::ComputeDuDt<1>;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -7,7 +7,7 @@ namespace GeneralizedHarmonic {
 template <size_t Dim>
 struct SpacetimeMetric : db::DataBoxTag {
   using type = tnsr::aa<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString_t label = "SpacetimeMetric";
+  static constexpr db::DataBoxString label = "SpacetimeMetric";
 };
 
 /*!
@@ -21,7 +21,7 @@ struct SpacetimeMetric : db::DataBoxTag {
 template <size_t Dim>
 struct Pi : db::DataBoxTag {
   using type = tnsr::aa<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString_t label = "Pi";
+  static constexpr db::DataBoxString label = "Pi";
 };
 
 /*!
@@ -33,12 +33,12 @@ struct Pi : db::DataBoxTag {
 template <size_t Dim>
 struct Phi : db::DataBoxTag {
   using type = tnsr::abb<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString_t label = "Phi";
+  static constexpr db::DataBoxString label = "Phi";
 };
 
 template <size_t Dim>
 struct InverseSpatialMetric : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "InverseSpatialMetric";
+  static constexpr db::DataBoxString label = "InverseSpatialMetric";
   // static constexpr auto function =
   // compute_inverse_spatial_metric_from_spacetime_metric<Dim,
   //      Frame::Grid>;
@@ -46,7 +46,7 @@ struct InverseSpatialMetric : db::ComputeItemTag {
 };
 template <size_t Dim>
 struct Shift : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "Shift";
+  static constexpr db::DataBoxString label = "Shift";
   // static constexpr auto function =
   //      compute_shift_from_spacetime_metric_and_invg<Dim, Frame::Grid>;
   using argument_tags =
@@ -54,36 +54,36 @@ struct Shift : db::ComputeItemTag {
 };
 template <size_t Dim>
 struct Lapse : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "Lapse";
+  static constexpr db::DataBoxString label = "Lapse";
   // static constexpr auto function =
   //     compute_lapse_from_spacetime_metric_shift<Dim, Frame::Grid>;
   using argument_tags = typelist<SpacetimeMetric<Dim>, Shift<Dim>>;
 };
 struct ConstraintGamma0 : db::DataBoxTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "ConstraintGamma0";
+  static constexpr db::DataBoxString label = "ConstraintGamma0";
 };
 struct ConstraintGamma1 : db::DataBoxTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "ConstraintGamma1";
+  static constexpr db::DataBoxString label = "ConstraintGamma1";
 };
 struct ConstraintGamma2 : db::DataBoxTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "ConstraintGamma2";
+  static constexpr db::DataBoxString label = "ConstraintGamma2";
 };
 template <size_t Dim>
 struct GaugeH : db::DataBoxTag {
   using type = tnsr::a<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString_t label = "GaugeH";
+  static constexpr db::DataBoxString label = "GaugeH";
 };
 template <size_t Dim>
 struct SpacetimeDerivGaugeH : db::DataBoxTag {
   using type = tnsr::ab<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString_t label = "SpacetimeDerivGaugeH";
+  static constexpr db::DataBoxString label = "SpacetimeDerivGaugeH";
 };
 template <size_t Dim>
 struct InverseSpacetimeMetric : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "InverseSpacetimeMetric";
+  static constexpr db::DataBoxString label = "InverseSpacetimeMetric";
   // static constexpr auto function =
   //     compute_inverse_spacetime_metric_from_invg_lapse_shift<Dim,
   //     Frame::Grid>;
@@ -92,7 +92,7 @@ struct InverseSpacetimeMetric : db::ComputeItemTag {
 };
 template <size_t Dim>
 struct SpacetimeChristoffelFirstKind : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "SpacetimeChristoffelFirstKind";
+  static constexpr db::DataBoxString label = "SpacetimeChristoffelFirstKind";
   // static constexpr auto function =
   //     compute_christoffel_first_kind_from_gh<Dim, Frame::Grid>;
   using argument_tags =
@@ -100,7 +100,7 @@ struct SpacetimeChristoffelFirstKind : db::ComputeItemTag {
 };
 template <size_t Dim>
 struct SpacetimeChristoffelSecondKind : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "SpactimeChristoffelSecondKind";
+  static constexpr db::DataBoxString label = "SpactimeChristoffelSecondKind";
   // static constexpr auto function =
   //     raise_index_1_of_3<Dim, Frame::Grid, IndexType::Spacetime>;
   using argument_tags =
@@ -108,21 +108,21 @@ struct SpacetimeChristoffelSecondKind : db::ComputeItemTag {
 };
 template <size_t Dim>
 struct SpacetimeNormalOneForm : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "SpacetimeNormalOneForm";
+  static constexpr db::DataBoxString label = "SpacetimeNormalOneForm";
   // static constexpr auto function =
   //     compute_normal_one_form_from_lapse<Dim, Frame::Grid>;
   using argument_tags = typelist<Lapse<Dim>>;
 };
 template <size_t Dim>
 struct SpacetimeNormalVector : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "SpacetimeNormalVector";
+  static constexpr db::DataBoxString label = "SpacetimeNormalVector";
   // static constexpr auto function =
   //     compute_normal_vector_from_lapse_and_shift<Dim, Frame::Grid>;
   using argument_tags = typelist<Lapse<Dim>, Shift<Dim>>;
 };
 template <size_t Dim>
 struct TraceSpacetimeChristoffelFirstKind : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label =
+  static constexpr db::DataBoxString label =
       "TraceSpacetimeChristoffelFirstKind";
   // static constexpr auto function =
   //     compute_trace_23_of_3<Dim, Frame::Grid, IndexType::Spacetime>;

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -68,12 +68,12 @@ namespace {
 template <size_t Dim>
 struct Kappa : db::DataBoxTag {
   using type = tnsr::abb<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString_t label = "Kappa";
+  static constexpr db::DataBoxString label = "Kappa";
 };
 template <size_t Dim>
 struct Psi : db::DataBoxTag {
   using type = tnsr::aa<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString_t label = "Psi";
+  static constexpr db::DataBoxString label = "Psi";
 };
 
 static void bench_all_gradient(benchmark::State& state) {

--- a/src/IO/H5/AccessType.hpp
+++ b/src/IO/H5/AccessType.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Contains functions and classes for manipulating HDF5 files
  *
  * Wraps many underlying C H5 routines making them easier to use and easier to
@@ -15,7 +15,7 @@
  */
 namespace h5 {
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Set the access type to the H5File
  */
 enum class AccessType {

--- a/src/IO/H5/CheckH5.hpp
+++ b/src/IO/H5/CheckH5.hpp
@@ -9,7 +9,7 @@
 #include "ErrorHandling/Error.hpp"
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Check if an HDF5 operation was successful
  *
  * \requires `h5_status` is a valid HDF5 return type, `m` is a stringstream

--- a/src/IO/H5/Dat.hpp
+++ b/src/IO/H5/Dat.hpp
@@ -17,7 +17,7 @@ class Matrix;
 
 namespace h5 {
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Represents a multicolumn dat file inside an HDF5 file
  *
  * A Dat object represents a dat file inside an H5File. A dat file is a

--- a/src/IO/H5/File.hpp
+++ b/src/IO/H5/File.hpp
@@ -26,7 +26,7 @@
 
 namespace h5 {
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Opens an HDF5 file for access and allows manipulation of data
  *
  * Opens an HDF5 file either in ReadOnly or ReadWrite mode depending on the

--- a/src/IO/H5/Header.hpp
+++ b/src/IO/H5/Header.hpp
@@ -13,7 +13,7 @@
 
 namespace h5 {
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Writes header info about the build, git commit, branch, etc.
  *
  * A Header object is used to store the ::info_from_build() result in the HDF5

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -18,13 +18,13 @@
 
 namespace h5 {
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Write a "Time" attribute to the group
  */
 void write_time(hid_t group_id, double time);
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Write a DataVector named `name` to the group `group_id`
  */
 template <size_t Dim>
@@ -32,7 +32,7 @@ void write_data(hid_t group_id, const DataVector& data,
                 const Index<Dim>& extents, const std::string& name = "scalar");
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Write the extents as an attribute named `name` to the group
  * `group_id`.
  */
@@ -41,47 +41,47 @@ void write_extents(hid_t group_id, const Index<Dim>& extents,
                    const std::string& name = "Extents");
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Write the connectivity into the group in the H5 file
  */
 void write_connectivity(hid_t group_id, const std::vector<int>& connectivity);
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Get the names of all the groups in a group
  */
 std::vector<std::string> get_group_names(hid_t file_id,
                                          const std::string& group_name);
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Get the names of all the attributes in a group
  */
 std::vector<std::string> get_attribute_names(hid_t file_id,
                                              const std::string& group_name);
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Check if an attribute is in a group
  */
 bool contains_attribute(hid_t file_id, const std::string& group_name,
                         const std::string& attribute_name);
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Get the "Time" attribute from a group
  */
 double get_time(hid_t file_id, const std::string& group_name,
                 const std::string& attr_name = "Time");
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Read a DataVector from a dataset in a group
  */
 DataVector read_data(hid_t group_id, const std::string& dataset_name);
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Read the HDF5 attribute representing extents from a group
  */
 template <size_t Dim>
@@ -93,7 +93,7 @@ Index<Dim> read_extents(hid_t group_id,
 namespace h5 {
 namespace detail {
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Write a vector of strings into an H5 dataset as an attribute
  *
  * \requires `dataset_id` is an open dataset
@@ -103,7 +103,7 @@ void write_strings_to_attribute(hid_t dataset_id, const std::string& name,
                                 const std::vector<std::string>& string_array);
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Read a vector of strings from an attribute inside an H5 dataset
  *
  * \requires `dataset_id` is an open dataset
@@ -113,7 +113,7 @@ std::vector<std::string> read_strings_from_attribute(hid_t group_id,
                                                      const std::string& name);
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Write a value of type `Type` to an HDF5 attribute named `name`
  */
 template <typename Type>
@@ -121,14 +121,14 @@ void write_value_to_attribute(hid_t location_id, const std::string& name,
                               const Type& value);
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Read a value of type `Type` from an HDF5 attribute named `name`
  */
 template <typename Type>
 Type read_value_from_attribute(hid_t location_id, const std::string& name);
 
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Create a dataset that can be extended/appended to
  *
  * \requires group_id is an open group, each element of `initial_size` is less

--- a/src/IO/H5/Object.hpp
+++ b/src/IO/H5/Object.hpp
@@ -8,7 +8,7 @@
 
 namespace h5 {
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Abstract base class representing an object in an HDF5 file
  */
 class Object {

--- a/src/IO/H5/OpenGroup.hpp
+++ b/src/IO/H5/OpenGroup.hpp
@@ -15,7 +15,7 @@
 namespace h5 {
 namespace detail {
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Open an H5 group
  *
  * Opens a group recursively on creation and closes the groups when destructed.

--- a/src/IO/H5/Type.hpp
+++ b/src/IO/H5/Type.hpp
@@ -14,7 +14,7 @@
 
 namespace h5 {
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Returns the HDF5 datatype for the corresponding type `T`
  *
  * \requires `T` is a valid type with a corresponding HDF5 datatype, i.e.

--- a/src/IO/H5/Version.hpp
+++ b/src/IO/H5/Version.hpp
@@ -15,7 +15,7 @@
 
 namespace h5 {
 /*!
- * \ingroup HDF5
+ * \ingroup HDF5Group
  * \brief Used to store the version of the file
  *
  * A Version object should be stored inside each H5 object that is to represent

--- a/src/IO/VolumeDataFile.hpp
+++ b/src/IO/VolumeDataFile.hpp
@@ -18,7 +18,7 @@
 
 namespace vis {
 
-/// \ingroup HDF5
+/// \ingroup HDF5Group
 /// Writes out volume data as an HDF5 file and an XDMF file to be visualized in
 /// ParaView or VisIt
 class VolumeFile {

--- a/src/Informer/InfoFromBuild.hpp
+++ b/src/Informer/InfoFromBuild.hpp
@@ -9,7 +9,7 @@
 #include <string>
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Information about the version, date, host, git commit, and link time
  *
  * The information returned by this function is invaluable for identifying
@@ -19,25 +19,25 @@
 std::string info_from_build();
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Retrieve a string containing the current version of SpECTRE
  */
 std::string spectre_version();
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Returns major version
  */
 int spectre_major_version();
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Returns minor version
  */
 int spectre_minor_version();
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Returns patch version
  */
 int spectre_patch_version();

--- a/src/Informer/Informer.hpp
+++ b/src/Informer/Informer.hpp
@@ -8,7 +8,7 @@
 
 #include <charm++.h>
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// The Informer manages textual output regarding the status of a simulation.
 class Informer {
  public:

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -36,7 +36,7 @@
 
 namespace Actions {
 /// \ingroup ActionsGroup
-/// \ingroup DiscontinuousGalerkin
+/// \ingroup DiscontinuousGalerkinGroup
 /// \brief Receive boundary data from neighbors and compute boundary
 /// contribution to the time derivative.
 ///
@@ -222,7 +222,7 @@ struct ComputeBoundaryFlux {
 };
 
 /// \ingroup ActionsGroup
-/// \ingroup DiscontinuousGalerkin
+/// \ingroup DiscontinuousGalerkinGroup
 /// \brief Compute local boundary data needed for fluxes and send it
 /// to neighbors.
 ///

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
@@ -10,7 +10,7 @@
 #include "DataStructures/Variables.hpp"
 
 namespace dg {
-/// \ingroup DiscontinuousGalerkin
+/// \ingroup DiscontinuousGalerkinGroup
 /// \brief Lifts the flux contribution from an interface to the volume.
 ///
 /// The lifting operation takes the (d-1)-dimensional flux term at the

--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp
@@ -16,7 +16,7 @@ namespace Basis {
 namespace lgl {
 
 /*!
- * \ingroup NumericalAlgorithms
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Compute the definite integral of a grid-function over a manifold.
  *
  * The integral is computed on the reference element by multiplying the

--- a/src/NumericalAlgorithms/LinearOperators/Linearize.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Linearize.hpp
@@ -13,7 +13,7 @@ template <size_t>
 class Index;
 
 /*!
- * \ingroup NumericalAlgorithms
+ * \ingroup NumericalAlgorithmsGroup
  * Truncate u to a linear function in each dimension.
  * Ex in 2D: \f$u^{Lin} = U_0 + U_x x + U_y y + U_{xy} xy\f$
  *
@@ -23,7 +23,7 @@ template <size_t Dim>
 DataVector linearize(const DataVector& u, const Index<Dim>& extents);
 
 /*!
- * \ingroup NumericalAlgorithms
+ * \ingroup NumericalAlgorithmsGroup
  * Truncate u to a linear function in the given dimension.
  *
  * \returns the linearization of `u`

--- a/src/NumericalAlgorithms/LinearOperators/MeanValue.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/MeanValue.hpp
@@ -11,7 +11,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 
 /*!
- * \ingroup NumericalAlgorithms
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Compute the mean value of a grid-function over a manifold.
  * \f$mean value = \int f dV / \int dV\f$
  *
@@ -30,7 +30,7 @@ double mean_value(const DataVector& f, const Index<Dim>& extents) {
 }
 
 /*!
- * \ingroup NumericalAlgorithms
+ * \ingroup NumericalAlgorithmsGroup
  * Compute the mean value of a grid-function on a boundary of a manifold.
  * \f$mean value = \int f dV / \int dV\f$
  *

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -21,7 +21,7 @@ template <size_t Dim, typename VariableTags, typename DerivativeTags>
 struct LogicalImpl;
 }  // namespace partial_derivatives_detail
 
-/// \ingroup NumericalAlgorithms
+/// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the partial derivatives of each variable with respect to
 /// the logical coordinate.
 template <typename DerivativeTags, typename VariableTags, size_t Dim>
@@ -31,7 +31,7 @@ auto logical_partial_derivatives(const Variables<VariableTags>& u,
       Dim, VariableTags, DerivativeTags>::apply(u, extents);
 }
 
-/// \ingroup NumericalAlgorithms
+/// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the partial derivatives of each variable with respect to
 /// the coordinates of `DerivativeFrame`.
 template <typename DerivativeTags, typename VariableTags, size_t Dim,

--- a/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
@@ -12,7 +12,7 @@
 #include "Utilities/Gsl.hpp"
 
 // @{
-/// \ingroup NumericalAlgorithms
+/// \ingroup NumericalAlgorithmsGroup
 /// \brief Function to compute transposed data.
 ///
 /// The primary use of this function is to rearrange the memory layout so that

--- a/src/NumericalAlgorithms/RootFinding/QuadraticEquation.hpp
+++ b/src/NumericalAlgorithms/RootFinding/QuadraticEquation.hpp
@@ -9,7 +9,7 @@
 #include <array>
 
 /*!
- * \ingroup NumericalAlgorithms
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Returns the positive root of a quadratic equation ax^2 + bx + c = 0
  * \returns The positive root of a quadratic equation.
  * \requires That there are two real roots, of which only one is positive.
@@ -17,7 +17,7 @@
 double positive_root(double a, double b, double c);
 
 /*!
- * \ingroup NumericalAlgorithms
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Returns the two real roots of a quadratic equation ax^2 + bx + c =
  * 0
  * \returns An array of the roots of a quadratic equation

--- a/src/NumericalAlgorithms/RootFinding/RootFinder.hpp
+++ b/src/NumericalAlgorithms/RootFinding/RootFinder.hpp
@@ -12,7 +12,7 @@
 #include <boost/math/tools/toms748_solve.hpp>
 
 /*!
- * \ingroup NumericalAlgorithms
+ * \ingroup NumericalAlgorithmsGroup
  * \brief Finds the root of the function f with the TOMS_748 method.
  *
  * \requires Function f be callable

--- a/src/NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp
+++ b/src/NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp
@@ -11,10 +11,10 @@
 class DataVector;
 class Matrix;
 
-/// \ingroup NumericalAlgorithms
+/// \ingroup NumericalAlgorithmsGroup
 /// Basis functions, derivative matrices, etc. for spectral-type methods
 namespace Basis {
-/// \ingroup NumericalAlgorithms
+/// \ingroup NumericalAlgorithmsGroup
 /// Functions for using Legendre-Gauss-Lobatto basis
 namespace lgl {
 /// Collocation points.

--- a/src/Options/Options.hpp
+++ b/src/Options/Options.hpp
@@ -18,7 +18,7 @@
 class Option;
 
 /// The string used in option structs
-using OptionString_t = const char* const;
+using OptionString = const char* const;
 
 /// \ingroup OptionParsingGroup
 /// Information about the nested operations being performed by the

--- a/src/Options/Options.hpp
+++ b/src/Options/Options.hpp
@@ -20,7 +20,7 @@ class Option;
 /// The string used in option structs
 using OptionString_t = const char* const;
 
-/// \ingroup OptionParsing
+/// \ingroup OptionParsingGroup
 /// Information about the nested operations being performed by the
 /// parser, for use in printing errors.  A default-constructed
 /// OptionContext is printed as an empty string.  This struct is
@@ -49,7 +49,7 @@ inline std::ostream& operator<<(std::ostream& s,
   return s;
 }
 
-/// \ingroup OptionParsing
+/// \ingroup OptionParsingGroup
 /// Like ERROR("\n" << (context) << m), but instead throws an
 /// exception that will be caught in a higher level Options if not
 /// passed a top-level context.  This is used to print a parsing
@@ -86,7 +86,7 @@ class propagate_context : public std::exception {
 };
 }  // namespace Options_detail
 
-/// \ingroup OptionParsing
+/// \ingroup OptionParsingGroup
 /// Used by the parser to create an object.  The default action is to
 /// parse options using `T::options`.  This struct may be specialized
 /// to change that behavior for specific types.

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -29,7 +29,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-/// \ingroup OptionParsing
+/// \ingroup OptionParsingGroup
 /// The type that options are passed around as.  Contains YAML node
 /// data and an OptionContext.
 class Option {
@@ -132,7 +132,7 @@ T Option::parse_as() const {
   }
 }
 
-/// \ingroup OptionParsing
+/// \ingroup OptionParsingGroup
 /// \brief Class that handles parsing an input file
 ///
 /// Options must be given YAML data to parse before output can be

--- a/src/Parallel/Abort.hpp
+++ b/src/Parallel/Abort.hpp
@@ -12,7 +12,7 @@
 
 namespace Parallel {
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Abort the program with an error message.
 [[noreturn]] inline void abort(const std::string& message) {
   CkAbort(message.c_str());

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -57,7 +57,7 @@ std::string get_template_parameters_as_string() {
 }  // namespace charmxx
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Lock a converse CmiNodeLock
  */
 inline void lock(const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
@@ -73,7 +73,7 @@ constexpr inline void lock(
 /// \endcond
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Returns true if the lock was successfully acquired and false if the
  * lock is already acquired by another processor.
  */
@@ -85,7 +85,7 @@ inline bool try_lock(const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
 }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Unlock a converse CmiNodeLock
  */
 inline void unlock(const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
@@ -127,7 +127,7 @@ struct build_action_return_types_impl<true, tmpl::list<AdditionalArgs...>> {
 };
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Returns a typelist of the return types of all Actions in ActionList
  *
  * \metareturns
@@ -237,7 +237,7 @@ class AlgorithmImpl;
 /// \endcond
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief A distributed object (Charm++ Chare) that executes a series of Actions
  * and is capable of sending and receiving data. Acts as an interface to
  * Charm++.

--- a/src/Parallel/ArrayIndex.hpp
+++ b/src/Parallel/ArrayIndex.hpp
@@ -8,7 +8,7 @@
 
 namespace Parallel {
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief The array index used for indexing Chare Arrays, mostly an
  * implementation detail
  *

--- a/src/Parallel/CharmPupable.hpp
+++ b/src/Parallel/CharmPupable.hpp
@@ -13,7 +13,7 @@
 #endif
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Mark derived classes as serializable
  *
  * Any class that derives off of a non-class template base class must contain
@@ -23,7 +23,7 @@
   PUPable_decl_template(SINGLE_ARG(className))
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Mark derived template classes as serializable
  *
  * Any class that derives off of a class template base class must contain

--- a/src/Parallel/ConstGlobalCache.hpp
+++ b/src/Parallel/ConstGlobalCache.hpp
@@ -29,7 +29,7 @@ struct type_for_get<std::unique_ptr<T, D>> {
 };
 }  // namespace ConstGlobalCache_detail
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// A Charm++ chare that caches constant data once per Charm++ node.
 ///
 /// Metavariables must define the following metavariables:
@@ -97,7 +97,7 @@ void ConstGlobalCache<Metavariables>::set_parallel_components(
 }
 
 // @{
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// \brief Access the Charm++ proxy associated with a ParallelComponent
 ///
 /// \requires ParallelComponentTag is a tag in component_list
@@ -122,7 +122,7 @@ get_parallel_component(const ConstGlobalCache<Metavariables>& cache) noexcept {
 // @}
 
 // @{
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// \brief Access data in the cache
 ///
 /// \requires ConstGlobalCacheTag is a tag in tag_list

--- a/src/Parallel/Exit.hpp
+++ b/src/Parallel/Exit.hpp
@@ -12,7 +12,7 @@
 /// Contains functions that forward to Charm++ parallel functions.
 namespace Parallel {
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// \brief Exit the program normally.
 /// This should only be called once over all processors.
 [[noreturn]] inline void exit() {

--- a/src/Parallel/Info.hpp
+++ b/src/Parallel/Info.hpp
@@ -10,31 +10,31 @@
 
 namespace Parallel {
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Number of processing elements.
  */
 inline int number_of_procs() { return CkNumPes(); }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief %Index of my processing element.
  */
 inline int my_proc() { return CkMyPe(); }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Number of nodes.
  */
 inline int number_of_nodes() { return CkNumNodes(); }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief %Index of my node.
  */
 inline int my_node() { return CkMyNode(); }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Number of processing elements on the given node.
  */
 inline int procs_on_node(const int node_index) {
@@ -51,14 +51,14 @@ inline int procs_on_node(const int node_index) {
 }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief The local index of my processing element on my node.
  * This is in the interval 0, ..., procs_on_node(my_node()) - 1.
  */
 inline int my_local_rank() { return CkMyRank(); }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief %Index of first processing element on the given node.
  */
 inline int first_proc_on_node(const int node_index) {
@@ -67,7 +67,7 @@ inline int first_proc_on_node(const int node_index) {
 }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief %Index of the node for the given processing element.
  */
 inline int node_of(const int proc_index) {
@@ -76,7 +76,7 @@ inline int node_of(const int proc_index) {
 }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief The local index for the given processing element on its node.
  */
 inline int local_rank_of(const int proc_index) {
@@ -85,7 +85,7 @@ inline int local_rank_of(const int proc_index) {
 }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief The current wall time in seconds
  */
 inline double wall_time() { return CmiWallTimer(); }

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -28,7 +28,7 @@
 
 namespace Parallel {
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// The main function of a Charm++ executable.
 ///
 /// Metavariables must define the following:

--- a/src/Parallel/Printf.hpp
+++ b/src/Parallel/Printf.hpp
@@ -73,16 +73,16 @@ inline void print_helper(const std::string& format, Ts&&... t) {
 }  // namespace detail
 
 /*!
-   * \ingroup Parallel
-   * \brief Print an atomic message to stdout with C printf usage.
-   *
-   * Similar to Python, you can print any object that's streamable by passing it
-   * in as an argument and using the formatter "%s". For example,
-   * \code
-   * std::vector<double> a{0.8, 73, 9.8};
-   * Parallel::printf("%s\n", a);
-   * \endcode
-   */
+ * \ingroup ParallelGroup
+ * \brief Print an atomic message to stdout with C printf usage.
+ *
+ * Similar to Python, you can print any object that's streamable by passing it
+ * in as an argument and using the formatter "%s". For example,
+ * \code
+ * std::vector<double> a{0.8, 73, 9.8};
+ * Parallel::printf("%s\n", a);
+ * \endcode
+ */
 template <typename... Args>
 inline void printf(const std::string& format, Args&&... args) {
   disable_floating_point_exceptions();

--- a/src/Parallel/PupStlCpp11.hpp
+++ b/src/Parallel/PupStlCpp11.hpp
@@ -19,7 +19,7 @@
 namespace PUP {
 
 // @{
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of std::array for Charm++
 template <typename T, std::size_t N,
           Requires<not std::is_arithmetic<T>::value> = nullptr>
@@ -34,14 +34,14 @@ inline void pup(PUP::er& p, std::array<T, N>& a) {  // NOLINT
 }
 // @}
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of std::array for Charm++
 template <typename T, std::size_t N>
 inline void operator|(er& p, std::array<T, N>& a) {  // NOLINT
   pup(p, a);
 }
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of std::unordered_map for Charm++
 /// \warning This does not work with custom hash functions that have state
 template <typename K, typename V, typename H>
@@ -61,7 +61,7 @@ inline void pup(PUP::er& p, std::unordered_map<K, V, H>& m) {  // NOLINT
   }
 }
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of std::unordered_map for Charm++
 /// \warning This does not work with custom hash functions that have state
 template <typename K, typename V, typename H>
@@ -69,7 +69,7 @@ inline void operator|(er& p, std::unordered_map<K, V, H>& m) {  // NOLINT
   pup(p, m);
 }
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of std::unordered_set for Charm++
 template <typename T>
 inline void pup(PUP::er& p, std::unordered_set<T>& s) {  // NOLINT
@@ -91,14 +91,14 @@ inline void pup(PUP::er& p, std::unordered_set<T>& s) {  // NOLINT
   }
 }
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of std::unordered_set for Charm++
 template <class T>
 inline void operator|(er& p, std::unordered_set<T>& s) {  // NOLINT
   pup(p, s);
 }
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of enum for Charm++
 ///
 /// \note This requires a change to Charm++ to work
@@ -125,7 +125,7 @@ void pup_tuple_impl(PUP::er& p, std::tuple<Args...>& t) {  // NOLINT
   pup_tuple_impl<N - 1>(p, t);
 }
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of std::tuple for Charm++
 template <typename... Args>
 inline void pup(PUP::er& p, std::tuple<Args...>& t) {  // NOLINT
@@ -135,7 +135,7 @@ inline void pup(PUP::er& p, std::tuple<Args...>& t) {  // NOLINT
   pup_tuple_impl<sizeof...(Args) - 1>(p, t);
 }
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of std::tuple for Charm++
 template <typename... Args>
 inline void operator|(PUP::er& p, std::tuple<Args...>& t) {  // NOLINT
@@ -143,7 +143,7 @@ inline void operator|(PUP::er& p, std::tuple<Args...>& t) {  // NOLINT
 }
 
 // @{
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of a unique_ptr for Charm++
 template <typename T,
           Requires<not std::is_base_of<PUP::able, T>::value> = nullptr>
@@ -177,7 +177,7 @@ inline void pup(PUP::er& p, std::unique_ptr<T>& t) {  // NOLINT
 }
 // @}
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Serialization of a unique_ptr for Charm++
 template <typename T>
 inline void operator|(PUP::er& p, std::unique_ptr<T>& t) {  // NOLINT

--- a/src/Parallel/Reduction.hpp
+++ b/src/Parallel/Reduction.hpp
@@ -12,7 +12,7 @@
 
 namespace Parallel {
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Used for reducing heterogeneous collection of types in a single
  * reduction call
  *
@@ -112,7 +112,7 @@ size_t ReductionData<Ts...>::size() noexcept {
 /// \endcond
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Retrieve the `Index`th element from a `ReductionData<Ts...>`, similar
  * to `std::get` for `std::tuple`s
  *
@@ -161,7 +161,7 @@ constexpr bool is_custom_reduction_type_v = is_custom_reduction_type<T>::value;
 }  // namespace Parallel_detail
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Perform a reduction from the current ParallelComponent to the
  * `TargetParallelComponent`, performing the `Action` upon receiving the
  * reduction
@@ -223,7 +223,7 @@ void contribute_to_reduction(const ConstGlobalCache<Metavariables>& cache,
 /// \endcond
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Convert a `ReductionData` to a `CkReductionMsg`. Used in custom
  * reducers.
  *

--- a/src/Parallel/Serialize.hpp
+++ b/src/Parallel/Serialize.hpp
@@ -11,7 +11,7 @@
 #include <pup.h>
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Serialize an object using PUP.
  *
  * The type to serialize as must be explicitly specified.  We require
@@ -41,7 +41,7 @@ std::vector<char> serialize(const U& obj) {
 }
 
 /*!
- * \ingroup Parallel
+ * \ingroup ParallelGroup
  * \brief Deserialize an object using PUP.
  *
  * \tparam T the type to deserialize to

--- a/src/Parallel/TypeTraits.hpp
+++ b/src/Parallel/TypeTraits.hpp
@@ -13,27 +13,27 @@
 
 namespace Parallel {
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Check if `T` is a Charm++ proxy for an array chare
 template <typename T>
 struct is_array_proxy : std::is_base_of<CProxy_ArrayElement, T>::type {};
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Check if `T` is a Charm++ proxy for a chare
 template <typename T>
 struct is_chare_proxy : std::is_base_of<CProxy_Chare, T>::type {};
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Check if `T` is a Charm++ proxy for a group chare
 template <typename T>
 struct is_group_proxy : std::is_base_of<CProxy_IrrGroup, T>::type {};
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Check if `T` is a Charm++ proxy for a node group chare
 template <typename T>
 struct is_node_group_proxy : std::is_base_of<CProxy_NodeGroup, T>::type {};
 
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// Check if `T` is a ParallelComponent for a Charm++ bound array
 template <typename T, typename = cpp17::void_t<>>
 struct is_bound_array : std::false_type {};
@@ -47,7 +47,7 @@ struct is_bound_array<T, cpp17::void_t<typename T::bind_to>> : std::true_type {
 };
 
 // @{
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// \brief Check if `T` has a `pup` member function
 ///
 /// \details
@@ -95,7 +95,7 @@ using has_pup_member_t = typename has_pup_member<T>::type;
 // @}
 
 // @{
-/// \ingroup Parallel
+/// \ingroup ParallelGroup
 /// \brief Check if type `T` has operator| defined for Charm++ serialization
 ///
 /// \details

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp
@@ -20,7 +20,7 @@ template <size_t Dim>
 class Minkowski {
  public:
   using options = tmpl::list<>;
-  static constexpr OptionString_t help{
+  static constexpr OptionString help{
       "Minkowski solution to Einstein's Equations"};
 
   Minkowski() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -33,25 +33,25 @@ class PlaneWave {
  public:
   struct WaveVector {
     using type = std::array<double, Dim>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "The direction of propagation of the wave."};
   };
 
   struct Center {
     using type = std::array<double, Dim>;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "The initial center of the profile of the wave."};
     static type default_value() { return make_array<Dim>(0.0); }
   };
 
   struct Profile {
     using type = std::unique_ptr<MathFunction<1>>;
-    static constexpr OptionString_t help = {"The profile of the wave."};
+    static constexpr OptionString help = {"The profile of the wave."};
   };
 
   using options = tmpl::list<WaveVector, Center, Profile>;
 
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
       "A plane wave solution of the Euclidean wave equation"};
 
   PlaneWave(std::array<double, Dim> wave_vector, std::array<double, Dim> center,

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -15,13 +15,13 @@ tnsr::aa<DataType, Dim, Fr> compute_spacetime_metric(
   tnsr::aa<DataType, Dim, Fr> spacetime_metric{
       make_with_value<DataType>(lapse.get(), 0.)};
 
-  spacetime_metric.template get<0, 0>() = -lapse.get() * lapse.get();
+  get<0, 0>(spacetime_metric) = -lapse.get() * lapse.get();
 
   for (size_t m = 0; m < Dim; ++m) {
-    spacetime_metric.template get<0, 0>() +=
+    get<0, 0>(spacetime_metric) +=
         spatial_metric.get(m, m) * shift.get(m) * shift.get(m);
     for (size_t n = 0; n < m; ++n) {
-      spacetime_metric.template get<0, 0>() +=
+      get<0, 0>(spacetime_metric) +=
           2 * spatial_metric.get(m, n) * shift.get(m) * shift.get(n);
     }
   }

--- a/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
@@ -21,22 +21,22 @@ class Gaussian : public MathFunction<1> {
  public:
   struct Amplitude {
     using type = double;
-    static constexpr OptionString_t help = {"The amplitude."};
+    static constexpr OptionString help = {"The amplitude."};
   };
 
   struct Width {
     using type = double;
-    static constexpr OptionString_t help = {"The width."};
+    static constexpr OptionString help = {"The width."};
     static type lower_bound() { return 0.; }
   };
 
   struct Center {
     using type = double;
-    static constexpr OptionString_t help = {"The center."};
+    static constexpr OptionString help = {"The center."};
   };
   using options = tmpl::list<Amplitude, Width, Center>;
 
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
       "Applies a Gaussian function to the input value"};
 
   WRAPPED_PUPable_decl_template(Gaussian);  // NOLINT

--- a/src/PointwiseFunctions/MathFunctions/PowX.hpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.hpp
@@ -19,12 +19,12 @@ class PowX : public MathFunction<1> {
  public:
   struct Power {
     using type = int;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "The power that the double is raised to."};
   };
   using options = tmpl::list<Power>;
 
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
       "Raises the input value to a given power"};
 
   PowX() = default;

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
@@ -21,22 +21,22 @@ class Sinusoid : public MathFunction<1> {
  public:
   struct Amplitude {
     using type = double;
-    static constexpr OptionString_t help = {"The amplitude."};
+    static constexpr OptionString help = {"The amplitude."};
   };
 
   struct Wavenumber {
     using type = double;
-    static constexpr OptionString_t help = {"The wavenumber."};
+    static constexpr OptionString help = {"The wavenumber."};
   };
 
   struct Phase {
     using type = double;
-    static constexpr OptionString_t help = {"The phase shift."};
+    static constexpr OptionString help = {"The phase shift."};
     static type default_value() { return 0.; }
   };
   using options = tmpl::list<Amplitude, Wavenumber, Phase>;
 
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
       "Applies a Sinusoid function to the input value"};
 
   Sinusoid(double amplitude, double wavenumber, double phase) noexcept;

--- a/src/Time/StepControllers/BinaryFraction.hpp
+++ b/src/Time/StepControllers/BinaryFraction.hpp
@@ -22,7 +22,7 @@ namespace StepControllers {
 class BinaryFraction : public StepController {
  public:
   using options = tmpl::list<>;
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
       "Chooses steps to be binary fractions of a slab"};
 
   TimeDelta choose_step(const Time& time,

--- a/src/Time/StepControllers/FullSlab.hpp
+++ b/src/Time/StepControllers/FullSlab.hpp
@@ -21,7 +21,7 @@ namespace StepControllers {
 class FullSlab : public StepController {
  public:
   using options = tmpl::list<>;
-  static constexpr OptionString_t help = {"Chooses the full slab."};
+  static constexpr OptionString help = {"Chooses the full slab."};
 
   TimeDelta choose_step(const Time& time,
                         const double desired_step) const noexcept override {

--- a/src/Time/StepControllers/SimpleTimes.hpp
+++ b/src/Time/StepControllers/SimpleTimes.hpp
@@ -24,7 +24,7 @@ namespace StepControllers {
 class SimpleTimes : public StepController {
  public:
   using options = tmpl::list<>;
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
       "Chooses steps by dividing the remainder of the slab approximately\n"
       "evenly, but preferring evaluation times that are simple (i.e., small\n"
       "denominator) fractions of the slab."};

--- a/src/Time/StepControllers/SplitRemaining.hpp
+++ b/src/Time/StepControllers/SplitRemaining.hpp
@@ -22,7 +22,7 @@ namespace StepControllers {
 class SplitRemaining : public StepController {
  public:
   using options = tmpl::list<>;
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
       "Chooses steps by dividing the remainder of the slab evenly.\n"
       "WARNING: With many steps per slab this often leads to overflow in the\n"
       "  time representations."};

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -20,7 +20,7 @@ class TimeStepper;
 
 namespace Tags {
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Tag for ::TimeId for the algorithm state
 struct TimeId : db::DataBoxTag {
@@ -28,7 +28,7 @@ struct TimeId : db::DataBoxTag {
   using type = ::TimeId;
 };
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Tag for step size
 struct TimeStep : db::DataBoxTag {
@@ -40,7 +40,7 @@ namespace TimeTags_detail {
 inline ::Time time_from_id(const ::TimeId& id) noexcept { return id.time; }
 }  // namespace TimeTags_detail
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Tag for compute item for current ::Time (from TimeId)
 struct Time : db::ComputeItemTag {
@@ -49,7 +49,7 @@ struct Time : db::ComputeItemTag {
   using argument_tags = tmpl::list<TimeId>;
 };
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Prefix for TimeStepper history
 ///
@@ -63,7 +63,7 @@ struct HistoryEvolvedVariables : db::DataBoxPrefix {
       std::deque<std::tuple<::Time, db::item_type<Tag>, db::item_type<DtTag>>>;
 };
 
-/// \ingroup DataBoxTags
+/// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// Prefix for TimeStepper boundary history
 ///
@@ -80,7 +80,7 @@ struct HistoryBoundaryVariables : db::DataBoxPrefix {
 
 namespace CacheTags {
 
-/// \ingroup CacheTags
+/// \ingroup CacheTagsGroup
 /// \ingroup TimeGroup
 /// \brief The final time
 struct FinalTime {
@@ -88,7 +88,7 @@ struct FinalTime {
   static constexpr OptionString_t help{"The final time"};
 };
 
-/// \ingroup CacheTags
+/// \ingroup CacheTagsGroup
 /// \ingroup TimeGroup
 /// \brief The ::TimeStepper
 struct TimeStepper {

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -24,7 +24,7 @@ namespace Tags {
 /// \ingroup TimeGroup
 /// \brief Tag for ::TimeId for the algorithm state
 struct TimeId : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "TimeId";
+  static constexpr db::DataBoxString label = "TimeId";
   using type = ::TimeId;
 };
 
@@ -32,7 +32,7 @@ struct TimeId : db::DataBoxTag {
 /// \ingroup TimeGroup
 /// \brief Tag for step size
 struct TimeStep : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "TimeStep";
+  static constexpr db::DataBoxString label = "TimeStep";
   using type = ::TimeDelta;
 };
 
@@ -44,7 +44,7 @@ inline ::Time time_from_id(const ::TimeId& id) noexcept { return id.time; }
 /// \ingroup TimeGroup
 /// \brief Tag for compute item for current ::Time (from TimeId)
 struct Time : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "Time";
+  static constexpr db::DataBoxString label = "Time";
   static constexpr auto function = TimeTags_detail::time_from_id;
   using argument_tags = tmpl::list<TimeId>;
 };
@@ -57,7 +57,7 @@ struct Time : db::ComputeItemTag {
 /// \tparam DtTag tag for the time derivative of the variables
 template <typename Tag, typename DtTag>
 struct HistoryEvolvedVariables : db::DataBoxPrefix {
-  static constexpr db::DataBoxString_t label = "HistoryEvolvedVariables";
+  static constexpr db::DataBoxString label = "HistoryEvolvedVariables";
   using tag = Tag;
   using type =
       std::deque<std::tuple<::Time, db::item_type<Tag>, db::item_type<DtTag>>>;
@@ -71,7 +71,7 @@ struct HistoryEvolvedVariables : db::DataBoxPrefix {
 /// \tparam Tag tag for boundary variables
 template <typename Key, typename Tag>
 struct HistoryBoundaryVariables : db::DataBoxPrefix {
-  static constexpr db::DataBoxString_t label = "HistoryBoundaryVariables";
+  static constexpr db::DataBoxString label = "HistoryBoundaryVariables";
   using tag = Tag;
   using type = std::unordered_map<Key, db::item_type<Tag>>;
 };

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -85,7 +85,7 @@ namespace CacheTags {
 /// \brief The final time
 struct FinalTime {
   using type = double;
-  static constexpr OptionString_t help{"The final time"};
+  static constexpr OptionString help{"The final time"};
 };
 
 /// \ingroup CacheTagsGroup
@@ -93,7 +93,7 @@ struct FinalTime {
 /// \brief The ::TimeStepper
 struct TimeStepper {
   using type = std::unique_ptr<::TimeStepper>;
-  static constexpr OptionString_t help{"The time stepper"};
+  static constexpr OptionString help{"The time stepper"};
 };
 
 }  // namespace CacheTags
@@ -105,7 +105,7 @@ namespace OptionTags {
 /// \brief The time at which to start the simulation
 struct InitialTime {
   using type = double;
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
       "The time at which the evolution is started."};
   static type default_value() { return 0.0; }
 };
@@ -116,6 +116,6 @@ struct InitialTime {
 /// overridden by an adaptive stepper
 struct DeltaT {
   using type = double;
-  static constexpr OptionString_t help = {"The initial time step size."};
+  static constexpr OptionString help = {"The initial time step size."};
 };
 }  // namespace OptionTags

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -40,19 +40,19 @@ class AdamsBashforthN : public TimeStepper::Inherit {
 
   struct TargetOrder {
     using type = size_t;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Target order of Adams-Bashforth method."};
     static type lower_bound() { return 1; }
     static type upper_bound() { return maximum_order; }
   };
   struct SelfStart {
     using type = bool;
-    static constexpr OptionString_t help = {
+    static constexpr OptionString help = {
         "Start at first order and increase."};
     static type default_value() { return false; }
   };
   using options = tmpl::list<TargetOrder, SelfStart>;
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
       "An Adams-Bashforth Nth order time-stepper. The target order is the\n"
       "order of the method. If a self-starting approach is chosen then the\n"
       "method starts at first order and increases the step-size until the\n"

--- a/src/Time/TimeSteppers/RungeKutta3.hpp
+++ b/src/Time/TimeSteppers/RungeKutta3.hpp
@@ -33,7 +33,7 @@ namespace TimeSteppers {
 class RungeKutta3 : public TimeStepper::Inherit {
  public:
   using options = tmpl::list<>;
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
       "A third-order strong stability-preserving Runge-Kutta time-stepper."};
 
   RungeKutta3() = default;

--- a/src/Utilities/Blas.hpp
+++ b/src/Utilities/Blas.hpp
@@ -31,7 +31,7 @@ void dgemv_(const char& TRANS, const int& M, const int& N, const double& ALPHA,
 }  // namespace blas_detail
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * The dot product of two vectors.
  *
  * \param N the length of the vectors.
@@ -54,7 +54,7 @@ inline double ddot_(const size_t& N, const double* X, const size_t& INCX,
 
 // @{
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Perform a matrix-matrix multiplication
  *
  * Perform the matrix-matrix multiplication
@@ -127,7 +127,7 @@ inline void dgemm_<true>(const char& TRANSA, const char& TRANSB,
 
 // @{
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Perform a matrix-vector multiplication
  *
  * \f[

--- a/src/Utilities/BoostHelpers.hpp
+++ b/src/Utilities/BoostHelpers.hpp
@@ -24,7 +24,7 @@ struct make_boost_variant_over_impl<Sequence<Ts...>> {
 }  // namespace detail
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Create a boost::variant with all all the types inside the typelist
  * Sequence
  *

--- a/src/Utilities/ConstantExpressions.hpp
+++ b/src/Utilities/ConstantExpressions.hpp
@@ -17,7 +17,7 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// Compute 2 to the n for integral types.
 ///
 /// \param n the power of two to compute.
@@ -28,7 +28,7 @@ SPECTRE_ALWAYS_INLINE constexpr T two_to_the(T n) {
   return T(1) << n;
 }
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// Get the nth bit from the right, counting from zero.
 ///
 /// \param i the value to be acted on.
@@ -39,21 +39,21 @@ SPECTRE_ALWAYS_INLINE constexpr size_t get_nth_bit(const size_t i,
   return (i >> N) % 2;
 }
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// \brief Compute the square of `x`
 template <typename T>
 SPECTRE_ALWAYS_INLINE constexpr decltype(auto) square(const T& x) {
   return x * x;
 }
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// \brief Compute the cube of `x`
 template <typename T>
 SPECTRE_ALWAYS_INLINE constexpr decltype(auto) cube(const T& x) {
   return x * x * x;
 }
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 namespace ConstantExpressions_detail {
 template <typename T, int N, typename = std::nullptr_t>
 struct pow;
@@ -82,7 +82,7 @@ struct pow<T, 0, Requires<not blaze::IsVector<T>::value>> {
 /// \endcond
 }  // namespace ConstantExpressions_detail
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// \brief Compute t^N where N is an integer (positive or negative)
 ///
 /// \warning If passing an integer this will do integer arithmatic, e.g.
@@ -96,7 +96,7 @@ SPECTRE_ALWAYS_INLINE constexpr decltype(auto) pow(const T& t) {
   return ConstantExpressions_detail::pow<T, N>::apply(t);
 }
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// \brief Compute the absolute value of of its argument
 ///
 /// The argument must be comparable to an int and muste be negatable.
@@ -114,7 +114,7 @@ struct CompareByMagnitude {
 };
 }  // namespace ConstantExpressions_detail
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// \brief Return the argument with the largest magnitude
 ///
 /// Magnitude is determined by constexpr_abs.  In case of a tie,
@@ -132,7 +132,7 @@ constexpr T max_by_magnitude(std::initializer_list<T> ilist) {
 }
 //@}
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// \brief Return the argument with the smallest magnitude
 ///
 /// Magnitude is determined by constexpr_abs.  In case of a tie,
@@ -163,7 +163,7 @@ make_array_from_list_helper(
 }
 }  // namespace detail
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// Make an array from a typelist that holds std::integral_constant's all of
 /// which have the same `value_type`
 ///
@@ -204,7 +204,7 @@ make_array_from_list_helper(
 }
 }  // namespace detail
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 ///
 /// Make an array of arrays from a typelist that holds typelists of
 /// std::integral_constant's all of which have the same `value_type`
@@ -218,7 +218,7 @@ inline constexpr auto make_array_from_list() {
       std::make_integer_sequence<size_t, tmpl::size<List>::value>{});
 }
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// \brief Compute the length of a const char* at compile time
 SPECTRE_ALWAYS_INLINE constexpr size_t cstring_length(
     const char* str) noexcept {
@@ -226,7 +226,7 @@ SPECTRE_ALWAYS_INLINE constexpr size_t cstring_length(
   return *str != 0 ? 1 + cstring_length(str + 1) : 0;  // NOLINT
 }
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// \brief Compute a hash of a const char* at compile time
 SPECTRE_ALWAYS_INLINE constexpr size_t cstring_hash(const char* str) noexcept {
   // clang-tidy: do not use pointer arithmetic
@@ -249,7 +249,7 @@ inline constexpr std::array<std::decay_t<T>, Size> replace_at_helper(
 }
 }  // namespace ConstantExpression_detail
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// Replace at compile time the `I`th entry in the array with `value`
 template <size_t I, typename T, size_t Size>
 inline constexpr std::array<std::decay_t<T>, Size> replace_at(
@@ -260,7 +260,7 @@ inline constexpr std::array<std::decay_t<T>, Size> replace_at(
       std::make_integer_sequence<size_t, Size - I - 1>{});
 }
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// Check at compile time if two `std::array`s are equal
 template <typename T, typename S, size_t size>
 inline constexpr bool array_equal(const std::array<T, size>& lhs,
@@ -273,7 +273,7 @@ inline constexpr bool array_equal(const std::array<T, size>& lhs,
                   : true;
 }
 
-/// \ingroup ConstantExpressions
+/// \ingroup ConstantExpressionsGroup
 /// \brief Returns a const reference to its argument.
 template <typename T>
 constexpr const T& as_const(const T& t) noexcept { return t; }

--- a/src/Utilities/Deferred.hpp
+++ b/src/Utilities/Deferred.hpp
@@ -104,7 +104,7 @@ using get_type_from_deferred = typename get_type_from_deferred_impl<T>::type;
 }  // namespace Deferred_detail
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Provides deferred or lazy evaluation of a function or function object,
  * as well as efficient storage of an object that is mutable.
  *
@@ -145,7 +145,7 @@ class Deferred {
 };
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Create a deferred function call object
  *
  * If creating a Deferred with a function object the call operator of the

--- a/src/Utilities/DereferenceWrapper.hpp
+++ b/src/Utilities/DereferenceWrapper.hpp
@@ -9,7 +9,7 @@
 #include <functional>
 #include <utility>
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// \brief Returns the reference object held by a reference wrapper, if a
 /// non-reference_wrapper type is passed in then the object is returned
 template <typename T>

--- a/src/Utilities/Digraph.hpp
+++ b/src/Utilities/Digraph.hpp
@@ -156,7 +156,7 @@ using has_edge = ::brigand::detail::has_edge_impl<Graph, S, D>;
 }  // namespace lazy
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Check if a digraph has an edge with source `S` and destination `D`
  *
  *

--- a/src/Utilities/FakeVirtual.hpp
+++ b/src/Utilities/FakeVirtual.hpp
@@ -12,7 +12,7 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// \brief Define a function that acts similarly to a virtual
 /// function, but can take template parameters.
 ///

--- a/src/Utilities/FileSystem.hpp
+++ b/src/Utilities/FileSystem.hpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief A light-weight file system library based on POSIX.
  *
  * We use this library instead of a subprocess based library because OpenMPI
@@ -21,7 +21,7 @@
 namespace file_system {
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Wraps the dirname function to get the pathname of the parent directory
  *
  * See the opengroup documentation:
@@ -36,7 +36,7 @@ namespace file_system {
 std::string get_parent_path(const std::string& path);
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Given a path to a file returns the file name
  *
  * \example
@@ -48,7 +48,7 @@ std::string get_parent_path(const std::string& path);
 std::string get_file_name(const std::string& file_path);
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Get the absolute path, resolving symlinks
  *
  * \requires `rel_path` is a valid path on the filesystem
@@ -57,7 +57,7 @@ std::string get_file_name(const std::string& file_path);
 std::string get_absolute_path(const std::string& rel_path);
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Creates a directory, including any parents that don't exist. If the
  * directory exists `create_directory` does nothing.
  *
@@ -73,7 +73,7 @@ void create_directory(const std::string& dir, double wait_time = 1,
                       size_t num_tries = 40);
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Returns true if the directory exists
  *
  * \returns `true` if the directory exists
@@ -81,7 +81,7 @@ void create_directory(const std::string& dir, double wait_time = 1,
 bool check_if_dir_exists(const std::string& dir);
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Returns true if the regular file or link to the regular file exists.
  *
  * \note See the stat(2) documentation, e.g. at
@@ -92,7 +92,7 @@ bool check_if_dir_exists(const std::string& dir);
 bool check_if_file_exists(const std::string& file);
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Returns true if the path points to a regular file or a link to a
  * regular file.
  *
@@ -105,7 +105,7 @@ bool check_if_file_exists(const std::string& file);
 bool is_file(const std::string& path);
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Returns the file size in bytes
  *
  * \requires `file` is a valid file on the filesystem
@@ -114,13 +114,13 @@ bool is_file(const std::string& path);
 size_t file_size(const std::string& file);
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Returns the current working directory, resolving symlinks
  */
 std::string cwd();
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Gets a list of files in a directory
  *
  * \returns vector of all files and directories inside `dir_name`
@@ -128,7 +128,7 @@ std::string cwd();
 std::vector<std::string> ls(const std::string& dir_name = "./");
 
 /*!
- * \ingroup FileSystem
+ * \ingroup FileSystemGroup
  * \brief Deletes a file or directory.
  *
  * \requires `path` be a valid path on the filesystem

--- a/src/Utilities/ForceInline.hpp
+++ b/src/Utilities/ForceInline.hpp
@@ -7,19 +7,19 @@
 #pragma once
 
 #if defined(__GNUC__)
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// Always inline a function. Only use this if you benchmarked the code.
 #define SPECTRE_ALWAYS_INLINE __attribute__((always_inline)) inline
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// Always inline a function, but do not mark it `inline`
 #define SPECTRE_JUST_ALWAYS_INLINE __attribute__((always_inline))
 #else
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// Always inline a function. Only use this if you benchmarked the code.
 #define SPECTRE_ALWAYS_INLINE inline
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// Always inline a function, but do not mark it `inline`
 #define SPECTRE_JUST_ALWAYS_INLINE
 #endif

--- a/src/Utilities/FractionUtilities.hpp
+++ b/src/Utilities/FractionUtilities.hpp
@@ -28,7 +28,7 @@ template <typename T>
 constexpr bool is_fraction_v = is_fraction<T>::value;
 //@}
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// \brief Compute the continued fraction representation of a number
 ///
 /// The template argument may be a fraction type or a floating point
@@ -99,7 +99,7 @@ class ContinuedFraction {
   bool done_{false};
 };
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// \brief Sum a continued fraction
 ///
 /// \tparam Fraction the result type, which must be a fraction type
@@ -130,7 +130,7 @@ class ContinuedFractionSummer {
   Term_t prev_denominator_{1};
 };
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// \brief Find the fraction in the supplied interval with the
 /// smallest denominator
 ///

--- a/src/Utilities/GenerateInstantiations.hpp
+++ b/src/Utilities/GenerateInstantiations.hpp
@@ -23,7 +23,7 @@
 /// \endcond
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Macro useful for generating many explicit instantiations of function
  * or class templates
  *

--- a/src/Utilities/Gsl.hpp
+++ b/src/Utilities/Gsl.hpp
@@ -37,39 +37,39 @@
 #if defined(__clang__) || defined(__GNUC__)
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * The if statement is expected to evaluate true most of the time
  */
 #define LIKELY(x) __builtin_expect(!!(x), 1)
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * The if statement is expected to evaluate false most of the time
  */
 #define UNLIKELY(x) __builtin_expect(!!(x), 0)
 
 #else
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * The if statement is expected to evaluate true most of the time
  */
 #define LIKELY(x) (x)
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * The if statement is expected to evaluate false most of the time
  */
 #define UNLIKELY(x) (x)
 #endif
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Implementations from the Guideline Support Library
  */
 namespace gsl {
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Cast `u` to a type `T` where the cast may result in narrowing
  */
 template <class T, class U>
@@ -85,7 +85,7 @@ struct is_same_signedness
 }  // namespace gsl_detail
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief A checked version of narrow_cast() that ERRORs if the cast changed
  * the value
  */
@@ -106,7 +106,7 @@ SPECTRE_ALWAYS_INLINE T narrow(U u) {
 
 // @{
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Retrieve a entry from a container, with checks in Debug mode that
  * the index being retrieved is valid.
  */
@@ -132,7 +132,7 @@ SPECTRE_ALWAYS_INLINE constexpr const T& at(std::initializer_list<T> cont,
 // @}
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Require a pointer to not be a `nullptr`
  *
  * Restricts a pointer or smart pointer to only hold non-null values.

--- a/src/Utilities/Literals.hpp
+++ b/src/Utilities/Literals.hpp
@@ -10,7 +10,7 @@
 
 using namespace std::literals::string_literals;  // NOLINT
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// Defines the _st size_t suffix
 inline constexpr size_t operator"" _st(const unsigned long long n) {  // NOLINT
   return static_cast<size_t>(n);

--- a/src/Utilities/MakeArray.hpp
+++ b/src/Utilities/MakeArray.hpp
@@ -64,7 +64,7 @@ SPECTRE_ALWAYS_INLINE constexpr std::array<std::decay_t<T>, size> make_array(
 }
 // clang-format on
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Helper class to initialize a std::array.
  *
  * \tparam size the length of the array
@@ -78,7 +78,7 @@ make_array(T&& value) noexcept(noexcept(make_array(
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Helper function to initialize a std::array with varying number of
  * arguments
  */
@@ -109,7 +109,7 @@ constexpr std::array<T, size> make_array_from_iterator_impl(
 }  // namespace MakeArray_detail
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Create an `std::array<T, size>` from the first `size` values of `seq`
  *
  * \requires `Seq` has a `begin` function

--- a/src/Utilities/Math.hpp
+++ b/src/Utilities/Math.hpp
@@ -9,7 +9,7 @@
 #include "Utilities/TypeTraits.hpp"
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Returns the number of digits in an integer number
  */
 template <typename T>

--- a/src/Utilities/NoSuchType.hpp
+++ b/src/Utilities/NoSuchType.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Used to mark "no type" or "bad state" for metaprogramming
  */
 struct NoSuchType {};

--- a/src/Utilities/Overloader.hpp
+++ b/src/Utilities/Overloader.hpp
@@ -19,7 +19,7 @@ struct no_such_type;
 }  // namespace overloader_detail
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Used for overloading lambdas, useful for lambda-SFINAE
  *
  * \snippet Utilities/Test_Overloader.cpp overloader_example
@@ -102,7 +102,7 @@ class Overloader<> {
 };
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Create `Overloader<Fs...>`, see Overloader for details
  */
 template <class... Fs>

--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -307,7 +307,7 @@ VT& operator-=(blaze::DenseVector<VT, TF>& vec, Scalar scalar) {
 /// \endcond
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief A raw pointer endowed with expression template support via the Blaze
  * library
  *

--- a/src/Utilities/PrettyType.hpp
+++ b/src/Utilities/PrettyType.hpp
@@ -19,7 +19,7 @@
 /// \endcond
 
 /*!
- * \ingroup PrettyType
+ * \ingroup PrettyTypeGroup
  * \brief Contains all functions that are part of PrettyType, used for printing
  * types in a pretty manner.
  */
@@ -178,7 +178,7 @@ std::string add_qualifiers() {
 }
 
 /*!
- * \ingroup PrettyType
+ * \ingroup PrettyTypeGroup
  * Used to construct the name of a container
  *
  * \tparam T the type whose name to print
@@ -611,7 +611,7 @@ struct construct_name<
 }  // namespace detail
 
 /*!
- * \ingroup PrettyType
+ * \ingroup PrettyTypeGroup
  * \brief typelist of basic types that can be pretty printed
  *
  * These are specializations of tt::Type<T>
@@ -623,7 +623,7 @@ using basics_map =
                           float, double, long double, bool, std::string>;
 
 /*!
- * \ingroup PrettyType
+ * \ingroup PrettyTypeGroup
  * \brief A list of type traits to check if something is an STL member
  *
  * Contains a template alias with the name template_list of type traits that
@@ -645,7 +645,7 @@ struct stl_templates {
 };
 
 /*!
- * \ingroup PrettyType
+ * \ingroup PrettyTypeGroup
  *  \brief Returns a string with the prettiest typename known for the type T.
  *
  *  Example usage: auto name = get_name<T>();
@@ -664,7 +664,7 @@ std::string get_name() {
 }
 
 /*!
- * \ingroup PrettyType
+ * \ingroup PrettyTypeGroup
  * \brief Returns a string with the prettiest typename known for the runtime
  * type of x.
  *
@@ -678,14 +678,14 @@ std::string get_runtime_type_name(const T& x) {
 }
 
 /*!
- * \ingroup PrettyType
+ * \ingroup PrettyTypeGroup
  * \brief Extract the "short name" from a name, that is, the name
  * without template parameters or scopes.
  */
 std::string extract_short_name(std::string name);
 
 /*!
- * \ingroup PrettyType
+ * \ingroup PrettyTypeGroup
  * \brief Return the "short name" of a class, that is, the name
  * without template parameters or scopes.
  */

--- a/src/Utilities/Requires.hpp
+++ b/src/Utilities/Requires.hpp
@@ -20,7 +20,7 @@ struct requires_impl<false> {};
 }  // namespace Requires_detail
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Express requirements on the template parameters of a function or
  * class, replaces `std::enable_if_t`
  *

--- a/src/Utilities/StdHelpers.hpp
+++ b/src/Utilities/StdHelpers.hpp
@@ -111,7 +111,7 @@ struct TuplePrinter<0> {
 }  // namespace StdHelpers_detail
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Output the items of a std::list
  */
 template <typename T>
@@ -121,7 +121,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::list<T>& v) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Output the items of a std::vector
  */
 template <typename T>
@@ -131,7 +131,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Output the items of a std::deque
  */
 template <typename T>
@@ -141,7 +141,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::deque<T>& v) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Output the items of a std::array
  */
 template <typename T, size_t N>
@@ -151,7 +151,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::array<T, N>& a) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Stream operator for tuples
  */
 template <typename... Args>
@@ -164,7 +164,7 @@ inline std::ostream& operator<<(std::ostream& os,
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Output all the key, value pairs of a std::unordered_map
  */
 template <typename K, typename V, typename H>
@@ -180,7 +180,7 @@ inline std::ostream& operator<<(std::ostream& os,
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Output all the key, value pairs of a std::map
  */
 template <typename K, typename V, typename C>
@@ -194,7 +194,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::map<K, V, C>& m) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Output the items of a std::unordered_set
  */
 template <typename T>
@@ -205,7 +205,7 @@ inline std::ostream& operator<<(std::ostream& os,
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Output the items of a std::set
  */
 template <typename T, typename C>
@@ -215,7 +215,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::set<T, C>& v) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Stream operator for std::unique_ptr
  */
 template <typename T, Requires<tt::is_streamable<std::ostream, T>::value>>
@@ -224,7 +224,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::unique_ptr<T>& t) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Stream operator for std::shared_ptr
  */
 template <typename T, Requires<tt::is_streamable<std::ostream, T>::value>>
@@ -233,7 +233,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::shared_ptr<T>& t) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Stream operator for std::pair
  */
 template <typename T, typename U>
@@ -242,7 +242,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::pair<T, U>& t) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Construct a string containing the keys of a std::unordered_map
  */
 template <typename K, typename V, typename H>
@@ -258,7 +258,7 @@ inline std::string keys_of(const std::unordered_map<K, V, H>& m) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Construct a string containing the keys of a std::map
  */
 template <typename K, typename V, typename C>
@@ -273,7 +273,7 @@ inline std::string keys_of(const std::map<K, V, C>& m) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Format a string like printf
  *
  * Given a formatting string and arguments this returns the corresponding
@@ -299,7 +299,7 @@ std::string formatted_string(const std::string& fmt, Args... args) {
 }
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Get the current date and time
  */
 inline std::string current_date_and_time() {
@@ -385,7 +385,7 @@ inline std::array<T, Dim> operator-(const std::array<T, Dim>& rhs) noexcept {
   return result;
 }
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// \brief Construct an array from an existing array omitting one element
 template <size_t ElementToRemove, typename T, size_t Dim>
 inline std::array<T, Dim - 1> all_but_specified_element_of(
@@ -402,7 +402,7 @@ inline std::array<T, Dim - 1> all_but_specified_element_of(
 }
 
 //@{
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// \brief Euclidean magnitude of the elements of the array.
 ///
 /// \details If T is a container the magnitude is computed separately for each

--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -467,25 +467,25 @@ using branch_if_t = typename branch_if<B>::template type<T, F>;
 
 namespace tmpl = brigand;
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// \brief Construct a typelist of types `Ts`.
 template <typename... Ts>
 using typelist = tmpl::list<Ts...>;
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Metaprogramming things that are not planned to be submitted to Brigand
  */
 namespace tmpl2 {
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief A compile-time list of values of the same type
  */
 template <class T, T...>
 struct value_list {};
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief A non-short-circuiting logical AND between bools 'B""
  *
  * Useful when arbitrarily large parameter packs need to be evaluated, since
@@ -497,7 +497,7 @@ using flat_all =
                  value_list<bool, (static_cast<void>(Bs), true)...>>;
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief A non-short-circuiting logical AND between bools 'B""
  *
  * Useful when arbitrarily large parameter packs need to be evaluated, since
@@ -507,7 +507,7 @@ template <bool... Bs>
 constexpr bool flat_all_v = flat_all<Bs...>::value;
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief A non-short-circuiting logical OR between bools 'B""
  *
  * Useful when arbitrarily large parameter packs need to be evaluated, since
@@ -521,7 +521,7 @@ using flat_any = std::integral_constant<
         value_list<bool, (static_cast<void>(Bs), false)...>>::value>;
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief A non-short-circuiting logical OR between bools 'B""
  *
  * Useful when arbitrarily large parameter packs need to be evaluated, since
@@ -532,7 +532,7 @@ constexpr bool flat_any_v = flat_any<Bs...>::value;
 }  // namespace tmpl2
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Allows zero-cost unordered expansion of a parameter
  *
  * \details

--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -253,7 +253,7 @@ struct disable_constructors {
 }  // namespace tuples_detail
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief An associative container that is indexed by structs
  *
  * A data structure that is indexed by Tags. A Tag is a struct that contains
@@ -633,7 +633,7 @@ struct tuple_size<const volatile TaggedTuple<Tags...>>
 // C++17 Draft 23.5.3.7 Element access
 // @{
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Retrieve the element of `Tag` in the TaggedTuple
  */
 template <class Tag, class... Tags>
@@ -820,7 +820,7 @@ struct tagged_tuple_typelist_impl<List<Tags...>> {
 };
 }  // namespace TaggedTuple_detail
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 template <typename T>
 using TaggedTupleTypelist =
     typename TaggedTuple_detail::tagged_tuple_typelist_impl<T>::type;

--- a/src/Utilities/TmplDebugging.hpp
+++ b/src/Utilities/TmplDebugging.hpp
@@ -9,7 +9,7 @@
 #include "Utilities/TMPL.hpp"
 
 /*!
- * \ingroup Utilities TypeTraits
+ * \ingroup UtilitiesGroup TypeTraits
  * \brief Get compiler error with type of template parameter
  *
  * The compiler error generated when using an object of type
@@ -31,7 +31,7 @@ template <typename...>
 struct TypeDisplayer;
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Metafunction to turn a parameter pack into a typelist
  *
  * This metafunction is really only useful for debugging metaprograms. For

--- a/src/Utilities/Tuple.hpp
+++ b/src/Utilities/Tuple.hpp
@@ -77,7 +77,7 @@ constexpr inline void tuple_transform_impl(
 
 // @{
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Perform a fold over a std::tuple
  *
  * \details
@@ -140,7 +140,7 @@ constexpr inline void tuple_counted_fold(
 // @}
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Perform a transform over a std::tuple
  *
  * \details

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -28,12 +28,12 @@
 #include "Utilities/Requires.hpp"
 #include "Utilities/StlStreamDeclarations.hpp"
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// C++ STL code present in C++17
 namespace cpp17 {
 
 /*!
- * \ingroup Utilities
+ * \ingroup UtilitiesGroup
  * \brief Mark a return type as being "void". In C++17 void is a regular type
  * under certain circumstances, so this can be replaced by `void` then.
  *
@@ -42,7 +42,7 @@ namespace cpp17 {
  */
 struct void_type {};
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief A compile-time boolean
 ///
 /// \usage
@@ -57,7 +57,7 @@ template <bool B>
 using bool_constant = std::integral_constant<bool, B>;
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief A logical AND on the template parameters
 ///
 /// \details
@@ -105,7 +105,7 @@ constexpr bool conjunction_v = conjunction<B...>::value;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief A logical OR on the template parameters
 ///
 /// \details
@@ -152,7 +152,7 @@ template <class... B>
 constexpr bool disjunction_v = disjunction<B...>::value;
 // @}
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Negate a ::bool_constant
 ///
 /// \details
@@ -180,7 +180,7 @@ constexpr bool disjunction_v = disjunction<B...>::value;
 template <class B>
 struct negation : bool_constant<!B::value> {};
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Given a set of types, returns `void`
 ///
 /// \details
@@ -210,146 +210,146 @@ template <typename... Ts>
 using void_t = void;
 
 /*!
- * \ingroup TypeTraits
+ * \ingroup TypeTraitsGroup
  * \brief Variable template for is_same
  */
 template <typename T, typename U>
 constexpr bool is_same_v = std::is_same<T, U>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <typename T>
 constexpr bool is_lvalue_reference_v = std::is_lvalue_reference<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <typename T>
 constexpr bool is_rvalue_reference_v = std::is_rvalue_reference<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <typename T>
 constexpr bool is_reference_v = std::is_reference<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T, class... Args>
 using is_constructible_t = typename std::is_constructible<T, Args...>::type;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T, class... Args>
 constexpr bool is_constructible_v = std::is_constructible<T, Args...>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T, class... Args>
 constexpr bool is_trivially_constructible_v =
     std::is_trivially_constructible<T, Args...>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T, class... Args>
 constexpr bool is_nothrow_constructible_v =
     std::is_nothrow_constructible<T, Args...>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_default_constructible_v =
     std::is_default_constructible<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_trivially_default_constructible_v =
     std::is_trivially_default_constructible<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_nothrow_default_constructible_v =
     std::is_nothrow_default_constructible<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_copy_constructible_v = std::is_copy_constructible<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_trivially_copy_constructible_v =
     std::is_trivially_copy_constructible<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_nothrow_copy_constructible_v =
     std::is_nothrow_copy_constructible<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_move_constructible_v = std::is_move_constructible<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_trivially_move_constructible_v =
     std::is_trivially_move_constructible<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_nothrow_move_constructible_v =
     std::is_nothrow_move_constructible<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T, class U>
 constexpr bool is_assignable_v = std::is_assignable<T, U>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T, class U>
 constexpr bool is_trivially_assignable_v =
     std::is_trivially_assignable<T, U>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T, class U>
 constexpr bool is_nothrow_assignable_v =
     std::is_nothrow_assignable<T, U>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class From, class To>
 constexpr bool is_convertible_v = std::is_convertible<From, To>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_copy_assignable_v = std::is_copy_assignable<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_trivially_copy_assignable_v =
     std::is_trivially_copy_assignable<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_nothrow_copy_assignable_v =
     std::is_nothrow_copy_assignable<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_move_assignable_v = std::is_move_assignable<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_trivially_move_assignable_v =
     std::is_trivially_move_assignable<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_nothrow_move_assignable_v =
     std::is_nothrow_move_assignable<T>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class Base, class Derived>
 constexpr bool is_base_of_v = std::is_base_of<Base, Derived>::value;
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_unsigned_v = std::is_unsigned<T>::value;
 
 }  // namespace cpp17
 
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// A collection of useful type traits
 namespace tt {
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type T is a std::array
 ///
 /// \details
@@ -395,7 +395,7 @@ using is_std_array_t = typename is_std_array<T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type T is a std::array of a given size
 ///
 /// \details
@@ -441,7 +441,7 @@ using is_std_array_of_size_t = typename is_std_array_of_size<N, T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` is a template specialization of `U`
 ///
 /// \requires `U` is a class template
@@ -487,7 +487,7 @@ using is_a_t = typename is_a<U, Args...>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type T has a begin() and end() function
 ///
 /// \details
@@ -535,7 +535,7 @@ using is_iterable_t = typename is_iterable<T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type T has <, <=, >, >=, ==, !=
 ///
 /// \details
@@ -595,7 +595,7 @@ std::integral_constant<std::size_t, N> array_size_impl(
 }  // namespace TypeTraits_detail
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Get the size of a std::array as a std::integral_constant
 ///
 /// \details
@@ -627,7 +627,7 @@ using array_size =
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` has operator== defined.
 ///
 /// \details
@@ -675,7 +675,7 @@ using has_equivalence_t = typename has_equivalence<T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` has operator!= defined.
 ///
 /// \details
@@ -723,7 +723,7 @@ using has_inequivalence_t = typename has_inequivalence<T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if a type `T` is callable, i.e. `T(Args...)` is evaluable.
 ///
 /// \details
@@ -788,7 +788,7 @@ using is_callable_t = typename is_callable<T, Args...>::type;
 // @}
 
 /*!
- * \ingroup TypeTraits
+ * \ingroup TypeTraitsGroup
  * \brief Generate a type trait to check if a class has a member function that
  * can be invoked with arguments of type `TArgs...`
  *
@@ -830,7 +830,7 @@ using is_callable_t = typename is_callable<T, Args...>::type;
       typename is_##METHOD_NAME##_callable<T, Args...>::type;
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if std::hash and std::equal_to are defined for type T
 ///
 /// \details
@@ -878,7 +878,7 @@ using is_hashable_t = typename is_hashable<T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` is like a std::map or std::unordored_map
 ///
 /// \details
@@ -932,7 +932,7 @@ using is_maplike_t = typename is_maplike<T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` has operator<<(`S`, `T`) defined.
 ///
 /// \details
@@ -984,7 +984,7 @@ using is_streamable_t = typename is_streamable<S, T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` is a std::string, or a C-style string
 ///
 /// \details
@@ -1035,7 +1035,7 @@ using is_string_like_t = typename is_string_like<T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` has a `get_clone()` member function
 ///
 /// \details
@@ -1094,7 +1094,7 @@ using has_get_clone_t = typename has_get_clone<T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` has a `clone()` member function
 ///
 /// \details
@@ -1148,7 +1148,7 @@ using has_clone_t = typename has_clone<T>::type;
 // @}
 
 // @{
-/// \ingroup TypeTraits
+/// \ingroup TypeTraitsGroup
 /// \brief Check if type `T` has a `size()` member function
 ///
 /// \details
@@ -1195,7 +1195,7 @@ using has_size_t = typename has_size<T>::type;
 
 // @{
 /*!
- * \ingroup TypeTraits
+ * \ingroup TypeTraitsGroup
  * \brief Check if `I` is an integer type (non-bool, non-character), unlike
  * std::is_integral
  *
@@ -1247,7 +1247,7 @@ constexpr bool is_integer_v = is_integer<T>::value;
 
 // @{
 /*!
- * \ingroup TypeTraits
+ * \ingroup TypeTraitsGroup
  * \brief Gets the underlying type if the type is a std::reference_wrapper,
  * otherwise returns the type itself
  *

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -67,7 +67,7 @@ struct get_array_index<ActionTesting_detail::MockArrayChare> {
 /// \endcond
 
 namespace ActionTesting {
-/// \ingroup TestingFramework
+/// \ingroup TestingFrameworkGroup
 /// A mock parallel component that acts like a component with
 /// chare_type Parallel::Algorithms::Array.
 template <typename Metavariables, typename Index,
@@ -84,7 +84,7 @@ struct MockArrayComponent {
   using initial_databox = NoSuchType;
 };
 
-/// \ingroup TestingFramework
+/// \ingroup TestingFrameworkGroup
 /// A class that mocks the infrastructure needed to run actions.  It
 /// simulates message passing using the inbox infrastructure and
 /// handles most of the arguments to the apply and is_ready action

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Determinant.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Determinant.cpp
@@ -21,47 +21,47 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
 
     {
       tnsr::ij<double, 2, Frame::Grid> matrix{};
-      matrix.get<0, 0>() = 2.1;
-      matrix.get<0, 1>() = 4.5;
-      matrix.get<1, 0>() = -18.3;
-      matrix.get<1, 1>() = -10.9;
+      get<0, 0>(matrix) = 2.1;
+      get<0, 1>(matrix) = 4.5;
+      get<1, 0>(matrix) = -18.3;
+      get<1, 1>(matrix) = -10.9;
       const auto det = determinant(matrix);
       CHECK(59.46 == approx(det.get()));
     }
 
     {
       tnsr::ij<double, 3, Frame::Grid> matrix{};
-      matrix.get<0, 0>() = 1.1;
-      matrix.get<0, 1>() = -10.4;
-      matrix.get<0, 2>() = -4.5;
-      matrix.get<1, 0>() = 3.2;
-      matrix.get<1, 1>() = 15.4;
-      matrix.get<1, 2>() = -19.2;
-      matrix.get<2, 0>() = 4.3;
-      matrix.get<2, 1>() = 16.8;
-      matrix.get<2, 2>() = 2.0;
+      get<0, 0>(matrix) = 1.1;
+      get<0, 1>(matrix) = -10.4;
+      get<0, 2>(matrix) = -4.5;
+      get<1, 0>(matrix) = 3.2;
+      get<1, 1>(matrix) = 15.4;
+      get<1, 2>(matrix) = -19.2;
+      get<2, 0>(matrix) = 4.3;
+      get<2, 1>(matrix) = 16.8;
+      get<2, 2>(matrix) = 2.0;
       const auto det = determinant(matrix);
       CHECK(1369.95 == approx(det.get()));
     }
 
     {
       tnsr::ij<double, 4, Frame::Grid> matrix{};
-      matrix.get<0, 0>() = 1.1;
-      matrix.get<0, 1>() = -10.4;
-      matrix.get<0, 2>() = -4.5;
-      matrix.get<0, 3>() = 3.2;
-      matrix.get<1, 0>() = 15.4;
-      matrix.get<1, 1>() = -19.2;
-      matrix.get<1, 2>() = 4.3;
-      matrix.get<1, 3>() = 16.8;
-      matrix.get<2, 0>() = 2.0;
-      matrix.get<2, 1>() = 3.1;
-      matrix.get<2, 2>() = 4.2;
-      matrix.get<2, 3>() = -0.2;
-      matrix.get<3, 0>() = -3.2;
-      matrix.get<3, 1>() = 2.6;
-      matrix.get<3, 2>() = 1.5;
-      matrix.get<3, 3>() = 2.8;
+      get<0, 0>(matrix) = 1.1;
+      get<0, 1>(matrix) = -10.4;
+      get<0, 2>(matrix) = -4.5;
+      get<0, 3>(matrix) = 3.2;
+      get<1, 0>(matrix) = 15.4;
+      get<1, 1>(matrix) = -19.2;
+      get<1, 2>(matrix) = 4.3;
+      get<1, 3>(matrix) = 16.8;
+      get<2, 0>(matrix) = 2.0;
+      get<2, 1>(matrix) = 3.1;
+      get<2, 2>(matrix) = 4.2;
+      get<2, 3>(matrix) = -0.2;
+      get<3, 0>(matrix) = -3.2;
+      get<3, 1>(matrix) = 2.6;
+      get<3, 2>(matrix) = 1.5;
+      get<3, 3>(matrix) = 2.8;
       const auto det = determinant(matrix);
       CHECK(1049.7072 == approx(det.get()));
     }
@@ -73,37 +73,37 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
   SECTION("Test symmetric Tensor<double,...> matrices") {
     {
       tnsr::ii<double, 2, Frame::Grid> matrix{};
-      matrix.get<0, 0>() = 2.1;
-      matrix.get<0, 1>() = 4.5;
-      matrix.get<1, 1>() = -10.9;
+      get<0, 0>(matrix) = 2.1;
+      get<0, 1>(matrix) = 4.5;
+      get<1, 1>(matrix) = -10.9;
       const auto det = determinant(matrix);
       CHECK(-43.14 == approx(det.get()));
     }
 
     {
       tnsr::ii<double, 3, Frame::Grid> matrix{};
-      matrix.get<0, 0>() = 1.1;
-      matrix.get<0, 1>() = -10.4;
-      matrix.get<0, 2>() = -4.5;
-      matrix.get<1, 1>() = 3.2;
-      matrix.get<1, 2>() = 15.4;
-      matrix.get<2, 2>() = -19.2;
+      get<0, 0>(matrix) = 1.1;
+      get<0, 1>(matrix) = -10.4;
+      get<0, 2>(matrix) = -4.5;
+      get<1, 1>(matrix) = 3.2;
+      get<1, 2>(matrix) = 15.4;
+      get<2, 2>(matrix) = -19.2;
       const auto det = determinant(matrix);
       CHECK(3124.852 == approx(det.get()));
     }
 
     {
       tnsr::ii<double, 4, Frame::Grid> matrix{};
-      matrix.get<0, 0>() = 1.1;
-      matrix.get<0, 1>() = -10.4;
-      matrix.get<0, 2>() = -4.5;
-      matrix.get<0, 3>() = 3.2;
-      matrix.get<1, 1>() = 15.4;
-      matrix.get<1, 2>() = -19.2;
-      matrix.get<1, 3>() = 4.3;
-      matrix.get<2, 2>() = 16.8;
-      matrix.get<2, 3>() = 2.0;
-      matrix.get<3, 3>() = 3.1;
+      get<0, 0>(matrix) = 1.1;
+      get<0, 1>(matrix) = -10.4;
+      get<0, 2>(matrix) = -4.5;
+      get<0, 3>(matrix) = 3.2;
+      get<1, 1>(matrix) = 15.4;
+      get<1, 2>(matrix) = -19.2;
+      get<1, 3>(matrix) = 4.3;
+      get<2, 2>(matrix) = 16.8;
+      get<2, 3>(matrix) = 2.0;
+      get<3, 3>(matrix) = 3.1;
       const auto det = determinant(matrix);
       CHECK(-22819.6093 == approx(det.get()));
     }
@@ -115,20 +115,20 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
   SECTION("Test Tensors of different types") {
     {
       tnsr::ij<int, 2, Frame::Grid> matrix{};
-      matrix.get<0, 0>() = 9;
-      matrix.get<0, 1>() = 1;
-      matrix.get<1, 0>() = -3;
-      matrix.get<1, 1>() = -4;
+      get<0, 0>(matrix) = 9;
+      get<0, 1>(matrix) = 1;
+      get<1, 0>(matrix) = -3;
+      get<1, 1>(matrix) = -4;
       const auto det = determinant(matrix);
       CHECK(-33 == det.get());
     }
 
     {
       tnsr::ij<DataVector, 2, Frame::Grid> matrix{};
-      matrix.get<0, 0>() = DataVector({6.0, 5.9, 9.8, 6.4});
-      matrix.get<0, 1>() = DataVector({6.1, 0.3, 2.4, 5.7});
-      matrix.get<1, 0>() = DataVector({4.2, 7.1, 1.1, 6.5});
-      matrix.get<1, 1>() = DataVector({7.2, 8.4, 6.1, 3.7});
+      get<0, 0>(matrix) = DataVector({6.0, 5.9, 9.8, 6.4});
+      get<0, 1>(matrix) = DataVector({6.1, 0.3, 2.4, 5.7});
+      get<1, 0>(matrix) = DataVector({4.2, 7.1, 1.1, 6.5});
+      get<1, 1>(matrix) = DataVector({7.2, 8.4, 6.1, 3.7});
       const auto det = determinant(matrix);
       CHECK(17.58 == approx(det.get()[0]));
       CHECK(47.43 == approx(det.get()[1]));

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_DeterminantAndInverse.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_DeterminantAndInverse.cpp
@@ -21,158 +21,158 @@ using tnsr_iJ = Tensor<DataType, tmpl::integral_list<int32_t, 2, 1>,
 template <typename TensorType>
 void verify_det_and_inv_1d() {
   TensorType t{};
-  t.template get<0, 0>() = 2.0;
+  get<0, 0>(t) = 2.0;
   const auto det_inv = determinant_and_inverse(t);
   CHECK(det_inv.first.get() == 2.0);
-  CHECK((det_inv.second.template get<0, 0>()) == 0.5);
+  CHECK((get<0, 0>(det_inv.second)) == 0.5);
 }
 
 template <typename TensorType>
 void verify_det_and_inv_generic_2d() {
   TensorType t{};
-  t.template get<0, 0>() = 2.0;
-  t.template get<0, 1>() = 3.0;
-  t.template get<1, 0>() = 4.0;
-  t.template get<1, 1>() = 5.0;
+  get<0, 0>(t) = 2.0;
+  get<0, 1>(t) = 3.0;
+  get<1, 0>(t) = 4.0;
+  get<1, 1>(t) = 5.0;
   const auto det_inv = determinant_and_inverse(t);
   CHECK(det_inv.first.get() == -2.0);
-  CHECK((det_inv.second.template get<0, 0>()) == -2.5);
-  CHECK((det_inv.second.template get<0, 1>()) == 1.5);
-  CHECK((det_inv.second.template get<1, 0>()) == 2.0);
-  CHECK((det_inv.second.template get<1, 1>()) == -1.0);
+  CHECK((get<0, 0>(det_inv.second)) == -2.5);
+  CHECK((get<0, 1>(det_inv.second)) == 1.5);
+  CHECK((get<1, 0>(det_inv.second)) == 2.0);
+  CHECK((get<1, 1>(det_inv.second)) == -1.0);
 }
 
 template <typename TensorType>
 void verify_det_and_inv_generic_3d() {
   TensorType t{};
-  t.template get<0, 0>() = 2.0;
-  t.template get<0, 1>() = 3.0;
-  t.template get<0, 2>() = 6.0;
-  t.template get<1, 0>() = 4.0;
-  t.template get<1, 1>() = 5.0;
-  t.template get<1, 2>() = 7.0;
-  t.template get<2, 0>() = 8.0;
-  t.template get<2, 1>() = 9.0;
-  t.template get<2, 2>() = 10.0;
+  get<0, 0>(t) = 2.0;
+  get<0, 1>(t) = 3.0;
+  get<0, 2>(t) = 6.0;
+  get<1, 0>(t) = 4.0;
+  get<1, 1>(t) = 5.0;
+  get<1, 2>(t) = 7.0;
+  get<2, 0>(t) = 8.0;
+  get<2, 1>(t) = 9.0;
+  get<2, 2>(t) = 10.0;
   const auto det_inv = determinant_and_inverse(t);
   CHECK(det_inv.first.get() == -2.0);
-  CHECK((det_inv.second.template get<0, 0>()) == 6.5);
-  CHECK((det_inv.second.template get<0, 1>()) == -12.0);
-  CHECK((det_inv.second.template get<0, 2>()) == 4.5);
-  CHECK((det_inv.second.template get<1, 0>()) == -8.0);
-  CHECK((det_inv.second.template get<1, 1>()) == 14.0);
-  CHECK((det_inv.second.template get<1, 2>()) == -5.0);
-  CHECK((det_inv.second.template get<2, 0>()) == 2.0);
-  CHECK((det_inv.second.template get<2, 1>()) == -3.0);
-  CHECK((det_inv.second.template get<2, 2>()) == 1.0);
+  CHECK((get<0, 0>(det_inv.second)) == 6.5);
+  CHECK((get<0, 1>(det_inv.second)) == -12.0);
+  CHECK((get<0, 2>(det_inv.second)) == 4.5);
+  CHECK((get<1, 0>(det_inv.second)) == -8.0);
+  CHECK((get<1, 1>(det_inv.second)) == 14.0);
+  CHECK((get<1, 2>(det_inv.second)) == -5.0);
+  CHECK((get<2, 0>(det_inv.second)) == 2.0);
+  CHECK((get<2, 1>(det_inv.second)) == -3.0);
+  CHECK((get<2, 2>(det_inv.second)) == 1.0);
 }
 
 template <typename TensorType>
 void verify_det_and_inv_generic_4d() {
   TensorType t{};
-  t.template get<0, 0>() = 2.0;
-  t.template get<0, 1>() = 3.0;
-  t.template get<0, 2>() = 6.0;
-  t.template get<0, 3>() = 11.0;
-  t.template get<1, 0>() = 4.0;
-  t.template get<1, 1>() = 5.0;
-  t.template get<1, 2>() = 7.0;
-  t.template get<1, 3>() = 12.0;
-  t.template get<2, 0>() = 8.0;
-  t.template get<2, 1>() = 9.0;
-  t.template get<2, 2>() = 10.0;
-  t.template get<2, 3>() = 13.0;
-  t.template get<3, 0>() = 14.0;
-  t.template get<3, 1>() = 15.0;
-  t.template get<3, 2>() = 16.0;
-  t.template get<3, 3>() = 17.0;
+  get<0, 0>(t) = 2.0;
+  get<0, 1>(t) = 3.0;
+  get<0, 2>(t) = 6.0;
+  get<0, 3>(t) = 11.0;
+  get<1, 0>(t) = 4.0;
+  get<1, 1>(t) = 5.0;
+  get<1, 2>(t) = 7.0;
+  get<1, 3>(t) = 12.0;
+  get<2, 0>(t) = 8.0;
+  get<2, 1>(t) = 9.0;
+  get<2, 2>(t) = 10.0;
+  get<2, 3>(t) = 13.0;
+  get<3, 0>(t) = 14.0;
+  get<3, 1>(t) = 15.0;
+  get<3, 2>(t) = 16.0;
+  get<3, 3>(t) = 17.0;
   const auto det_inv = determinant_and_inverse(t);
   CHECK(det_inv.first.get() == -8.0);
-  CHECK((det_inv.second.template get<0, 0>()) == -4.0);
-  CHECK((det_inv.second.template get<0, 1>()) == 9.0);
-  CHECK((det_inv.second.template get<0, 2>()) == -9.5);
-  CHECK((det_inv.second.template get<0, 3>()) == 3.5);
-  CHECK((det_inv.second.template get<1, 0>()) == 3.25);
-  CHECK((det_inv.second.template get<1, 1>()) == -8.5);
-  CHECK((det_inv.second.template get<1, 2>()) == 10.0);
-  CHECK((det_inv.second.template get<1, 3>()) == -3.75);
-  CHECK((det_inv.second.template get<2, 0>()) == 1.25);
-  CHECK((det_inv.second.template get<2, 1>()) == -1.5);
-  CHECK((det_inv.second.template get<2, 2>()) == 0.0);
-  CHECK((det_inv.second.template get<2, 3>()) == 0.25);
-  CHECK((det_inv.second.template get<3, 0>()) == -0.75);
-  CHECK((det_inv.second.template get<3, 1>()) == 1.5);
-  CHECK((det_inv.second.template get<3, 2>()) == -1.0);
-  CHECK((det_inv.second.template get<3, 3>()) == 0.25);
+  CHECK((get<0, 0>(det_inv.second)) == -4.0);
+  CHECK((get<0, 1>(det_inv.second)) == 9.0);
+  CHECK((get<0, 2>(det_inv.second)) == -9.5);
+  CHECK((get<0, 3>(det_inv.second)) == 3.5);
+  CHECK((get<1, 0>(det_inv.second)) == 3.25);
+  CHECK((get<1, 1>(det_inv.second)) == -8.5);
+  CHECK((get<1, 2>(det_inv.second)) == 10.0);
+  CHECK((get<1, 3>(det_inv.second)) == -3.75);
+  CHECK((get<2, 0>(det_inv.second)) == 1.25);
+  CHECK((get<2, 1>(det_inv.second)) == -1.5);
+  CHECK((get<2, 2>(det_inv.second)) == 0.0);
+  CHECK((get<2, 3>(det_inv.second)) == 0.25);
+  CHECK((get<3, 0>(det_inv.second)) == -0.75);
+  CHECK((get<3, 1>(det_inv.second)) == 1.5);
+  CHECK((get<3, 2>(det_inv.second)) == -1.0);
+  CHECK((get<3, 3>(det_inv.second)) == 0.25);
 }
 
 template <typename TensorType>
 void verify_det_and_inv_symmetric_2d() {
   TensorType t{};
-  t.template get<0, 0>() = 2.0;
-  t.template get<0, 1>() = 3.0;
-  t.template get<1, 1>() = 5.0;
+  get<0, 0>(t) = 2.0;
+  get<0, 1>(t) = 3.0;
+  get<1, 1>(t) = 5.0;
   const auto det_inv = determinant_and_inverse(t);
   CHECK(det_inv.first.get() == 1.0);
-  CHECK((det_inv.second.template get<0, 0>()) == 5.0);
-  CHECK((det_inv.second.template get<0, 1>()) == -3.0);
-  CHECK((det_inv.second.template get<1, 0>()) == -3.0);
-  CHECK((det_inv.second.template get<1, 1>()) == 2.0);
+  CHECK((get<0, 0>(det_inv.second)) == 5.0);
+  CHECK((get<0, 1>(det_inv.second)) == -3.0);
+  CHECK((get<1, 0>(det_inv.second)) == -3.0);
+  CHECK((get<1, 1>(det_inv.second)) == 2.0);
 }
 
 template <typename TensorType>
 void verify_det_and_inv_symmetric_3d() {
   TensorType t{};
-  t.template get<0, 0>() = 2.0;
-  t.template get<0, 1>() = 3.0;
-  t.template get<0, 2>() = 6.0;
-  t.template get<1, 1>() = 5.0;
-  t.template get<1, 2>() = 7.0;
-  t.template get<2, 2>() = 10.0;
+  get<0, 0>(t) = 2.0;
+  get<0, 1>(t) = 3.0;
+  get<0, 2>(t) = 6.0;
+  get<1, 1>(t) = 5.0;
+  get<1, 2>(t) = 7.0;
+  get<2, 2>(t) = 10.0;
   const auto det_inv = determinant_and_inverse(t);
   CHECK(det_inv.first.get() == -16.0);
-  CHECK((det_inv.second.template get<0, 0>()) == -0.0625);
-  CHECK((det_inv.second.template get<0, 1>()) == -0.75);
-  CHECK((det_inv.second.template get<0, 2>()) == 0.5625);
-  CHECK((det_inv.second.template get<1, 0>()) == -0.75);
-  CHECK((det_inv.second.template get<1, 1>()) == 1.0);
-  CHECK((det_inv.second.template get<1, 2>()) == -0.25);
-  CHECK((det_inv.second.template get<2, 0>()) == 0.5625);
-  CHECK((det_inv.second.template get<2, 1>()) == -0.25);
-  CHECK((det_inv.second.template get<2, 2>()) == -0.0625);
+  CHECK((get<0, 0>(det_inv.second)) == -0.0625);
+  CHECK((get<0, 1>(det_inv.second)) == -0.75);
+  CHECK((get<0, 2>(det_inv.second)) == 0.5625);
+  CHECK((get<1, 0>(det_inv.second)) == -0.75);
+  CHECK((get<1, 1>(det_inv.second)) == 1.0);
+  CHECK((get<1, 2>(det_inv.second)) == -0.25);
+  CHECK((get<2, 0>(det_inv.second)) == 0.5625);
+  CHECK((get<2, 1>(det_inv.second)) == -0.25);
+  CHECK((get<2, 2>(det_inv.second)) == -0.0625);
 }
 
 template <typename TensorType>
 void verify_det_and_inv_symmetric_4d() {
   TensorType t{};
-  t.template get<0, 0>() = 2.0;
-  t.template get<0, 1>() = 3.0;
-  t.template get<0, 2>() = 6.0;
-  t.template get<0, 3>() = 11.0;
-  t.template get<1, 1>() = 5.0;
-  t.template get<1, 2>() = 7.0;
-  t.template get<1, 3>() = 12.0;
-  t.template get<2, 2>() = 10.0;
-  t.template get<2, 3>() = 13.0;
-  t.template get<3, 3>() = 17.0;
+  get<0, 0>(t) = 2.0;
+  get<0, 1>(t) = 3.0;
+  get<0, 2>(t) = 6.0;
+  get<0, 3>(t) = 11.0;
+  get<1, 1>(t) = 5.0;
+  get<1, 2>(t) = 7.0;
+  get<1, 3>(t) = 12.0;
+  get<2, 2>(t) = 10.0;
+  get<2, 3>(t) = 13.0;
+  get<3, 3>(t) = 17.0;
   const auto det_inv = determinant_and_inverse(t);
   CHECK(det_inv.first.get() == -100.0);
-  CHECK((det_inv.second.template get<0, 0>()) == approx(0.84));
-  CHECK((det_inv.second.template get<0, 1>()) == approx(-0.94));
-  CHECK((det_inv.second.template get<0, 2>()) == approx(-0.34));
-  CHECK((det_inv.second.template get<0, 3>()) == approx(0.38));
-  CHECK((det_inv.second.template get<1, 0>()) == approx(-0.94));
-  CHECK((det_inv.second.template get<1, 1>()) == approx(1.04));
-  CHECK((det_inv.second.template get<1, 2>()) == approx(-0.06));
-  CHECK((det_inv.second.template get<1, 3>()) == approx(-0.08));
-  CHECK((det_inv.second.template get<2, 0>()) == approx(-0.34));
-  CHECK((det_inv.second.template get<2, 1>()) == approx(-0.06));
-  CHECK((det_inv.second.template get<2, 2>()) == approx(0.84));
-  CHECK((det_inv.second.template get<2, 3>()) == approx(-0.38));
-  CHECK((det_inv.second.template get<3, 0>()) == approx(0.38));
-  CHECK((det_inv.second.template get<3, 1>()) == approx(-0.08));
-  CHECK((det_inv.second.template get<3, 2>()) == approx(-0.38));
-  CHECK((det_inv.second.template get<3, 3>()) == approx(0.16));
+  CHECK((get<0, 0>(det_inv.second)) == approx(0.84));
+  CHECK((get<0, 1>(det_inv.second)) == approx(-0.94));
+  CHECK((get<0, 2>(det_inv.second)) == approx(-0.34));
+  CHECK((get<0, 3>(det_inv.second)) == approx(0.38));
+  CHECK((get<1, 0>(det_inv.second)) == approx(-0.94));
+  CHECK((get<1, 1>(det_inv.second)) == approx(1.04));
+  CHECK((get<1, 2>(det_inv.second)) == approx(-0.06));
+  CHECK((get<1, 3>(det_inv.second)) == approx(-0.08));
+  CHECK((get<2, 0>(det_inv.second)) == approx(-0.34));
+  CHECK((get<2, 1>(det_inv.second)) == approx(-0.06));
+  CHECK((get<2, 2>(det_inv.second)) == approx(0.84));
+  CHECK((get<2, 3>(det_inv.second)) == approx(-0.38));
+  CHECK((get<3, 0>(det_inv.second)) == approx(0.38));
+  CHECK((get<3, 1>(det_inv.second)) == approx(-0.08));
+  CHECK((get<3, 2>(det_inv.second)) == approx(-0.38));
+  CHECK((get<3, 3>(det_inv.second)) == approx(0.16));
 }
 }  // namespace
 
@@ -231,19 +231,15 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DeterminantAndInverse",
   // Check paired determinant and inverse for a Tensor<DataVector>.
   {
     tnsr::ij<DataVector, 2, Frame::Grid> t{};
-    t.template get<0, 0>() = DataVector({2.0, 3.0, 5.0, 1.0});
-    t.template get<0, 1>() = DataVector({3.0, 5.0, 4.0, -1.0});
-    t.template get<1, 0>() = DataVector({4.0, 2.0, 2.0, 1.0});
-    t.template get<1, 1>() = DataVector({5.0, 3.0, 2.0, 1.0});
+    get<0, 0>(t) = DataVector({2.0, 3.0, 5.0, 1.0});
+    get<0, 1>(t) = DataVector({3.0, 5.0, 4.0, -1.0});
+    get<1, 0>(t) = DataVector({4.0, 2.0, 2.0, 1.0});
+    get<1, 1>(t) = DataVector({5.0, 3.0, 2.0, 1.0});
     const auto det_inv = determinant_and_inverse(t);
     CHECK(det_inv.first.get() == DataVector({-2.0, -1.0, 2.0, 2.0}));
-    CHECK((det_inv.second.template get<0, 0>()) ==
-          DataVector({-2.5, -3.0, 1.0, 0.5}));
-    CHECK((det_inv.second.template get<0, 1>()) ==
-          DataVector({1.5, 5.0, -2.0, 0.5}));
-    CHECK((det_inv.second.template get<1, 0>()) ==
-          DataVector({2.0, 2.0, -1.0, -0.5}));
-    CHECK((det_inv.second.template get<1, 1>()) ==
-          DataVector({-1.0, -3.0, 2.5, 0.5}));
+    CHECK((get<0, 0>(det_inv.second)) == DataVector({-2.5, -3.0, 1.0, 0.5}));
+    CHECK((get<0, 1>(det_inv.second)) == DataVector({1.5, 5.0, -2.0, 0.5}));
+    CHECK((get<1, 0>(det_inv.second)) == DataVector({2.0, 2.0, -1.0, -0.5}));
+    CHECK((get<1, 1>(det_inv.second)) == DataVector({-1.0, -3.0, 2.5, 0.5}));
   }
 }

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_DivideBy.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_DivideBy.cpp
@@ -22,7 +22,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
       one_d_covector{{{two}}};
   const auto normalized_one_d_covector = divide_by(one_d_covector, two);
   for (size_t s = 0; s < npts; ++s) {
-    CHECK(normalized_one_d_covector.get<0>()[s] == 1.0);
+    CHECK(get<0>(normalized_one_d_covector)[s] == 1.0);
   }
 
   const Tensor<DataVector, Symmetry<1>,
@@ -30,8 +30,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
       two_d_vector{{{three, four}}};
   const auto normalized_two_d_vector = divide_by(two_d_vector, five);
   for (size_t s = 0; s < npts; ++s) {
-    CHECK(normalized_two_d_vector.get<0>()[s] == 0.6);
-    CHECK(normalized_two_d_vector.get<1>()[s] == 0.8);
+    CHECK(get<0>(normalized_two_d_vector)[s] == 0.6);
+    CHECK(get<1>(normalized_two_d_vector)[s] == 0.8);
   }
 
   const Tensor<DataVector, Symmetry<1>,
@@ -40,8 +40,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
   const auto normalized_two_d_spatial_vector =
       divide_by(two_d_spatial_vector, thirteen);
   for (size_t s = 0; s < npts; ++s) {
-    CHECK(normalized_two_d_spatial_vector.get<0>()[s] == 5.0 / 13.0);
-    CHECK(normalized_two_d_spatial_vector.get<1>()[s] == 12.0 / 13.0);
+    CHECK(get<0>(normalized_two_d_spatial_vector)[s] == 5.0 / 13.0);
+    CHECK(get<1>(normalized_two_d_spatial_vector)[s] == 12.0 / 13.0);
   }
 
   const Tensor<DataVector, Symmetry<1>,
@@ -50,9 +50,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
   const auto normalized_three_d_covector =
       divide_by(three_d_covector, thirteen);
   for (size_t s = 0; s < npts; ++s) {
-    CHECK(normalized_three_d_covector.get<0>()[s] == 3.0 / 13.0);
-    CHECK(normalized_three_d_covector.get<1>()[s] == 12.0 / 13.0);
-    CHECK(normalized_three_d_covector.get<2>()[s] == 4.0 / 13.0);
+    CHECK(get<0>(normalized_three_d_covector)[s] == 3.0 / 13.0);
+    CHECK(get<1>(normalized_three_d_covector)[s] == 12.0 / 13.0);
+    CHECK(get<2>(normalized_three_d_covector)[s] == 4.0 / 13.0);
   }
 
   const Tensor<DataVector, Symmetry<1>,
@@ -60,10 +60,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
       five_d_covector{{{two, twelve, four, one, two}}};
   const auto normalized_five_d_covector = divide_by(five_d_covector, thirteen);
   for (size_t s = 0; s < npts; ++s) {
-    CHECK(normalized_five_d_covector.get<0>()[s] == 2.0 / 13.0);
-    CHECK(normalized_five_d_covector.get<1>()[s] == 12.0 / 13.0);
-    CHECK(normalized_five_d_covector.get<2>()[s] == 4.0 / 13.0);
-    CHECK(normalized_five_d_covector.get<3>()[s] == 1.0 / 13.0);
-    CHECK(normalized_five_d_covector.get<4>()[s] == 2.0 / 13.0);
+    CHECK(get<0>(normalized_five_d_covector)[s] == 2.0 / 13.0);
+    CHECK(get<1>(normalized_five_d_covector)[s] == 12.0 / 13.0);
+    CHECK(get<2>(normalized_five_d_covector)[s] == 4.0 / 13.0);
+    CHECK(get<3>(normalized_five_d_covector)[s] == 1.0 / 13.0);
+    CHECK(get<4>(normalized_five_d_covector)[s] == 2.0 / 13.0);
   }
 }

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
@@ -87,7 +87,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
     const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector{{{two}}};
     const tnsr::II<DataVector, 1, Frame::Grid> inv_h = [&four]() {
       tnsr::II<DataVector, 1, Frame::Grid> tensor;
-      tensor.template get<0, 0>() = four;
+      get<0, 0>(tensor) = four;
       return tensor;
     }();
 
@@ -100,12 +100,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
     const tnsr::II<DataVector, 3, Frame::Grid> inv_g =
         [&two, &minus_three, &four, &minus_five, &twelve, &thirteen]() {
           tnsr::II<DataVector, 3, Frame::Grid> tensor;
-          tensor.get<0, 0>() = two;
-          tensor.get<0, 1>() = minus_three;
-          tensor.get<0, 2>() = four;
-          tensor.get<1, 1>() = minus_five;
-          tensor.get<1, 2>() = twelve;
-          tensor.get<2, 2>() = thirteen;
+          get<0, 0>(tensor) = two;
+          get<0, 1>(tensor) = minus_three;
+          get<0, 2>(tensor) = four;
+          get<1, 1>(tensor) = minus_five;
+          get<1, 2>(tensor) = twelve;
+          get<2, 2>(tensor) = thirteen;
           return tensor;
         }();
     const DataVector magnitude_three_d_covector =
@@ -120,7 +120,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
     const tnsr::i<double, 1, Frame::Grid> one_d_covector{2};
     const tnsr::II<double, 1, Frame::Grid> inv_h = []() {
       tnsr::II<double, 1, Frame::Grid> tensor{};
-      tensor.template get<0, 0>() = 4.;
+      get<0, 0>(tensor) = 4.;
       return tensor;
     }();
 
@@ -129,12 +129,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
     const tnsr::i<double, 3, Frame::Grid> three_d_covector{{{-3, 12, 4}}};
     const tnsr::II<double, 3, Frame::Grid> inv_g = []() {
       tnsr::II<double, 3, Frame::Grid> tensor{};
-      tensor.get<0, 0>() = 2;
-      tensor.get<0, 1>() = -3;
-      tensor.get<0, 2>() = 4;
-      tensor.get<1, 1>() = -5;
-      tensor.get<1, 2>() = 12;
-      tensor.get<2, 2>() = 13;
+      get<0, 0>(tensor) = 2;
+      get<0, 1>(tensor) = -3;
+      get<0, 2>(tensor) = 4;
+      get<1, 1>(tensor) = -5;
+      get<1, 2>(tensor) = 12;
+      get<2, 2>(tensor) = 13;
       return tensor;
     }();
     CHECK(magnitude(three_d_covector, inv_g) == sqrt(778.0));

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -632,12 +632,12 @@ auto multiply_variables_by_two(
       out_vars(vars.number_of_grid_points(), 2.0);
   get<test_databox_tags::ScalarTag4>(out_vars).get() *=
       get<test_databox_tags::ScalarTag>(vars).get();
-  get<test_databox_tags::VectorTag4>(out_vars).get<0>() *=
-      get<test_databox_tags::VectorTag>(vars).get<0>();
-  get<test_databox_tags::VectorTag4>(out_vars).get<1>() *=
-      get<test_databox_tags::VectorTag>(vars).get<1>();
-  get<test_databox_tags::VectorTag4>(out_vars).get<2>() *=
-      get<test_databox_tags::VectorTag>(vars).get<2>();
+  get<0>(get<test_databox_tags::VectorTag4>(out_vars)) *=
+      get<0>(get<test_databox_tags::VectorTag>(vars));
+  get<1>(get<test_databox_tags::VectorTag4>(out_vars)) *=
+      get<1>(get<test_databox_tags::VectorTag>(vars));
+  get<2>(get<test_databox_tags::VectorTag4>(out_vars)) *=
+      get<2>(get<test_databox_tags::VectorTag>(vars));
   return out_vars;
 }
 }  // namespace
@@ -912,9 +912,9 @@ struct test_databox_mutate_apply {
                     const gsl::not_null<tnsr::I<DataVector, 3>*> vector,
                     const std::string& tag2) {
     scalar->get() *= 2.0;
-    vector->template get<0>() *= 3.0;
-    vector->template get<1>() *= 4.0;
-    vector->template get<2>() *= 5.0;
+    get<0>(*vector) *= 3.0;
+    get<1>(*vector) *= 4.0;
+    get<2>(*vector) *= 5.0;
     CHECK(tag2 == "My Sample String"s);
   }
 };
@@ -968,9 +968,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_apply",
          const gsl::not_null<tnsr::I<DataVector, 3>*> vector,
          const std::string& tag2) {
         scalar->get() *= 2.0;
-        vector->template get<0>() *= 3.0;
-        vector->template get<1>() *= 4.0;
-        vector->template get<2>() *= 5.0;
+        get<0>(*vector) *= 3.0;
+        get<1>(*vector) *= 4.0;
+        get<2>(*vector) *= 5.0;
         CHECK(tag2 == "My Sample String"s);
       },
       box);
@@ -995,9 +995,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_apply",
              vars,
          const std::string& tag2) {
         get<test_databox_tags::ScalarTag>(*vars).get() *= 2.0;
-        get<test_databox_tags::VectorTag>(*vars).template get<0>() *= 3.0;
-        get<test_databox_tags::VectorTag>(*vars).template get<1>() *= 4.0;
-        get<test_databox_tags::VectorTag>(*vars).template get<2>() *= 5.0;
+        get<0>(get<test_databox_tags::VectorTag>(*vars)) *= 3.0;
+        get<1>(get<test_databox_tags::VectorTag>(*vars)) *= 4.0;
+        get<2>(get<test_databox_tags::VectorTag>(*vars)) *= 5.0;
         CHECK(tag2 == "My Sample String"s);
       },
       box);

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -29,44 +29,44 @@ namespace test_databox_tags {
 /// [databox_tag_example]
 struct Tag0 : db::DataBoxTag {
   using type = double;
-  static constexpr db::DataBoxString_t label = "Tag0";
+  static constexpr db::DataBoxString label = "Tag0";
 };
 /// [databox_tag_example]
 struct Tag1 : db::DataBoxTag {
   using type = std::vector<double>;
-  static constexpr db::DataBoxString_t label = "Tag1";
+  static constexpr db::DataBoxString label = "Tag1";
 };
 struct Tag2 : db::DataBoxTag {
   using type = std::string;
-  static constexpr db::DataBoxString_t label = "Tag2";
+  static constexpr db::DataBoxString label = "Tag2";
 };
 struct Tag3 : db::DataBoxTag {
   using type = std::string;
-  static constexpr db::DataBoxString_t label = "Tag3";
+  static constexpr db::DataBoxString label = "Tag3";
 };
 
 /// [databox_compute_item_tag_example]
 struct ComputeTag0 : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "ComputeTag0";
+  static constexpr db::DataBoxString label = "ComputeTag0";
   static constexpr auto function = multiply_by_two;
   using argument_tags = typelist<Tag0>;
 };
 /// [databox_compute_item_tag_example]
 struct ComputeTag1 : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "ComputeTag1";
+  static constexpr db::DataBoxString label = "ComputeTag1";
   static constexpr auto function = append_word;
   using argument_tags = typelist<Tag2, ComputeTag0>;
 };
 
 struct TagTensor : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "TagTensor";
+  static constexpr db::DataBoxString label = "TagTensor";
   static constexpr auto function = get_tensor;
   using argument_tags = typelist<>;
 };
 
 /// [compute_item_tag_function]
 struct ComputeLambda0 : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "ComputeLambda0";
+  static constexpr db::DataBoxString label = "ComputeLambda0";
   static constexpr double function(const double a) { return 3.0 * a; }
   using argument_tags = typelist<Tag0>;
 };
@@ -74,7 +74,7 @@ struct ComputeLambda0 : db::ComputeItemTag {
 
 /// [compute_item_tag_no_tags]
 struct ComputeLambda1 : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "ComputeLambda1";
+  static constexpr db::DataBoxString label = "ComputeLambda1";
   static constexpr double function() { return 7.0; }
   using argument_tags = typelist<>;
 };
@@ -85,7 +85,7 @@ template <typename Tag>
 struct TagPrefix : db::DataBoxPrefix {
   using type = typename Tag::type;
   using tag = Tag;
-  static constexpr db::DataBoxString_t label = "TagPrefix";
+  static constexpr db::DataBoxString label = "TagPrefix";
 };
 /// [databox_prefix_tag_example]
 }  // namespace test_databox_tags
@@ -519,14 +519,14 @@ namespace {
 auto get_vector() { return tnsr::I<DataVector, 3, Frame::Grid>(5_st, 2.0); }
 
 struct Var1 : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "Var1";
+  static constexpr db::DataBoxString label = "Var1";
   static constexpr auto function = get_vector;
   using argument_tags = typelist<>;
 };
 
 struct Var2 : db::DataBoxTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "Var2";
+  static constexpr db::DataBoxString label = "Var2";
 };
 
 using two_vars = typelist<Var1, Var2>;
@@ -563,35 +563,35 @@ static_assert(cpp17::is_same_v<
 namespace test_databox_tags {
 struct ScalarTag : db::DataBoxTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "ScalarTag";
+  static constexpr db::DataBoxString label = "ScalarTag";
 };
 struct VectorTag : db::DataBoxTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::DataBoxString_t label = "VectorTag";
+  static constexpr db::DataBoxString label = "VectorTag";
 };
 struct ScalarTag2 : db::DataBoxTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "ScalarTag2";
+  static constexpr db::DataBoxString label = "ScalarTag2";
 };
 struct VectorTag2 : db::DataBoxTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::DataBoxString_t label = "VectorTag2";
+  static constexpr db::DataBoxString label = "VectorTag2";
 };
 struct ScalarTag3 : db::DataBoxTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "ScalarTag3";
+  static constexpr db::DataBoxString label = "ScalarTag3";
 };
 struct VectorTag3 : db::DataBoxTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::DataBoxString_t label = "VectorTag3";
+  static constexpr db::DataBoxString label = "VectorTag3";
 };
 struct ScalarTag4 : db::DataBoxTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "ScalarTag4";
+  static constexpr db::DataBoxString label = "ScalarTag4";
 };
 struct VectorTag4 : db::DataBoxTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::DataBoxString_t label = "VectorTag4";
+  static constexpr db::DataBoxString label = "VectorTag4";
 };
 }  // namespace test_databox_tags
 
@@ -646,37 +646,37 @@ namespace test_databox_tags {
 struct MultiplyScalarByTwo : db::ComputeItemTag {
   using variables_tags =
       tmpl::list<test_databox_tags::ScalarTag2, test_databox_tags::VectorTag2>;
-  static constexpr db::DataBoxString_t label = "MultiplyScalarByTwo";
+  static constexpr db::DataBoxString label = "MultiplyScalarByTwo";
   static constexpr auto function = multiply_scalar_by_two;
   using argument_tags = typelist<test_databox_tags::ScalarTag>;
 };
 
 struct MultiplyScalarByFour : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "MultiplyScalarByFour";
+  static constexpr db::DataBoxString label = "MultiplyScalarByFour";
   static constexpr auto function = multiply_scalar_by_four;
   using argument_tags = typelist<test_databox_tags::ScalarTag2>;
 };
 
 struct MultiplyScalarByThree : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "MultiplyScalarByThree";
+  static constexpr db::DataBoxString label = "MultiplyScalarByThree";
   static constexpr auto function = multiply_scalar_by_three;
   using argument_tags = typelist<test_databox_tags::MultiplyScalarByFour>;
 };
 
 struct DivideScalarByThree : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "DivideScalarByThree";
+  static constexpr db::DataBoxString label = "DivideScalarByThree";
   static constexpr auto function = divide_scalar_by_three;
   using argument_tags = typelist<test_databox_tags::MultiplyScalarByThree>;
 };
 
 struct DivideScalarByTwo : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "DivideScalarByTwo";
+  static constexpr db::DataBoxString label = "DivideScalarByTwo";
   static constexpr auto function = divide_scalar_by_two;
   using argument_tags = typelist<test_databox_tags::DivideScalarByThree>;
 };
 
 struct MultiplyVariablesByTwo : db::ComputeItemTag {
-  static constexpr db::DataBoxString_t label = "MultiplyVariablesByTwo";
+  static constexpr db::DataBoxString label = "MultiplyVariablesByTwo";
   static constexpr auto function = multiply_variables_by_two;
   using argument_tags = typelist<Tags::Variables<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>>;

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -411,9 +411,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.RankAndSize",
     CHECK(spatial_vector3.get(0) == 1);
     CHECK(spatial_vector3.get(1) == 8);
     CHECK(spatial_vector3.get(2) == 3);
-    CHECK(spatial_vector3.get<0>() == 1);
-    CHECK(spatial_vector3.get<1>() == 8);
-    CHECK(spatial_vector3.get<2>() == 3);
+    CHECK(get<0>(spatial_vector3) == 1);
+    CHECK(get<1>(spatial_vector3) == 8);
+    CHECK(get<2>(spatial_vector3) == 3);
   }
 
   {
@@ -428,9 +428,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.RankAndSize",
     CHECK(spatial_vector3.get(0) == 1);
     CHECK(spatial_vector3.get(1) == 8);
     CHECK(spatial_vector3.get(2) == 3);
-    CHECK(spatial_vector3.get<0>() == 1);
-    CHECK(spatial_vector3.get<1>() == 8);
-    CHECK(spatial_vector3.get<2>() == 3);
+    CHECK(get<0>(spatial_vector3) == 1);
+    CHECK(get<1>(spatial_vector3) == 8);
+    CHECK(get<2>(spatial_vector3) == 3);
   }
 
   Tensor<double, Symmetry<3>,

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -16,7 +16,7 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Given a Map and a CoordinateMapBase, checks that the maps are equal by
  * downcasting `map_base` and then comparing to `map`. Returns false if the
  * downcast fails.
@@ -30,7 +30,7 @@ bool are_maps_equal(
   return map_derived == nullptr ? false : (*map_derived == map);
 }
 
-/// \ingroup TestingFramework
+/// \ingroup TestingFrameworkGroup
 /// \brief Given two coordinate maps (but not their types), check that the maps
 /// are equal by evaluating them at a random set of points.
 template <typename SourceFrame, typename TargetFrame, size_t VolumeDim>
@@ -52,7 +52,7 @@ void check_if_maps_are_equal(
 }
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Given a Map `map`, checks that the jacobian gives expected results
  * when compared to the numerical derivative in each direction.
  */
@@ -72,7 +72,7 @@ void test_jacobian(const Map& map,
 }
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Given a Map `map`, checks that the inverse jacobian and jacobian
  * multiply together to produce the identity matrix
  */
@@ -105,7 +105,7 @@ void test_inv_jacobian(const Map& map,
 }
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Checks that the CoordinateMap `map` functions as expected when used as
  * the template parameter to the `CoordinateMap` type.
  */
@@ -149,7 +149,7 @@ void test_coordinate_map_implementation(const Map& map) {
 }
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Checks that the CoordinateMap `map` functions as expected when used
  * with different argument types.
  */
@@ -218,7 +218,7 @@ void test_coordinate_map_argument_types(
 }
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Given a Map `map`, checks that the inverse map gives expected results
  */
 template <typename Map>

--- a/tests/Unit/Domain/CoordinateMaps/Test_AffineMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_AffineMap.cpp
@@ -36,17 +36,14 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Affine", "[Domain][Unit]") {
 
   const double inv_jacobian_00 = (xB - xA) / (xb - xa);
 
-  CHECK((affine_map.inv_jacobian(point_A).template get<0, 0>()) ==
-        inv_jacobian_00);
-  CHECK((affine_map.inv_jacobian(point_B).template get<0, 0>()) ==
-        inv_jacobian_00);
-  CHECK((affine_map.inv_jacobian(point_xi).template get<0, 0>()) ==
-        inv_jacobian_00);
+  CHECK((get<0, 0>(affine_map.inv_jacobian(point_A))) == inv_jacobian_00);
+  CHECK((get<0, 0>(affine_map.inv_jacobian(point_B))) == inv_jacobian_00);
+  CHECK((get<0, 0>(affine_map.inv_jacobian(point_xi))) == inv_jacobian_00);
 
   const double jacobian_00 = (xb - xa) / (xB - xA);
-  CHECK((affine_map.jacobian(point_A).template get<0, 0>()) == jacobian_00);
-  CHECK((affine_map.jacobian(point_B).template get<0, 0>()) == jacobian_00);
-  CHECK((affine_map.jacobian(point_xi).template get<0, 0>()) == jacobian_00);
+  CHECK((get<0, 0>(affine_map.jacobian(point_A))) == jacobian_00);
+  CHECK((get<0, 0>(affine_map.jacobian(point_B))) == jacobian_00);
+  CHECK((get<0, 0>(affine_map.jacobian(point_xi))) == jacobian_00);
 
   // Check inequivalence operator
   CHECK_FALSE(affine_map != affine_map);

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -244,33 +244,31 @@ void test_coordinate_map_with_affine_map() {
         tnsr::I<double, 2, Frame::Logical>{{{-1.0 + 2.0 / i, 0.0 + 2.0 / i}}});
     const auto expected_mapped_point =
         tnsr::I<double, 2, Frame::Grid>{{{4.0 / i + 2.0, 8.0 / i + 0.0}}};
-    CHECK(expected_mapped_point.template get<0>() ==
-          approx(mapped_point.template get<0>()));
-    CHECK(expected_mapped_point.template get<1>() ==
-          approx(mapped_point.template get<1>()));
+    CHECK(get<0>(expected_mapped_point) == approx(get<0>(mapped_point)));
+    CHECK(get<1>(expected_mapped_point) == approx(get<1>(mapped_point)));
 
     const auto inv_mapped_point = prod_map2d.inverse(
         tnsr::I<double, 2, Frame::Grid>{{{4.0 / i + 2.0, 8.0 / i + 0.0}}});
     const auto expected_inv_mapped_point =
         tnsr::I<double, 2, Frame::Grid>{{{-1.0 + 2.0 / i, 0.0 + 2.0 / i}}};
-    CHECK(expected_inv_mapped_point.template get<0>() ==
-          approx(inv_mapped_point.template get<0>()));
-    CHECK(expected_inv_mapped_point.template get<1>() ==
-          approx(inv_mapped_point.template get<1>()));
+    CHECK(get<0>(expected_inv_mapped_point) ==
+          approx(get<0>(inv_mapped_point)));
+    CHECK(get<1>(expected_inv_mapped_point) ==
+          approx(get<1>(inv_mapped_point)));
 
     const auto inv_jac = prod_map2d.inv_jacobian(
         tnsr::I<double, 2, Frame::Logical>{{{-1.0 + 2.0 / i, 0.0 + 2.0 / i}}});
-    CHECK(0.5 == approx(inv_jac.template get<0, 0>()));
-    CHECK(0.0 == approx(inv_jac.template get<1, 0>()));
-    CHECK(0.0 == approx(inv_jac.template get<0, 1>()));
-    CHECK(0.25 == approx(inv_jac.template get<1, 1>()));
+    CHECK(0.5 == approx(get<0, 0>(inv_jac)));
+    CHECK(0.0 == approx(get<1, 0>(inv_jac)));
+    CHECK(0.0 == approx(get<0, 1>(inv_jac)));
+    CHECK(0.25 == approx(get<1, 1>(inv_jac)));
 
     const auto jac = prod_map2d.jacobian(
         tnsr::I<double, 2, Frame::Logical>{{{-1.0 + 2.0 / i, 0.0 + 2.0 / i}}});
-    CHECK(2.0 == approx(jac.template get<0, 0>()));
-    CHECK(0.0 == approx(jac.template get<1, 0>()));
-    CHECK(0.0 == approx(jac.template get<0, 1>()));
-    CHECK(4.0 == approx(jac.template get<1, 1>()));
+    CHECK(2.0 == approx(get<0, 0>(jac)));
+    CHECK(0.0 == approx(get<1, 0>(jac)));
+    CHECK(0.0 == approx(get<0, 1>(jac)));
+    CHECK(4.0 == approx(get<1, 1>(jac)));
   }
 
   // Test 3D
@@ -287,49 +285,46 @@ void test_coordinate_map_with_affine_map() {
         {{-1.0 + 2.0 / i, 0.0 + 2.0 / i, 5.0 + 2.0 / i}}});
     const auto expected_mapped_point = tnsr::I<double, 3, Frame::Grid>{
         {{4.0 / i + 2.0, 8.0 / i + 0.0, 3.0 + 20.0 / i}}};
-    CHECK(expected_mapped_point.template get<0>() ==
-          approx(mapped_point.template get<0>()));
-    CHECK(expected_mapped_point.template get<1>() ==
-          approx(mapped_point.template get<1>()));
-    CHECK(expected_mapped_point.template get<2>() ==
-          approx(mapped_point.template get<2>()));
+    CHECK(get<0>(expected_mapped_point) == approx(get<0>(mapped_point)));
+    CHECK(get<1>(expected_mapped_point) == approx(get<1>(mapped_point)));
+    CHECK(get<2>(expected_mapped_point) == approx(get<2>(mapped_point)));
 
     const auto inv_mapped_point =
         prod_map3d.inverse(tnsr::I<double, 3, Frame::Grid>{
             {{4.0 / i + 2.0, 8.0 / i + 0.0, 3.0 + 20.0 / i}}});
     const auto expected_inv_mapped_point = tnsr::I<double, 3, Frame::Grid>{
         {{-1.0 + 2.0 / i, 0.0 + 2.0 / i, 5.0 + 2.0 / i}}};
-    CHECK(expected_inv_mapped_point.template get<0>() ==
-          approx(inv_mapped_point.template get<0>()));
-    CHECK(expected_inv_mapped_point.template get<1>() ==
-          approx(inv_mapped_point.template get<1>()));
-    CHECK(expected_inv_mapped_point.template get<2>() ==
-          approx(inv_mapped_point.template get<2>()));
+    CHECK(get<0>(expected_inv_mapped_point) ==
+          approx(get<0>(inv_mapped_point)));
+    CHECK(get<1>(expected_inv_mapped_point) ==
+          approx(get<1>(inv_mapped_point)));
+    CHECK(get<2>(expected_inv_mapped_point) ==
+          approx(get<2>(inv_mapped_point)));
 
     const auto inv_jac =
         prod_map3d.inv_jacobian(tnsr::I<double, 3, Frame::Logical>{
             {{-1.0 + 2.0 / i, 0.0 + 2.0 / i, 5.0 + 2.0 / i}}});
-    CHECK(0.5 == approx(inv_jac.template get<0, 0>()));
-    CHECK(0.0 == approx(inv_jac.template get<1, 0>()));
-    CHECK(0.0 == approx(inv_jac.template get<0, 1>()));
-    CHECK(0.25 == approx(inv_jac.template get<1, 1>()));
-    CHECK(0.0 == approx(inv_jac.template get<0, 2>()));
-    CHECK(0.0 == approx(inv_jac.template get<1, 2>()));
-    CHECK(0.0 == approx(inv_jac.template get<2, 0>()));
-    CHECK(0.0 == approx(inv_jac.template get<2, 1>()));
-    CHECK(0.1 == approx(inv_jac.template get<2, 2>()));
+    CHECK(0.5 == approx(get<0, 0>(inv_jac)));
+    CHECK(0.0 == approx(get<1, 0>(inv_jac)));
+    CHECK(0.0 == approx(get<0, 1>(inv_jac)));
+    CHECK(0.25 == approx(get<1, 1>(inv_jac)));
+    CHECK(0.0 == approx(get<0, 2>(inv_jac)));
+    CHECK(0.0 == approx(get<1, 2>(inv_jac)));
+    CHECK(0.0 == approx(get<2, 0>(inv_jac)));
+    CHECK(0.0 == approx(get<2, 1>(inv_jac)));
+    CHECK(0.1 == approx(get<2, 2>(inv_jac)));
 
     const auto jac = prod_map3d.jacobian(tnsr::I<double, 3, Frame::Logical>{
         {{-1.0 + 2.0 / i, 0.0 + 2.0 / i, 5.0 + 2.0 / i}}});
-    CHECK(2.0 == approx(jac.template get<0, 0>()));
-    CHECK(0.0 == approx(jac.template get<1, 0>()));
-    CHECK(0.0 == approx(jac.template get<0, 1>()));
-    CHECK(4.0 == approx(jac.template get<1, 1>()));
-    CHECK(0.0 == approx(jac.template get<0, 2>()));
-    CHECK(0.0 == approx(jac.template get<1, 2>()));
-    CHECK(0.0 == approx(jac.template get<2, 0>()));
-    CHECK(0.0 == approx(jac.template get<2, 1>()));
-    CHECK(10.0 == approx(jac.template get<2, 2>()));
+    CHECK(2.0 == approx(get<0, 0>(jac)));
+    CHECK(0.0 == approx(get<1, 0>(jac)));
+    CHECK(0.0 == approx(get<0, 1>(jac)));
+    CHECK(4.0 == approx(get<1, 1>(jac)));
+    CHECK(0.0 == approx(get<0, 2>(jac)));
+    CHECK(0.0 == approx(get<1, 2>(jac)));
+    CHECK(0.0 == approx(get<2, 0>(jac)));
+    CHECK(0.0 == approx(get<2, 1>(jac)));
+    CHECK(10.0 == approx(get<2, 2>(jac)));
   }
 }
 

--- a/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
@@ -39,16 +39,16 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Rotation<2>", "[Domain][Unit]") {
   CHECK(half_pi_rotation_map.inverse(x2)[1] == approx(xi2[1]));
 
   const auto inv_jac = half_pi_rotation_map.inv_jacobian(xi2);
-  CHECK((inv_jac.template get<0, 0>()) == approx(0.0));
-  CHECK((inv_jac.template get<0, 1>()) == approx(1.0));
-  CHECK((inv_jac.template get<1, 0>()) == approx(-1.0));
-  CHECK((inv_jac.template get<1, 1>()) == approx(0.0));
+  CHECK((get<0, 0>(inv_jac)) == approx(0.0));
+  CHECK((get<0, 1>(inv_jac)) == approx(1.0));
+  CHECK((get<1, 0>(inv_jac)) == approx(-1.0));
+  CHECK((get<1, 1>(inv_jac)) == approx(0.0));
 
   const auto jac = half_pi_rotation_map.jacobian(xi2);
-  CHECK((jac.template get<0, 0>()) == approx(0.0));
-  CHECK((jac.template get<0, 1>()) == approx(-1.0));
-  CHECK((jac.template get<1, 0>()) == approx(1.0));
-  CHECK((jac.template get<1, 1>()) == approx(0.0));
+  CHECK((get<0, 0>(jac)) == approx(0.0));
+  CHECK((get<0, 1>(jac)) == approx(-1.0));
+  CHECK((get<1, 0>(jac)) == approx(1.0));
+  CHECK((get<1, 1>(jac)) == approx(0.0));
 
   // Check inequivalence operator
   CHECK_FALSE(half_pi_rotation_map != half_pi_rotation_map);

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -611,11 +611,11 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeFile2D", "[Unit][IO][H5]") {
   CHECK(3.8 == h5::get_time(file_id, "/[0][0]"));
   h5::detail::OpenGroup group(file_id, "/[0][0]", h5::AccessType::ReadOnly);
   CHECK(extents == h5::read_extents<dim>(group.id(), "Extents"));
-  CHECK(grid_coords.get<0>() == h5::read_data(group.id(), "x-coord"));
-  CHECK(grid_coords.get<1>() == h5::read_data(group.id(), "y-coord"));
+  CHECK(get<0>(grid_coords) == h5::read_data(group.id(), "x-coord"));
+  CHECK(get<1>(grid_coords) == h5::read_data(group.id(), "y-coord"));
   CHECK(scalar.get() == h5::read_data(group.id(), "scalar"));
-  CHECK(vector.get<0>() == h5::read_data(group.id(), "vector_x"));
-  CHECK(vector.get<1>() == h5::read_data(group.id(), "vector_y"));
+  CHECK(get<0>(vector) == h5::read_data(group.id(), "vector_x"));
+  CHECK(get<1>(vector) == h5::read_data(group.id(), "vector_y"));
   CHECK_H5(H5Fclose(file_id), "Failed to close file: '" << file_name << "'");
 }
 
@@ -654,12 +654,12 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeFile3D", "[Unit][IO][H5]") {
   CHECK(3.8 == h5::get_time(file_id, "/[0][0]"));
   h5::detail::OpenGroup group(file_id, "/[0][0]", h5::AccessType::ReadOnly);
   CHECK(extents == h5::read_extents<dim>(group.id(), "Extents"));
-  CHECK(grid_coords.get<0>() == h5::read_data(group.id(), "x-coord"));
-  CHECK(grid_coords.get<1>() == h5::read_data(group.id(), "y-coord"));
-  CHECK(grid_coords.get<2>() == h5::read_data(group.id(), "z-coord"));
+  CHECK(get<0>(grid_coords) == h5::read_data(group.id(), "x-coord"));
+  CHECK(get<1>(grid_coords) == h5::read_data(group.id(), "y-coord"));
+  CHECK(get<2>(grid_coords) == h5::read_data(group.id(), "z-coord"));
   CHECK(scalar.get() == h5::read_data(group.id(), "scalar"));
-  CHECK(vector.get<0>() == h5::read_data(group.id(), "vector_x"));
-  CHECK(vector.get<1>() == h5::read_data(group.id(), "vector_y"));
-  CHECK(vector.get<2>() == h5::read_data(group.id(), "vector_z"));
+  CHECK(get<0>(vector) == h5::read_data(group.id(), "vector_x"));
+  CHECK(get<1>(vector) == h5::read_data(group.id(), "vector_y"));
+  CHECK(get<2>(vector) == h5::read_data(group.id(), "vector_z"));
   CHECK_H5(H5Fclose(file_id), "Failed to close file: '" << file_name << "'");
 }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -42,8 +42,8 @@ struct System {
     static auto apply(const Variables<tmpl::list<Var>>& value) noexcept {
       using flux_tag = Tags::Flux<Var, tmpl::size_t<2>, Frame::Grid>;
       Variables<tmpl::list<flux_tag>> result(value.number_of_grid_points());
-      get<flux_tag>(result).get<0>() = 10. * value;
-      get<flux_tag>(result).get<1>() = 20. * value;
+      get<0>(get<flux_tag>(result)) = 10. * value;
+      get<1>(get<flux_tag>(result)) = 20. * value;
       return result;
     }
   };

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -27,7 +27,7 @@
 
 namespace {
 struct Var : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "Var";
+  static constexpr db::DataBoxString label = "Var";
   using type = Scalar<DataVector>;
 };
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -23,7 +23,7 @@ namespace {
 template <size_t Dim>
 struct Var1 : db::DataBoxTag {
   using type = tnsr::i<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString_t label = "Vector_t";
+  static constexpr db::DataBoxString label = "Vector_t";
   static auto f(const std::array<size_t, Dim>& coeffs,
                 const tnsr::I<DataVector, Dim, Frame::Grid>& x) {
     tnsr::i<DataVector, Dim, Frame::Grid> result(x.begin()->size(), 0.);
@@ -61,7 +61,7 @@ struct Var1 : db::DataBoxTag {
 
 struct Var2 : db::DataBoxTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "Scalar_t";
+  static constexpr db::DataBoxString label = "Scalar_t";
   template <size_t Dim>
   static auto f(const std::array<size_t, Dim>& coeffs,
                 const tnsr::I<DataVector, Dim, Frame::Grid>& x) {

--- a/tests/Unit/Options/Test_CustomTypeConstruction.cpp
+++ b/tests/Unit/Options/Test_CustomTypeConstruction.cpp
@@ -16,7 +16,7 @@ template <typename>
 class CreateFromOptions;
 struct CFO {
   using type = CreateFromOptions<int>;
-  static constexpr OptionString_t help = {"help"};
+  static constexpr OptionString help = {"help"};
 };
 
 template <typename T>
@@ -24,10 +24,10 @@ class CreateFromOptions {
  public:
   struct Option {
     using type = std::string;
-    static constexpr OptionString_t help = {"Option help text"};
+    static constexpr OptionString help = {"Option help text"};
   };
   using options = tmpl::list<Option>;
-  static constexpr OptionString_t help = {"Class help text"};
+  static constexpr OptionString help = {"Class help text"};
 
   CreateFromOptions() = default;
   // The OptionContext argument can be left off if unneeded.
@@ -79,7 +79,7 @@ enum class CreateFromOptionsAnimal { Cat, Dog };
 
 struct CFOAnimal {
   using type = CreateFromOptionsAnimal;
-  static constexpr OptionString_t help = {"Option help text"};
+  static constexpr OptionString help = {"Option help text"};
 };
 }  // namespace
 

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -22,7 +22,7 @@ class TestWithArg;
 /// [factory_example]
 struct OptionType {
   using type = std::unique_ptr<OptionTest>;
-  static constexpr OptionString_t help = {"The type of OptionTest"};
+  static constexpr OptionString help = {"The type of OptionTest"};
 };
 
 class OptionTest {
@@ -42,7 +42,7 @@ class OptionTest {
 class Test1 : public OptionTest {
  public:
   using options = tmpl::list<>;
-  static constexpr OptionString_t help = {"A derived class"};
+  static constexpr OptionString help = {"A derived class"};
   Test1() = default;
 
   std::string name() const override { return "Test1"; }
@@ -52,7 +52,7 @@ class Test1 : public OptionTest {
 class Test2 : public OptionTest {
  public:
   using options = tmpl::list<>;
-  static constexpr OptionString_t help = {""};
+  static constexpr OptionString help = {""};
   Test2() = default;
 
   std::string name() const override { return "Test2"; }
@@ -62,10 +62,10 @@ class TestWithArg : public OptionTest {
  public:
   struct Arg {
     using type = std::string;
-    static constexpr OptionString_t help = {"halp"};
+    static constexpr OptionString help = {"halp"};
   };
   using options = tmpl::list<Arg>;
-  static constexpr OptionString_t help = {""};
+  static constexpr OptionString help = {""};
   TestWithArg() = default;
   explicit TestWithArg(std::string arg) : arg_(std::move(arg)) {}
 
@@ -77,12 +77,12 @@ class TestWithArg : public OptionTest {
 
 struct Vector {
   using type = std::vector<std::unique_ptr<OptionTest>>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 
 struct Map {
   using type = std::map<std::string, std::unique_ptr<OptionTest>>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 }  // namespace
 

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -46,7 +46,7 @@ SPECTRE_TEST_CASE("Unit.Options.syntax_error", "[Unit][Options]") {
 namespace {
 struct Simple {
   using type = int;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 }  // namespace
 
@@ -96,7 +96,7 @@ namespace {
 /// [options_example_scalar_struct]
 struct Bounded {
   using type = int;
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
     "Option with bounds and a default value"};
   // These are optional
   static type default_value() { return 3; }
@@ -153,7 +153,7 @@ SPECTRE_TEST_CASE("Unit.Options.Bounded.above", "[Unit][Options]") {
 namespace {
 struct BadDefault {
   using type = int;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
   static type default_value() { return 3; }
   static type lower_bound() { return 4; }
 };
@@ -172,7 +172,7 @@ namespace {
 /// [options_example_vector_struct]
 struct Vector {
   using type = std::vector<int>;
-  static constexpr OptionString_t help = {"A vector with length limits"};
+  static constexpr OptionString help = {"A vector with length limits"};
   // These are optional
   static size_t lower_bound_on_size() { return 2; }
   static size_t upper_bound_on_size() { return 5; }
@@ -222,7 +222,7 @@ SPECTRE_TEST_CASE("Unit.Options.Vector.empty_too_short", "[Unit][Options]") {
 namespace {
 struct Array {
   using type = std::array<int, 3>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 }  // namespace
 
@@ -276,7 +276,7 @@ SPECTRE_TEST_CASE("Unit.Options.Array.missing", "[Unit][Options]") {
 namespace {
 struct ZeroArray {
   using type = std::array<int, 0>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 }  // namespace
 
@@ -289,7 +289,7 @@ SPECTRE_TEST_CASE("Unit.Options.ZeroArray.missing", "[Unit][Options]") {
 namespace {
 struct Map {
   using type = std::map<std::string, int>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 }  // namespace
 
@@ -332,7 +332,7 @@ SPECTRE_TEST_CASE("Unit.Options.Map.invalid_entry", "[Unit][Options]") {
 namespace {
 struct UnorderedMap {
   using type = std::unordered_map<std::string, int>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 }  // namespace
 
@@ -383,27 +383,27 @@ struct create_from_yaml<Wrapped<T>> {
 namespace {
 struct WrapMap {
   using type = std::map<Wrapped<int>, Wrapped<std::string>>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 struct WrapVector {
   using type = std::vector<Wrapped<int>>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 struct WrapList {
   using type = std::list<Wrapped<int>>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 struct WrapArray {
   using type = std::array<Wrapped<int>, 2>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 struct WrapPair {
   using type = std::pair<Wrapped<int>, Wrapped<std::string>>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 struct WrapUnorderedMap {
   using type = std::unordered_map<Wrapped<int>, Wrapped<std::string>>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 }  // namespace
 
@@ -433,13 +433,13 @@ namespace {
 struct A {
   struct Duplicate {
     using type = int;
-    static constexpr OptionString_t help = {"halp"};
+    static constexpr OptionString help = {"halp"};
   };
 };
 struct B {
   struct Duplicate {
     using type = int;
-    static constexpr OptionString_t help = {"halp"};
+    static constexpr OptionString help = {"halp"};
   };
 };
 }  // namespace
@@ -456,15 +456,15 @@ struct B {
 namespace {
 struct TooooooooooooooooooooLong {
   using type = int;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 struct NoHelp {
   using type = int;
-  static constexpr OptionString_t help = {""};
+  static constexpr OptionString help = {""};
 };
 struct TooLongHelp {
   using type = int;
-  static constexpr OptionString_t help = {
+  static constexpr OptionString help = {
     "halp halp halp halp halp halp halp halp halp halp halp halp"};
 };
 }  // namespace
@@ -500,15 +500,15 @@ struct TooLongHelp {
 namespace {
 struct Apply1 {
   using type = int;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 struct Apply2 {
   using type = std::string;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 struct Apply3 {
   using type = std::vector<int>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 }  // namespace
 

--- a/tests/Unit/Parallel/ParallelTestTentacles.hpp
+++ b/tests/Unit/Parallel/ParallelTestTentacles.hpp
@@ -23,7 +23,7 @@ struct CreatableNonCopyable {
   ~CreatableNonCopyable() = default;
 
   using options = tmpl::list<>;
-  static constexpr OptionString_t help{""};
+  static constexpr OptionString help{""};
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& /*p*/) {}  // NOLINT
@@ -42,13 +42,13 @@ namespace Options {
 // all have to have default values.
 struct Integer {
   using type = int;
-  static constexpr OptionString_t help{"halp"};
+  static constexpr OptionString help{"halp"};
   static type default_value() { return 7; }
 };
 
 struct NonCopyable {
   using type = MainTestObjects::CreatableNonCopyable;
-  static constexpr OptionString_t help{"halp"};
+  static constexpr OptionString help{"halp"};
   static type default_value() { return {}; }
 };
 }  // namespace Options

--- a/tests/Unit/Parallel/Test_Algorithm.cpp
+++ b/tests/Unit/Parallel/Test_Algorithm.cpp
@@ -49,22 +49,22 @@ struct ElementId {};
 /// \endcond
 
 struct CountActionsCalled : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "CountActionsCalled";
+  static constexpr db::DataBoxString label = "CountActionsCalled";
   using type = int;
 };
 
 struct Int0 : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "Int0";
+  static constexpr db::DataBoxString label = "Int0";
   using type = int;
 };
 
 struct Int1 : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "Int1";
+  static constexpr db::DataBoxString label = "Int1";
   using type = int;
 };
 
 struct TemporalId : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "TemporalId";
+  static constexpr db::DataBoxString label = "TemporalId";
   using type = TestAlgorithmArrayInstance;
 };
 }  // namespace

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -22,12 +22,12 @@ struct NodegroupParallelComponent;
 
 namespace Tags {
 struct vector_of_array_indexs : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "vector_of_array_indexs";
+  static constexpr db::DataBoxString label = "vector_of_array_indexs";
   using type = std::vector<int>;
 };
 
 struct total_receives_on_node : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "total_receives_on_node";
+  static constexpr db::DataBoxString label = "total_receives_on_node";
   using type = int;
 };
 }  // namespace Tags

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -17,17 +17,17 @@ static constexpr int number_of_1d_array_elements = 14;
 
 namespace Tags {
 struct Int0 : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "Int0";
+  static constexpr db::DataBoxString label = "Int0";
   using type = int;
 };
 
 struct Int1 : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "Int1";
+  static constexpr db::DataBoxString label = "Int1";
   using type = int;
 };
 
 struct CountActionsCalled : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "CountActionsCalled";
+  static constexpr db::DataBoxString label = "CountActionsCalled";
   using type = int;
 };
 

--- a/tests/Unit/TestFactoryCreation.hpp
+++ b/tests/Unit/TestFactoryCreation.hpp
@@ -17,7 +17,7 @@ struct Opt {
 };
 }  // namespace TestFactoryCreation_detail
 
-/// \ingroup TestingFramework
+/// \ingroup TestingFrameworkGroup
 /// Construct a factory object from a given string.  Each line in the
 /// string must be indented.
 template <typename BaseClass>

--- a/tests/Unit/TestFactoryCreation.hpp
+++ b/tests/Unit/TestFactoryCreation.hpp
@@ -13,7 +13,7 @@ namespace TestFactoryCreation_detail {
 template <typename T>
 struct Opt {
   using type = std::unique_ptr<T>;
-  static constexpr OptionString_t help = {"halp"};
+  static constexpr OptionString help = {"halp"};
 };
 }  // namespace TestFactoryCreation_detail
 

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -22,13 +22,13 @@
 #include "Utilities/TypeTraits.hpp"
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief A replacement for Catch's TEST_CASE that silences clang-tidy warnings
  */
 #define SPECTRE_TEST_CASE(m, n) TEST_CASE(m, n)  // NOLINT
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief A similar to Catch's REQUIRE statement, but can be used in tests that
  * spawn several chares with possibly complex interaction between the chares.
  */
@@ -41,7 +41,7 @@
   } while (false)
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief A similar to Catch's REQUIRE_FALSE statement, but can be used in tests
  * that spawn several chares with possibly complex interaction between the
  * chares.
@@ -55,7 +55,7 @@
   } while (false)
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Set a default tolerance for floating-point number comparison
  *
  * \details
@@ -73,7 +73,7 @@ static Approx approx = Approx::custom().epsilon(    // NOLINT
     std::numeric_limits<double>::epsilon() * 100);  // NOLINT
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief A wrapper around Catch's CHECK macro that checks approximate
  * equality of entries in iterable containers.  For maplike
  * containers, keys are checked for strict equality and values are
@@ -155,7 +155,7 @@ struct check_iterable_approx<
 /// \endcond
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Mark a test as checking a call to ERROR
  *
  * \details
@@ -173,7 +173,7 @@ struct check_iterable_approx<
   } while (false)
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Mark a test to be checking an ASSERT
  *
  * \details
@@ -206,7 +206,7 @@ struct check_iterable_approx<
 #endif
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Serializes and deserializes an object `t` of type `T`
  *
  * \example
@@ -339,7 +339,7 @@ void test_reverse_iterators(Container& c) {
 }
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Function to test comparison operators.  Pass values with
  * less < greater.
  */
@@ -364,7 +364,7 @@ void check_cmp(const T& less, const T& greater) {
 }
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Check a op b == c and also the op= version.
  */
 #define CHECK_OP(a, op, b, c)   \
@@ -379,7 +379,7 @@ void check_cmp(const T& less, const T& greater) {
   } while (false)
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Get the streamed output `c` as a `std::string`
  */
 template <typename Container>
@@ -390,7 +390,7 @@ std::string get_output(const Container& c) {
 }
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Alternative to Catch's CAPTURE that prints more digits.
  */
 #define CAPTURE_PRECISE(variable)                                    \
@@ -398,7 +398,7 @@ std::string get_output(const Container& c) {
                        << (variable));
 
 /*!
- * \ingroup TestingFramework
+ * \ingroup TestingFrameworkGroup
  * \brief Calculates the derivative of an Invocable at a point x - represented
  * by an array of doubles - in the domain of `map` with a sixth-order finite
  * difference method.

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -20,7 +20,7 @@
 
 namespace {
 struct Var : db::DataBoxTag {
-  static constexpr db::DataBoxString_t label = "Var";
+  static constexpr db::DataBoxString label = "Var";
   using type = double;
 };
 


### PR DESCRIPTION
## Proposed changes

Addresses the following:

- Tensor's template get function is now a friend function, similar to get for Variables, DataBox, TaggedTuple, etc.
- Closes #346 (Make DeferredTaggedTuple's get function a friend)
- Closes #328  (Travis runs checks on CheckFiles.sh)
- Silence a Doxygen warning in GH/Equations, and ignore build directories in Doxygen
- Closes #267 (require GCC 5.4 or newer because of a GCC bug)
- Adds parts of #370 (more code review guidelines)
- Closes #353 (All Doxygen groups are named BlahGroup)
- Rename OptionString_t to OptionString
- Rename DataBoxString_t to DataBoxString (closes #323 )
- Make sure all Travis environments are checked to prevent unintentional not running of a test suite.


### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."