### PR TITLE
Add trace

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp
@@ -27,3 +27,17 @@ raise_or_lower_first_index(
     const Tensor<DataType, Symmetry<1, 1>,
                  index_list<change_index_up_lo<Index0>,
                             change_index_up_lo<Index0>>>& metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes trace of a rank 3 tensor, which is symmetric in its last two
+ * indices with all indices lower.
+ *
+ * \details If \f$ T_{abc} \f$ is a tensor such that \f$T_{abc} = T_{acb} \f$
+ * then \f$ T_a = g^{bc}T_{abc} \f$ is computed, where \f$ g^{bc} \f$ is the
+ * inverse metric. The indices \f$ a,b,c...\f$ can be spatial or spacetime.
+ */
+template <size_t Dim, typename Frame, IndexType TypeOfIndex, typename DataType>
+tnsr::a<DataType, Dim, Frame, TypeOfIndex> trace_last_indices(
+    const tnsr::abb<DataType, Dim, Frame, TypeOfIndex>& tensor,
+    const tnsr::AA<DataType, Dim, Frame, TypeOfIndex>& upper_metric);

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
@@ -247,6 +247,65 @@ void test_3d_spacetime_lower(const DataVector& used_for_size) {
           make_spacetime_metric<dim>(used_for_size)),
       lowered_tensor);
 }
+void test_1d_spatial_trace(const DataVector& used_for_size) {
+  const size_t dim = 1;
+  const tnsr::i<double, dim> covector = trace_last_indices(
+      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
+
+  CHECK(covector.get(0) == approx(3.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      trace_last_indices(make_deriv_spatial_metric<dim>(used_for_size),
+                         make_inverse_spatial_metric<dim>(used_for_size)),
+      covector);
+}
+
+void test_2d_spatial_trace(const DataVector& used_for_size) {
+  const size_t dim = 2;
+  const tnsr::i<double, dim> covector = trace_last_indices(
+      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
+
+  CHECK(covector.get(0) == approx(75));
+  CHECK(covector.get(1) == approx(84));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      trace_last_indices(make_deriv_spatial_metric<dim>(used_for_size),
+                         make_inverse_spatial_metric<dim>(used_for_size)),
+      covector);
+}
+
+void test_3d_spatial_trace(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const tnsr::i<double, dim> covector = trace_last_indices(
+      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
+
+  CHECK(covector.get(0) == approx(588));
+  CHECK(covector.get(1) == approx(624));
+  CHECK(covector.get(2) == approx(660));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      trace_last_indices(make_deriv_spatial_metric<dim>(used_for_size),
+                         make_inverse_spatial_metric<dim>(used_for_size)),
+      covector);
+}
+
+void test_3d_spacetime_trace(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const tnsr::a<double, dim> vector =
+      trace_last_indices(make_spacetime_deriv_spacetime_metric<dim>(0.),
+                         make_inverse_spacetime_metric<dim>(0.));
+
+  CHECK(vector.get(0) == approx(-9600));
+  CHECK(vector.get(1) == approx(-12800));
+  CHECK(vector.get(2) == approx(-16000));
+  CHECK(vector.get(3) == approx(-19200));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      trace_last_indices(
+          make_spacetime_deriv_spacetime_metric<dim>(used_for_size),
+          make_inverse_spacetime_metric<dim>(used_for_size)),
+      vector);
+}
 
 }  // namespace
 
@@ -263,4 +322,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.IndexManipulation",
   test_3d_spatial_lower(dv);
   test_3d_spacetime_raise(dv);
   test_3d_spacetime_lower(dv);
+  test_1d_spatial_trace(dv);
+  test_2d_spatial_trace(dv);
+  test_3d_spatial_trace(dv);
+  test_3d_spacetime_trace(dv);
 }


### PR DESCRIPTION
## Proposed changes

Adds compute trace for tensors of type tnsr::abb. 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`

