### PR TITLE
Remove ordered_frame_list

### DIFF
--- a/src/DataStructures/Tensor/IndexType.hpp
+++ b/src/DataStructures/Tensor/IndexType.hpp
@@ -45,10 +45,6 @@ struct Distorted {};
 /// intermediate frame that is irrelevant to the interface.
 struct NoFrame {};
 
-/// This ordered list is needed to determine the ordering of frames
-/// for jacobians.
-using ordered_frame_list = typelist<Logical, Grid, Inertial, Distorted>;
-
 /// \ingroup TensorGroup
 /// Returns std::true_type if the frame is "physical" in the sense that it is
 /// meaningful to evaluate an analytic solution in that frame.

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -323,9 +323,9 @@ using iAA = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
                               SpacetimeIndex<SpatialDim, UpLo::Up, Fr>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using Iaa = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
-index_list<SpatialIndex<SpatialDim, UpLo::Up, Fr>,
-           SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>,
-           SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
+                   index_list<SpatialIndex<SpatialDim, UpLo::Up, Fr>,
+                              SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>,
+                              SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
 
 // Rank 4 - Mixed
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
@@ -335,20 +335,10 @@ using ijaa = Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
                                SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>,
                                SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
 
-namespace detail {
-template <size_t Dim, typename Frame1, typename Frame2>
-struct inverse_jacobian_impl {
-  static_assert(tmpl::index_of<Frame::ordered_frame_list, Frame1>::value <
-                    tmpl::index_of<Frame::ordered_frame_list, Frame2>::value,
-                "Inverse Jacobian must go other direction.");
-  using type = Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                      typelist<SpatialIndex<Dim, UpLo::Up, Frame1>,
-                               SpatialIndex<Dim, UpLo::Lo, Frame2>>>;
-};
-}  // namespace detail
-
 }  // namespace tnsr
 
 template <size_t Dim, typename Frame1, typename Frame2>
 using InverseJacobian =
-    typename tnsr::detail::inverse_jacobian_impl<Dim, Frame1, Frame2>::type;
+    Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+           typelist<SpatialIndex<Dim, UpLo::Up, Frame1>,
+                    SpatialIndex<Dim, UpLo::Lo, Frame2>>>;


### PR DESCRIPTION
There will be Frames (e.g. Spherical) that can not be ordered.

## Proposed changes

Fixes #379 

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
