### PR TITLE
Add MathFunctions::TensorProduct

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -130,6 +130,9 @@
  * \brief Functions and classes for manipulating HDF5 files
  */
 
+/// \defgroup MathFunctionsGroup Math Functions
+/// \brief Useful analytic functions
+
 /*!
  * \defgroup NumericalAlgorithmsGroup Numerical Algorithms
  * \brief Generic numerical algorithms

--- a/src/PointwiseFunctions/MathFunctions/CMakeLists.txt
+++ b/src/PointwiseFunctions/MathFunctions/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Gaussian.cpp
   PowX.cpp
   Sinusoid.cpp
+  TensorProduct.cpp
   )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
@@ -12,7 +12,7 @@
 namespace MathFunctions {
 
 /*!
- *  \ingroup MathFunctions
+ *  \ingroup MathFunctionsGroup
  *  \brief Gaussian \f$f = A \exp\left(-\frac{(x-x_0)^2}{w^2}\right)\f$.
  *
  *  \details Input file options are: Amplitude, Width, and Center

--- a/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
+++ b/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Parallel/CharmPupable.hpp"
 
+/// \ingroup MathFunctionsGroup
 /// Holds classes implementing MathFunction (functions \f$R^n \to R\f$).
 namespace MathFunctions {
 class Gaussian;
@@ -19,14 +20,14 @@ class Sinusoid;
 }  // namespace MathFunctions
 
 /*!
- *  \ingroup MathFunctions
+ *  \ingroup MathFunctionsGroup
  *  Encodes a function \f$R^n \to R\f$ where n is `VolumeDim`.
  */
 template <size_t VolumeDim>
 class MathFunction;
 
 /*!
- * \ingroup MathFunctions
+ * \ingroup MathFunctionsGroup
  * Partial template specialization of MathFunction which encodes a
  * function \f$R \to R\f$.
  */

