### PR TITLE
Change sonarqube to sonarcloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@
 # - COVERALLS_TOKEN: Sign up to coveralls and link to GitHub. Add the
 #                    repository you want to display, and copy the repo_token.
 #                    The repo_token is what COVERALLS_TOKEN must be set to.
-# - SONAR_TOKEN: Setup your repository on SonarQUBE, then go to My Account
+# - SONAR_TOKEN: Setup your repository on SonarCloud, then go to My Account
 #                and select Security. You can now generate a new token that
-#                will be used to upload SonarQUBE reports. This is the value
+#                will be used to upload SonarCloud reports. This is the value
 #                that SONAR_TOKEN must be set to.
 # - ENCRYPTION_LABEL:
 #      The file encryption mechanism of TravisCI is used to encrypt the private
@@ -119,7 +119,7 @@ matrix:
 
 # Travis allows caching of data between builds to reduce build times or perform
 # regression testing. We use ccache (https://ccache.samba.org/) to reduce
-# compilation time. SonarQUBE, a static analysis tool (https://sonarqube.com/)
+# compilation time. SonarCloud, a static analysis tool (https://sonarcloud.io/)
 # also has a cache directory that needs to be managed.
 cache:
   ccache: true

--- a/.travis/TravisPushDocumentation.sh
+++ b/.travis/TravisPushDocumentation.sh
@@ -7,8 +7,8 @@
 # environment variables are defined, or received from TravisCI.
 
 # Add executables for SonarSQUBE to PATH
