### PR TITLE
Datavector hypot

### DIFF
--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -62,6 +62,7 @@ using std::abs;  // NOLINT
  * - exp2
  * - exp10
  * - fabs
+ * - hypot
  * - invsqrt
  * - log
  * - log2
@@ -425,6 +426,11 @@ class DataVector {
   SPECTRE_ALWAYS_INLINE friend decltype(auto) log10(
       const DataVector& t) noexcept {
     return log10(t.data_);
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) hypot(
+      const DataVector& x, const DataVector& y) noexcept {
+    return hypot(x.data_, y.data_);
   }
 
   SPECTRE_ALWAYS_INLINE friend decltype(auto) sin(

--- a/src/DataStructures/Tensor/IndexType.hpp
+++ b/src/DataStructures/Tensor/IndexType.hpp
@@ -7,10 +7,14 @@
 #pragma once
 
 #include <ostream>
+#include <type_traits>
 
 #include "Utilities/Literals.hpp"
-#include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits.hpp"
+
+namespace brigand {
+template <class...>
+struct list;
+}  // namespace brigand
 
 /// \ingroup TensorGroup
 /// Whether a \ref SpacetimeIndex "TensorIndexType" is covariant or
@@ -53,7 +57,7 @@ struct NoFrame {};
 template <typename CheckFrame>
 using is_frame_physical =
     std::integral_constant<bool,
-                           cpp17::is_base_of_v<FrameIsPhysical, CheckFrame>>;
+                           std::is_base_of<FrameIsPhysical, CheckFrame>::value>;
 
 /// \ingroup TensorGroup
 /// Returns true if the frame is "physical" in the sense that it is
@@ -192,4 +196,4 @@ using change_index_up_lo = Tensor_detail::TensorIndexType<
     Index::index_type>;
 
 template <typename... Ts>
-using index_list = typelist<Ts...>;
+using index_list = brigand::list<Ts...>;

--- a/src/Domain/CoordinateMaps/AffineMap.hpp
+++ b/src/Domain/CoordinateMaps/AffineMap.hpp
@@ -11,6 +11,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Parallel/CharmPupable.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 namespace CoordinateMaps {
 

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -295,6 +295,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   check_vectors(DataVector(num_pts, log10(9.0)), log10(nine));
 
   DataVector point_nine(num_pts, 0.9);
+  check_vectors(DataVector(num_pts, hypot(0.9, 9.0)), hypot(point_nine, nine));
+  check_vectors(DataVector(num_pts, hypot(0.9, 9.0)),
+                hypot(point_nine, one * nine));
+  check_vectors(DataVector(num_pts, hypot(0.9, 9.0)),
+                hypot(one * point_nine, nine));
+  check_vectors(DataVector(num_pts, hypot(0.9, 9.0)),
+                hypot(one * point_nine, one * nine));
+
   check_vectors(DataVector(num_pts, sin(9.0)), sin(nine));
   check_vectors(DataVector(num_pts, cos(9.0)), cos(nine));
   check_vectors(DataVector(num_pts, tan(9.0)), tan(nine));


### PR DESCRIPTION
## Proposed changes

- Add support for `hypot(x, y)` for DataVector
- Simplify included header files in `IndexType.hpp` to simplify `TypeAliases.hpp`

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
