### PR TITLE
Rename Numerical test tag to NumericalAlgorithms

### DIFF
--- a/cmake/SpectreParseTests.py
+++ b/cmake/SpectreParseTests.py
@@ -17,7 +17,7 @@ allowed_tags = [
                 "H5",
                 "IO",
                 "LinearOperators",
-                "Numerical",
+                "NumericalAlgorithms",
                 "Options",
                 "Parallel",
                 "PointwiseFunctions",

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -83,7 +83,7 @@ struct Metavariables {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
-                  "[Unit][Numerical][Actions]") {
+                  "[Unit][NumericalAlgorithms][Actions]") {
   ActionTesting::ActionRunner<Metavariables> runner{{}};
 
   const Slab slab(1., 3.);
@@ -247,7 +247,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
 
 SPECTRE_TEST_CASE(
     "Unit.DiscontinuousGalerkin.Actions.FluxCommunication.NoNeighbors",
-    "[Unit][Numerical][Actions]") {
+    "[Unit][NumericalAlgorithms][Actions]") {
   ActionTesting::ActionRunner<Metavariables> runner{{}};
 
   const Slab slab(1., 3.);

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -25,7 +25,8 @@ struct Var {
 };
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.LiftFlux", "[Unit][Numerical]") {
+SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.LiftFlux",
+                  "[Unit][NumericalAlgorithms]") {
   const size_t perpendicular_extent = 5;
 
   const CoordinateMaps::AffineMap xi_map(-1., 1., -5., 7.);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_LagrangePolynomial.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_LagrangePolynomial.cpp
@@ -8,7 +8,7 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.LagrangePolynomial",
-                  "[Unit][Numerical]") {
+                  "[Unit][NumericalAlgorithms]") {
   std::array<double, 4> control{{-1., 0., 1.5, 6.}};
 
   for (size_t i = 0; i < control.size(); ++i) {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
@@ -82,7 +82,7 @@ void test_definite_integral_3d(const Index<3>& extents) {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.DefiniteIntegral",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   const size_t min_extents = 2;
   for (size_t n0 = min_extents; n0 <= Basis::lgl::maximum_number_of_pts; ++n0) {
     test_definite_integral_1d(Index<1>(n0));

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
@@ -14,7 +14,7 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Linearize",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   // The start and end are chosen to give fast tests
   const size_t n_start = 2, n_end = 5;
   for (size_t nx = n_start; nx < n_end; ++nx) {
@@ -48,7 +48,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Linearize",
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LinearizeALinearFunction",
-                  "[Numerical][LinearOperators][Unit]"){
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   const size_t n_start = 2, n_end = 5;
   for (size_t nx = n_start; nx < n_end; ++nx) {
     const DataVector& x = Basis::lgl::collocation_points(nx);
@@ -69,7 +69,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LinearizeALinearFunction",
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LinearizeInOneDim",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   // The start and end are chosen to give fast tests
   const size_t n_start = 3, n_end = 5;
   for (size_t nx = n_start; nx < n_end; ++nx) {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
@@ -14,7 +14,7 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.MeanValue",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   for (size_t nx = 2; nx < 7; ++nx) {
     const DataVector& x = Basis::lgl::collocation_points(nx);
     for (size_t ny = 2; ny < 7; ++ny) {
@@ -36,7 +36,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.MeanValue",
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.MeanValueOnBoundary",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   for (size_t nx = 2; nx < 7; ++nx) {
     const DataVector& x = Basis::lgl::collocation_points(nx);
     for (size_t ny = 2; ny < 7; ++ny) {
@@ -96,7 +96,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.MeanValueOnBoundary",
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.MeanValueOnBoundary1D",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   for (size_t nx = 2; nx < 7; ++nx) {
     const DataVector& x = Basis::lgl::collocation_points(nx);
     const Index<1> extents(nx);

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -339,7 +339,7 @@ void test_partial_derivatives_3d(const Index<3>& extents) {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   for (size_t n0 = 2; n0 <= Basis::lgl::maximum_number_of_pts / 2; ++n0) {
     const Index<1> extents_1d(n0);
     test_logical_partial_derivatives_1d<two_vars<1>>(extents_1d);
@@ -359,7 +359,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs",
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   const size_t n0 = Basis::lgl::maximum_number_of_pts / 2;
   const size_t n1 = Basis::lgl::maximum_number_of_pts / 2 + 1;
   const size_t n2 = Basis::lgl::maximum_number_of_pts / 2 - 1;
@@ -481,7 +481,7 @@ void test_partial_derivatives_compute_item(
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs.ComputeItems",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   Index<3> max_extents{10, 10, 5};
 
   for (size_t a = 1; a < max_extents[0]; ++a) {
@@ -500,7 +500,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs.ComputeItems",
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs.ComputeItems",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   using AffineMap = CoordinateMaps::AffineMap;
   using AffineMap2d = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
   using AffineMap3d =

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
@@ -27,7 +27,7 @@ using one_var = typelist<Var1<Dim>>;
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Transpose",
-                  "[Numerical][LinearOperators][Unit]") {
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
   /// [return_transpose_example]
   const size_t chunk_size = 8;
   const size_t number_of_chunks = 2;

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_OneDRootFinder.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_OneDRootFinder.cpp
@@ -14,7 +14,7 @@ struct F {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver",
-                  "[Numerical][RootFinding][Unit]") {
+                  "[NumericalAlgorithms][RootFinding][Unit]") {
   const double abs_tol = 1e-15;
   const double rel_tol = 1e-15;
   const double upper = 2.0;
@@ -34,7 +34,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver",
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.Bounds",
-                  "[Numerical][RootFinding][Unit]") {
+                  "[NumericalAlgorithms][RootFinding][Unit]") {
   /// [double_root_find]
   const double abs_tol = 1e-15;
   const double rel_tol = 1e-15;
@@ -57,7 +57,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.Bounds",
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.DataVector",
-                  "[Numerical][RootFinding][Unit]") {
+                  "[NumericalAlgorithms][RootFinding][Unit]") {
   /// [datavector_root_find]
   const double abs_tol = 1e-15;
   const double rel_tol = 1e-15;

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
@@ -9,7 +9,7 @@
 // [[OutputRegex, Assumes that there are two real roots]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.Numerical.RootFinding.RealRoots.TwoRealRoots",
-    "[Numerical][RootFinding][Unit]") {
+    "[NumericalAlgorithms][RootFinding][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   real_roots(1.0, -3.0, 3.0);
@@ -20,7 +20,7 @@
 // [[OutputRegex, Assumes that there are two real roots]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.Numerical.RootFinding.PositiveRoot.TwoRealRoots",
-    "[Numerical][RootFinding][Unit]") {
+    "[NumericalAlgorithms][RootFinding][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   positive_root(1.0, -3.0, 3.0);
@@ -31,7 +31,7 @@
 // [[OutputRegex, Ensures violated: x0 <= 0.0 and x1 >= 0.0]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.Numerical.RootFinding.PositiveRoot.TwoPosRoots",
-    "[Numerical][RootFinding][Unit]") {
+    "[NumericalAlgorithms][RootFinding][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   positive_root(1.0, -3.0, 2.0);
@@ -40,12 +40,12 @@
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.OnePositiveRoot",
-                  "[Numerical][RootFinding][Unit]") {
+                  "[NumericalAlgorithms][RootFinding][Unit]") {
   CHECK(approx(6.31662479035539985) == positive_root(1.0, -6.0, -2.0));
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.RealRoots",
-                  "[Numerical][RootFinding][Unit]") {
+                  "[NumericalAlgorithms][RootFinding][Unit]") {
   auto roots = real_roots(2.0, -11.0, 5.0);
   CHECK(approx(0.5) == roots[0]);
   CHECK(approx(5.0) == roots[1]);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_LegendreGaussLobatto.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_LegendreGaussLobatto.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.Points",
-                  "[Numerical][Spectral][Unit]") {
+                  "[NumericalAlgorithms][Spectral][Unit]") {
   // Compare LGL points to matlab code accompanying the
   // book "Nodal Discontinuous Galerkin Methods" by Hesthaven and Warburton
   // http://www.nudg.org/
@@ -151,7 +151,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.Points",
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.DiffMatrix",
-                  "[Numerical][Spectral][Unit]") {
+                  "[NumericalAlgorithms][Spectral][Unit]") {
   // Compare differentiation matrix values to matlab code accompanying the
   // book "Nodal Discontinuous Galerkin Methods" by Hesthaven and Warburton
   // http://www.nudg.org/
@@ -317,7 +317,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.DiffMatrix",
 
 SPECTRE_TEST_CASE(
     "Unit.Numerical.Spectral.LegendreGaussLobatto.LinearFilterMatrix",
-    "[Numerical][Spectral][Unit]") {
+    "[NumericalAlgorithms][Spectral][Unit]") {
   for (size_t n = 2; n < 10; ++n) {
     const Matrix& filter_matrix = Basis::lgl::linear_filter_matrix(n);
     const Matrix& grid_points_to_spectral_matrix =
@@ -341,7 +341,7 @@ SPECTRE_TEST_CASE(
 
 SPECTRE_TEST_CASE(
     "Unit.Numerical.Spectral.LegendreGaussLobatto.InterpolationMatrix",
-    "[Numerical][Spectral][Unit]") {
+    "[NumericalAlgorithms][Spectral][Unit]") {
   auto check_interp = [](const size_t num_pts, auto func) {
     const DataVector& collocation_points =
         Basis::lgl::collocation_points(num_pts);


### PR DESCRIPTION
Fixes #434

## Proposed changes

Rename Numerical test tag to NumericalAlgorithms

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
