### PR TITLE
Generalize grid normal to work on ElementMap

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -17,7 +17,7 @@ set(LIBRARY_SOURCES
     ElementId.cpp
     ElementIndex.cpp
     ElementMap.cpp
-    GridNormal.cpp
+    FaceNormal.cpp
     InitialElementIds.cpp
     LogicalCoordinates.cpp
     Neighbors.cpp

--- a/src/Domain/ElementMap.cpp
+++ b/src/Domain/ElementMap.cpp
@@ -62,4 +62,8 @@ void ElementMap<Dim, TargetFrame>::pup(PUP::er& p) noexcept {
 template class ElementMap<1, Frame::Inertial>;
 template class ElementMap<2, Frame::Inertial>;
 template class ElementMap<3, Frame::Inertial>;
+// For dual frame evolutions the ElementMap only goes to the grid frame
+template class ElementMap<1, Frame::Grid>;
+template class ElementMap<2, Frame::Grid>;
+template class ElementMap<3, Frame::Grid>;
 /// \endcond

--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -26,6 +26,8 @@
 template <size_t Dim, typename TargetFrame>
 class ElementMap {
  public:
+  static constexpr size_t dim = Dim;
+
   /// \cond HIDDEN_SYMBOLS
   ElementMap() = default;
   /// \endcond

--- a/src/Domain/FaceNormal.cpp
+++ b/src/Domain/FaceNormal.cpp
@@ -11,7 +11,7 @@
 #include "Domain/LogicalCoordinates.hpp"
 
 template <size_t VolumeDim>
-tnsr::i<DataVector, VolumeDim, Frame::Grid> unnormalized_grid_normal(
+tnsr::i<DataVector, VolumeDim, Frame::Grid> unnormalized_face_normal(
     const Index<VolumeDim - 1>& interface_extents,
     const CoordinateMapBase<Frame::Logical, Frame::Grid, VolumeDim>& map,
     const Direction<VolumeDim>& direction) noexcept {
@@ -22,27 +22,27 @@ tnsr::i<DataVector, VolumeDim, Frame::Grid> unnormalized_grid_normal(
   const auto sliced_away_dim = direction.dimension();
   const double sign = direction.sign();
 
-  tnsr::i<DataVector, VolumeDim, Frame::Grid> grid_normal(
+  tnsr::i<DataVector, VolumeDim, Frame::Grid> face_normal(
       interface_extents.product());
 
   for (size_t d = 0; d < VolumeDim; ++d) {
-    grid_normal.get(d) =
+    face_normal.get(d) =
         sign * inv_jacobian_on_interface.get(sliced_away_dim, d);
   }
-  return grid_normal;
+  return face_normal;
 }
 
-template tnsr::i<DataVector, 1, Frame::Grid> unnormalized_grid_normal(
+template tnsr::i<DataVector, 1, Frame::Grid> unnormalized_face_normal(
     const Index<0>& interface_extents,
     const CoordinateMapBase<Frame::Logical, Frame::Grid, 1>& map,
     const Direction<1>& direction) noexcept;
 
-template tnsr::i<DataVector, 2, Frame::Grid> unnormalized_grid_normal(
+template tnsr::i<DataVector, 2, Frame::Grid> unnormalized_face_normal(
     const Index<1>& interface_extents,
     const CoordinateMapBase<Frame::Logical, Frame::Grid, 2>& map,
     const Direction<2>& direction) noexcept;
 
-template tnsr::i<DataVector, 3, Frame::Grid> unnormalized_grid_normal(
+template tnsr::i<DataVector, 3, Frame::Grid> unnormalized_face_normal(
     const Index<2>& interface_extents,
     const CoordinateMapBase<Frame::Logical, Frame::Grid, 3>& map,
     const Direction<3>& direction) noexcept;

--- a/src/Domain/FaceNormal.cpp
+++ b/src/Domain/FaceNormal.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Domain/GridNormal.hpp"
+#include "Domain/FaceNormal.hpp"
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -28,7 +28,7 @@ class Index;
  * with the given map.
  *
  * \example
- * \snippet Test_GridNormal.cpp grid_normal_example
+ * \snippet Test_FaceNormal.cpp grid_normal_example
  */
 template <size_t VolumeDim>
 tnsr::i<DataVector, VolumeDim, Frame::Grid> unnormalized_grid_normal(

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Declares function unnormalized_grid_normal
+/// Declares function unnormalized_face_normal
 
 #pragma once
 
@@ -28,10 +28,10 @@ class Index;
  * with the given map.
  *
  * \example
- * \snippet Test_FaceNormal.cpp grid_normal_example
+ * \snippet Test_FaceNormal.cpp face_normal_example
  */
 template <size_t VolumeDim>
-tnsr::i<DataVector, VolumeDim, Frame::Grid> unnormalized_grid_normal(
+tnsr::i<DataVector, VolumeDim, Frame::Grid> unnormalized_face_normal(
     const Index<VolumeDim - 1>& interface_extents,
     const CoordinateMapBase<Frame::Logical, Frame::Grid, VolumeDim>& map,
     const Direction<VolumeDim>& direction) noexcept;

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -13,9 +13,12 @@ class CoordinateMapBase;
 class DataVector;
 template <size_t>
 class Direction;
+template <size_t Dim, typename Frame>
+class ElementMap;
 template <size_t>
 class Index;
 
+// @{
 /*!
  * \ingroup ComputationalDomainGroup
  * \brief Compute the outward grid normal on a face of an Element
@@ -30,8 +33,15 @@ class Index;
  * \example
  * \snippet Test_FaceNormal.cpp face_normal_example
  */
-template <size_t VolumeDim>
-tnsr::i<DataVector, VolumeDim, Frame::Grid> unnormalized_face_normal(
+template <size_t VolumeDim, typename TargetFrame>
+tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
     const Index<VolumeDim - 1>& interface_extents,
-    const CoordinateMapBase<Frame::Logical, Frame::Grid, VolumeDim>& map,
+    const ElementMap<VolumeDim, TargetFrame>& map,
     const Direction<VolumeDim>& direction) noexcept;
+
+template <size_t VolumeDim, typename TargetFrame>
+tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
+    const Index<VolumeDim - 1>& interface_extents,
+    const CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>& map,
+    const Direction<VolumeDim>& direction) noexcept;
+// @}

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -14,7 +14,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"
-#include "Domain/GridNormal.hpp"
+#include "Domain/FaceNormal.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 
 class DataVector;

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -88,7 +88,7 @@ struct InverseJacobian : db::ComputeItemTag, db::DataBoxPrefix {
 
 namespace detail {
 template <size_t VolumeDim>
-auto make_unnormalized_grid_normals(
+auto make_unnormalized_face_normals(
     const Index<VolumeDim>& extents,
     const std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid,
                                             VolumeDim>>& map) noexcept {
@@ -96,7 +96,7 @@ auto make_unnormalized_grid_normals(
                      tnsr::i<DataVector, VolumeDim, Frame::Grid>>
       result;
   for (const auto& d : Direction<VolumeDim>::all_directions()) {
-    result.emplace(d, unnormalized_grid_normal(
+    result.emplace(d, unnormalized_face_normal(
                           extents.slice_away(d.dimension()), *map, d));
   }
   return result;
@@ -107,10 +107,10 @@ auto make_unnormalized_grid_normals(
 /// \ingroup ComputationalDomainGroup
 /// The unnormalized grid normal one form on each side
 template <size_t VolumeDim>
-struct UnnormalizedGridNormal : db::ComputeItemTag {
-  static constexpr db::DataBoxString label = "UnnormalizedGridNormal";
+struct UnnormalizedFaceNormal : db::ComputeItemTag {
+  static constexpr db::DataBoxString label = "UnnormalizedFaceNormal";
   static constexpr auto function =
-      detail::make_unnormalized_grid_normals<VolumeDim>;
+      detail::make_unnormalized_face_normals<VolumeDim>;
   using argument_tags = tmpl::list<Extents<VolumeDim>, ElementMap<VolumeDim>>;
 };
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp
@@ -35,8 +35,8 @@ template <typename Tags>
 Variables<Tags> lift_flux(const Variables<Tags>& local_flux,
                           Variables<Tags> numerical_flux,
                           const size_t extent_perpendicular_to_boundary,
-                          DataVector magnitude_of_grid_normal) noexcept {
-  auto& lift_factor = magnitude_of_grid_normal;
+                          DataVector magnitude_of_face_normal) noexcept {
+  auto& lift_factor = magnitude_of_face_normal;
   lift_factor *= -0.5 * (extent_perpendicular_to_boundary *
                          (extent_perpendicular_to_boundary - 1));
 

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -25,7 +25,7 @@ set(DOMAIN_TESTS
     Domain/Test_ElementId.cpp
     Domain/Test_ElementIndex.cpp
     Domain/Test_ElementMap.cpp
-    Domain/Test_GridNormal.cpp
+    Domain/Test_FaceNormal.cpp
     Domain/Test_InitialElementIds.cpp
     Domain/Test_LogicalCoordinates.cpp
     Domain/Test_Neighbors.cpp

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -11,7 +11,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/Direction.hpp"
-#include "Domain/GridNormal.hpp"
+#include "Domain/FaceNormal.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -21,9 +21,9 @@ void check(const Map& map,
            const std::array<std::array<double, Map::dim>, Map::dim>& expected) {
   const Index<Map::dim - 1> extents(3);
   for (size_t d = 0; d < Map::dim; ++d) {
-    const auto upper_normal = unnormalized_grid_normal(
+    const auto upper_normal = unnormalized_face_normal(
         extents, map, Direction<Map::dim>(d, Side::Upper));
-    const auto lower_normal = unnormalized_grid_normal(
+    const auto lower_normal = unnormalized_face_normal(
         extents, map, Direction<Map::dim>(d, Side::Lower));
     for (size_t i = 0; i < 2; ++i) {
       CHECK_ITERABLE_APPROX(upper_normal.get(i),
@@ -37,19 +37,19 @@ void check(const Map& map,
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.GridNormal", "[Unit][Domain]") {
-  /// [grid_normal_example]
+SPECTRE_TEST_CASE("Unit.Domain.FaceNormal", "[Unit][Domain]") {
+  /// [face_normal_example]
   const Index<0> extents_0d;
   const auto map_1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
       CoordinateMaps::AffineMap(-1.0, 1.0, -3.0, 7.0));
   const auto normal_1d_lower =
-      unnormalized_grid_normal(extents_0d, map_1d, Direction<1>::lower_xi());
-  /// [grid_normal_example]
+      unnormalized_face_normal(extents_0d, map_1d, Direction<1>::lower_xi());
+  /// [face_normal_example]
 
   CHECK(normal_1d_lower.get(0) == DataVector(1, -0.2));
 
   const auto normal_1d_upper =
-      unnormalized_grid_normal(extents_0d, map_1d, Direction<1>::upper_xi());
+      unnormalized_face_normal(extents_0d, map_1d, Direction<1>::upper_xi());
 
   CHECK(normal_1d_upper.get(0) == DataVector(1, 0.2));
 

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -11,6 +11,8 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementMap.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -37,7 +39,7 @@ void check(const Map& map,
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.FaceNormal", "[Unit][Domain]") {
+SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.CoordMap", "[Unit][Domain]") {
   /// [face_normal_example]
   const Index<0> extents_0d;
   const auto map_1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
@@ -62,4 +64,43 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal", "[Unit][Domain]") {
                                            CoordinateMaps::Rotation<2>>(
                 {-1., 1., 2., 7.}, CoordinateMaps::Rotation<2>(atan2(4., 3.)))),
         {{{{0.4, 0., 0.}}, {{0., 0.6, 0.8}}, {{0., -0.8, 0.6}}}});
+}
+
+namespace {
+template <typename TargetFrame>
+void test_face_normal_element_map() {
+  const Index<0> extents_0d;
+  const auto map_1d = ElementMap<1, TargetFrame>(
+      ElementId<1>{0}, make_coordinate_map_base<Frame::Logical, TargetFrame>(
+                           CoordinateMaps::AffineMap(-1.0, 1.0, -3.0, 7.0)));
+  const auto normal_1d_lower =
+      unnormalized_face_normal(extents_0d, map_1d, Direction<1>::lower_xi());
+
+  CHECK(normal_1d_lower.get(0) == DataVector(1, -0.2));
+
+  const auto normal_1d_upper =
+      unnormalized_face_normal(extents_0d, map_1d, Direction<1>::upper_xi());
+
+  CHECK(normal_1d_upper.get(0) == DataVector(1, 0.2));
+
+  check(ElementMap<2, TargetFrame>(
+            ElementId<2>(0),
+            make_coordinate_map_base<Frame::Logical, TargetFrame>(
+                CoordinateMaps::Rotation<2>(atan2(4., 3.)))),
+        {{{{0.6, 0.8}}, {{-0.8, 0.6}}}});
+
+  check(ElementMap<3, TargetFrame>(
+            ElementId<3>(0),
+            make_coordinate_map_base<Frame::Logical, TargetFrame>(
+                CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
+                                               CoordinateMaps::Rotation<2>>(
+                    {-1., 1., 2., 7.},
+                    CoordinateMaps::Rotation<2>(atan2(4., 3.))))),
+        {{{{0.4, 0., 0.}}, {{0., 0.6, 0.8}}, {{0., -0.8, 0.6}}}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ElementMap", "[Unit][Domain]") {
+  test_face_normal_element_map<Frame::Inertial>();
+  test_face_normal_element_map<Frame::Grid>();
 }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -132,7 +132,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
     return db::create<db::AddTags<Tags::TimeId, Tags::Extents<2>,
                                   Tags::Element<2>, Tags::ElementMap<2>,
                                   System::variables_tag>,
-                      db::AddComputeItemsTags<Tags::UnnormalizedGridNormal<2>>>(
+                      db::AddComputeItemsTags<Tags::UnnormalizedFaceNormal<2>>>(
         time_id, extents, element, std::move(map), std::move(variables));
   }();
 
@@ -270,7 +270,7 @@ SPECTRE_TEST_CASE(
       db::create<db::AddTags<Tags::TimeId, Tags::Extents<2>,
                              Tags::Element<2>, Tags::ElementMap<2>,
                              System::variables_tag>,
-                 db::AddComputeItemsTags<Tags::UnnormalizedGridNormal<2>>>(
+                 db::AddComputeItemsTags<Tags::UnnormalizedFaceNormal<2>>>(
       time_id, extents, element, std::move(map), std::move(variables));
 
   auto sent_box =

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -41,8 +41,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.LiftFlux",
   const double weight = Basis::lgl::quadrature_weights(perpendicular_extent)[0];
 
   const Index<1> boundary_extents{{{3}}};
-  const DataVector magnitude_of_grid_normal =
-      magnitude(unnormalized_grid_normal(boundary_extents, coordinate_map,
+  const DataVector magnitude_of_face_normal =
+      magnitude(unnormalized_face_normal(boundary_extents, coordinate_map,
                                          Direction<2>::lower_eta()));
 
   Variables<tmpl::list<Var>> local_flux(boundary_extents.product());
@@ -54,6 +54,6 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.LiftFlux",
       -2. / (element_length * weight) * (numerical_flux - local_flux);
 
   CHECK(dg::lift_flux(local_flux, numerical_flux, perpendicular_extent,
-                      magnitude_of_grid_normal) ==
+                      magnitude_of_face_normal) ==
         expected);
 }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -13,7 +13,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
-#include "Domain/GridNormal.hpp"
+#include "Domain/FaceNormal.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp"
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
 #include "Utilities/TMPL.hpp"


### PR DESCRIPTION
## Proposed changes

- Rename grid normal to face normal to avoid confusion about what Frame it's in. I've separated this out into two commits, the first renames just the files, the second renames the functions. I did this to make the diffs easy to understand. I'm happy to squash them together after things are approved, but I figured this would be easiest to review.
- Enable passing ElementMap to face normal function
- Instantiate ElementMap in Frame::Grid as well as Frame::Inertial
- Add `static constexpr size_t dim` to ElementMap so that its interface is identical to CoordinateMapBase


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
