### PR TITLE
Precompiled Headers

### DIFF
--- a/.travis/RunClangTidy.sh
+++ b/.travis/RunClangTidy.sh
@@ -61,6 +61,7 @@ done
 
 if [ -f "${CLANG_TIDY_OUTPUT}" ]; then
     sed -i'.bak' "s^warning: /usr/bin/clang++: 'linker' input unused.*^^g" ${CLANG_TIDY_OUTPUT}
+    sed -i'.bak' "s^warning: ccache: 'linker' input unused.*^^g" ${CLANG_TIDY_OUTPUT}
 fi
 
 if [ -f "${CLANG_TIDY_OUTPUT}" ] \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ include(SetupLIBXSMM)
 include(SetupPapi)
 include(SetupYamlCpp)
 
+# The precompiled header must be setup after all libraries have been found
+include(SetupPch)
+
 # Generate Charm++ files
 generate_algorithms(${CMAKE_BINARY_DIR}/src/Parallel/Algorithms)
 

--- a/cmake/SetupCCache.cmake
+++ b/cmake/SetupCCache.cmake
@@ -5,8 +5,9 @@ option(USE_CCACHE "Use CCache if available of speed up builds" OFF)
 if(USE_CCACHE)
   find_program(CCACHE_FOUND ccache)
   if(CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    # CCache offers no benefit for linking
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE
+      "CCACHE_SLOPPINESS=pch_defines,time_macros ccache")
     message(STATUS "Using ccache for compilation")
   else()
     message(STATUS "Could not find ccache")

--- a/cmake/SetupClangTidy.cmake
+++ b/cmake/SetupClangTidy.cmake
@@ -38,6 +38,7 @@ if (CLANG_TIDY_BIN)
     module_ConstGlobalCache
     module_Main
     module_Test_ConstGlobalCache
+    pch
     )
   configure_file(
     ${CMAKE_SOURCE_DIR}/tools/ClangTidyAll.sh

--- a/cmake/SetupPch.cmake
+++ b/cmake/SetupPch.cmake
@@ -1,0 +1,132 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+option(
+  USE_PCH
+  "Use precompiled headers for STL, Blaze, and Brigand"
+  ON
+  )
+
+function(is_implicit_include_directory INCLUDE_DIR)
+  set(FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES OFF PARENT_SCOPE)
+  foreach(DIR ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+    if("${INCLUDE_DIR}" STREQUAL "${DIR}")
+      set(FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES ON PARENT_SCOPE)
+    endif()
+  endforeach()
+endfunction()
+
+if (USE_PCH)
+  # We store the header to precompile in ${CMAKE_SOURCE_DIR}/tools so
+  # that it cannot accidentally be included incorrectly anywhere since
+  # ${CMAKE_SOURCE_DIR}/tools is not in the include list.
+  # We copy it to the build directory and include it from there because
+  # GCC's precompiled headers require the hpp and the precompiled header
+  # be in the same directory.
+  set(PCH_PATH "${CMAKE_BINARY_DIR}/SpectrePch.hpp")
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/tools/SpectrePch.hpp
+    ${CMAKE_BINARY_DIR}/SpectrePch.hpp
+    )
+
+  # The compiler flags need to be turned into a CMake list
+  if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    string(REPLACE " " ";" PCH_COMPILE_FLAGS
+      "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}"
+      )
+  elseif("${CMAKE_BUILD_TYPE}" STREQUAL "None")
+    string(REPLACE " " ";" PCH_COMPILE_FLAGS "${CMAKE_CXX_FLAGS}")
+  else()
+    string(REPLACE " " ";" PCH_COMPILE_FLAGS
+      "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}"
+      )
+  endif()
+
+  is_implicit_include_directory(${BLAZE_INCLUDE_DIR})
+  if(NOT ${FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES})
+    set(BLAZE_INCLUDE_ARGUMENT "-isystem${BLAZE_INCLUDE_DIR}")
+  else()
+    set(BLAZE_INCLUDE_ARGUMENT "")
+  endif()
+
+  is_implicit_include_directory(${BRIGAND_INCLUDE_DIR})
+  if(NOT ${FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES})
+    set(BRIGAND_INCLUDE_ARGUMENT "-isystem${BRIGAND_INCLUDE_DIR}")
+  else()
+    set(BRIGAND_INCLUDE_ARGUMENT "")
+  endif()
+
+  is_implicit_include_directory(${CHARM_INCLUDE_DIRS})
+  if(NOT ${FOUND_IN_IMPLICIT_INCLUDE_DIRECTORIES})
+    set(CHARM_INCLUDE_ARGUMENT "-isystem${CHARM_INCLUDE_DIRS}")
+  else()
+    set(CHARM_INCLUDE_ARGUMENT "")
+  endif()
+
+  add_custom_command(
+    OUTPUT ${PCH_PATH}.gch
+    COMMAND ${CMAKE_CXX_COMPILER}
+    ARGS
+    -std=c++14
+    ${PCH_COMPILE_FLAGS}
+    -I${CMAKE_SOURCE_DIR}/src
+    ${BLAZE_INCLUDE_ARGUMENT}
+    ${BRIGAND_INCLUDE_ARGUMENT}
+    ${CHARM_INCLUDE_ARGUMENT}
+    ${PCH_PATH}
+    -o ${PCH_PATH}.gch
+    DEPENDS
+    ${CMAKE_SOURCE_DIR}/src/ErrorHandling/Assert.hpp
+    ${CMAKE_SOURCE_DIR}/src/Utilities/Blaze.hpp
+    ${CMAKE_SOURCE_DIR}/src/Utilities/PointerVector.hpp
+    ${CMAKE_SOURCE_DIR}/src/Utilities/TMPL.hpp
+    ${PCH_PATH}
+    )
+
+  add_custom_target(
+    pch
+    DEPENDS
+    ${PCH_PATH}
+    ${PCH_PATH}.gch
+    )
+
+  # Prepend the compiler-dependent flags needed to use precompiled headers
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "-include ${PCH_PATH} ${CMAKE_CXX_FLAGS}")
+  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "-include-pch ${PCH_PATH}.gch ${CMAKE_CXX_FLAGS}")
+  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+    set(CMAKE_CXX_FLAGS "-include-pch ${PCH_PATH}.gch ${CMAKE_CXX_FLAGS}")
+  else()
+    message(
+      STATUS "Precompiled headers have not been configured for"
+      " the compiler: ${CMAKE_CXX_COMPILER_ID}"
+      )
+  endif()
+
+  # Override the default add_library and add_executable function provided
+  # by CMake so that it adds the precompiled header as a dependency to
+  # all of them.
+  #
+  # In addition to the library/executable depending on the precompiled header,
+  # all source files (technically the objects generated from them) must also
+  # depend on the precompiled header.
+  function(add_library TARGET_NAME)
+    _add_library(${TARGET_NAME} ${ARGN})
+    add_dependencies(${TARGET_NAME} pch)
+    set_source_files_properties(
+      ${ARGN}
+      OBJECT_DEPENDS "${PCH_PATH};${PCH_PATH}.gch"
+      )
+  endfunction()
+
+  function(add_executable TARGET_NAME)
+    _add_executable(${TARGET_NAME} ${ARGN})
+    add_dependencies(${TARGET_NAME} pch)
+    set_source_files_properties(
+      ${ARGN}
+      OBJECT_DEPENDS "${PCH_PATH};${PCH_PATH}.gch"
+      )
+  endfunction()
+
+endif (USE_PCH)

