### PR TITLE
Compute divergence

### DIFF
--- a/src/DataStructures/Tensor/Metafunctions.hpp
+++ b/src/DataStructures/Tensor/Metafunctions.hpp
@@ -568,41 +568,50 @@ constexpr bool check_index_symmetry_v =
 
 /*!
  * \ingroup TensorGroup
- * \brief Add a spatial index to the from of a Tensor
+ * \brief Add a spatial index to the front of a Tensor
  *
- * \tparam Tensor_t the tensor type to prepend
+ * \tparam Tensor the tensor type to which the new index is prepended
  * \tparam VolumeDim the volume dimension of the tensor index to prepend
  * \tparam Fr the ::Frame of the tensor index to prepend
  */
-template <typename Tensor_t, std::size_t VolumeDim, UpLo Ul,
+template <typename Tensor, std::size_t VolumeDim, UpLo Ul,
           typename Fr = Frame::Grid>
-using prepend_spatial_index = Tensor<
-    typename Tensor_t::type,
+using prepend_spatial_index = ::Tensor<
+    typename Tensor::type,
     tmpl::push_front<
-        typename Tensor_t::symmetry,
+        typename Tensor::symmetry,
         tmpl::int32_t<
-            1 + tmpl::fold<typename Tensor_t::symmetry, tmpl::int32_t<0>,
+            1 + tmpl::fold<typename Tensor::symmetry, tmpl::int32_t<0>,
                            tmpl::max<tmpl::_state, tmpl::_element>>::value>>,
-    tmpl::push_front<typename Tensor_t::index_list,
+    tmpl::push_front<typename Tensor::index_list,
                      SpatialIndex<VolumeDim, Ul, Fr>>>;
 
 /*!
  * \ingroup TensorGroup
- * \brief Add a spacetime index to the from of a Tensor
+ * \brief Add a spacetime index to the front of a Tensor
  *
- * \tparam Tensor_t the tensor type to prepend
+ * \tparam Tensor the tensor type to which the new index is prepended
  * \tparam VolumeDim the volume dimension of the tensor index to prepend
  * \tparam Fr the ::Frame of the tensor index to prepend
  */
-template <typename Tensor_t, std::size_t VolumeDim, UpLo Ul,
+template <typename Tensor, std::size_t VolumeDim, UpLo Ul,
           typename Fr = Frame::Grid>
-using prepend_spacetime_index = Tensor<
-    typename Tensor_t::type,
+using prepend_spacetime_index = ::Tensor<
+    typename Tensor::type,
     tmpl::push_front<
-        typename Tensor_t::symmetry,
+        typename Tensor::symmetry,
         tmpl::int32_t<
-            1 + tmpl::fold<typename Tensor_t::symmetry, tmpl::int32_t<0>,
+            1 + tmpl::fold<typename Tensor::symmetry, tmpl::int32_t<0>,
                            tmpl::max<tmpl::_state, tmpl::_element>>::value>>,
-    tmpl::push_front<typename Tensor_t::index_list,
+    tmpl::push_front<typename Tensor::index_list,
                      SpacetimeIndex<VolumeDim, Ul, Fr>>>;
