### PR TITLE
Add CMAKE_BUILD_TYPE None

### DIFF
--- a/cmake/SetBuildType.cmake
+++ b/cmake/SetBuildType.cmake
@@ -1,7 +1,58 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(CMAKE_BUILD_TYPES "Debug" "Release" "RelWithDebInfo" "MinSizeRel")
+# CMake lets the user define CMAKE_BUILD_TYPE on the command line and recognizes
+# the values "Debug", "Release", "RelWithDebInfo", and "MinSizeRel", which add
+# specific compiler or linker flags.  CMake's default behavior is to add no
+# additional compiler or linker flags if the user does not define
+# CMAKE_BUILD_TYPE on the command line, or passes an unrecognized value.
+# We add a sanity check that checks if CMAKE_BUILD_TYPE is one of the recognized
+# values, and we also set the CMAKE_BUILD_TYPE to "Debug" if the user does not
+# specify it on the command line.  In addition, we add "None" as a valid value
+# for CMAKE_BUILD_TYPE whose behavior is to add no additional compiler or linker
+# flags. This is done by defining the following flags analagous to those used by
+# the other build types. Additional build types can be defined in a similar
+# manner by defining the appropriate flags, and adding the name of the build
+# type to CMAKE_BUILD_TYPES below.
+set(CMAKE_CXX_FLAGS_NONE "" CACHE STRING
+  "Additional flags used by the compiler for Build type None."
+  FORCE)
+
+set(CMAKE_C_FLAGS_NONE "" CACHE STRING
+  "Additional flags used by the compiler for Build type None."
+  FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS_NONE "" CACHE STRING
+  "Additional flags used by the linker for Build type None."
+  FORCE)
+
+set(CMAKE_Fortran_FLAGS_NONE "" CACHE STRING
+  "Additional flags used by the compiler for Build type None."
+  FORCE)
+
+set(CMAKE_MODULE_LINKER_FLAGS_NONE "" CACHE STRING
+  "Additional flags used by the linker for Build type None."
+  FORCE)
+
+set(CMAKE_SHARED_LINKER_FLAGS_NONE "" CACHE STRING
+  "Additional flags used by the linker for Build type None."
+  FORCE)
+
+set(CMAKE_STATIC_LINKER_FLAGS_NONE "" CACHE STRING
+  "Additional flags used by the linker for Build type None."
+  FORCE)
+
+mark_as_advanced(
+  CMAKE_CXX_FLAGS_NONE
+  CMAKE_C_FLAGS_NONE
+  CMAKE_EXE_LINKER_FLAGS_NONE
+  CMAKE_Fortran_FLAGS_NONE
+  CMAKE_MODULE_LINKER_FLAGS_NONE
+  CMAKE_SHARED_LINKER_FLAGS_NONE
+  CMAKE_STATIC_LINKER_FLAGS_NONE
+  )
+
+set(CMAKE_BUILD_TYPES "Debug" "Release" "None" "RelWithDebInfo" "MinSizeRel")
 
 if (NOT CMAKE_BUILD_TYPE)
   message(STATUS "CMAKE_BUILD_TYPE not specified, setting to 'Debug'")


### PR DESCRIPTION
## Proposed changes
Closes #108 (no way to prevent compiler flag overriding)

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
