### PR TITLE
Add generic test of initial Domain

### DIFF
--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -351,7 +351,8 @@ namespace cpp20 {
 /// \ingroup TypeTraits
 template <class T>
 struct remove_cvref {
-  typedef std::remove_cv_t<std::remove_reference_t<T>> type;
+  // clang-tidy use using instead of typedef
+  typedef std::remove_cv_t<std::remove_reference_t<T>> type;  // NOLINT
 };
 
 /// \ingroup TypeTraits

--- a/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
@@ -45,6 +45,8 @@ void test_brick_construction(
           AffineMap3D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
                       AffineMap{-1., 1., lower_bound[1], upper_bound[1]},
                       AffineMap{-1., 1., lower_bound[2], upper_bound[2]}})));
+
+  test_initial_domain(domain, brick.initial_refinement_levels());
 }
 }  // namespace
 
@@ -189,11 +191,24 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick.Factory",
                   "[Domain][Unit]") {
-  test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-      "  Brick:\n"
-      "    LowerBound: [0,0,0]\n"
-      "    UpperBound: [1,2,3]\n"
-      "    IsPeriodicIn: [True,False,True]\n"
-      "    InitialGridPoints: [3,4,3]\n"
-      "    InitialRefinement: [2,3,2]\n");
+  const auto domain_creator =
+      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+          "  Brick:\n"
+          "    LowerBound: [0,0,0]\n"
+          "    UpperBound: [1,2,3]\n"
+          "    IsPeriodicIn: [True,False,True]\n"
+          "    InitialGridPoints: [3,4,3]\n"
+          "    InitialRefinement: [2,3,2]\n");
+  const auto* brick_creator =
+      dynamic_cast<const DomainCreators::Brick*>(domain_creator.get());
+  test_brick_construction(
+      *brick_creator, {{0., 0., 0.}}, {{1., 2., 3.}}, {{{3, 4, 3}}},
+      {{{2, 3, 2}}},
+      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+          {{Direction<3>::lower_xi(), {0, {}}},
+           {Direction<3>::upper_xi(), {0, {}}},
+           {Direction<3>::lower_zeta(), {0, {}}},
+           {Direction<3>::upper_zeta(), {0, {}}}}},
+      std::vector<std::unordered_set<Direction<3>>>{
+          {{Direction<3>::lower_eta()}, {Direction<3>::upper_eta()}}});
 }

--- a/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
@@ -14,12 +14,16 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
-void test_interval(
+void test_interval_construction(
     const DomainCreators::Interval& interval,
     const std::array<double, 1>& lower_bound,
     const std::array<double, 1>& upper_bound,
     const std::vector<std::array<size_t, 1>>& expected_extents,
-    const std::vector<std::array<size_t, 1>>& expected_refinement_level) {
+    const std::vector<std::array<size_t, 1>>& expected_refinement_level,
+    const std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>&
+        expected_block_neighbors,
+    const std::vector<std::unordered_set<Direction<1>>>&
+        expected_external_boundaries) noexcept {
   const auto domain = interval.create_domain();
   const auto& block = domain.blocks()[0];
   const auto& neighbors = block.neighbors();
@@ -32,40 +36,10 @@ void test_interval(
   PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
                          CoordinateMaps::AffineMap>));
   test_domain_construction(
-      domain,
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{{}},
-      std::vector<std::unordered_set<Direction<1>>>{
-          {{Direction<1>::lower_xi()}, {Direction<1>::upper_xi()}}},
+      domain, expected_block_neighbors, expected_external_boundaries,
       make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           CoordinateMaps::AffineMap{-1., 1., lower_bound[0], upper_bound[0]})));
