### PR TITLE
Additions for evolutions 3

### DIFF
--- a/src/DataStructures/DataBox.hpp
+++ b/src/DataStructures/DataBox.hpp
@@ -25,10 +25,17 @@
 /// \cond
 template <typename TagList>
 class Variables;
+// clang-tidy: redundant declaration: DataBox doesn't need to include
+// Variables.hpp, but just these forward declarations. However, clang-tidy
+// sometimes complains about this.
 template <typename Tag, typename TagList>
-constexpr typename Tag::type& get(Variables<TagList>& v) noexcept;
+constexpr typename Tag::type& get(Variables<TagList>& v) noexcept;  // NOLINT
+// clang-tidy: redundant declaration: DataBox doesn't need to include
+// Variables.hpp, but just these forward declarations. However, clang-tidy
+// sometimes complains about this.
 template <typename Tag, typename TagList>
-constexpr const typename Tag::type& get(const Variables<TagList>& v) noexcept;
+constexpr const typename Tag::type& get(  // NOLINT
+    const Variables<TagList>& v) noexcept;
 /// \endcond
 
 /*!

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -16,31 +16,6 @@
 
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
-/// \brief prefix for a `VolumeDim` spatial derivatives with respect to the `Fr`
-/// coordinate frame.
-template <typename Tag, typename VolumeDim, typename Fr,
-          typename = std::nullptr_t>
-struct d;
-
-template <typename Tag, typename VolumeDim, typename Fr>
-struct d<Tag, VolumeDim, Fr, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::DataBoxPrefix {
-  using type = TensorMetafunctions::prepend_spatial_index<
-      db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Fr>;
-  using tag = Tag;
-  static constexpr db::DataBoxString label = "d";
-};
-
-template <typename Tag, typename VolumeDim, typename Fr>
-struct d<Tag, VolumeDim, Fr,
-         Requires<tt::is_a_v<::Variables, db::item_type<Tag>>>>
-    : db::DataBoxPrefix {
-  using type = db::item_type<Tag>;
-  using tag = Tag;
-  static constexpr db::DataBoxString label = "d";
-};
-
-/// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a time derivative
 template <typename Tag>
 struct dt : db::DataBoxPrefix {

--- a/src/DataStructures/DataBoxTag.hpp
+++ b/src/DataStructures/DataBoxTag.hpp
@@ -13,6 +13,7 @@
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/NoSuchType.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -378,8 +379,16 @@ struct compute_item_result_impl<
 };
 
 template <typename Tag>
-struct compute_item_result_impl<Tag, Requires<not is_compute_item_v<Tag>>> {
+struct compute_item_result_impl<
+    Tag, Requires<not is_compute_item_v<Tag> and
+                  std::is_base_of<db::DataBoxTag, Tag>::value>> {
   using type = typename Tag::type;
+};
+
+template <typename Tag>
+struct compute_item_result_impl<
+    Tag, Requires<not std::is_base_of<db::DataBoxTag, Tag>::value>> {
+  using type = NoSuchType;
 };
 }  // namespace detail
 

--- a/src/DataStructures/DataBoxTag.hpp
+++ b/src/DataStructures/DataBoxTag.hpp
@@ -429,7 +429,7 @@ struct is_variables_compute_item<
 template <template <typename...> class Wrapper, typename TagList,
           typename... Args>
 using wrap_tags_in =
-    tmpl::transform<TagList, tmpl::bind<Wrapper, tmpl::_1, Args...>>;
+    tmpl::transform<TagList, tmpl::bind<Wrapper, tmpl::_1, tmpl::pin<Args>...>>;
 
 namespace detail {
 template <bool IsVariables>

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -334,11 +334,15 @@ using ijaa = Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
                                SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
                                SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>,
                                SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
-
 }  // namespace tnsr
 
-template <size_t Dim, typename Frame1, typename Frame2>
+template <size_t Dim, typename SourceFrame, typename TargetFrame>
 using InverseJacobian =
     Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-           typelist<SpatialIndex<Dim, UpLo::Up, Frame1>,
-                    SpatialIndex<Dim, UpLo::Lo, Frame2>>>;
+           typelist<SpatialIndex<Dim, UpLo::Up, SourceFrame>,
+                    SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>;
+
+template <size_t Dim, typename SourceFrame, typename TargetFrame>
+using Jacobian = Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+                        typelist<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
+                                 SpatialIndex<Dim, UpLo::Lo, SourceFrame>>>;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -6,14 +6,24 @@
 
 #pragma once
 
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
-#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 
 class DataVector;
+
+namespace Tags {
+template <typename>
+class dt;
+
+template <typename, typename, typename>
+class d;
+}  // namespace Tags
+
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
 
 namespace GeneralizedHarmonic {
 template <size_t Dim>

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -17,7 +17,7 @@ template <typename>
 class dt;
 
 template <typename, typename, typename>
-class d;
+class deriv;
 }  // namespace Tags
 
 namespace gsl {
@@ -33,10 +33,10 @@ struct ComputeDuDt {
                                Tags::dt<Pi<Dim>>, Tags::dt<Phi<Dim>>>;
   using argument_tags = typelist<
       SpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>,
-      Tags::d<SpacetimeMetric<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
-      Tags::d<Pi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
-      Tags::d<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>, ConstraintGamma0,
-      ConstraintGamma1, ConstraintGamma2, GaugeH<Dim>,
+      Tags::deriv<SpacetimeMetric<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+      Tags::deriv<Pi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+      Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+      ConstraintGamma0, ConstraintGamma1, ConstraintGamma2, GaugeH<Dim>,
       SpacetimeDerivGaugeH<Dim>, Lapse<Dim>, Shift<Dim>,
       InverseSpatialMetric<Dim>, InverseSpacetimeMetric<Dim>,
       TraceSpacetimeChristoffelFirstKind<Dim>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 
 class DataVector;
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -1,9 +1,17 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#pragma once
+
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
 
-#pragma once
+namespace brigand {
+template <class...>
+struct list;
+}  // namespace brigand
+
+template <class>
+class Variables;
 
 namespace GeneralizedHarmonic {
 template <size_t Dim>
@@ -11,9 +19,9 @@ struct System {
   static constexpr size_t volume_dim = Dim;
   static constexpr bool is_euclidean = false;
 
-  using variables_tags = typelist<SpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>>;
+  using variables_tags = brigand::list<SpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>>;
   using gradient_tags = variables_tags;
 
   using Variables = ::Variables<variables_tags>;
 };
-} // namespace GeneralizedHarmonic
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#include "DataStructures/DataBoxTag.hpp"
+
+class DataVector;
+
 namespace GeneralizedHarmonic {
 template <size_t Dim, typename Frame>
 struct SpacetimeMetric : db::DataBoxTag {

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace GeneralizedHarmonic {
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeMetric;

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
@@ -1,0 +1,177 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBoxTag.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/LinearOperators/Transpose.hpp"
+#include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace partial_derivatives_detail {
+template <size_t Dim, typename VariableTags, typename DerivativeTags>
+struct LogicalImpl;
+}  // namespace partial_derivatives_detail
+
+template <typename DerivativeTags, typename VariableTags, size_t Dim>
+std::array<Variables<DerivativeTags>, Dim> logical_partial_derivatives(
+    const Variables<VariableTags>& u, const Index<Dim>& extents) noexcept {
+  return partial_derivatives_detail::LogicalImpl<
+      Dim, VariableTags, DerivativeTags>::apply(u, extents);
+}
+
+template <typename DerivativeTags, typename VariableTags, size_t Dim,
+          typename DerivativeFrame>
+Variables<db::wrap_tags_in<Tags::d, DerivativeTags, tmpl::size_t<Dim>,
+                           DerivativeFrame>>
+partial_derivatives(
+    const Variables<VariableTags>& u, const Index<Dim>& extents,
+    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+                 typelist<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
+                          SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
+        inverse_jacobian) noexcept {
+  const auto logical_partial_derivatives_of_u =
+      logical_partial_derivatives<DerivativeTags>(u, extents);
+
+  Variables<db::wrap_tags_in<Tags::d, DerivativeTags, tmpl::size_t<Dim>,
+                             DerivativeFrame>>
+      partial_derivatives_of_u(u.number_of_grid_points(), 0.0);
+
+  tmpl::for_each<DerivativeTags>([
+    &partial_derivatives_of_u, &inverse_jacobian,
+    &logical_partial_derivatives_of_u
+  ](auto tag) noexcept {
+    using Tag = tmpl::type_from<decltype(tag)>;
+    using DerivativeTag = Tags::d<Tag, tmpl::size_t<Dim>, DerivativeFrame>;
+    auto& partial_derivatives_of_variable =
+        get<DerivativeTag>(partial_derivatives_of_u);
+    for (auto it = partial_derivatives_of_variable.begin();
+         it != partial_derivatives_of_variable.end(); ++it) {
+      const auto deriv_indices =
+          partial_derivatives_of_variable.get_tensor_index(it);
+      const size_t deriv_index = deriv_indices[0];
+      const auto tensor_indices =
+          all_but_specified_element_of<0>(deriv_indices);
+      for (size_t d = 0; d < Dim; ++d) {
+        *it += inverse_jacobian.get(d, deriv_index) *
+               get<Tag>(gsl::at(logical_partial_derivatives_of_u, d))
+                   .get(tensor_indices);
+      }
+    }
+  });
+
+  return partial_derivatives_of_u;
+}
+
+namespace partial_derivatives_detail {
+template <typename VariableTags, typename DerivativeTags>
+struct LogicalImpl<1, VariableTags, DerivativeTags> {
+  static constexpr const size_t Dim = 1;
+  static auto apply(const Variables<VariableTags>& u,
+                    const Index<Dim>& extents) noexcept {
+    auto logical_partial_derivatives_of_u = make_array<Dim>(
+        Variables<DerivativeTags>(u.number_of_grid_points(), 0.0));
+    const Matrix& differentiation_matrix_xi =
+        Basis::lgl::differentiation_matrix(extents[0]);
+    dgemm_('N', 'N', extents[0],
+           logical_partial_derivatives_of_u[0].size() / extents[0], extents[0],
+           1.0, differentiation_matrix_xi.data(), extents[0], u.data(),
+           extents[0], 0.0, logical_partial_derivatives_of_u[0].data(),
+           extents[0]);
+
+    return logical_partial_derivatives_of_u;
+  }
+};
+
+template <typename VariableTags, typename DerivativeTags>
+struct LogicalImpl<2, VariableTags, DerivativeTags> {
+  static constexpr size_t Dim = 2;
+  static auto apply(const Variables<VariableTags>& u,
+                    const Index<2>& extents) noexcept {
+    auto logical_partial_derivatives_of_u =
+        make_array<Dim>(Variables<DerivativeTags>(u.number_of_grid_points()));
+    const Matrix& differentiation_matrix_xi =
+        Basis::lgl::differentiation_matrix(extents[0]);
+    const size_t num_components_times_xi_slices =
+        logical_partial_derivatives_of_u[0].size() / extents[0];
+    dgemm_('N', 'N', extents[0], num_components_times_xi_slices, extents[0],
+           1.0, differentiation_matrix_xi.data(), extents[0], u.data(),
+           extents[0], 0.0, logical_partial_derivatives_of_u[0].data(),
+           extents[0]);
+
+    const auto u_eta_fastest =
+        transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
+            u, extents[0], num_components_times_xi_slices);
+    Variables<DerivativeTags> partial_u_wrt_eta(u.number_of_grid_points());
+    const Matrix& differentiation_matrix_eta =
+        Basis::lgl::differentiation_matrix(extents[1]);
+    const size_t num_components_times_eta_slices =
+        logical_partial_derivatives_of_u[1].size() / extents[1];
+    dgemm_('N', 'N', extents[1], num_components_times_eta_slices, extents[1],
+           1.0, differentiation_matrix_eta.data(), extents[1],
+           u_eta_fastest.data(), extents[1], 0.0, partial_u_wrt_eta.data(),
+           extents[1]);
+    transpose(partial_u_wrt_eta, num_components_times_xi_slices, extents[0],
+              make_not_null(&logical_partial_derivatives_of_u[1]));
+
+    return logical_partial_derivatives_of_u;
+  }
+};
+
+template <typename VariableTags, typename DerivativeTags>
+struct LogicalImpl<3, VariableTags, DerivativeTags> {
+  static constexpr size_t Dim = 3;
+  static auto apply(const Variables<VariableTags>& u,
+                    const Index<3>& extents) noexcept {
+    auto logical_partial_derivatives_of_u =
+        make_array<Dim>(Variables<DerivativeTags>(u.number_of_grid_points()));
+    const Matrix& differentiation_matrix_xi =
+        Basis::lgl::differentiation_matrix(extents[0]);
+    const size_t num_components_times_xi_slices =
+        logical_partial_derivatives_of_u[0].size() / extents[0];
+    dgemm_('N', 'N', extents[0], num_components_times_xi_slices, extents[0],
+           1.0, differentiation_matrix_xi.data(), extents[0], u.data(),
+           extents[0], 0.0, logical_partial_derivatives_of_u[0].data(),
+           extents[0]);
+
+    auto u_eta_or_zeta_fastest =
+        transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
+            u, extents[0], num_components_times_xi_slices);
+    Variables<DerivativeTags> partial_u_wrt_eta_or_zeta(
+        u.number_of_grid_points());
+    const Matrix& differentiation_matrix_eta =
+        Basis::lgl::differentiation_matrix(extents[1]);
+    const size_t num_components_times_eta_slices =
+        logical_partial_derivatives_of_u[1].size() / extents[1];
+    dgemm_('N', 'N', extents[1], num_components_times_eta_slices, extents[1],
+           1.0, differentiation_matrix_eta.data(), extents[1],
+           u_eta_or_zeta_fastest.data(), extents[1], 0.0,
+           partial_u_wrt_eta_or_zeta.data(), extents[1]);
+    transpose(partial_u_wrt_eta_or_zeta, num_components_times_xi_slices,
+              extents[0], make_not_null(&logical_partial_derivatives_of_u[1]));
+
+    const size_t chunk_size = extents[0] * extents[1];
+    const size_t number_of_chunks =
+        logical_partial_derivatives_of_u[1].size() / chunk_size;
+    transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
+        u, chunk_size, number_of_chunks, make_not_null(&u_eta_or_zeta_fastest));
+    const Matrix& differentiation_matrix_zeta =
+        Basis::lgl::differentiation_matrix(extents[2]);
+    const size_t num_components_times_zeta_slices =
+        logical_partial_derivatives_of_u[2].size() / extents[2];
+    dgemm_('N', 'N', extents[2], num_components_times_zeta_slices, extents[2],
+           1.0, differentiation_matrix_zeta.data(), extents[2],
+           u_eta_or_zeta_fastest.data(), extents[2], 0.0,
+           partial_u_wrt_eta_or_zeta.data(), extents[2]);
+    transpose(partial_u_wrt_eta_or_zeta, number_of_chunks, chunk_size,
+              make_not_null(&logical_partial_derivatives_of_u[2]));
+
+    return logical_partial_derivatives_of_u;
+  }
+};
+}  // namespace partial_derivatives_detail

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
@@ -27,7 +27,7 @@ std::array<Variables<DerivativeTags>, Dim> logical_partial_derivatives(
 
 template <typename DerivativeTags, typename VariableTags, size_t Dim,
           typename DerivativeFrame>
-Variables<db::wrap_tags_in<Tags::d, DerivativeTags, tmpl::size_t<Dim>,
+Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags, tmpl::size_t<Dim>,
                            DerivativeFrame>>
 partial_derivatives(
     const Variables<VariableTags>& u, const Index<Dim>& extents,
@@ -38,7 +38,7 @@ partial_derivatives(
   const auto logical_partial_derivatives_of_u =
       logical_partial_derivatives<DerivativeTags>(u, extents);
 
-  Variables<db::wrap_tags_in<Tags::d, DerivativeTags, tmpl::size_t<Dim>,
+  Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags, tmpl::size_t<Dim>,
                              DerivativeFrame>>
       partial_derivatives_of_u(u.number_of_grid_points(), 0.0);
 
@@ -47,7 +47,7 @@ partial_derivatives(
     &logical_partial_derivatives_of_u
   ](auto tag) noexcept {
     using Tag = tmpl::type_from<decltype(tag)>;
-    using DerivativeTag = Tags::d<Tag, tmpl::size_t<Dim>, DerivativeFrame>;
+    using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<Dim>, DerivativeFrame>;
     auto& partial_derivatives_of_variable =
         get<DerivativeTag>(partial_derivatives_of_u);
     for (auto it = partial_derivatives_of_variable.begin();

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -52,7 +52,7 @@ struct deriv_impl;
  * last parameter being a `std::integral_constant` of the dimension of the mesh.
  */
 template <typename Tag, typename VolumeDim, typename Frame>
