### PR TITLE
Stop deleting stack objects in H5 tests

### DIFF
--- a/src/IO/H5/File.cpp
+++ b/src/IO/H5/File.cpp
@@ -74,13 +74,9 @@ H5File<Access_t>& H5File<Access_t>::operator=(H5File&& rhs) noexcept {
 
 template <AccessType Access_t>
 H5File<Access_t>::~H5File() {
-  current_object_ = nullptr;
   if (file_id_ != -1) {
     CHECK_H5(H5Fclose(file_id_),
              "Failed to close file: '" << file_name_ << "'");
-    // Allows destructor to be run manually in tests without relying on HDF5
-    // implementation
-    file_id_ = -1;
   }
 }
 /// \endcond


### PR DESCRIPTION
They contain STL objects, which get deleted a second time when the
object goes out of scope.  This causes memory corruption.

### Types of changes:

- [X] Bugfix
- [ ] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
