### PR TITLE
Datavector root finder

### DIFF
--- a/src/NumericalAlgorithms/RootFinding/RootFinder.hpp
+++ b/src/NumericalAlgorithms/RootFinding/RootFinder.hpp
@@ -6,10 +6,11 @@
 
 #pragma once
 
+#include <boost/math/tools/toms748_solve.hpp>
 #include <functional>
 #include <limits>
 
-#include <boost/math/tools/toms748_solve.hpp>
+#include "DataStructures/DataVector.hpp"
 
 /*!
  * \ingroup NumericalAlgorithmsGroup
@@ -47,4 +48,55 @@ double find_root_of_function(const Function& f, const double lower_bound,
       f, lower_bound - absolute_tolerance, upper_bound + absolute_tolerance,
       tol, max_iter);
   return result.first + 0.5 * (result.second - result.first);
+}
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Finds the root of the function `f` with the TOMS_748 method on each
+ * element in a `DataVector`.
+ *
+ * `f` is a binary invokable that takes a `double` as its first argument and a
+ * `size_t` as its second. The `double` is the current value at which to
+ * evaluate `f`, and the `size_t` is the current index into the `DataVector`s.
+ * Below is an example of how to root find different functions by indexing into
+ * a lambda-captured `DataVector` using the `size_t` passed to `f`.
+ *
+ * \snippet Test_OneDRootFinder.cpp datavector_root_find
+ *
+ * See the [Boost](http://www.boost.org/) documentation for more details.
+ *
+ * \requires Function f be callable with a `double` and a `size_t`
+ */
+template <typename Function>
+DataVector find_root_of_function(const Function& f,
+                                 const DataVector& lower_bound,
+                                 const DataVector& upper_bound,
+                                 const double absolute_tolerance,
+                                 const double relative_tolerance,
+                                 const size_t max_iterations = 100) {
+  // This solver requires tol to be passed as a termination condition. This
+  // termination condition is equivalent to the convergence criteria used by the
+  // GSL
+  auto tol = [absolute_tolerance, relative_tolerance](const double lhs,
+                                                      const double rhs) {
+    return (fabs(lhs - rhs) <=
+            absolute_tolerance +
+                relative_tolerance * fmin(fabs(lhs), fabs(rhs)));
+  };
+  // Lower and upper bound are shifted by absolute tolerance so that the root
+  // find does not fail if upper or lower bound are equal to the root within
+  // tolerance
+  DataVector result_vector{lower_bound.size()};
+  for (size_t i = 0; i < result_vector.size(); ++i) {
+    // toms748_solver modifies the max_iter after the root is found to the
+    // number of iterations that it took to find the root, so we reset it to
+    // max_iterations after each root find.
+    boost::uintmax_t max_iter = max_iterations;
+    auto result = boost::math::tools::toms748_solve(
+        [&f, i](double x) { return f(x, i); },
+        lower_bound[i] - absolute_tolerance,
+        upper_bound[i] + absolute_tolerance, tol, max_iter);
+    result_vector[i] = result.first + 0.5 * (result.second - result.first);
+  }
+  return result_vector;
 }

--- a/src/NumericalAlgorithms/RootFinding/RootFinder.hpp
+++ b/src/NumericalAlgorithms/RootFinding/RootFinder.hpp
@@ -13,12 +13,19 @@
 
 /*!
  * \ingroup NumericalAlgorithmsGroup
- * \brief Finds the root of the function f with the TOMS_748 method.
+ * \brief Finds the root of the function `f` with the TOMS_748 method.
  *
- * \requires Function f be callable
+ * `f` is a unary invokable that takes a `double` which is the current value at
+ * which to evaluate `f`. An example is below.
+ *
+ * \snippet Test_OneDRootFinder.cpp double_root_find
+ *
+ * See the [Boost](http://www.boost.org/) documentation for more details.
+ *
+ * \requires Function f is invokable with a `double`
  */
 template <typename Function>