-export PATH=$PATH:/work/sonarqube/sonar-scanner-2.8/bin
-export PATH=$PATH:/work/sonarqube/build-wrapper-linux-x86
+export PATH=$PATH:/work/sonarcloud/sonar-scanner-2.8/bin
+export PATH=$PATH:/work/sonarcloud/build-wrapper-linux-x86
 
 # Setup lmod and spack to load dependencies
 . /etc/profile.d/lmod.sh

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Build Status](https://travis-ci.org/sxs-collaboration/spectre.svg?branch=develop)](https://travis-ci.org/sxs-collaboration/spectre)
 [![Coverage Status](https://coveralls.io/repos/github/sxs-collaboration/spectre/badge.svg?branch=develop)](https://coveralls.io/github/sxs-collaboration/spectre?branch=develop)
 [![codecov](https://codecov.io/gh/sxs-collaboration/spectre/branch/develop/graph/badge.svg)](https://codecov.io/gh/sxs-collaboration/spectre)
-[![Quality Gate](https://sonarqube.com/api/badges/gate?key=spectre:/develop)](https://sonarcloud.io/dashboard?id=spectre%3A%2Fdevelop)
-[![Technical debt ratio](https://sonarqube.com/api/badges/measure?key=spectre:/develop&metric=sqale_debt_ratio)](https://sonarqube.com/dashboard/index/com.qualinsight.plugins.sonarqube:qualinsight-plugins-sonarqube-badges)
+[![Quality Gate](https://sonarcloud.io/api/badges/gate?key=spectre:/develop)](https://sonarcloud.io/dashboard?id=spectre%3A%2Fdevelop)
+[![Technical debt ratio](https://sonarcloud.io/api/badges/measure?key=spectre:/develop&metric=sqale_debt_ratio)](https://sonarcloud.io/dashboard?id=spectre%3A%2Fdevelop)
 
 ## What is SpECTRE?
 

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -38,18 +38,18 @@ RUN apt-get install -y ccache
 RUN apt-get install -y doxygen python-pip
 RUN pip install coverxygen
 
-# wget and unzip are needed for retrieving SonarQUBE executables. Java is needed
-# for running SonarQUBE's sonar-scanner, which does the code analysis
-# Get the sonarqube source files and extract them. These are needed for static
-# analysis using SonarQUBE.
+# wget and unzip are needed for retrieving SonarCloud executables. Java is needed
+# for running SonarCloud's sonar-scanner, which does the code analysis
+# Get the SonarCloud source files and extract them. These are needed for static
+# analysis using SonarCloud.
 RUN apt-get update -y && apt-get install -y wget unzip openjdk-8-jdk
 RUN wget https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-2.8.zip \
-https://sonarqube.com/static/cpp/build-wrapper-linux-x86.zip \
-&& mkdir /work && mkdir /work/sonarqube/ \
-&& unzip sonar-scanner-2.8.zip -d /work/sonarqube/ \
-&& unzip build-wrapper-linux-x86.zip -d /work/sonarqube/ \
-&& echo "export PATH=\$PATH:/work/sonarqube/sonar-scanner-2.8/bin" >> root/.bashrc \
-&& echo "export PATH=\$PATH:/work/sonarqube/build-wrapper-linux-x86" >> root/.bashrc
+https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip \
+&& mkdir /work && mkdir /work/sonarcloud/ \
+&& unzip sonar-scanner-2.8.zip -d /work/sonarcloud/ \
+&& unzip build-wrapper-linux-x86.zip -d /work/sonarcloud/ \
+&& echo "export PATH=\$PATH:/work/sonarcloud/sonar-scanner-2.8/bin" >> root/.bashrc \
+&& echo "export PATH=\$PATH:/work/sonarcloud/build-wrapper-linux-x86" >> root/.bashrc
 
 # Add ruby gems and install coveralls using gem
 RUN apt-get update -y && apt-get install -y rubygems && gem install coveralls-lcov

--- a/containers/Dockerfile.travis
+++ b/containers/Dockerfile.travis
@@ -107,7 +107,7 @@ RUN if [ ${SONARQUBE} ] \
     && [ ${TRAVIS_SECURE_ENV_VARS} = true ] \
     && [ ${TRAVIS_EVENT_TYPE} = cron ] \
     && [ ${CC} = gcc ]; then \
-      /work/sonarqube/build-wrapper-linux-x86/build-wrapper-linux-x86-64 \
+      /work/sonarcloud/build-wrapper-linux-x86/build-wrapper-linux-x86-64 \
         --out-dir sonar-output make -j2; \
     elif [ -z "${RUN_CPPCHECK}" ] \
     && [ -z "${RUN_CLANG_TIDY}" ]; then \
@@ -178,11 +178,11 @@ RUN if [ ${CC} = gcc ] \
         # code coverage. Here ${TRAVIS_REPO_SLUG}=sxs-collaboration/spectre
         # The SONAR_TOKEN variable is an env variable set in the TravisCI config
         # that is not visible in the build logs and provides secure access to
-        # the SXS collaboration SpECTRE project on SonarQUBE.
+        # the SXS collaboration SpECTRE project on SonarCloud.
         # The sonar.host.url is set to where the Sonar server is running, which
-        # we use sonarqube.com for since it is available for open-source
+        # we use sonarcloud.io for since it is available for open-source
         # projects.
-        /work/sonarqube/sonar-scanner-2.8/bin/sonar-scanner \
+        /work/sonarcloud/sonar-scanner-2.8/bin/sonar-scanner \
             -Dsonar.projectKey=spectre \
             -Dsonar.projectName=spectre \
             -Dsonar.projectVersion=${TRAVIS_COMMIT} \
@@ -194,7 +194,7 @@ RUN if [ ${CC} = gcc ] \
             -Dsonar.sources=/work/spectre \
             -Dsonar.exclusions=build/CMakeFiles/**,build/doc/**,tests/** \
             -Dsonar.cfamily.build-wrapper-output=/work/build_${BUILD_TYPE}_${CC}/sonar-output \
-            -Dsonar.host.url=https://sonarqube.com \
+            -Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.cfamily.gcov.reportsPath=/work/build_${BUILD_TYPE}_${CC}/tmp \
             -Dsonar.organization=sxs-collaboration \
             -Dsonar.login=${SONAR_TOKEN}; \


### PR DESCRIPTION
## Proposed changes

SonarQUBE is moving to SonarCloud, so we need to adjust. I intentionally did not just the variable in Travis because that would cause builds to fail until this is merged and I figured that's better to do next week when it's easier to coordinate with people.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