+
+/// \ingroup TensorGroup
+/// \brief remove the first index of a tensor
+/// \tparam Tensor the tensor type whose first index is removed
+template <typename Tensor>
+using remove_first_index =
+    ::Tensor<typename Tensor::type,
+           tmpl::pop_front<typename Tensor::symmetry>,
+           tmpl::pop_front<typename Tensor::index_list>>;
 }  // namespace TensorMetafunctions

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines functions and tags for taking a divergence.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Utilities/TMPL.hpp"
+
+template <size_t Dim>
+class Index;
+template <typename DataType, typename Symm, typename IndexList>
+class Tensor;
+template <typename TagsList>
+class Variables;
+
+namespace Tags {
+template <size_t Dim>
+struct Extents;
+template <class TagList>
+struct Variables;
+
+namespace Tags_detail {
+template <typename T, typename S, typename = std::nullptr_t>
+struct div_impl;
+}  // namespace Tags_detail
+
+/// \ingroup DataBoxTagsGroup
+/// \brief Prefix indicating the divergence
+///
+/// There are two variants of this tag that change how the derivatives are
+/// computed depending on which is chosen. The simplest is the non-compute
+/// item versions for a Tensor tag. This takes two template parameters:
+/// 1. The tag to wrap
+/// 2. The frame in which the divergence was taken
+///
+/// The second variant of the divergence tag is a compute item that computes
+/// the divergence in a Frame that is not the logical frame. This compute
+/// item is used by specifying the the list of flux tags to be differentiated,
+/// and the Tag for the inverse Jacobian between the logical frame and the frame
+/// in which the divergence is taken.
+template <typename T, typename S>
+struct div : Tags_detail::div_impl<T, S> {};
+}  // namespace Tags
+
+/// \ingroup NumericalAlgorithmsGroup
+/// \brief Compute the (Euclidean) divergence of fluxes
+///
+/// \return a `Variables` with the same structure as `F` and each tag in
+/// `FluxTags` wrapped with a `Tags::div`.
+template <typename FluxTags, size_t Dim, typename DerivativeFrame>
+Variables<db::wrap_tags_in<Tags::div, FluxTags, DerivativeFrame>> divergence(
+    const Variables<FluxTags>& F, const Index<Dim>& extents,
+    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+                 typelist<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
+                          SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
+        inverse_jacobian) noexcept;
+
+namespace Tags {
+namespace Tags_detail {
+template <typename Tag, typename Frame>
+struct div_impl<Tag, Frame, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
+    : db::DataBoxPrefix {
+  static_assert(
+      cpp17::is_same_v<Frame,
+                       std::tuple_element_t<
+                           0, decltype(db::item_type<Tag>::index_frames())>>,
+      "the first index is not in the specified Frame");
+  using type = TensorMetafunctions::remove_first_index<db::item_type<Tag>>;
+  using tag = Tag;
+  static constexpr db::DataBoxString label = "div";
+};
+
+template <typename... FluxTags, typename InverseJacobianTag>
+struct div_impl<tmpl::list<FluxTags...>, InverseJacobianTag,
+                Requires<tt::is_a_v<Tensor, db::item_type<InverseJacobianTag>>>>
+    : db::ComputeItemTag {
+ private:
+  using derivative_frame_index =
+      tmpl::back<typename db::item_type<InverseJacobianTag>::index_list>;
+  using flux_tags = tmpl::list<FluxTags...>;
+
+ public:
+  static constexpr db::DataBoxString label = "div";
+  static constexpr auto function =
+      divergence<flux_tags, derivative_frame_index::dim,
+                 typename derivative_frame_index::Frame>;
+  using argument_tags = tmpl::list<Tags::Variables<flux_tags>,
+                                   Tags::Extents<derivative_frame_index::dim>,
+                                   InverseJacobianTag>;
+};
+}  // namespace Tags_detail
+}  // namespace Tags

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
@@ -1,0 +1,46 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+template <typename FluxTags, size_t Dim, typename DerivativeFrame>
+Variables<db::wrap_tags_in<Tags::div, FluxTags, DerivativeFrame>> divergence(
+    const Variables<FluxTags>& F, const Index<Dim>& extents,
+    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+                 typelist<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
+                          SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
+        inverse_jacobian) noexcept {
+  const auto logical_partial_derivatives_of_F =
+      logical_partial_derivatives<FluxTags>(F, extents);
+
+  Variables<db::wrap_tags_in<Tags::div, FluxTags, DerivativeFrame>>
+      divergence_of_F(F.number_of_grid_points(), 0.0);
+
+  tmpl::for_each<FluxTags>([
+    &divergence_of_F, &inverse_jacobian, &logical_partial_derivatives_of_F
+  ](auto tag) noexcept {
+    using FluxTag = tmpl::type_from<decltype(tag)>;
+    using DivFluxTag = Tags::div<FluxTag, DerivativeFrame>;
+    auto& divergence_of_flux = get<DivFluxTag>(divergence_of_F);
+    for (auto it = divergence_of_flux.begin(); it != divergence_of_flux.end();
+         ++it) {
+      const auto div_flux_indices = divergence_of_flux.get_tensor_index(it);
+      for (size_t i0 = 0; i0 < Dim; ++i0) {
+        const auto flux_indices = prepend(div_flux_indices, i0);
+        for (size_t d = 0; d < Dim; ++d) {
+          *it += inverse_jacobian.get(d, i0) *
+                 get<FluxTag>(gsl::at(logical_partial_derivatives_of_F, d))
+                     .get(flux_indices);
+        }
+      }
+    }
+  });
+
+  return divergence_of_F;
+}

