### PR TITLE
Mutating compute items

### DIFF
--- a/src/DataStructures/DataBox.hpp
+++ b/src/DataStructures/DataBox.hpp
@@ -980,10 +980,11 @@ template <typename ComputeItem, typename... Tags, typename... ComputeItemTags,
 SPECTRE_ALWAYS_INLINE static constexpr void add_reset_compute_item_to_box(
     databox_detail::TaggedDeferredTuple<Tags...>& data,
     tmpl::list<ComputeItemTags...> /*meta*/) {
-  ::db::databox_detail::get<ComputeItem>(data) =
-      make_deferred<db::item_type<ComputeItem>>(
-          ComputeItem::function,
-          ::db::databox_detail::get<ComputeItemTags>(data)...);
+  update_deferred_args(
+      make_not_null(&::db::databox_detail::get<ComputeItem>(data)),
+      ComputeItem::function,
+      ::db::databox_detail::get<ComputeItemTags>(data)...);
+
   // If `tag` holds a Variables then add the contained Tensor's
   add_variables_compute_item_tags_to_box<ComputeItem>(
       data, typename select_if_variables<ComputeItem>::type{});

--- a/tests/Unit/Utilities/Test_Deferred.cpp
+++ b/tests/Unit/Utilities/Test_Deferred.cpp
@@ -19,7 +19,35 @@ struct func2 {
 };
 
 double lazy_function(const double t) { return 10.0 * t; }
+
+void mutate_function(const gsl::not_null<double*> t, const double t0) {
+  *t = t0;
+}
+
+void mutate_function_vector(const gsl::not_null<std::vector<double>*> t,
+                            const std::vector<double>& t0) {
+  if (t->size() != t0.size()) {
+    t->resize(t0.size(), 0.0);
+  }
+  // Check the size again just to be sure the resize above happened.
+  CHECK(t->size() == t0.size());
+  for (size_t i = 0; i < t->size(); ++i) {
+    t->operator[](i) = 10.0 * t0[i];
+  }
+}
 /// [functions_used]
+
+void mutate_function_vector_evil(const gsl::not_null<std::vector<double>*> t,
+                                 const std::vector<double>& t0) {
+  if (t->size() != t0.size()) {
+    t->resize(t0.size(), 0.0);
+  }
+  // Check the size again just to be sure the resize above happened.
+  CHECK(t->size() == t0.size());
+  for (size_t i = 0; i < t->size(); ++i) {
+    t->operator[](i) += 10.0 * t0[i];
+  }
+}
 
 void simple_deferred() {
   /// [deferred_with_update]
@@ -34,27 +62,76 @@ void simple_deferred() {
 
 void single_call_deferred() {
   /// [make_deferred_with_function_object]
-  auto def = make_deferred(func{});
+  auto def = make_deferred<double>(func{});
   CHECK(8.2 == def.get());
   /// [make_deferred_with_function_object]
 
   /// [make_deferred_with_function]
-  auto def2 = make_deferred(dummy);
+  auto def2 = make_deferred<double>(dummy);
   CHECK(6.7 == def2.get());
   /// [make_deferred_with_function]
 
   const auto function_name = dummy;
-  auto def3 = make_deferred(function_name);
+  auto def3 = make_deferred<double>(function_name);
   CHECK(6.7 == def3.get());
 }
 
 void deferred_as_argument_to_deferred() {
   /// [make_deferred_with_deferred_arg]
-  auto def2 = make_deferred(func2{}, 6.82);
-  auto def3 = make_deferred(lazy_function, def2);
+  auto def2 = make_deferred<double>(func2{}, 6.82);
+  auto def3 = make_deferred<double>(lazy_function, def2);
   CHECK(68.2 == def3.get());
   CHECK(6.82 == def2.get());
   /// [make_deferred_with_deferred_arg]
+}
+
+void mutating_deferred() {
+  auto def2 = make_deferred<double>(func2{}, 6.82);
+  auto def_mutate = make_deferred<double>(mutate_function, def2);
+  CHECK(6.82 == def_mutate.get());
+
+  auto def_mutate_vector = make_deferred<std::vector<double>>(
+      mutate_function_vector, std::vector<double>{2.3, 8.9, 7.8});
+  CHECK((std::vector<double>{23.0, 89.0, 78.0}) == def_mutate_vector.get());
+}
+
+void update_deferred() {
+  auto lazy_deferred = make_deferred<double>(lazy_function, 3.4);
+  CHECK(lazy_deferred.get() == 34.);
+  update_deferred_args(make_not_null(&lazy_deferred), lazy_function, 5.5);
+  CHECK(lazy_deferred.get() == 55.);
+
+  /// [update_args_of_deferred_deduced_fp]
+  auto mutate_deferred = make_deferred<std::vector<double>>(
+      mutate_function_vector, std::vector<double>{1.3, 7.8, 9.8});
+  CHECK(mutate_deferred.get() == (std::vector<double>{13., 78., 98.}));
+  update_deferred_args(make_not_null(&mutate_deferred), mutate_function_vector,
+                       std::vector<double>{10., 70., 90.});
+  CHECK(mutate_deferred.get() == (std::vector<double>{100., 700., 900.}));
+  /// [update_args_of_deferred_deduced_fp]
+
+  /// [update_args_of_deferred_specified_fp]
+  update_deferred_args<std::vector<double>, decltype(mutate_function_vector)>(
+      &mutate_deferred, std::vector<double>{20., 8., 9.});
+  CHECK(mutate_deferred.get() == (std::vector<double>{200., 80., 90.}));
+  /// [update_args_of_deferred_specified_fp]
+
+  auto mutate_deferred_evil = make_deferred<std::vector<double>>(
+      mutate_function_vector_evil, std::vector<double>{1.3, 7.8, 9.8});
+  CHECK(mutate_deferred_evil.get() == (std::vector<double>{13., 78., 98.}));
+  const double* const initial_pointer = mutate_deferred_evil.get().data();
+  update_deferred_args(make_not_null(&mutate_deferred_evil),
+                       mutate_function_vector_evil,
+                       std::vector<double>{10., 70., 90.});
+  CHECK(mutate_deferred_evil.get() == (std::vector<double>{113., 778., 998.}));
+  CHECK(initial_pointer == mutate_deferred_evil.get().data());
+
+  update_deferred_args<std::vector<double>,
+                       decltype(mutate_function_vector_evil)>(
+      &mutate_deferred_evil, std::vector<double>{10., 70., 90.});
+  CHECK(mutate_deferred_evil.get() ==
+        (std::vector<double>{213., 1478., 1898.}));
+  CHECK(initial_pointer == mutate_deferred_evil.get().data());
 }
 }  // namespace
 
@@ -62,6 +139,35 @@ SPECTRE_TEST_CASE("Unit.Utilities.Deferred", "[Utilities][Unit]") {
   simple_deferred();
   single_call_deferred();
   deferred_as_argument_to_deferred();
+  mutating_deferred();
+  update_deferred();
+}
+
+// [[OutputRegex, Cannot cast the Deferred class to:
+// Deferred_detail::deferred_assoc_state]]
+SPECTRE_TEST_CASE("Unit.Utilities.Deferred.UpdateArgsError0",
+                  "[Utilities][Unit]") {
+  ERROR_TEST();
+  auto lazy_deferred = make_deferred<double>(lazy_function, 3.4);
+  update_deferred_args<double>(&lazy_deferred, lazy_function, 5);
+}
+
+// [[OutputRegex, Cannot cast the Deferred class to:
+// Deferred_detail::deferred_assoc_state]]
+SPECTRE_TEST_CASE("Unit.Utilities.Deferred.UpdateArgsError1",
+                  "[Utilities][Unit]") {
+  ERROR_TEST();
+  auto lazy_deferred = make_deferred<double>(lazy_function, 3.4);
+  update_deferred_args<double, decltype(lazy_function)>(&lazy_deferred, 5);
+}
+
+// [[OutputRegex, Cannot cast the Deferred class to:
+// Deferred_detail::deferred_assoc_state]]
+SPECTRE_TEST_CASE("Unit.Utilities.Deferred.UpdateArgsError2",
+                  "[Utilities][Unit]") {
+  ERROR_TEST();
+  auto lazy_deferred = make_deferred<double>(lazy_function, 3.4);
+  update_deferred_args<double, decltype(mutate_function)>(&lazy_deferred, 5.5);
 }
 
 // [[OutputRegex, Cannot mutate a computed Deferred]]
@@ -69,7 +175,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.Deferred", "[Utilities][Unit]") {
                                "[Utilities][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto def = make_deferred(func{});
+  auto def = make_deferred<double>(func{});
   auto& mutate = def.mutate();
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif


### PR DESCRIPTION
## Proposed changes

Adds support for mutating compute items. The details of this is in the updated documentation for `db::ComputeItemTag`.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
