### PR TITLE
Add inverse and choice of coordinates for Wedge2D

### DIFF
--- a/src/Domain/CoordinateMaps/Wedge2D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.hpp
@@ -15,16 +15,21 @@
 
 namespace CoordinateMaps {
 
-/// \ingroup CoordinateMaps
-/// Two dimensional map from the unit square to a wedge, which forms one
-/// quadrant of an annulus. The wedge can be oriented in the +/- x or y axis,
-/// with the inner and outer radii specifiable.
+/// \ingroup CoordinateMapsGroup
+/// Two dimensional map from the unit square to a wedge, which is constructed
+/// by interpolating between a circular arc of radius `radius_of_circle` and a
+/// flat face which is circumscribed by a circular arc of radius
+/// `radius_of_other`. These arcs extend \f$\pi/2\f$ in angle, and can be
+/// oriented along the +/- x or y axis. The choice of using either equiangular
+/// or equidistant coordinates along the arcs is specifiable with
+/// `with_equiangular_map`. For a more detailed discussion, see the
+/// documentation for Wedge3D.
 class Wedge2D {
  public:
   static constexpr size_t dim = 2;
 
-  explicit Wedge2D(double inner_radius, double outer_radius,
-                   Direction<2> positioning_of_wedge);
+  Wedge2D(double radius_of_other, double radius_of_circle,
+          Direction<2> direction_of_wedge, bool with_equiangular_map) noexcept;
 
   Wedge2D() = default;
   ~Wedge2D() = default;
@@ -37,33 +42,33 @@ class Wedge2D {
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> operator()(
       const std::array<T, 2>& x) const noexcept;
 
-  // Currently unimplemented, hence the noreturn attribute
   template <typename T>
-  [[noreturn]] std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2>
-  inverse(const std::array<T, 2>& x) const noexcept;
+  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> inverse(
+      const std::array<T, 2>& x) const noexcept;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 2>& xi) const noexcept;
+  jacobian(const std::array<T, 2>& x) const noexcept;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 2>& xi) const noexcept;
+  inv_jacobian(const std::array<T, 2>& x) const noexcept;
 
   // clang-tidy: google runtime references
   void pup(PUP::er& p);  // NOLINT
  private:
   friend bool operator==(const Wedge2D& lhs, const Wedge2D& rhs) noexcept;
 
-  double inner_radius_{};
-  double outer_radius_{};
-  Direction<2> positioning_of_wedge_{};
+  double radius_of_other_{};
+  double radius_of_circle_{};
+  Direction<2> direction_of_wedge_{};
+  bool with_equiangular_map_ = false;
 };
 bool operator!=(const Wedge2D& lhs, const Wedge2D& rhs) noexcept;
 }  // namespace CoordinateMaps

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -66,6 +66,7 @@ void test_jacobian(const Map& map,
   for (size_t i = 0; i < Map::dim; ++i) {
     const auto numerical_deriv_i = numerical_derivative(map, test_point, i, dx);
     for (size_t j = 0; j < Map::dim; ++j) {
+      INFO("i: " << i << " j: " << j);
       CHECK(jacobian.get(j, i) == local_approx(gsl::at(numerical_deriv_i, j)));
     }
   }

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -510,7 +510,7 @@ void test_coordinate_map_with_rotation_wedge() {
   using Wedge2D = CoordinateMaps::Wedge2D;
 
   const auto first_map = Rotate(2.);
-  const auto second_map = Wedge2D(3., 7., Direction<2>::lower_eta());
+  const auto second_map = Wedge2D(3., 7., Direction<2>::lower_eta(), false);
 
   const auto composed_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(first_map, second_map);

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -10,7 +10,8 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equidistant",
+                  "[Domain][Unit]") {
   // Set up random number generator:
   std::random_device rd;
   std::mt19937 gen(rd());
@@ -22,10 +23,10 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D", "[Domain][Unit]") {
   // corners of the wedge.
   const std::array<double, 2> lower_right_corner{{1.0, -1.0}};
   const std::array<double, 2> upper_right_corner{{1.0, 1.0}};
-  for (size_t i = 0; i < 2; ++i) {
-    CAPTURE_PRECISE(gsl::at(lower_right_corner, i));
-    CAPTURE_PRECISE(gsl::at(upper_right_corner, i));
-  }
+  CAPTURE_PRECISE(gsl::at(lower_right_corner, 0));
+  CAPTURE_PRECISE(gsl::at(upper_right_corner, 0));
+  CAPTURE_PRECISE(gsl::at(lower_right_corner, 1));
+  CAPTURE_PRECISE(gsl::at(upper_right_corner, 1));
 
   const double random_inner_radius_upper_xi = inner_dis(gen);
   CAPTURE_PRECISE(random_inner_radius_upper_xi);
@@ -46,16 +47,16 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D", "[Domain][Unit]") {
 
   const CoordinateMaps::Wedge2D map_upper_xi(random_inner_radius_upper_xi,
                                              random_outer_radius_upper_xi,
-                                             Direction<2>::upper_xi());
+                                             Direction<2>::upper_xi(), false);
   const CoordinateMaps::Wedge2D map_upper_eta(random_inner_radius_upper_eta,
                                               random_outer_radius_upper_eta,
-                                              Direction<2>::upper_eta());
+                                              Direction<2>::upper_eta(), false);
   const CoordinateMaps::Wedge2D map_lower_xi(random_inner_radius_lower_xi,
                                              random_outer_radius_lower_xi,
-                                             Direction<2>::lower_xi());
+                                             Direction<2>::lower_xi(), false);
   const CoordinateMaps::Wedge2D map_lower_eta(random_inner_radius_lower_eta,
                                               random_outer_radius_lower_eta,
-                                              Direction<2>::lower_eta());
+                                              Direction<2>::lower_eta(), false);
   CHECK(map_lower_eta != map_lower_xi);
   CHECK(map_upper_eta != map_lower_eta);
   CHECK(map_lower_eta != map_upper_xi);