--- a/src/Utilities/StdHelpers.hpp
+++ b/src/Utilities/StdHelpers.hpp
@@ -401,6 +401,19 @@ inline std::array<T, Dim - 1> all_but_specified_element_of(
   return result;
 }
 
+/// \ingroup UtilitiesGroup
+/// \brief Construct an array from an existing array prepending a value
+template <typename T, size_t Dim>
+inline constexpr std::array<T, Dim + 1> prepend(const std::array<T, Dim>& a,
+                                                T value) noexcept {
+  std::array<T, Dim + 1> result{};
+  gsl::at(result, 0) = std::move(value);
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(result, i + 1) = gsl::at(a, i);
+  }
+  return result;
+}
+
 //@{
 /// \ingroup UtilitiesGroup
 /// \brief Euclidean magnitude of the elements of the array.

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -49,6 +49,36 @@ static_assert(cpp17::is_same_v<tnsr::iJ<double, 3, Frame::Grid>,
                                    Frame::Grid>>,
               "Failed testing prepend_spatial_index");
 
+// Test remove_first_index
+static_assert(
+    cpp17::is_same_v<Scalar<double>, TensorMetafunctions::remove_first_index<
+                                         tnsr::a<double, 3, Frame::Grid>>>,
+    "Failed testing remove_first_index");
+static_assert(cpp17::is_same_v<tnsr::A<double, 3, Frame::Grid>,
+                               TensorMetafunctions::remove_first_index<
+                                   tnsr::aB<double, 3, Frame::Grid>>>,
+              "Failed testing remove_first_index");
+static_assert(cpp17::is_same_v<tnsr::ab<double, 3, Frame::Grid>,
+                               TensorMetafunctions::remove_first_index<
+                                   tnsr::abc<double, 3, Frame::Grid>>>,
+              "Failed testing remove_first_index");
+static_assert(
+    cpp17::is_same_v<
+        tnsr::ab<double, 3, Frame::Grid>,
+        TensorMetafunctions::remove_first_index<Tensor<
+            double, tmpl::integral_list<std::int32_t, 2, 2, 1>,
+            index_list<Tensor_detail::TensorIndexType<3, UpLo::Lo, Frame::Grid,
+                                                      IndexType::Spacetime>,
+                       Tensor_detail::TensorIndexType<3, UpLo::Lo, Frame::Grid,
+                                                      IndexType::Spacetime>,
+                       Tensor_detail::TensorIndexType<3, UpLo::Lo, Frame::Grid,
+                                                      IndexType::Spacetime>>>>>,
+    "Failed testing remove_first_index");
+static_assert(cpp17::is_same_v<tnsr::aa<double, 3, Frame::Grid>,
+                               TensorMetafunctions::remove_first_index<
+                                   tnsr::abb<double, 3, Frame::Grid>>>,
+              "Failed testing remove_first_index");
+
 // Test check_index_symmetry
 static_assert(
     TensorMetafunctions::check_index_symmetry_v<typelist<>, typelist<>>,

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(SPECTRE_UNIT_LINEAR_OPERATORS
   NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+  NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
   NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
   NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
   NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -1,0 +1,257 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/IndexIterator.hpp"
+#include "DataStructures/MakeWithValue.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"
+#include "PointwiseFunctions/MathFunctions/TensorProduct.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+using Affine = CoordinateMaps::Affine;
+using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D =
+    CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+template <size_t VolumeDim>
+auto make_affine_map() noexcept;
+
+template <>
+auto make_affine_map<1>() noexcept {
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine{-1.0, 1.0, -0.3, 0.7});
+}
+
+template <>
+auto make_affine_map<2>() noexcept {
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine2D{
+      Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55}});
+}
+
+template <>
+auto make_affine_map<3>() noexcept {
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
+      Affine{-1.0, 1.0, 2.3, 2.8}});
+}
+
+template <size_t Dim, typename Frame>
+struct Flux1 : db::DataBoxTag {
+  using type = tnsr::I<DataVector, Dim, Frame>;
+  static constexpr db::DataBoxString label = "Flux1";
+  static auto flux(const MathFunctions::TensorProduct<Dim>& f,
+                   const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
+    auto result = make_with_value<tnsr::I<DataVector, Dim, Frame>>(x, 0.);
+    const auto f_of_x = f(x);
+    for (size_t d = 0; d < Dim; ++d) {
+      result.get(d) = (d + 0.5) * get(f_of_x);
+    }
+    return result;
+  }
+  static auto divergence_of_flux(
+      const MathFunctions::TensorProduct<Dim>& f,
+      const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
+    auto result = make_with_value<Scalar<DataVector>>(x, 0.);
+    const auto df = f.first_derivatives(x);
+    for (size_t d = 0; d < Dim; ++d) {
+      get(result) += (d + 0.5) * df.get(d);
+    }
+    return result;
+  }
+};
+
+template <size_t Dim, typename Frame>
+struct Flux2 : db::DataBoxTag {
+  using type = tnsr::Ij<DataVector, Dim, Frame>;
+  static constexpr db::DataBoxString label = "Flux2";
+  static auto flux(const MathFunctions::TensorProduct<Dim>& f,
+                   const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
+    auto result = make_with_value<tnsr::Ij<DataVector, Dim, Frame>>(x, 0.);
+    const auto f_of_x = f(x);
+    for (size_t d = 0; d < Dim; ++d) {
+      for (size_t j = 0; j < Dim; ++j) {
+        result.get(d, j) = (d + 0.5) * (j + 0.25) * get(f_of_x);
+      }
+    }
+    return result;
+  }
+  static auto divergence_of_flux(
+      const MathFunctions::TensorProduct<Dim>& f,
+      const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
+    auto result = make_with_value<tnsr::i<DataVector, Dim, Frame>>(x, 0.);
+    const auto df = f.first_derivatives(x);
+    for (size_t j = 0; j < Dim; ++j) {
+      for (size_t d = 0; d < Dim; ++d) {
+        result.get(j) += (d + 0.5) * (j + 0.25) * df.get(d);
+      }
+    }
+    return result;
+  }
+};
+
+template <size_t Dim, typename Frame>
+using two_fluxes = typelist<Flux1<Dim, Frame>, Flux2<Dim, Frame>>;
+
+template <size_t Dim, typename Frame = Frame::Inertial>
+void test_divergence(
+    const Index<Dim>& extents,
+    std::array<std::unique_ptr<MathFunction<1>>, Dim> functions) noexcept {
+  const auto coordinate_map = make_affine_map<Dim>();
+  const size_t number_of_grid_points = extents.product();
+  const auto xi = logical_coordinates(extents);
+  const auto x = coordinate_map(xi);
+  const auto inv_jacobian = coordinate_map.inv_jacobian(xi);
+  MathFunctions::TensorProduct<Dim> f(1.0, std::move(functions));
+  using flux_tags = two_fluxes<Dim, Frame>;
+  Variables<flux_tags> fluxes(number_of_grid_points);
+  Variables<db::wrap_tags_in<Tags::div, flux_tags, Frame>> expected_div_fluxes(
+      number_of_grid_points);
+  tmpl::for_each<flux_tags>([&x, &f, &fluxes,
+                             &expected_div_fluxes ](auto tag) noexcept {
+    using FluxTag = tmpl::type_from<decltype(tag)>;
+    get<FluxTag>(fluxes) = FluxTag::flux(f, x);
+    using DivFluxTag = Tags::div<FluxTag, Frame>;
+    get<DivFluxTag>(expected_div_fluxes) = FluxTag::divergence_of_flux(f, x);
+  });
+  const auto div_fluxes = divergence<flux_tags>(fluxes, extents, inv_jacobian);
+  CHECK(div_fluxes.size() == expected_div_fluxes.size());
+  CHECK(Dim * div_fluxes.size() == fluxes.size());
+  for (size_t n = 0; n < div_fluxes.size(); ++n) {
+    // clang-tidy: pointer arithmetic
+    CAPTURE_PRECISE(div_fluxes.data()[n] -                         // NOLINT
+                    expected_div_fluxes.data()[n]);                // NOLINT
+    CHECK(div_fluxes.data()[n] ==                                  // NOLINT
+          approx(expected_div_fluxes.data()[n]).epsilon(1.e-11));  // NOLINT
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Divergence",
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+  const size_t n0 = Basis::lgl::maximum_number_of_pts / 2;
+  const size_t n1 = Basis::lgl::maximum_number_of_pts / 2 + 1;
+  const size_t n2 = Basis::lgl::maximum_number_of_pts / 2 - 1;
+  const Index<1> extents_1d(n0);
+  const Index<2> extents_2d(n0, n1);
+  const Index<3> extents_3d(n0, n1, n2);
+  for (size_t a = 0; a < 5; ++a) {
+    std::array<std::unique_ptr<MathFunction<1>>, 1> functions_1d{
+        {std::make_unique<MathFunctions::PowX>(a)}};
+    test_divergence(extents_1d, std::move(functions_1d));
+    for (size_t b = 0; b < 4; ++b) {
+      std::array<std::unique_ptr<MathFunction<1>>, 2> functions_2d{
+          {std::make_unique<MathFunctions::PowX>(a),
+           std::make_unique<MathFunctions::PowX>(b)}};
+      test_divergence(extents_2d, std::move(functions_2d));
+      for (size_t c = 0; c < 3; ++c) {
+        std::array<std::unique_ptr<MathFunction<1>>, 3> functions_3d{
+            {std::make_unique<MathFunctions::PowX>(a),
+             std::make_unique<MathFunctions::PowX>(b),
+             std::make_unique<MathFunctions::PowX>(c)}};
+        test_divergence(extents_3d, std::move(functions_3d));
+      }
+    }
+  }
+}
+
+namespace {
+template <class MapType>
+struct MapTag : db::DataBoxTag {
+  using type = MapType;
+  static constexpr db::DataBoxString label = "MapTag";
+};
+
+template <size_t Dim, typename Frame = Frame::Inertial>
+void test_divergence_compute_item(
+    const Index<Dim>& extents,
+    std::array<std::unique_ptr<MathFunction<1>>, Dim> functions) noexcept {
+  const auto coordinate_map = make_affine_map<Dim>();
+  using map_tag = MapTag<std::decay_t<decltype(coordinate_map)>>;
+  using inv_jac_tag =
+      Tags::InverseJacobian<map_tag, Tags::LogicalCoordinates<Dim>>;
+  using flux_tags = two_fluxes<Dim, Frame>;
+  using div_tag = Tags::div<flux_tags, inv_jac_tag>;
+
+  const size_t number_of_grid_points = extents.product();
+  const auto xi = logical_coordinates(extents);
+  const auto x = coordinate_map(xi);
+  const auto inv_jacobian = coordinate_map.inv_jacobian(xi);
+  MathFunctions::TensorProduct<Dim> f(1.0, std::move(functions));
+  Variables<flux_tags> fluxes(number_of_grid_points);
+  Variables<db::wrap_tags_in<Tags::div, flux_tags, Frame>> expected_div_fluxes(
+      number_of_grid_points);
+
+
+  tmpl::for_each<flux_tags>([&x, &f, &fluxes,
+                             &expected_div_fluxes ](auto tag) noexcept {
+    using FluxTag = tmpl::type_from<decltype(tag)>;
+    get<FluxTag>(fluxes) = FluxTag::flux(f, x);
+    using DivFluxTag = Tags::div<FluxTag, Frame>;
+    get<DivFluxTag>(expected_div_fluxes) = FluxTag::divergence_of_flux(f, x);
+  });
+
+  auto box = db::create<
+      db::AddTags<Tags::Extents<Dim>, Tags::Variables<flux_tags>, map_tag>,
+      db::AddComputeItemsTags<Tags::LogicalCoordinates<Dim>, inv_jac_tag,
+                              div_tag>>(extents, fluxes, coordinate_map);
+
+  const auto& div_fluxes = db::get<div_tag>(box);
+
+  CHECK(div_fluxes.size() == expected_div_fluxes.size());
+  for (size_t n = 0; n < div_fluxes.size(); ++n) {
+    // clang-tidy: pointer arithmetic
+    CAPTURE_PRECISE(div_fluxes.data()[n] -                         // NOLINT
+                    expected_div_fluxes.data()[n]);                // NOLINT
+    CHECK(div_fluxes.data()[n] ==                                  // NOLINT
+          approx(expected_div_fluxes.data()[n]).epsilon(1.e-11));  // NOLINT
+  }
+}
+} // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Divergence.ComputeItem",
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+  const size_t n0 = Basis::lgl::maximum_number_of_pts / 2;
+  const size_t n1 = Basis::lgl::maximum_number_of_pts / 2 + 1;
+  const size_t n2 = Basis::lgl::maximum_number_of_pts / 2 - 1;
+  const Index<1> extents_1d(n0);
+  const Index<2> extents_2d(n0, n1);
+  const Index<3> extents_3d(n0, n1, n2);
+  for (size_t a = 0; a < 5; ++a) {
+    std::array<std::unique_ptr<MathFunction<1>>, 1> functions_1d{
+        {std::make_unique<MathFunctions::PowX>(a)}};
+    test_divergence_compute_item(extents_1d, std::move(functions_1d));
+    for (size_t b = 0; b < 4; ++b) {
+      std::array<std::unique_ptr<MathFunction<1>>, 2> functions_2d{
+          {std::make_unique<MathFunctions::PowX>(a),
+           std::make_unique<MathFunctions::PowX>(b)}};
+      test_divergence_compute_item(extents_2d, std::move(functions_2d));
+      for (size_t c = 0; c < 3; ++c) {
+        std::array<std::unique_ptr<MathFunction<1>>, 3> functions_3d{
+            {std::make_unique<MathFunctions::PowX>(a),
+             std::make_unique<MathFunctions::PowX>(b),
+             std::make_unique<MathFunctions::PowX>(c)}};
+        test_divergence_compute_item(extents_3d, std::move(functions_3d));
+      }
+    }
+  }
+}
+
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
@@ -303,3 +303,5 @@ SPECTRE_TEST_CASE(
       "  Center: [1.0,3.0,2.0]");
   opts.get<KerrSchild>();
 }