-}
-
-void test_periodic_interval(
-    const DomainCreators::Interval& interval,
-    const std::array<double, 1>& lower_bound,
-    const std::array<double, 1>& upper_bound,
-    const std::vector<std::array<size_t, 1>>& expected_extents,
-    const std::vector<std::array<size_t, 1>>& expected_refinement_level) {
-  const auto domain = interval.create_domain();
-  const auto& block = domain.blocks()[0];
-  const auto& neighbors = block.neighbors();
-  const auto& external_boundaries = block.external_boundaries();
-
-  CHECK(block.id() == 0);
-  CHECK(interval.initial_extents() == expected_extents);
-  CHECK(interval.initial_refinement_levels() == expected_refinement_level);
-
-  const OrientationMap<1> aligned_orientation{{{Direction<1>::lower_xi()}},
-                                              {{Direction<1>::lower_xi()}}};
-
-  test_domain_construction(
-      domain,
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
-          {{Direction<1>::lower_xi(), {0, aligned_orientation}},
-           {Direction<1>::upper_xi(), {0, aligned_orientation}}}},
-      std::vector<std::unordered_set<Direction<1>>>{{}},
-      make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::AffineMap{-1., 1., lower_bound[0], upper_bound[0]})));
+  test_initial_domain(domain, interval.initial_refinement_levels());
 }
 }  // namespace
 
@@ -73,22 +47,32 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval", "[Domain][Unit]") {
   const std::vector<std::array<size_t, 1>> grid_points{{{4}}},
       refinement_level{{{3}}};
   const std::array<double, 1> lower_bound{{-1.2}}, upper_bound{{0.8}};
+  // default Orientation is aligned
+  const OrientationMap<1> aligned_orientation{};
 
   const DomainCreators::Interval interval{lower_bound, upper_bound,
                                           std::array<bool, 1>{{false}},
                                           refinement_level[0], grid_points[0]};
-
-  test_interval(interval, lower_bound, upper_bound, grid_points,
-                refinement_level);
+  test_interval_construction(
+      interval, lower_bound, upper_bound, grid_points, refinement_level,
+      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{{}},
+      std::vector<std::unordered_set<Direction<1>>>{
+          {{Direction<1>::lower_xi()}, {Direction<1>::upper_xi()}}});
 
   const DomainCreators::Interval periodic_interval{
       lower_bound, upper_bound, std::array<bool, 1>{{true}},
       refinement_level[0], grid_points[0]};
-  test_periodic_interval(periodic_interval, lower_bound, upper_bound,
-                         grid_points, refinement_level);
+  test_interval_construction(
+      periodic_interval, lower_bound, upper_bound, grid_points,
+      refinement_level,
+      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+          {{Direction<1>::lower_xi(), {0, aligned_orientation}},
+           {Direction<1>::upper_xi(), {0, aligned_orientation}}}},
+      std::vector<std::unordered_set<Direction<1>>>{{}});
 
   // Test serialization of the map
   DomainCreators::register_derived_with_charm();
+
   const auto base_map =
       make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           CoordinateMaps::AffineMap{-1., 1., lower_bound[0], upper_bound[0]});
@@ -103,11 +87,20 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval", "[Domain][Unit]") {
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval.Factory",
                   "[Domain][Unit]") {
-  test_factory_creation<DomainCreator<1, Frame::Inertial>>(
-      "  Interval:\n"
-      "    LowerBound: [0]\n"
-      "    UpperBound: [1]\n"
-      "    IsPeriodicIn: [True]\n"
-      "    InitialGridPoints: [3]\n"
-      "    InitialRefinement: [2]\n");
+  const auto domain_creator =
+      test_factory_creation<DomainCreator<1, Frame::Inertial>>(
+          "  Interval:\n"
+          "    LowerBound: [0]\n"
+          "    UpperBound: [1]\n"
+          "    IsPeriodicIn: [True]\n"
+          "    InitialGridPoints: [3]\n"
+          "    InitialRefinement: [2]\n");
+  const auto* interval_creator =
+      dynamic_cast<const DomainCreators::Interval*>(domain_creator.get());
+  test_interval_construction(
+      *interval_creator, {{0.}}, {{1.}}, {{{3}}}, {{{2}}},
+      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+          {{Direction<1>::lower_xi(), {0, {}}},
+           {Direction<1>::upper_xi(), {0, {}}}}},
+      std::vector<std::unordered_set<Direction<1>>>{{}});
 }