--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -9,6 +9,7 @@
 #include <cmath>
 
 // The Utilities/Blaze.hpp configures Blaze
+#include "ErrorHandling/Assert.hpp"
 #include "Utilities/Blaze.hpp"
 
 #include <blaze/math/CustomVector.h>

--- a/tests/Unit/Utilities/Test_BoostHelpers.cpp
+++ b/tests/Unit/Utilities/Test_BoostHelpers.cpp
@@ -2,13 +2,7 @@
 // See LICENSE.txt for details.
 
 #include "Utilities/BoostHelpers.hpp"
-
-/// \cond
-namespace {
-template <typename...>
-struct typelist {};
-}  // namespace
-/// \endcond
+#include "Utilities/TMPL.hpp"
 
 static_assert(
     cpp17::is_same_v<boost::variant<double, int, char>,

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -285,7 +285,10 @@ standard_checks+=(ls_list)
 
 # Check for pragma once in all header files
 pragma_once() {
-    is_hpp "$1" && ! grep -q -x '#pragma once' "$1"
+    is_hpp "$1" && \
+        whitelist "$1" \
+                  'tools/SpectrePch.hpp$' && \
+        ! grep -q -x '#pragma once' "$1"
 }
 pragma_once_report() {
     echo "Did not find '#pragma once' in these header files:"

--- a/tools/SpectrePch.hpp
+++ b/tools/SpectrePch.hpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#ifndef SPECTRE_PCH_HPP
+#define SPECTRE_PCH_HPP
+
+// Include STL headers
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <ostream>
+#include <utility>
+#include <vector>
+
+// Include PointerVector.hpp since this is what we use to wrap Blaze
+#include <@CMAKE_SOURCE_DIR@/src/Utilities/PointerVector.hpp>
+#include <blaze/math/typetraits/IsVector.h>
+
+// Include Brigand related headers
+#include <@CMAKE_SOURCE_DIR@/src/Utilities/TMPL.hpp>
+
+#endif  // SPECTRE_PCH_HPP


### PR DESCRIPTION
## Proposed changes

Use precompiled header for STL, Blaze, and Brigand to reduce compile times

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
