### PR TITLE
Use CHECK_ITERABLE_APPROX instead of looping over CHECK

### DIFF
--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -154,10 +154,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector_Ref",
 namespace {
 template <typename T1, typename T2>
 void check_vectors(const T1& t1, const T2& t2) {
-  CHECK(t1.size() == t2.size());
-  for (size_t i = 0; i < t1.size(); ++i) {
-    CHECK(t1[i] == approx(t2[i]));
-  }
+  CHECK_ITERABLE_APPROX(t1, t2);
 }
 }  // namespace
 
@@ -429,40 +426,29 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   points -= point;
   CHECK(points == expected2);
 
-  for (size_t i = 0; i < 3; i++) {
-    check_vectors(gsl::at((dvectors1 + dvectors2), i), gsl::at(expected3, i));
-    check_vectors(gsl::at((dvectors1 - dvectors2), i), gsl::at(expected4, i));
-  }
+  CHECK_ITERABLE_APPROX(dvectors1 + dvectors2, expected3);
+  CHECK_ITERABLE_APPROX(dvectors1 - dvectors2, expected4);
+
   dvectors1 += dvectors2;
-  for (size_t i = 0; i < 3; i++) {
-    check_vectors(gsl::at(dvectors1, i), gsl::at(expected3, i));
-  }
+  CHECK_ITERABLE_APPROX(dvectors1, expected3);
   dvectors1 -= dvectors2;
   dvectors1 -= dvectors2;
-  for (size_t i = 0; i < 3; i++) {
-    check_vectors(gsl::at(dvectors1, i), gsl::at(expected4, i));
-  }
+  CHECK_ITERABLE_APPROX(dvectors1, expected4);
 
   // Test calculation of magnitude of DataVector
   const std::array<DataVector, 1> d1{{DataVector{-2.5, 3.4}}};
   const DataVector expected_d1{2.5, 3.4};
   const auto magnitude_d1 = magnitude(d1);
-  for (size_t i = 0; i < 2; ++i) {
-    CHECK(expected_d1[i] == approx(magnitude_d1[i]));
-  }
+  CHECK_ITERABLE_APPROX(expected_d1, magnitude_d1);
   const std::array<DataVector, 2> d2{{DataVector(2, 3.), DataVector(2, 4.)}};
   const DataVector expected_d2(2, 5.);
   const auto magnitude_d2 = magnitude(d2);
-  for (size_t i = 0; i < 2; ++i) {
-    CHECK(expected_d2[i] == approx(magnitude_d2[i]));
-  }
+  CHECK_ITERABLE_APPROX(expected_d2, magnitude_d2);
   const std::array<DataVector, 3> d3{
       {DataVector(2, 3.), DataVector(2, -4.), DataVector(2, 12.)}};
   const DataVector expected_d3(2, 13.);
   const auto magnitude_d3 = magnitude(d3);
-  for (size_t i = 0; i < 2; ++i) {
-    CHECK(expected_d3[i] == approx(magnitude_d3[i]));
-  }
+  CHECK_ITERABLE_APPROX(expected_d3, magnitude_d3);
 }
 
 // [[OutputRegex, Must copy into same size]]

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
@@ -62,9 +62,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LinearizeALinearFunction",
           u[i.offset()] = 3*x[i()[0]]+5*y[i()[1]]+z[i()[2]];
         }
         const DataVector u_lin = linearize(u, extents);
