### PR TITLE
Length whitelists

### DIFF
--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -15,8 +15,7 @@
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementIndex.hpp"
 #include "Domain/Tags.hpp"
-#include \
-  "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -131,10 +131,13 @@ standard_checks=()
 
 # Check for lines longer than 80 characters
 long_lines() {
-    is_c++ "$1" && grep -q '^[^#].\{80,\}' "$1"
+    is_c++ "$1" && grep '^[^#].\{80,\}' "$1" | grep -Evq 'https?://'
 }
 long_lines_report() {
     echo "Found lines over 80 characters:"
+    # This doesn't filter out URLs, but I can't think of a way to do
+    # that without breaking the highlighting.  They only get printed
+    # if there's another problem in the file.
     pretty_grep '^[^#].\{80,\}' "$@"
 }
 long_lines_test() {
@@ -144,6 +147,8 @@ long_lines_test() {
     test_check fail foo.cpp "${eighty}x"$'\n'
     test_check pass foo.yaml "${eighty}x"$'\n'
     test_check pass foo.cpp "#include ${eighty}x"$'\n'
+    test_check pass foo.cpp "xxx http://${eighty}x"$'\n'
+    test_check pass foo.cpp "xxx https://${eighty}x"$'\n'
 }
 standard_checks+=(long_lines)
 

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -131,11 +131,11 @@ standard_checks=()
 
 # Check for lines longer than 80 characters
 long_lines() {
-    is_c++ "$1" && grep -q '.\{81,\}' "$1"
+    is_c++ "$1" && grep -q '^[^#].\{80,\}' "$1"
 }
 long_lines_report() {
     echo "Found lines over 80 characters:"
-    pretty_grep '.\{81,\}' "$@"
+    pretty_grep '^[^#].\{80,\}' "$@"
 }
 long_lines_test() {
     local ten=xxxxxxxxxx
@@ -143,6 +143,7 @@ long_lines_test() {
     test_check pass foo.cpp "${eighty}"$'\n'
     test_check fail foo.cpp "${eighty}x"$'\n'
     test_check pass foo.yaml "${eighty}x"$'\n'
+    test_check pass foo.cpp "#include ${eighty}x"$'\n'
 }
 standard_checks+=(long_lines)
 


### PR DESCRIPTION
## Proposed changes

Exclude preprocessor directives and URLs from line length restrictions.

### Types of changes:

- [X] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
