### PR TITLE
Make tensors used in GrTests nonzero

### DIFF
--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
@@ -16,7 +16,7 @@ template <size_t SpatialDim, typename DataType>
 tnsr::I<DataType, SpatialDim> make_shift(const DataType& used_for_size) {
   tnsr::I<DataType, SpatialDim> shift{};
   for (size_t i = 0; i < SpatialDim; ++i) {
-    shift.get(i) = make_with_value<DataType>(used_for_size, i);
+    shift.get(i) = make_with_value<DataType>(used_for_size, i + 1);
   }
   return shift;
 }
@@ -56,7 +56,8 @@ template <size_t SpatialDim, typename DataType>
 tnsr::I<DataType, SpatialDim> make_dt_shift(const DataType& used_for_size) {
   tnsr::I<DataType, SpatialDim> dt_shift{};
   for (size_t i = 0; i < SpatialDim; ++i) {
-    dt_shift.get(i) = make_with_value<DataType>(used_for_size, SpatialDim * i);
+    dt_shift.get(i) =
+        make_with_value<DataType>(used_for_size, SpatialDim * (i + 1.));
   }
   return dt_shift;
 }
@@ -77,7 +78,8 @@ template <size_t SpatialDim, typename DataType>
 tnsr::i<DataType, SpatialDim> make_deriv_lapse(const DataType& used_for_size) {
   tnsr::i<DataType, SpatialDim> deriv_lapse{};
   for (size_t i = 0; i < SpatialDim; ++i) {
-    deriv_lapse.get(i) = make_with_value<DataType>(used_for_size, 2.5 * i);
+    deriv_lapse.get(i) =
+        make_with_value<DataType>(used_for_size, 2.5 * (i + 1.));
   }
   return deriv_lapse;
 }
@@ -88,7 +90,7 @@ tnsr::iJ<DataType, SpatialDim> make_deriv_shift(const DataType& used_for_size) {
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = 0; j < SpatialDim; ++j) {
       deriv_shift.get(i, j) =
-          make_with_value<DataType>(used_for_size, 3. * (j + 1.) - i);
+          make_with_value<DataType>(used_for_size, 3. * (j + 1.) - i + 4.);
     }
   }
   return deriv_shift;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -15,8 +15,8 @@ void test_compute_1d_spacetime_metric(const DataVector& used_for_size) {
   const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
                                             make_spatial_metric<dim>(0.));
 
