### PR TITLE
Additions for evolution

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
     Element.cpp
     ElementId.cpp
     ElementIndex.cpp
+    ElementMap.cpp
     GridNormal.cpp
     InitialElementIds.cpp
     LogicalCoordinates.cpp

--- a/src/Domain/CoordinateMaps/Wedge3D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.cpp
@@ -297,11 +297,12 @@ Wedge3D::inv_jacobian(const std::array<T, 3>& xi) const noexcept {
   return determinant_and_inverse(jacobian(xi)).second;
 }
 
-void Wedge3D::pup(PUP::er& p) {
+void Wedge3D::pup(PUP::er& p) noexcept {
   p | radius_of_other_surface_;
   p | radius_of_spherical_surface_;
   p | direction_of_wedge_;
   p | sphericity_of_other_surface_;
+  p | with_equiangular_map_;
 }
 
 bool operator==(const Wedge3D& lhs, const Wedge3D& rhs) noexcept {
@@ -309,7 +310,9 @@ bool operator==(const Wedge3D& lhs, const Wedge3D& rhs) noexcept {
          lhs.radius_of_spherical_surface_ ==
              rhs.radius_of_spherical_surface_ and
          lhs.direction_of_wedge_ == rhs.direction_of_wedge_ and
-         lhs.sphericity_of_other_surface_ == rhs.sphericity_of_other_surface_;
+         lhs.sphericity_of_other_surface_ ==
+             rhs.sphericity_of_other_surface_ and
+         lhs.with_equiangular_map_ == rhs.with_equiangular_map_;
 }
 
 bool operator!=(const Wedge3D& lhs, const Wedge3D& rhs) noexcept {

--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -222,7 +222,7 @@ class Wedge3D {
   inv_jacobian(const std::array<T, 3>& xi) const noexcept;
 
   // clang-tidy: google runtime references
-  void pup(PUP::er& p);  // NOLINT
+  void pup(PUP::er& p) noexcept;  // NOLINT
 
  private:
   friend bool operator==(const Wedge3D& lhs, const Wedge3D& rhs) noexcept;

--- a/src/Domain/DomainCreators/CMakeLists.txt
+++ b/src/Domain/DomainCreators/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Brick.cpp
   Interval.cpp
   Rectangle.cpp
+  RegisterDerivedWithCharm.cpp
   )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/DomainCreators/Interval.hpp"
+#include "Parallel/CharmPupable.hpp"
+
+namespace DomainCreators {
+namespace DomainCreaters_detail {
+template <size_t Dim>
+void register_with_charm();
+
+template <>
+void register_with_charm<1>() {
+  PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                         CoordinateMaps::AffineMap>));
+}
+
+template <>
+void register_with_charm<2>() {
+  PUPable_reg(
+      SINGLE_ARG(::CoordinateMap<
+                 Frame::Logical, Frame::Inertial,
+                 CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
+                                                CoordinateMaps::AffineMap>>));
+}
+template <>
+void register_with_charm<3>() {
+  PUPable_reg(SINGLE_ARG(
+      ::CoordinateMap<Frame::Logical, Frame::Inertial,
+                      CoordinateMaps::ProductOf3Maps<
+                          CoordinateMaps::AffineMap, CoordinateMaps::AffineMap,
+                          CoordinateMaps::AffineMap>>));
+}
+}  // namespace DomainCreaters_detail
+
+void register_derived_with_charm() {
+  DomainCreaters_detail::register_with_charm<1>();
+  DomainCreaters_detail::register_with_charm<2>();
+  DomainCreaters_detail::register_with_charm<3>();
+}
+}  // namespace DomainCreators

--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.hpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace DomainCreators {
+void register_derived_with_charm();
+}  // namespace DomainCreators

--- a/src/Domain/ElementId.hpp
+++ b/src/Domain/ElementId.hpp
@@ -12,8 +12,12 @@
 
 #include "Domain/SegmentId.hpp"
 #include "ErrorHandling/Assert.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdHelpers.hpp"
+
+template <size_t>
+class ElementIndex;
 
 /// \ingroup ComputationalDomainGroup
 /// An ElementId uniquely labels a Element.
@@ -29,12 +33,15 @@ class ElementId {
   /// Create the ElementId of the root Element of a Block.
   explicit ElementId(size_t block_id) noexcept;
 
+  /// Convert an ElementIndex to an ElementId
+  // clang-tidy: mark explicit: we want to allow conversion
+  ElementId(const ElementIndex<VolumeDim>& index) noexcept;  // NOLINT
+
   /// Create an arbitrary ElementId.
   ElementId(size_t block_id,
-                      std::array<SegmentId, VolumeDim> segment_ids) noexcept;
+            std::array<SegmentId, VolumeDim> segment_ids) noexcept;
 
-  ElementId<VolumeDim> id_of_child(size_t dim, Side side) const
-      noexcept;
+  ElementId<VolumeDim> id_of_child(size_t dim, Side side) const noexcept;
 
   ElementId<VolumeDim> id_of_parent(size_t dim) const noexcept;
 
@@ -45,7 +52,7 @@ class ElementId {
   }
 
   /// Serialization for Charm++
-  void pup(PUP::er& p);  // NOLINT
+  void pup(PUP::er& p) noexcept;  // NOLINT
 
  private:
   size_t block_id_ = std::numeric_limits<size_t>::max();

--- a/src/Domain/ElementIndex.cpp
+++ b/src/Domain/ElementIndex.cpp
@@ -13,14 +13,15 @@
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 
-namespace ElementIndex_detail {
 SegmentIndex::SegmentIndex(size_t block_id,
                            const SegmentId& segment_id) noexcept
-  : block_id_(block_id), refinement_level_(segment_id.refinement_level()),
-    index_(segment_id.index()) {
-  ASSERT(block_id < two_to_the(block_id_bits),
+    : block_id_(block_id),
+      refinement_level_(segment_id.refinement_level()),
+      index_(segment_id.index()) {
+  ASSERT(block_id < two_to_the(ElementIndex_detail::block_id_bits),
          "Block id out of bounds: " << block_id);
-  ASSERT(segment_id.refinement_level() <= max_refinement_level,
+  ASSERT(segment_id.refinement_level() <=
+             ElementIndex_detail::max_refinement_level,
          "Refinement level out of bounds: " << segment_id.refinement_level());
 }
 
@@ -28,18 +29,16 @@ static_assert(std::is_pod<SegmentIndex>::value, "SegmentIndex is not POD");
 static_assert(sizeof(SegmentIndex) == sizeof(int),
               "SegmentIndex does not fit in an int");
 
-std::ostream& operator<<(std::ostream& s,
-                         const SegmentIndex& index) noexcept {
-  return s << '[' << index.block_id_ << ':' << index.refinement_level_ << ':'
-           << index.index_ << ']';
+std::ostream& operator<<(std::ostream& s, const SegmentIndex& index) noexcept {
+  return s << '[' << index.block_id() << ':' << index.refinement_level() << ':'
+           << index.index() << ']';
 }
-}  // namespace ElementIndex_detail
 
 template <size_t VolumeDim>
 ElementIndex<VolumeDim>::ElementIndex(const ElementId<VolumeDim>& id) noexcept {
   for (size_t d = 0; d < VolumeDim; ++d) {
-    gsl::at(segments_, d) = ElementIndex_detail::SegmentIndex(
-        id.block_id(), gsl::at(id.segment_ids(), d));
+    gsl::at(segments_, d) =
+        SegmentIndex(id.block_id(), gsl::at(id.segment_ids(), d));
   }
 }
 
@@ -65,7 +64,7 @@ bool operator==(const ElementIndex<VolumeDim>& a,
 template <size_t VolumeDim>
 bool operator!=(const ElementIndex<VolumeDim>& a,
                 const ElementIndex<VolumeDim>& b) noexcept {
-  return not (a == b);
+  return not(a == b);
 }
 
 template <size_t VolumeDim>
@@ -87,7 +86,7 @@ size_t std::hash<ElementIndex<VolumeDim>>::operator()(
 template <size_t VolumeDim>
 std::ostream& operator<<(std::ostream& s,
                          const ElementIndex<VolumeDim>& index) noexcept {
-  for (const auto si : index.segments_) {
+  for (const auto si : index.segments()) {
     s << si;
   }
   return s;

--- a/src/Domain/ElementMap.cpp
+++ b/src/Domain/ElementMap.cpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/ElementMap.hpp"
+
+/// \cond
+template <size_t Dim, typename TargetFrame>
+ElementMap<Dim, TargetFrame>::ElementMap(
+    ElementId<Dim> element_id,
+    std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, Dim>>
+        block_map) noexcept
+    : block_map_(std::move(block_map)),
+      element_id_(std::move(element_id)),
+      map_slope_{[](const ElementId<Dim>& id) {
+        std::array<double, Dim> result{};
+        for (size_t d = 0; d < Dim; ++d) {
+          gsl::at(result, d) =
+              0.5 * (gsl::at(id.segment_ids(), d).endpoint(Side::Upper) -
+                     gsl::at(id.segment_ids(), d).endpoint(Side::Lower));
+        }
+        return result;
+      }(element_id_)},
+      map_offset_{[](const ElementId<Dim>& id) {
+        std::array<double, Dim> result{};
+        for (size_t d = 0; d < Dim; ++d) {
+          gsl::at(result, d) =
+              0.5 * (gsl::at(id.segment_ids(), d).endpoint(Side::Upper) +
+                     gsl::at(id.segment_ids(), d).endpoint(Side::Lower));
+        }
+        return result;
+      }(element_id_)},
+      map_inverse_slope_{[this]() {
+        std::array<double, Dim> result{};
+        for (size_t d = 0; d < Dim; ++d) {
+          gsl::at(result, d) = 1.0 / gsl::at(this->map_slope_, d);
+        }
+        return result;
+      }()},
+      map_inverse_offset_{[this]() {
+        std::array<double, Dim> result{};
+        for (size_t d = 0; d < Dim; ++d) {
+          gsl::at(result, d) =
+              -gsl::at(this->map_offset_, d) / gsl::at(this->map_slope_, d);
+        }
+        return result;
+      }()},
+      jacobian_{map_slope_},
+      inverse_jacobian_{map_inverse_slope_} {}
+
+template <size_t Dim, typename TargetFrame>
+void ElementMap<Dim, TargetFrame>::pup(PUP::er& p) noexcept {
+  p | block_map_;
+  p | element_id_;
+  p | map_slope_;
+  p | map_offset_;
+  p | map_inverse_slope_;
+  p | map_inverse_offset_;
+  p | jacobian_;
+  p | inverse_jacobian_;
+}
+
+template class ElementMap<1, Frame::Inertial>;
+template class ElementMap<2, Frame::Inertial>;
+template class ElementMap<3, Frame::Inertial>;
+/// \endcond

--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <charm++.h>
+#include <memory>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/ElementId.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief The CoordinateMap for the Element from the Logical frame to the
+ * `TargetFrame`
+ *
+ * An ElementMap takes a CoordinateMap for a Block and an ElementId as input,
+ * and then "prepends" the correct affine map to the CoordinateMap so that the
+ * map corresponds to the coordinate map for the Element rather than the Block.
+ * This allows DomainCreators to only specify the maps for the Blocks without
+ * worrying about how the domain may be decomposed beyond that.
+ */
+template <size_t Dim, typename TargetFrame>
+class ElementMap {
+ public:
+  /// \cond HIDDEN_SYMBOLS
+  ElementMap() = default;
+  /// \endcond
+
+  ElementMap(
+      ElementId<Dim> element_id,
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, Dim>>
+          block_map) noexcept;
+
+  const CoordinateMapBase<Frame::Logical, TargetFrame, Dim>& block_map() const
+      noexcept {
+    return *block_map_;
+  }
+
+  const ElementId<Dim>& element_id() const noexcept { return element_id_; }
+
+  template <typename T>
+  tnsr::I<T, Dim, TargetFrame> operator()(
+      tnsr::I<T, Dim, Frame::Logical> source_point) const noexcept {
+    apply_affine_transformation_to_point(source_point);
+    return block_map_->operator()(source_point);
+  }
+
+  template <typename T>
+  tnsr::I<T, Dim, Frame::Logical> inverse(
+      const tnsr::I<T, Dim, TargetFrame>& target_point) const noexcept {
+    auto source_point{block_map_->inverse(target_point)};
+    // Apply the affine map to the points
+    for (size_t d = 0; d < Dim; ++d) {
+      source_point.get(d) =
+          source_point.get(d) * gsl::at(map_inverse_slope_, d) +
+          gsl::at(map_inverse_offset_, d);
+    }
+    return source_point;
+  }
+
+  template <typename T>
+  Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
+         index_list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
+                    SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>
+  inv_jacobian(tnsr::I<T, Dim, Frame::Logical> source_point) const noexcept {
+    apply_affine_transformation_to_point(source_point);
+    auto inv_jac = block_map_->inv_jacobian(source_point);
+    for (size_t d = 0; d < Dim; ++d) {
+      for (size_t i = 0; i < Dim; ++i) {
+        inv_jac.get(d, i) *= gsl::at(inverse_jacobian_, d);
+      }
+    }
+    return inv_jac;
+  }
+
+  template <typename T>
+  Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
+         index_list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
+                    SpatialIndex<Dim, UpLo::Lo, Frame::Logical>>>
+  jacobian(tnsr::I<T, Dim, Frame::Logical> source_point) const noexcept {
+    apply_affine_transformation_to_point(source_point);
+    auto jac = block_map_->jacobian(source_point);
+    for (size_t d = 0; d < Dim; ++d) {
+      for (size_t i = 0; i < Dim; ++i) {
+        jac.get(i, d) *= gsl::at(jacobian_, d);
+      }
+    }
+    return jac;
+  }
+
+  // clang-tidy: do not use references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  template <typename T>
+  void apply_affine_transformation_to_point(
+      tnsr::I<T, Dim, Frame::Logical>& source_point) const noexcept {
+    for (size_t d = 0; d < Dim; ++d) {
+      source_point.get(d) = source_point.get(d) * gsl::at(map_slope_, d) +
+                            gsl::at(map_offset_, d);
+    }
+  }
+
+  std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, Dim>>
+      block_map_{nullptr};
+  ElementId<Dim> element_id_{};
+  // map_slope_[i] = 0.5 * (segment_ids[i].endpoint(Side::Upper) -
+  //                        segment_ids[i].endpoint(Side::Lower))
+  std::array<double, Dim> map_slope_{
+      make_array<Dim>(std::numeric_limits<double>::signaling_NaN())};
+  // map_offset_[i] = 0.5 * (segment_ids[i].endpoint(Side::Upper) +
+  //                         segment_ids[i].endpoint(Side::Lower))
+  std::array<double, Dim> map_offset_{
+      make_array<Dim>(std::numeric_limits<double>::signaling_NaN())};
+  // map_inverse_slope_[i] = 1.0 / map_slope_[i]
+  std::array<double, Dim> map_inverse_slope_{
+      make_array<Dim>(std::numeric_limits<double>::signaling_NaN())};
+  // map_inverse_offset_[i] = -map_offset_[i] / map_slope_[i]
+  std::array<double, Dim> map_inverse_offset_{
+      make_array<Dim>(std::numeric_limits<double>::signaling_NaN())};
+  // Note: The Jacobian is diagonal
+  std::array<double, Dim> jacobian_{map_slope_};
+  std::array<double, Dim> inverse_jacobian_{map_inverse_slope_};
+};

--- a/src/Domain/InitialElementIds.cpp
+++ b/src/Domain/InitialElementIds.cpp
@@ -3,77 +3,84 @@
 
 #include "Domain/InitialElementIds.hpp"
 
+#include <iterator>
+
 #include "Domain/ElementId.hpp"
 #include "Domain/SegmentId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/MakeArray.hpp"
 
 template <>
-std::vector<ElementId<1>> initial_element_ids(
+std::vector<ElementId<1>> initial_element_ids<1>(
+    const size_t block_id, const std::array<size_t, 1> initial_ref_levs) {
+  std::vector<ElementId<1>> ids;
+  ids.reserve(two_to_the(initial_ref_levs[0]));
+  for (size_t x_i = 0; x_i < two_to_the(initial_ref_levs[0]); ++x_i) {
+    SegmentId x_segment_id(initial_ref_levs[0], x_i);
+    ids.emplace_back(block_id, make_array<1>(x_segment_id));
+  }
+  return ids;
+}
+
+template <>
+std::vector<ElementId<2>> initial_element_ids<2>(
+    const size_t block_id, const std::array<size_t, 2> initial_ref_levs) {
+  std::vector<ElementId<2>> ids;
+  ids.reserve(two_to_the(initial_ref_levs[0]) *
+              two_to_the(initial_ref_levs[1]));
+  for (size_t x_i = 0; x_i < two_to_the(initial_ref_levs[0]); ++x_i) {
+    SegmentId x_segment_id(initial_ref_levs[0], x_i);
+    for (size_t y_i = 0; y_i < two_to_the(initial_ref_levs[1]); ++y_i) {
+      SegmentId y_segment_id(initial_ref_levs[1], y_i);
+      ids.emplace_back(block_id, make_array(x_segment_id, y_segment_id));
+    }
+  }
+  return ids;
+}
+
+template <>
+std::vector<ElementId<3>> initial_element_ids<3>(
+    const size_t block_id, const std::array<size_t, 3> initial_ref_levs) {
+  std::vector<ElementId<3>> ids;
+  ids.reserve(two_to_the(initial_ref_levs[0]) *
+              two_to_the(initial_ref_levs[1]) *
+              two_to_the(initial_ref_levs[2]));
+  for (size_t x_i = 0; x_i < two_to_the(initial_ref_levs[0]); ++x_i) {
+    SegmentId x_segment_id(initial_ref_levs[0], x_i);
+    for (size_t y_i = 0; y_i < two_to_the(initial_ref_levs[1]); ++y_i) {
+      SegmentId y_segment_id(initial_ref_levs[1], y_i);
+      for (size_t z_i = 0; z_i < two_to_the(initial_ref_levs[2]); ++z_i) {
+        SegmentId z_segment_id(initial_ref_levs[2], z_i);
+        ids.emplace_back(block_id,
+                         make_array(x_segment_id, y_segment_id, z_segment_id));
+      }
+    }
+  }
+  return ids;
+}
+
+template <size_t VolumeDim>
+std::vector<ElementId<VolumeDim>> initial_element_ids(
+    const std::vector<std::array<size_t, VolumeDim>>&
+        initial_refinement_levels) noexcept {
+  std::vector<ElementId<VolumeDim>> element_ids;
+  for (size_t block_id = 0; block_id < initial_refinement_levels.size();
+       ++block_id) {
+    auto ids_for_block =
+        initial_element_ids(block_id, initial_refinement_levels[block_id]);
+    element_ids.reserve(element_ids.size() + ids_for_block.size());
+    std::move(ids_for_block.begin(), ids_for_block.end(),
+              std::back_inserter(element_ids));
+  }
+  return element_ids;
+}
+
+template std::vector<ElementId<1>> initial_element_ids<1>(
     const std::vector<std::array<size_t, 1>>&
-        initial_refinement_levels) noexcept {
-  std::vector<ElementId<1>> element_ids;
-  for (size_t block_id = 0; block_id < initial_refinement_levels.size();
-       ++block_id) {
-    const size_t xi_refinement_level = initial_refinement_levels[block_id][0];
-    for (size_t xi_index = 0; xi_index < two_to_the(xi_refinement_level);
-         ++xi_index) {
-      element_ids.emplace_back(
-          block_id, make_array<1>(SegmentId(xi_refinement_level, xi_index)));
-    }
-  }
-  return element_ids;
-}
-
-template <>
-std::vector<ElementId<2>> initial_element_ids(
+        initial_refinement_levels) noexcept;
+template std::vector<ElementId<2>> initial_element_ids<2>(
     const std::vector<std::array<size_t, 2>>&
-        initial_refinement_levels) noexcept {
-  std::vector<ElementId<2>> element_ids;
-  for (size_t block_id = 0; block_id < initial_refinement_levels.size();
-       ++block_id) {
-    const size_t xi_refinement_level = initial_refinement_levels[block_id][0];
-    for (size_t xi_index = 0; xi_index < two_to_the(xi_refinement_level);
-         ++xi_index) {
-      const size_t eta_refinement_level =
-          initial_refinement_levels[block_id][1];
-      for (size_t eta_index = 0; eta_index < two_to_the(eta_refinement_level);
-           ++eta_index) {
-        element_ids.emplace_back(
-            block_id, make_array(SegmentId(xi_refinement_level, xi_index),
-                                 SegmentId(eta_refinement_level, eta_index)));
-      }
-    }
-  }
-  return element_ids;
-}
-
-template <>
-std::vector<ElementId<3>> initial_element_ids(
+        initial_refinement_levels) noexcept;
+template std::vector<ElementId<3>> initial_element_ids<3>(
     const std::vector<std::array<size_t, 3>>&
-        initial_refinement_levels) noexcept {
-  std::vector<ElementId<3>> element_ids;
-  for (size_t block_id = 0; block_id < initial_refinement_levels.size();
-       ++block_id) {
-    const size_t xi_refinement_level = initial_refinement_levels[block_id][0];
-    for (size_t xi_index = 0; xi_index < two_to_the(xi_refinement_level);
-         ++xi_index) {
-      const size_t eta_refinement_level =
-          initial_refinement_levels[block_id][1];
-      for (size_t eta_index = 0; eta_index < two_to_the(eta_refinement_level);
-           ++eta_index) {
-        const size_t zeta_refinement_level =
-            initial_refinement_levels[block_id][2];
-        for (size_t zeta_index = 0;
-             zeta_index < two_to_the(zeta_refinement_level); ++zeta_index) {
-          element_ids.emplace_back(
-              block_id,
-              make_array(SegmentId(xi_refinement_level, xi_index),
-                         SegmentId(eta_refinement_level, eta_index),
-                         SegmentId(zeta_refinement_level, zeta_index)));
-        }
-      }
-    }
-  }
-  return element_ids;
-}
+        initial_refinement_levels) noexcept;

--- a/src/Domain/InitialElementIds.hpp
+++ b/src/Domain/InitialElementIds.hpp
@@ -10,7 +10,13 @@ template <size_t VolumeDim>
 class ElementId;
 
 /// \ingroup ComputationalDomainGroup
-/// \brief Create the ElementIds of the initial computational domain.
+/// \brief Create the `ElementId`s of the a single Block
+template <size_t VolumeDim>
+std::vector<ElementId<VolumeDim>> initial_element_ids(
+    size_t block_id, std::array<size_t, VolumeDim> initial_ref_levs);
+
+/// \ingroup ComputationalDomainGroup
+/// \brief Create the `ElementId`s of the initial computational domain.
 template <size_t VolumeDim>
 std::vector<ElementId<VolumeDim>> initial_element_ids(
     const std::vector<std::array<size_t, VolumeDim>>&

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -23,6 +23,7 @@ set(DOMAIN_TESTS
     Domain/Test_Element.cpp
     Domain/Test_ElementId.cpp
     Domain/Test_ElementIndex.cpp
+    Domain/Test_ElementMap.cpp
     Domain/Test_GridNormal.cpp
     Domain/Test_InitialElementIds.cpp
     Domain/Test_LogicalCoordinates.cpp

--- a/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
@@ -7,6 +7,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Brick.hpp"
+#include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
@@ -169,6 +170,21 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
            {Direction<3>::lower_zeta(), {0, aligned_orientation}},
            {Direction<3>::upper_zeta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<3>>>{{}});
+
+  // Test serialization of the map
+  DomainCreators::register_derived_with_charm();
+
+  const auto base_map =
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          AffineMap3D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
+                      AffineMap{-1., 1., lower_bound[1], upper_bound[1]},
+                      AffineMap{-1., 1., lower_bound[2], upper_bound[2]}});
+  are_maps_equal(
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          AffineMap3D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
+                      AffineMap{-1., 1., lower_bound[1], upper_bound[1]},
+                      AffineMap{-1., 1., lower_bound[2], upper_bound[2]}}),
+      *serialize_and_deserialize(base_map));
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick.Factory",

--- a/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
@@ -6,6 +6,7 @@
 #include "Domain/CoordinateMaps/AffineMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Interval.hpp"
+#include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
@@ -85,6 +86,19 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval", "[Domain][Unit]") {
       refinement_level[0], grid_points[0]};
   test_periodic_interval(periodic_interval, lower_bound, upper_bound,
                          grid_points, refinement_level);
+
+  // Test serialization of the map
+  DomainCreators::register_derived_with_charm();
+  const auto base_map =
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          CoordinateMaps::AffineMap{-1., 1., lower_bound[0], upper_bound[0]});
+  const auto base_map_deserialized = serialize_and_deserialize(base_map);
+  using MapType = const CoordinateMap<Frame::Logical, Frame::Inertial,
+                                      CoordinateMaps::AffineMap>*;
+  REQUIRE(dynamic_cast<MapType>(base_map.get()) != nullptr);
+  const auto coord_map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      CoordinateMaps::AffineMap{-1., 1., lower_bound[0], upper_bound[0]});
+  CHECK(*dynamic_cast<MapType>(base_map.get()) == coord_map);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval.Factory",

--- a/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
@@ -7,6 +7,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Rectangle.hpp"
+#include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
@@ -100,6 +101,22 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
            {Direction<2>::lower_eta(), {0, aligned_orientation}},
            {Direction<2>::upper_eta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<2>>>{{}});
+
+  // Test serialization of the map
+  DomainCreators::register_derived_with_charm();
+
+  const auto base_map =
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          AffineMap2D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
+                      AffineMap{-1., 1., lower_bound[1], upper_bound[1]}});
+  const auto base_map_deserialized = serialize_and_deserialize(base_map);
+  using MapType =
+      const CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap2D>*;
+  REQUIRE(dynamic_cast<MapType>(base_map.get()) != nullptr);
+  const auto coord_map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      AffineMap2D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
+                  AffineMap{-1., 1., lower_bound[1], upper_bound[1]}});
+  CHECK(*dynamic_cast<MapType>(base_map.get()) == coord_map);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle.Factory",

