### PR TITLE
Improve Test_DataVector

### DIFF
--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -48,25 +48,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector", "[DataStructures][Unit]") {
   CHECK(t_move_constructor.is_owning());
 }
 
-SPECTRE_TEST_CASE("Unit.Serialization.DataVector",
-                  "[DataStructures][Unit][Serialization]") {
-  const size_t npts = 10;
-  DataVector t(npts), tgood(npts);
-  std::iota(t.begin(), t.end(), 1.2);
-  std::iota(tgood.begin(), tgood.end(), 1.2);
-  CHECK(tgood == serialize_and_deserialize(t));
-}
-
-SPECTRE_TEST_CASE("Unit.Serialization.DataVector_Ref",
-                  "[DataStructures][Unit][Serialization]") {
-  const size_t npts = 10;
-  DataVector t(npts);
-  std::iota(t.begin(), t.end(), 4.3);
-  DataVector t2;
-  t2.set_data_ref(&t);
-  CHECK(t == serialize_and_deserialize(t2));
-}
-
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector_Ref",
                   "[DataStructures][Unit]") {
   DataVector data{1.43, 2.83, 3.94, 7.85};
@@ -486,4 +467,23 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math_array<DataVector>",
   one_ref = (one_b * one_b);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
+}
+
+SPECTRE_TEST_CASE("Unit.Serialization.DataVector",
+                  "[DataStructures][Unit][Serialization]") {
+  const size_t npts = 10;
+  DataVector t(npts), tgood(npts);
+  std::iota(t.begin(), t.end(), 1.2);
+  std::iota(tgood.begin(), tgood.end(), 1.2);
+  CHECK(tgood == serialize_and_deserialize(t));
+}
+
+SPECTRE_TEST_CASE("Unit.Serialization.DataVector_Ref",
+                  "[DataStructures][Unit][Serialization]") {
+  const size_t npts = 10;
+  DataVector t(npts);
+  std::iota(t.begin(), t.end(), 4.3);
+  DataVector t2;
+  t2.set_data_ref(&t);
+  CHECK(t == serialize_and_deserialize(t2));
 }

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -191,26 +191,26 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
     check_vectors(-nine, DataVector(num_pts, -9.0));
 
     // Test expressions with one DataVector, one double
-    check_vectors(nine + 2.0, DataVector(num_pts, 11.0));
-    check_vectors(2.0 + nine, DataVector(num_pts, 11.0));
-    check_vectors(nine - 2.0, DataVector(num_pts, 7.0));
-    check_vectors(2.0 - nine, DataVector(num_pts, -7.0));
+    check_vectors(DataVector(num_pts, 11.0), nine + 2.0);
+    check_vectors(DataVector(num_pts, 11.0), 2.0 + nine);
+    check_vectors(DataVector(num_pts, 7.0)), nine - 2.0;
+    check_vectors(DataVector(num_pts, -7.0), 2.0 - nine);
     check_vectors(DataVector(num_pts, 81.0), 9.0 * nine);
     check_vectors(DataVector(num_pts, 81.0), nine * 9.0);
     check_vectors(DataVector(num_pts, 1.0), 9.0 / nine);
     check_vectors(DataVector(num_pts, 1.0), nine / 9.0);
 
     // Test expressions with two DataVectors
-    check_vectors(nine + nine, DataVector(num_pts, 18.0));
-    check_vectors(nine - eight, DataVector(num_pts, 1.0));
+    check_vectors(DataVector(num_pts, 18.0), nine + nine);
+    check_vectors(DataVector(num_pts, 1.0), nine - eight;
     check_vectors(DataVector(num_pts, 81.0), nine * nine);
     check_vectors(DataVector(num_pts, -1.0 / 9.0), -one / nine);
 
     // Test more complex expressions
-    check_vectors(nine + (one * nine), DataVector(num_pts, 18.0));
-    check_vectors((one * nine) + nine, DataVector(num_pts, 18.0));
-    check_vectors(nine - (one * nine), DataVector(num_pts, 0.0));
-    check_vectors((one * nine) - nine, DataVector(num_pts, 0.0));
+    check_vectors(DataVector(num_pts, 18.0), nine + (one * nine));
+    check_vectors(DataVector(num_pts, 18.0), (one * nine) + nine);
+    check_vectors(DataVector(num_pts, 0.0)), nine - (one * nine);
+    check_vectors(DataVector(num_pts, 0.0)), (one * nine) - nine;
     check_vectors(DataVector(num_pts, -8.0 / 9.0), -(nine - one) / nine);
     check_vectors(DataVector(num_pts, 18.0), (one / 0.5) * nine);
     check_vectors(DataVector(num_pts, 1.0), (one * 9.0) / nine);
@@ -221,10 +221,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
     check_vectors(DataVector(num_pts, 9.0), (one * nine) / one);
 
     // Test powers
-    check_vectors(sqrt(nine), DataVector(num_pts, 3.0));
-    check_vectors(invsqrt(nine), DataVector(num_pts, 1.0 / 3.0));
-    check_vectors(cbrt(eight), DataVector(num_pts, 2.0));
-    check_vectors(invcbrt(eight), DataVector(num_pts, 0.5));
+    check_vectors(DataVector(num_pts, 3.0), sqrt(nine));
+    check_vectors(DataVector(num_pts, 1.0 / 3.0), invsqrt(nin));
+    check_vectors(DataVector(num_pts, 2.0), cbrt(eight));
+    check_vectors(DataVector(num_pts, 0.5), invcbrt(eight));
     check_vectors(DataVector(num_pts, 81.0), pow(nine, 2));
 
     check_vectors(DataVector(num_pts, 81.0), pow<2>(nine));
@@ -267,8 +267,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
     check_vectors(DataVector(num_pts, erf(0.9)), erf(point_nine));
     check_vectors(DataVector(num_pts, erfc(0.9)), erfc(point_nine));
 
-    check_vectors(step_function(DataVector{-12.3, 2.0, -4.0, 0.0, 7.0, -8.0}),
-                  DataVector{0.0, 1.0, 0.0, 1.0, 1.0, 0.0});
+    check_vectors(DataVector{0.0, 1.0, 0.0, 1.0, 1.0, 0.0},
+                  step_function(DataVector{-12.3, 2.0, -4.0, 0.0, 7.0, -8.0}));
   }
 
   // Test composition of constant expressions with DataVector math member