-  CHECK(psi.get(0, 0) == approx(-9.0));
-  CHECK(psi.get(0, 1) == approx(0.0));
+  CHECK(psi.get(0, 0) == approx(-8.0));
+  CHECK(psi.get(0, 1) == approx(1.0));
   CHECK(psi.get(1, 1) == approx(1.0));
 
   check_tensor_doubles_equals_tensor_datavectors(
@@ -31,9 +31,9 @@ void test_compute_2d_spacetime_metric(const DataVector& used_for_size) {
   const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
                                             make_spatial_metric<dim>(0.));
 
-  CHECK(psi.get(0, 0) == approx(-5.0));
-  CHECK(psi.get(0, 1) == approx(2.0));
-  CHECK(psi.get(0, 2) == approx(4.0));
+  CHECK(psi.get(0, 0) == approx(16.0));
+  CHECK(psi.get(0, 1) == approx(5.0));
+  CHECK(psi.get(0, 2) == approx(10.0));
   CHECK(psi.get(1, 1) == approx(1.0));
   CHECK(psi.get(1, 2) == approx(2.0));
   CHECK(psi.get(2, 2) == approx(4.0));
@@ -49,16 +49,17 @@ void test_compute_3d_spacetime_metric(const DataVector& used_for_size) {
   const size_t dim = 3;
   const auto psi = compute_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
                                             make_spatial_metric<dim>(0.));
-  CHECK(psi.get(0, 0) == approx(55.));
-  CHECK(psi.get(0, 1) == approx(8.));
-  CHECK(psi.get(0, 2) == approx(16.));
-  CHECK(psi.get(0, 3) == approx(24.));
-  CHECK(psi.get(1, 1) == approx(1.));
-  CHECK(psi.get(1, 2) == approx(2.));
-  CHECK(psi.get(1, 3) == approx(3.));
-  CHECK(psi.get(2, 2) == approx(4.));
-  CHECK(psi.get(2, 3) == approx(6.));
-  CHECK(psi.get(3, 3) == approx(9.));
+
+  CHECK(psi.get(0, 0) == approx(187.0));
+  CHECK(psi.get(0, 1) == approx(14.0));
+  CHECK(psi.get(0, 2) == approx(28.0));
+  CHECK(psi.get(0, 3) == approx(42.0));
+  CHECK(psi.get(1, 1) == approx(1.0));
+  CHECK(psi.get(1, 2) == approx(2.0));
+  CHECK(psi.get(1, 3) == approx(3.0));
+  CHECK(psi.get(2, 2) == approx(4.0));
+  CHECK(psi.get(2, 3) == approx(6.0));
+  CHECK(psi.get(3, 3) == approx(9.0));
 
   check_tensor_doubles_equals_tensor_datavectors(
       compute_spacetime_metric(make_lapse(used_for_size),
@@ -72,9 +73,10 @@ void test_compute_1d_inverse_spacetime_metric(const DataVector& used_for_size) {
   const auto inverse_spacetime_metric =
       compute_inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
                                        make_inverse_spatial_metric<dim>(0.));
+
   CHECK(inverse_spacetime_metric.get(0, 0) == approx(-1. / 9.));
-  CHECK(inverse_spacetime_metric.get(0, 1) == approx(0.0));
-  CHECK(inverse_spacetime_metric.get(1, 1) == approx(1.0));
+  CHECK(inverse_spacetime_metric.get(0, 1) == approx(1. / 9.));
+  CHECK(inverse_spacetime_metric.get(1, 1) == approx(8. / 9.));
 
   check_tensor_doubles_equals_tensor_datavectors(
       compute_inverse_spacetime_metric(
@@ -88,12 +90,13 @@ void test_compute_2d_inverse_spacetime_metric(const DataVector& used_for_size) {
   const auto inverse_spacetime_metric =
       compute_inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
                                        make_inverse_spatial_metric<dim>(0.));
+
   CHECK(inverse_spacetime_metric.get(0, 0) == approx(-1. / 9.));
-  CHECK(inverse_spacetime_metric.get(0, 1) == approx(0.0));
-  CHECK(inverse_spacetime_metric.get(0, 2) == approx(1. / 9.));
-  CHECK(inverse_spacetime_metric.get(1, 1) == approx(1.0));
-  CHECK(inverse_spacetime_metric.get(1, 2) == approx(2.0));
-  CHECK(inverse_spacetime_metric.get(2, 2) == approx(35. / 9.));
+  CHECK(inverse_spacetime_metric.get(0, 1) == approx(1. / 9.));
+  CHECK(inverse_spacetime_metric.get(0, 2) == approx(2. / 9.));
+  CHECK(inverse_spacetime_metric.get(1, 1) == approx(8. / 9.));
+  CHECK(inverse_spacetime_metric.get(1, 2) == approx(16. / 9.));
+  CHECK(inverse_spacetime_metric.get(2, 2) == approx(32. / 9.));
 
   check_tensor_doubles_equals_tensor_datavectors(
       compute_inverse_spacetime_metric(
@@ -107,16 +110,17 @@ void test_compute_3d_inverse_spacetime_metric(const DataVector& used_for_size) {
   const auto inverse_spacetime_metric =
       compute_inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
                                        make_inverse_spatial_metric<dim>(0.));
+
   CHECK(inverse_spacetime_metric.get(0, 0) == approx(-1. / 9.));
-  CHECK(inverse_spacetime_metric.get(0, 1) == approx(0.));
-  CHECK(inverse_spacetime_metric.get(0, 2) == approx(1. / 9.));
-  CHECK(inverse_spacetime_metric.get(0, 3) == approx(2. / 9.));
-  CHECK(inverse_spacetime_metric.get(1, 1) == approx(1.));
-  CHECK(inverse_spacetime_metric.get(1, 2) == approx(2.));
-  CHECK(inverse_spacetime_metric.get(1, 3) == approx(3.));
-  CHECK(inverse_spacetime_metric.get(2, 2) == approx(35. / 9.));
-  CHECK(inverse_spacetime_metric.get(2, 3) == approx(52. / 9.));
-  CHECK(inverse_spacetime_metric.get(3, 3) == approx(77. / 9.));
+  CHECK(inverse_spacetime_metric.get(0, 1) == approx(1. / 9.));
+  CHECK(inverse_spacetime_metric.get(0, 2) == approx(2. / 9.));
+  CHECK(inverse_spacetime_metric.get(0, 3) == approx(3. / 9.));
+  CHECK(inverse_spacetime_metric.get(1, 1) == approx(8. / 9.));
+  CHECK(inverse_spacetime_metric.get(1, 2) == approx(16. / 9.));
+  CHECK(inverse_spacetime_metric.get(1, 3) == approx(24. / 9.));
+  CHECK(inverse_spacetime_metric.get(2, 2) == approx(32. / 9.));
+  CHECK(inverse_spacetime_metric.get(2, 3) == approx(48. / 9.));
+  CHECK(inverse_spacetime_metric.get(3, 3) == approx(8.0));
 
   check_tensor_doubles_equals_tensor_datavectors(
       compute_inverse_spacetime_metric(
@@ -134,11 +138,11 @@ void test_compute_1d_derivatives_spacetime_metric(
       make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
       make_deriv_spatial_metric<dim>(0.));
 
-  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(-30.0));
-  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(0.0));
+  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(-28.0));
+  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(1.0));
   CHECK(d_spacetime_metric.get(0, 1, 1) == approx(0.0));
-  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(0.0));
-  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(3.0));
+  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(2.0));
+  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(10.0));
   CHECK(d_spacetime_metric.get(1, 1, 1) == approx(3.0));
 
   check_tensor_doubles_equals_tensor_datavectors(
@@ -162,21 +166,21 @@ void test_compute_2d_derivatives_spacetime_metric(
       make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
       make_deriv_spatial_metric<dim>(0.));
 
-  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(-12.0));
-  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(5.0));
-  CHECK(d_spacetime_metric.get(0, 0, 2) == approx(10.0));
+  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(82.0));
+  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(12.0));
+  CHECK(d_spacetime_metric.get(0, 0, 2) == approx(25.0));
   CHECK(d_spacetime_metric.get(0, 1, 1) == approx(0.0));
   CHECK(d_spacetime_metric.get(0, 1, 2) == approx(1.0));
   CHECK(d_spacetime_metric.get(0, 2, 2) == approx(2.0));
