### PR TITLE
Template DomainCreators on the target Frame

### DIFF
--- a/src/Domain/DomainCreators/Brick.hpp
+++ b/src/Domain/DomainCreators/Brick.hpp
@@ -13,7 +13,8 @@ namespace DomainCreators {
 
 /// \ingroup DomainCreatorsGroup
 /// Create a 3D Domain consisting of a single Block.
-class Brick : public DomainCreator<3, Frame::Inertial> {
+template <typename TargetFrame>
+class Brick : public DomainCreator<3, TargetFrame> {
  public:
   struct LowerBound {
     using type = std::array<double, 3>;
@@ -63,7 +64,7 @@ class Brick : public DomainCreator<3, Frame::Inertial> {
   Brick& operator=(Brick&&) noexcept = default;
   ~Brick() noexcept override = default;
 
-  Domain<3, Frame::Inertial> create_domain() const noexcept override;
+  Domain<3, TargetFrame> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 3>> initial_extents() const noexcept override;
 

--- a/src/Domain/DomainCreators/DomainCreator.hpp
+++ b/src/Domain/DomainCreators/DomainCreator.hpp
@@ -24,8 +24,11 @@ class Domain;
 
 /// Defines classes that create Domains.
 namespace DomainCreators {
+template <typename TargetFrame>
 class Brick;
+template <typename TargetFrame>
 class Interval;
+template <typename TargetFrame>
 class Rectangle;
 }  // namespace DomainCreators
 
@@ -35,15 +38,18 @@ struct domain_creators;
 
 template <>
 struct domain_creators<1> {
-  using type = typelist<DomainCreators::Interval>;
+  template <typename Frame>
+  using creators = typelist<DomainCreators::Interval<Frame>>;
 };
 template <>
 struct domain_creators<2> {
-  using type = typelist<DomainCreators::Rectangle>;
+  template <typename Frame>
+  using creators = typelist<DomainCreators::Rectangle<Frame>>;
 };
 template <>
 struct domain_creators<3> {
-  using type = typelist<DomainCreators::Brick>;
+  template <typename Frame>
+  using creators = typelist<DomainCreators::Brick<Frame>>;
 };
 }  // namespace DomainCreators_detail
 
@@ -51,8 +57,8 @@ struct domain_creators<3> {
 template <size_t VolumeDim, typename TargetFrame>
 class DomainCreator {
  public:
-  using creatable_classes =
-      typename DomainCreators_detail::domain_creators<VolumeDim>::type;
+  using creatable_classes = typename DomainCreators_detail::domain_creators<
+      VolumeDim>::template creators<TargetFrame>;
 
   DomainCreator() = default;
   DomainCreator(const DomainCreator<VolumeDim, TargetFrame>&) = delete;

--- a/src/Domain/DomainCreators/DomainCreator.hpp
+++ b/src/Domain/DomainCreators/DomainCreator.hpp
@@ -25,16 +25,8 @@ class Domain;
 /// Defines classes that create Domains.
 namespace DomainCreators {
 class Brick;
-// class Disk;
 class Interval;
 class Rectangle;
-// class RotatedBricks;
-// class RotatedIntervals;
-// class RotatedRectangles;
-// class RubiksCubeWithHole;
-// class Shell;
-// class Sphere;
-// class UnevenBricks;
 }  // namespace DomainCreators
 
 namespace DomainCreators_detail {
@@ -43,26 +35,15 @@ struct domain_creators;
 
 template <>
 struct domain_creators<1> {
-  using type = typelist<DomainCreators::Interval
-                        //, DomainCreators::RotatedIntervals
-                        >;
+  using type = typelist<DomainCreators::Interval>;
 };
 template <>
 struct domain_creators<2> {
-  using type =
-      typelist<DomainCreators::Rectangle  //, DomainCreators::Disk,
-                                          // DomainCreators::RotatedRectangles
-               >;
+  using type = typelist<DomainCreators::Rectangle>;
 };
 template <>
 struct domain_creators<3> {
-  using type = typelist<
-      DomainCreators::Brick  //, DomainCreators::RubiksCubeWithHole,
-                             //                DomainCreators::Shell,
-                             //                DomainCreators::Sphere,
-                             //                DomainCreators::RotatedBricks,
-                             //                DomainCreators::UnevenBricks
-      >;
+  using type = typelist<DomainCreators::Brick>;
 };
 }  // namespace DomainCreators_detail
 
@@ -94,13 +75,5 @@ class DomainCreator {
 };
 
 #include "Domain/DomainCreators/Brick.hpp"
-// #include "Domain/DomainCreators/Disk.hpp"
 #include "Domain/DomainCreators/Interval.hpp"
 #include "Domain/DomainCreators/Rectangle.hpp"
-// #include "Domain/DomainCreators/RotatedBricks.hpp"
-// #include "Domain/DomainCreators/RotatedIntervals.hpp"
-// #include "Domain/DomainCreators/RotatedRectangles.hpp"
-// #include "Domain/DomainCreators/RubiksCubeWithHole.hpp"
-// #include "Domain/DomainCreators/Shell.hpp"
-// #include "Domain/DomainCreators/Sphere.hpp"
-// #include "Domain/DomainCreators/UnevenBricks.hpp"

--- a/src/Domain/DomainCreators/Interval.cpp
+++ b/src/Domain/DomainCreators/Interval.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <vector>
 
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/AffineMap.hpp"
@@ -16,7 +17,8 @@
 
 namespace DomainCreators {
 
-Interval::Interval(
+template <typename TargetFrame>
+Interval<TargetFrame>::Interval(
     typename LowerBound::type lower_x, typename UpperBound::type upper_x,
     typename IsPeriodicIn::type is_periodic_in_x,
     typename InitialRefinement::type initial_refinement_level_x,
@@ -31,24 +33,28 @@ Interval::Interval(
       initial_number_of_grid_points_in_x_(                   // NOLINT
           std::move(initial_number_of_grid_points_in_x)) {}  // NOLINT
 
-Domain<1, Frame::Inertial> Interval::create_domain() const noexcept {
-  return Domain<1, Frame::Inertial>{
-      make_vector<std::unique_ptr<
-          CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>(
-          std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         CoordinateMaps::AffineMap>>(
-              CoordinateMaps::AffineMap{-1., 1., lower_x_[0], upper_x_[0]})),
+template <typename TargetFrame>
+Domain<1, TargetFrame> Interval<TargetFrame>::create_domain() const noexcept {
+  return Domain<1, TargetFrame>{
+      make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
+          CoordinateMaps::AffineMap{-1., 1., lower_x_[0], upper_x_[0]}),
       std::vector<std::array<size_t, 2>>{{{1, 2}}},
       is_periodic_in_x_[0] ? std::vector<PairOfFaces>{{{1}, {2}}}
                            : std::vector<PairOfFaces>{}};
 }
 
-std::vector<std::array<size_t, 1>> Interval::initial_extents() const noexcept {
+template <typename TargetFrame>
+std::vector<std::array<size_t, 1>> Interval<TargetFrame>::initial_extents()
+    const noexcept {
   return {{{initial_number_of_grid_points_in_x_}}};
 }
 
-std::vector<std::array<size_t, 1>> Interval::initial_refinement_levels() const
-    noexcept {
+template <typename TargetFrame>
+std::vector<std::array<size_t, 1>>
+Interval<TargetFrame>::initial_refinement_levels() const noexcept {
   return {{{initial_refinement_level_x_}}};
 }
 }  // namespace DomainCreators
+
+template class DomainCreators::Interval<Frame::Inertial>;
+template class DomainCreators::Interval<Frame::Grid>;

--- a/src/Domain/DomainCreators/Interval.hpp
+++ b/src/Domain/DomainCreators/Interval.hpp
@@ -13,7 +13,8 @@ namespace DomainCreators {
 
 /// \ingroup DomainCreatorsGroup
 /// Create a 1D Domain consisting of a single Block.
-class Interval : public DomainCreator<1, Frame::Inertial> {
+template <typename TargetFrame>
+class Interval : public DomainCreator<1, TargetFrame> {
  public:
   struct LowerBound {
     using type = std::array<double, 1>;
@@ -59,7 +60,7 @@ class Interval : public DomainCreator<1, Frame::Inertial> {
   Interval& operator=(Interval&&) noexcept = default;
   ~Interval() override = default;
 
-  Domain<1, Frame::Inertial> create_domain() const noexcept override;
+  Domain<1, TargetFrame> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 1>> initial_extents() const noexcept override;
 

--- a/src/Domain/DomainCreators/Rectangle.hpp
+++ b/src/Domain/DomainCreators/Rectangle.hpp
@@ -13,7 +13,8 @@ namespace DomainCreators {
 
 /// \ingroup DomainCreatorsGroup
 /// Create a 2D Domain consisting of a single Block.
-class Rectangle : public DomainCreator<2, Frame::Inertial> {
+template <typename TargetFrame>
+class Rectangle : public DomainCreator<2, TargetFrame> {
  public:
   struct LowerBound {
     using type = std::array<double, 2>;
@@ -63,7 +64,7 @@ class Rectangle : public DomainCreator<2, Frame::Inertial> {
   Rectangle& operator=(Rectangle&&) noexcept = default;
   ~Rectangle() noexcept override = default;
 
-  Domain<2, Frame::Inertial> create_domain() const noexcept override;
+  Domain<2, TargetFrame> create_domain() const noexcept override;
 
   std::vector<std::array<size_t, 2>> initial_extents() const noexcept override;
 

--- a/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
@@ -19,7 +19,7 @@ using AffineMap = CoordinateMaps::AffineMap;
 using AffineMap3D =
     CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
 void test_brick_construction(
-    const DomainCreators::Brick& brick,
+    const DomainCreators::Brick<Frame::Inertial>& brick,
     const std::array<double, 3>& lower_bound,
     const std::array<double, 3>& upper_bound,
     const std::vector<std::array<size_t, 3>>& expected_extents,
@@ -56,9 +56,9 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   // Default OrientationMap is aligned.
   const OrientationMap<3> aligned_orientation{};
 
-  const DomainCreators::Brick brick{lower_bound, upper_bound,
-                                    std::array<bool, 3>{{false, false, false}},
-                                    refinement_level[0], grid_points[0]};
+  const DomainCreators::Brick<Frame::Inertial> brick{
+      lower_bound, upper_bound, std::array<bool, 3>{{false, false, false}},
+      refinement_level[0], grid_points[0]};
   test_brick_construction(
       brick, lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{{}},
@@ -70,7 +70,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
            {Direction<3>::lower_zeta()},
            {Direction<3>::upper_zeta()}}});
 
-  const DomainCreators::Brick periodic_x_brick{
+  const DomainCreators::Brick<Frame::Inertial> periodic_x_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, false, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -84,7 +84,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
            {Direction<3>::lower_zeta()},
            {Direction<3>::upper_zeta()}}});
 
-  const DomainCreators::Brick periodic_y_brick{
+  const DomainCreators::Brick<Frame::Inertial> periodic_y_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, true, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -98,7 +98,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
            {Direction<3>::lower_zeta()},
            {Direction<3>::upper_zeta()}}});
 
-  const DomainCreators::Brick periodic_z_brick{
+  const DomainCreators::Brick<Frame::Inertial> periodic_z_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, false, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -112,7 +112,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
            {Direction<3>::lower_eta()},
            {Direction<3>::upper_eta()}}});
 
-  const DomainCreators::Brick periodic_xy_brick{
+  const DomainCreators::Brick<Frame::Inertial> periodic_xy_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, true, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -126,7 +126,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
       std::vector<std::unordered_set<Direction<3>>>{
           {{Direction<3>::lower_zeta()}, {Direction<3>::upper_zeta()}}});
 
-  const DomainCreators::Brick periodic_yz_brick{
+  const DomainCreators::Brick<Frame::Inertial> periodic_yz_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, true, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -142,7 +142,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
           {Direction<3>::upper_xi()},
       }});
 
-  const DomainCreators::Brick periodic_xz_brick{
+  const DomainCreators::Brick<Frame::Inertial> periodic_xz_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, false, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -156,7 +156,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
       std::vector<std::unordered_set<Direction<3>>>{
           {{Direction<3>::lower_eta()}, {Direction<3>::upper_eta()}}});
 
-  const DomainCreators::Brick periodic_xyz_brick{
+  const DomainCreators::Brick<Frame::Inertial> periodic_xyz_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, true, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -198,7 +198,8 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick.Factory",
           "    InitialGridPoints: [3,4,3]\n"
           "    InitialRefinement: [2,3,2]\n");
   const auto* brick_creator =
-      dynamic_cast<const DomainCreators::Brick*>(domain_creator.get());
+      dynamic_cast<const DomainCreators::Brick<Frame::Inertial>*>(
+          domain_creator.get());
   test_brick_construction(
       *brick_creator, {{0., 0., 0.}}, {{1., 2., 3.}}, {{{3, 4, 3}}},
       {{{2, 3, 2}}},

--- a/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
@@ -15,7 +15,7 @@
 
 namespace {
 void test_interval_construction(
-    const DomainCreators::Interval& interval,
+    const DomainCreators::Interval<Frame::Inertial>& interval,
     const std::array<double, 1>& lower_bound,
     const std::array<double, 1>& upper_bound,
     const std::vector<std::array<size_t, 1>>& expected_extents,
@@ -48,16 +48,16 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval", "[Domain][Unit]") {
   // default Orientation is aligned
   const OrientationMap<1> aligned_orientation{};
 
-  const DomainCreators::Interval interval{lower_bound, upper_bound,
-                                          std::array<bool, 1>{{false}},
-                                          refinement_level[0], grid_points[0]};
+  const DomainCreators::Interval<Frame::Inertial> interval{
+      lower_bound, upper_bound, std::array<bool, 1>{{false}},
+      refinement_level[0], grid_points[0]};
   test_interval_construction(
       interval, lower_bound, upper_bound, grid_points, refinement_level,
       std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{{}},
       std::vector<std::unordered_set<Direction<1>>>{
           {{Direction<1>::lower_xi()}, {Direction<1>::upper_xi()}}});
 
-  const DomainCreators::Interval periodic_interval{
+  const DomainCreators::Interval<Frame::Inertial> periodic_interval{
       lower_bound, upper_bound, std::array<bool, 1>{{true}},
       refinement_level[0], grid_points[0]};
   test_interval_construction(
@@ -94,7 +94,8 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval.Factory",
           "    InitialGridPoints: [3]\n"
           "    InitialRefinement: [2]\n");
   const auto* interval_creator =
-      dynamic_cast<const DomainCreators::Interval*>(domain_creator.get());
+      dynamic_cast<const DomainCreators::Interval<Frame::Inertial>*>(
+          domain_creator.get());
   test_interval_construction(
       *interval_creator, {{0.}}, {{1.}}, {{{3}}}, {{{2}}},
       std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{

--- a/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
@@ -18,7 +18,7 @@ namespace {
 using AffineMap = CoordinateMaps::AffineMap;
 using AffineMap2D = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
 void test_rectangle_construction(
-    const DomainCreators::Rectangle& rectangle,
+    const DomainCreators::Rectangle<Frame::Inertial>& rectangle,
     const std::array<double, 2>& lower_bound,
     const std::array<double, 2>& upper_bound,
     const std::vector<std::array<size_t, 2>>& expected_extents,
@@ -52,7 +52,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
   // default OrientationMap is aligned
   const OrientationMap<2> aligned_orientation{};
 
-  const DomainCreators::Rectangle rectangle{
+  const DomainCreators::Rectangle<Frame::Inertial> rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{false, false}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -64,7 +64,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
            {Direction<2>::lower_eta()},
            {Direction<2>::upper_eta()}}});
 
-  const DomainCreators::Rectangle periodic_x_rectangle{
+  const DomainCreators::Rectangle<Frame::Inertial> periodic_x_rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{true, false}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -76,7 +76,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
       std::vector<std::unordered_set<Direction<2>>>{
           {{Direction<2>::lower_eta()}, {Direction<2>::upper_eta()}}});
 
-  const DomainCreators::Rectangle periodic_y_rectangle{
+  const DomainCreators::Rectangle<Frame::Inertial> periodic_y_rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{false, true}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -88,7 +88,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
       std::vector<std::unordered_set<Direction<2>>>{
           {{Direction<2>::lower_xi()}, {Direction<2>::upper_xi()}}});
 
-  const DomainCreators::Rectangle periodic_xy_rectangle{
+  const DomainCreators::Rectangle<Frame::Inertial> periodic_xy_rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{true, true}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -129,7 +129,8 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle.Factory",
           "    InitialGridPoints: [3,4]\n"
           "    InitialRefinement: [2,3]\n");
   const auto* rectangle_creator =
-      dynamic_cast<const DomainCreators::Rectangle*>(domain_creator.get());
+      dynamic_cast<const DomainCreators::Rectangle<Frame::Inertial>*>(
+          domain_creator.get());
   test_rectangle_construction(
       *rectangle_creator, {{0., 0.}}, {{1., 2.}}, {{{3, 4}}}, {{{2, 3}}},
       std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{


### PR DESCRIPTION
## Proposed changes

We need to be able to deal with dual and single frame evolutions. One possible solution is to template DomainCreators on the target Frame. The target Frame will then be either Grid (dual frames) or Inertial (single frame).

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`

