### PR TITLE
Add spacetime normals

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -204,6 +204,15 @@ tnsr::aa<DataType, SpatialDim, Frame> compute_pi(
   return pi;
 }
 
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> compute_spacetime_normal_one_form(
+    const Scalar<DataType>& lapse) noexcept {
+  auto normal_one_form =
+      make_with_value<tnsr::a<DataType, SpatialDim, Frame>>(get<>(lapse), 0.);
+  get<0>(normal_one_form) = -get<>(lapse);
+  return normal_one_form;
+}
+
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
@@ -247,7 +256,10 @@ tnsr::aa<DataType, SpatialDim, Frame> compute_pi(
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& dt_shift,           \
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
-      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
+  compute_spacetime_normal_one_form(                                          \
+      const Scalar<DTYPE(data)>& lapse) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Inertial))

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -213,6 +213,20 @@ tnsr::a<DataType, SpatialDim, Frame> compute_spacetime_normal_one_form(
   return normal_one_form;
 }
 
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::A<DataType, SpatialDim, Frame> compute_spacetime_normal_vector(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift) noexcept {
+  auto spacetime_normal_vector{
+      make_with_value<tnsr::A<DataType, SpatialDim, Frame>>(get<>(lapse), 0.)};
+  get<0>(spacetime_normal_vector) = 1. / get<>(lapse);
+  for (size_t i = 0; i < SpatialDim; i++) {
+    spacetime_normal_vector.get(i + 1) =
+        -shift.get(i) * get<0>(spacetime_normal_vector);
+  }
+  return spacetime_normal_vector;
+}
+
 /// \cond
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
@@ -259,7 +273,11 @@ tnsr::a<DataType, SpatialDim, Frame> compute_spacetime_normal_one_form(
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
   template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
   compute_spacetime_normal_one_form(                                          \
-      const Scalar<DTYPE(data)>& lapse) noexcept;
+      const Scalar<DTYPE(data)>& lapse) noexcept;                             \
+  template tnsr::A<DTYPE(data), DIM(data), FRAME(data)>                       \
+  compute_spacetime_normal_vector(                                            \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Inertial))

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -132,3 +132,15 @@ tnsr::aa<DataType, SpatialDim, Frame> compute_pi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+/*!
+ * \brief Computes spacetime normal one-form from lapse.
+ *
+ * \details If \f$N\f$ is the lapse, then
+ * \f{align} n_t &=& - N \\
+ * n_i &=& 0 \f}
+ * is computed.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> compute_spacetime_normal_one_form(
+    const Scalar<DataType>& lapse) noexcept;

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -144,3 +144,16 @@ tnsr::aa<DataType, SpatialDim, Frame> compute_pi(
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::a<DataType, SpatialDim, Frame> compute_spacetime_normal_one_form(
     const Scalar<DataType>& lapse) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief  Computes spacetime normal vector from lapse and shift.
+ * \details If $N, N^i$ are the lapse and shift respectively, then
+ * \f{align} n^t &=& 1/N \\
+ * n^i &=& -\frac{N^i}{N} \f}
+ * is computed.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::A<DataType, SpatialDim, Frame> compute_spacetime_normal_vector(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift) noexcept;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -431,6 +431,20 @@ void test_compute_3d_pi(const DataVector& used_for_size) {
       pi);
 }
 
+template<size_t Dim>
+void test_compute_spacetime_normal_one_form(const DataVector& used_for_size) {
+  const auto spacetime_normal_one_form =
+      compute_spacetime_normal_one_form<Dim, Frame::Inertial>(make_lapse(0.));
+
+  CHECK(spacetime_normal_one_form.get(0) == approx(-3.0));
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK(spacetime_normal_one_form.get(i + 1) == 0.);
+  }
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_spacetime_normal_one_form<Dim, Frame::Inertial>(
+          make_lapse(used_for_size)),
+      spacetime_normal_one_form);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
@@ -451,4 +465,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   test_compute_1d_pi(dv);
   test_compute_2d_pi(dv);
   test_compute_3d_pi(dv);
+  test_compute_spacetime_normal_one_form<1>(dv);
+  test_compute_spacetime_normal_one_form<2>(dv);
+  test_compute_spacetime_normal_one_form<3>(dv);
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -445,6 +445,49 @@ void test_compute_spacetime_normal_one_form(const DataVector& used_for_size) {
           make_lapse(used_for_size)),
       spacetime_normal_one_form);
 }
+
+void test_compute_1d_spacetime_normal_vector(const DataVector& used_for_size) {
+  const size_t dim = 1;
+  const auto spacetime_normal_vector =
+      compute_spacetime_normal_vector(make_lapse(0.), make_shift<dim>(0.));
+
+  CHECK(spacetime_normal_vector.get(0) == approx(1. / 3.));
+  CHECK(spacetime_normal_vector.get(1) == approx(-1. / 3.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_spacetime_normal_vector(make_lapse(used_for_size),
+                                      make_shift<dim>(used_for_size)),
+      spacetime_normal_vector);
+}
+void test_compute_2d_spacetime_normal_vector(const DataVector& used_for_size) {
+  const size_t dim = 2;
+  const auto spacetime_normal_vector =
+      compute_spacetime_normal_vector(make_lapse(0.), make_shift<dim>(0.));
+
+  CHECK(spacetime_normal_vector.get(0) == approx(1. / 3.));
+  CHECK(spacetime_normal_vector.get(1) == approx(-1. / 3.));
+  CHECK(spacetime_normal_vector.get(2) == approx(-2. / 3.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_spacetime_normal_vector(make_lapse(used_for_size),
+                                      make_shift<dim>(used_for_size)),
+      spacetime_normal_vector);
+}
+void test_compute_3d_spacetime_normal_vector(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const auto spacetime_normal_vector =
+      compute_spacetime_normal_vector(make_lapse(0.), make_shift<dim>(0.));
+
+  CHECK(spacetime_normal_vector.get(0) == approx(1. / 3.));
+  CHECK(spacetime_normal_vector.get(1) == approx(-1. / 3.));
+  CHECK(spacetime_normal_vector.get(2) == approx(-2. / 3.));
+  CHECK(spacetime_normal_vector.get(3) == approx(-1.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      compute_spacetime_normal_vector(make_lapse(used_for_size),
+                                      make_shift<dim>(used_for_size)),
+      spacetime_normal_vector);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
@@ -468,4 +511,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   test_compute_spacetime_normal_one_form<1>(dv);
   test_compute_spacetime_normal_one_form<2>(dv);
   test_compute_spacetime_normal_one_form<3>(dv);
+  test_compute_1d_spacetime_normal_vector(dv);
+  test_compute_2d_spacetime_normal_vector(dv);
+  test_compute_3d_spacetime_normal_vector(dv);
 }


### PR DESCRIPTION
## Proposed changes

Add computation of spacetime normal vector and one form. 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