-  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(72.0));
-  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(21.0));
-  CHECK(d_spacetime_metric.get(1, 0, 2) == approx(42.0));
+  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(330.0));
+  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(42.0));
+  CHECK(d_spacetime_metric.get(1, 0, 2) == approx(84.0));
   CHECK(d_spacetime_metric.get(1, 1, 1) == approx(3.0));
   CHECK(d_spacetime_metric.get(1, 1, 2) == approx(6.0));
   CHECK(d_spacetime_metric.get(1, 2, 2) == approx(12.0));
-  CHECK(d_spacetime_metric.get(2, 0, 0) == approx(46.0));
-  CHECK(d_spacetime_metric.get(2, 0, 1) == approx(19.0));
-  CHECK(d_spacetime_metric.get(2, 0, 2) == approx(37.0));
+  CHECK(d_spacetime_metric.get(2, 0, 0) == approx(294.0));
+  CHECK(d_spacetime_metric.get(2, 0, 1) == approx(42.0));
+  CHECK(d_spacetime_metric.get(2, 0, 2) == approx(81.0));
   CHECK(d_spacetime_metric.get(2, 1, 1) == approx(4.0));
   CHECK(d_spacetime_metric.get(2, 1, 2) == approx(7.0));
   CHECK(d_spacetime_metric.get(2, 2, 2) == approx(13.0));
@@ -202,46 +206,46 @@ void test_compute_3d_derivatives_spacetime_metric(
       make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
       make_deriv_spatial_metric<dim>(0.));
 
