### PR TITLE
Fix typo in RegisterDerivedWithCharm

### DIFF
--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -8,7 +8,7 @@
 #include "Parallel/CharmPupable.hpp"
 
 namespace DomainCreators {
-namespace DomainCreaters_detail {
+namespace DomainCreators_detail {
 template <size_t Dim>
 void register_with_charm();
 
@@ -34,11 +34,11 @@ void register_with_charm<3>() {
                           CoordinateMaps::AffineMap, CoordinateMaps::AffineMap,
                           CoordinateMaps::AffineMap>>));
 }
-}  // namespace DomainCreaters_detail
+}  // namespace DomainCreators_detail
 
 void register_derived_with_charm() {
-  DomainCreaters_detail::register_with_charm<1>();
-  DomainCreaters_detail::register_with_charm<2>();
-  DomainCreaters_detail::register_with_charm<3>();
+  DomainCreators_detail::register_with_charm<1>();
+  DomainCreators_detail::register_with_charm<2>();
+  DomainCreators_detail::register_with_charm<3>();
 }
 }  // namespace DomainCreators


### PR DESCRIPTION
## Proposed changes
Fix name to match the `DomainCreators_detail` namespace in DomainCreator.hpp

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
