### PR TITLE
Add compute_trace.

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp
@@ -40,4 +40,17 @@ raise_or_lower_first_index(
 template <size_t Dim, typename Frame, IndexType TypeOfIndex, typename DataType>
 tnsr::a<DataType, Dim, Frame, TypeOfIndex> trace_last_indices(
     const tnsr::abb<DataType, Dim, Frame, TypeOfIndex>& tensor,
-    const tnsr::AA<DataType, Dim, Frame, TypeOfIndex>& upper_metric);
+    const tnsr::AA<DataType, Dim, Frame, TypeOfIndex>& upper_metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes trace of a rank-2 symmetric lower-index tensor.
+ * \details Computes \f$g^{ab}T_{ab}\f$ where \f$(a,b)\f$ can be spatial or
+ * spacetime indices.
+ */
+template <size_t SpatialDim, typename Frame, IndexType TypeOfIndex,
+          typename DataType>
+Scalar<DataType> trace(
+    const tnsr::aa<DataType, SpatialDim, Frame, TypeOfIndex>& tensor,
+    const tnsr::AA<DataType, SpatialDim, Frame, TypeOfIndex>&
+        upper_metric) noexcept;

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
@@ -142,6 +142,20 @@ tnsr::iaa<DataType, SpatialDim> make_spatial_deriv_spacetime_metric(
 }
 
 template <size_t SpatialDim, typename DataType>
+tnsr::aa<DataType, SpatialDim> make_dt_spacetime_metric(
+    const DataType& used_for_size){
+  auto dt_spacetime_metric =
+      make_with_value<tnsr::aa<DataType, SpatialDim>>(used_for_size, 0.);
+  for (size_t i = 0; i < SpatialDim + 1; i++) {
+    for (size_t j = i; j < SpatialDim + 1; j++) {
+      dt_spacetime_metric.get(i, j) =
+          make_with_value<DataType>(used_for_size, i * j + 0.5);
+    }
+  }
+  return dt_spacetime_metric;
+}
+
+template <size_t SpatialDim, typename DataType>
 tnsr::Abb<DataType, SpatialDim> make_spacetime_christoffel_second_kind(
     const DataType& used_for_size) {
   tnsr::Abb<DataType, SpatialDim> christoffel{};
@@ -212,6 +226,8 @@ tnsr::AA<DataType, SpatialDim> make_inverse_spacetime_metric(
   template tnsr::I<DTYPE(data), DIM(data)> make_dt_shift(const DTYPE(data) & \
                                                          used_for_size);     \
   template tnsr::ii<DTYPE(data), DIM(data)> make_dt_spatial_metric(          \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::aa<DTYPE(data), DIM(data)> make_dt_spacetime_metric(        \
       const DTYPE(data) & used_for_size);                                    \
   template tnsr::i<DTYPE(data), DIM(data)> make_deriv_lapse(                 \
       const DTYPE(data) & used_for_size);                                    \

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
@@ -69,6 +69,10 @@ tnsr::abb<DataType, SpatialDim> make_spacetime_deriv_spacetime_metric(
     const DataType& used_for_size);
 
 template <size_t SpatialDim, typename DataType>
+tnsr::aa<DataType, SpatialDim> make_dt_spacetime_metric(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
 tnsr::iaa<DataType, SpatialDim> make_spatial_deriv_spacetime_metric(
     const DataType& used_for_size);
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
@@ -306,7 +306,56 @@ void test_3d_spacetime_trace(const DataVector& used_for_size) {
           make_inverse_spacetime_metric<dim>(used_for_size)),
       vector);
 }
+void test_1d_spatial_trace_tensor_type_aa(const DataVector& used_for_size) {
+  const size_t dim = 1;
+  const Scalar<double> scalar = trace(make_dt_spatial_metric<dim>(0.),
+                                      make_inverse_spatial_metric<dim>(0.));
 
+  CHECK(scalar.get() == approx(0.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      trace(make_dt_spatial_metric<dim>(used_for_size),
+            make_inverse_spatial_metric<dim>(used_for_size)),
+      scalar);
+}
+
+void test_2d_spatial_trace_tensor_type_aa(const DataVector& used_for_size) {
+  const size_t dim = 2;
+  const Scalar<double> scalar = trace(make_dt_spatial_metric<dim>(0.),
+                                      make_inverse_spatial_metric<dim>(0.));
+
+  CHECK(scalar.get() == approx(12.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      trace(make_dt_spatial_metric<dim>(used_for_size),
+            make_inverse_spatial_metric<dim>(used_for_size)),
+      scalar);
+}
+
+void test_3d_spatial_trace_tensor_type_aa(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const Scalar<double> scalar = trace(make_dt_spatial_metric<dim>(0.),
+                                      make_inverse_spatial_metric<dim>(0.));
+
+  CHECK(scalar.get() == approx(96.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      trace(make_dt_spatial_metric<dim>(used_for_size),
+            make_inverse_spatial_metric<dim>(used_for_size)),
+      scalar);
+}
+void test_3d_spacetime_trace_tensor_type_aa(const DataVector& used_for_size) {
+  const size_t dim = 3;
+  const Scalar<double> scalar = trace(make_dt_spacetime_metric<dim>(0.),
+                                      make_inverse_spacetime_metric<dim>(0.));
+
+  CHECK(scalar.get() == approx(-1548.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      trace(make_dt_spacetime_metric<dim>(used_for_size),
+            make_inverse_spacetime_metric<dim>(used_for_size)),
+      scalar);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.IndexManipulation",
@@ -326,4 +375,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.IndexManipulation",
   test_2d_spatial_trace(dv);
   test_3d_spatial_trace(dv);
   test_3d_spacetime_trace(dv);
+  test_1d_spatial_trace_tensor_type_aa(dv);
+  test_2d_spatial_trace_tensor_type_aa(dv);
+  test_3d_spatial_trace_tensor_type_aa(dv);
+  test_3d_spacetime_trace_tensor_type_aa(dv);
 }


### PR DESCRIPTION
## Proposed changes

Adds a function that takes the trace of a rank-2 tensor.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