--- a/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
@@ -43,6 +43,7 @@ void test_rectangle_construction(
       make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           AffineMap2D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
                       AffineMap{-1., 1., lower_bound[1], upper_bound[1]}})));
+  test_initial_domain(domain, rectangle.initial_refinement_levels());
 }
 }  // namespace
 
@@ -121,11 +122,21 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle.Factory",
                   "[Domain][Unit]") {
-  test_factory_creation<DomainCreator<2, Frame::Inertial>>(
-      "  Rectangle:\n"
-      "    LowerBound: [0,0]\n"
-      "    UpperBound: [1,2]\n"
-      "    IsPeriodicIn: [True,False]\n"
-      "    InitialGridPoints: [3,4]\n"
-      "    InitialRefinement: [2,3]\n");
+  const auto domain_creator =
+      test_factory_creation<DomainCreator<2, Frame::Inertial>>(
+          "  Rectangle:\n"
+          "    LowerBound: [0,0]\n"
+          "    UpperBound: [1,2]\n"
+          "    IsPeriodicIn: [True,False]\n"
+          "    InitialGridPoints: [3,4]\n"
+          "    InitialRefinement: [2,3]\n");
+  const auto* rectangle_creator =
+      dynamic_cast<const DomainCreators::Rectangle*>(domain_creator.get());
+  test_rectangle_construction(
+      *rectangle_creator, {{0., 0.}}, {{1., 2.}}, {{{3, 4}}}, {{{2, 3}}},
+      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+          {{Direction<2>::lower_xi(), {0, {}}},
+           {Direction<2>::upper_xi(), {0, {}}}}},
+      std::vector<std::unordered_set<Direction<2>>>{
+          {{Direction<2>::lower_eta()}, {Direction<2>::upper_eta()}}});
 }

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -8,12 +8,154 @@
 
 #include "Domain/Block.hpp"
 #include "Domain/BlockNeighbor.hpp"
+#include "Domain/CreateInitialElement.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Domain.hpp"
+#include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"
+#include "Domain/InitialElementIds.hpp"
 #include "Domain/SegmentId.hpp"