-double find_root_of_function(Function f, const double lower_bound,
+double find_root_of_function(const Function& f, const double lower_bound,
                              const double upper_bound,
                              const double absolute_tolerance,
                              const double relative_tolerance,

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_OneDRootFinder.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_OneDRootFinder.cpp
@@ -15,17 +15,17 @@ struct F {
 
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver",
                   "[Numerical][RootFinding][Unit]") {
-  double abs_tol = 1e-15;
-  double rel_tol = 1e-15;
-  double upper = 2.0;
-  double lower = 0.0;
-  auto f_lambda = [](double x) { return 2.0 - x * x; };
-  F f_functor;
-  auto root_from_lambda =
+  const double abs_tol = 1e-15;
+  const double rel_tol = 1e-15;
+  const double upper = 2.0;
+  const double lower = 0.0;
+  const auto f_lambda = [](double x) { return 2.0 - x * x; };
+  const F f_functor{};
+  const auto root_from_lambda =
       find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);
-  auto root_from_free =
+  const auto root_from_free =
       find_root_of_function(f_free, lower, upper, abs_tol, rel_tol);
-  auto root_from_functor =
+  const auto root_from_functor =
       find_root_of_function(f_functor, lower, upper, abs_tol, rel_tol);
   CHECK(std::abs(root_from_lambda - sqrt(2)) < abs_tol);
   CHECK(std::abs(root_from_lambda - sqrt(2)) / sqrt(2) < rel_tol);
@@ -35,13 +35,16 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver",
 
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.Bounds",
                   "[Numerical][RootFinding][Unit]") {
-  double abs_tol = 1e-15;
-  double rel_tol = 1e-15;
+  /// [double_root_find]
+  const double abs_tol = 1e-15;
+  const double rel_tol = 1e-15;
   double upper = 2.0;
   double lower = sqrt(2.);
-  auto f_lambda = [](double x) { return 2.0 - x * x; };
+  const auto f_lambda = [](double x) { return 2.0 - x * x; };
 
   auto root = find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);
+  /// [double_root_find]
+
   CHECK(std::abs(root - sqrt(2)) < abs_tol);
   CHECK(std::abs(root - sqrt(2)) / sqrt(2) < rel_tol);
 

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_OneDRootFinder.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_OneDRootFinder.cpp
@@ -56,3 +56,29 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.Bounds",
   CHECK(std::abs(root - sqrt(2)) / sqrt(2) < rel_tol);
 }
 
+SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.DataVector",
+                  "[Numerical][RootFinding][Unit]") {
+  /// [datavector_root_find]
+  const double abs_tol = 1e-15;
+  const double rel_tol = 1e-15;
+  const DataVector upper{2.0, 3.0, -sqrt(2.0), -sqrt(2.0)};
+  const DataVector lower{sqrt(2.), sqrt(2.0), -2.0, -3.0};
+
+  const DataVector constant{2.0, 4.0, 2.0, 4.0};
+  const auto f_lambda = [&constant](const double x, const size_t i) noexcept {
+    return constant[i] - x * x;
+  };
+
+  const auto root =
+      find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);
+  /// [datavector_root_find]
+
+  CHECK(std::abs(root[0] - sqrt(2.0)) < abs_tol);
+  CHECK(std::abs(root[0] - sqrt(2.0)) / sqrt(2.0) < rel_tol);
+  CHECK(std::abs(root[1] - 2.0) < abs_tol);
+  CHECK(std::abs(root[1] - 2.0) / 2.0 < rel_tol);
+  CHECK(std::abs(root[2] + sqrt(2.0)) < abs_tol);
+  CHECK(std::abs(root[2] + sqrt(2.0)) / sqrt(2.0) < rel_tol);
+  CHECK(std::abs(root[3] + 2.0) < abs_tol);
+  CHECK(std::abs(root[3] + 2.0) / 2.0 < rel_tol);
+}


### PR DESCRIPTION
## Proposed changes

- Add support for element-wise root finding to DataVector
- Clean up root finding tests

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`

