### PR TITLE
Add get_element and get_size

### DIFF
--- a/src/Utilities/ContainerHelpers.hpp
+++ b/src/Utilities/ContainerHelpers.hpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Requires.hpp"
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Returns the `i`th element if `T` has a subscript operator, otherwise
+ * if `T` is fundamental returns `t`.
+ */
+template <class T>
+SPECTRE_ALWAYS_INLINE auto get_element(T& t, const size_t i) noexcept
+    -> decltype(t[i]) {
+  return t[i];
+}
+
+/// \cond
+template <class T, Requires<std::is_fundamental<T>::value> = nullptr>
+SPECTRE_ALWAYS_INLINE T& get_element(T& t, size_t /*i*/) noexcept {
+  return t;
+}
+/// \endcond
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Retrieve the size of `t` if `t.size()` is a valid expression,
+ * otherwise if `T` is fundamental returns 1
+ */
+template <class T>
+SPECTRE_ALWAYS_INLINE auto get_size(const T& t) noexcept -> decltype(t.size()) {
+  return t.size();
+}
+
+/// \cond
+template <class T, Requires<std::is_fundamental<T>::value> = nullptr>
+SPECTRE_ALWAYS_INLINE size_t get_size(const T& /*t*/) noexcept {
+  return 1;
+}
+/// \endcond

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -6,6 +6,7 @@ set(UTILITIES_TESTS
     Utilities/Test_BoostHelpers.cpp
     Utilities/Test_CachedFunction.cpp
     Utilities/Test_ConstantExpressions.cpp
+    Utilities/Test_ContainerHelpers.cpp
     Utilities/Test_Deferred.cpp
     Utilities/Test_DereferenceWrapper.cpp
     Utilities/Test_EqualWithinRoundoff.cpp

--- a/tests/Unit/Utilities/Test_ContainerHelpers.cpp
+++ b/tests/Unit/Utilities/Test_ContainerHelpers.cpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.ContainerHelpers", "[Unit][Utilities]") {
+  const std::vector<double> a{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+  const double b = 10.0;
+  const DataVector c(10, 2.0);
+  std::vector<double> a2{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+  double b2 = 10.0;
+  DataVector c2(10, 2.0);
+  REQUIRE(get_size(a) == 10);
+  REQUIRE(get_size(b) == 1);
+  REQUIRE(get_size(c) == 10);
+  REQUIRE(get_size(a2) == 10);
+  REQUIRE(get_size(b2) == 1);
+  REQUIRE(get_size(c2) == 10);
+  for (size_t i = 0; i < a.size(); ++i) {
+    get_element(a2, i) = get_element(a, i) * 2.0;
+    get_element(b2, i) = get_element(b, i) * 2.0;
+    get_element(c2, i) = get_element(c, i) * 2.0;
+    CHECK(get_element(a, i) == static_cast<double>(i));
+    CHECK(get_element(b, i) == 10.0);
+    CHECK(get_element(c, i) == 2.0);
+    CHECK(get_element(a2, i) == 2.0 * static_cast<double>(i));
+    CHECK(get_element(b2, i) == 20.0);
+    CHECK(get_element(c2, i) == 4.0);
+  }
+}


### PR DESCRIPTION
## Proposed Changes:

These functions are useful in generic code where one may be dealing
with either a indexable container or a fundamental type.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