@@ -402,13 +402,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.MathAfterMove",
     CHECK(a.is_owning());
     CHECK(b.size() == 10);
     CHECK(b.is_owning());
-    check_vectors(b, DataVector(10, 2.0));
+    check_vectors(DataVector(10, 2.0), b);
     b = m0 + m1;
     CHECK(a.size() == 0);  // NOLINT
-    check_vectors(b, DataVector(10, 12.0));
+    check_vectors(DataVector(10, 12.0), b);
     a = m0 * m1;
-    check_vectors(a, DataVector(10, 27.0));
-    check_vectors(b, DataVector(10, 12.0));
+    check_vectors(DataVector(10, 27.0), a);
+    check_vectors(DataVector(10, 12.0), b);
   }
 
   // Test math after a move constructor
@@ -420,13 +420,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.MathAfterMove",
     CHECK(a.is_owning());
     CHECK(b.size() == 10);
     CHECK(b.is_owning());
-    check_vectors(b, DataVector(10, 2.0));
+    check_vectors(DataVector(10, 2.0), b);
     b = m0 + m1;
     CHECK(a.size() == 0);  // NOLINT
-    check_vectors(b, DataVector(10, 12.0));
+    check_vectors(DataVector(10, 12.0), b);
     a = m0 * m1;
-    check_vectors(a, DataVector(10, 27.0));
-    check_vectors(b, DataVector(10, 12.0));
+    check_vectors(DataVector(10, 27.0), a);
+    check_vectors(DataVector(10, 12.0), b);
   }
 }
 

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -173,52 +173,44 @@ void check_vectors(const T1& t1, const T2& t2) {
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.MathAfterMove",
                   "[Unit][DataStructures]") {
-  DataVector m0(10, 3.0), m1(10, 9.0);
+  const DataVector m0(10, 3.0);
+  const DataVector m1(10, 9.0);
+  // Test math after a move assignment
   {
     DataVector a(10, 2.0);
     DataVector b{};
     b = std::move(a);
-    b = m0 + m1;
-    check_vectors(b, DataVector(10, 12.0));
     // clang-tidy: use after move (intentional here)
     CHECK(a.size() == 0);  // NOLINT
     CHECK(a.is_owning());
-    a = m0 * m1;
-    check_vectors(a, DataVector(10, 27.0));
-    check_vectors(b, DataVector(10, 12.0));
-  }
-
-  {
-    DataVector a(10, 2.0);
-    DataVector b{};
-    b = std::move(a);
-    a = m0 + m1;
-    check_vectors(b, DataVector(10, 2.0));
-    check_vectors(a, DataVector(10, 12.0));
-  }
-
-  {
-    DataVector a(10, 2.0);
-    DataVector b{std::move(a)};
-    b = m0 + m1;
     CHECK(b.size() == 10);
-    check_vectors(b, DataVector(10, 12.0));
-    // clang-tidy: use after move (intentional here)
+    CHECK(b.is_owning());
+    check_vectors(b, DataVector(10, 2.0));
+    b = m0 + m1;
     CHECK(a.size() == 0);  // NOLINT
-    CHECK(a.is_owning());
+    check_vectors(b, DataVector(10, 12.0));
     a = m0 * m1;
     check_vectors(a, DataVector(10, 27.0));
     check_vectors(b, DataVector(10, 12.0));
   }
 
+  // Test math after a move constructor
   {
     DataVector a(10, 2.0);
     DataVector b{std::move(a)};
-    a = m0 + m1;
+    // clang-tidy: use after move (intentional here)
+    CHECK(a.size() == 0);  // NOLINT
+    CHECK(a.is_owning());
+    CHECK(b.size() == 10);
+    CHECK(b.is_owning());
     check_vectors(b, DataVector(10, 2.0));
-    check_vectors(a, DataVector(10, 12.0));
+    b = m0 + m1;
+    CHECK(a.size() == 0);  // NOLINT
+    check_vectors(b, DataVector(10, 12.0));
+    a = m0 * m1;
+    check_vectors(a, DataVector(10, 27.0));
+    check_vectors(b, DataVector(10, 12.0));
   }
-}
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
                   "[Unit][DataStructures]") {

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -171,6 +171,223 @@ void check_vectors(const T1& t1, const T2& t2) {
 }
 }  // namespace
 
+SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
+                  "[Unit][DataStructures]") {
+  // Test min/max/abs
+  {
+    const DataVector val{1., 2., 3., -4., 8., 12., -14.};
+    CHECK(-14. == min(val));
+    CHECK(12. == max(val));
+    check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, abs(val));
+    check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, fabs(val));
+  }
+
+  constexpr size_t num_pts = 19;
+  DataVector one(num_pts, 1.0);
+  DataVector eight(num_pts, 8.0);
+  DataVector nine(num_pts, 9.0);
+  {
+    // Test unary minus
+    check_vectors(-nine, DataVector(num_pts, -9.0));
+
+    // Test expressions with one DataVector, one double
+    check_vectors(nine + 2.0, DataVector(num_pts, 11.0));
+    check_vectors(2.0 + nine, DataVector(num_pts, 11.0));
+    check_vectors(nine - 2.0, DataVector(num_pts, 7.0));
+    check_vectors(2.0 - nine, DataVector(num_pts, -7.0));
+    check_vectors(DataVector(num_pts, 81.0), 9.0 * nine);
+    check_vectors(DataVector(num_pts, 81.0), nine * 9.0);
+    check_vectors(DataVector(num_pts, 1.0), 9.0 / nine);
+    check_vectors(DataVector(num_pts, 1.0), nine / 9.0);
+
+    // Test expressions with two DataVectors
+    check_vectors(nine + nine, DataVector(num_pts, 18.0));
+    check_vectors(nine - eight, DataVector(num_pts, 1.0));
+    check_vectors(DataVector(num_pts, 81.0), nine * nine);
+    check_vectors(DataVector(num_pts, -1.0 / 9.0), -one / nine);
+
+    // Test more complex expressions
+    check_vectors(nine + (one * nine), DataVector(num_pts, 18.0));
+    check_vectors((one * nine) + nine, DataVector(num_pts, 18.0));
+    check_vectors(nine - (one * nine), DataVector(num_pts, 0.0));
+    check_vectors((one * nine) - nine, DataVector(num_pts, 0.0));
+    check_vectors(DataVector(num_pts, -8.0 / 9.0), -(nine - one) / nine);
+    check_vectors(DataVector(num_pts, 18.0), (one / 0.5) * nine);
+    check_vectors(DataVector(num_pts, 1.0), (one * 9.0) / nine);
+
+    check_vectors(DataVector(num_pts, 81.0), nine * (nine * one));
+    check_vectors(DataVector(num_pts, 81.0), (nine * nine) * one);
+    check_vectors(DataVector(num_pts, 1.0), nine / (one * 9.0));
+    check_vectors(DataVector(num_pts, 9.0), (one * nine) / one);
+
+    // Test powers
+    check_vectors(sqrt(nine), DataVector(num_pts, 3.0));
+    check_vectors(invsqrt(nine), DataVector(num_pts, 1.0 / 3.0));
+    check_vectors(cbrt(eight), DataVector(num_pts, 2.0));
+    check_vectors(invcbrt(eight), DataVector(num_pts, 0.5));
+    check_vectors(DataVector(num_pts, 81.0), pow(nine, 2));
+
+    check_vectors(DataVector(num_pts, 81.0), pow<2>(nine));
+    check_vectors(DataVector(num_pts, 81.0), pow<2>(nine * one));
+    check_vectors(DataVector(num_pts, 1.0 / 81.0),
+                  DataVector(num_pts, 1.0) / pow<2>(nine));
+
+    // Test exp/log
+    check_vectors(DataVector(num_pts, exp(9.0)), exp(nine));
+    check_vectors(DataVector(num_pts, exp2(9.0)), exp2(nine));
+    check_vectors(DataVector(num_pts, pow<9>(10.0)), DataVector(exp10(nine)));
+    check_vectors(DataVector(num_pts, log(9.0)), log(nine));
+    check_vectors(DataVector(num_pts, log2(9.0)), log2(nine));
+    check_vectors(DataVector(num_pts, log10(9.0)), log10(nine));
+
+    // Test trig and other special functions
+    DataVector point_nine(num_pts, 0.9);
+    check_vectors(DataVector(num_pts, sin(9.0)), sin(nine));
+    check_vectors(DataVector(num_pts, cos(9.0)), cos(nine));
+    check_vectors(DataVector(num_pts, tan(9.0)), tan(nine));
+    check_vectors(DataVector(num_pts, asin(0.9)), asin(point_nine));
+    check_vectors(DataVector(num_pts, acos(0.9)), acos(point_nine));
+    check_vectors(DataVector(num_pts, atan(0.9)), atan(point_nine));
+    check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
+                  atan2(point_nine, nine));
+    check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
+                  atan2(point_nine * one, nine));
+    check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
+                  atan2(point_nine, nine * one));
+    check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
+                  atan2(point_nine * one, nine * one));
+
+    check_vectors(DataVector(num_pts, sinh(9.0)), sinh(nine));
+    check_vectors(DataVector(num_pts, cosh(9.0)), cosh(nine));
+    check_vectors(DataVector(num_pts, tanh(9.0)), tanh(nine));
+    check_vectors(DataVector(num_pts, asinh(9.0)), asinh(nine));
+    check_vectors(DataVector(num_pts, acosh(9.0)), acosh(nine));
+    check_vectors(DataVector(num_pts, atanh(0.9)), atanh(point_nine));
+
+    check_vectors(DataVector(num_pts, erf(0.9)), erf(point_nine));
+    check_vectors(DataVector(num_pts, erfc(0.9)), erfc(point_nine));
+
+    check_vectors(step_function(DataVector{-12.3, 2.0, -4.0, 0.0, 7.0, -8.0}),
+                  DataVector{0.0, 1.0, 0.0, 1.0, 1.0, 0.0});
+  }
+
+  // Test composition of constant expressions with DataVector math member
+  // functions
+  {
+    DataVector x(num_pts, 2.);
+    check_vectors(DataVector(num_pts, 0.82682181043180603), square(sin(x)));
+    check_vectors(DataVector(num_pts, -0.072067555747765299), cube(cos(x)));
+  }
+
+  // Test assignment
+  {
+    DataVector test_81(num_pts, -1.0);
+    test_81 = nine * nine;
+    check_vectors(DataVector(num_pts, 81.0), test_81);
+    CHECK(test_81.is_owning());
+  }
+
+  // Test assignment with various RHS's
+  {
+    DataVector test_assignment(num_pts, 7.0);
+    test_assignment += nine;
+    check_vectors(DataVector(num_pts, 16.0), test_assignment);
+    test_assignment += 3.0;
+    check_vectors(DataVector(num_pts, 19.0), test_assignment);
+    test_assignment += (nine * nine);
+    check_vectors(DataVector(num_pts, 100.0), test_assignment);
+
+    test_assignment = 7.0;
+    test_assignment -= nine;
+    check_vectors(DataVector(num_pts, -2.0), test_assignment);
+    test_assignment -= 3.0;
+    check_vectors(DataVector(num_pts, -5.0), test_assignment);
+    test_assignment -= nine * nine;
+    check_vectors(DataVector(num_pts, -86.0), test_assignment);
+
+    test_assignment = 2.0;
+    test_assignment *= 3.0;
+    check_vectors(DataVector(num_pts, 6.0), test_assignment);
+    test_assignment *= nine;
+    check_vectors(DataVector(num_pts, 54.0), test_assignment);
+    test_assignment = 1.0;
+    test_assignment *= nine * nine;
+    check_vectors(DataVector(num_pts, 81.0), test_assignment);
+
+    test_assignment = 2.0;
+    test_assignment /= 2.0;
+    check_vectors(DataVector(num_pts, 1.0), test_assignment);
+    test_assignment /= DataVector(num_pts, 0.5);
+    check_vectors(DataVector(num_pts, 2.0), test_assignment);
+    test_assignment /= (DataVector(num_pts, 2.0) * DataVector(num_pts, 3.0));
+    check_vectors(DataVector(num_pts, 1.0 / 3.0), test_assignment);
+  }
+
+  // Test assignment where the RHS is an expression that contains the LHS
+  {
+    DataVector x(num_pts, 4.);
+    x += sqrt(x);
+    check_vectors(DataVector(num_pts, 6.0), x);
+    x -= sqrt(x - 2.0);
+    check_vectors(DataVector(num_pts, 4.0), x);
+    x = sqrt(x);
+    check_vectors(DataVector(num_pts, 2.0), x);
+    x *= x;
+    check_vectors(DataVector(num_pts, 4.0), x);
+    x /= x;
+    check_vectors(DataVector(num_pts, 1.0), x);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math_Ref",
+                  "[Unit][DataStructures]") {
+  constexpr size_t num_pts = 19;
+  DataVector nine(num_pts, 9.0);
+  DataVector t(num_pts, -1.0);
+
+  // Test expressions with reference DataVectors
+  DataVector t_ref(t.data(), t.size());
+  t_ref = 0.0;
+  CHECK(t.is_owning());
+  CHECK_FALSE(t_ref.is_owning());
+  check_vectors(DataVector(num_pts, 0.0), t);
+  check_vectors(DataVector(num_pts, 0.0), t_ref);
+  t = 1.0;
+  CHECK(t.is_owning());
+  CHECK_FALSE(t_ref.is_owning());
+  check_vectors(DataVector(num_pts, 1.0), t);
+  check_vectors(DataVector(num_pts, 1.0), t_ref);
+  t_ref = nine * nine;
+  CHECK(t.is_owning());
+  CHECK_FALSE(t_ref.is_owning());
+  check_vectors(DataVector(num_pts, 81.0), t);
+  check_vectors(DataVector(num_pts, 81.0), t_ref);
+  t = nine + nine;
+  CHECK(t.is_owning());
+  CHECK_FALSE(t_ref.is_owning());
+  check_vectors(DataVector(num_pts, 18.0), t);
+  check_vectors(DataVector(num_pts, 18.0), t_ref);
+
+  DataVector t_refref(t_ref.data(), t_ref.size());
+  CHECK_FALSE(t_refref.is_owning());
+  check_vectors(DataVector(num_pts, 18.0), t_refref);
+  t_ref -= nine;
+  CHECK(t.is_owning());
+  CHECK_FALSE(t_ref.is_owning());
+  CHECK_FALSE(t_refref.is_owning());
+  check_vectors(DataVector(num_pts, 9.0), t);
+  check_vectors(DataVector(num_pts, 9.0), t_ref);
+  check_vectors(DataVector(num_pts, 9.0), t_refref);
+  t_refref = square(nine);
+  check_vectors(DataVector(num_pts, 81.0), t);
+  check_vectors(DataVector(num_pts, 81.0), t_ref);
+  check_vectors(DataVector(num_pts, 81.0), t_refref);
+  t = sqrt(t_ref);
+  check_vectors(DataVector(num_pts, 9.0), t);
+  check_vectors(DataVector(num_pts, 9.0), t_ref);
+  check_vectors(DataVector(num_pts, 9.0), t_refref);
+}
+
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.MathAfterMove",
                   "[Unit][DataStructures]") {
   const DataVector m0(10, 3.0);
@@ -211,189 +428,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.MathAfterMove",
     check_vectors(a, DataVector(10, 27.0));
     check_vectors(b, DataVector(10, 12.0));
   }
