### PR TITLE
Fix frame of GH Tags from Grid to Inertial

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 namespace GeneralizedHarmonic {
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct SpacetimeMetric : db::DataBoxTag {
-  using type = tnsr::aa<DataVector, Dim, Frame::Grid>;
+  using type = tnsr::aa<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "SpacetimeMetric";
 };
 
@@ -18,9 +18,9 @@ struct SpacetimeMetric : db::DataBoxTag {
  * \f$ \Pi_{ab} = -\frac{1}{N} ( \partial_t \psi_{ab} + N^{i} \phi_{iab} ) \f$
  * where \f$\phi_{iab}\f$ is the variable defined by the tag Phi.
  */
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct Pi : db::DataBoxTag {
-  using type = tnsr::aa<DataVector, Dim, Frame::Grid>;
+  using type = tnsr::aa<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "Pi";
 };
 
@@ -30,33 +30,33 @@ struct Pi : db::DataBoxTag {
  * \details If \f$\psi_{ab}\f$ is the spacetime metric then we define
  * \f$\phi_{iab} = \partial_i \psi_{ab}\f$
  */
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct Phi : db::DataBoxTag {
-  using type = tnsr::abb<DataVector, Dim, Frame::Grid>;
+  using type = tnsr::abb<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "Phi";
 };
 
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct InverseSpatialMetric : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "InverseSpatialMetric";
   // static constexpr auto function =
   // compute_inverse_spatial_metric_from_spacetime_metric<Dim,
-  //      Frame::Grid>;
+  //      Frame::Inertial>;
   using argument_tags = typelist<SpacetimeMetric<Dim>>;
 };
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct Shift : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "Shift";
   // static constexpr auto function =
-  //      compute_shift_from_spacetime_metric_and_invg<Dim, Frame::Grid>;
+  //      compute_shift_from_spacetime_metric_and_invg<Dim, Frame>;
   using argument_tags =
       typelist<SpacetimeMetric<Dim>, InverseSpatialMetric<Dim>>;
 };
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct Lapse : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "Lapse";
   // static constexpr auto function =
-  //     compute_lapse_from_spacetime_metric_shift<Dim, Frame::Grid>;
+  //     compute_lapse_from_spacetime_metric_shift<Dim, Frame>;
   using argument_tags = typelist<SpacetimeMetric<Dim>, Shift<Dim>>;
 };
 struct ConstraintGamma0 : db::DataBoxTag {
@@ -71,61 +71,61 @@ struct ConstraintGamma2 : db::DataBoxTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "ConstraintGamma2";
 };
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct GaugeH : db::DataBoxTag {
-  using type = tnsr::a<DataVector, Dim, Frame::Grid>;
+  using type = tnsr::a<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "GaugeH";
 };
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct SpacetimeDerivGaugeH : db::DataBoxTag {
-  using type = tnsr::ab<DataVector, Dim, Frame::Grid>;
+  using type = tnsr::ab<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "SpacetimeDerivGaugeH";
 };
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct InverseSpacetimeMetric : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "InverseSpacetimeMetric";
   // static constexpr auto function =
   //     compute_inverse_spacetime_metric_from_invg_lapse_shift<Dim,
-  //     Frame::Grid>;
+  //     Frame::Inertial>;
   using argument_tags =
       typelist<InverseSpatialMetric<Dim>, Shift<Dim>, Lapse<Dim>>;
 };
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct SpacetimeChristoffelFirstKind : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "SpacetimeChristoffelFirstKind";
   // static constexpr auto function =
-  //     compute_christoffel_first_kind_from_gh<Dim, Frame::Grid>;
+  //     compute_christoffel_first_kind_from_gh<Dim, Frame>;
   using argument_tags =
       typelist<InverseSpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>>;
 };
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct SpacetimeChristoffelSecondKind : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "SpactimeChristoffelSecondKind";
   // static constexpr auto function =
-  //     raise_index_1_of_3<Dim, Frame::Grid, IndexType::Spacetime>;
+  //     raise_index_1_of_3<Dim, Frame, IndexType::Spacetime>;
   using argument_tags =
       typelist<SpacetimeChristoffelFirstKind<Dim>, InverseSpacetimeMetric<Dim>>;
 };
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct SpacetimeNormalOneForm : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "SpacetimeNormalOneForm";
   // static constexpr auto function =
-  //     compute_normal_one_form_from_lapse<Dim, Frame::Grid>;
+  //     compute_normal_one_form_from_lapse<Dim, Frame>;
   using argument_tags = typelist<Lapse<Dim>>;
 };
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct SpacetimeNormalVector : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "SpacetimeNormalVector";
   // static constexpr auto function =
-  //     compute_normal_vector_from_lapse_and_shift<Dim, Frame::Grid>;
+  //     compute_normal_vector_from_lapse_and_shift<Dim, Frame>;
   using argument_tags = typelist<Lapse<Dim>, Shift<Dim>>;
 };
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct TraceSpacetimeChristoffelFirstKind : db::ComputeItemTag {
   static constexpr db::DataBoxString label =
       "TraceSpacetimeChristoffelFirstKind";
   // static constexpr auto function =
-  //     compute_trace_23_of_3<Dim, Frame::Grid, IndexType::Spacetime>;
+  //     compute_trace_23_of_3<Dim, Frame, IndexType::Spacetime>;
   using argument_tags =
       typelist<SpacetimeChristoffelFirstKind<Dim>, InverseSpacetimeMetric<Dim>>;
 };

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -4,37 +4,36 @@
 #pragma once
 
 namespace GeneralizedHarmonic {
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeMetric;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct Pi;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct Phi;
 
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct InverseSpatialMetric;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct Shift;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct Lapse;
 struct ConstraintGamma0;
 struct ConstraintGamma1;
 struct ConstraintGamma2;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct GaugeH;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeDerivGaugeH;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct InverseSpacetimeMetric;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeChristoffelFirstKind;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeChristoffelSecondKind;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeNormalOneForm;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeNormalVector;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct TraceSpacetimeChristoffelFirstKind;
-} // namespace GeneralizedHarmonic
-
+}  // namespace GeneralizedHarmonic


### PR DESCRIPTION
## Proposed changes

Fixes #416 

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`

