### PR TITLE
Add make_vector_coordinate_map_base

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -404,7 +404,7 @@ bool operator!=(
 }
 
 /// \ingroup ComputationalDomainGroup
-/// \brief Creates a CoordinateMap of `maps...`
+/// \brief Creates a `CoordinateMap` of `maps...`
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 constexpr CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>
 make_coordinate_map(Maps&&... maps) {
@@ -413,7 +413,7 @@ make_coordinate_map(Maps&&... maps) {
 }
 
 /// \ingroup ComputationalDomainGroup
-/// \brief Creates a std::unique_ptr<CoordinateMapBase> of `maps...`
+/// \brief Creates a `std::unique_ptr<CoordinateMapBase>` of `maps...`
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 std::unique_ptr<CoordinateMapBase<
     SourceFrame, TargetFrame,
@@ -422,6 +422,30 @@ make_coordinate_map_base(Maps&&... maps) noexcept {
   return std::make_unique<
       CoordinateMap<SourceFrame, TargetFrame, std::decay_t<Maps>...>>(
       std::forward<Maps>(maps)...);
+}
+
+/// \ingroup ComputationalDomainGroup
+/// \brief Creates a `std::vector<std::unique_ptr<CoordinateMapBase>>`
+/// containing the result of `make_coordinate_map_base` applied to each
+/// argument passed in.
+template <typename SourceFrame, typename TargetFrame, typename Arg0,
+          typename... Args>
+std::vector<std::unique_ptr<
+    CoordinateMapBase<SourceFrame, TargetFrame, std::decay_t<Arg0>::dim>>>
+make_vector_coordinate_map_base(Arg0&& arg_0,
+                                Args&&... remaining_args) noexcept {
+  std::vector<std::unique_ptr<
+      CoordinateMapBase<SourceFrame, TargetFrame, std::decay_t<Arg0>::dim>>>
+      return_vector;
+  return_vector.reserve(sizeof...(Args) + 1);
+  return_vector.emplace_back(make_coordinate_map_base<SourceFrame, TargetFrame>(
+      std::forward<Arg0>(arg_0)));
+  (void)std::initializer_list<int>{
+      (((void)return_vector.emplace_back(
+           make_coordinate_map_base<SourceFrame, TargetFrame>(
+               std::forward<Args>(remaining_args)))),
+       0)...};
+  return return_vector;
 }
 
 /// \cond

--- a/src/Utilities/MakeVector.hpp
+++ b/src/Utilities/MakeVector.hpp
@@ -17,13 +17,13 @@
  * \example
  * \snippet Utilities/Test_MakeVector.cpp make_vector_example
  */
-template <class ValueType = void, class Arg1, class... Args>
-auto make_vector(Arg1&& arg_1, Args&&... remaining_args) {
+template <class ValueType = void, class Arg0, class... Args>
+auto make_vector(Arg0&& arg_0, Args&&... remaining_args) {
   std::vector<
-      std::conditional_t<cpp17::is_same_v<ValueType, void>, Arg1, ValueType>>
+      std::conditional_t<cpp17::is_same_v<ValueType, void>, Arg0, ValueType>>
       return_vector;
   return_vector.reserve(sizeof...(Args) + 1);
-  return_vector.emplace_back(std::forward<Arg1>(arg_1));
+  return_vector.emplace_back(std::forward<Arg0>(arg_0));
   (void)std::initializer_list<int>{
       (((void)return_vector.emplace_back(std::forward<Args>(remaining_args))),
        0)...};

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -532,6 +532,48 @@ void test_coordinate_map_with_rotation_wedge() {
       compose_inv_jacobians(first_map, second_map, test_point_array);
   CHECK_ITERABLE_APPROX(inv_jac, expected_inv_jac);
 }
+
+void test_make_vector_coordinate_map_base() {
+  using AffineMap = CoordinateMaps::AffineMap;
+
+  const auto affine1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
+      AffineMap{-1.0, 1.0, 2.0, 8.0});
+  const auto affine1d_base =
+      make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+          AffineMap{-1.0, 1.0, 2.0, 8.0});
+  const auto vector_of_affine1d =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Grid>(
+          AffineMap{-1.0, 1.0, 2.0, 8.0});
+
+  CHECK(affine1d == *affine1d_base);
+  CHECK(*affine1d_base == affine1d);
+  CHECK(affine1d == *(vector_of_affine1d[0]));
+  CHECK(*(vector_of_affine1d[0]) == affine1d);
+
+  using Wedge2DMap = CoordinateMaps::Wedge2D;
+  const auto vector_of_wedges =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{1.0, 2.0, Direction<2>::upper_xi(), true},
+          Wedge2DMap{1.0, 2.0, Direction<2>::upper_eta(), true},
+          Wedge2DMap{1.0, 2.0, Direction<2>::lower_xi(), true},
+          Wedge2DMap{1.0, 2.0, Direction<2>::lower_eta(), true});
+  const auto upper_xi_wedge =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{1.0, 2.0, Direction<2>::upper_xi(), true});
+  const auto upper_eta_wedge =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{1.0, 2.0, Direction<2>::upper_eta(), true});
+  const auto lower_xi_wedge =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{1.0, 2.0, Direction<2>::lower_xi(), true});
+  const auto lower_eta_wedge =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{1.0, 2.0, Direction<2>::lower_eta(), true});
+  CHECK(upper_xi_wedge == *(vector_of_wedges[0]));
+  CHECK(upper_eta_wedge == *(vector_of_wedges[1]));
+  CHECK(lower_xi_wedge == *(vector_of_wedges[2]));
+  CHECK(lower_eta_wedge == *(vector_of_wedges[3]));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMap", "[Domain][Unit]") {
@@ -540,4 +582,5 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMap", "[Domain][Unit]") {
   test_coordinate_map_with_rotation_map();
   test_coordinate_map_with_rotation_map_datavector();
   test_coordinate_map_with_rotation_wedge();
+  test_make_vector_coordinate_map_base();
 }


### PR DESCRIPTION
## Proposed changes

A `make_vector` for maps that applies make_coordinate_map_base to each map. 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
