### PR TITLE
Add INFO to test_orient_vars

### DIFF
--- a/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
+++ b/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
@@ -71,6 +71,7 @@ void check_orient_variables_on_slice(
   const auto& expected_coords = coords_on_neighbor_slice;
   for (size_t d = 0; d < SpatialDim; ++d) {
     for (size_t s = 0; s < extents_on_my_slice.product(); ++s) {
+      INFO("d: " << d << "\t" << "s: " << s);
       CHECK(computed_coords.get(d)[s] == approx(expected_coords.get(d)[s]));
     }
   }


### PR DESCRIPTION
Since we're having the random builds fail, info about the dimension and gridpoints could be useful.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
