### PR TITLE
Variables prefix math

### DIFF
--- a/src/DataStructures/DataBoxTag.hpp
+++ b/src/DataStructures/DataBoxTag.hpp
@@ -466,4 +466,23 @@ using add_tag_prefix = typename detail::add_tag_prefix_impl<
 /// tags if the unwrapped tag is a `Tags::Variables`.
 template <typename Tag>
 using remove_tag_prefix = typename detail::remove_tag_prefix_impl<Tag>::type;
+
+namespace databox_detail {
+template <class Tag, bool IsPrefix = false>
+struct remove_all_prefixes {
+  using type = Tag;
+};
+
+template <template <class...> class F, class Tag, class... Args>
+struct remove_all_prefixes<F<Tag, Args...>, true> {
+  using type = typename remove_all_prefixes<
+      Tag, cpp17::is_base_of_v<db::DataBoxPrefix, Tag>>::type;
+};
+}  // namespace databox_detail
+
+/// \ingroup DataBoxGroup
+/// Completely remove all prefix tags from a Tag
+template <typename Tag>
+using remove_all_prefixes = typename databox_detail::remove_all_prefixes<
+    Tag, cpp17::is_base_of_v<db::DataBoxPrefix, Tag>>::type;
 }  // namespace db

--- a/src/DataStructures/DataBoxTag.hpp
+++ b/src/DataStructures/DataBoxTag.hpp
@@ -329,10 +329,16 @@ constexpr bool is_compute_item_v = is_compute_item<T>::value;
 
 namespace detail {
 template <class T, class = void>
-constexpr bool has_return_type_member_v = false;
+struct has_return_type_member : std::false_type {};
 template <class T>
-constexpr bool
-    has_return_type_member_v<T, cpp17::void_t<typename T::return_type>> = true;
+struct has_return_type_member<T, cpp17::void_t<typename T::return_type>>
+    : std::true_type {};
+
+/*!
+ * \brief `true` if `T` has nested type alias named `return_type`
+ */
+template <class T>
+constexpr bool has_return_type_member_v = has_return_type_member<T>::value;
 
 template <typename Tag, typename = std::nullptr_t>
 struct compute_item_result_impl;

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -124,12 +124,15 @@ class Variables<tmpl::list<Tags...>> {
   ~Variables() noexcept = default;
   /// \endcond
 
-  constexpr size_t number_of_grid_points() const noexcept {
+  constexpr SPECTRE_ALWAYS_INLINE size_t number_of_grid_points() const
+      noexcept {
     return number_of_grid_points_;
   }
 
   /// Number of grid points * number of independent components
-  constexpr size_type size() const noexcept { return size_; }
+  constexpr SPECTRE_ALWAYS_INLINE size_type size() const noexcept {
+    return size_;
+  }
 
   //{@
   /// Access pointer to underlying data
@@ -170,12 +173,14 @@ class Variables<tmpl::list<Tags...>> {
             Requires<tmpl2::flat_all_v<
                 cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
                                  db::remove_all_prefixes<Tags>>...>> = nullptr>
-  Variables& operator+=(const Variables<tmpl::list<WrappedTags...>>& rhs) {
+  SPECTRE_ALWAYS_INLINE Variables& operator+=(
+      const Variables<tmpl::list<WrappedTags...>>& rhs) noexcept {
     variable_data_ += rhs.variable_data_;
     return *this;
   }
   template <typename VT, bool VF>
-  Variables& operator+=(const blaze::Vector<VT, VF>& rhs) {
+  SPECTRE_ALWAYS_INLINE Variables& operator+=(
+      const blaze::Vector<VT, VF>& rhs) noexcept {
     variable_data_ += rhs;
     return *this;
   }
@@ -184,22 +189,24 @@ class Variables<tmpl::list<Tags...>> {
             Requires<tmpl2::flat_all_v<
                 cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
                                  db::remove_all_prefixes<Tags>>...>> = nullptr>
-  Variables& operator-=(const Variables<tmpl::list<WrappedTags...>>& rhs) {
+  SPECTRE_ALWAYS_INLINE Variables& operator-=(
+      const Variables<tmpl::list<WrappedTags...>>& rhs) noexcept {
     variable_data_ -= rhs.variable_data_;
     return *this;
   }
   template <typename VT, bool VF>
-  Variables& operator-=(const blaze::Vector<VT, VF>& rhs) {
+  SPECTRE_ALWAYS_INLINE Variables& operator-=(
+      const blaze::Vector<VT, VF>& rhs) noexcept {
     variable_data_ -= rhs;
     return *this;
   }
 
-  Variables& operator*=(const double& rhs) {
+  SPECTRE_ALWAYS_INLINE Variables& operator*=(const double& rhs) noexcept {
     variable_data_ *= rhs;
     return *this;
   }
 
-  Variables& operator/=(const double& rhs) {
+  SPECTRE_ALWAYS_INLINE Variables& operator/=(const double& rhs) noexcept {
     variable_data_ /= rhs;
     return *this;
   }
@@ -208,19 +215,19 @@ class Variables<tmpl::list<Tags...>> {
             Requires<tmpl2::flat_all_v<
                 cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
                                  db::remove_all_prefixes<Tags>>...>> = nullptr>
-  friend decltype(auto) operator+(
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator+(
       const Variables<tmpl::list<WrappedTags...>>& lhs,
       const Variables& rhs) noexcept {
     return lhs.get_variable_data() + rhs.variable_data_;
   }
   template <typename VT, bool VF>
-  friend decltype(auto) operator+(const blaze::Vector<VT, VF>& lhs,
-                                  const Variables& rhs) {
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator+(
+      const blaze::Vector<VT, VF>& lhs, const Variables& rhs) noexcept {
     return ~lhs + rhs.variable_data_;
   }
   template <typename VT, bool VF>
-  friend decltype(auto) operator+(const Variables& lhs,
-                                  const blaze::Vector<VT, VF>& rhs) {
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator+(
+      const Variables& lhs, const blaze::Vector<VT, VF>& rhs) noexcept {
     return lhs.variable_data_ + ~rhs;
   }
 
@@ -228,31 +235,33 @@ class Variables<tmpl::list<Tags...>> {
             Requires<tmpl2::flat_all_v<
                 cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
                                  db::remove_all_prefixes<Tags>>...>> = nullptr>
-
-  friend decltype(auto) operator-(
-      const Variables<tmpl::list<WrappedTags...>>& lhs, const Variables& rhs) {
-    return lhs.variable_data_ - rhs.variable_data_;
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator-(
+      const Variables<tmpl::list<WrappedTags...>>& lhs,
+      const Variables& rhs) noexcept {
     return lhs.get_variable_data() - rhs.variable_data_;
   }
   template <typename VT, bool VF>
-  friend decltype(auto) operator-(const blaze::Vector<VT, VF>& lhs,
-                                  const Variables& rhs) {
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator-(
+      const blaze::Vector<VT, VF>& lhs, const Variables& rhs) noexcept {
     return ~lhs - rhs.variable_data_;
   }
   template <typename VT, bool VF>
-  friend decltype(auto) operator-(const Variables& lhs,
-                                  const blaze::Vector<VT, VF>& rhs) {
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator-(
+      const Variables& lhs, const blaze::Vector<VT, VF>& rhs) noexcept {
     return lhs.variable_data_ - ~rhs;
   }
 
-  friend decltype(auto) operator*(const Variables& lhs, const double& rhs) {
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator*(
+      const Variables& lhs, const double& rhs) noexcept {
     return lhs.variable_data_ * rhs;
   }
-  friend decltype(auto) operator*(const double& lhs, const Variables& rhs) {
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator*(
+      const double& lhs, const Variables& rhs) noexcept {
     return lhs * rhs.variable_data_;
   }
 
-  friend decltype(auto) operator/(const Variables& lhs, const double& rhs) {
+  friend SPECTRE_ALWAYS_INLINE decltype(auto) operator/(
+      const Variables& lhs, const double& rhs) noexcept {
     return lhs.variable_data_ / rhs;
   }
 
@@ -269,8 +278,11 @@ class Variables<tmpl::list<Tags...>> {
    *
    *  \requires `i >= 0 and i < size()`
    */
-  double& operator[](const size_type i) noexcept { return variable_data_[i]; }
-  const double& operator[](const size_type i) const noexcept {
+  SPECTRE_ALWAYS_INLINE double& operator[](const size_type i) noexcept {
+    return variable_data_[i];
+  }
+  SPECTRE_ALWAYS_INLINE const double& operator[](const size_type i) const
+      noexcept {
     return variable_data_[i];
   }
   //@}

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -95,6 +95,31 @@ class Variables<tmpl::list<Tags...>> {
   Variables(const Variables& rhs);
   Variables& operator=(const Variables& rhs);
 
+  // @{
+  /// Copy and move semantics for wrapped variables
+  template <typename... WrappedTags,
+            Requires<tmpl2::flat_all_v<
+                cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
+                                 db::remove_all_prefixes<Tags>>...>> = nullptr>
+  explicit Variables(Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept;
+  template <typename... WrappedTags,
+            Requires<tmpl2::flat_all_v<
+                cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
+                                 db::remove_all_prefixes<Tags>>...>> = nullptr>
+  Variables& operator=(Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept;
+
+  template <typename... WrappedTags,
+            Requires<tmpl2::flat_all_v<
+                cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
+                                 db::remove_all_prefixes<Tags>>...>> = nullptr>
+  explicit Variables(const Variables<tmpl::list<WrappedTags...>>& rhs);
+  template <typename... WrappedTags,
+            Requires<tmpl2::flat_all_v<
+                cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
+                                 db::remove_all_prefixes<Tags>>...>> = nullptr>
+  Variables& operator=(const Variables<tmpl::list<WrappedTags...>>& rhs);
+  // @}
+
   /// \cond HIDDEN_SYMBOLS
   ~Variables() noexcept = default;
   /// \endcond
@@ -111,6 +136,15 @@ class Variables<tmpl::list<Tags...>> {
   double* data() noexcept { return variable_data_.data(); }
   const double* data() const noexcept { return variable_data_.data(); }
   //@}
+
+  /// \cond HIDDEN_SYMBOLS
+  /// Needed because of limitations and inconsistency between compiler
+  /// implementations of friend function templates with auto return type of
+  /// class templates
+  const PointerVector<double>& get_variable_data() const noexcept {
+    return variable_data_;
+  }
+  /// \endcond
 
   // clang-tidy: redundant-declaration
   template <typename Tag, typename TagList>
@@ -132,7 +166,11 @@ class Variables<tmpl::list<Tags...>> {
   template <typename VT, bool VF>
   Variables& operator=(const blaze::Vector<VT, VF>& expression);
 
-  Variables& operator+=(const Variables& rhs) {
+  template <typename... WrappedTags,
+            Requires<tmpl2::flat_all_v<
+                cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
+                                 db::remove_all_prefixes<Tags>>...>> = nullptr>
+  Variables& operator+=(const Variables<tmpl::list<WrappedTags...>>& rhs) {
     variable_data_ += rhs.variable_data_;
     return *this;
   }
@@ -142,7 +180,11 @@ class Variables<tmpl::list<Tags...>> {
     return *this;
   }
 
-  Variables& operator-=(const Variables& rhs) {
+  template <typename... WrappedTags,
+            Requires<tmpl2::flat_all_v<
+                cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
+                                 db::remove_all_prefixes<Tags>>...>> = nullptr>
+  Variables& operator-=(const Variables<tmpl::list<WrappedTags...>>& rhs) {
     variable_data_ -= rhs.variable_data_;
     return *this;
   }
@@ -162,8 +204,14 @@ class Variables<tmpl::list<Tags...>> {
     return *this;
   }
 
-  friend decltype(auto) operator+(const Variables& lhs, const Variables& rhs) {
-    return lhs.variable_data_ + rhs.variable_data_;
+  template <typename... WrappedTags,
+            Requires<tmpl2::flat_all_v<
+                cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
+                                 db::remove_all_prefixes<Tags>>...>> = nullptr>
+  friend decltype(auto) operator+(
+      const Variables<tmpl::list<WrappedTags...>>& lhs,
+      const Variables& rhs) noexcept {
+    return lhs.get_variable_data() + rhs.variable_data_;
   }
   template <typename VT, bool VF>
   friend decltype(auto) operator+(const blaze::Vector<VT, VF>& lhs,
@@ -176,8 +224,15 @@ class Variables<tmpl::list<Tags...>> {
     return lhs.variable_data_ + ~rhs;
   }
 
-  friend decltype(auto) operator-(const Variables& lhs, const Variables& rhs) {
+  template <typename... WrappedTags,
+            Requires<tmpl2::flat_all_v<
+                cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
+                                 db::remove_all_prefixes<Tags>>...>> = nullptr>
+
+  friend decltype(auto) operator-(
+      const Variables<tmpl::list<WrappedTags...>>& lhs, const Variables& rhs) {
     return lhs.variable_data_ - rhs.variable_data_;
+    return lhs.get_variable_data() - rhs.variable_data_;
   }
   template <typename VT, bool VF>
   friend decltype(auto) operator-(const blaze::Vector<VT, VF>& lhs,
@@ -238,6 +293,9 @@ class Variables<tmpl::list<Tags...>> {
     return lhs.variable_data_ == rhs.variable_data_;
   }
 
+  template <class FriendTags>
+  friend class Variables;
+
   std::vector<double, allocator_type> variable_data_impl_;
   // variable_data_ is only used to plug into the Blaze expression templates
   PointerVector<double> variable_data_;
@@ -296,6 +354,72 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   return *this;
 }
 
+template <typename... Tags>
+template <typename... WrappedTags, Requires<tmpl2::flat_all_v<cpp17::is_same_v<
+                                       db::remove_all_prefixes<WrappedTags>,
+                                       db::remove_all_prefixes<Tags>>...>>>
+Variables<tmpl::list<Tags...>>::Variables(
+    const Variables<tmpl::list<WrappedTags...>>& rhs)
+    : variable_data_impl_(rhs.variable_data_impl_),
+      variable_data_(variable_data_impl_.data(), variable_data_impl_.size()),
+      size_(rhs.size_),
+      number_of_grid_points_(rhs.number_of_grid_points()) {
+  add_reference_variable_data(typelist<Tags...>{});
+}
+
+template <typename... Tags>
+template <typename... WrappedTags, Requires<tmpl2::flat_all_v<cpp17::is_same_v<
+                                       db::remove_all_prefixes<WrappedTags>,
+                                       db::remove_all_prefixes<Tags>>...>>>
+Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
+    const Variables<tmpl::list<WrappedTags...>>& rhs) {
+  variable_data_impl_ = rhs.variable_data_impl_;
+  variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
+  size_ = rhs.size_;
+  number_of_grid_points_ = rhs.number_of_grid_points();
+  add_reference_variable_data(typelist<Tags...>{});
+  return *this;
+}
+
+template <typename... Tags>
+template <typename... WrappedTags, Requires<tmpl2::flat_all_v<cpp17::is_same_v<
+                                       db::remove_all_prefixes<WrappedTags>,
+                                       db::remove_all_prefixes<Tags>>...>>>
+Variables<tmpl::list<Tags...>>::Variables(
+    Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept
+    : variable_data_impl_(std::move(rhs.variable_data_impl_)),
+      variable_data_(std::move(rhs.variable_data_)),
+      size_(rhs.size()),
+      number_of_grid_points_(rhs.number_of_grid_points()),
+      reference_variable_data_(std::move(rhs.reference_variable_data_)) {}
+
+template <typename... Tags>
+template <typename... WrappedTags, Requires<tmpl2::flat_all_v<cpp17::is_same_v<
+                                       db::remove_all_prefixes<WrappedTags>,
+                                       db::remove_all_prefixes<Tags>>...>>>
+Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
+    Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept {
+  variable_data_impl_ = std::move(rhs.variable_data_impl_);
+  variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
+  size_ = rhs.size_;
+  number_of_grid_points_ = std::move(rhs.number_of_grid_points_);
+  add_reference_variable_data(typelist<Tags...>{});
+  return *this;
+}
+
+template <typename... Tags>
+void Variables<tmpl::list<Tags...>>::pup(PUP::er& p) {
+  p | variable_data_impl_;
+  p | size_;
+  p | number_of_grid_points_;
+  if (p.isUnpacking()) {
+    variable_data_.reset(variable_data_impl_.data(),
+                         variable_data_impl_.size());
+    add_reference_variable_data(typelist<Tags...>{});
+  }
+}
+/// \endcond
+
 // {@
 /*!
  * \ingroup DataStructuresGroup
@@ -312,19 +436,6 @@ constexpr const typename Tag::type& get(const Variables<TagList>& v) noexcept {
   return tuples::get<Tag>(v.reference_variable_data_);
 }
 // @}
-
-template <typename... Tags>
-void Variables<tmpl::list<Tags...>>::pup(PUP::er& p) {
-  p | variable_data_impl_;
-  p | size_;
-  p | number_of_grid_points_;
-  if (p.isUnpacking()) {
-    variable_data_.reset(variable_data_impl_.data(),
-                         variable_data_impl_.size());
-    add_reference_variable_data(typelist<Tags...>{});
-  }
-}
-/// \endcond
 
 template <typename... Tags>
 template <typename VT, bool VF>

--- a/src/Domain/ElementIndex.hpp
+++ b/src/Domain/ElementIndex.hpp
@@ -52,7 +52,8 @@ template <size_t VolumeDim>
 class ElementIndex {
  public:
   ElementIndex() = default;
-  explicit ElementIndex(const ElementId<VolumeDim>& id) noexcept;
+  // clang-tidy: mark explicit: we want to allow conversion
+  ElementIndex(const ElementId<VolumeDim>& id) noexcept;  // NOLINT
   size_t block_id() const noexcept { return segments_[0].block_id(); }
   const std::array<SegmentIndex, VolumeDim>& segments() const noexcept {
     return segments_;

--- a/tests/Unit/DataStructures/Test_DataBoxTag.cpp
+++ b/tests/Unit/DataStructures/Test_DataBoxTag.cpp
@@ -66,3 +66,9 @@ static_assert(
             double>>,
         Tags::Variables<tmpl::list<Var>>>,
     "Failed testing remove_tag_prefix");
+
+static_assert(
+    cpp17::is_same_v<db::remove_all_prefixes<PrefixWithArgs<
+                         PrefixWithArgs<Var, int, double>, char, bool>>,
+                     Var>,
+    "Failed testing remove_tag_prefix");


### PR DESCRIPTION
## Proposed changes

- Allow convert from Variables of wrapped tags to Variables of other wrapped tags (or not wrapped tags).
- Allow math between wrapped Variables tags
- Allow implicit conversion between ElementIndex and ElementId

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