-struct d : Tags_detail::deriv_impl<Tag, VolumeDim, Frame> {};
+struct deriv : Tags_detail::deriv_impl<Tag, VolumeDim, Frame> {};
 }  // namespace Tags
 
 /// \ingroup NumericalAlgorithmsGroup
@@ -67,7 +67,7 @@ std::array<Variables<DerivativeTags>, Dim> logical_partial_derivatives(
 /// the coordinates of `DerivativeFrame`.
 template <typename DerivativeTags, typename VariableTags, size_t Dim,
           typename DerivativeFrame>
-Variables<db::wrap_tags_in<Tags::d, DerivativeTags, tmpl::size_t<Dim>,
+Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags, tmpl::size_t<Dim>,
                            DerivativeFrame>>
 partial_derivatives(
     const Variables<VariableTags>& u, const Index<Dim>& extents,
@@ -85,7 +85,7 @@ struct deriv_impl<Tag, VolumeDim, Frame,
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "d";
+  static constexpr db::DataBoxString label = "deriv";
 };
 
 template <typename Tag, typename VolumeDim, typename Frame>
@@ -94,7 +94,7 @@ struct deriv_impl<Tag, VolumeDim, Frame,
     : db::DataBoxPrefix {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "d";
+  static constexpr db::DataBoxString label = "deriv";
 };
 
 // Partial derivatives with derivative index in the frame related to the logical
@@ -112,7 +112,7 @@ struct deriv_impl<
   using variables_tags = tmpl::list<VariablesTags...>;
 
  public:
-  static constexpr db::DataBoxString label = "d";
+  static constexpr db::DataBoxString label = "deriv";
   static constexpr auto function =
       partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
                           derivative_frame_index::dim,
@@ -129,7 +129,7 @@ struct deriv_impl<tmpl::list<VariablesTags...>, tmpl::list<DerivativeTags...>,
                   std::integral_constant<T, Dim>,
                   Requires<(0 < Dim and 4 > Dim)>> : db::ComputeItemTag {
   using variables_tags = tmpl::list<VariablesTags...>;
-  static constexpr db::DataBoxString label = "d";
+  static constexpr db::DataBoxString label = "deriv";
   static constexpr auto function =
       logical_partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
                                   Dim>;

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -6,177 +6,135 @@
 
 #pragma once
 
-#include "DataStructures/DataBox/Prefixes.hpp"
-#include "DataStructures/DataBoxTag.hpp"
-#include "DataStructures/Index.hpp"
-#include "DataStructures/Matrix.hpp"
-#include "DataStructures/Variables.hpp"
-#include "NumericalAlgorithms/LinearOperators/Transpose.hpp"
-#include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
-#include "Utilities/Blas.hpp"
-#include "Utilities/MakeArray.hpp"
+#include <array>
 
-namespace partial_derivatives_detail {
-template <size_t Dim, typename VariableTags, typename DerivativeTags>
-struct LogicalImpl;
-}  // namespace partial_derivatives_detail
+#include "DataStructures/DataBoxTag.hpp"
+#include "DataStructures/Variables.hpp"
+
+template <size_t Dim>
+class Index;
+
+namespace Tags {
+template <size_t Dim>
+struct Extents;
+template <class TagList>
+struct Variables;
+
+namespace Tags_detail {
+template <typename Tag, typename VolumeDim, typename Frame,
+          typename = std::nullptr_t>
+struct deriv_impl;
+}  // namespace Tags_detail
+
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \brief Prefix for a spatial derivative
+ *
+ * There are four variants of this tag that change how the derivatives are
+ * computed depending on which is chosen. The two simplest are the non-compute
+ * item versions for Tensor and Variables tags. These take three template
+ * parameters:
+ * 1. The tag to wrap
+ * 2. The volume dim as a type (e.g. `tmpl::size_t<Dim>`)
+ * 3. The frame of the derivative index in `Tensor`s
+ *
+ * The third variant of the derivative tag is a compute item that computes
+ * the partial derivatives in a Frame that is not the logical frame. This
+ * compute item is used by specifying the list of tags in the
+ * `Tags::Variables<tmpl::list<Tags...>>`, the list of tags to be
+ * differentiated, and the Tag for inverse Jacobian between the logical frame
+ * and the frame in which the derivative is taken. Note that the derivative Tags
+ * must be a contiguous subset from the head of the `Tags...` pack.
+ *
+ * The fourth variant of the derivative tag is a compute item that computes the
+ * partial derivatives in the logical frame. In that case the template
+ * parameters must be the list of Variables tags and derivative tags, with the
+ * last parameter being a `std::integral_constant` of the dimension of the mesh.
+ */
+template <typename Tag, typename VolumeDim, typename Frame>
+struct d : Tags_detail::deriv_impl<Tag, VolumeDim, Frame> {};
+}  // namespace Tags
 
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the partial derivatives of each variable with respect to
 /// the logical coordinate.
 template <typename DerivativeTags, typename VariableTags, size_t Dim>
-auto logical_partial_derivatives(const Variables<VariableTags>& u,
-                                 const Index<Dim>& extents) {
-  return partial_derivatives_detail::LogicalImpl<
-      Dim, VariableTags, DerivativeTags>::apply(u, extents);
-}
+std::array<Variables<DerivativeTags>, Dim> logical_partial_derivatives(
+    const Variables<VariableTags>& u, const Index<Dim>& extents) noexcept;
 
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the partial derivatives of each variable with respect to
 /// the coordinates of `DerivativeFrame`.
 template <typename DerivativeTags, typename VariableTags, size_t Dim,
           typename DerivativeFrame>
-auto partial_derivatives(
+Variables<db::wrap_tags_in<Tags::d, DerivativeTags, tmpl::size_t<Dim>,
+                           DerivativeFrame>>
+partial_derivatives(
     const Variables<VariableTags>& u, const Index<Dim>& extents,
     const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                  typelist<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
                           SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
-        inverse_jacobian) {
-  const auto logical_partial_derivatives_of_u =
-      logical_partial_derivatives<DerivativeTags>(u, extents);
+        inverse_jacobian) noexcept;
 
-  Variables<db::wrap_tags_in<Tags::d, DerivativeTags, tmpl::size_t<Dim>,
-                             DerivativeFrame>>
-      partial_derivatives_of_u(u.number_of_grid_points(), 0.0);
-
-  tmpl::for_each<DerivativeTags>([
-    &partial_derivatives_of_u, &inverse_jacobian,
-    &logical_partial_derivatives_of_u
-  ](auto tag) noexcept {
-    using Tag = tmpl::type_from<decltype(tag)>;
-    using DerivativeTag = Tags::d<Tag, tmpl::size_t<Dim>, DerivativeFrame>;
-    auto& partial_derivatives_of_variable =
-        get<DerivativeTag>(partial_derivatives_of_u);
-    for (auto it = partial_derivatives_of_variable.begin();
-         it != partial_derivatives_of_variable.end(); ++it) {
-      const auto deriv_indices =
-          partial_derivatives_of_variable.get_tensor_index(it);
-      const size_t deriv_index = deriv_indices[0];
-      const auto tensor_indices =
-          all_but_specified_element_of<0>(deriv_indices);
-      for (size_t d = 0; d < Dim; ++d) {
-        *it += inverse_jacobian.get(d, deriv_index) *
-               get<Tag>(gsl::at(logical_partial_derivatives_of_u, d))
-                   .get(tensor_indices);
-      }
-    }
-  });
-
-  return partial_derivatives_of_u;
-}
-
-namespace partial_derivatives_detail {
-template <typename VariableTags, typename DerivativeTags>
-struct LogicalImpl<1, VariableTags, DerivativeTags> {
-  static constexpr const size_t Dim = 1;
-  static auto apply(const Variables<VariableTags>& u,
-                    const Index<Dim>& extents) {
-    auto logical_partial_derivatives_of_u = make_array<Dim>(
-        Variables<DerivativeTags>(u.number_of_grid_points(), 0.0));
-    const Matrix& differentiation_matrix_xi =
-        Basis::lgl::differentiation_matrix(extents[0]);
-    dgemm_('N', 'N', extents[0],
-           logical_partial_derivatives_of_u[0].size() / extents[0], extents[0],
-           1.0, differentiation_matrix_xi.data(), extents[0], u.data(),
-           extents[0], 0.0, logical_partial_derivatives_of_u[0].data(),
-           extents[0]);
-
-    return logical_partial_derivatives_of_u;
-  }
+namespace Tags {
+namespace Tags_detail {
+template <typename Tag, typename VolumeDim, typename Frame>
+struct deriv_impl<Tag, VolumeDim, Frame,
+                  Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
+    : db::DataBoxPrefix {
+  using type = TensorMetafunctions::prepend_spatial_index<
+      db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
+  using tag = Tag;
+  static constexpr db::DataBoxString label = "d";
 };
 
-template <typename VariableTags, typename DerivativeTags>
-struct LogicalImpl<2, VariableTags, DerivativeTags> {
-  static constexpr size_t Dim = 2;
-  static auto apply(const Variables<VariableTags>& u, const Index<2>& extents) {
-    auto logical_partial_derivatives_of_u =
-        make_array<Dim>(Variables<DerivativeTags>(u.number_of_grid_points()));
-    const Matrix& differentiation_matrix_xi =
-        Basis::lgl::differentiation_matrix(extents[0]);
-    const size_t num_components_times_xi_slices =
-        logical_partial_derivatives_of_u[0].size() / extents[0];
-    dgemm_('N', 'N', extents[0], num_components_times_xi_slices, extents[0],
-           1.0, differentiation_matrix_xi.data(), extents[0], u.data(),
-           extents[0], 0.0, logical_partial_derivatives_of_u[0].data(),
-           extents[0]);
-
-    const auto u_eta_fastest =
-        transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
-            u, extents[0], num_components_times_xi_slices);
-    Variables<DerivativeTags> partial_u_wrt_eta(u.number_of_grid_points());
-    const Matrix& differentiation_matrix_eta =
-        Basis::lgl::differentiation_matrix(extents[1]);
-    const size_t num_components_times_eta_slices =
-        logical_partial_derivatives_of_u[1].size() / extents[1];
-    dgemm_('N', 'N', extents[1], num_components_times_eta_slices, extents[1],
-           1.0, differentiation_matrix_eta.data(), extents[1],
-           u_eta_fastest.data(), extents[1], 0.0, partial_u_wrt_eta.data(),
-           extents[1]);
-    transpose(partial_u_wrt_eta, num_components_times_xi_slices, extents[0],
-              make_not_null(&logical_partial_derivatives_of_u[1]));
-
-    return logical_partial_derivatives_of_u;
-  }
+template <typename Tag, typename VolumeDim, typename Frame>
+struct deriv_impl<Tag, VolumeDim, Frame,
+                  Requires<tt::is_a_v<::Variables, db::item_type<Tag>>>>
+    : db::DataBoxPrefix {
+  using type = db::item_type<Tag>;
+  using tag = Tag;
+  static constexpr db::DataBoxString label = "d";
 };
 
-template <typename VariableTags, typename DerivativeTags>
-struct LogicalImpl<3, VariableTags, DerivativeTags> {
-  static constexpr size_t Dim = 3;
-  static auto apply(const Variables<VariableTags>& u, const Index<3>& extents) {
-    auto logical_partial_derivatives_of_u =
-        make_array<Dim>(Variables<DerivativeTags>(u.number_of_grid_points()));
-    const Matrix& differentiation_matrix_xi =
-        Basis::lgl::differentiation_matrix(extents[0]);
-    const size_t num_components_times_xi_slices =
-        logical_partial_derivatives_of_u[0].size() / extents[0];
-    dgemm_('N', 'N', extents[0], num_components_times_xi_slices, extents[0],
-           1.0, differentiation_matrix_xi.data(), extents[0], u.data(),
-           extents[0], 0.0, logical_partial_derivatives_of_u[0].data(),
-           extents[0]);
+// Partial derivatives with derivative index in the frame related to the logical
+// coordinates by InverseJacobianTag
+template <typename... VariablesTags, typename... DerivativeTags,
+          typename InverseJacobianTag>
+struct deriv_impl<
+    tmpl::list<VariablesTags...>, tmpl::list<DerivativeTags...>,
+    InverseJacobianTag,
+    Requires<tt::is_a_v<Tensor, db::item_type<InverseJacobianTag>>>>
+    : db::ComputeItemTag {
+ private:
+  using derivative_frame_index =
+      tmpl::back<typename db::item_type<InverseJacobianTag>::index_list>;
+  using variables_tags = tmpl::list<VariablesTags...>;
 
-    auto u_eta_or_zeta_fastest =
-        transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
-            u, extents[0], num_components_times_xi_slices);
-    Variables<DerivativeTags> partial_u_wrt_eta_or_zeta(
-        u.number_of_grid_points());
-    const Matrix& differentiation_matrix_eta =
-        Basis::lgl::differentiation_matrix(extents[1]);
-    const size_t num_components_times_eta_slices =
-        logical_partial_derivatives_of_u[1].size() / extents[1];
-    dgemm_('N', 'N', extents[1], num_components_times_eta_slices, extents[1],
-           1.0, differentiation_matrix_eta.data(), extents[1],
-           u_eta_or_zeta_fastest.data(), extents[1], 0.0,
-           partial_u_wrt_eta_or_zeta.data(), extents[1]);
-    transpose(partial_u_wrt_eta_or_zeta, num_components_times_xi_slices,
-              extents[0], make_not_null(&logical_partial_derivatives_of_u[1]));
-
-    const size_t chunk_size = extents[0] * extents[1];
-    const size_t number_of_chunks =
-        logical_partial_derivatives_of_u[1].size() / chunk_size;
-    transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
-        u, chunk_size, number_of_chunks, make_not_null(&u_eta_or_zeta_fastest));
-    const Matrix& differentiation_matrix_zeta =
-        Basis::lgl::differentiation_matrix(extents[2]);
-    const size_t num_components_times_zeta_slices =
-        logical_partial_derivatives_of_u[2].size() / extents[2];
-    dgemm_('N', 'N', extents[2], num_components_times_zeta_slices, extents[2],
-           1.0, differentiation_matrix_zeta.data(), extents[2],
-           u_eta_or_zeta_fastest.data(), extents[2], 0.0,
-           partial_u_wrt_eta_or_zeta.data(), extents[2]);
-    transpose(partial_u_wrt_eta_or_zeta, number_of_chunks, chunk_size,
-              make_not_null(&logical_partial_derivatives_of_u[2]));
-
-    return logical_partial_derivatives_of_u;
-  }
+ public:
+  static constexpr db::DataBoxString label = "d";
+  static constexpr auto function =
+      partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
+                          derivative_frame_index::dim,
+                          typename derivative_frame_index::Frame>;
+  using argument_tags =
+      typelist<Tags::Variables<variables_tags>,
+               Tags::Extents<derivative_frame_index::dim>, InverseJacobianTag>;
 };
-}  // namespace partial_derivatives_detail
+
+// Logical partial derivatives
+template <typename... VariablesTags, typename... DerivativeTags, typename T,
+          T Dim>
+struct deriv_impl<tmpl::list<VariablesTags...>, tmpl::list<DerivativeTags...>,
+                  std::integral_constant<T, Dim>,
+                  Requires<(0 < Dim and 4 > Dim)>> : db::ComputeItemTag {
+  using variables_tags = tmpl::list<VariablesTags...>;
+  static constexpr db::DataBoxString label = "d";
+  static constexpr auto function =
+      logical_partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
+                                  Dim>;
+  using argument_tags =
+      typelist<Tags::Variables<variables_tags>, Tags::Extents<Dim>>;
+};
+}  // namespace Tags_detail
+}  // namespace Tags

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -5,7 +5,6 @@
 #include <memory>
 
 #include "DataStructures/DataBox.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBoxHelpers.hpp"
 #include "DataStructures/DataBoxTag.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -529,35 +528,45 @@ struct Var2 : db::DataBoxTag {
   static constexpr db::DataBoxString label = "Var2";
 };
 
+template <class Tag, class VolumeDim, class Frame>
+struct PrefixTag0 : db::DataBoxPrefix {
+  using type = TensorMetafunctions::prepend_spatial_index<
+      db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
+  using tag = Tag;
+  static constexpr db::DataBoxString label = "PrefixTag0";
+};
+
 using two_vars = typelist<Var1, Var2>;
 using vector_only = typelist<Var1>;
 using scalar_only = typelist<Var2>;
 
 static_assert(
     cpp17::is_same_v<
-        tmpl::back<db::wrap_tags_in<Tags::d, scalar_only, tmpl::size_t<2>,
+        tmpl::back<db::wrap_tags_in<PrefixTag0, scalar_only, tmpl::size_t<2>,
                                     Frame::Grid>>::type,
         tnsr::i<DataVector, 2, Frame::Grid>>,
     "Failed db::wrap_tags_in scalar_only");
 
 static_assert(
     cpp17::is_same_v<
-        tmpl::back<db::wrap_tags_in<Tags::d, vector_only, tmpl::size_t<3>,
+        tmpl::back<db::wrap_tags_in<PrefixTag0, vector_only, tmpl::size_t<3>,
                                     Frame::Grid>>::type,
         tnsr::iJ<DataVector, 3, Frame::Grid>>,
     "Failed db::wrap_tags_in vector_only");
 
-static_assert(cpp17::is_same_v<
-                  tmpl::back<db::wrap_tags_in<
-                      Tags::d, two_vars, tmpl::size_t<2>, Frame::Grid>>::type,
-                  tnsr::i<DataVector, 2, Frame::Grid>>,
-              "Failed db::wrap_tags_in two_vars scalar");
+static_assert(
+    cpp17::is_same_v<
+        tmpl::back<db::wrap_tags_in<PrefixTag0, two_vars, tmpl::size_t<2>,
+                                    Frame::Grid>>::type,
+        tnsr::i<DataVector, 2, Frame::Grid>>,
+    "Failed db::wrap_tags_in two_vars scalar");
 
-static_assert(cpp17::is_same_v<
-                  tmpl::front<db::wrap_tags_in<
-                      Tags::d, two_vars, tmpl::size_t<3>, Frame::Grid>>::type,
-                  tnsr::iJ<DataVector, 3, Frame::Grid>>,
-              "Failed db::wrap_tags_in two_vars vector");
+static_assert(
+    cpp17::is_same_v<
+        tmpl::front<db::wrap_tags_in<PrefixTag0, two_vars, tmpl::size_t<3>,
+                                     Frame::Grid>>::type,
+        tnsr::iJ<DataVector, 3, Frame::Grid>>,
+    "Failed db::wrap_tags_in two_vars vector");
 }  // namespace
 
 namespace test_databox_tags {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -223,7 +223,7 @@ void test_partial_derivatives_1d(const Index<1>& extents) {
 
   Variables<VariableTags> u(number_of_grid_points);
   Variables<
-      db::wrap_tags_in<Tags::d, GradientTags, tmpl::size_t<1>, Frame::Grid>>
+      db::wrap_tags_in<Tags::deriv, GradientTags, tmpl::size_t<1>, Frame::Grid>>
       expected_du(number_of_grid_points);
   for (size_t a = 0; a < extents[0]; ++a) {
     tmpl::for_each<VariableTags>([&a, &x, &u ](auto tag) noexcept {
@@ -232,7 +232,7 @@ void test_partial_derivatives_1d(const Index<1>& extents) {
     });
     tmpl::for_each<GradientTags>([&a, &x, &expected_du ](auto tag) noexcept {
       using Tag = typename decltype(tag)::type;
-      using DerivativeTag = Tags::d<Tag, tmpl::size_t<1>, Frame::Grid>;
+      using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<1>, Frame::Grid>;
       get<DerivativeTag>(expected_du) = Tag::df({{a}}, x);
     });
 
@@ -262,7 +262,7 @@ void test_partial_derivatives_2d(const Index<2>& extents) {
 
   Variables<VariableTags> u(number_of_grid_points);
   Variables<
-      db::wrap_tags_in<Tags::d, GradientTags, tmpl::size_t<2>, Frame::Grid>>
+      db::wrap_tags_in<Tags::deriv, GradientTags, tmpl::size_t<2>, Frame::Grid>>
       expected_du(number_of_grid_points);
   for (size_t a = 0; a < extents[0]; ++a) {
     for (size_t b = 0; b < extents[1]; ++b) {
@@ -270,12 +270,12 @@ void test_partial_derivatives_2d(const Index<2>& extents) {
         using Tag = typename decltype(tag)::type;
         get<Tag>(u) = Tag::f({{a, b}}, x);
       });
-      tmpl::for_each<GradientTags>(
-          [&a, &b, &x, &expected_du ](auto tag) noexcept {
-            using Tag = typename decltype(tag)::type;
-            using DerivativeTag = Tags::d<Tag, tmpl::size_t<2>, Frame::Grid>;
-            get<DerivativeTag>(expected_du) = Tag::df({{a, b}}, x);
-          });
+      tmpl::for_each<GradientTags>([&a, &b, &x,
+                                    &expected_du ](auto tag) noexcept {
+        using Tag = typename decltype(tag)::type;
+        using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<2>, Frame::Grid>;
+        get<DerivativeTag>(expected_du) = Tag::df({{a, b}}, x);
+      });
 
       const auto du =
           partial_derivatives<GradientTags>(u, extents, inverse_jacobian);
@@ -308,7 +308,7 @@ void test_partial_derivatives_3d(const Index<3>& extents) {
 
   Variables<VariableTags> u(number_of_grid_points);
   Variables<
-      db::wrap_tags_in<Tags::d, GradientTags, tmpl::size_t<3>, Frame::Grid>>
+      db::wrap_tags_in<Tags::deriv, GradientTags, tmpl::size_t<3>, Frame::Grid>>
       expected_du(number_of_grid_points);
   for (size_t a = 0; a < extents[0] / 2; ++a) {
     for (size_t b = 0; b < extents[1] / 2; ++b) {
@@ -317,12 +317,12 @@ void test_partial_derivatives_3d(const Index<3>& extents) {
           using Tag = typename decltype(tag)::type;
           get<Tag>(u) = Tag::f({{a, b, c}}, x);
         });
-        tmpl::for_each<GradientTags>(
-            [&a, &b, &c, &x, &expected_du ](auto tag) noexcept {
-              using Tag = typename decltype(tag)::type;
-              using DerivativeTag = Tags::d<Tag, tmpl::size_t<3>, Frame::Grid>;
-              get<DerivativeTag>(expected_du) = Tag::df({{a, b, c}}, x);
-            });
+        tmpl::for_each<GradientTags>([&a, &b, &c, &x,
+                                      &expected_du ](auto tag) noexcept {
+          using Tag = typename decltype(tag)::type;
+          using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<3>, Frame::Grid>;
+          get<DerivativeTag>(expected_du) = Tag::df({{a, b, c}}, x);
+        });
 
         const auto du =
             partial_derivatives<GradientTags>(u, extents, inverse_jacobian);
@@ -380,14 +380,14 @@ void test_logical_derivatives_compute_item(
     const std::array<size_t, Dim> extents_array) noexcept {
   using vars_tags = tmpl::list<Var1<Dim, Frame::Logical>, Var2>;
   using deriv_tag =
-      Tags::d<vars_tags, vars_tags, std::integral_constant<size_t, Dim>>;
+      Tags::deriv<vars_tags, vars_tags, std::integral_constant<size_t, Dim>>;
 
   const std::array<size_t, Dim> array_to_functions{extents_array -
                                                    make_array<Dim>(size_t{1})};
   const Index<Dim> extents{extents_array};
   Variables<vars_tags> u(extents.product());
-  Variables<
-      db::wrap_tags_in<Tags::d, vars_tags, tmpl::size_t<Dim>, Frame::Logical>>
+  Variables<db::wrap_tags_in<Tags::deriv, vars_tags, tmpl::size_t<Dim>,
+                             Frame::Logical>>
       expected_du(extents.product());
   const auto x = logical_coordinates(extents);
 
@@ -395,12 +395,12 @@ void test_logical_derivatives_compute_item(
     using Tag = tmpl::type_from<decltype(tag)>;
     get<Tag>(u) = Tag::f(array_to_functions, x);
   });
-  tmpl::for_each<vars_tags>(
-      [&array_to_functions, &x, &expected_du ](auto tag) noexcept {
-        using Tag = typename decltype(tag)::type;
-        using DerivativeTag = Tags::d<Tag, tmpl::size_t<Dim>, Frame::Logical>;
-        get<DerivativeTag>(expected_du) = Tag::df(array_to_functions, x);
-      });
+  tmpl::for_each<vars_tags>([&array_to_functions, &x,
+                             &expected_du ](auto tag) noexcept {
+    using Tag = typename decltype(tag)::type;
+    using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<Dim>, Frame::Logical>;
+    get<DerivativeTag>(expected_du) = Tag::df(array_to_functions, x);
+  });
 
   auto box = db::create<
       db::AddTags<Tags::Extents<Dim>, Tags::Variables<vars_tags>>,
@@ -411,7 +411,7 @@ void test_logical_derivatives_compute_item(
 
   tmpl::for_each<vars_tags>([&du, &expected_du, &extents ](auto tag) noexcept {
     using Tag = tmpl::type_from<decltype(tag)>;
-    using DerivativeTag = Tags::d<Tag, tmpl::size_t<Dim>, Frame::Logical>;
+    using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<Dim>, Frame::Logical>;
     auto& expected_dvariable = get<DerivativeTag>(expected_du);
     for (auto it = expected_dvariable.begin(); it != expected_dvariable.end();
          ++it) {
@@ -442,14 +442,14 @@ void test_partial_derivatives_compute_item(
   using map_tag = MapTag<std::decay_t<decltype(map)>>;
   using inv_jac_tag =
       Tags::InverseJacobian<map_tag, Tags::LogicalCoordinates<Dim>>;
-  using deriv_tag = Tags::d<vars_tags, vars_tags, inv_jac_tag>;
+  using deriv_tag = Tags::deriv<vars_tags, vars_tags, inv_jac_tag>;
 
   const std::array<size_t, Dim> array_to_functions{extents_array -
                                                    make_array<Dim>(size_t{1})};
   const Index<Dim> extents{extents_array};
   Variables<vars_tags> u(extents.product());
   Variables<
-      db::wrap_tags_in<Tags::d, vars_tags, tmpl::size_t<Dim>, Frame::Grid>>
+      db::wrap_tags_in<Tags::deriv, vars_tags, tmpl::size_t<Dim>, Frame::Grid>>
       expected_du(extents.product());
   const auto x_logical = logical_coordinates(extents);
   const auto x = map(logical_coordinates(extents));
@@ -461,7 +461,7 @@ void test_partial_derivatives_compute_item(
   tmpl::for_each<vars_tags>(
       [&array_to_functions, &x, &expected_du ](auto tag) noexcept {
         using Tag = typename decltype(tag)::type;
-        using DerivativeTag = Tags::d<Tag, tmpl::size_t<Dim>, Frame::Grid>;
+        using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<Dim>, Frame::Grid>;
         get<DerivativeTag>(expected_du) = Tag::df(array_to_functions, x);
       });
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -18,15 +18,20 @@
 #include "Utilities/MakeArray.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+#include "DataStructures/DataBox.hpp"
+#include "Domain/Tags.hpp"
+
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp"
+
 namespace {
 
-template <size_t Dim>
+template <size_t Dim, class Frame = ::Frame::Grid>
 struct Var1 : db::DataBoxTag {
-  using type = tnsr::i<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString label = "Vector_t";
+  using type = tnsr::i<DataVector, Dim, Frame>;
+  static constexpr db::DataBoxString label = "Var1";
   static auto f(const std::array<size_t, Dim>& coeffs,
-                const tnsr::I<DataVector, Dim, Frame::Grid>& x) {
-    tnsr::i<DataVector, Dim, Frame::Grid> result(x.begin()->size(), 0.);
+                const tnsr::I<DataVector, Dim, Frame>& x) {
+    tnsr::i<DataVector, Dim, Frame> result(x.begin()->size(), 0.);
     for (size_t i = 0; i < Dim; ++i) {
       result.get(i) = (i + 2);
       for (size_t d = 0; d < Dim; ++d) {
@@ -36,8 +41,8 @@ struct Var1 : db::DataBoxTag {
     return result;
   }
   static auto df(const std::array<size_t, Dim>& coeffs,
-                 const tnsr::I<DataVector, Dim, Frame::Grid>& x) {
-    tnsr::ij<DataVector, Dim, Frame::Grid> result(x.begin()->size(), 0.);
+                 const tnsr::I<DataVector, Dim, Frame>& x) {
+    tnsr::ij<DataVector, Dim, Frame> result(x.begin()->size(), 0.);
     for (size_t i = 0; i < Dim; ++i) {
       for (size_t j = 0; j < Dim; ++j) {
         result.get(i, j) = (j + 2);
@@ -61,20 +66,20 @@ struct Var1 : db::DataBoxTag {
 
 struct Var2 : db::DataBoxTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Scalar_t";
-  template <size_t Dim>
+  static constexpr db::DataBoxString label = "Var2";
+  template <size_t Dim, class Frame>
   static auto f(const std::array<size_t, Dim>& coeffs,
-                const tnsr::I<DataVector, Dim, Frame::Grid>& x) {
+                const tnsr::I<DataVector, Dim, Frame>& x) {
     Scalar<DataVector> result(x.begin()->size(), 1.);
     for (size_t d = 0; d < Dim; ++d) {
       result.get() *= pow(x.get(d), gsl::at(coeffs, d));
     }
     return result;
   }
-  template <size_t Dim>
+  template <size_t Dim, class Frame>
   static auto df(const std::array<size_t, Dim>& coeffs,
-                 const tnsr::I<DataVector, Dim, Frame::Grid>& x) {
-    tnsr::i<DataVector, Dim, Frame::Grid> result(x.begin()->size(), 1.);
+                 const tnsr::I<DataVector, Dim, Frame>& x) {
+    tnsr::i<DataVector, Dim, Frame> result(x.begin()->size(), 1.);
     for (size_t i = 0; i < Dim; ++i) {
       for (size_t d = 0; d < Dim; ++d) {
         if (d == i) {
@@ -367,4 +372,163 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs",
   const Index<3> extents_3d(n0, n1, n2);
   test_partial_derivatives_3d<two_vars<3>>(extents_3d);
   test_partial_derivatives_3d<two_vars<3>, one_var<3>>(extents_3d);
+}
+
+namespace {
+template <size_t Dim>
+void test_logical_derivatives_compute_item(
+    const std::array<size_t, Dim> extents_array) noexcept {
+  using vars_tags = tmpl::list<Var1<Dim, Frame::Logical>, Var2>;
+  using deriv_tag =
+      Tags::d<vars_tags, vars_tags, std::integral_constant<size_t, Dim>>;
+
+  const std::array<size_t, Dim> array_to_functions{extents_array -
+                                                   make_array<Dim>(size_t{1})};
+  const Index<Dim> extents{extents_array};
+  Variables<vars_tags> u(extents.product());
+  Variables<
+      db::wrap_tags_in<Tags::d, vars_tags, tmpl::size_t<Dim>, Frame::Logical>>
+      expected_du(extents.product());
+  const auto x = logical_coordinates(extents);
+
+  tmpl::for_each<vars_tags>([&array_to_functions, &x, &u ](auto tag) noexcept {
+    using Tag = tmpl::type_from<decltype(tag)>;
+    get<Tag>(u) = Tag::f(array_to_functions, x);
+  });
+  tmpl::for_each<vars_tags>(
+      [&array_to_functions, &x, &expected_du ](auto tag) noexcept {
+        using Tag = typename decltype(tag)::type;
+        using DerivativeTag = Tags::d<Tag, tmpl::size_t<Dim>, Frame::Logical>;
+        get<DerivativeTag>(expected_du) = Tag::df(array_to_functions, x);
+      });
+
+  auto box = db::create<
+      db::AddTags<Tags::Extents<Dim>, Tags::Variables<vars_tags>>,
+      db::AddComputeItemsTags<Tags::LogicalCoordinates<Dim>, deriv_tag>>(
+      extents, u);
+
+  const auto& du = db::get<deriv_tag>(box);
+
+  tmpl::for_each<vars_tags>([&du, &expected_du, &extents ](auto tag) noexcept {
+    using Tag = tmpl::type_from<decltype(tag)>;
+    using DerivativeTag = Tags::d<Tag, tmpl::size_t<Dim>, Frame::Logical>;
+    auto& expected_dvariable = get<DerivativeTag>(expected_du);
+    for (auto it = expected_dvariable.begin(); it != expected_dvariable.end();
+         ++it) {
+      const auto deriv_indices = expected_dvariable.get_tensor_index(it);
+      const size_t deriv_index = deriv_indices[0];
+      const auto tensor_indices =
+          all_but_specified_element_of<0>(deriv_indices);
+      for (size_t n = 0; n < extents.product(); ++n) {
+        CAPTURE_PRECISE(get<Tag>(du[deriv_index]).get(tensor_indices)[n] -
+                        (*it)[n]);
+        CHECK(get<Tag>(du[deriv_index]).get(tensor_indices)[n] ==
+              approx((*it)[n]));
+      }
+    }
+  });
+}
+
+template <class MapType>
+struct MapTag : db::DataBoxTag {
+  using type = MapType;
+  static constexpr db::DataBoxString label = "MapTag";
+};
+
+template <size_t Dim, typename T>
+void test_partial_derivatives_compute_item(
+    const std::array<size_t, Dim> extents_array, const T& map) noexcept {
+  using vars_tags = tmpl::list<Var1<Dim>, Var2>;
+  using map_tag = MapTag<std::decay_t<decltype(map)>>;
+  using inv_jac_tag =
+      Tags::InverseJacobian<map_tag, Tags::LogicalCoordinates<Dim>>;
+  using deriv_tag = Tags::d<vars_tags, vars_tags, inv_jac_tag>;
+
+  const std::array<size_t, Dim> array_to_functions{extents_array -
+                                                   make_array<Dim>(size_t{1})};
+  const Index<Dim> extents{extents_array};
+  Variables<vars_tags> u(extents.product());
+  Variables<
+      db::wrap_tags_in<Tags::d, vars_tags, tmpl::size_t<Dim>, Frame::Grid>>
+      expected_du(extents.product());
+  const auto x_logical = logical_coordinates(extents);
+  const auto x = map(logical_coordinates(extents));
+
+  tmpl::for_each<vars_tags>([&array_to_functions, &x, &u ](auto tag) noexcept {
+    using Tag = tmpl::type_from<decltype(tag)>;
+    get<Tag>(u) = Tag::f(array_to_functions, x);
+  });
+  tmpl::for_each<vars_tags>(
+      [&array_to_functions, &x, &expected_du ](auto tag) noexcept {
+        using Tag = typename decltype(tag)::type;
+        using DerivativeTag = Tags::d<Tag, tmpl::size_t<Dim>, Frame::Grid>;
+        get<DerivativeTag>(expected_du) = Tag::df(array_to_functions, x);
+      });
+
+  auto box = db::create<
+      db::AddTags<Tags::Extents<Dim>, Tags::Variables<vars_tags>, map_tag>,
+      db::AddComputeItemsTags<Tags::LogicalCoordinates<Dim>, inv_jac_tag,
+                              deriv_tag>>(extents, u, map);
+
+  const auto& du = db::get<deriv_tag>(box);
+
+  for (size_t n = 0; n < du.size(); ++n) {
+    // clang-tidy: pointer arithmetic
+    CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
+    CHECK(du.data()[n] == approx(expected_du.data()[n]));   // NOLINT
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs.ComputeItems",
+                  "[Numerical][LinearOperators][Unit]") {
+  Index<3> max_extents{10, 10, 5};
+
+  for (size_t a = 1; a < max_extents[0]; ++a) {
+    test_logical_derivatives_compute_item(std::array<size_t, 1>{{a + 1}});
+    for (size_t b = 1; b < max_extents[1]; ++b) {
+      test_logical_derivatives_compute_item(
+          std::array<size_t, 2>{{a + 1, b + 1}});
+      for (size_t c = 1; a < max_extents[0] / 2 and b < max_extents[1] / 2 and
+                         c < max_extents[2];
+           ++c) {
+        test_logical_derivatives_compute_item(
+            std::array<size_t, 3>{{a + 1, b + 1, c + 1}});
+      }
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs.ComputeItems",
+                  "[Numerical][LinearOperators][Unit]") {
+  using AffineMap = CoordinateMaps::AffineMap;
+  using AffineMap2d = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+  using AffineMap3d =
+      CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+
+  Index<3> max_extents{10, 10, 5};
+
+  for (size_t a = 1; a < max_extents[0]; ++a) {
+    test_partial_derivatives_compute_item(
+        std::array<size_t, 1>{{a + 1}},
+        make_coordinate_map<Frame::Logical, Frame::Grid>(
+            CoordinateMaps::AffineMap{-1.0, 1.0, -0.3, 0.7}));
+    for (size_t b = 1; b < max_extents[1]; ++b) {
+      test_partial_derivatives_compute_item(
+          std::array<size_t, 2>{{a + 1, b + 1}},
+          make_coordinate_map<Frame::Logical, Frame::Grid>(
+              AffineMap2d{AffineMap{-1.0, 1.0, -0.3, 0.7},
+                          AffineMap{-1.0, 1.0, 0.3, 0.55}}));
+      for (size_t c = 1; a < max_extents[0] / 2 and b < max_extents[1] / 2 and
+                         c < max_extents[2];
+           ++c) {
+        test_partial_derivatives_compute_item(
+            std::array<size_t, 3>{{a + 1, b + 1, c + 1}},
+            make_coordinate_map<Frame::Logical, Frame::Grid>(
+                AffineMap3d{AffineMap{-1.0, 1.0, -0.3, 0.7},
+                            AffineMap{-1.0, 1.0, 0.3, 0.55},
+                            AffineMap{-1.0, 1.0, 2.3, 2.8}}));
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Proposed changes

- Adds a type alias for the Jacobian type, similar to the `InverseJacobian` type alias
- Fixes a bug in `compute_item_result_impl` that caused really confusing template errors
- Adds tags for the logical coordinates (item) and inverse jacobian (compute item)
- Generalizes the spatial derivative prefix `d` to be a compute item and item depending on its template parameters
- Renames `Tags::d` to `Tags::deriv`
- Fixes a clang-tidy warning in DataBox.hpp

These are again changes I had to make for getting evolutions working.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
