### PR TITLE
Add find benchmark

### DIFF
--- a/cmake/FindGoogleBenchmark.cmake
+++ b/cmake/FindGoogleBenchmark.cmake
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Find GOOGLE_BENCHMARK: https://github.com/google/benchmark
+# If not in one of the default paths specify
+# -DGOOGLE_BENCHMARK_ROOT=/path/to/GOOGLE_BENCHMARK to search there as well.
+
+find_path(GOOGLE_BENCHMARK_INCLUDE_DIRS benchmark.h
+    PATH_SUFFIXES include/benchmark
+    HINTS ${GOOGLE_BENCHMARK_ROOT})
+
+find_library(GOOGLE_BENCHMARK_LIBRARIES
+    NAMES benchmark
+    PATH_SUFFIXES lib64 lib
+    HINTS ${GOOGLE_BENCHMARK_ROOT})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GOOGLE_BENCHMARK
+    DEFAULT_MSG GOOGLE_BENCHMARK_INCLUDE_DIRS GOOGLE_BENCHMARK_LIBRARIES)
+mark_as_advanced(GOOGLE_BENCHMARK_INCLUDE_DIRS GOOGLE_BENCHMARK_LIBRARIES)

--- a/cmake/SetupGoogleBenchmark.cmake
+++ b/cmake/SetupGoogleBenchmark.cmake
@@ -1,14 +1,17 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(benchmark QUIET)
+find_package(GoogleBenchmark QUIET)
 
-if (${benchmark_FOUND})
-  message(STATUS "Google Benchmark version: ${benchmark_VERSION}")
+if (${GOOGLE_BENCHMARK_FOUND})
+  include_directories(SYSTEM ${GOOGLE_BENCHMARK_INCLUDE_DIRS})
+  set(SPECTRE_LIBRARIES "${SPECTRE_LIBRARIES};${GOOGLE_BENCHMARK_LIBRARIES}")
+
+  message(STATUS "Google Benchmark libs: " ${GOOGLE_BENCHMARK_LIBRARIES})
+  message(STATUS "Google Benchmark incl: " ${GOOGLE_BENCHMARK_INCLUDE_DIRS})
 
   file(APPEND
     "${CMAKE_BINARY_DIR}/LibraryVersions.txt"
-    "Google Benchmark Version:  ${benchmark_VERSION}\n"
+    "Google Benchmark Found\n"
     )
-
 endif()

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -14,8 +14,8 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/LogicalCoordinates.hpp"
-#include "Numerical/LinearOperators/PartialDerivatives.hpp"
-#include "Numerical/Spectral/LegendreGaussLobatto.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"
 
 // Charm looks for this function but since we build without a main function or

--- a/src/Executables/Benchmark/CMakeLists.txt
+++ b/src/Executables/Benchmark/CMakeLists.txt
@@ -3,9 +3,9 @@
 
 # Since benchmarking is only interesting in Release mode the executable isn't
 # added in any other build. Charm++'s main function is overridden with the main
-# from the Benchmark library. The executable is not added to the `all` make
+# from the Google Benchmark library. The executable is not added to the `all` make
 # target since it is only interesting in specific circumstances.
-if(${benchmark_FOUND} AND "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+if("${GOOGLE_BENCHMARK_FOUND}" AND "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
   set(executable Benchmark)
 
   add_executable(

--- a/src/Executables/Benchmark/CMakeLists.txt
+++ b/src/Executables/Benchmark/CMakeLists.txt
@@ -18,6 +18,7 @@ if(${benchmark_FOUND} AND "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
   target_link_libraries(
     ${executable}
     benchmark
+    Domain
     CoordinateMaps
     Spectral
     ${SPECTRE_LIBRARIES}


### PR DESCRIPTION
## Proposed changes

Add's find benchmark. Although this is included in benchmark 3.2(?) it seems to not work, and also this means we don't need a minimum version 3.2. 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`



