### PR TITLE
Add BulgedCube

### DIFF
--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -1,0 +1,320 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/BulgedCube.hpp"
+
+#include <pup.h>
+
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/RootFinding/RootFinder.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace {
+template <typename DType>
+class RootFunction {
+ public:
+  RootFunction(const double radius, const double sphericity,
+               const DType& physical_r_squared, const DType& x_sq,
+               const DType& y_sq, const DType& z_sq) noexcept
+      : radius_(radius),
+        sphericity_(sphericity),
+        physical_r_squared_(physical_r_squared),
+        x_sq_(x_sq),
+        y_sq_(y_sq),
+        z_sq_(z_sq) {}
+
+  double operator()(const double rho, const size_t i = 0) const noexcept {
+    if (not(equal_within_roundoff(get_element(physical_r_squared_, i), 0.0))) {
+      const double x_sq_over_r_sq =
+          get_element(x_sq_, i) / get_element(physical_r_squared_, i);
+      const double y_sq_over_r_sq =
+          get_element(y_sq_, i) / get_element(physical_r_squared_, i);
+      const double z_sq_over_r_sq =
+          get_element(z_sq_, i) / get_element(physical_r_squared_, i);
+      return sqrt(get_element(physical_r_squared_, i)) -
+             radius_ * rho *
+                 (1.0 / sqrt(3.0) +
+                  sphericity_ *
+                      (1.0 / sqrt(1.0 + square(rho) *
+                                            (x_sq_over_r_sq + y_sq_over_r_sq)) +
+                       1.0 / sqrt(1.0 + square(rho) *
+                                            (x_sq_over_r_sq + z_sq_over_r_sq)) +
+                       1.0 / sqrt(1.0 + square(rho) *
+                                            (y_sq_over_r_sq + z_sq_over_r_sq)) -
+                       1.0 / sqrt(2.0 + square(rho) * x_sq_over_r_sq) -
+                       1.0 / sqrt(2.0 + square(rho) * y_sq_over_r_sq) -
+                       1.0 / sqrt(2.0 + square(rho) * z_sq_over_r_sq)));
+    } else {
+      return 0.0;
+    }
+  }
+  const DType& get_x_sq() noexcept { return x_sq_; }
+  const DType& get_r_sq() noexcept { return physical_r_squared_; }
+
+ private:
+  const double radius_;
+  const double sphericity_;
+  const DType& physical_r_squared_;
+  const DType& x_sq_;
+  const DType& y_sq_;
+  const DType& z_sq_;
+};
+
+template <typename DType>
+DType scaling_factor(RootFunction<DType>&& rootfunction) noexcept {
+  const DType& x_sq = rootfunction.get_x_sq();
+  const DType& physical_r_squared = rootfunction.get_r_sq();
+  DType rho = find_root_of_function(
+      rootfunction, make_with_value<DType>(x_sq, 0.0),
+      make_with_value<DType>(x_sq, sqrt(3.0)), 1.0e-16, 1.0e-16);
+  for (size_t i = 0; i < get_size(rho); i++) {
+    if (not(equal_within_roundoff(get_element(physical_r_squared, i), 0.0))) {
+      get_element(rho, i) /= sqrt(get_element(physical_r_squared, i));
+    } else {
+      ASSERT(equal_within_roundoff(get_element(rho, i), 0.0),
+             "r == 0 must imply rho == 0. This has failed.");
+    }
+  }
+  return rho;
+}
+}  // namespace
+
+namespace CoordinateMaps {
+BulgedCube::BulgedCube(const double radius, const double sphericity,
+                       const bool use_equiangular_map) noexcept
+    : radius_(radius),
+      sphericity_(sphericity),
+      use_equiangular_map_(use_equiangular_map) {
+  ASSERT(radius > 0.0, "The radius of the cube must be greater than zero");
+  ASSERT(sphericity >= 0.0 and sphericity < 1.0,
+         "The sphericity must be strictly less than one.");
+}
+
+template <typename T>
+std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> BulgedCube::
+operator()(const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = std::decay_t<tt::remove_reference_wrapper_t<T>>;
+  const auto physical_coordinates = [this](
+      const ReturnType& cap_xi, const ReturnType& cap_eta,
+      const ReturnType& cap_zeta) noexcept {
+    const auto one_over_rho_xi = 1.0 / sqrt(2.0 + square(cap_xi));
+    const auto one_over_rho_eta = 1.0 / sqrt(2.0 + square(cap_eta));
+    const auto one_over_rho_zeta = 1.0 / sqrt(2.0 + square(cap_zeta));
+    const auto one_over_rho_xi_eta =
+        1.0 / sqrt(1.0 + square(cap_xi) + square(cap_eta));
+    const auto one_over_rho_xi_zeta =
+        1.0 / sqrt(1.0 + square(cap_xi) + square(cap_zeta));
+    const auto one_over_rho_eta_zeta =
+        1.0 / sqrt(1.0 + square(cap_eta) + square(cap_zeta));
+    const ReturnType radial_scaling_factor =
+        radius_ * (1.0 / sqrt(3.0) +
+                   sphericity_ * (one_over_rho_eta_zeta + one_over_rho_xi_zeta +
+                                  one_over_rho_xi_eta - one_over_rho_xi -
+                                  one_over_rho_eta - one_over_rho_zeta));
+
+    ReturnType physical_x = radial_scaling_factor * cap_xi;
+    ReturnType physical_y = radial_scaling_factor * cap_eta;
+    ReturnType physical_z = radial_scaling_factor * cap_zeta;
+    return std::array<ReturnType, 3>{
+        {std::move(physical_x), std::move(physical_y), std::move(physical_z)}};
+  };
+
+  if (use_equiangular_map_) {
+    return physical_coordinates(
+        tan(M_PI_4 * dereference_wrapper(source_coords[0])),
+        tan(M_PI_4 * dereference_wrapper(source_coords[1])),
+        tan(M_PI_4 * dereference_wrapper(source_coords[2])));
+  }
+  return physical_coordinates(dereference_wrapper(source_coords[0]),
+                              dereference_wrapper(source_coords[1]),
+                              dereference_wrapper(source_coords[2]));
+}
+
+template <typename T>
+std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3>
+BulgedCube::inverse(const std::array<T, 3>& target_coords) const noexcept {
+  using ReturnType = std::decay_t<tt::remove_reference_wrapper_t<T>>;
+  const ReturnType& physical_x = target_coords[0];
+  const ReturnType& physical_y = target_coords[1];
+  const ReturnType& physical_z = target_coords[2];
+  const ReturnType x_sq = square(physical_x);
+  const ReturnType y_sq = square(physical_y);
+  const ReturnType z_sq = square(physical_z);
+  const ReturnType physical_r_squared = x_sq + y_sq + z_sq;
+  const auto scaling_factor =
+      ::scaling_factor<ReturnType>(RootFunction<ReturnType>{
+          radius_, sphericity_, physical_r_squared, x_sq, y_sq, z_sq});
+  if (use_equiangular_map_) {
+    return {{2.0 * M_2_PI * atan(physical_x * scaling_factor),
+             2.0 * M_2_PI * atan(physical_y * scaling_factor),
+             2.0 * M_2_PI * atan(physical_z * scaling_factor)}};
+  }
+  return {{physical_x * scaling_factor, physical_y * scaling_factor,
+           physical_z * scaling_factor}};
+}
+
+template <typename T>
+std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3>
+BulgedCube::xi_derivative(const std::array<T, 3>& source_coords) const
+    noexcept {
+  using ReturnType = std::decay_t<tt::remove_reference_wrapper_t<T>>;
+  const auto derivative_lambda = [this](const ReturnType& cap_xi,
+                                        const ReturnType& cap_eta,
+                                        const ReturnType& cap_zeta,
+                                        const auto& cap_xi_deriv) {
+    const ReturnType one_over_rho_xi_cubed =
+        pow<3>(1.0 / sqrt(2.0 + square(cap_xi)));
+    const ReturnType one_over_rho_eta = 1.0 / sqrt(2.0 + square(cap_eta));
+    const ReturnType one_over_rho_zeta = 1.0 / sqrt(2.0 + square(cap_zeta));
+    const ReturnType one_over_rho_xi_eta_cubed =
+        pow<3>(1.0 / sqrt(1.0 + square(cap_xi) + square(cap_eta)));
+    const ReturnType one_over_rho_xi_zeta_cubed =
+        pow<3>(1.0 / sqrt(1.0 + square(cap_xi) + square(cap_zeta)));
+    const ReturnType one_over_rho_eta_zeta =
+        1.0 / sqrt(1.0 + square(cap_eta) + square(cap_zeta));
+    const ReturnType common_factor =
+        sphericity_ * radius_ * cap_xi * cap_xi_deriv *
+        (one_over_rho_xi_cubed - one_over_rho_xi_eta_cubed -
+         one_over_rho_xi_zeta_cubed);
+
+    const ReturnType physical_x =
+        radius_ * cap_xi_deriv *
+        (1.0 / sqrt(3.0) +
+         sphericity_ *
+             (((1.0 + square(cap_eta)) * one_over_rho_xi_eta_cubed +
+               (1.0 + square(cap_zeta)) * one_over_rho_xi_zeta_cubed -
+               2.0 * one_over_rho_xi_cubed) +
+              one_over_rho_eta_zeta - one_over_rho_eta - one_over_rho_zeta));
+    const ReturnType physical_y = cap_eta * common_factor;
+    const ReturnType physical_z = cap_zeta * common_factor;
+
+    return std::array<ReturnType, 3>{{physical_x, physical_y, physical_z}};
+  };
+  if (use_equiangular_map_) {
+    return derivative_lambda(
+        tan(M_PI_4 * dereference_wrapper(source_coords[0])),
+        tan(M_PI_4 * dereference_wrapper(source_coords[1])),
+        tan(M_PI_4 * dereference_wrapper(source_coords[2])),
+        ReturnType{M_PI_4 *
+                   (1.0 + square(tan(M_PI_4 *
+                                     dereference_wrapper(source_coords[0]))))});
+  }
+  return derivative_lambda(dereference_wrapper(source_coords[0]),
+                           dereference_wrapper(source_coords[1]),
+                           dereference_wrapper(source_coords[2]), 1.0);
+}
+
+template <typename T>
+Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
+       tmpl::integral_list<std::int32_t, 2, 1>,
+       index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
+                  SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
+BulgedCube::jacobian(const std::array<T, 3>& source_coords) const noexcept {
+  const auto dX_dxi = xi_derivative(source_coords);
+  const auto dX_deta = xi_derivative(
+      std::array<std::reference_wrapper<
+                     const std::decay_t<tt::remove_reference_wrapper_t<T>>>,
+                 3>{{std::cref(dereference_wrapper(source_coords[1])),
+                     std::cref(dereference_wrapper(source_coords[0])),
+                     std::cref(dereference_wrapper(source_coords[2]))}});
+  const auto dX_dzeta = xi_derivative(
+      std::array<std::reference_wrapper<
+                     const std::decay_t<tt::remove_reference_wrapper_t<T>>>,
+                 3>{{std::cref(dereference_wrapper(source_coords[2])),
+                     std::cref(dereference_wrapper(source_coords[1])),
+                     std::cref(dereference_wrapper(source_coords[0]))}});
+  auto jacobian_matrix = make_with_value<
+      Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
+             tmpl::integral_list<std::int32_t, 2, 1>,
+             index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
+                        SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>>(
+      dereference_wrapper(source_coords[0]), 0.0);
+
+  get<0, 0>(jacobian_matrix) = dX_dxi[0];
+  get<0, 1>(jacobian_matrix) = dX_deta[1];
+  get<0, 2>(jacobian_matrix) = dX_dzeta[2];
+  get<1, 0>(jacobian_matrix) = dX_dxi[1];
+  get<1, 1>(jacobian_matrix) = dX_deta[0];
+  get<1, 2>(jacobian_matrix) = dX_dzeta[1];
+  get<2, 0>(jacobian_matrix) = dX_dxi[2];
+  get<2, 1>(jacobian_matrix) = dX_deta[2];
+  get<2, 2>(jacobian_matrix) = dX_dzeta[0];
+  return jacobian_matrix;
+}
+
+void BulgedCube::pup(PUP::er& p) noexcept {
+  p | radius_;
+  p | sphericity_;
+  p | use_equiangular_map_;
+}
+
+template <typename T>
+Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
+       tmpl::integral_list<std::int32_t, 2, 1>,
+       index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
+                  SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
+BulgedCube::inv_jacobian(const std::array<T, 3>& source_coords) const noexcept {
+  const auto jac = jacobian(source_coords);
+  return determinant_and_inverse(jac).second;
+}
+
+bool operator==(const BulgedCube& lhs, const BulgedCube& rhs) noexcept {
+  return lhs.radius_ == rhs.radius_ and lhs.sphericity_ == rhs.sphericity_ and
+         lhs.use_equiangular_map_ == rhs.use_equiangular_map_;
+}
+
+bool operator!=(const BulgedCube& lhs, const BulgedCube& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                \
+  template std::array<DTYPE(data), 3> BulgedCube::operator()(               \
+      const std::array<std::reference_wrapper<const DTYPE(data)>, 3>&       \
+          source_coords) const noexcept;                                    \
+  template std::array<DTYPE(data), 3> BulgedCube::operator()(               \
+      const std::array<DTYPE(data), 3>& source_coords) const noexcept;      \
+  template std::array<DTYPE(data), 3> BulgedCube::inverse(                  \
+      const std::array<std::reference_wrapper<const DTYPE(data)>, 3>&       \
+          target_coords) const noexcept;                                    \
+  template std::array<DTYPE(data), 3> BulgedCube::inverse(                  \
+      const std::array<DTYPE(data), 3>& target_coords) const noexcept;      \
+  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,     \
+                  index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,     \
+                             SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>    \
+  BulgedCube::jacobian(                                                     \
+      const std::array<std::reference_wrapper<const DTYPE(data)>, 3>&       \
+          source_coords) const noexcept;                                    \
+  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,     \
+                  index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,     \
+                             SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>    \
+  BulgedCube::jacobian(const std::array<DTYPE(data), 3>& source_coords)     \
+      const noexcept;                                                       \
+  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,     \
+                  index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,     \
+                             SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>    \
+  BulgedCube::inv_jacobian(                                                 \
+      const std::array<std::reference_wrapper<const DTYPE(data)>, 3>&       \
+          source_coords) const noexcept;                                    \
+  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,     \
+                  index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,     \
+                             SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>    \
+  BulgedCube::inv_jacobian(const std::array<DTYPE(data), 3>& source_coords) \
+      const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+}  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/BulgedCube.hpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.hpp
@@ -1,0 +1,511 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// Defines the class BulgedCube.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
+
+namespace CoordinateMaps {
+
+/*!
+ *  \ingroup CoordinateMapsGroup
+ *
+ *  \brief Three dimensional map from the cube to a bulged cube.
+ *  The cube is shaped such that the surface is compatible
+ *  with the inner surface of Wedge3D.
+ *  The shape of the object can be chosen to be cubical,
+ *  if the sphericity is set to 0, or to a sphere, if
+ *  the sphericity is set to 1. The sphericity can
+ *  be set to any number between 0 and 1 for a bulged cube.
+ *
+ *  \details The volume map from the cube to a bulged cube is obtained by
+ *  interpolating between six surface maps, twelve bounding curves, and
+ *  eight corners. The surface map for the upper +z axis is obtained by
+ *  interpolating between a cubical surface and a spherical surface. The
+ *  two surfaces are chosen such that the latter circumscribes the former.
+ *
+ *  We make a choice here as to whether we wish to use the logical coordinates
+ *  parameterizing these surface as they are, in which case we have the
+ *  equidistant choice of coordinates, or whether to apply a tangent map to them
+ *  which leads us to the equiangular choice of coordinates. In terms of the
+ *  logical coordinates, the equiangular coordinates are:
+ *
+ *  \f[\textrm{equiangular xi} : \Xi(\xi) = \textrm{tan}(\xi\pi/4)\f]
+ *
+ *  \f[\textrm{equiangular eta}  : \mathrm{H}(\eta) = \textrm{tan}(\eta\pi/4)\f]
+ *
+ *  With derivatives:
+ *
+ *  \f[\Xi'(\xi) = \frac{\pi}{4}(1+\Xi^2)\f]
+ *
+ *  \f[\mathrm{H}'(\eta) = \frac{\pi}{4}(1+\mathrm{H}^2)\f]
+ *
+ *  The equidistant coordinates are:
+ *
+ *  \f[ \textrm{equidistant xi}  : \Xi = \xi\f]
+ *
+ *  \f[ \textrm{equidistant eta}  : \mathrm{H} = \eta\f]
+ *
+ *  with derivatives:
+ *
+ *  <center>\f$\Xi'(\xi) = 1\f$, and \f$\mathrm{H}'(\eta) = 1\f$</center>
+ *
+ *  We also define the variable \f$\rho\f$, given by:
+ *
+ *  \f[\rho = \sqrt{1+\Xi^2+\mathrm{H}^2}\f]
+ *
+ *  ### The Spherical Face Map
+ *  The surface map for the spherical face of radius \f$R\f$ lying in the
+ *  \f$+z\f$
+ *  direction in either choice of coordinates is then given by:
+ *
+ *  \f[\vec{\sigma}_{spherical}: \vec{\xi} \rightarrow \vec{x}(\vec{\xi})\f]
+ *  Where
+ *  \f[
+ *  \vec{x}(\xi,\eta) =
+ *  \begin{bmatrix}
+ *  x(\xi,\eta)\\
+ *  y(\xi,\eta)\\
+ *  z(\xi,\eta)\\
+ *  \end{bmatrix}  = \frac{R}{\rho}
+ *  \begin{bmatrix}
+ *  \Xi\\
+ *  \mathrm{H}\\
+ *  1\\
+ *  \end{bmatrix}
+ *  \f]
+ *
+ *  ### The Cubical Face Map
+ *  The surface map for the cubical face of side length \f$2L\f$ lying in the
+ *  \f$+z\f$ direction is given by:
+ *
+ *  \f[\vec{\sigma}_{cubical}: \vec{\xi} \rightarrow \vec{x}(\vec{\xi})\f]
+ *  Where
+ *  \f[
+ *  \vec{x}(\xi,\eta) =
+ *  \begin{bmatrix}
+ *  x(\xi,\eta)\\
+ *  y(\xi,\eta)\\
+ *  L\\
+ *  \end{bmatrix}  = L
+ *  \begin{bmatrix}
+ *  \Xi\\
+ *  \mathrm{H}\\
+ *  1\\
+ *  \end{bmatrix}
+ *  \f]
+ *
+ *  ### The Bulged Face Map
+ *  To construct the bulged map we interpolate between this cubical face map
+ *  and a spherical face map of radius `radius_of_other_surface`, with the
+ *  interpolation parameter being \f$s\f$, the `sphericity`.
+ *  The surface map for the bulged face lying in the \f$+z\f$ direction is then
+ *  given by:
+ *
+ *  \f[
+ *  \vec{\sigma}_{+z}(\xi,\eta) = \left\{(1-s)L + \frac{sR}{\rho}\right\}
+ *  \begin{bmatrix}
+ *  \Xi\\
+ *  \mathrm{H}\\
+ *  1\\
+ *  \end{bmatrix}
+ *  \f]
+ *
+ *  We constrain L by demanding that the spherical face circumscribe the cube.
+ *  With this condition, we have \f$L = R/\sqrt3\f$.
+ *
+ *  ### The General Formula for 3D Isoparametric Maps
+ *  The general formula is given by Eq. 1 in section 2.1 of Hesthaven's paper
+ *  "A Stable Penalty Method For The Compressible Navier-Stokes Equations III.
+ *  Multidimensional Domain Decomposition Schemes" available
+ *  <a href="
+ *  http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.699.1161&rep=rep1&type=pdf
+ *  "> here </a>.
+ *
+ *  Hesthaven's formula is general in the degree of the shape functions used,
+ *  so for our purposes we take the special case where the shape functions are
+ *  linear, and define new variables accordingly.
+ *
+ *  We define the following variables for
+ *  \f$\alpha, \beta, \gamma \in\{\xi,\eta,\zeta\}\f$:
+ *
+ *  \f[
+ *  f^{\pm}_{\alpha} = \frac{1}{2}(1\pm\alpha)\\
+ *  f^{\pm\pm}_{\alpha \ \beta} = \frac{1}{4}(1\pm\alpha)(1\pm\beta)\\
+ *  f^{\pm\pm\pm}_{\alpha \ \beta \ \gamma} =
+ *  \frac{1}{8}(1\pm\alpha)(1\pm\beta)(1\pm\gamma)
+ *  \f]
+ *
+ *  The formula involves six surfaces, which we will denote by
+ *  \f$\vec{\sigma}\f$, twelve curves, denoted by \f$\vec{\Gamma}\f$, and eight
+ *  vertices, denoted by \f$\vec{\pi}\f$, with the subscripts denoting which
+ *  face(s) these objects belong to. The full volume map is given by:
+ *
+ *  \f{align*}
+ *  \phi(\xi,\eta,\zeta) = &
+ *  f^{+}_{\zeta}\vec{\sigma}_{+\zeta}(\xi, \eta)+
+ *  f^{-}_{\zeta}\vec{\sigma}_{-\zeta}(\xi, \eta)\\
+ *  &+ f^{+}_{\eta}\vec{\sigma}_{+\eta}(\xi, \zeta)+
+ *  f^{-}_{\eta}\vec{\sigma}_{-\eta}(\xi, \zeta)+
+ *  f^{+}_{\xi}\vec{\sigma}_{+\xi}(\eta, \zeta)+
+ *  f^{-}_{\xi}\vec{\sigma}_{-\xi}(\eta, \zeta)\\
+ *  &- f^{++}_{\xi \ \eta}\vec{\Gamma}_{+\xi +\eta}(\zeta)-
+ *  f^{-+}_{\xi \ \eta}\vec{\Gamma}_{-\xi +\eta}(\zeta)-
+ *  f^{+-}_{\xi \ \eta}\vec{\Gamma}_{+\xi -\eta}(\zeta)-
+ *  f^{--}_{\xi \ \eta}\vec{\Gamma}_{-\xi -\eta}(\zeta)\\
+ *  &- f^{++}_{\xi \ \zeta}\vec{\Gamma}_{+\xi +\zeta}(\eta)-
+ *  f^{-+}_{\xi \ \zeta}\vec{\Gamma}_{-\xi +\zeta}(\eta)-
+ *  f^{+-}_{\xi \ \zeta}\vec{\Gamma}_{+\xi -\zeta}(\eta)-
+ *  f^{--}_{\xi \ \zeta}\vec{\Gamma}_{-\xi -\zeta}(\eta)\\
+ *  &- f^{++}_{\eta \ \zeta}\vec{\Gamma}_{+\eta +\zeta}(\xi)-
+ *  f^{-+}_{\eta \ \zeta}\vec{\Gamma}_{-\eta +\zeta}(\xi)-
+ *  f^{+-}_{\eta \ \zeta}\vec{\Gamma}_{+\eta -\zeta}(\xi)-
+ *  f^{--}_{\eta \zeta}\vec{\Gamma}_{-\eta -\zeta}(\xi)\\
+ *  &+ f^{+++}_{\xi \ \eta \ \zeta}\vec{\pi}_{+\xi +\eta +\zeta}+
+ *  f^{-++}_{\xi \ \eta \ \zeta}\vec{\pi}_{-\xi +\eta +\zeta}+
+ *  f^{+-+}_{\xi \ \eta \ \zeta}\vec{\pi}_{+\xi -\eta +\zeta}+
+ *  f^{--+}_{\xi \ \eta \ \zeta}\vec{\pi}_{-\xi -\eta +\zeta}\\
+ *  &+ f^{++-}_{\xi \ \eta \ \zeta}\vec{\pi}_{+\xi +\eta -\zeta}+
+ *  f^{-+-}_{\xi \ \eta \ \zeta}\vec{\pi}_{-\xi +\eta -\zeta}+
+ *  f^{+--}_{\xi \ \eta \ \zeta}\vec{\pi}_{+\xi -\eta -\zeta}+
+ *  f^{---}_{\xi \ \eta \ \zeta}\vec{\pi}_{-\xi -\eta -\zeta}
+ *  \f}
+ *
+ *
+ *  ### The Special Case for Octahedral Symmetry
+ *  The general formula is for the case in which there are six independently
+ *  specified bounding surfaces. In our case, the surfaces are obtained by
+ *  rotations and reflections of the upper-\f$\zeta\f$ face.
+ *
+ * We define the matrices corresponding to these transformations to be:
+ *
+ * \f[
+ * S_{xy} =
+ *  \begin{bmatrix}
+ *  0 & 1 & 0\\
+ *  1 & 0 & 0\\
+ *  0 & 0 & 1\\
+ *  \end{bmatrix},\
+ *
+ * S_{xz} =
+ *  \begin{bmatrix}
+ *  0 & 0 & 1\\
+ *  0 & 1 & 0\\
+ *  1 & 0 & 0\\
+ *  \end{bmatrix},\
+ *
+ * S_{yz} =
+ *  \begin{bmatrix}
+ *  1 & 0 & 0\\
+ *  0 & 0 & 1\\
+ *  0 & 1 & 0\\
+ *  \end{bmatrix}\f]
+ *
+ * \f[C_{zxy} =
+ *  \begin{bmatrix}
+ *  0 & 0 & 1\\
+ *  1 & 0 & 0\\
+ *  0 & 1 & 0\\
+ *  \end{bmatrix},\
+ *
+ * C_{yzx} =
+ *  \begin{bmatrix}
+ *  0 & 1 & 0\\
+ *  0 & 0 & 1\\
+ *  1 & 0 & 0\\
+ *  \end{bmatrix}\f]
+ *
+ * \f[N_{x} =
+ *  \begin{bmatrix}
+ *  -1 & 0 & 0\\
+ *  0 & 1 & 0\\
+ *  0 & 0 & 1\\
+ *  \end{bmatrix},\
+ *
+ * N_{y} =
+ *  \begin{bmatrix}
+ *  1 & 0 & 0\\
+ *  0 & -1 & 0\\
+ *  0 & 0 & 1\\
+ *  \end{bmatrix},\
+ *
+ * N_{z} =
+ *  \begin{bmatrix}
+ *  1 & 0 & 0\\
+ *  0 & 1 & 0\\
+ *  0 & 0 & -1\\
+ *  \end{bmatrix}
+ *  \f]
+ *
+ * The surface maps can now all be written in terms of
+ * \f$\vec{\sigma}_{+\zeta}\f$ and these matrices:
+ * <center>
+ * \f$\vec{\sigma}_{-\zeta}(\xi, \eta) = N_z\vec{\sigma}_{+\zeta}(\xi, \eta)\\
+ * \vec{\sigma}_{+\eta}(\xi, \zeta) = S_{yz}\vec{\sigma}_{+\zeta}(\xi, \zeta)\\
+ * \vec{\sigma}_{-\eta}(\xi, \zeta) = N_yS_{yz}\vec{\sigma}_{+\zeta}(\xi,
+ * \zeta)\\
+ * \vec{\sigma}_{+\xi}(\eta, \zeta) = C_{zxy}\vec{\sigma}_{+\zeta}(\eta,
+ * \zeta)\\
+ * \vec{\sigma}_{-\xi}(\eta, \zeta) = N_xC_{zyx}\vec{\sigma}_{+\zeta}(\eta,
+ * \zeta)\f$
+ * </center>
+ *
+ * The four bounding curves \f$\vec{\Gamma}\f$ on the \f$+\zeta\f$ face are
+ * given by:
+ *
+ * <center>
+ * \f$\vec{\Gamma}_{+\xi,+\zeta}(\eta) = \vec{\sigma}_{+\zeta}(+1,\eta)\\
+ * \vec{\Gamma}_{-\xi,+\zeta}(\eta) = \vec{\sigma}_{+\zeta}(-1,\eta)
+ * = N_x\vec{\sigma}_{+\zeta}(+1, \eta)\\
+ * \vec{\Gamma}_{+\eta,+\zeta}(\xi) = \vec{\sigma}_{+\zeta}(\xi,+1)
+ * = S_{xy}\vec{\sigma}_{+\zeta}(+1, \xi)\\
+ * \vec{\Gamma}_{-\eta,+\zeta}(\xi) = \vec{\sigma}_{+\zeta}(\xi,-1)
+ * = N_yS_{xy}\vec{\sigma}_{+\zeta}(+1,\xi)\f$
+ * </center>
+ *
+ * The bounding curves on the other surfaces can be obtained by transformations
+ * on the \f$+\zeta\f$ face:
+ *
+ * <center>
+ * \f$\vec{\Gamma}_{+\xi,-\zeta}(\eta) = N_z\vec{\sigma}_{+\zeta}(+1,\eta)\\
+ * \vec{\Gamma}_{-\xi,-\zeta}(\eta) = N_z\vec{\sigma}_{+\zeta}(-1,\eta)
+ * = N_zN_x\vec{\sigma}_{+\zeta}(+1,\eta)\\
+ * \vec{\Gamma}_{+\eta,-\zeta}(\xi) = N_z\vec{\sigma}_{+\zeta}(\xi,+1)
+ * = N_zS_{xy}\vec{\sigma}_{+\zeta}(+1, \xi)\\
+ * \vec{\Gamma}_{-\eta,-\zeta}(\xi) = N_z\vec{\sigma}_{+\zeta}(\xi,-1)
+ * = N_zN_yS_{xy}\vec{\sigma}_{+\zeta}(+1, \xi)\\
+ * \vec{\Gamma}_{+\xi,+\eta}(\zeta) =
+ * C_{zxy}\vec{\sigma}_{+\zeta}(+1,\zeta)\\
+ * \vec{\Gamma}_{-\xi,+\eta}(\zeta) =
+ * N_xC_{zxy}\vec{\sigma}_{+\zeta}(+1,\zeta)\\
+ * \vec{\Gamma}_{+\xi,-\eta}(\zeta) = C_{zxy}\vec{\sigma}_{+\zeta}(-1,\zeta)
+ * = C_{zxy}N_x\vec{\sigma}_{+\zeta}(+1,\zeta)\\
+ * \vec{\Gamma}_{-\xi,-\eta}(\zeta) = N_xC_{zxy}\vec{\sigma}_{+\zeta}(-1,\zeta)
+ * = N_xC_{zxy}N_x\vec{\sigma}_{+\zeta}(+1,\zeta)\f$
+ * </center>
+ *
+ * Now we can write the volume map \f$\phi\f$ in terms of
+ * \f$\vec{\sigma}_{+\zeta}\f$ only:
+ * \f{align*}\phi(\xi,\eta,\zeta) = &
+ * (f^{+}_{\zeta} + f^{-}_{\zeta}N_z)
+ * \vec{\sigma}_{+\zeta}(\xi, \eta)\\
+ * &+ (f^{+}_{\eta} + f^{-}_{\eta}N_y)
+ * S_{yz}\vec{\sigma}_{+\zeta}(\xi, \zeta)\\
+ * &+ (f^{+}_{\xi} + f^{-}_{\xi}N_x)
+ * C_{zxy}\vec{\sigma}_{+\zeta}(\eta, \zeta)\\
+ * &- (f^{+}_{\xi}+f^{-}_{\xi}N_x)
+ * (f^{+}_{\eta}+f^{-}_{\eta}N_y)
+ * C_{zxy}\vec{\sigma}_{+\zeta}(+1, \zeta)\\
+ * &- (f^{+}_{\zeta}+f^{-}_{\zeta}N_z)\left\{
+ * (f^{+}_{\xi}+f^{-}_{\xi}N_x)\vec{\sigma}_{+\zeta}(+1, \eta)+
+ * (f^{+}_{\eta}+f^{-}_{\eta}N_y)S_{xy}\vec{\sigma}_{+\zeta}(+1, \xi)\right\}\\
+ * &+ \frac{r}{\sqrt{3}}\vec{\xi}
+ *  \f}
+ *
+ * Note that we can now absorb all of the \f$f\f$s into the matrix prefactors
+ * in the above equation and obtain a final set of matrices. We define the
+ * following *blending matrices*:
+ *
+ *  \f[
+ *  B_{\xi} =
+ *  \begin{bmatrix}
+ *  0 & 0 & \xi\\
+ *  1 & 0 & 0\\
+ *  0 & 1 & 0\\
+ *  \end{bmatrix},\
+ *
+ *  B_{\eta} =
+ *  \begin{bmatrix}
+ *  1 & 0 & 0\\
+ *  0 & 0 & \eta\\
+ *  0 & 1 & 0\\
+ *  \end{bmatrix},\
+ *
+ *  B_{\zeta} =
+ *  \begin{bmatrix}
+ *  1 & 0 & 0\\
+ *  0 & 1 & 0\\
+ *  0 & 0 & \zeta\\
+ *  \end{bmatrix}\\
+ *
+ *  B_{\xi\eta} =
+ *  \begin{bmatrix}
+ *  0 & 0 & \xi\\
+ *  \eta & 0 & 0\\
+ *  0 & 1 & 0\\
+ *  \end{bmatrix},\
+ *
+ *  B_{\xi\zeta} =
+ *  \begin{bmatrix}
+ *  \xi & 0 & 0\\
+ *  0 & 1 & 0\\
+ *  0 & 0 & \zeta\\
+ *  \end{bmatrix},\
+ *
+ *  B_{\eta\zeta} =
+ *  \begin{bmatrix}
+ *  0 & 1 & 0\\
+ *  \eta & 0 & 0\\
+ *  0 & 0 & \zeta\\
+ *  \end{bmatrix}\\
+ *
+ *  B_{\xi\eta\zeta} =
+ *  \begin{bmatrix}
+ *  \xi & 0 & 0\\
+ *  0 & \eta & 0\\
+ *  0 & 0 & \zeta\\
+ *  \end{bmatrix}
+ *  \f]
+ *
+ *  Now we can write the volume map \f$\phi\f$ in these terms:
+ *
+ * \f{align*}
+ * \phi(\xi,\eta,\zeta) = &
+ * B_{\zeta}
+ * \vec{\sigma}_{+\zeta}(\xi, \eta)\\& +
+ * B_{\eta}
+ * \vec{\sigma}_{+\zeta}(\xi, \zeta)+
+ * B_{\xi}
+ * \vec{\sigma}_{+\zeta}(\eta, \zeta)\\& -
+ * B_{\xi \eta}
+ * \vec{\sigma}_{+\zeta}(+1, \zeta)-
+ * B_{\xi \zeta}
+ * \vec{\sigma}_{+\zeta}(+1, \eta)+
+ * B_{\eta \zeta}
+ * \vec{\sigma}_{+\zeta}(+1, \xi)\\& +
+ * B_{\xi \eta \zeta}
+ * \vec{\sigma}_{+\zeta}(+1, +1)
+ * \f}
+ *
+ * ### The Bulged Cube Map
+ * We now use the result above to provide the mapping for the bulged cube.
+ * First we will define the variables \f$\rho_A\f$ and \f$\rho_{AB}\f$, for
+ * \f$A, B \in \{\Xi,\mathrm{H}, \mathrm{Z}\} \f$:
+ * \f[
+ * \rho_A = \sqrt{2 + A^2}\\
+ * \rho_{AB} = \sqrt{1 + A^2 + B^2}
+ * \f]
+ * The final mapping is then:
+ * \f[
+ * \vec{x}(\xi,\eta,\zeta) = \frac{(1-s)r}{\sqrt{3}}
+ * \begin{bmatrix}
+ * \Xi\\
+ * \mathrm{H}\\
+ * \mathrm{Z}\\
+ * \end{bmatrix} +
+ * \frac{sr}{\sqrt{3}}
+ * \begin{bmatrix}
+ * \xi\\
+ * \eta\\
+ * \zeta\\
+ * \end{bmatrix} + sr
+ * \begin{bmatrix}
+ * \xi & \Xi & \Xi\\
+ * \mathrm{H} & \eta &\mathrm{H}\\
+ * \mathrm{Z} & \mathrm{Z} & \zeta\\
+ * \end{bmatrix}
+ * \begin{bmatrix}
+ * 1/\rho_{\mathrm{H}\mathrm{Z}}\\
+ * 1/\rho_{\Xi\mathrm{Z}}\\
+ * 1/\rho_{\Xi\mathrm{H}}\\
+ * \end{bmatrix} - sr
+ * \begin{bmatrix}
+ * \Xi & \xi & \xi\\
+ * \eta & \mathrm{H} &\eta\\
+ * \zeta & \zeta & \mathrm{Z}\\
+ * \end{bmatrix}
+ * \begin{bmatrix}
+ * 1/\rho_{\Xi}\\
+ * 1/\rho_{\mathrm{H}}\\
+ * 1/\rho_{\mathrm{Z}}\\
+ * \end{bmatrix}
+ * \f]
+ *
+ * In the case where the same coordinates are used for the cube and the sphere,
+ * we have \f$\xi = \Xi\f$, etc. In this case, the formula reduces further.
+ * It is given by:
+ *
+ * \f[
+ * \vec{x}(\xi,\eta,\zeta) =
+ * \left\{
+ * \frac{r}{\sqrt{3}}
+ * + sr
+ * \left(
+ * 1/\rho_{\mathrm{H}\mathrm{Z}}+
+ * 1/\rho_{\Xi\mathrm{Z}}+
+ * 1/\rho_{\Xi\mathrm{H}}-
+ * 1/\rho_{\Xi}-
+ * 1/\rho_{\mathrm{H}}-
+ * 1/\rho_{\mathrm{Z}}
+ * \right)
+ * \right\}
+ * \begin{bmatrix}
+ * \Xi\\
+ * \mathrm{H}\\
+ * \mathrm{Z}\\
+ * \end{bmatrix}
+ * \f]
+ *
+ */
+class BulgedCube {
+ public:
+  static constexpr size_t dim = 3;
+  BulgedCube(double radius, double sphericity,
+             bool use_equiangular_map) noexcept;
+  BulgedCube() noexcept = default;
+  ~BulgedCube() noexcept = default;
+  BulgedCube(BulgedCube&&) noexcept = default;
+  BulgedCube(const BulgedCube&) noexcept = default;
+  BulgedCube& operator=(const BulgedCube&) noexcept = default;
+  BulgedCube& operator=(BulgedCube&&) noexcept = default;
+
+  template <typename T>
+  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> inverse(
+      const std::array<T, 3>& target_coords) const noexcept;
+
+  template <typename T>
+  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
+         tmpl::integral_list<std::int32_t, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
+                    SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
+  jacobian(const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
+         tmpl::integral_list<std::int32_t, 2, 1>,
+         index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
+                    SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
+  inv_jacobian(const std::array<T, 3>& source_coords) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  template <typename T>
+  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> xi_derivative(
+      const std::array<T, 3>& source_coords) const noexcept;
+  friend bool operator==(const BulgedCube& lhs, const BulgedCube& rhs) noexcept;
+  double radius_;
+  double sphericity_;
+  bool use_equiangular_map_;
+};
+
+bool operator!=(const BulgedCube& lhs, const BulgedCube& rhs) noexcept;
+}  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY CoordinateMaps)
 
 set(LIBRARY_SOURCES
     Affine.cpp
+    BulgedCube.cpp
     Equiangular.cpp
     Identity.cpp
     Rotation.cpp

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(DOMAIN_TESTS
     Domain/CoordinateMaps/Test_Affine.cpp
+    Domain/CoordinateMaps/Test_BulgedCube.cpp
     Domain/CoordinateMaps/Test_CoordinateMap.cpp
     Domain/CoordinateMaps/Test_Equiangular.cpp
     Domain/CoordinateMaps/Test_Identity.cpp

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -222,8 +222,8 @@ void test_coordinate_map_argument_types(
  * \ingroup TestingFrameworkGroup
  * \brief Given a Map `map`, checks that the inverse map gives expected results
  */
-template <typename Map>
+template <typename Map, typename T>
 void test_inverse_map(const Map& map,
-                      const std::array<double, Map::dim>& test_point) {
+                      const std::array<T, Map::dim>& test_point) {
   CHECK_ITERABLE_APPROX(test_point, map.inverse(map(test_point)));
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
@@ -1,0 +1,103 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <catch.hpp>
+#include <random>
+
+#include "Domain/CoordinateMaps/BulgedCube.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Identity",
+                  "[Domain][Unit]") {
+  const CoordinateMaps::BulgedCube map(sqrt(3.0), 0, false);
+  const std::array<double, 3> lower_corner{{-1.0, -1.0, -1.0}};
+  const std::array<double, 3> upper_corner{{1.0, 1.0, 1.0}};
+  const std::array<double, 3> test_point1{{-1.0, 0.25, 0.0}};
+  const std::array<double, 3> test_point2{{1.0, 1.0, -0.5}};
+  const std::array<double, 3> test_point3{{0.7, -0.2, 0.4}};
+
+  CHECK_ITERABLE_APPROX(map(lower_corner), lower_corner);
+  CHECK_ITERABLE_APPROX(map(upper_corner), upper_corner);
+  CHECK_ITERABLE_APPROX(map(test_point1), test_point1);
+  CHECK_ITERABLE_APPROX(map(test_point2), test_point2);
+  CHECK_ITERABLE_APPROX(map(test_point3), test_point3);
+
+  test_jacobian(map, test_point1);
+  test_jacobian(map, test_point2);
+  test_jacobian(map, test_point3);
+
+  test_inv_jacobian(map, test_point1);
+  test_inv_jacobian(map, test_point2);
+  test_inv_jacobian(map, test_point3);
+
+  test_coordinate_map_implementation<CoordinateMaps::BulgedCube>(map);
+
+  CHECK(serialize_and_deserialize(map) == map);
+  CHECK_FALSE(serialize_and_deserialize(map) != map);
+
+  test_coordinate_map_argument_types<true>(map, test_point1);
+}
+
+void test_bulged_cube(bool with_equiangular_map) {
+  const std::array<double, 3> lower_corner{{-1.0, -1.0, -1.0}};
+  const std::array<double, 3> upper_corner{{1.0, 1.0, 1.0}};
+  const CoordinateMaps::BulgedCube map(2.0 * sqrt(3.0), 0.5,
+                                       with_equiangular_map);
+
+  CHECK(map(lower_corner)[0] == approx(-2.0));
+  CHECK(map(lower_corner)[1] == approx(-2.0));
+  CHECK(map(lower_corner)[2] == approx(-2.0));
+  CHECK(map(upper_corner)[0] == approx(2.0));
+  CHECK(map(upper_corner)[1] == approx(2.0));
+  CHECK(map(upper_corner)[2] == approx(2.0));
+
+  const std::array<double, 3> test_point1{{-1.0, 0.25, 0.0}};
+  const std::array<double, 3> test_point2{{1.0, 1.0, -0.5}};
+  const std::array<double, 3> test_point3{{0.7, -0.2, 0.4}};
+  const std::array<double, 3> test_point4{{0.0, 0.0, 0.0}};
+  const std::array<DataVector, 3> test_points{
+      {DataVector{-1.0, 1.0, 0.7, 0.0}, DataVector{0.25, 1.0, -0.2, 0.0},
+       DataVector{0.0, -0.5, 0.4, 0.0}}};
+  const DataVector& collocation_pts = Basis::lgl::collocation_points(7);
+  const std::array<DataVector, 3> test_points2{
+      {collocation_pts, collocation_pts, collocation_pts}};
+
+  test_jacobian(map, test_point1);
+  test_jacobian(map, test_point2);
+  test_jacobian(map, test_point3);
+  test_jacobian(map, test_point4);
+
+  test_inv_jacobian(map, test_point1);
+  test_inv_jacobian(map, test_point2);
+  test_inv_jacobian(map, test_point3);
+  test_inv_jacobian(map, test_point4);
+
+  test_coordinate_map_implementation<CoordinateMaps::BulgedCube>(map);
+
+  CHECK(serialize_and_deserialize(map) == map);
+  CHECK_FALSE(serialize_and_deserialize(map) != map);
+
+  test_coordinate_map_argument_types<true>(map, test_point1);
+
+  test_inverse_map(map, test_point1);
+  test_inverse_map(map, test_point2);
+  test_inverse_map(map, test_point3);
+  test_inverse_map(map, test_point4);
+  test_inverse_map(map, test_points);
+  test_inverse_map(map, test_points2);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Bulged.Equiangular",
+                  "[Domain][Unit]") {
+  test_bulged_cube(true);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Bulged.Equidistant",
+                  "[Domain][Unit]") {
+  test_bulged_cube(false);
+}


### PR DESCRIPTION
## Proposed changes

The coordinatemap to the center block in the Sphere domaincreator.
This map allows for the `sphericity` to be set to any number between 0 and 1 for the Sphere
while allowing the wedges to conform to the bulged cube in the center. This map also allows
for a choice of equidistant or equiangular coordinates.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
