### PR TITLE
Make template index_dim a friend function

### DIFF
--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -343,10 +343,6 @@ class Tensor<X, Symm, IndexList<Indices...>> {
                   "retrieve the dimensionality.");
     return gsl::at(structure::dims(), i);
   }
-  template <int I>
-  SPECTRE_ALWAYS_INLINE static constexpr size_t index_dim() noexcept {
-    return structure::template dim<I>();
-  }
   // @}
 
   //@{
@@ -415,6 +411,11 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   /// \endcond
 
  private:
+  // clang-tidy: redundant declaration
+  template <int I, class... Ts>
+  friend SPECTRE_ALWAYS_INLINE constexpr size_t index_dim(  // NOLINT
+      const Tensor<Ts...>& /*t*/) noexcept;
+
   storage_type data_;
 };
 
@@ -484,6 +485,14 @@ template <typename X, typename Symm, template <typename...> class IndexList,
 bool operator!=(const Tensor<X, Symm, IndexList<Indices...>>& lhs,
                 const Tensor<X, Symm, IndexList<Indices...>>& rhs) {
   return not(lhs == rhs);
+}
+
+/// \ingroup TensorGroup
+/// Get dimensionality of i'th tensor index
+template <int I, class... Ts>
+SPECTRE_ALWAYS_INLINE constexpr size_t index_dim(
+    const Tensor<Ts...>& /*t*/) noexcept {
+  return Tensor<Ts...>::structure::template dim<I>();
 }
 
 // We place the stream operators in the header file so they do not need to be

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -11,8 +11,7 @@ template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 tnsr::abb<DataType, SpatialDim, Frame, Index> compute_christoffel_first_kind(
     const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric) {
   tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel{};
-  constexpr auto dimensionality =
-      tnsr::abb<DataType, SpatialDim, Frame, Index>::template index_dim<0>();
+  constexpr auto dimensionality = index_dim<0>(christoffel);
   for (size_t k = 0; k < dimensionality; ++k) {
     for (size_t i = 0; i < dimensionality; ++i) {
       for (size_t j = i; j < dimensionality; ++j) {

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -405,7 +405,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.RankAndSize",
     Tensor<double, Symmetry<3>,
            index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
         spatial_vector3{std::array<double, 3>{{1, 8, 3}}};
-    CHECK(spatial_vector3.index_dim<0>() == 3);
+    CHECK(index_dim<0>(spatial_vector3) == 3);
     CHECK(1 == spatial_vector3.rank());
     CHECK(3 == spatial_vector3.size());
     CHECK(spatial_vector3.get(0) == 1);
@@ -422,7 +422,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.RankAndSize",
                  index_list<SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
         spatial_vector3{std::array<double, 3>{{1, 8, 3}}};
     CHECK(Scalar<double>{}.multiplicity(0_st) == 1);  // 0 can be a pointer
-    CHECK(spatial_vector3.index_dim<0>() == 3);
+    CHECK(index_dim<0>(spatial_vector3) == 3);
     CHECK(1 == spatial_vector3.rank());
     CHECK(3 == spatial_vector3.size());
     CHECK(spatial_vector3.get(0) == 1);


### PR DESCRIPTION
## Proposed changes

This change is in line with how we treat `get` functions. It removes the need to use the `template` keyword.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