-
-SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
-                  "[Unit][DataStructures]") {
-  constexpr size_t num_pts = 19;
-  DataVector val{1., 2., 3., -4., 8., 12., -14.};
-  DataVector nine(num_pts, 9.0);
-  DataVector one(num_pts, 1.0);
-
-  // Test unary minus
-  check_vectors(-nine, DataVector(num_pts, -9.0));
-
-  check_vectors(nine + 2.0, DataVector(num_pts, 11.0));
-  check_vectors(2.0 + nine, DataVector(num_pts, 11.0));
-  check_vectors(nine - 2.0, DataVector(num_pts, 7.0));
-  check_vectors(2.0 - nine, DataVector(num_pts, -7.0));
-  check_vectors(nine + nine, DataVector(num_pts, 18.0));
-  check_vectors(nine + (one * nine), DataVector(num_pts, 18.0));
-  check_vectors((one * nine) + nine, DataVector(num_pts, 18.0));
-  check_vectors(nine - DataVector(num_pts, 8.0), DataVector(num_pts, 1.0));
-  check_vectors(nine - (one * nine), DataVector(num_pts, 0.0));
-  check_vectors((one * nine) - nine, DataVector(num_pts, 0.0));
-
-  check_vectors(DataVector(num_pts, -1.0 / 9.0), -one / nine);
-  check_vectors(DataVector(num_pts, -8.0 / 9.0), -(nine - one) / nine);
-  check_vectors(DataVector(num_pts, 18.0), (one / 0.5) * nine);
-  check_vectors(DataVector(num_pts, 1.0), 9.0 / nine);
-  check_vectors(DataVector(num_pts, 1.0), (one * 9.0) / nine);
-
-  CHECK(-14 == min(val));
-  CHECK(12 == max(val));
-  check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, abs(val));
-  check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, fabs(val));
-
-  check_vectors(step_function(DataVector{-12.3, 2.0, -4.0, 0.0, 7.0, -8.0}),
-                DataVector{0.0, 1.0, 0.0, 1.0, 1.0, 0.0});
-
-  check_vectors(DataVector(num_pts, 81.0), nine * nine);
-  check_vectors(DataVector(num_pts, 81.0), nine * (nine * one));
-  check_vectors(DataVector(num_pts, 81.0), (nine * nine) * one);
-  check_vectors(DataVector(num_pts, 81.0), 9.0 * nine);
-  check_vectors(DataVector(num_pts, 81.0), nine * 9.0);
-  check_vectors(DataVector(num_pts, 1.0), nine / 9.0);
-  check_vectors(DataVector(num_pts, 1.0), nine / (one * 9.0));
-  check_vectors(DataVector(num_pts, 9.0), (one * nine) / one);
-
-  check_vectors(sqrt(nine), DataVector(num_pts, 3.0));
-  check_vectors(invsqrt(nine), DataVector(num_pts, 1.0 / 3.0));
-  DataVector eight(num_pts, 8.0);
-  check_vectors(cbrt(eight), DataVector(num_pts, 2.0));
-  check_vectors(invcbrt(eight), DataVector(num_pts, 0.5));
-  check_vectors(DataVector(num_pts, 81.0), pow(nine, 2));
-
-  DataVector dummy(nine * nine * 1.0);
-  check_vectors(DataVector(num_pts, 81.0), dummy);
-  check_vectors(DataVector(num_pts, 81.0), pow<2>(nine));
-  check_vectors(DataVector(num_pts, 81.0), pow<2>(nine * one));
-  check_vectors(DataVector(num_pts, 1.0 / 81.0),
-                DataVector(num_pts, 1.0) / pow<2>(nine));
-
-  check_vectors(DataVector(num_pts, exp(9.0)), exp(nine));
-  check_vectors(DataVector(num_pts, exp2(9.0)), exp2(nine));
-  check_vectors(DataVector(num_pts, pow<9>(10.0)), DataVector(exp10(nine)));
-  check_vectors(DataVector(num_pts, log(9.0)), log(nine));
-  check_vectors(DataVector(num_pts, log2(9.0)), log2(nine));
-  check_vectors(DataVector(num_pts, log10(9.0)), log10(nine));
-
-  DataVector point_nine(num_pts, 0.9);
-  check_vectors(DataVector(num_pts, sin(9.0)), sin(nine));
-  check_vectors(DataVector(num_pts, cos(9.0)), cos(nine));
-  check_vectors(DataVector(num_pts, tan(9.0)), tan(nine));
-  check_vectors(DataVector(num_pts, asin(0.9)), asin(point_nine));
-  check_vectors(DataVector(num_pts, acos(0.9)), acos(point_nine));
-  check_vectors(DataVector(num_pts, atan(0.9)), atan(point_nine));
-  check_vectors(DataVector(num_pts, atan2(0.9, 9.0)), atan2(point_nine, nine));
-  check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
-                atan2(point_nine * one, nine));
-  check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
-                atan2(point_nine, nine * one));
-  check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
-                atan2(point_nine * one, nine * one));
-
-  check_vectors(DataVector(num_pts, sinh(9.0)), sinh(nine));
-  check_vectors(DataVector(num_pts, cosh(9.0)), cosh(nine));
-  check_vectors(DataVector(num_pts, tanh(9.0)), tanh(nine));
-  check_vectors(DataVector(num_pts, asinh(9.0)), asinh(nine));
-  check_vectors(DataVector(num_pts, acosh(9.0)), acosh(nine));
-  check_vectors(DataVector(num_pts, atanh(0.9)), atanh(point_nine));
-
-  check_vectors(DataVector(num_pts, erf(0.9)), erf(point_nine));
-  check_vectors(DataVector(num_pts, erfc(0.9)), erfc(point_nine));
-
-  // Test assignment
-  DataVector test_81(num_pts, -1.0);
-  test_81 = nine * nine;
-  check_vectors(DataVector(num_pts, 81.0), test_81);
-  CHECK(test_81.is_owning());
-  DataVector test_81_ref(test_81.data(), test_81.size());
-  test_81_ref = 0.0;
-  test_81 = 0.0;
-  test_81_ref = nine * nine;
-  check_vectors(DataVector(num_pts, 81.0), test_81);
-  CHECK(test_81.is_owning());
-  check_vectors(DataVector(num_pts, 81.0), test_81_ref);
-  CHECK_FALSE(test_81_ref.is_owning());
-  DataVector second_81(num_pts);
-  second_81 = test_81;
-  check_vectors(DataVector(num_pts, 81.0), second_81);
-  CHECK(second_81.is_owning());
-  test_81_ref = 0.0;
-  check_vectors(DataVector(num_pts, 0.0), test_81_ref);
-  test_81_ref = second_81;
-  check_vectors(DataVector(num_pts, 81.0), test_81_ref);
-  second_81 = 0.0;
-  test_81_ref.set_data_ref(&test_81);
-  second_81 = std::move(test_81_ref);
-  check_vectors(DataVector(num_pts, 81.0), second_81);
-  CHECK_FALSE(second_81.is_owning());
-  second_81 = 0.0;
-  check_vectors(DataVector(num_pts, 0.0), second_81);
-  test_81 = 81.0;
-  check_vectors(DataVector(num_pts, 81.0), second_81);
-  CHECK_FALSE(second_81.is_owning());
-
-  test_81 = 81.0;
-  DataVector test_081;
-  test_081.set_data_ref(&test_81);
-  check_vectors(DataVector(num_pts, 81.0), test_081);
-  CHECK_FALSE(test_081.is_owning());
-  test_081 = square(point_nine);
-  check_vectors(DataVector(num_pts, 0.81), test_081);
-  CHECK_FALSE(test_081.is_owning());
-
-  DataVector test_assignment(num_pts, 7.0);
-  test_assignment += nine;
-  check_vectors(DataVector(num_pts, 16.0), test_assignment);
-  test_assignment += 3.0;
-  check_vectors(DataVector(num_pts, 19.0), test_assignment);
-  test_assignment += (nine * nine);
-  check_vectors(DataVector(num_pts, 100.0), test_assignment);
-
-  test_assignment = 7.0;
-  test_assignment -= nine;
-  check_vectors(DataVector(num_pts, -2.0), test_assignment);
-  test_assignment -= 3.0;
-  check_vectors(DataVector(num_pts, -5.0), test_assignment);
-  test_assignment -= nine * nine;
-  check_vectors(DataVector(num_pts, -86.0), test_assignment);
-
-  test_assignment = 2.0;
-  test_assignment *= 3.0;
-  check_vectors(DataVector(num_pts, 6.0), test_assignment);
-  test_assignment *= nine;
-  check_vectors(DataVector(num_pts, 54.0), test_assignment);
-  test_assignment = 1.0;
-  test_assignment *= nine * nine;
-  check_vectors(DataVector(num_pts, 81.0), test_assignment);
-
-  test_assignment = 2.0;
-  test_assignment /= 2.0;
-  check_vectors(DataVector(num_pts, 1.0), test_assignment);
-  test_assignment /= DataVector(num_pts, 0.5);
-  check_vectors(DataVector(num_pts, 2.0), test_assignment);
-  test_assignment /= (DataVector(num_pts, 2.0) * DataVector(num_pts, 3.0));
-  check_vectors(DataVector(num_pts, 1.0 / 3.0), test_assignment);
-
-  // Test assignment where the RHS is an expression that contains the LHS
-  DataVector x(num_pts, 4.);
-  x += sqrt(x);
-  check_vectors(DataVector(num_pts, 6.0), x);
-  x -= sqrt(x - 2.0);
-  check_vectors(DataVector(num_pts, 4.0), x);
-  x = sqrt(x);
-  check_vectors(DataVector(num_pts, 2.0), x);
-  x *= x;
-  check_vectors(DataVector(num_pts, 4.0), x);
-  x /= x;
-  check_vectors(DataVector(num_pts, 1.0), x);
-
-  // Test composition of constant expressions with DataVector math member
-  // functions
-  x = DataVector(num_pts, 2.);
-  check_vectors(DataVector(num_pts, 0.82682181043180603), square(sin(x)));
-  check_vectors(DataVector(num_pts, -0.072067555747765299), cube(cos(x)));
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math_array<DataVector>",

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -6,6 +6,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector", "[DataStructures][Unit]") {
@@ -392,8 +393,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   x = DataVector(num_pts, 2.);
   check_vectors(DataVector(num_pts, 0.82682181043180603), square(sin(x)));
   check_vectors(DataVector(num_pts, -0.072067555747765299), cube(cos(x)));