@@ -101,18 +102,132 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D", "[Domain][Unit]") {
   CAPTURE_PRECISE(inner_radius);
   const double outer_radius = outer_dis(gen);
   CAPTURE_PRECISE(outer_radius);
+  const std::array<double, 2> test_point{{xi, eta}};
 
   for (const auto& direction : Direction<2>::all_directions()) {
-    const CoordinateMaps::Wedge2D map{inner_radius, outer_radius, direction};
-    const std::array<double, 2> test_point{{xi, eta}};
-
+    const CoordinateMaps::Wedge2D map{inner_radius, outer_radius, direction,
+                                      false};
     test_jacobian(map, test_point);
+
     test_inv_jacobian(map, test_point);
 
     test_serialization(map);
 
     test_coordinate_map_implementation(map);
 
-    test_coordinate_map_argument_types<false>(map, test_point);
+    test_coordinate_map_argument_types<true>(map, test_point);
+
+    test_inverse_map(map, test_point);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equiangular",
+                  "[Domain][Unit]") {
+  // Set up random number generator:
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> real_dis(-1, 1);
+  std::uniform_real_distribution<> inner_dis(1, 3);
+  std::uniform_real_distribution<> outer_dis(4, 7);
+
+  // Check that points on the corners of the reference square map to the correct
+  // corners of the wedge.
+  const std::array<double, 2> lower_right_corner{{1.0, -1.0}};
+  const std::array<double, 2> upper_right_corner{{1.0, 1.0}};
+  CAPTURE_PRECISE(gsl::at(lower_right_corner, 0));
+  CAPTURE_PRECISE(gsl::at(upper_right_corner, 0));
+  CAPTURE_PRECISE(gsl::at(lower_right_corner, 1));
+  CAPTURE_PRECISE(gsl::at(upper_right_corner, 1));
+
+  const double random_inner_radius_upper_xi = inner_dis(gen);
+  CAPTURE_PRECISE(random_inner_radius_upper_xi);
+  const double random_inner_radius_upper_eta = inner_dis(gen);
+  CAPTURE_PRECISE(random_inner_radius_upper_eta);
+  const double random_inner_radius_lower_xi = inner_dis(gen);
+  CAPTURE_PRECISE(random_inner_radius_lower_xi);
+  const double random_inner_radius_lower_eta = inner_dis(gen);
+  CAPTURE_PRECISE(random_inner_radius_lower_eta);
+  const double random_outer_radius_upper_xi = outer_dis(gen);
+  CAPTURE_PRECISE(random_outer_radius_upper_xi);
+  const double random_outer_radius_upper_eta = outer_dis(gen);
+  CAPTURE_PRECISE(random_outer_radius_upper_eta);
+  const double random_outer_radius_lower_xi = outer_dis(gen);
+  CAPTURE_PRECISE(random_outer_radius_lower_xi);
+  const double random_outer_radius_lower_eta = outer_dis(gen);
+  CAPTURE_PRECISE(random_outer_radius_lower_eta);
+
+  const CoordinateMaps::Wedge2D map_upper_xi(random_inner_radius_upper_xi,
+                                             random_outer_radius_upper_xi,
+                                             Direction<2>::upper_xi(), true);
+  const CoordinateMaps::Wedge2D map_upper_eta(random_inner_radius_upper_eta,
+                                              random_outer_radius_upper_eta,
+                                              Direction<2>::upper_eta(), true);
+  const CoordinateMaps::Wedge2D map_lower_xi(random_inner_radius_lower_xi,
+                                             random_outer_radius_lower_xi,
+                                             Direction<2>::lower_xi(), true);
+  const CoordinateMaps::Wedge2D map_lower_eta(random_inner_radius_lower_eta,
+                                              random_outer_radius_lower_eta,
+                                              Direction<2>::lower_eta(), true);
+  CHECK(map_lower_eta != map_lower_xi);
+  CHECK(map_upper_eta != map_lower_eta);
+  CHECK(map_lower_eta != map_upper_xi);
+
+  CHECK(map_upper_xi(lower_right_corner)[0] ==
+        approx(random_outer_radius_upper_xi / sqrt(2.0)));
+  CHECK(map_upper_eta(lower_right_corner)[1] ==
+        approx(random_outer_radius_upper_eta / sqrt(2.0)));
+  CHECK(map_lower_xi(upper_right_corner)[0] ==
+        approx(-random_outer_radius_lower_xi / sqrt(2.0)));
+  CHECK(map_lower_eta(upper_right_corner)[1] ==
+        approx(-random_outer_radius_lower_eta / sqrt(2.0)));
+
+  // Check that random points on the edges of the reference square map to the
+  // correct edges of the wedge.
+  const std::array<double, 2> random_right_edge{{1.0, real_dis(gen)}};
+  const std::array<double, 2> random_left_edge{{-1.0, real_dis(gen)}};
+
+  CHECK(magnitude(map_upper_xi(random_right_edge)) ==
+        approx(random_outer_radius_upper_xi));
+  CHECK(map_upper_xi(random_left_edge)[0] ==
+        approx(random_inner_radius_upper_xi / sqrt(2.0)));
+  CHECK(magnitude(map_upper_eta(random_right_edge)) ==
+        approx(random_outer_radius_upper_eta));
+  CHECK(map_upper_eta(random_left_edge)[1] ==
+        approx(random_inner_radius_upper_eta / sqrt(2.0)));
+  CHECK(magnitude(map_lower_xi(random_right_edge)) ==
+        approx(random_outer_radius_lower_xi));
+  CHECK(map_lower_xi(random_left_edge)[0] ==
+        approx(-random_inner_radius_lower_xi / sqrt(2.0)));
+  CHECK(magnitude(map_lower_eta(random_right_edge)) ==
+        approx(random_outer_radius_lower_eta));
+  CHECK(map_lower_eta(random_left_edge)[1] ==
+        approx(-random_inner_radius_lower_eta / sqrt(2.0)));
+
+  const double dxi = 1e-5;
+  const double deta = 1e-5;
+  const double xi = real_dis(gen);
+  CAPTURE_PRECISE(xi);
+  const double eta = real_dis(gen);
+  CAPTURE_PRECISE(eta);
+  const double inner_radius = inner_dis(gen);
+  CAPTURE_PRECISE(inner_radius);
+  const double outer_radius = outer_dis(gen);
+  CAPTURE_PRECISE(outer_radius);
+  const std::array<double, 2> test_point{{xi, eta}};
+
+  for (const auto& direction : Direction<2>::all_directions()) {
+    const CoordinateMaps::Wedge2D map{inner_radius, outer_radius, direction,
+                                      true};
+    test_jacobian(map, test_point);
+
+    test_inv_jacobian(map, test_point);
+
+    test_serialization(map);
+
+    test_coordinate_map_implementation(map);
+
+    test_coordinate_map_argument_types<true>(map, test_point);
+
+    test_inverse_map(map, test_point);
   }
 }

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -132,7 +132,7 @@ void test_element_map<2>() {
 
   // test with a rotation and a wedge
   test_element_impl(false, element_id, affine_map, first_map,
-                    Wedge2D(3., 7., Direction<2>::lower_eta()),
+                    Wedge2D(3., 7., Direction<2>::lower_eta(), false),
                     logical_point_double, logical_point_dv);
 }
 


### PR DESCRIPTION
## Proposed changes

The equivalent changes made to Wedge3D are now made to Wedge2D:
Adding an inverse map.
Allowing for the use of equiangular and equidistant coordinates.
The corresponding tests are also added
This needs to be merged before Disk is because Disk needs to be updated to allow the choice of variables.
### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