-        for(size_t i=0; i<u.size(); i++){
-          CHECK(u[i] == approx(u_lin[i]));
-        }
+        CHECK_ITERABLE_APPROX(u, u_lin);
       }
     }
   }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -39,13 +39,13 @@ void check_solution_x(const double kx, const double omega, const DataVector& u,
   const DataVector d2psi_dt2 = 6.0 * square(omega) * u;
   const DataVector d2psi_dtdx = -6.0 * omega * kx * u;
   const DataVector d2psi_dxdx = 6.0 * square(kx) * u;
+  CHECK_ITERABLE_APPROX(psi, pw.psi(x, t).get());
+  CHECK_ITERABLE_APPROX(dpsi_dt, pw.dpsi_dt(x, t).get());
+  CHECK_ITERABLE_APPROX(d2psi_dt2, pw.d2psi_dt2(x, t).get());
+  CHECK_ITERABLE_APPROX(dpsi_dx, pw.dpsi_dx(x, t).get(0));
+  CHECK_ITERABLE_APPROX(d2psi_dtdx, pw.d2psi_dtdx(x, t).get(0));
+  CHECK_ITERABLE_APPROX(d2psi_dxdx, pw.d2psi_dxdx(x, t).get(0, 0));
   for (size_t s = 0; s < u.size(); ++s) {
-    CHECK(approx(psi[s]) == pw.psi(x, t).get()[s]);
-    CHECK(approx(dpsi_dt[s]) == pw.dpsi_dt(x, t).get()[s]);
-    CHECK(approx(d2psi_dt2[s]) == pw.d2psi_dt2(x, t).get()[s]);
-    CHECK(approx(dpsi_dx[s]) == pw.dpsi_dx(x, t).get(0)[s]);
-    CHECK(approx(d2psi_dtdx[s]) == pw.d2psi_dtdx(x, t).get(0)[s]);
-    CHECK(approx(d2psi_dxdx[s]) == pw.d2psi_dxdx(x, t).get(0, 0)[s]);
     const auto p = extract_point_from_coords(s, x);
     CHECK(approx(psi[s]) == pw.psi(p, t).get());
     CHECK(approx(dpsi_dt[s]) == pw.dpsi_dt(p, t).get());
@@ -65,12 +65,12 @@ void check_solution_y(const double kx, const double ky, const double omega,
   const DataVector d2psi_dtdy = -6.0 * omega * ky * u;
   const DataVector d2psi_dxdy = 6.0 * kx * ky * u;
   const DataVector d2psi_dydy = 6.0 * square(ky) * u;
+  CHECK_ITERABLE_APPROX(dpsi_dy, pw.dpsi_dx(x, t).get(1));
+  CHECK_ITERABLE_APPROX(d2psi_dtdy, pw.d2psi_dtdx(x, t).get(1));
+  CHECK_ITERABLE_APPROX(d2psi_dxdy, pw.d2psi_dxdx(x, t).get(0, 1));
+  CHECK_ITERABLE_APPROX(d2psi_dxdy, pw.d2psi_dxdx(x, t).get(1, 0));
+  CHECK_ITERABLE_APPROX(d2psi_dydy, pw.d2psi_dxdx(x, t).get(1, 1));
   for (size_t s = 0; s < u.size(); ++s) {
-    CHECK(approx(dpsi_dy[s]) == pw.dpsi_dx(x, t).get(1)[s]);
-    CHECK(approx(d2psi_dtdy[s]) == pw.d2psi_dtdx(x, t).get(1)[s]);
-    CHECK(approx(d2psi_dxdy[s]) == pw.d2psi_dxdx(x, t).get(0, 1)[s]);
-    CHECK(approx(d2psi_dxdy[s]) == pw.d2psi_dxdx(x, t).get(1, 0)[s]);
-    CHECK(approx(d2psi_dydy[s]) == pw.d2psi_dxdx(x, t).get(1, 1)[s]);
     const auto p = extract_point_from_coords(s, x);
     CHECK(approx(dpsi_dy[s]) == pw.dpsi_dx(p, t).get(1));
     CHECK(approx(d2psi_dtdy[s]) == pw.d2psi_dtdx(p, t).get(1));
@@ -89,14 +89,14 @@ void check_solution_z(const double kx, const double ky, const double kz,
   const DataVector d2psi_dxdz = 6.0 * kx * kz * u;
   const DataVector d2psi_dydz = 6.0 * ky * kz * u;
   const DataVector d2psi_dzdz = 6.0 * square(kz) * u;
+  CHECK_ITERABLE_APPROX(dpsi_dz, pw.dpsi_dx(x, t).get(2));
+  CHECK_ITERABLE_APPROX(d2psi_dtdz, pw.d2psi_dtdx(x, t).get(2));
+  CHECK_ITERABLE_APPROX(d2psi_dxdz, pw.d2psi_dxdx(x, t).get(0, 2));
+  CHECK_ITERABLE_APPROX(d2psi_dxdz, pw.d2psi_dxdx(x, t).get(2, 0));
+  CHECK_ITERABLE_APPROX(d2psi_dydz, pw.d2psi_dxdx(x, t).get(2, 1));
+  CHECK_ITERABLE_APPROX(d2psi_dydz, pw.d2psi_dxdx(x, t).get(1, 2));
+  CHECK_ITERABLE_APPROX(d2psi_dzdz, pw.d2psi_dxdx(x, t).get(2, 2));
   for (size_t s = 0; s < u.size(); ++s) {
-    CHECK(approx(dpsi_dz[s]) == pw.dpsi_dx(x, t).get(2)[s]);
-    CHECK(approx(d2psi_dtdz[s]) == pw.d2psi_dtdx(x, t).get(2)[s]);
-    CHECK(approx(d2psi_dxdz[s]) == pw.d2psi_dxdx(x, t).get(0, 2)[s]);
-    CHECK(approx(d2psi_dxdz[s]) == pw.d2psi_dxdx(x, t).get(2, 0)[s]);
-    CHECK(approx(d2psi_dydz[s]) == pw.d2psi_dxdx(x, t).get(2, 1)[s]);
-    CHECK(approx(d2psi_dydz[s]) == pw.d2psi_dxdx(x, t).get(1, 2)[s]);
-    CHECK(approx(d2psi_dzdz[s]) == pw.d2psi_dxdx(x, t).get(2, 2)[s]);
     const auto p = extract_point_from_coords(s, x);
     CHECK(approx(dpsi_dz[s]) == pw.dpsi_dx(p, t).get(2));
     CHECK(approx(d2psi_dtdz[s]) == pw.d2psi_dtdx(p, t).get(2));

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
@@ -39,16 +39,14 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian",
   }
 
   const DataVector one{1., 1.};
-  for (size_t s = 0; s < one.size(); ++s) {
-    const auto mapped_point = amplitude * exp(-square((one - center) / width));
-    CHECK(gauss(one)[s] == approx(mapped_point[s]));
-    CHECK(gauss.first_deriv(one)[s] ==
-          approx(-2. * (one[s] - center) / square(width) * mapped_point[s]));
-    CHECK(gauss.second_deriv(one)[s] ==
-          approx((4 * square(one[s] - center) / pow<4>(width) -
-                  2 / square(width)) *
-                 mapped_point[s]));
-  }
+  const auto mapped_point = amplitude * exp(-square((one - center) / width));
+  const auto first_deriv = -2. * (one - center) / square(width) * mapped_point;
+  const auto second_deriv =
+      (4 * square(one - center) / pow<4>(width) - 2 / square(width)) *
+      mapped_point;
+  CHECK_ITERABLE_APPROX(gauss(one), mapped_point);
+  CHECK_ITERABLE_APPROX(gauss.first_deriv(one), first_deriv);
+  CHECK_ITERABLE_APPROX(gauss.second_deriv(one), second_deriv);
   test_math_helpers::test_pup_function(gauss);
 
   // Test base class serialization

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
@@ -35,15 +35,14 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid",
   }
 
   const DataVector one{1., 1.};
-  for (size_t s = 0; s < one.size(); ++s) {
-    const DataVector mapped_point = amplitude * sin(wavenumber * one + phase);
-    const DataVector mapped_first_deriv =
-        amplitude * wavenumber * cos(wavenumber * one + phase);
-    const DataVector mapped_second_deriv = -square(wavenumber) * mapped_point;
-    CHECK(sinusoid(one)[s] == approx(mapped_point[s]));
-    CHECK(sinusoid.first_deriv(one)[s] == approx(mapped_first_deriv[s]));
-    CHECK(sinusoid.second_deriv(one)[s] == approx(mapped_second_deriv[s]));
-  }
+  const DataVector mapped_point = amplitude * sin(wavenumber * one + phase);
+  const DataVector mapped_first_deriv =
+      amplitude * wavenumber * cos(wavenumber * one + phase);
+  const DataVector mapped_second_deriv = -square(wavenumber) * mapped_point;
+  CHECK_ITERABLE_APPROX(sinusoid(one), mapped_point);
+  CHECK_ITERABLE_APPROX(sinusoid.first_deriv(one), mapped_first_deriv);
+  CHECK_ITERABLE_APPROX(sinusoid.second_deriv(one), mapped_second_deriv);
+
   test_math_helpers::test_pup_function(sinusoid);
 
   // Test base class serialization


### PR DESCRIPTION
## Proposed changes
 Closes #307 (using CHECK_ITERABLE_APPROX from #312)

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