+}
 
-  // Test addition of arrays of DataVectors to arrays of doubles.
+SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math_array<DataVector>",
+                  "[Unit][DataStructures]") {
   const DataVector t1{0.0, 1.0, 2.0, 3.0};
   const DataVector t2{-0.1, -0.2, -0.3, -0.4};
   const DataVector t3{5.0, 4.0, 3.0, 2.0};
@@ -410,40 +413,46 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   const DataVector e11{-20.0, -20.0, -20.0, -20.0};
   const DataVector e12{-30.0, -30.0, -30.0, -30.0};
 
-  const std::array<double, 3> point{{10.0, 20.0, 30.0}};
-  std::array<DataVector, 3> points{{t1, t2, t3}};
-  const std::array<DataVector, 3> expected{{e1, e2, e3}};
-  const std::array<DataVector, 3> expected2{{e4, e5, e6}};
-  std::array<DataVector, 3> dvectors1{{t1, t2, t3}};
-  const std::array<DataVector, 3> dvectors2{{e1, e2, e3}};
-  const std::array<DataVector, 3> expected3{{e7, e8, e9}};
-  const std::array<DataVector, 3> expected4{{e10, e11, e12}};
-  CHECK(points + point == expected);
-  CHECK(point + points == expected);
-  CHECK(points - point == expected2);
-  CHECK(point - points == -expected2);
+  // Test +/- on array<DataVector> with array<double>
+  {
+    std::array<DataVector, 3> array_dvecs{{t1, t2, t3}};
+    const std::array<double, 3> array_doubles{{10.0, 20.0, 30.0}};
+    const std::array<DataVector, 3> expected1{{e1, e2, e3}};
+    const std::array<DataVector, 3> expected2{{e4, e5, e6}};
 
-  points += point;
-  CHECK(points == expected);
-  points -= point;
-  points -= point;
-  CHECK(points == expected2);
-
-  for (size_t i = 0; i < 3; i++) {
-    check_vectors(gsl::at((dvectors1 + dvectors2), i), gsl::at(expected3, i));
-    check_vectors(gsl::at((dvectors1 - dvectors2), i), gsl::at(expected4, i));
-  }
-  dvectors1 += dvectors2;
-  for (size_t i = 0; i < 3; i++) {
-    check_vectors(gsl::at(dvectors1, i), gsl::at(expected3, i));
-  }
-  dvectors1 -= dvectors2;
-  dvectors1 -= dvectors2;
-  for (size_t i = 0; i < 3; i++) {
-    check_vectors(gsl::at(dvectors1, i), gsl::at(expected4, i));
+    CHECK(array_dvecs + array_doubles == expected1);
+    CHECK(array_doubles + array_dvecs == expected1);
+    CHECK(array_dvecs - array_doubles == expected2);
+    CHECK(array_doubles - array_dvecs == -expected2);
+    array_dvecs += array_doubles;
+    CHECK(array_dvecs == expected1);
+    array_dvecs -= array_doubles;
+    array_dvecs -= array_doubles;
+    CHECK(array_dvecs == expected2);
   }
 
-  // Test calculation of magnitude of DataVector
+  // Test +/- on array<DataVector> with array<DataVector>
+  {
+    std::array<DataVector, 3> array0{{t1, t2, t3}};
+    const std::array<DataVector, 3> array1{{e1, e2, e3}};
+    const std::array<DataVector, 3> expected3{{e7, e8, e9}};
+    const std::array<DataVector, 3> expected4{{e10, e11, e12}};
+    for (size_t i = 0; i < 3; i++) {
+      check_vectors(gsl::at((array0 + array1), i), gsl::at(expected3, i));
+      check_vectors(gsl::at((array0 - array1), i), gsl::at(expected4, i));
+    }
+    array0 += array1;
+    for (size_t i = 0; i < 3; i++) {
+      check_vectors(gsl::at(array0, i), gsl::at(expected3, i));
+    }
+    array0 -= array1;
+    array0 -= array1;
+    for (size_t i = 0; i < 3; i++) {
+      check_vectors(gsl::at(array0, i), gsl::at(expected4, i));
+    }
+  }
+
+  // Test calculation of magnitude for array<DataVector>
   const std::array<DataVector, 1> d1{{DataVector{-2.5, 3.4}}};
   const DataVector expected_d1{2.5, 3.4};
   const auto magnitude_d1 = magnitude(d1);

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -10,42 +10,53 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector", "[DataStructures][Unit]") {
-  DataVector a{2};
-  CHECK(a.size() == 2);
-  DataVector b{2, 10.0};
-  CHECK(b.size() == 2);
-  for (size_t i = 0; i < b.size(); ++i) {
-    INFO(i);
-    CHECK(b[i] == 10.0);
+  {
+    const DataVector a{2};
+    CHECK(a.size() == 2);
+    CHECK(a.is_owning());
   }
-
-  DataVector t(5, 10.0);
-  CHECK(t.size() == 5);
-  for (size_t i = 0; i < t.size(); ++i) {
-    INFO(i);
-    CHECK(t[i] == 10.0);
+  {
+    const DataVector b{2, 10.0};
+    CHECK(b.size() == 2);
+    CHECK(b.is_owning());
+    for (size_t i = 0; i < b.size(); ++i) {
+      INFO(i);
+      CHECK(b[i] == 10.0);
+    }
+    const DataVector t(5, 10.0);
+    CHECK(t.size() == 5);
+    CHECK(t.is_owning());
+    for (size_t i = 0; i < t.size(); ++i) {
+      INFO(i);
+      CHECK(t[i] == 10.0);
+    }
+    for (const auto& p : t) {
+      CHECK(p == 10.0);
+    }
+    for (auto& p : t) {
+      CHECK(p == 10.0);
+    }
   }
-  for (const auto& p : t) {
-    CHECK(p == 10.0);
+  {
+    const DataVector t{1.43, 2.83, 3.94, 7.85};
+    CHECK(t.size() == 4);
+    CHECK(t.is_owning());
+    CHECK(t[0] == 1.43);
+    CHECK(t[1] == 2.83);
+    CHECK(t[2] == 3.94);
+    CHECK(t[3] == 7.85);
   }
-  for (auto& p : t) {
-    CHECK(p == 10.0);
+  {
+    DataVector t{1.43, 2.83, 3.94, 7.85};
+    test_copy_semantics(t);
+    auto t_copy = t;
+    CHECK(t_copy.is_owning());
+    test_move_semantics(std::move(t), t_copy);
+    DataVector t_move_assignment = std::move(t_copy);
+    CHECK(t_move_assignment.is_owning());
+    DataVector t_move_constructor = std::move(t_move_assignment);
+    CHECK(t_move_constructor.is_owning());
   }
-  DataVector t2{1.43, 2.83, 3.94, 7.85};
-  CHECK(t2.size() == 4);
-  CHECK(t2.is_owning());
-  CHECK(t2[0] == 1.43);
-  CHECK(t2[1] == 2.83);
-  CHECK(t2[2] == 3.94);
-  CHECK(t2[3] == 7.85);
-  test_copy_semantics(t);
-  auto t_copy = t;
-  CHECK(t_copy.is_owning());
-  test_move_semantics(std::move(t), t_copy);
-  DataVector t_move_assignment = std::move(t_copy);
-  CHECK(t_move_assignment.is_owning());
-  DataVector t_move_constructor = std::move(t_move_assignment);
-  CHECK(t_move_constructor.is_owning());
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector_Ref",


### PR DESCRIPTION
## Proposed changes

This PR aims to organize the tests cases within Test_DataVector, which were a little scattered and sometimes redundant. In particular, the changes done are,

1. Split the long "Math" test to pull out the testing of reference DataVectors and `array<DataVector>`.
1. Group the checks in the "Math" test according to the type of expression being tested.
1. Add a few more checks of math with reference DataVectors, with the intention of closing #83. Perhaps more checks are still needed, so let me know if you can think of any I should add.
1. Add some scoping and comments throughout the file to improve legibility.
1. Remove some redundant checks within/between test cases.
1. Reorder some tests (purely to satisfy my sense of aesthetics).

Still to do:

1. Squash these commits.
1. Understand why clang-format chokes on the 2nd test case ("DataVector_Ref") and produces garbage formatting.

### Types of changes:

- [x] Cleanup
- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