-  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(384.));
-  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(29.));
-  CHECK(d_spacetime_metric.get(0, 0, 2) == approx(56.));
-  CHECK(d_spacetime_metric.get(0, 0, 3) == approx(83.));
-  CHECK(d_spacetime_metric.get(0, 1, 1) == approx(0.));
-  CHECK(d_spacetime_metric.get(0, 1, 2) == approx(1.));
-  CHECK(d_spacetime_metric.get(0, 1, 3) == approx(2.));
-  CHECK(d_spacetime_metric.get(0, 2, 2) == approx(2.));
-  CHECK(d_spacetime_metric.get(0, 2, 3) == approx(3.));
-  CHECK(d_spacetime_metric.get(0, 3, 3) == approx(4.));
-  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(864.));
-  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(66.));
-  CHECK(d_spacetime_metric.get(1, 0, 2) == approx(132.));
-  CHECK(d_spacetime_metric.get(1, 0, 3) == approx(198.));
-  CHECK(d_spacetime_metric.get(1, 1, 1) == approx(3.));
-  CHECK(d_spacetime_metric.get(1, 1, 2) == approx(6.));
-  CHECK(d_spacetime_metric.get(1, 1, 3) == approx(9.));
-  CHECK(d_spacetime_metric.get(1, 2, 2) == approx(12));
-  CHECK(d_spacetime_metric.get(1, 2, 3) == approx(18));
-  CHECK(d_spacetime_metric.get(1, 3, 3) == approx(27));
-  CHECK(d_spacetime_metric.get(2, 0, 0) == approx(762.));
-  CHECK(d_spacetime_metric.get(2, 0, 1) == approx(63.));
-  CHECK(d_spacetime_metric.get(2, 0, 2) == approx(123.));
-  CHECK(d_spacetime_metric.get(2, 0, 3) == approx(183.));
-  CHECK(d_spacetime_metric.get(2, 1, 1) == approx(4.));
-  CHECK(d_spacetime_metric.get(2, 1, 2) == approx(7.));
-  CHECK(d_spacetime_metric.get(2, 1, 3) == approx(10));
-  CHECK(d_spacetime_metric.get(2, 2, 2) == approx(13));
-  CHECK(d_spacetime_metric.get(2, 2, 3) == approx(19));
-  CHECK(d_spacetime_metric.get(2, 3, 3) == approx(28));
-  CHECK(d_spacetime_metric.get(3, 0, 0) == approx(660.));
-  CHECK(d_spacetime_metric.get(3, 0, 1) == approx(60.));
-  CHECK(d_spacetime_metric.get(3, 0, 2) == approx(114.));
-  CHECK(d_spacetime_metric.get(3, 0, 3) == approx(168.));
-  CHECK(d_spacetime_metric.get(3, 1, 1) == approx(5.));
-  CHECK(d_spacetime_metric.get(3, 1, 2) == approx(8.));
-  CHECK(d_spacetime_metric.get(3, 1, 3) == approx(11.));
-  CHECK(d_spacetime_metric.get(3, 2, 2) == approx(14.));
-  CHECK(d_spacetime_metric.get(3, 2, 3) == approx(20.));
-  CHECK(d_spacetime_metric.get(3, 3, 3) == approx(29.));
+  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(1242.0));
+  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(50.0));
+  CHECK(d_spacetime_metric.get(0, 0, 2) == approx(98.0));
+  CHECK(d_spacetime_metric.get(0, 0, 3) == approx(146.0));
+  CHECK(d_spacetime_metric.get(0, 1, 1) == approx(0.0));
+  CHECK(d_spacetime_metric.get(0, 1, 2) == approx(1.0));
+  CHECK(d_spacetime_metric.get(0, 1, 3) == approx(2.0));
+  CHECK(d_spacetime_metric.get(0, 2, 2) == approx(2.0));
+  CHECK(d_spacetime_metric.get(0, 2, 3) == approx(3.0));
+  CHECK(d_spacetime_metric.get(0, 3, 3) == approx(4.0));
+  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(2421.0));
+  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(108.0));
+  CHECK(d_spacetime_metric.get(1, 0, 2) == approx(216.0));
+  CHECK(d_spacetime_metric.get(1, 0, 3) == approx(324.0));
+  CHECK(d_spacetime_metric.get(1, 1, 1) == approx(3.0));
+  CHECK(d_spacetime_metric.get(1, 1, 2) == approx(6.0));
+  CHECK(d_spacetime_metric.get(1, 1, 3) == approx(9.0));
+  CHECK(d_spacetime_metric.get(1, 2, 2) == approx(12.0));
+  CHECK(d_spacetime_metric.get(1, 2, 3) == approx(18.0));
+  CHECK(d_spacetime_metric.get(1, 3, 3) == approx(27.0));
+  CHECK(d_spacetime_metric.get(2, 0, 0) == approx(2274.0));
+  CHECK(d_spacetime_metric.get(2, 0, 1) == approx(108.0));
+  CHECK(d_spacetime_metric.get(2, 0, 2) == approx(210.0));
+  CHECK(d_spacetime_metric.get(2, 0, 3) == approx(312.0));
+  CHECK(d_spacetime_metric.get(2, 1, 1) == approx(4.0));
+  CHECK(d_spacetime_metric.get(2, 1, 2) == approx(7.0));
+  CHECK(d_spacetime_metric.get(2, 1, 3) == approx(10.0));
+  CHECK(d_spacetime_metric.get(2, 2, 2) == approx(13.0));
+  CHECK(d_spacetime_metric.get(2, 2, 3) == approx(19.0));
+  CHECK(d_spacetime_metric.get(2, 3, 3) == approx(28.0));
+  CHECK(d_spacetime_metric.get(3, 0, 0) == approx(2127.0));
+  CHECK(d_spacetime_metric.get(3, 0, 1) == approx(108.0));
+  CHECK(d_spacetime_metric.get(3, 0, 2) == approx(204.0));
+  CHECK(d_spacetime_metric.get(3, 0, 3) == approx(300.0));
+  CHECK(d_spacetime_metric.get(3, 1, 1) == approx(5.0));
+  CHECK(d_spacetime_metric.get(3, 1, 2) == approx(8.0));
+  CHECK(d_spacetime_metric.get(3, 1, 3) == approx(11.0));
+  CHECK(d_spacetime_metric.get(3, 2, 2) == approx(14.0));
+  CHECK(d_spacetime_metric.get(3, 2, 3) == approx(20.0));
+  CHECK(d_spacetime_metric.get(3, 3, 3) == approx(29.0));
 
   check_tensor_doubles_equals_tensor_datavectors(
       compute_derivatives_of_spacetime_metric(


### PR DESCRIPTION
## Proposed changes

Make sure that zero values are not used in the general relativity tests. 

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
