### PR TITLE
TaggedTuple: work around bug in older clang versions

### DIFF
--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -418,39 +418,6 @@ class TaggedTuple : private tuples_detail::TaggedTupleLeaf<Tags>... {  // NOLINT
    * \example
    * \snippet Test_TaggedTuple.cpp construction_example
    */
-  template <
-      bool Dummy = true,
-      typename std::enable_if<args_constructor<Dummy>::template enable_explicit<
-          tag_type<Tags> const&...>()>::type* = nullptr>
-  constexpr explicit TaggedTuple(tag_type<Tags> const&... ts) noexcept(
-      tuples_detail::all<std::is_nothrow_copy_constructible<
-          tuples_detail::TaggedTupleLeaf<Tags>>::value...>::value)
-      : tuples_detail::TaggedTupleLeaf<Tags>(ts)... {}
-
-  /*!
-   * \brief Construct a TaggedTuple with Args
-   * \requires `std::is_convertible_v<Us, typename Tags::type>...` is `true`
-   *
-   * \example
-   * \snippet Test_TaggedTuple.cpp construction_example
-   */
-  template <
-      bool Dummy = true,
-      typename std::enable_if<args_constructor<Dummy>::template enable_implicit<
-          tag_type<Tags> const&...>()>::type* = nullptr>
-  // clang-tidy: mark explicit
-  constexpr TaggedTuple(tag_type<Tags> const&... ts) noexcept(  // NOLINT
-      tuples_detail::all<std::is_nothrow_copy_constructible<
-          tuples_detail::TaggedTupleLeaf<Tags>>::value...>::value)
-      : tuples_detail::TaggedTupleLeaf<Tags>(ts)... {}
-
-  /*!
-   * \brief Construct a TaggedTuple with Args
-   * \requires `std::is_convertible_v<Us, typename Tags::type>...` is `true`
-   *
-   * \example
-   * \snippet Test_TaggedTuple.cpp construction_example
-   */
   template <class... Us,
             typename std::enable_if<
                 args_constructor<not pack_is_TaggedTuple<Us...>::value and
@@ -857,4 +824,3 @@ std::ostream& operator<<(std::ostream& os, const TaggedTuple<Tags...>& t) {
 }
 
 }  // namespace tuples
-

--- a/tests/Unit/Utilities/Test_TaggedTuple.cpp
+++ b/tests/Unit/Utilities/Test_TaggedTuple.cpp
@@ -1,7 +1,9 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <memory>
 #include <sstream>
+#include <vector>
 
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -895,6 +897,27 @@ SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple.swap", "[Unit][Utilities]") {
     static_assert(not noexcept(tuples::swap(t0, t1)),
                   "Failed testing Unit.Utilities.TaggedTuple.swap");
   }
+}
+
+namespace tags {
+struct NonCopyable0 {
+  using type = std::vector<std::unique_ptr<int>>;
+};
+struct NonCopyable1 {
+  using type = std::vector<std::unique_ptr<int>>;
+};
+}  // namespace tags
+
+SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple.NonCopyable",
+                  "[Unit][Utilities]") {
+  std::vector<std::unique_ptr<int>> a{};
+  a.reserve(2);
+  a.emplace_back(std::make_unique<int>(1));
+  a.emplace_back(std::make_unique<int>(3));
+  tuples::TaggedTuple<tags::NonCopyable0, tags::NonCopyable1> t(
+      std::move(a), tags::NonCopyable1::type{});
+  CHECK(*tuples::get<tags::NonCopyable0>(t)[0] == 1);
+  CHECK(*tuples::get<tags::NonCopyable0>(t)[1] == 3);
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Clang seems to be confused about when it should be
selecting the forwarding constructor (almost always), so we have to
removed the const& constructors (which is fine since they can bind to
forwarding references.)

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