--- a/tests/Unit/Domain/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Test_ElementId.cpp
@@ -4,6 +4,7 @@
 #include <catch.hpp>
 
 #include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
@@ -47,4 +48,27 @@ SPECTRE_TEST_CASE("Unit.Domain.ElementId", "[Domain][Unit]") {
 
   // Test output operator:
   CHECK(get_output(block_2_3d) == "[B2,(L2I3,L1I0,L1I1)]");
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.ElementId.ElementIndexConversion",
+                  "[Domain][Unit]") {
+  auto segment_ids = std::array<SegmentId, 3>(
+      {{SegmentId(2, 3), SegmentId(1, 0), SegmentId(1, 1)}});
+  ElementId<3> block_2_3d(2, segment_ids);
+  CHECK(block_2_3d.block_id() == 2);
+  CHECK(block_2_3d.segment_ids() == segment_ids);
+
+  ElementIndex<3> block_2_3d_index(block_2_3d);
+  CHECK(block_2_3d_index.block_id() == 2);
+  CHECK(block_2_3d_index.segments().size() == segment_ids.size());
+  for (size_t i = 0; i < segment_ids.size(); ++i) {
+    CHECK(gsl::at(block_2_3d_index.segments(), i).block_id() == 2);
+    CHECK(gsl::at(block_2_3d_index.segments(), i).index() ==
+          gsl::at(segment_ids, i).index());
+    CHECK(gsl::at(block_2_3d_index.segments(), i).refinement_level() ==
+          gsl::at(segment_ids, i).refinement_level());
+  }
+  ElementId<3> block_2_3d_from_index(block_2_3d_index);
+  CHECK(block_2_3d_from_index.block_id() == 2);
+  CHECK(block_2_3d_from_index.segment_ids() == segment_ids);
 }

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -1,0 +1,177 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/Rotation.hpp"
+#include "Domain/CoordinateMaps/Wedge2D.hpp"
+#include "Domain/CoordinateMaps/Wedge3D.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+using DV = DataVector;
+
+template <size_t Dim, typename S, typename T, typename U>
+void test_element_impl(
+    bool test_inverse, const ElementId<Dim>& element_id, const S& affine_map,
+    const T& first_map, const U& second_map,
+    const tnsr::I<double, Dim, Frame::Logical>& logical_point_double,
+    const tnsr::I<DV, Dim, Frame::Logical>& logical_point_dv) {
+  PUPable_reg(
+      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, T, U>));
+  const auto composed_map =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          affine_map, first_map, second_map);
+
+  ElementMap<Dim, Frame::Inertial> element_map{
+      element_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+                      first_map, second_map)};
+  ElementMap<Dim, Frame::Inertial> element_map_deserialized =
+      serialize_and_deserialize(element_map);
+
+  CHECK(element_map(logical_point_dv) == composed_map(logical_point_dv));
+  CHECK(element_map(logical_point_double) ==
+        composed_map(logical_point_double));
+  CHECK(element_map_deserialized(logical_point_dv) ==
+        composed_map(logical_point_dv));
+  CHECK(element_map_deserialized(logical_point_double) ==
+        composed_map(logical_point_double));
+
+  const tnsr::I<double, Dim, Frame::Inertial> inertial_point_double =
+      composed_map(logical_point_double);
+  const tnsr::I<DV, Dim, Frame::Inertial> inertial_point_dv =
+      composed_map(logical_point_dv);
+
+  if (test_inverse) {
+    CHECK(element_map.inverse(inertial_point_dv) ==
+          composed_map.inverse(inertial_point_dv));
+    CHECK(element_map.inverse(inertial_point_double) ==
+          composed_map.inverse(inertial_point_double));
+    CHECK(element_map_deserialized.inverse(inertial_point_dv) ==
+          composed_map.inverse(inertial_point_dv));
+    CHECK(element_map_deserialized.inverse(inertial_point_double) ==
+          composed_map.inverse(inertial_point_double));
+  }
+
+  CHECK(element_map.inv_jacobian(logical_point_dv) ==
+        composed_map.inv_jacobian(logical_point_dv));
+  CHECK(element_map.inv_jacobian(logical_point_double) ==
+        composed_map.inv_jacobian(logical_point_double));
+  CHECK(element_map_deserialized.inv_jacobian(logical_point_dv) ==
+        composed_map.inv_jacobian(logical_point_dv));
+  CHECK(element_map_deserialized.inv_jacobian(logical_point_double) ==
+        composed_map.inv_jacobian(logical_point_double));
+
+  CHECK(element_map.inv_jacobian(logical_point_dv) ==
+        composed_map.inv_jacobian(logical_point_dv));
+  CHECK(element_map.jacobian(logical_point_double) ==
+        composed_map.jacobian(logical_point_double));
+  CHECK(element_map_deserialized.inv_jacobian(logical_point_dv) ==
+        composed_map.inv_jacobian(logical_point_dv));
+  CHECK(element_map_deserialized.jacobian(logical_point_double) ==
+        composed_map.jacobian(logical_point_double));
+
+  CHECK(element_map.block_map() ==
+        *(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            first_map, second_map)));
+}
+
+template <size_t Dim>
+void test_element_map();
+
+template <>
+void test_element_map<1>() {
+  using AffineMap = CoordinateMaps::AffineMap;
+
+  auto segment_ids = std::array<SegmentId, 1>({{SegmentId(2, 3)}});
+  ElementId<1> element_id(0, segment_ids);
+  const tnsr::I<double, 1, Frame::Logical> logical_point_double{0.0};
+  const tnsr::I<DV, 1, Frame::Logical> logical_point_dv(
+      DV{-1.0, -0.5, 0.0, 0.5, 1.0});
+
+  const AffineMap affine_map{-1.0, 1.0, 0.5, 1.0};
+  const AffineMap first_map{-1.0, 1.0, 2.0, 8.0};
+
+  // Aligned maps
+  test_element_impl(true, element_id, affine_map, first_map,
+                    AffineMap{2.0, 8.0, -2.0, -1.0}, logical_point_double,
+                    logical_point_dv);
+
+  // Flip axis in second map
+  test_element_impl(true, element_id, affine_map, first_map,
+                    AffineMap{2.0, 8.0, 2.0, -1.0}, logical_point_double,
+                    logical_point_dv);
+}
+
+template <>
+void test_element_map<2>() {
+  using Rotate = CoordinateMaps::Rotation<2>;
+  using Wedge2D = CoordinateMaps::Wedge2D;
+  using AffineMap = CoordinateMaps::AffineMap;
+
+  auto segment_ids =
+      std::array<SegmentId, 2>({{SegmentId(2, 3), SegmentId(1, 0)}});
+  ElementId<2> element_id(0, segment_ids);
+
+  const tnsr::I<double, 2, Frame::Logical> logical_point_double(
+      std::array<double, 2>{{-0.5, 0.5}});
+  const tnsr::I<DV, 2, Frame::Logical> logical_point_dv(std::array<DV, 2>{
+      {DV{-1.0, 0.5, 0.0, 0.5, 1.0}, DV{-1.0, 0.5, 0.0, 0.5, 1.0}}});
+
+  const CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap> affine_map(
+      AffineMap{-1.0, 1.0, 0.5, 1.0}, AffineMap{-1.0, 1.0, -1.0, 0.0});
+  const auto first_map = Rotate(2.);
+
+  // Test with two rotations
+  test_element_impl(true, element_id, affine_map, first_map, Rotate(1.8472),
+                    logical_point_double, logical_point_dv);
+
+  // test with a rotation and a wedge
+  test_element_impl(false, element_id, affine_map, first_map,
+                    Wedge2D(3., 7., Direction<2>::lower_eta()),
+                    logical_point_double, logical_point_dv);
+}
+
+template <>
+void test_element_map<3>() {
+  using Rotate = CoordinateMaps::Rotation<3>;
+  using AffineMap = CoordinateMaps::AffineMap;
+
+  auto segment_ids = std::array<SegmentId, 3>(
+      {{SegmentId(2, 3), SegmentId(1, 0), SegmentId(2, 1)}});
+  ElementId<3> element_id(0, segment_ids);
+
+  const tnsr::I<double, 3, Frame::Logical> logical_point_double{
+      {{0.78, 0.12, -0.37}}};
+  const tnsr::I<DataVector, 3, Frame::Logical> logical_point_dv{
+      {{DV{-1.0, 0.5, 0.0, 0.5, 1.0}, DV{-1.0, 0.5, 0.0, 0.5, 1.0},
+        DV{-1.0, 0.5, 0.0, 0.5, 1.0}}}};
+
+  const CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>
+      affine_map(AffineMap{-1.0, 1.0, 0.5, 1.0},
+                 AffineMap{-1.0, 1.0, -1.0, 0.0},
+                 AffineMap{-1.0, 1.0, -0.5, 0.0});
+  const auto first_map = Rotate{M_PI_4, M_PI_4, M_PI_2};
+
+  // test with 2 rotations
+  test_element_impl(true, element_id, affine_map, first_map,
+                    Rotate{M_PI_2, M_PI_4, M_PI_4}, logical_point_double,
+                    logical_point_dv);
+
+  // test with rotation and wedge
+  test_element_impl(
+      true, element_id, affine_map, first_map,
+      CoordinateMaps::Wedge3D{3.0, 7.0, Direction<3>::lower_eta(), 0.8, true},
+      logical_point_double, logical_point_dv);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.ElementMap", "[Unit][Domain]") {
+  test_element_map<1>();
+  test_element_map<2>();
+  test_element_map<3>();
+}


### PR DESCRIPTION
## Proposed changes

**Note:** Either #377 or this PR will need to be checked to make sure the tensor get function change doesn't break anything.

- Fix two bugs in Wedge3D
- Allow converting between ElementId and ElementIndex
- Provide place to register CoordinateMap classes to be serializable through the base class. Needed for serializing ElementMap
- Add ElementMap, the map that goes from the Logical coordinates to the Grid coordinates in evolutions where there are time dependent maps. For time independent maps it could go straight to the Inertial frame.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."