### PR TITLE
Remove use of tensor default constructor in GeneralRelativity

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -10,7 +10,9 @@
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 tnsr::abb<DataType, SpatialDim, Frame, Index> compute_christoffel_first_kind(
     const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric) {
-  tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel{};
+  auto christoffel =
+      make_with_value<tnsr::abb<DataType, SpatialDim, Frame, Index>>(d_metric,
+                                                                     0.);
   constexpr auto dimensionality = index_dim<0>(christoffel);
   for (size_t k = 0; k < dimensionality; ++k) {
     for (size_t i = 0; i < dimensionality; ++i) {

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -12,10 +12,10 @@ template <size_t Dim, typename Frame, typename DataType>
 tnsr::aa<DataType, Dim, Frame> compute_spacetime_metric(
     const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Frame>& shift,
     const tnsr::ii<DataType, Dim, Frame>& spatial_metric) noexcept {
-  tnsr::aa<DataType, Dim, Frame> spacetime_metric{
-      make_with_value<DataType>(lapse.get(), 0.)};
+  auto spacetime_metric =
+      make_with_value<tnsr::aa<DataType, Dim, Frame>>(lapse, 0.);
 
-  get<0, 0>(spacetime_metric) = -lapse.get() * lapse.get();
+  get<0, 0>(spacetime_metric) = -get(lapse) * get(lapse);
 
   for (size_t m = 0; m < Dim; ++m) {
     get<0, 0>(spacetime_metric) +=
@@ -41,10 +41,11 @@ template <size_t Dim, typename Frame, typename DataType>
 tnsr::AA<DataType, Dim, Frame> compute_inverse_spacetime_metric(
     const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Frame>& shift,
     const tnsr::II<DataType, Dim, Frame>& inverse_spatial_metric) noexcept {
-  tnsr::AA<DataType, Dim, Frame> inverse_spacetime_metric{};
+  auto inverse_spacetime_metric =
+      make_with_value<tnsr::AA<DataType, Dim, Frame>>(lapse, 0.);
 
   get<0, 0>(inverse_spacetime_metric) =
-      -1.0 / (lapse.get() * lapse.get());
+      -1.0 / (get(lapse) * get(lapse));
 
   const auto& minus_one_over_lapse_sqrd = get<0, 0>(inverse_spacetime_metric);
 
@@ -73,11 +74,11 @@ tnsr::abb<DataType, Dim, Frame> compute_derivatives_of_spacetime_metric(
     const tnsr::ii<DataType, Dim, Frame>& spatial_metric,
     const tnsr::ii<DataType, Dim, Frame>& dt_spatial_metric,
     const tnsr::ijj<DataType, Dim, Frame>& deriv_spatial_metric) noexcept {
-  tnsr::abb<DataType, Dim, Frame> spacetime_deriv_spacetime_metric{
-      make_with_value<DataType>(lapse.get(), 0.)};
+  auto spacetime_deriv_spacetime_metric =
+      make_with_value<tnsr::abb<DataType, Dim, Frame>>(lapse, 0.);
 
   get<0, 0, 0>(spacetime_deriv_spacetime_metric) =
-      -2.0 * lapse.get() * dt_lapse.get();
+      -2.0 * get(lapse) * get(dt_lapse);
 
   for (size_t m = 0; m < Dim; ++m) {
     for (size_t n = 0; n < Dim; ++n) {
@@ -101,7 +102,7 @@ tnsr::abb<DataType, Dim, Frame> compute_derivatives_of_spacetime_metric(
 
   for (size_t k = 0; k < Dim; ++k) {
     spacetime_deriv_spacetime_metric.get(k + 1, 0, 0) =
-        -2.0 * lapse.get() * deriv_lapse.get(k);
+        -2.0 * get(lapse) * deriv_lapse.get(k);
     for (size_t m = 0; m < Dim; ++m) {
       for (size_t n = 0; n < Dim; ++n) {
         spacetime_deriv_spacetime_metric.get(k + 1, 0, 0) +=
@@ -136,8 +137,9 @@ tnsr::iaa<DataType, SpatialDim, Frame> compute_phi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept {
-  tnsr::iaa<DataType, SpatialDim, Frame> phi(
-      make_with_value<DataType>(*deriv_lapse.begin(), 0.));
+  auto phi =
+      make_with_value<tnsr::iaa<DataType, SpatialDim, Frame>>(deriv_lapse, 0.);
+
   for (size_t k = 0; k < SpatialDim; ++k) {
     phi.get(k, 0, 0) = -2.0 * lapse.get() * deriv_lapse.get(k);
     for (size_t m = 0; m < SpatialDim; ++m) {
@@ -171,14 +173,14 @@ tnsr::aa<DataType, SpatialDim, Frame> compute_pi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
-  tnsr::aa<DataType, SpatialDim, Frame> pi{
-      make_with_value<DataType>(*lapse.begin(), 0.)};
+  auto pi =
+      make_with_value<tnsr::aa<DataType, SpatialDim, Frame>>(lapse, 0.);
 
-  pi.get(0, 0) = -2.0 * lapse.get() * dt_lapse.get();
+  get<0, 0>(pi) = -2.0 * lapse.get() * dt_lapse.get();
 
   for (size_t m = 0; m < SpatialDim; ++m) {
     for (size_t n = 0; n < SpatialDim; ++n) {
-      pi.get(0, 0) +=
+      get<0, 0>(pi) +=
           dt_spatial_metric.get(m, n) * shift.get(m) * shift.get(n) +
           2.0 * spatial_metric.get(m, n) * shift.get(m) * dt_shift.get(n);
     }
@@ -208,8 +210,8 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::a<DataType, SpatialDim, Frame> compute_spacetime_normal_one_form(
     const Scalar<DataType>& lapse) noexcept {
   auto normal_one_form =
-      make_with_value<tnsr::a<DataType, SpatialDim, Frame>>(get<>(lapse), 0.);
-  get<0>(normal_one_form) = -get<>(lapse);
+      make_with_value<tnsr::a<DataType, SpatialDim, Frame>>(lapse, 0.);
+  get<0>(normal_one_form) = -get(lapse);
   return normal_one_form;
 }
 
@@ -217,9 +219,9 @@ template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::A<DataType, SpatialDim, Frame> compute_spacetime_normal_vector(
     const Scalar<DataType>& lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift) noexcept {
-  auto spacetime_normal_vector{
-      make_with_value<tnsr::A<DataType, SpatialDim, Frame>>(get<>(lapse), 0.)};
-  get<0>(spacetime_normal_vector) = 1. / get<>(lapse);
+  auto spacetime_normal_vector =
+      make_with_value<tnsr::A<DataType, SpatialDim, Frame>>(lapse, 0.);
+  get<0>(spacetime_normal_vector) = 1. / get(lapse);
   for (size_t i = 0; i < SpatialDim; i++) {
     spacetime_normal_vector.get(i + 1) =
         -shift.get(i) * get<0>(spacetime_normal_vector);

--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
@@ -15,9 +15,10 @@ raise_or_lower_first_index(
     const Tensor<DataType, Symmetry<1, 1>,
                  index_list<change_index_up_lo<Index0>,
                             change_index_up_lo<Index0>>>& metric) noexcept {
-  Tensor<DataType, Symmetry<2, 1, 1>,
-         index_list<change_index_up_lo<Index0>, Index1, Index1>>
-      tensor_opposite_valence{make_with_value<DataType>(*tensor.begin(), 0.)};
+  auto tensor_opposite_valence = make_with_value<
+      Tensor<DataType, Symmetry<2, 1, 1>,
+             index_list<change_index_up_lo<Index0>, Index1, Index1>>>(metric,
+                                                                      0.);
 
   constexpr auto dimension = Index0::dim;
 
@@ -38,8 +39,9 @@ template <size_t Dim, typename Frame, IndexType TypeOfIndex, typename DataType>
 tnsr::a<DataType, Dim, Frame, TypeOfIndex> trace_last_indices(
     const tnsr::abb<DataType, Dim, Frame, TypeOfIndex>& tensor,
     const tnsr::AA<DataType, Dim, Frame, TypeOfIndex>& upper_metric) noexcept {
-  tnsr::a<DataType, Dim, Frame, TypeOfIndex> trace_of_tensor{
-      make_with_value<DataType>(*tensor.begin(), 0.)};
+  auto trace_of_tensor =
+      make_with_value<tnsr::a<DataType, Dim, Frame, TypeOfIndex>>(upper_metric,
+                                                                  0.);
 
   const auto dimension = index_dim<0>(tensor);
   for (size_t i = 0; i < dimension; ++i) {

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
@@ -14,7 +14,8 @@ Scalar<DataType> make_lapse(const DataType& used_for_size) {
 
 template <size_t SpatialDim, typename DataType>
 tnsr::I<DataType, SpatialDim> make_shift(const DataType& used_for_size) {
-  tnsr::I<DataType, SpatialDim> shift{};
+  auto shift =
+      make_with_value<tnsr::I<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
     shift.get(i) = make_with_value<DataType>(used_for_size, i + 1);
   }
@@ -24,7 +25,8 @@ tnsr::I<DataType, SpatialDim> make_shift(const DataType& used_for_size) {
 template <size_t SpatialDim, typename DataType>
 tnsr::ii<DataType, SpatialDim> make_spatial_metric(
     const DataType& used_for_size) {
-  tnsr::ii<DataType, SpatialDim> metric{};
+  auto metric =
+      make_with_value<tnsr::ii<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = i; j < SpatialDim; ++j) {
       metric.get(i, j) =
@@ -37,7 +39,8 @@ tnsr::ii<DataType, SpatialDim> make_spatial_metric(
 template <size_t SpatialDim, typename DataType>
 tnsr::II<DataType, SpatialDim> make_inverse_spatial_metric(
     const DataType& used_for_size) {
-  tnsr::II<DataType, SpatialDim> metric{};
+  auto metric =
+      make_with_value<tnsr::II<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = i; j < SpatialDim; ++j) {
       metric.get(i, j) =
@@ -54,7 +57,8 @@ Scalar<DataType> make_dt_lapse(const DataType& used_for_size) {
 
 template <size_t SpatialDim, typename DataType>
 tnsr::I<DataType, SpatialDim> make_dt_shift(const DataType& used_for_size) {
-  tnsr::I<DataType, SpatialDim> dt_shift{};
+  auto dt_shift =
+      make_with_value<tnsr::I<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
     dt_shift.get(i) =
         make_with_value<DataType>(used_for_size, SpatialDim * (i + 1.));
@@ -65,18 +69,20 @@ tnsr::I<DataType, SpatialDim> make_dt_shift(const DataType& used_for_size) {
 template <size_t SpatialDim, typename DataType>
 tnsr::ii<DataType, SpatialDim> make_dt_spatial_metric(
     const DataType& used_for_size) {
-  tnsr::ii<DataType, SpatialDim> metric{};
+  auto dt_metric =
+      make_with_value<tnsr::ii<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = i; j < SpatialDim; ++j) {
-      metric.get(i, j) = make_with_value<DataType>(used_for_size, i + j);
+      dt_metric.get(i, j) = make_with_value<DataType>(used_for_size, i + j);
     }
   }
-  return metric;
+  return dt_metric;
 }
 
 template <size_t SpatialDim, typename DataType>
 tnsr::i<DataType, SpatialDim> make_deriv_lapse(const DataType& used_for_size) {
-  tnsr::i<DataType, SpatialDim> deriv_lapse{};
+  auto deriv_lapse =
+      make_with_value<tnsr::i<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
     deriv_lapse.get(i) =
         make_with_value<DataType>(used_for_size, 2.5 * (i + 1.));
@@ -86,7 +92,8 @@ tnsr::i<DataType, SpatialDim> make_deriv_lapse(const DataType& used_for_size) {
 
 template <size_t SpatialDim, typename DataType>
 tnsr::iJ<DataType, SpatialDim> make_deriv_shift(const DataType& used_for_size) {
-  tnsr::iJ<DataType, SpatialDim> deriv_shift{};
+  auto deriv_shift =
+      make_with_value<tnsr::iJ<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = 0; j < SpatialDim; ++j) {
       deriv_shift.get(i, j) =
@@ -99,7 +106,8 @@ tnsr::iJ<DataType, SpatialDim> make_deriv_shift(const DataType& used_for_size) {
 template <size_t SpatialDim, typename DataType>
 tnsr::ijj<DataType, SpatialDim> make_deriv_spatial_metric(
     const DataType& used_for_size) {
-  tnsr::ijj<DataType, SpatialDim> deriv_spatial_metric{};
+  auto deriv_spatial_metric =
+      make_with_value<tnsr::ijj<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = i; j < SpatialDim; ++j) {
       for (size_t k = 0; k < SpatialDim; ++k) {
@@ -114,7 +122,8 @@ tnsr::ijj<DataType, SpatialDim> make_deriv_spatial_metric(
 template <size_t SpatialDim, typename DataType>
 tnsr::abb<DataType, SpatialDim> make_spacetime_deriv_spacetime_metric(
     const DataType& used_for_size) {
-  tnsr::abb<DataType, SpatialDim> d_spacetime_metric{};
+  auto d_spacetime_metric =
+      make_with_value<tnsr::abb<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim + 1; i++) {
     for (size_t j = i; j < SpatialDim + 1; j++) {
       for (size_t k = 0; k < SpatialDim + 1; k++) {
@@ -129,7 +138,8 @@ tnsr::abb<DataType, SpatialDim> make_spacetime_deriv_spacetime_metric(
 template <size_t SpatialDim, typename DataType>
 tnsr::iaa<DataType, SpatialDim> make_spatial_deriv_spacetime_metric(
     const DataType& used_for_size) {
-  tnsr::iaa<DataType, SpatialDim> d_spacetime_metric{};
+  auto d_spacetime_metric =
+      make_with_value<tnsr::iaa<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim + 1; i++) {
     for (size_t j = i; j < SpatialDim + 1; j++) {
       for (size_t k = 0; k < SpatialDim; k++) {
@@ -158,7 +168,8 @@ tnsr::aa<DataType, SpatialDim> make_dt_spacetime_metric(
 template <size_t SpatialDim, typename DataType>
 tnsr::Abb<DataType, SpatialDim> make_spacetime_christoffel_second_kind(
     const DataType& used_for_size) {
-  tnsr::Abb<DataType, SpatialDim> christoffel{};
+  auto christoffel =
+      make_with_value<tnsr::Abb<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim + 1; i++) {
     for (size_t j = i; j < SpatialDim + 1; j++) {
       for (size_t k = 0; k < SpatialDim + 1; k++) {
@@ -174,7 +185,8 @@ tnsr::Abb<DataType, SpatialDim> make_spacetime_christoffel_second_kind(
 template <size_t SpatialDim, typename DataType>
 tnsr::Ijj<DataType, SpatialDim> make_spatial_christoffel_second_kind(
     const DataType& used_for_size){
-  tnsr::Ijj<DataType, SpatialDim> christoffel{};
+  auto christoffel =
+      make_with_value<tnsr::Ijj<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; i++) {
     for (size_t j = i; j < SpatialDim; j++) {
       for (size_t k = 0; k < SpatialDim; k++) {
@@ -189,7 +201,8 @@ tnsr::Ijj<DataType, SpatialDim> make_spatial_christoffel_second_kind(
 template <size_t SpatialDim, typename DataType>
 tnsr::aa<DataType, SpatialDim> make_spacetime_metric(
     const DataType& used_for_size){
-  tnsr::aa<DataType, SpatialDim> spacetime_metric{};
+  auto spacetime_metric =
+      make_with_value<tnsr::aa<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t mu = 0; mu < SpatialDim + 1; ++mu) {
     for (size_t nu = mu; nu < SpatialDim + 1; ++nu) {
       spacetime_metric.get(mu, nu) =
@@ -202,7 +215,8 @@ tnsr::aa<DataType, SpatialDim> make_spacetime_metric(
 template <size_t SpatialDim, typename DataType>
 tnsr::AA<DataType, SpatialDim> make_inverse_spacetime_metric(
     const DataType& used_for_size) {
-  tnsr::AA<DataType, SpatialDim> inverse_spacetime_metric{};
+  auto inverse_spacetime_metric =
+      make_with_value<tnsr::AA<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t mu = 0; mu < SpatialDim + 1; ++mu) {
     for (size_t nu = mu; nu < SpatialDim + 1; ++nu) {
       inverse_spacetime_metric.get(mu, nu) =


### PR DESCRIPTION
## Proposed changes

Removes use of Tensor's default constructor

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