+#include "Utilities/ForceInline.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
+
+namespace {
+template <size_t VolumeDim>
+boost::rational<size_t> fraction_of_block_face_area(
+    const ElementId<VolumeDim>& element_id,
+    const Direction<VolumeDim>& direction) noexcept {
+  const auto& segment_ids = element_id.segment_ids();
+  size_t sum_of_refinement_levels = 0;
+  const size_t dim_normal_to_face = direction.dimension();
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    if (dim_normal_to_face != d) {
+      sum_of_refinement_levels += gsl::at(segment_ids, d).refinement_level();
+    }
+  }
+  return boost::rational<size_t>(1, two_to_the(sum_of_refinement_levels));
+}
+
+template <size_t VolumeDim>
+bool is_a_neighbor_of_my_neighbor_me(
+    const ElementId<VolumeDim>& my_id, const Element<VolumeDim>& my_neighbor,
+    const Direction<VolumeDim>& direction_to_me_in_neighbor) noexcept {
+  size_t number_of_matches = 0;
+  for (const auto& id_of_neighbor_of_neighbor :
+       my_neighbor.neighbors().at(direction_to_me_in_neighbor).ids()) {
+    if (my_id == id_of_neighbor_of_neighbor) {
+      ++number_of_matches;
+    }
+  }
+  return 1 == number_of_matches;
+}
+
+template <size_t VolumeDim>
+void test_domain_connectivity(
+    const Domain<VolumeDim, Frame::Inertial>& domain,
+    const std::unordered_map<ElementId<VolumeDim>, Element<VolumeDim>>&
+        elements_in_domain) noexcept {
+  boost::rational<size_t> volume_of_elements{0};
+  boost::rational<size_t> surface_area_of_external_boundaries{0};
+  // For internal boundaries within a Block, lower/upper is defined with
+  // respect to the logical coordinates of the block
+  // for internal boundaries between two Blocks, lower/upper is defined
+  // using the id of the Block (the Block with the smaller/larger id being
+  // associated with the lower/upper internal boundary).
+  boost::rational<size_t> surface_area_of_lower_internal_boundaries{0};
+  boost::rational<size_t> surface_area_of_upper_internal_boundaries{0};
+
+  for (const auto& key_value : elements_in_domain) {
+    const auto& element_id = key_value.first;
+    const auto& element = key_value.second;
+    CHECK(element_id == element.id());
+    volume_of_elements += fraction_of_block_volume(element_id);
+    for (const auto& direction : element.external_boundaries()) {
+      surface_area_of_external_boundaries +=
+          fraction_of_block_face_area(element_id, direction);
+    }
+    for (const auto& direction_neighbors : element.neighbors()) {
+      const auto& direction = direction_neighbors.first;
+      const auto& neighbors = direction_neighbors.second;
+      const auto& direction_to_me_in_neighbor =
+          neighbors.orientation()(direction.opposite());
+      for (const auto& neighbor_id : neighbors.ids()) {
+        CHECK(is_a_neighbor_of_my_neighbor_me(
+            element_id, elements_in_domain.at(neighbor_id),
+            direction_to_me_in_neighbor));
+      }
+      const size_t element_block_id = element_id.block_id();
+      const size_t neighbor_block_id = neighbors.ids().begin()->block_id();
+      if (element_block_id == neighbor_block_id) {
+        if (Side::Lower == direction.side()) {
+          surface_area_of_lower_internal_boundaries +=
+              fraction_of_block_face_area(element_id, direction);
+        } else {
+          surface_area_of_upper_internal_boundaries +=
+              fraction_of_block_face_area(element_id, direction);
+        }
+      } else {
+        if (neighbor_block_id > element_block_id) {
+          surface_area_of_lower_internal_boundaries +=
+              fraction_of_block_face_area(element_id, direction);
+        } else {
+          surface_area_of_upper_internal_boundaries +=
+              fraction_of_block_face_area(element_id, direction);
+        }
+      }
+    }
+  }
+
+  CHECK(boost::rational<size_t>{domain.blocks().size()} == volume_of_elements);
+  CHECK(surface_area_of_lower_internal_boundaries ==
+        surface_area_of_upper_internal_boundaries);
+  size_t number_of_external_block_faces{0};
+  for (const auto& block : domain.blocks()) {
+    number_of_external_block_faces += block.external_boundaries().size();
+  }
+  CHECK(boost::rational<size_t>{number_of_external_block_faces} ==
+        surface_area_of_external_boundaries);
+}
+
+template <size_t AllowedDifference>
+SPECTRE_ALWAYS_INLINE void check_if_levels_are_within(
+    const size_t level_1, const size_t level_2) noexcept {
+  CHECK(level_1 <= level_2 + AllowedDifference);
+  CHECK(level_2 <= level_1 + AllowedDifference);
+}
+
+template <>
+SPECTRE_ALWAYS_INLINE void check_if_levels_are_within<0>(
+    const size_t level_1, const size_t level_2) noexcept {
+  CHECK(level_1 == level_2);
+}
+
+template <size_t AllowedDifference, size_t VolumeDim>
+void test_refinement_levels_of_neighbors(
+    const std::unordered_map<ElementId<VolumeDim>, Element<VolumeDim>>&
+        elements) noexcept {
+  for (const auto& key_value : elements) {
+    const auto& element_id = key_value.first;
+    const auto& element = key_value.second;
+    for (const auto& direction_neighbors : element.neighbors()) {
+      const auto& direction = direction_neighbors.first;
+      const auto& neighbors = direction_neighbors.second;
+      const auto& orientation = neighbors.orientation();
+      for (size_t d = 0; d < VolumeDim; ++d) {
+        const size_t my_dim_in_neighbor = orientation(d);
+        const size_t my_level =
+            gsl::at(element_id.segment_ids(), d).refinement_level();
+        for (const auto neighbor_id : neighbors.ids()) {
+          const size_t neighbor_level =
+              gsl::at(neighbor_id.segment_ids(), my_dim_in_neighbor)
+                  .refinement_level();
+          check_if_levels_are_within<AllowedDifference>(my_level,
+                                                        neighbor_level);
+        }
+      }
+    }
+  }
+}
+}  // namespace
 
 template <size_t VolumeDim>
 void test_domain_construction(
@@ -23,9 +165,8 @@ void test_domain_construction(
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
-    const std::vector<std::unique_ptr<
-        CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>&
-        expected_maps) noexcept {
+    const std::vector<std::unique_ptr<CoordinateMapBase<
+        Frame::Logical, Frame::Inertial, VolumeDim>>>& expected_maps) noexcept {
   const auto& blocks = domain.blocks();
   CHECK(blocks.size() == expected_external_boundaries.size());
   CHECK(blocks.size() == expected_block_neighbors.size());
@@ -54,6 +195,22 @@ boost::rational<size_t> fraction_of_block_volume(
   return boost::rational<size_t>(1, two_to_the(sum_of_refinement_levels));
 }
 
+template <size_t VolumeDim>
+void test_initial_domain(const Domain<VolumeDim, Frame::Inertial>& domain,
+                         const std::vector<std::array<size_t, VolumeDim>>&
+                             initial_refinement_levels) noexcept {
+  const auto element_ids = initial_element_ids(initial_refinement_levels);
+  const auto& blocks = domain.blocks();
+  std::unordered_map<ElementId<VolumeDim>, Element<VolumeDim>> elements;
+  for (const auto& element_id : element_ids) {
+    elements.emplace(
+        element_id,
+        create_initial_element(element_id, blocks[element_id.block_id()]));
+  }
+  test_domain_connectivity(domain, elements);
+  test_refinement_levels_of_neighbors<0>(elements);
+}
+
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
@@ -69,7 +226,11 @@ boost::rational<size_t> fraction_of_block_volume(
           CoordinateMapBase<Frame::Logical, Frame::Inertial, DIM(data)>>>&     \
           expected_maps) noexcept;                                             \
   template boost::rational<size_t> fraction_of_block_volume(                   \
-      const ElementId<DIM(data)>& element_id) noexcept;
+      const ElementId<DIM(data)>& element_id) noexcept;                        \
+  template void test_initial_domain(                                           \
+      const Domain<DIM(data), Frame::Inertial>& domain,                        \
+      const std::vector<std::array<size_t, DIM(data)>>&                        \
+          initial_refinement_levels) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -22,6 +22,7 @@ class Domain;
 template <size_t VolumeDim>
 class ElementId;
 
+// Test that the Blocks in the Domain are constructed correctly.
 template <size_t VolumeDim>
 void test_domain_construction(
     const Domain<VolumeDim, Frame::Inertial>& domain,
@@ -39,3 +40,11 @@ void test_domain_construction(
 template <size_t VolumeDim>
 boost::rational<size_t> fraction_of_block_volume(
     const ElementId<VolumeDim>& element_id) noexcept;
+
+// Test that the Elements of the initial domain are connected and cover the
+// computational domain, as well as that neighboring Elements  are at the same
+// refinement level.
+template <size_t VolumeDim>
+void test_initial_domain(const Domain<VolumeDim, Frame::Inertial>& domain,
+                         const std::vector<std::array<size_t, VolumeDim>>&
+                             initial_refinement_levels) noexcept;


### PR DESCRIPTION

## Proposed changes

This tests whether the initial Elements of a Domain are properly connected,
cover the entire domain, and have the same refinement levels as their
neighbors.


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
