### PR TITLE
Use unit normal in flux calculation

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -134,6 +134,15 @@ struct ComputeBoundaryFlux {
 
       const auto& face_normal =
           db::get<Tags::UnnormalizedFaceNormal<volume_dim>>(box).at(direction);
+
+      DataVector magnitude_of_face_normal = magnitude(face_normal);
+
+      std::decay_t<decltype(face_normal)> unit_face_normal(
+          magnitude_of_face_normal.size(), 0.0);
+      for (size_t d = 0; d < volume_dim; ++d) {
+        unit_face_normal.get(d) = face_normal.get(d) / magnitude_of_face_normal;
+      }
+
       // Using this instead of auto prevents incomprehensible errors
       // if the return type of compute_flux is wrong.
       using FluxType = db::item_type<db::add_tag_prefix<
@@ -150,7 +159,7 @@ struct ComputeBoundaryFlux {
           local_boundary_flux.number_of_grid_points(), 0.);
       tmpl::for_each<typename variables_tag::tags_list>([
         &local_normal_flux, &neighbor_normal_flux, &local_boundary_flux,
-        &neighbor_boundary_flux, &face_normal
+        &neighbor_boundary_flux, &unit_face_normal
       ](auto tag) noexcept {
         using Tag = tmpl::type_from<decltype(tag)>;
         using flux_tag = Tags::Flux<Tag, tmpl::size_t<2>, Frame::Grid>;
@@ -167,9 +176,10 @@ struct ComputeBoundaryFlux {
           const auto other_indices =
               all_but_specified_element_of<0>(flux_index);
           local_nf.get(other_indices) +=
-              face_normal.get(contract_index) * local_bf.get(flux_index);
+              unit_face_normal.get(contract_index) * local_bf.get(flux_index);
           neighbor_nf.get(other_indices) +=
-              face_normal.get(contract_index) * neighbor_bf.get(flux_index);
+              unit_face_normal.get(contract_index) *
+              neighbor_bf.get(flux_index);
         }
       });
 
@@ -183,7 +193,6 @@ struct ComputeBoundaryFlux {
           typename std::decay_t<decltype(flux_computer)>::argument_tags{});
 
       // Needs fixing for GH/curved
-      DataVector magnitude_of_face_normal = magnitude(face_normal);
       const auto lifted_data = dg::lift_flux(
           tuples::get<normal_flux_tag>(self_data),
           std::move(numerical_flux),

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -232,12 +232,38 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
   const double eta_lift = -6./(eta_map(std::array<double, 1>{{1.}}) -
                                eta_map(std::array<double, 1>{{-1.}}))[0];
 
-  const DataVector xi_boundaries{0., 0., 105150.,
-                                 0., 0., 120300.,
-                                 0., 0., 135450.};
-  const DataVector eta_boundaries{0., 0., 0.,
-                                  0., 0., 0.,
-                                  221400./3., 241600./3., 261800./3.};
+  const DataVector xi_boundaries{
+      0.,
+      0.,
+      105150. /
+          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::lower_xi()))[0],
+      0.,
+      0.,
+      120300. /
+          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::lower_xi()))[1],
+      0.,
+      0.,
+      135450. /
+          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::lower_xi()))[2]};
+  const DataVector eta_boundaries{
+      0.,
+      0.,
+      0.,
+      0.,
+      0.,
+      0.,
+      221400. / 3. /
+          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::upper_eta()))[0],
+      241600. / 3. /
+          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::upper_eta()))[1],
+      261800. / 3. /
+          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::upper_eta()))[2]};
 
   CHECK_ITERABLE_APPROX(
       get<Tags::dt<Var>>(db::get<System::dt_variables_tag>(received_box)).get(),


### PR DESCRIPTION
## Proposed changes

Use the unit normal in the flux calculation

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
