### PR TITLE
Make tensor output terser

### DIFF
--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -495,19 +495,12 @@ std::ostream& operator<<(std::ostream& os,
   static_assert(tt::is_streamable_v<decltype(os), X>,
                 "operator<< is not defined for the type you are trying to "
                 "stream in Tensor");
-  os << "--Symmetry:  " << x.symmetries() << "\n";
-  os << "--Types:     " << x.index_types() << "\n";
-  os << "--Dims:      " << x.index_dims() << "\n";
-  os << "--Locations: " << x.index_valences() << "\n";
-  os << "--Frames:    " << x.index_frames() << "\n";
   for (size_t i = 0; i < x.size() - 1; ++i) {
-    os << " T" << x.get_tensor_index(i) << "=" << x[i]
-       << "\n     Multiplicity: " << x.multiplicity(i) << " Index: " << i
+    os << "T" << x.get_tensor_index(i) << "=" << x[i]
        << "\n";
   }
   size_t i = x.size() - 1;
-  os << " T" << x.get_tensor_index(i) << "=" << x[i]
-     << "\n     Multiplicity: " << x.multiplicity(i) << " Index: " << i;
+  os << "T" << x.get_tensor_index(i) << "=" << x[i];
   return os;
 }
 

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -381,7 +382,7 @@ Variables<tmpl::list<Tags...>>& operator*=(Variables<tmpl::list<Tags...>>& lhs,
                                            const DataVector& rhs) noexcept {
   ASSERT(lhs.number_of_grid_points() == rhs.size(),
          "Size mismatch in multiplication: " << lhs.number_of_grid_points()
-         << " and " << rhs.size());
+                                             << " and " << rhs.size());
   double* const lhs_data = lhs.data();
   const double* const rhs_data = rhs.data();
   for (size_t c = 0; c < lhs.number_of_independent_components; ++c) {
@@ -414,7 +415,7 @@ Variables<tmpl::list<Tags...>>& operator/=(Variables<tmpl::list<Tags...>>& lhs,
                                            const DataVector& rhs) noexcept {
   ASSERT(lhs.number_of_grid_points() == rhs.size(),
          "Size mismatch in multiplication: " << lhs.number_of_grid_points()
-         << " and " << rhs.size());
+                                             << " and " << rhs.size());
   double* const lhs_data = lhs.data();
   const double* const rhs_data = rhs.data();
   for (size_t c = 0; c < lhs.number_of_independent_components; ++c) {
@@ -444,14 +445,16 @@ std::ostream& print_helper(std::ostream& os, const Variables<TagsList>& /*d*/,
 template <typename Tag, typename TagsList>
 std::ostream& print_helper(std::ostream& os, const Variables<TagsList>& d,
                            typelist<Tag> /*meta*/) {
-  return os << get<Tag>(d);
+  return os << pretty_type::short_name<Tag>() << ":\n" << get<Tag>(d);
 }
+
 template <typename Tag, typename SecondTag, typename... RemainingTags,
           typename TagsList>
 std::ostream& print_helper(
     std::ostream& os, const Variables<TagsList>& d,
     typelist<Tag, SecondTag, RemainingTags...> /*meta*/) {
-  os << get<Tag>(d) << '\n';
+  os << pretty_type::short_name<Tag>() << ":\n";
+  os << get<Tag>(d) << "\n\n";
   print_helper(os, d, typelist<SecondTag, RemainingTags...>{});
   return os;
 }

--- a/src/Utilities/StdHelpers.hpp
+++ b/src/Utilities/StdHelpers.hpp
@@ -86,7 +86,7 @@ struct TuplePrinter {
   template <typename... Args>
   static std::ostream& print(std::ostream& os, const std::tuple<Args...>& t) {
     TuplePrinter<N - 1>::print(os, t);
-    os << ", " << std::get<N - 1>(t);
+    os << "," << std::get<N - 1>(t);
     return os;
   }
 };

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -609,33 +609,73 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Multiplicity",
   }
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Stream",
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.StreamData",
                   "[DataStructures][Unit]") {
   std::string compare_out =
-      "--Symmetry:  (1)\n"
-      "--Types:     (Spatial)\n"
-      "--Dims:      (3)\n"
-      "--Locations: (Lo)\n"
-      "--Frames:    (Grid)\n"
-      " T(0)=(2,2,2,2,2,2,2,2,2,2)\n"
-      "     Multiplicity: 1 Index: 0\n"
-      " T(1)=(2,2,2,2,2,2,2,2,2,2)\n"
-      "     Multiplicity: 1 Index: 1\n"
-      " T(2)=(2,2,2,2,2,2,2,2,2,2)\n"
-      "     Multiplicity: 1 Index: 2";
+      "T(0)=(2,2,2,2,2,2,2,2,2,2)\n"
+      "T(1)=(2,2,2,2,2,2,2,2,2,2)\n"
+      "T(2)=(2,2,2,2,2,2,2,2,2,2)";
+
   CHECK(get_output(Tensor<std::vector<double>, Symmetry<1>,
                           index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>>>(
             10_st, 2.0)) == compare_out);
 
   compare_out =
-      "--Symmetry:  ()\n"
-      "--Types:     ()\n"
-      "--Dims:      ()\n"
-      "--Locations: ()\n"
-      "--Frames:    ()\n"
-      " T()=(2,2,2,2,2,2,2,2,2,2)\n"
-      "     Multiplicity: 1 Index: 0";
+      "T()=(2,2,2,2,2,2,2,2,2,2)";
   CHECK(get_output(Scalar<std::vector<double>>(10_st, 2.0)) == compare_out);
+
+  compare_out =
+      "T(0,0,0)=0\n"
+      "T(1,0,0)=1\n"
+      "T(2,0,0)=2\n"
+      "T(0,1,0)=3\n"
+      "T(1,1,0)=4\n"
+      "T(2,1,0)=5\n"
+      "T(0,2,0)=6\n"
+      "T(1,2,0)=7\n"
+      "T(2,2,0)=8\n"
+      "T(0,1,1)=9\n"
+      "T(1,1,1)=10\n"
+      "T(2,1,1)=11\n"
+      "T(0,2,1)=12\n"
+      "T(1,2,1)=13\n"
+      "T(2,2,1)=14\n"
+      "T(0,2,2)=15\n"
+      "T(1,2,2)=16\n"
+      "T(2,2,2)=17";
+
+  CHECK(get_output([]() {
+          tnsr::abb<double, 2, Frame::Inertial> tensor{};
+          std::iota(tensor.begin(), tensor.end(), 0);
+          return tensor;
+        }()) == compare_out);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.StreamStructure",
+                  "[DataStructures][Unit]") {
+  {
+    const Scalar<double> tensor{};
+    CHECK(get_output(tensor.symmetries()) == "()");
+    CHECK(get_output(tensor.index_types()) == "()");
+    CHECK(get_output(tensor.index_dims()) == "()");
+    CHECK(get_output(tensor.index_valences()) == "()");
+    CHECK(get_output(tensor.index_frames()) == "()");
+  }
+  {
+    using structure = Tensor_detail::Structure<Symmetry<1, 1, 3, 2>,
+                             SpatialIndex<2, UpLo::Lo, Frame::Inertial>,
+                             SpatialIndex<2, UpLo::Lo, Frame::Inertial>,
+                             SpacetimeIndex<3, UpLo::Lo, Frame::Logical>,
+                             SpacetimeIndex<2, UpLo::Up, Frame::Distorted>>;
+
+    CHECK(get_output(structure::symmetries()) == "(3,3,2,1)");
+    CHECK(get_output(structure::index_types()) ==
+          "(Spatial,Spatial,Spacetime,Spacetime)");
+    CHECK(get_output(structure::dims()) == "(2,2,4,3)");
+    CHECK(get_output(structure::index_valences()) == "(Lo,Lo,Lo,Up)");
+    CHECK(get_output(structure::index_frames()) ==
+          "(Inertial,Inertial,Logical,Distorted)");
+  }
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Structure.Indices",

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -88,32 +88,18 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
   CHECK(v2 == v3);
 
   const std::string expected_output =
-      "--Symmetry:  (1)\n"
-      "--Types:     (Spatial)\n"
-      "--Dims:      (3)\n"
-      "--Locations: (Up)\n"
-      "--Frames:    (Grid)\n"
-      " T(0)=(-4)\n"
-      "     Multiplicity: 1 Index: 0\n"
-      " T(1)=(-4)\n"
-      "     Multiplicity: 1 Index: 1\n"
-      " T(2)=(-4)\n"
-      "     Multiplicity: 1 Index: 2\n"
-      "--Symmetry:  ()\n"
-      "--Types:     ()\n"
-      "--Dims:      ()\n"
-      "--Locations: ()\n"
-      "--Frames:    ()\n"
-      " T()=(-3)\n"
-      "     Multiplicity: 1 Index: 0\n"
-      "--Symmetry:  ()\n"
-      "--Types:     ()\n"
-      "--Dims:      ()\n"
-      "--Locations: ()\n"
-      "--Frames:    ()\n"
-      " T()=(-3)\n"
-      "     Multiplicity: 1 Index: 0";
+      "vector:\n"
+      "T(0)=(-4)\n"
+      "T(1)=(-4)\n"
+      "T(2)=(-4)\n\n"
+      "scalar:\n"
+      "T()=(-3)\n\n"
+      "scalar2:\n"
+      "T()=(-3)";
   CHECK(get_output(v) == expected_output);
+
+  Variables<tmpl::list<>> empty_vars;
+  CHECK(get_output(empty_vars) == "Variables is empty!");
 
   // Check self-assignment
   v = v;

--- a/tests/Unit/Utilities/Test_StdHelpers.cpp
+++ b/tests/Unit/Utilities/Test_StdHelpers.cpp
@@ -52,7 +52,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.StdHelpers.Output", "[Utilities][Unit]") {
   CHECK(get_output(a5) == "(1,2,3,4,5)");
 
   auto tuple1 = std::make_tuple<int, double, std::string>(1, 1.87, "test");
-  CHECK(get_output(tuple1) == "(1, 1.87, test)");
+  CHECK(get_output(tuple1) == "(1,1.87,test)");
   std::tuple<> tuple0{};
   CHECK(get_output(tuple0) == "()");
 


### PR DESCRIPTION
## Proposed changes

Removes the structure information from the tensor stream operator. 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


