### PR TITLE
Add Raise and Lower

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY GeneralRelativity)
 set(LIBRARY_SOURCES
     Christoffel.cpp
     ComputeSpacetimeQuantities.cpp
+    IndexManipulation.cpp
     )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+template <typename DataType, typename Index0, typename Index1>
+Tensor<DataType, Symmetry<2, 1, 1>,
+       index_list<change_index_up_lo<Index0>, Index1, Index1>>
+ raise_or_lower_first_index (
+    const Tensor<DataType, Symmetry<2, 1, 1>,
+                 index_list<Index0, Index1, Index1>>& tensor,
+    const Tensor<DataType, Symmetry<1, 1>,
+                 index_list<change_index_up_lo<Index0>,
+                            change_index_up_lo<Index0>>>& metric) noexcept {
+  Tensor<DataType, Symmetry<2, 1, 1>,
+         index_list<change_index_up_lo<Index0>, Index1, Index1>>
+      tensor_opposite_valence{make_with_value<DataType>(*tensor.begin(), 0.)};
+
+  constexpr auto dimension = Index0::dim;
+
+  for (size_t i = 0; i < dimension; ++i) {
+    for (size_t j = 0; j < dimension; ++j) {
+      for (size_t k = j; k < dimension; ++k) {
+        for (size_t m = 0; m < dimension; ++m) {
+          tensor_opposite_valence.get(i, j, k) +=
+              tensor.get(m, j, k) * metric.get(i, m);
+        }
+      }
+    }
+  }
+  return tensor_opposite_valence;
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define UPORLO(data) BOOST_PP_TUPLE_ELEM(3, data)
+#define INDEXTYPE(data) BOOST_PP_TUPLE_ELEM(4, data)
+
+#define INDEX0(data) INDEXTYPE(data)<DIM(data), UPORLO(data), FRAME(data)>
+#define INDEX1(data) INDEXTYPE(data)<DIM(data), UpLo::Lo, FRAME(data)>
+
+#define INSTANTIATE(_, data)                                                 \
+  template Tensor<DTYPE(data), Symmetry<2, 1, 1>,                            \
+                  index_list<change_index_up_lo<INDEX0(data)>, INDEX1(data), \
+                             INDEX1(data)>>                                  \
+  raise_or_lower_first_index(                                                \
+      const Tensor<DTYPE(data), Symmetry<2, 1, 1>,                           \
+                   index_list<INDEX0(data), INDEX1(data), INDEX1(data)>>&    \
+          tensor,                                                            \
+      const Tensor<DTYPE(data), Symmetry<1, 1>,                              \
+                   index_list<change_index_up_lo<INDEX0(data)>,              \
+                              change_index_up_lo<INDEX0(data)>>>&            \
+          metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial), (UpLo::Lo, UpLo::Up),
+                        (SpatialIndex, SpacetimeIndex))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef UPORLO
+#undef INDEXTYPE
+#undef INDEX0
+#undef INDEX1
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/Tensor.hpp"
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Raises or lowers the first index of a rank 3 tensor which is symmetric
+ * in the last two indices.
+ *
+ * \details If \f$T_{abc}\f$ is a tensor with \f$T_{abc} = T_{acb}\f$ and the
+ * indices \f$a,b,c,...\f$ can represent either spatial or spacetime indices,
+ * then the tensor \f$ T^a_{bc} = g^{ad} T_{abc} \f$ is computed, where \f$
+ * g^{ab}\f$ is the inverse metric, which is either a spatial or spacetime
+ * metric. If a tensor \f$ S^a_{bc} \f$ is passed as an argument than the
+ * corresponding tensor \f$ S_{abc} \f$ is calculated with respect to the metric
+ * \f$g_{ab}\f$.
+ */
+template <typename DataType, typename Index0, typename Index1>
+Tensor<DataType, Symmetry<2, 1, 1>,
+       index_list<change_index_up_lo<Index0>, Index1, Index1>>
+raise_or_lower_first_index(
+    const Tensor<DataType, Symmetry<2, 1, 1>,
+                 index_list<Index0, Index1, Index1>>& tensor,
+    const Tensor<DataType, Symmetry<1, 1>,
+                 index_list<change_index_up_lo<Index0>,
+                            change_index_up_lo<Index0>>>& metric) noexcept;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SPECTRE_UNIT_GENERAL_RELATIVITY
     PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
     PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
     PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+    PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
     )
 
 set(SPECTRE_UNIT_POINTWISE_FUNCTIONS

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
@@ -141,6 +141,64 @@ tnsr::iaa<DataType, SpatialDim> make_spatial_deriv_spacetime_metric(
   return d_spacetime_metric;
 }
 
+template <size_t SpatialDim, typename DataType>
+tnsr::Abb<DataType, SpatialDim> make_spacetime_christoffel_second_kind(
+    const DataType& used_for_size) {
+  tnsr::Abb<DataType, SpatialDim> christoffel{};
+  for (size_t i = 0; i < SpatialDim + 1; i++) {
+    for (size_t j = i; j < SpatialDim + 1; j++) {
+      for (size_t k = 0; k < SpatialDim + 1; k++) {
+        christoffel.get(k, i, j) = make_with_value<DataType>(
+            used_for_size, (i + 2.) * (j + 1.) * (k + 2.));
+      }
+    }
+  }
+  return christoffel;
+}
+
+
+template <size_t SpatialDim, typename DataType>
+tnsr::Ijj<DataType, SpatialDim> make_spatial_christoffel_second_kind(
+    const DataType& used_for_size){
+  tnsr::Ijj<DataType, SpatialDim> christoffel{};
+  for (size_t i = 0; i < SpatialDim; i++) {
+    for (size_t j = i; j < SpatialDim; j++) {
+      for (size_t k = 0; k < SpatialDim; k++) {
+        christoffel.get(k, i, j) = make_with_value<DataType>(
+            used_for_size, 4. * (i + 1.) * (j + 1.) - k);
+      }
+    }
+  }
+  return christoffel;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::aa<DataType, SpatialDim> make_spacetime_metric(
+    const DataType& used_for_size){
+  tnsr::aa<DataType, SpatialDim> spacetime_metric{};
+  for (size_t mu = 0; mu < SpatialDim + 1; ++mu) {
+    for (size_t nu = mu; nu < SpatialDim + 1; ++nu) {
+      spacetime_metric.get(mu, nu) =
+          make_with_value<DataType>(used_for_size, -2. * (mu + 2.) * (nu + 2.));
+    }
+  }
+  return spacetime_metric;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::AA<DataType, SpatialDim> make_inverse_spacetime_metric(
+    const DataType& used_for_size) {
+  tnsr::AA<DataType, SpatialDim> inverse_spacetime_metric{};
+  for (size_t mu = 0; mu < SpatialDim + 1; ++mu) {
+    for (size_t nu = mu; nu < SpatialDim + 1; ++nu) {
+      inverse_spacetime_metric.get(mu, nu) =
+          make_with_value<DataType>(used_for_size, -2. * (mu + 2.) * (nu + 2.));
+    }
+  }
+  return inverse_spacetime_metric;
+}
+
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -164,7 +222,15 @@ tnsr::iaa<DataType, SpatialDim> make_spatial_deriv_spacetime_metric(
   template tnsr::abb<DTYPE(data), DIM(data)>                                 \
   make_spacetime_deriv_spacetime_metric(const DTYPE(data) & used_for_size);  \
   template tnsr::iaa<DTYPE(data), DIM(data)>                                 \
-  make_spatial_deriv_spacetime_metric(const DTYPE(data) & used_for_size);
+  make_spatial_deriv_spacetime_metric(const DTYPE(data) & used_for_size);    \
+  template tnsr::Abb<DTYPE(data), DIM(data)>                                 \
+  make_spacetime_christoffel_second_kind(const DTYPE(data) & used_for_size); \
+  template tnsr::Ijj<DTYPE(data), DIM(data)>                                 \
+  make_spatial_christoffel_second_kind(const DTYPE(data) & used_for_size);   \
+  template tnsr::aa<DTYPE(data), DIM(data)> make_spacetime_metric(           \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::AA<DTYPE(data), DIM(data)> make_inverse_spacetime_metric(   \
+      const DTYPE(data) & used_for_size);
 
 template Scalar<double> make_lapse(const double& used_for_size);
 template Scalar<DataVector> make_lapse(const DataVector& used_for_size);

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
@@ -61,9 +61,25 @@ tnsr::ijj<DataType, SpatialDim> make_deriv_spatial_metric(
     const DataType& used_for_size);
 
 template <size_t SpatialDim, typename DataType>
+tnsr::Ijj<DataType, SpatialDim> make_spatial_christoffel_second_kind(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
 tnsr::abb<DataType, SpatialDim> make_spacetime_deriv_spacetime_metric(
     const DataType& used_for_size);
 
 template <size_t SpatialDim, typename DataType>
 tnsr::iaa<DataType, SpatialDim> make_spatial_deriv_spacetime_metric(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::Abb<DataType, SpatialDim> make_spacetime_christoffel_second_kind(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::aa<DataType, SpatialDim> make_spacetime_metric(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::AA<DataType, SpatialDim> make_inverse_spacetime_metric(
     const DataType& used_for_size);

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
@@ -1,0 +1,266 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+void test_1d_spatial_raise(const DataVector& used_for_size) {
+  const size_t dim = 1;
+  const tnsr::Ijj<double, dim> raised_tensor = raise_or_lower_first_index(
+      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
+
+  CHECK(raised_tensor.get(0, 0, 0) == approx(3.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_first_index(
+          make_deriv_spatial_metric<dim>(used_for_size),
+          make_inverse_spatial_metric<dim>(used_for_size)),
+      raised_tensor);
+}
+
+void test_1d_spatial_lower(const DataVector& used_for_size) {
+  const size_t dim = 1;
+  const tnsr::ijj<double, dim> lowered_tensor =
+      raise_or_lower_first_index(make_spatial_christoffel_second_kind<dim>(0.),
+                                 make_spatial_metric<dim>(0.));
+
+  CHECK(lowered_tensor.get(0, 0, 0) == approx(4.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_first_index(
+          make_spatial_christoffel_second_kind<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size)),
+      lowered_tensor);
+}
+
+void test_2d_spatial_raise(const DataVector& used_for_size) {
+  const size_t dim = 2;
+
+  const tnsr::Ijj<double, dim> raised_tensor = raise_or_lower_first_index(
+      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
+
+  CHECK(raised_tensor.get(0, 0, 0) == approx(11));
+  CHECK(raised_tensor.get(0, 0, 1) == approx(20));
+  CHECK(raised_tensor.get(0, 1, 1) == approx(38));
+  CHECK(raised_tensor.get(1, 0, 0) == approx(22));
+  CHECK(raised_tensor.get(1, 0, 1) == approx(40));
+  CHECK(raised_tensor.get(1, 1, 1) == approx(76));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_first_index(
+          make_deriv_spatial_metric<dim>(used_for_size),
+          make_inverse_spatial_metric<dim>(used_for_size)),
+      raised_tensor);
+}
+
+void test_2d_spatial_lower(const DataVector& used_for_size) {
+  const size_t dim = 2;
+
+  const tnsr::ijj<double, dim> lowered_tensor =
+      raise_or_lower_first_index(make_spatial_christoffel_second_kind<dim>(0.),
+                                 make_spatial_metric<dim>(0.));
+
+  CHECK(lowered_tensor.get(0, 0, 0) == approx(10));
+  CHECK(lowered_tensor.get(0, 0, 1) == approx(22));
+  CHECK(lowered_tensor.get(0, 1, 1) == approx(46));
+  CHECK(lowered_tensor.get(1, 0, 0) == approx(20));
+  CHECK(lowered_tensor.get(1, 0, 1) == approx(44));
+  CHECK(lowered_tensor.get(1, 1, 1) == approx(92));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_first_index(
+          make_spatial_christoffel_second_kind<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size)),
+      lowered_tensor);
+}
+
+void test_3d_spatial_raise(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const tnsr::Ijj<double, dim> raised_tensor = raise_or_lower_first_index(
+      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
+
+  CHECK(raised_tensor.get(0, 0, 0) == approx(26));
+  CHECK(raised_tensor.get(0, 0, 1) == approx(44));
+  CHECK(raised_tensor.get(0, 0, 2) == approx(62));
+  CHECK(raised_tensor.get(0, 1, 1) == approx(80));
+  CHECK(raised_tensor.get(0, 1, 2) == approx(116));
+  CHECK(raised_tensor.get(0, 2, 2) == approx(170));
+  CHECK(raised_tensor.get(1, 0, 0) == approx(52));
+  CHECK(raised_tensor.get(1, 0, 1) == approx(88));
+  CHECK(raised_tensor.get(1, 0, 2) == approx(124));
+  CHECK(raised_tensor.get(1, 1, 1) == approx(160));
+  CHECK(raised_tensor.get(1, 1, 2) == approx(232));
+  CHECK(raised_tensor.get(1, 2, 2) == approx(340));
+  CHECK(raised_tensor.get(2, 0, 0) == approx(78));
+  CHECK(raised_tensor.get(2, 0, 1) == approx(132));
+  CHECK(raised_tensor.get(2, 0, 2) == approx(186));
+  CHECK(raised_tensor.get(2, 1, 1) == approx(240));
+  CHECK(raised_tensor.get(2, 1, 2) == approx(348));
+  CHECK(raised_tensor.get(2, 2, 2) == approx(510));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_first_index(
+          make_deriv_spatial_metric<dim>(used_for_size),
+          make_inverse_spatial_metric<dim>(used_for_size)),
+      raised_tensor);
+}
+void test_3d_spatial_lower(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const tnsr::ijj<double, dim> lowered_tensor =
+      raise_or_lower_first_index(make_spatial_christoffel_second_kind<dim>(0.),
+                                 make_spatial_metric<dim>(0.));
+
+  CHECK(lowered_tensor.get(0, 0, 0) == approx(16));
+  CHECK(lowered_tensor.get(0, 0, 1) == approx(40));
+  CHECK(lowered_tensor.get(0, 0, 2) == approx(64));
+  CHECK(lowered_tensor.get(0, 1, 1) == approx(88));
+  CHECK(lowered_tensor.get(0, 1, 2) == approx(136));
+  CHECK(lowered_tensor.get(0, 2, 2) == approx(208));
+  CHECK(lowered_tensor.get(1, 0, 0) == approx(32));
+  CHECK(lowered_tensor.get(1, 0, 1) == approx(80));
+  CHECK(lowered_tensor.get(1, 0, 2) == approx(128));
+  CHECK(lowered_tensor.get(1, 1, 1) == approx(176));
+  CHECK(lowered_tensor.get(1, 1, 2) == approx(272));
+  CHECK(lowered_tensor.get(1, 2, 2) == approx(416));
+  CHECK(lowered_tensor.get(2, 0, 0) == approx(48));
+  CHECK(lowered_tensor.get(2, 0, 1) == approx(120));
+  CHECK(lowered_tensor.get(2, 0, 2) == approx(192));
+  CHECK(lowered_tensor.get(2, 1, 1) == approx(264));
+  CHECK(lowered_tensor.get(2, 1, 2) == approx(408));
+  CHECK(lowered_tensor.get(2, 2, 2) == approx(624));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_first_index(
+          make_spatial_christoffel_second_kind<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size)),
+      lowered_tensor);
+}
+
+void test_3d_spacetime_raise(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const tnsr::Abb<double, dim> raised_tensor =
+      raise_or_lower_first_index(make_spacetime_deriv_spacetime_metric<dim>(0.),
+                                 make_inverse_spacetime_metric<dim>(0.));
+
+  CHECK(raised_tensor.get(0, 0, 0) == approx(-272));
+  CHECK(raised_tensor.get(0, 0, 1) == approx(-544));
+  CHECK(raised_tensor.get(0, 0, 2) == approx(-816));
+  CHECK(raised_tensor.get(0, 0, 3) == approx(-1088));
+  CHECK(raised_tensor.get(0, 1, 1) == approx(-1088));
+  CHECK(raised_tensor.get(0, 1, 2) == approx(-1632));
+  CHECK(raised_tensor.get(0, 1, 3) == approx(-2176));
+  CHECK(raised_tensor.get(0, 2, 2) == approx(-2448));
+  CHECK(raised_tensor.get(0, 2, 3) == approx(-3264));
+  CHECK(raised_tensor.get(0, 3, 3) == approx(-4352));
+  CHECK(raised_tensor.get(1, 0, 0) == approx(-408));
+  CHECK(raised_tensor.get(1, 0, 1) == approx(-816));
+  CHECK(raised_tensor.get(1, 0, 2) == approx(-1224));
+  CHECK(raised_tensor.get(1, 0, 3) == approx(-1632));
+  CHECK(raised_tensor.get(1, 1, 1) == approx(-1632));
+  CHECK(raised_tensor.get(1, 1, 2) == approx(-2448));
+  CHECK(raised_tensor.get(1, 1, 3) == approx(-3264));
+  CHECK(raised_tensor.get(1, 2, 2) == approx(-3672));
+  CHECK(raised_tensor.get(1, 2, 3) == approx(-4896));
+  CHECK(raised_tensor.get(1, 3, 3) == approx(-6528));
+  CHECK(raised_tensor.get(2, 0, 0) == approx(-544));
+  CHECK(raised_tensor.get(2, 0, 1) == approx(-1088));
+  CHECK(raised_tensor.get(2, 0, 2) == approx(-1632));
+  CHECK(raised_tensor.get(2, 0, 3) == approx(-2176));
+  CHECK(raised_tensor.get(2, 1, 1) == approx(-2176));
+  CHECK(raised_tensor.get(2, 1, 2) == approx(-3264));
+  CHECK(raised_tensor.get(2, 1, 3) == approx(-4352));
+  CHECK(raised_tensor.get(2, 2, 2) == approx(-4896));
+  CHECK(raised_tensor.get(2, 2, 3) == approx(-6528));
+  CHECK(raised_tensor.get(2, 3, 3) == approx(-8704));
+  CHECK(raised_tensor.get(3, 0, 0) == approx(-680));
+  CHECK(raised_tensor.get(3, 0, 1) == approx(-1360));
+  CHECK(raised_tensor.get(3, 0, 2) == approx(-2040));
+  CHECK(raised_tensor.get(3, 0, 3) == approx(-2720));
+  CHECK(raised_tensor.get(3, 1, 1) == approx(-2720));
+  CHECK(raised_tensor.get(3, 1, 2) == approx(-4080));
+  CHECK(raised_tensor.get(3, 1, 3) == approx(-5440));
+  CHECK(raised_tensor.get(3, 2, 2) == approx(-6120));
+  CHECK(raised_tensor.get(3, 2, 3) == approx(-8160));
+  CHECK(raised_tensor.get(3, 3, 3) == approx(-10880));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_first_index(
+          make_spacetime_deriv_spacetime_metric<dim>(used_for_size),
+          make_inverse_spacetime_metric<dim>(used_for_size)),
+      raised_tensor);
+}
+
+void test_3d_spacetime_lower(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const tnsr::abb<double, dim> lowered_tensor = raise_or_lower_first_index(
+      make_spacetime_christoffel_second_kind<dim>(0.),
+      make_spacetime_metric<dim>(0.));
+
+  CHECK(lowered_tensor.get(0, 0, 0) == approx(-432));
+  CHECK(lowered_tensor.get(0, 0, 1) == approx(-864));
+  CHECK(lowered_tensor.get(0, 0, 2) == approx(-1296));
+  CHECK(lowered_tensor.get(0, 0, 3) == approx(-1728));
+  CHECK(lowered_tensor.get(0, 1, 1) == approx(-1296));
+  CHECK(lowered_tensor.get(0, 1, 2) == approx(-1944));
+  CHECK(lowered_tensor.get(0, 1, 3) == approx(-2592));
+  CHECK(lowered_tensor.get(0, 2, 2) == approx(-2592));
+  CHECK(lowered_tensor.get(0, 2, 3) == approx(-3456));
+  CHECK(lowered_tensor.get(0, 3, 3) == approx(-4320));
+  CHECK(lowered_tensor.get(1, 0, 0) == approx(-648));
+  CHECK(lowered_tensor.get(1, 0, 1) == approx(-1296));
+  CHECK(lowered_tensor.get(1, 0, 2) == approx(-1944));
+  CHECK(lowered_tensor.get(1, 0, 3) == approx(-2592));
+  CHECK(lowered_tensor.get(1, 1, 1) == approx(-1944));
+  CHECK(lowered_tensor.get(1, 1, 2) == approx(-2916));
+  CHECK(lowered_tensor.get(1, 1, 3) == approx(-3888));
+  CHECK(lowered_tensor.get(1, 2, 2) == approx(-3888));
+  CHECK(lowered_tensor.get(1, 2, 3) == approx(-5184));
+  CHECK(lowered_tensor.get(1, 3, 3) == approx(-6480));
+  CHECK(lowered_tensor.get(2, 0, 0) == approx(-864));
+  CHECK(lowered_tensor.get(2, 0, 1) == approx(-1728));
+  CHECK(lowered_tensor.get(2, 0, 2) == approx(-2592));
+  CHECK(lowered_tensor.get(2, 0, 3) == approx(-3456));
+  CHECK(lowered_tensor.get(2, 1, 1) == approx(-2592));
+  CHECK(lowered_tensor.get(2, 1, 2) == approx(-3888));
+  CHECK(lowered_tensor.get(2, 1, 3) == approx(-5184));
+  CHECK(lowered_tensor.get(2, 2, 2) == approx(-5184));
+  CHECK(lowered_tensor.get(2, 2, 3) == approx(-6912));
+  CHECK(lowered_tensor.get(2, 3, 3) == approx(-8640));
+  CHECK(lowered_tensor.get(3, 0, 0) == approx(-1080));
+  CHECK(lowered_tensor.get(3, 0, 1) == approx(-2160));
+  CHECK(lowered_tensor.get(3, 0, 2) == approx(-3240));
+  CHECK(lowered_tensor.get(3, 0, 3) == approx(-4320));
+  CHECK(lowered_tensor.get(3, 1, 1) == approx(-3240));
+  CHECK(lowered_tensor.get(3, 1, 2) == approx(-4860));
+  CHECK(lowered_tensor.get(3, 1, 3) == approx(-6480));
+  CHECK(lowered_tensor.get(3, 2, 2) == approx(-6480));
+  CHECK(lowered_tensor.get(3, 2, 3) == approx(-8640));
+  CHECK(lowered_tensor.get(3, 3, 3) == approx(-10800));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_first_index(
+          make_spacetime_christoffel_second_kind<dim>(used_for_size),
+          make_spacetime_metric<dim>(used_for_size)),
+      lowered_tensor);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.IndexManipulation",
+                  "[PointwiseFunctions][Unit]") {
+  const size_t dim = 3;
+  const DataVector dv(2);
+
+  test_1d_spatial_raise(dv);
+  test_2d_spatial_raise(dv);
+  test_3d_spatial_raise(dv);
+  test_1d_spatial_lower(dv);
+  test_2d_spatial_lower(dv);
+  test_3d_spatial_lower(dv);
+  test_3d_spacetime_raise(dv);
+  test_3d_spacetime_lower(dv);
+}


### PR DESCRIPTION
## Proposed changes

Adds function to raise and lower index of Christoffel type tensors. 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`

