### PR TITLE
Add compute gh quantities

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -76,3 +76,30 @@ tnsr::abb<DataType, SpatialDim, Frame> compute_derivatives_of_spacetime_metric(
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the auxiliary variable \f$\phi_{iab}\f$ used by the
+ * generalized harmonic formulation of Einstein's equations.
+ *
+ * \details If \f$ N, N^i\f$ and \f$ g_{ij} \f$ are the lapse, shift and spatial
+ * metric respectively, then \f$\phi_{iab} \f$ is computed as
+ *
+ * \f{align}
+ *     \phi_{ktt} &=& - 2 N \partial_k N
+ *                 + 2 g_{mn} N^m \partial_k N^n
+ *                 + N^m N^n \partial_k g_{mn} \\
+ *     \phi_{kti} &=& g_{mi} \partial_k N^m
+ *                 + N^m \partial_k g_{mi} \\
+ *     \phi_{kij} &=& \partial_k g_{ij}
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::iaa<DataType, SpatialDim, Frame> compute_phi(
+    const Scalar<DataType>& lapse,
+    const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::ijj<DataType, SpatialDim, Frame>&
+        deriv_spatial_metric) noexcept;

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -103,3 +103,32 @@ tnsr::iaa<DataType, SpatialDim, Frame> compute_phi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes the conjugate momentum \f$\Pi_{ab}\f$ of the spacetime metric
+ * \f$ \psi_{ab} \f$.
+ *
+ * \details If \f$ N, N^i\f$ are the lapse and shift
+ * respectively, and \f$ \phi_{iab} = \partial_i \psi_{ab} \f$ then
+ * \f$\Pi_{\mu\nu} = -(1/N) ( \partial_t \psi_{\mu\nu}  -
+ *      N^m \phi_{m\mu\nu}) \f$ where \f$ \partial_t \psi_{ab} \f$ is computed
+ * as
+ *
+ * \f{align}
+ *     \partial_t \psi_{tt} &=& - 2 N \partial_t N
+ *                 + 2 g_{mn} N^m \partial_t N^n
+ *                 + N^m N^n \partial_t g_{mn} \\
+ *     \partial_t \psi_{ti} &=& g_{mi} \partial_t N^m
+ *                 + N^m \partial_t g_{mi} \\
+ *     \partial_t \psi_{ij} &=& \partial_t g_{ij}
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::aa<DataType, SpatialDim, Frame> compute_pi(
+    const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
@@ -126,6 +126,21 @@ tnsr::abb<DataType, SpatialDim> make_spacetime_deriv_spacetime_metric(
   return d_spacetime_metric;
 }
 
+template <size_t SpatialDim, typename DataType>
+tnsr::iaa<DataType, SpatialDim> make_spatial_deriv_spacetime_metric(
+    const DataType& used_for_size) {
+  tnsr::iaa<DataType, SpatialDim> d_spacetime_metric{};
+  for (size_t i = 0; i < SpatialDim + 1; i++) {
+    for (size_t j = i; j < SpatialDim + 1; j++) {
+      for (size_t k = 0; k < SpatialDim; k++) {
+        d_spacetime_metric.get(k, i, j) = make_with_value<DataType>(
+            used_for_size, (i + 1.) * (j + 1.) * (k + 3.));
+      }
+    }
+  }
+  return d_spacetime_metric;
+}
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
@@ -147,7 +162,9 @@ tnsr::abb<DataType, SpatialDim> make_spacetime_deriv_spacetime_metric(
   template tnsr::ijj<DTYPE(data), DIM(data)> make_deriv_spatial_metric(      \
       const DTYPE(data) & used_for_size);                                    \
   template tnsr::abb<DTYPE(data), DIM(data)>                                 \
-  make_spacetime_deriv_spacetime_metric(const DTYPE(data) & used_for_size);
+  make_spacetime_deriv_spacetime_metric(const DTYPE(data) & used_for_size);  \
+  template tnsr::iaa<DTYPE(data), DIM(data)>                                 \
+  make_spatial_deriv_spacetime_metric(const DTYPE(data) & used_for_size);
 
 template Scalar<double> make_lapse(const double& used_for_size);
 template Scalar<DataVector> make_lapse(const DataVector& used_for_size);

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
@@ -63,3 +63,7 @@ tnsr::ijj<DataType, SpatialDim> make_deriv_spatial_metric(
 template <size_t SpatialDim, typename DataType>
 tnsr::abb<DataType, SpatialDim> make_spacetime_deriv_spacetime_metric(
     const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::iaa<DataType, SpatialDim> make_spatial_deriv_spacetime_metric(
+    const DataType& used_for_size);

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -355,6 +355,82 @@ void test_compute_3d_phi(const DataVector& used_for_size) {
       phi);
 }
 
+void test_compute_1d_pi(const DataVector& used_for_size) {
+  const size_t dim = 1;
+  const auto pi =
+      compute_pi(make_lapse(0.), make_dt_lapse(0.), make_shift<dim>(0.),
+                 make_dt_shift<dim>(0.), make_spatial_metric<dim>(0.),
+                 make_dt_spatial_metric<dim>(0.),
+                 make_spatial_deriv_spacetime_metric<dim>(0.));
+
+  CHECK(pi.get(0, 0) == approx(31. / 3.));
+  CHECK(pi.get(0, 1) == approx(5. / 3.));
+  CHECK(pi.get(1, 1) == approx(4.0));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_pi(make_lapse(used_for_size), make_dt_lapse(used_for_size),
+                 make_shift<dim>(used_for_size),
+                 make_dt_shift<dim>(used_for_size),
+                 make_spatial_metric<dim>(used_for_size),
+                 make_dt_spatial_metric<dim>(used_for_size),
+                 make_spatial_deriv_spacetime_metric<dim>(used_for_size)),
+      pi);
+}
+
+void test_compute_2d_pi(const DataVector& used_for_size) {
+  const size_t dim = 2;
+  const auto pi =
+      compute_pi(make_lapse(0.), make_dt_lapse(0.), make_shift<dim>(0.),
+                 make_dt_shift<dim>(0.), make_spatial_metric<dim>(0.),
+                 make_dt_spatial_metric<dim>(0.),
+                 make_spatial_deriv_spacetime_metric<dim>(0.));
+
+  CHECK(pi.get(0, 0) == approx(-71. / 3.));
+  CHECK(pi.get(0, 1) == approx(10. / 3.));
+  CHECK(pi.get(0, 2) == approx(8. / 3.));
+  CHECK(pi.get(1, 1) == approx(44. / 3.));
+  CHECK(pi.get(1, 2) == approx(65. / 3.));
+  CHECK(pi.get(2, 2) == approx(97. / 3.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_pi(make_lapse(used_for_size), make_dt_lapse(used_for_size),
+                 make_shift<dim>(used_for_size),
+                 make_dt_shift<dim>(used_for_size),
+                 make_spatial_metric<dim>(used_for_size),
+                 make_dt_spatial_metric<dim>(used_for_size),
+                 make_spatial_deriv_spacetime_metric<dim>(used_for_size)),
+      pi);
+}
+
+void test_compute_3d_pi(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const auto pi =
+      compute_pi(make_lapse(0.), make_dt_lapse(0.), make_shift<dim>(0.),
+                 make_dt_shift<dim>(0.), make_spatial_metric<dim>(0.),
+                 make_dt_spatial_metric<dim>(0.),
+                 make_spatial_deriv_spacetime_metric<dim>(0.));
+
+  CHECK(pi.get(0, 0) == approx(-1216./3.));
+  CHECK(pi.get(0, 1) == approx(2. / 3.));
+  CHECK(pi.get(0, 2) == approx(-20. / 3.));
+  CHECK(pi.get(0, 3) == approx(-14.0));
+  CHECK(pi.get(1, 1) == approx(104. / 3.));
+  CHECK(pi.get(1, 2) == approx(155. / 3.));
+  CHECK(pi.get(1, 3) == approx(206. / 3.));
+  CHECK(pi.get(2, 2) == approx(232. / 3.));
+  CHECK(pi.get(2, 3) == approx(103.0));
+  CHECK(pi.get(3, 3) == approx(412. / 3.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_pi(make_lapse(used_for_size), make_dt_lapse(used_for_size),
+                 make_shift<dim>(used_for_size),
+                 make_dt_shift<dim>(used_for_size),
+                 make_spatial_metric<dim>(used_for_size),
+                 make_dt_spatial_metric<dim>(used_for_size),
+                 make_spatial_deriv_spacetime_metric<dim>(used_for_size)),
+      pi);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
@@ -372,4 +448,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   test_compute_1d_phi(dv);
   test_compute_2d_phi(dv);
   test_compute_3d_phi(dv);
+  test_compute_1d_pi(dv);
+  test_compute_2d_pi(dv);
+  test_compute_3d_pi(dv);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -258,6 +258,103 @@ void test_compute_3d_derivatives_spacetime_metric(
           make_deriv_spatial_metric<dim>(used_for_size)),
       d_spacetime_metric);
 }
+
+void test_compute_1d_phi(const DataVector& used_for_size) {
+  const size_t dim = 1;
+  const auto phi = compute_phi(make_lapse(0.), make_deriv_lapse<dim>(0.),
+                               make_shift<dim>(0.), make_deriv_shift<dim>(0.),
+                               make_spatial_metric<dim>(0.),
+                               make_deriv_spatial_metric<dim>(0.));
+
+  CHECK(phi.get(0, 0, 0) == approx(2.0));
+  CHECK(phi.get(0, 0, 1) == approx(10.0));
+  CHECK(phi.get(0, 1, 1) == approx(3.0));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_phi(
+          make_lapse(used_for_size), make_deriv_lapse<dim>(used_for_size),
+          make_shift<dim>(used_for_size), make_deriv_shift<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size),
+          make_deriv_spatial_metric<dim>(used_for_size)),
+      phi);
+}
+
+void test_compute_2d_phi(const DataVector& used_for_size) {
+  const size_t dim = 2;
+  const auto phi = compute_phi(make_lapse(0.), make_deriv_lapse<dim>(0.),
+                               make_shift<dim>(0.), make_deriv_shift<dim>(0.),
+                               make_spatial_metric<dim>(0.),
+                               make_deriv_spatial_metric<dim>(0.));
+
+  CHECK(phi.get(0, 0, 0) == approx(330.0));
+  CHECK(phi.get(0, 0, 1) == approx(42.0));
+  CHECK(phi.get(0, 0, 2) == approx(84.0));
+  CHECK(phi.get(0, 1, 1) == approx(3.0));
+  CHECK(phi.get(0, 1, 2) == approx(6.0));
+  CHECK(phi.get(0, 2, 2) == approx(12.0));
+  CHECK(phi.get(1, 0, 0) == approx(294.0));
+  CHECK(phi.get(1, 0, 1) == approx(42.0));
+  CHECK(phi.get(1, 0, 2) == approx(81.0));
+  CHECK(phi.get(1, 1, 1) == approx(4.0));
+  CHECK(phi.get(1, 1, 2) == approx(7.0));
+  CHECK(phi.get(1, 2, 2) == approx(13.0));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_phi(
+          make_lapse(used_for_size), make_deriv_lapse<dim>(used_for_size),
+          make_shift<dim>(used_for_size), make_deriv_shift<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size),
+          make_deriv_spatial_metric<dim>(used_for_size)),
+      phi);
+}
+
+void test_compute_3d_phi(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const auto phi = compute_phi(make_lapse(0.), make_deriv_lapse<dim>(0.),
+                               make_shift<dim>(0.), make_deriv_shift<dim>(0.),
+                               make_spatial_metric<dim>(0.),
+                               make_deriv_spatial_metric<dim>(0.));
+
+  CHECK(phi.get(0, 0, 0) == approx(2421.0));
+  CHECK(phi.get(0, 0, 1) == approx(108.0));
+  CHECK(phi.get(0, 0, 2) == approx(216.0));
+  CHECK(phi.get(0, 0, 3) == approx(324.0));
+  CHECK(phi.get(0, 1, 1) == approx(3.0));
+  CHECK(phi.get(0, 1, 2) == approx(6.0));
+  CHECK(phi.get(0, 1, 3) == approx(9.0));
+  CHECK(phi.get(0, 2, 2) == approx(12.0));
+  CHECK(phi.get(0, 2, 3) == approx(18.0));
+  CHECK(phi.get(0, 3, 3) == approx(27.0));
+  CHECK(phi.get(1, 0, 0) == approx(2274.0));
+  CHECK(phi.get(1, 0, 1) == approx(108.0));
+  CHECK(phi.get(1, 0, 2) == approx(210.0));
+  CHECK(phi.get(1, 0, 3) == approx(312.0));
+  CHECK(phi.get(1, 1, 1) == approx(4.0));
+  CHECK(phi.get(1, 1, 2) == approx(7.0));
+  CHECK(phi.get(1, 1, 3) == approx(10.0));
+  CHECK(phi.get(1, 2, 2) == approx(13.0));
+  CHECK(phi.get(1, 2, 3) == approx(19.0));
+  CHECK(phi.get(1, 3, 3) == approx(28.0));
+  CHECK(phi.get(2, 0, 0) == approx(2127.0));
+  CHECK(phi.get(2, 0, 1) == approx(108.0));
+  CHECK(phi.get(2, 0, 2) == approx(204.0));
+  CHECK(phi.get(2, 0, 3) == approx(300.0));
+  CHECK(phi.get(2, 1, 1) == approx(5.0));
+  CHECK(phi.get(2, 1, 2) == approx(8.0));
+  CHECK(phi.get(2, 1, 3) == approx(11.0));
+  CHECK(phi.get(2, 2, 2) == approx(14.0));
+  CHECK(phi.get(2, 2, 3) == approx(20.0));
+  CHECK(phi.get(2, 3, 3) == approx(29.0));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_phi(
+          make_lapse(used_for_size), make_deriv_lapse<dim>(used_for_size),
+          make_shift<dim>(used_for_size), make_deriv_shift<dim>(used_for_size),
+          make_spatial_metric<dim>(used_for_size),
+          make_deriv_spatial_metric<dim>(used_for_size)),
+      phi);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
@@ -272,4 +369,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   test_compute_1d_derivatives_spacetime_metric(dv);
   test_compute_2d_derivatives_spacetime_metric(dv);
   test_compute_3d_derivatives_spacetime_metric(dv);
+  test_compute_1d_phi(dv);
+  test_compute_2d_phi(dv);
+  test_compute_3d_phi(dv);
 }


### PR DESCRIPTION
## Proposed changes

Adds compute pi and phi

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`