--- a/src/PointwiseFunctions/MathFunctions/PowX.hpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.hpp
@@ -12,7 +12,7 @@
 namespace MathFunctions {
 
 /*!
- * \ingroup MathFunctions
+ * \ingroup MathFunctionsGroup
  * \brief Power of X \f$f(x)=x^X\f$
  */
 class PowX : public MathFunction<1> {

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
@@ -12,7 +12,7 @@
 namespace MathFunctions {
 
 /*!
- *  \ingroup MathFunctions
+ *  \ingroup MathFunctionsGroup
  *  \brief Sinusoid \f$f = A \sin\left(k x + \delta \right)\f$.
  *
  *  \details Input file options are: Amplitude, Phase, and Wavenumber

--- a/src/PointwiseFunctions/MathFunctions/TensorProduct.cpp
+++ b/src/PointwiseFunctions/MathFunctions/TensorProduct.cpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/MathFunctions/TensorProduct.hpp"
+
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace MathFunctions {
+
+template <size_t Dim>
+TensorProduct<Dim>::TensorProduct(
+    double scale, std::array<std::unique_ptr<MathFunction<1>>, Dim>&& functions)
+    : scale_(scale), functions_(std::move(functions)) {}
+
+template <size_t Dim>
+template <typename T>
+Scalar<T> TensorProduct<Dim>::operator()(const tnsr::I<T, Dim>& x) const
+    noexcept {
+  auto result = make_with_value<Scalar<T>>(x, scale_);
+  for (size_t d = 0; d < Dim; ++d) {
+    result.get() *= gsl::at(functions_, d)->operator()(x.get(d));
+  }
+  return result;
+}
+
+template <size_t Dim>
+template <typename T>
+tnsr::i<T, Dim> TensorProduct<Dim>::first_derivatives(
+    const tnsr::I<T, Dim>& x) const noexcept {
+  auto result = make_with_value<tnsr::i<T, Dim>>(x, scale_);
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t d = 0; d < Dim; ++d) {
+      if (i == d) {
+        result.get(i) *= gsl::at(functions_, d)->first_deriv(x.get(d));
+      } else {
+        result.get(i) *= gsl::at(functions_, d)->operator()(x.get(d));
+      }
+    }
+  }
+  return result;
+}
+
+template <size_t Dim>
+template <typename T>
+tnsr::ii<T, Dim> TensorProduct<Dim>::second_derivatives(
+    const tnsr::I<T, Dim>& x) const noexcept {
+  auto result = make_with_value<tnsr::ii<T, Dim>>(x, scale_);
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t d = 0; d < Dim; ++d) {
+      if (i == d) {
+        result.get(i, i) *= gsl::at(functions_, d)->second_deriv(x.get(d));
+      } else {
+        result.get(i, i) *= gsl::at(functions_, d)->operator()(x.get(d));
+      }
+    }
+    for (size_t j = i + 1; j < Dim; ++j) {
+      for (size_t d = 0; d < Dim; ++d) {
+        if (i == d or j == d) {
+          result.get(i, j) *= gsl::at(functions_, d)->first_deriv(x.get(d));
+        } else {
+          result.get(i, j) *= gsl::at(functions_, d)->operator()(x.get(d));
+        }
+      }
+    }
+  }
+  return result;
+}
+
+}  // namespace MathFunctions
+
+/// \cond
+template class MathFunctions::TensorProduct<1>;
+template class MathFunctions::TensorProduct<2>;
+template class MathFunctions::TensorProduct<3>;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                             \
+  template Scalar<DTYPE(data)> MathFunctions::TensorProduct<DIM(data)>:: \
+  operator()(const tnsr::I<DTYPE(data), DIM(data)>& x) const noexcept;   \
+  template tnsr::i<DTYPE(data), DIM(data)>                               \
+  MathFunctions::TensorProduct<DIM(data)>::first_derivatives(            \
+      const tnsr::I<DTYPE(data), DIM(data)>& x) const noexcept;          \
+  template tnsr::ii<DTYPE(data), DIM(data)>                              \
+  MathFunctions::TensorProduct<DIM(data)>::second_derivatives(           \
+      const tnsr::I<DTYPE(data), DIM(data)>& x) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))
+
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/MathFunctions/TensorProduct.hpp
+++ b/src/PointwiseFunctions/MathFunctions/TensorProduct.hpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines a tensor product of one-dimensional MathFunctions
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+template <size_t Dim>
+class MathFunction;
+
+namespace MathFunctions {
+
+/// \ingroup MathFunctionsGroup
+/// \brief a tensor product of one-dimensional MathFunctions
+template <size_t Dim>
+class TensorProduct {
+ public:
+  TensorProduct(double scale,
+                std::array<std::unique_ptr<MathFunction<1>>, Dim>&& functions);
+
+  TensorProduct(const TensorProduct&) = delete;
+  TensorProduct(TensorProduct&&) = default;
+  TensorProduct& operator=(const TensorProduct&) = delete;
+  TensorProduct& operator=(TensorProduct&&) = default;
+  ~TensorProduct() = default;
+
+  /// The value of the function
+  template <typename T>
+  Scalar<T> operator()(const tnsr::I<T, Dim>& x) const noexcept;
+
+  /// The partial derivatives of the function
+  template <typename T>
+  tnsr::i<T, Dim> first_derivatives(const tnsr::I<T, Dim>& x) const noexcept;
+
+  /// The second partial derivatives of the function
+  template <typename T>
+  tnsr::ii<T, Dim> second_derivatives(const tnsr::I<T, Dim>& x) const noexcept;
+
+ private:
+  double scale_{1.0};
+  std::array<std::unique_ptr<MathFunction<1>>, Dim> functions_;
+};
+}  // namespace MathFunctions

--- a/tests/Unit/PointwiseFunctions/MathFunctions/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SPECTRE_UNIT_MATH_FUNCTIONS
   PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
   PointwiseFunctions/MathFunctions/Test_PowX.cpp
   PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
+  PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
   )
 
 set(SPECTRE_UNIT_POINTWISE_FUNCTIONS

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -1,0 +1,231 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <catch.hpp>
+#include <memory>
+#include <utility>
+
+#include "DataStructures/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/MakeWithValue.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"
+#include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
+#include "PointwiseFunctions/MathFunctions/TensorProduct.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+using AffineMap = CoordinateMaps::AffineMap;
+using AffineMap2D = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+using AffineMap3D =
+    CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+
+template <size_t VolumeDim>
+auto make_affine_map() noexcept;
+
+template <>
+auto make_affine_map<1>() noexcept {
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      AffineMap{-1.0, 1.0, -0.3, 0.7});
+}
+
+template <>
+auto make_affine_map<2>() noexcept {
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(AffineMap2D{
+      AffineMap{-1.0, 1.0, -0.3, 0.7}, AffineMap{-1.0, 1.0, 0.3, 0.55}});
+}
+
+template <>
+auto make_affine_map<3>() noexcept {
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(AffineMap3D{
+      AffineMap{-1.0, 1.0, -0.3, 0.7}, AffineMap{-1.0, 1.0, 0.3, 0.55},
+      AffineMap{-1.0, 1.0, 2.3, 2.8}});
+}
+
+template <typename T, size_t VolumeDim>
+Scalar<T> expected_value(const tnsr::I<T, VolumeDim>& x,
+                         const std::array<size_t, VolumeDim>& powers,
+                         const double scale) noexcept {
+  auto result = make_with_value<Scalar<T>>(x, scale);
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    result.get() *= pow(x.get(d), gsl::at(powers, d));
+  }
+  return result;
+}
+
+template <typename T, size_t VolumeDim>
+tnsr::i<T, VolumeDim> expected_first_derivs(
+    const tnsr::I<T, VolumeDim>& x, const std::array<size_t, VolumeDim>& powers,
+    const double scale) noexcept {
+  auto result = make_with_value<tnsr::i<T, VolumeDim>>(x, scale);
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    const size_t p = gsl::at(powers, d);
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      if (d == i) {
+        if (0 == p) {
+          result.get(i) = 0.0;
+        } else {
+          result.get(i) *= p * pow(x.get(d), p - 1);
+        }
+      } else {
+        result.get(i) *= pow(x.get(d), p);
+      }
+    }
+  }
+  return result;
+}
+
+template <typename T, size_t VolumeDim>
+tnsr::ii<T, VolumeDim> expected_second_derivs(
+    const tnsr::I<T, VolumeDim>& x, const std::array<size_t, VolumeDim>& powers,
+    const double scale) noexcept {
+  auto result = make_with_value<tnsr::ii<T, VolumeDim>>(x, scale);
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    const size_t p = gsl::at(powers, d);
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      if (d == i) {
+        if (2 > p) {
+          result.get(i, i) = 0.0;
+        } else {
+          result.get(i, i) *= p * (p - 1) * pow(x.get(d), p - 2);
+        }
+      } else {
+        result.get(i, i) *= pow(x.get(d), p);
+      }
+      for (size_t j = i + 1; j < VolumeDim; ++j) {
+        if (d == j or d == i) {
+          if (0 == p) {
+            result.get(i, j) = 0.0;
+          } else {
+            result.get(i, j) *= p * pow(x.get(d), p - 1);
+          }
+        } else {
+          result.get(i, j) *= pow(x.get(d), p);
+        }
+      }
+    }
+  }
+  return result;
+}
+
+template <size_t VolumeDim>
+void test_tensor_product(
+    const Index<VolumeDim>& extents, const double scale,
+    std::array<std::unique_ptr<MathFunction<1>>, VolumeDim>&& functions,
+    const std::array<size_t, VolumeDim>& powers) noexcept {
+  const auto coordinate_map = make_affine_map<VolumeDim>();
+  const size_t number_of_grid_points = extents.product();
+  const auto x = coordinate_map(logical_coordinates(extents));
+  MathFunctions::TensorProduct<VolumeDim> f(scale, std::move(functions));
+  CHECK_ITERABLE_APPROX(f(x), expected_value(x, powers, scale));
+  CHECK_ITERABLE_APPROX(f.first_derivatives(x),
+                        expected_first_derivs(x, powers, scale));
+  CHECK_ITERABLE_APPROX(f.second_derivatives(x),
+                        expected_second_derivs(x, powers, scale));
+  tnsr::I<double, VolumeDim> point{2.2};
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    point.get(d) += d * 1.7;
+  }
+  CHECK_ITERABLE_APPROX(f(point), expected_value(point, powers, scale));
+  CHECK_ITERABLE_APPROX(f.first_derivatives(point),
+                        expected_first_derivs(point, powers, scale));
+  CHECK_ITERABLE_APPROX(f.second_derivatives(point),
+                        expected_second_derivs(point, powers, scale));
+}
+
+struct Var1 : db::DataBoxTag {
+  using type = Scalar<DataVector>;
+  static constexpr db::DataBoxString label = "Var1";
+};
+
+template <size_t VolumeDim>
+struct Var2 : db::DataBoxTag {
+  using type = tnsr::i<DataVector, VolumeDim, Frame::Inertial>;
+  static constexpr db::DataBoxString label = "Var2";
+};
+
+template <size_t VolumeDim>
+using TwoVars = tmpl::list<Var1, Var2<VolumeDim>>;
+
+template <size_t VolumeDim>
+void test_with_numerical_derivatives(
+    const Index<VolumeDim>& extents, const double scale,
+    std::array<std::unique_ptr<MathFunction<1>>, VolumeDim>&&
+        functions) noexcept {
+  const auto coordinate_map = make_affine_map<VolumeDim>();
+  const size_t number_of_grid_points = extents.product();
+  Variables<TwoVars<VolumeDim>> u(number_of_grid_points);
+  const auto xi = logical_coordinates(extents);
+  const auto x = coordinate_map(xi);
+  const auto inv_jacobian = coordinate_map.inv_jacobian(xi);
+  MathFunctions::TensorProduct<VolumeDim> f(scale, std::move(functions));
+  get<Var1>(u) = f(x);
+  get<Var2<VolumeDim>>(u) = f.first_derivatives(x);
+  const auto du =
+      partial_derivatives<TwoVars<VolumeDim>>(u, extents, inv_jacobian);
+  const auto& dVar1 =
+      get<Tags::deriv<Var1, tmpl::size_t<VolumeDim>, Frame::Inertial>>(du);
+  Approx custom_approx = Approx::custom().epsilon(1.e-6);
+  CHECK_ITERABLE_CUSTOM_APPROX(f.first_derivatives(x), dVar1, custom_approx);
+  const auto& dVar2 = get<
+      Tags::deriv<Var2<VolumeDim>, tmpl::size_t<VolumeDim>, Frame::Inertial>>(
+      du);
+  const auto d2f = f.second_derivatives(x);
+  for (size_t i = 0; i < VolumeDim; ++i) {
+    for (size_t j = 0; j < VolumeDim; ++j) {
+      const auto& d2f_ij = d2f.get(i, j);
+      const auto& dVar2_ij = dVar2.get(i, j);
+      CHECK_ITERABLE_CUSTOM_APPROX(d2f_ij, dVar2_ij, custom_approx);
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.TensorProduct",
+                  "[PointwiseFunctions][Unit]") {
+  for (size_t a = 0; a < 5; ++a) {
+    std::array<std::unique_ptr<MathFunction<1>>, 1> functions{
+        {std::make_unique<MathFunctions::PowX>(a)}};
+    test_tensor_product(Index<1>{4}, 1.5, std::move(functions), {{a}});
+    for (size_t b = 0; b < 4; ++b) {
+      std::array<std::unique_ptr<MathFunction<1>>, 2> functions_2d{
+          {std::make_unique<MathFunctions::PowX>(a),
+           std::make_unique<MathFunctions::PowX>(b)}};
+      test_tensor_product(Index<2>{4, 3}, 2.5, std::move(functions_2d),
+                          {{a, b}});
+      for (size_t c = 0; c < 3; ++c) {
+        std::array<std::unique_ptr<MathFunction<1>>, 3> functions_3d{
+            {std::make_unique<MathFunctions::PowX>(a),
+             std::make_unique<MathFunctions::PowX>(b),
+             std::make_unique<MathFunctions::PowX>(c)}};
+        test_tensor_product(Index<3>{4, 3, 5}, 3.5, std::move(functions_3d),
+                            {{a, b, c}});
+      }
+    }
+  }
+
+  std::array<std::unique_ptr<MathFunction<1>>, 1> sinusoid{
+      {std::make_unique<MathFunctions::Sinusoid>(1.0, 1.0, -1.0)}};
+
+  test_with_numerical_derivatives(Index<1>{8}, 1.5, std::move(sinusoid));
+
+  std::array<std::unique_ptr<MathFunction<1>>, 3> generic_3d{
+      {std::make_unique<MathFunctions::Sinusoid>(1.0, 1.0, -1.0),
+       std::make_unique<MathFunctions::Gaussian>(1.0, 1.0, 0.4),
+       std::make_unique<MathFunctions::PowX>(2)}};
+
+  test_with_numerical_derivatives(Index<3>{8, 8, 8}, 1.5,
+                                  std::move(generic_3d));
+}


### PR DESCRIPTION
## Proposed changes

Adds class template TensorProduct which is a tensor product of `VolumeDim` `MathFunction<1>`s
This will reduce duplicated code in tests, and may be useful for setting analytic data.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
