### PR TITLE
Fix spelling of GeneralRelativityGroup in GroupDefs

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -106,7 +106,7 @@
  */
 
 /*!
- * \defgroup GeneralRelavitiyGroup General Relativity
+ * \defgroup GeneralRelativityGroup General Relativity
  * \brief Contains functions used in General Relativistic simulations
  */
 


### PR DESCRIPTION
## Proposed changes

The title literally says it all. This change is needed for the documentation to not be broken. It also re-emphasizes that people should look at the documentation after writing it, and that ideally we would have an automated way to do this for code review. I'll look into seeing if this is possible with Travis.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