+
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.cpp
@@ -18,16 +18,3 @@ using GaugeH = ::GeneralizedHarmonic::GaugeH<3, Frame::Inertial>;
 
 using VariablesTags = typelist<SpacetimeMetric, Pi, Phi, GaugeH>;
 }  // namespace
-
-// Need explicit instantiation of derivatives.
-
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp"
-
-template Variables<db::wrap_tags_in<Tags::deriv, VariablesTags, tmpl::size_t<3>,
-                                    Frame::Inertial>>
-partial_derivatives<VariablesTags, VariablesTags, 3, Frame::Inertial>(
-    const Variables<VariablesTags>&, const Index<3>&,
-    const Tensor<
-        DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-        typelist<SpatialIndex<3, UpLo::Up, Frame::Logical>,
-                 SpatialIndex<3, UpLo::Lo, Frame::Inertial>>>&) noexcept;

--- a/tests/Unit/Utilities/Test_StdHelpers.cpp
+++ b/tests/Unit/Utilities/Test_StdHelpers.cpp
@@ -199,3 +199,17 @@ SPECTRE_TEST_CASE("Unit.Utilities.StdHelpers.AllButSpecifiedElementOf",
   CHECK(b1 == c1);
   CHECK(a0 == all_but_specified_element_of<0>(b1));
 }
+
+SPECTRE_TEST_CASE("Unit.Utilities.StdHelpers.StdArrayPrepend",
+                  "[Utilities][Unit]") {
+  const std::array<size_t, 3> a3{{5, 2, 3}};
+  const std::array<size_t, 2> a2{{2, 3}};
+  const std::array<size_t, 1> a1{{3}};
+  const std::array<size_t, 0> a0{{}};
+  const auto p1 = prepend(a0, 3_st);
+  CHECK(p1 == a1);
+  const auto p2 = prepend(a1, 2_st);
+  CHECK(p2 == a2);
+  const auto p3 = prepend(a2, 5_st);
+  CHECK(p3 == a3);
+}


### PR DESCRIPTION
## Proposed changes

Add function to compute divergence of a flux

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
