### PR TITLE
Rename inputs to functions in CoordinateMaps

### DIFF
--- a/src/Domain/CoordinateMaps/Affine.cpp
+++ b/src/Domain/CoordinateMaps/Affine.cpp
@@ -22,14 +22,16 @@ Affine::Affine(const double A, const double B, const double a, const double b)
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> Affine::
-operator()(const std::array<T, 1>& xi) const {
-  return {{(length_of_range_ * xi[0] + a_ * B_ - b_ * A_) / length_of_domain_}};
+operator()(const std::array<T, 1>& source_coords) const {
+  return {{(length_of_range_ * source_coords[0] + a_ * B_ - b_ * A_) /
+           length_of_domain_}};
 }
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> Affine::inverse(
-    const std::array<T, 1>& x) const {
-  return {{(length_of_domain_ * x[0] - a_ * B_ + b_ * A_) / length_of_range_}};
+    const std::array<T, 1>& target_coords) const {
+  return {{(length_of_domain_ * target_coords[0] - a_ * B_ + b_ * A_) /
+           length_of_range_}};
 }
 
 template <typename T>
@@ -37,13 +39,13 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Affine::jacobian(const std::array<T, 1>& xi) const {
+Affine::jacobian(const std::array<T, 1>& source_coords) const {
   return Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
                 tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>{
       make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
-          dereference_wrapper(xi[0]), jacobian_)};
+          dereference_wrapper(source_coords[0]), jacobian_)};
 }
 
 template <typename T>
@@ -51,13 +53,13 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Affine::inv_jacobian(const std::array<T, 1>& xi) const {
+Affine::inv_jacobian(const std::array<T, 1>& source_coords) const {
   return Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
                 tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>{
       make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
-          dereference_wrapper(xi[0]), inverse_jacobian_)};
+          dereference_wrapper(source_coords[0]), inverse_jacobian_)};
 }
 
 void Affine::pup(PUP::er& p) {
@@ -82,60 +84,62 @@ bool operator==(const CoordinateMaps::Affine& lhs,
 
 // Explicit instantiations
 template std::array<double, 1> Affine::operator()(
-    const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
+    const std::array<std::reference_wrapper<const double>, 1>& source_coords)
+    const;
 template std::array<double, 1> Affine::operator()(
-    const std::array<double, 1>& /*xi*/) const;
+    const std::array<double, 1>& source_coords) const;
 template std::array<DataVector, 1> Affine::operator()(
-    const std::array<std::reference_wrapper<const DataVector>, 1>& /*xi*/)
-    const;
+    const std::array<std::reference_wrapper<const DataVector>, 1>&
+        source_coords) const;
 template std::array<DataVector, 1> Affine::operator()(
-    const std::array<DataVector, 1>& /*xi*/) const;
+    const std::array<DataVector, 1>& source_coords) const;
 
 template std::array<double, 1> Affine::inverse(
-    const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
-template std::array<double, 1> Affine::inverse(
-    const std::array<double, 1>& /*xi*/) const;
-template std::array<DataVector, 1> Affine::inverse(
-    const std::array<std::reference_wrapper<const DataVector>, 1>& /*xi*/)
+    const std::array<std::reference_wrapper<const double>, 1>& target_coords)
     const;
+template std::array<double, 1> Affine::inverse(
+    const std::array<double, 1>& target_coords) const;
 template std::array<DataVector, 1> Affine::inverse(
-    const std::array<DataVector, 1>& /*xi*/) const;
+    const std::array<std::reference_wrapper<const DataVector>, 1>&
+        target_coords) const;
+template std::array<DataVector, 1> Affine::inverse(
+    const std::array<DataVector, 1>& target_coords) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Affine::jacobian(
-    const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
+Affine::jacobian(const std::array<std::reference_wrapper<const double>, 1>&
+                     source_coords) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Affine::jacobian(const std::array<double, 1>& /*xi*/) const;
+Affine::jacobian(const std::array<double, 1>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Affine::jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                  1>& /*xi*/) const;
+Affine::jacobian(const std::array<std::reference_wrapper<const DataVector>, 1>&
+                     source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Affine::jacobian(const std::array<DataVector, 1>& /*xi*/) const;
+Affine::jacobian(const std::array<DataVector, 1>& source_coords) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Affine::inv_jacobian(
-    const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
+Affine::inv_jacobian(const std::array<std::reference_wrapper<const double>, 1>&
+                         source_coords) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Affine::inv_jacobian(const std::array<double, 1>& /*xi*/) const;
+Affine::inv_jacobian(const std::array<double, 1>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
 Affine::inv_jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                      1>& /*xi*/) const;
+                                      1>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Affine::inv_jacobian(const std::array<DataVector, 1>& /*xi*/) const;
+Affine::inv_jacobian(const std::array<DataVector, 1>& source_coords) const;
 }  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/Affine.cpp
+++ b/src/Domain/CoordinateMaps/Affine.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/MakeWithValue.hpp"
@@ -10,8 +10,7 @@
 
 namespace CoordinateMaps {
 
-AffineMap::AffineMap(const double A, const double B, const double a,
-                     const double b)
+Affine::Affine(const double A, const double B, const double a, const double b)
     : A_(A),
       B_(B),
       a_(a),
@@ -22,14 +21,14 @@ AffineMap::AffineMap(const double A, const double B, const double a,
       inverse_jacobian_(length_of_domain_ / length_of_range_) {}
 
 template <typename T>
-std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> AffineMap::
+std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> Affine::
 operator()(const std::array<T, 1>& xi) const {
   return {{(length_of_range_ * xi[0] + a_ * B_ - b_ * A_) / length_of_domain_}};
 }
 
 template <typename T>
-std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1>
-AffineMap::inverse(const std::array<T, 1>& x) const {
+std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> Affine::inverse(
+    const std::array<T, 1>& x) const {
   return {{(length_of_domain_ * x[0] - a_ * B_ + b_ * A_) / length_of_range_}};
 }
 
@@ -38,7 +37,7 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-AffineMap::jacobian(const std::array<T, 1>& xi) const {
+Affine::jacobian(const std::array<T, 1>& xi) const {
   return Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
                 tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
@@ -52,7 +51,7 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-AffineMap::inv_jacobian(const std::array<T, 1>& xi) const {
+Affine::inv_jacobian(const std::array<T, 1>& xi) const {
   return Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
                 tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
@@ -61,7 +60,7 @@ AffineMap::inv_jacobian(const std::array<T, 1>& xi) const {
           dereference_wrapper(xi[0]), inverse_jacobian_)};
 }
 
-void AffineMap::pup(PUP::er& p) {
+void Affine::pup(PUP::er& p) {
   p | A_;
   p | B_;
   p | a_;
@@ -72,8 +71,8 @@ void AffineMap::pup(PUP::er& p) {
   p | inverse_jacobian_;
 }
 
-bool operator==(const CoordinateMaps::AffineMap& lhs,
-                const CoordinateMaps::AffineMap& rhs) noexcept {
+bool operator==(const CoordinateMaps::Affine& lhs,
+                const CoordinateMaps::Affine& rhs) noexcept {
   return lhs.A_ == rhs.A_ and lhs.B_ == rhs.B_ and lhs.a_ == rhs.a_ and
          lhs.b_ == rhs.b_ and lhs.length_of_domain_ == rhs.length_of_domain_ and
          lhs.length_of_range_ == rhs.length_of_range_ and
@@ -82,62 +81,61 @@ bool operator==(const CoordinateMaps::AffineMap& lhs,
 }
 
 // Explicit instantiations
-template std::array<double, 1> AffineMap::operator()(
+template std::array<double, 1> Affine::operator()(
     const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
-template std::array<double, 1> AffineMap::operator()(
+template std::array<double, 1> Affine::operator()(
     const std::array<double, 1>& /*xi*/) const;
-template std::array<DataVector, 1> AffineMap::operator()(
+template std::array<DataVector, 1> Affine::operator()(
     const std::array<std::reference_wrapper<const DataVector>, 1>& /*xi*/)
     const;
-template std::array<DataVector, 1> AffineMap::operator()(
+template std::array<DataVector, 1> Affine::operator()(
     const std::array<DataVector, 1>& /*xi*/) const;
 
-template std::array<double, 1> AffineMap::inverse(
+template std::array<double, 1> Affine::inverse(
     const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
-template std::array<double, 1> AffineMap::inverse(
+template std::array<double, 1> Affine::inverse(
     const std::array<double, 1>& /*xi*/) const;
-template std::array<DataVector, 1> AffineMap::inverse(
+template std::array<DataVector, 1> Affine::inverse(
     const std::array<std::reference_wrapper<const DataVector>, 1>& /*xi*/)
     const;
-template std::array<DataVector, 1> AffineMap::inverse(
+template std::array<DataVector, 1> Affine::inverse(
     const std::array<DataVector, 1>& /*xi*/) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-AffineMap::jacobian(
+Affine::jacobian(
     const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-AffineMap::jacobian(const std::array<double, 1>& /*xi*/) const;
+Affine::jacobian(const std::array<double, 1>& /*xi*/) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-AffineMap::jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                     1>& /*xi*/) const;
+Affine::jacobian(const std::array<std::reference_wrapper<const DataVector>,
+                                  1>& /*xi*/) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-AffineMap::jacobian(const std::array<DataVector, 1>& /*xi*/) const;
+Affine::jacobian(const std::array<DataVector, 1>& /*xi*/) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-AffineMap::inv_jacobian(
+Affine::inv_jacobian(
     const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-AffineMap::inv_jacobian(const std::array<double, 1>& /*xi*/) const;
+Affine::inv_jacobian(const std::array<double, 1>& /*xi*/) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-AffineMap::inv_jacobian(
-    const std::array<std::reference_wrapper<const DataVector>, 1>& /*xi*/)
-    const;
+Affine::inv_jacobian(const std::array<std::reference_wrapper<const DataVector>,
+                                      1>& /*xi*/) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-AffineMap::inv_jacobian(const std::array<DataVector, 1>& /*xi*/) const;
+Affine::inv_jacobian(const std::array<DataVector, 1>& /*xi*/) const;
 }  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/Affine.hpp
+++ b/src/Domain/CoordinateMaps/Affine.hpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Defines the class AffineMap.
+/// Defines the class Affine.
 
 #pragma once
 
@@ -26,19 +26,19 @@ namespace CoordinateMaps {
  * \f[
  * \xi =\frac{B}{b-a} (x-a) +\frac{A}{b-a}(b-x)
  * \f]
-*/
-class AffineMap {
+ */
+class Affine {
  public:
   static constexpr size_t dim = 1;
 
-  AffineMap(double A, double B, double a, double b);
+  Affine(double A, double B, double a, double b);
 
-  AffineMap() = default;
-  ~AffineMap() = default;
-  AffineMap(const AffineMap&) = default;
-  AffineMap(AffineMap&&) noexcept = default;  // NOLINT
-  AffineMap& operator=(const AffineMap&) = default;
-  AffineMap& operator=(AffineMap&&) = default;
+  Affine() = default;
+  ~Affine() = default;
+  Affine(const Affine&) = default;
+  Affine(Affine&&) noexcept = default;  // NOLINT
+  Affine& operator=(const Affine&) = default;
+  Affine& operator=(Affine&&) = default;
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> operator()(
@@ -66,7 +66,7 @@ class AffineMap {
   void pup(PUP::er& p);  // NOLINT
 
  private:
-  friend bool operator==(const AffineMap& lhs, const AffineMap& rhs) noexcept;
+  friend bool operator==(const Affine& lhs, const Affine& rhs) noexcept;
 
   double A_{-1.0};
   double B_{1.0};
@@ -78,8 +78,8 @@ class AffineMap {
   double inverse_jacobian_{length_of_domain_ / length_of_range_};
 };
 
-inline bool operator!=(const CoordinateMaps::AffineMap& lhs,
-                       const CoordinateMaps::AffineMap& rhs) noexcept {
+inline bool operator!=(const CoordinateMaps::Affine& lhs,
+                       const CoordinateMaps::Affine& rhs) noexcept {
   return not(lhs == rhs);
 }
 

--- a/src/Domain/CoordinateMaps/Affine.hpp
+++ b/src/Domain/CoordinateMaps/Affine.hpp
@@ -17,7 +17,7 @@ namespace CoordinateMaps {
 
 /*!
  * \ingroup CoordinateMapsGroup
- * \brief Linear map from \f$\xi \in [A, B]\rightarrow x \in [a, b]\f$.
+ * \brief Affine map from \f$\xi \in [A, B]\rightarrow x \in [a, b]\f$.
  *
  * The formula for the mapping is...
  * \f[
@@ -42,25 +42,25 @@ class Affine {
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> operator()(
-      const std::array<T, 1>& xi) const;
+      const std::array<T, 1>& source_coords) const;
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> inverse(
-      const std::array<T, 1>& x) const;
+      const std::array<T, 1>& target_coords) const;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 1>& /*xi*/) const;
+  inv_jacobian(const std::array<T, 1>& source_coords) const;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 1>& /*xi*/) const;
+  jacobian(const std::array<T, 1>& source_coords) const;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p);  // NOLINT

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -4,7 +4,7 @@
 set(LIBRARY CoordinateMaps)
 
 set(LIBRARY_SOURCES
-    AffineMap.cpp
+    Affine.cpp
     Equiangular.cpp
     Identity.cpp
     Rotation.cpp

--- a/src/Domain/CoordinateMaps/Equiangular.cpp
+++ b/src/Domain/CoordinateMaps/Equiangular.cpp
@@ -29,19 +29,20 @@ Equiangular::Equiangular(const double A, const double B, const double a,
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> Equiangular::
-operator()(const std::array<T, 1>& xi) const noexcept {
-  return {{0.5 * (a_ + b_ +
-                  length_of_range_ * tan(m_pi_4_over_length_of_domain_ *
-                                         (-B_ - A_ + 2.0 * xi[0])))}};
+operator()(const std::array<T, 1>& source_coords) const noexcept {
+  return {
+      {0.5 * (a_ + b_ +
+              length_of_range_ * tan(m_pi_4_over_length_of_domain_ *
+                                     (-B_ - A_ + 2.0 * source_coords[0])))}};
 }
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1>
-Equiangular::inverse(const std::array<T, 1>& x) const noexcept {
-  return {
-      {0.5 * (A_ + B_ +
-              length_of_domain_over_m_pi_4_ *
-                  atan(one_over_length_of_range_ * (-a_ - b_ + 2.0 * x[0])))}};
+Equiangular::inverse(const std::array<T, 1>& target_coords) const noexcept {
+  return {{0.5 * (A_ + B_ +
+                  length_of_domain_over_m_pi_4_ *
+                      atan(one_over_length_of_range_ *
+                           (-a_ - b_ + 2.0 * target_coords[0])))}};
 }
 
 template <typename T>
@@ -49,9 +50,9 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Equiangular::jacobian(const std::array<T, 1>& xi) const noexcept {
+Equiangular::jacobian(const std::array<T, 1>& source_coords) const noexcept {
   const std::decay_t<tt::remove_reference_wrapper_t<T>> tan_variable =
-      tan(m_pi_4_over_length_of_domain_ * (-B_ - A_ + 2.0 * xi[0]));
+      tan(m_pi_4_over_length_of_domain_ * (-B_ - A_ + 2.0 * source_coords[0]));
   return Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
                 tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
@@ -64,9 +65,10 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Equiangular::inv_jacobian(const std::array<T, 1>& xi) const noexcept {
+Equiangular::inv_jacobian(const std::array<T, 1>& source_coords) const
+    noexcept {
   const std::decay_t<tt::remove_reference_wrapper_t<T>> tan_variable =
-      tan(m_pi_4_over_length_of_domain_ * (-B_ - A_ + 2.0 * xi[0]));
+      tan(m_pi_4_over_length_of_domain_ * (-B_ - A_ + 2.0 * source_coords[0]));
   return Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
                 tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
@@ -107,38 +109,38 @@ bool operator==(const CoordinateMaps::Equiangular& lhs,
 /// \cond
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                  \
-  template std::array<DTYPE(data), 1> Equiangular::operator()(                \
-      const std::array<std::reference_wrapper<const DTYPE(data)>, 1>& /*xi*/) \
-      const noexcept;                                                         \
-  template std::array<DTYPE(data), 1> Equiangular::operator()(                \
-      const std::array<DTYPE(data), 1>& /*xi*/) const noexcept;               \
-  template std::array<DTYPE(data), 1> Equiangular::inverse(                   \
-      const std::array<std::reference_wrapper<const DTYPE(data)>, 1>& /*xi*/) \
-      const noexcept;                                                         \
-  template std::array<DTYPE(data), 1> Equiangular::inverse(                   \
-      const std::array<DTYPE(data), 1>& /*xi*/) const noexcept;               \
-  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,       \
-                  index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,       \
-                             SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>      \
-  Equiangular::jacobian(                                                      \
-      const std::array<std::reference_wrapper<const DTYPE(data)>, 1>& /*xi*/) \
-      const noexcept;                                                         \
-  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,       \
-                  index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,       \
-                             SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>      \
-  Equiangular::jacobian(const std::array<DTYPE(data), 1>& /*xi*/)             \
-      const noexcept;                                                         \
-  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,       \
-                  index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,       \
-                             SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>      \
-  Equiangular::inv_jacobian(                                                  \
-      const std::array<std::reference_wrapper<const DTYPE(data)>, 1>& /*xi*/) \
-      const noexcept;                                                         \
-  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,       \
-                  index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,       \
-                             SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>      \
-  Equiangular::inv_jacobian(const std::array<DTYPE(data), 1>& /*xi*/)         \
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<DTYPE(data), 1> Equiangular::operator()(               \
+      const std::array<std::reference_wrapper<const DTYPE(data)>, 1>&        \
+          source_coords) const noexcept;                                     \
+  template std::array<DTYPE(data), 1> Equiangular::operator()(               \
+      const std::array<DTYPE(data), 1>& source_coords) const noexcept;       \
+  template std::array<DTYPE(data), 1> Equiangular::inverse(                  \
+      const std::array<std::reference_wrapper<const DTYPE(data)>, 1>&        \
+          target_coords) const noexcept;                                     \
+  template std::array<DTYPE(data), 1> Equiangular::inverse(                  \
+      const std::array<DTYPE(data), 1>& target_coords) const noexcept;       \
+  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,      \
+                  index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,      \
+                             SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>     \
+  Equiangular::jacobian(                                                     \
+      const std::array<std::reference_wrapper<const DTYPE(data)>, 1>&        \
+          source_coords) const noexcept;                                     \
+  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,      \
+                  index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,      \
+                             SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>     \
+  Equiangular::jacobian(const std::array<DTYPE(data), 1>& source_coords)     \
+      const noexcept;                                                        \
+  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,      \
+                  index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,      \
+                             SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>     \
+  Equiangular::inv_jacobian(                                                 \
+      const std::array<std::reference_wrapper<const DTYPE(data)>, 1>&        \
+          source_coords) const noexcept;                                     \
+  template Tensor<DTYPE(data), tmpl::integral_list<std::int32_t, 2, 1>,      \
+                  index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,      \
+                             SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>     \
+  Equiangular::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords) \
       const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))

--- a/src/Domain/CoordinateMaps/Equiangular.hpp
+++ b/src/Domain/CoordinateMaps/Equiangular.hpp
@@ -58,25 +58,25 @@ class Equiangular {
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> operator()(
-      const std::array<T, 1>& xi) const noexcept;
+      const std::array<T, 1>& source_coords) const noexcept;
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> inverse(
-      const std::array<T, 1>& x) const noexcept;
+      const std::array<T, 1>& target_coords) const noexcept;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 1>& xi) const noexcept;
+  inv_jacobian(const std::array<T, 1>& source_coords) const noexcept;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 1>& xi) const noexcept;
+  jacobian(const std::array<T, 1>& source_coords) const noexcept;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/Domain/CoordinateMaps/Identity.cpp
+++ b/src/Domain/CoordinateMaps/Identity.cpp
@@ -13,15 +13,17 @@ namespace CoordinateMaps {
 template <size_t Dim>
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim> Identity<Dim>::
-operator()(const std::array<T, Dim>& xi) const {
-  return make_array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim>(xi);
+operator()(const std::array<T, Dim>& source_coords) const {
+  return make_array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim>(
+      source_coords);
 }
 
 template <size_t Dim>
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim>
-Identity<Dim>::inverse(const std::array<T, Dim>& x) const {
-  return make_array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim>(x);
+Identity<Dim>::inverse(const std::array<T, Dim>& target_coords) const {
+  return make_array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim>(
+      target_coords);
 }
 
 template <size_t Dim>
@@ -30,13 +32,13 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
-Identity<Dim>::jacobian(const std::array<T, Dim>& xi) const {
+Identity<Dim>::jacobian(const std::array<T, Dim>& source_coords) const {
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
       jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
-          dereference_wrapper(xi[0]), 0.0)};
+          dereference_wrapper(source_coords[0]), 0.0)};
   for (size_t i = 0; i < Dim; ++i) {
     jac.get(i, i) = 1.0;
   }
@@ -49,13 +51,13 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
-Identity<Dim>::inv_jacobian(const std::array<T, Dim>& xi) const {
+Identity<Dim>::inv_jacobian(const std::array<T, Dim>& source_coords) const {
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
       inv_jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
-          dereference_wrapper(xi[0]), 0.0)};
+          dereference_wrapper(source_coords[0]), 0.0)};
   for (size_t i = 0; i < Dim; ++i) {
     inv_jac.get(i, i) = 1.0;
   }
@@ -70,121 +72,125 @@ template class Identity<2>;
 
 /// \cond HIDDEN_SYMBOLS
 template std::array<double, 1> Identity<1>::operator()(
-    const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
+    const std::array<std::reference_wrapper<const double>, 1>& source_coords)
+    const;
 template std::array<double, 1> Identity<1>::operator()(
-    const std::array<double, 1>& /*xi*/) const;
+    const std::array<double, 1>& source_coords) const;
 template std::array<DataVector, 1> Identity<1>::operator()(
-    const std::array<std::reference_wrapper<const DataVector>, 1>& /*xi*/)
-    const;
+    const std::array<std::reference_wrapper<const DataVector>, 1>&
+        source_coords) const;
 template std::array<DataVector, 1> Identity<1>::operator()(
-    const std::array<DataVector, 1>& /*xi*/) const;
+    const std::array<DataVector, 1>& source_coords) const;
 
 template std::array<double, 1> Identity<1>::inverse(
-    const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
-template std::array<double, 1> Identity<1>::inverse(
-    const std::array<double, 1>& /*xi*/) const;
-template std::array<DataVector, 1> Identity<1>::inverse(
-    const std::array<std::reference_wrapper<const DataVector>, 1>& /*xi*/)
+    const std::array<std::reference_wrapper<const double>, 1>& target_coords)
     const;
+template std::array<double, 1> Identity<1>::inverse(
+    const std::array<double, 1>& target_coords) const;
 template std::array<DataVector, 1> Identity<1>::inverse(
-    const std::array<DataVector, 1>& /*xi*/) const;
+    const std::array<std::reference_wrapper<const DataVector>, 1>&
+        target_coords) const;
+template std::array<DataVector, 1> Identity<1>::inverse(
+    const std::array<DataVector, 1>& target_coords) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::jacobian(
-    const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
+Identity<1>::jacobian(const std::array<std::reference_wrapper<const double>, 1>&
+                          source_coords) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::jacobian(const std::array<double, 1>& /*xi*/) const;
+Identity<1>::jacobian(const std::array<double, 1>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
 Identity<1>::jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                       1>& /*xi*/) const;
+                                       1>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::jacobian(const std::array<DataVector, 1>& /*xi*/) const;
+Identity<1>::jacobian(const std::array<DataVector, 1>& source_coords) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::inv_jacobian(
-    const std::array<std::reference_wrapper<const double>, 1>& /*xi*/) const;
+Identity<1>::inv_jacobian(const std::array<std::reference_wrapper<const double>,
+                                           1>& source_coords) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::inv_jacobian(const std::array<double, 1>& /*xi*/) const;
+Identity<1>::inv_jacobian(const std::array<double, 1>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
 Identity<1>::inv_jacobian(
-    const std::array<std::reference_wrapper<const DataVector>, 1>& /*xi*/)
-    const;
+    const std::array<std::reference_wrapper<const DataVector>, 1>&
+        source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::inv_jacobian(const std::array<DataVector, 1>& /*xi*/) const;
+Identity<1>::inv_jacobian(const std::array<DataVector, 1>& source_coords) const;
 
 template std::array<double, 2> Identity<2>::operator()(
-    const std::array<std::reference_wrapper<const double>, 2>& /*xi*/) const;
-template std::array<double, 2> Identity<2>::operator()(
-    const std::array<double, 2>& /*xi*/) const;
-template std::array<DataVector, 2> Identity<2>::operator()(
-    const std::array<std::reference_wrapper<const DataVector>, 2>& /*xi*/)
+    const std::array<std::reference_wrapper<const double>, 2>& source_coords)
     const;
+template std::array<double, 2> Identity<2>::operator()(
+    const std::array<double, 2>& source_coords) const;
 template std::array<DataVector, 2> Identity<2>::operator()(
-    const std::array<DataVector, 2>& /*xi*/) const;
+    const std::array<std::reference_wrapper<const DataVector>, 2>&
+        source_coords) const;
+template std::array<DataVector, 2> Identity<2>::operator()(
+    const std::array<DataVector, 2>& source_coords) const;
 
 template std::array<double, 2> Identity<2>::inverse(
-    const std::array<std::reference_wrapper<const double>, 2>& /*xi*/) const;
-template std::array<double, 2> Identity<2>::inverse(
-    const std::array<double, 2>& /*xi*/) const;
-template std::array<DataVector, 2> Identity<2>::inverse(
-    const std::array<std::reference_wrapper<const DataVector>, 2>& /*xi*/)
+    const std::array<std::reference_wrapper<const double>, 2>& target_coords)
     const;
+template std::array<double, 2> Identity<2>::inverse(
+    const std::array<double, 2>& target_coords) const;
 template std::array<DataVector, 2> Identity<2>::inverse(
-    const std::array<DataVector, 2>& /*xi*/) const;
+    const std::array<std::reference_wrapper<const DataVector>, 2>&
+        target_coords) const;
+template std::array<DataVector, 2> Identity<2>::inverse(
+    const std::array<DataVector, 2>& target_coords) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::jacobian(
-    const std::array<std::reference_wrapper<const double>, 2>& /*xi*/) const;
+Identity<2>::jacobian(const std::array<std::reference_wrapper<const double>, 2>&
+                          source_coords) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::jacobian(const std::array<double, 2>& /*xi*/) const;
+Identity<2>::jacobian(const std::array<double, 2>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
 Identity<2>::jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                       2>& /*xi*/) const;
+                                       2>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::jacobian(const std::array<DataVector, 2>& /*xi*/) const;
+Identity<2>::jacobian(const std::array<DataVector, 2>& source_coords) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::inv_jacobian(
-    const std::array<std::reference_wrapper<const double>, 2>& /*xi*/) const;
+Identity<2>::inv_jacobian(const std::array<std::reference_wrapper<const double>,
+                                           2>& source_coords) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::inv_jacobian(const std::array<double, 2>& /*xi*/) const;
+Identity<2>::inv_jacobian(const std::array<double, 2>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
 Identity<2>::inv_jacobian(
-    const std::array<std::reference_wrapper<const DataVector>, 2>& /*xi*/)
-    const;
+    const std::array<std::reference_wrapper<const DataVector>, 2>&
+        source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::inv_jacobian(const std::array<DataVector, 2>& /*xi*/) const;
+Identity<2>::inv_jacobian(const std::array<DataVector, 2>& source_coords) const;
 /// \endcond
 }  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/Identity.hpp
+++ b/src/Domain/CoordinateMaps/Identity.hpp
@@ -30,25 +30,25 @@ class Identity {
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim> operator()(
-      const std::array<T, Dim>& xi) const;
+      const std::array<T, Dim>& source_coords) const;
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim> inverse(
-      const std::array<T, Dim>& x) const;
+      const std::array<T, Dim>& target_coords) const;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, Dim>& /*xi*/) const;
+  jacobian(const std::array<T, Dim>& source_coords) const;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, Dim>& /*xi*/) const;
+  inv_jacobian(const std::array<T, Dim>& source_coords) const;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& /*p*/) {}  // NOLINT

--- a/src/Domain/CoordinateMaps/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/Rotation.cpp
@@ -21,20 +21,20 @@ Rotation<2>::Rotation(const double rotation_angle)
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> Rotation<2>::
-operator()(const std::array<T, 2>& xi) const {
-  return {{xi[0] * get<0, 0>(rotation_matrix_) +
-               xi[1] * get<0, 1>(rotation_matrix_),
-           xi[0] * get<1, 0>(rotation_matrix_) +
-               xi[1] * get<1, 1>(rotation_matrix_)}};
+operator()(const std::array<T, 2>& source_coords) const {
+  return {{source_coords[0] * get<0, 0>(rotation_matrix_) +
+               source_coords[1] * get<0, 1>(rotation_matrix_),
+           source_coords[0] * get<1, 0>(rotation_matrix_) +
+               source_coords[1] * get<1, 1>(rotation_matrix_)}};
 }
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2>
-Rotation<2>::inverse(const std::array<T, 2>& x) const {
-  return {
-      {x[0] * get<0, 0>(rotation_matrix_) + x[1] * get<1, 0>(rotation_matrix_),
-       x[0] * get<0, 1>(rotation_matrix_) +
-           x[1] * get<1, 1>(rotation_matrix_)}};
+Rotation<2>::inverse(const std::array<T, 2>& target_coords) const {
+  return {{target_coords[0] * get<0, 0>(rotation_matrix_) +
+               target_coords[1] * get<1, 0>(rotation_matrix_),
+           target_coords[0] * get<0, 1>(rotation_matrix_) +
+               target_coords[1] * get<1, 1>(rotation_matrix_)}};
 }
 
 template <typename T>
@@ -42,13 +42,13 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::jacobian(const std::array<T, 2>& xi) const {
+Rotation<2>::jacobian(const std::array<T, 2>& source_coords) const {
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
       jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
-          dereference_wrapper(xi[0]), 0.0)};
+          dereference_wrapper(source_coords[0]), 0.0)};
   get<0, 0>(jac) = get<0, 0>(rotation_matrix_);
   get<1, 0>(jac) = get<1, 0>(rotation_matrix_);
   get<0, 1>(jac) = get<0, 1>(rotation_matrix_);
@@ -61,13 +61,13 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::inv_jacobian(const std::array<T, 2>& xi) const {
+Rotation<2>::inv_jacobian(const std::array<T, 2>& source_coords) const {
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
       inv_jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
-          dereference_wrapper(xi[0]), 0.0)};
+          dereference_wrapper(source_coords[0]), 0.0)};
   get<0, 0>(inv_jac) = get<0, 0>(rotation_matrix_);
   get<1, 0>(inv_jac) = get<0, 1>(rotation_matrix_);
   get<0, 1>(inv_jac) = get<1, 0>(rotation_matrix_);
@@ -118,29 +118,31 @@ Rotation<3>::Rotation(const double rotation_about_z,
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> Rotation<3>::
-operator()(const std::array<T, 3>& xi) const {
-  return {{xi[0] * get<0, 0>(rotation_matrix_) +
-               xi[1] * get<0, 1>(rotation_matrix_) +
-               xi[2] * get<0, 2>(rotation_matrix_),
-           xi[0] * get<1, 0>(rotation_matrix_) +
-               xi[1] * get<1, 1>(rotation_matrix_) +
-               xi[2] * get<1, 2>(rotation_matrix_),
-           xi[0] * get<2, 0>(rotation_matrix_) +
-               xi[1] * get<2, 1>(rotation_matrix_) +
-               xi[2] * get<2, 2>(rotation_matrix_)}};
+operator()(const std::array<T, 3>& source_coords) const {
+  return {{source_coords[0] * get<0, 0>(rotation_matrix_) +
+               source_coords[1] * get<0, 1>(rotation_matrix_) +
+               source_coords[2] * get<0, 2>(rotation_matrix_),
+           source_coords[0] * get<1, 0>(rotation_matrix_) +
+               source_coords[1] * get<1, 1>(rotation_matrix_) +
+               source_coords[2] * get<1, 2>(rotation_matrix_),
+           source_coords[0] * get<2, 0>(rotation_matrix_) +
+               source_coords[1] * get<2, 1>(rotation_matrix_) +
+               source_coords[2] * get<2, 2>(rotation_matrix_)}};
 }
 
 template <typename T>
 std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3>
-Rotation<3>::inverse(const std::array<T, 3>& x) const {
+Rotation<3>::inverse(const std::array<T, 3>& target_coords) const {
   // Inverse rotation matrix is the same as the transpose.
-  return {
-      {x[0] * get<0, 0>(rotation_matrix_) + x[1] * get<1, 0>(rotation_matrix_) +
-           x[2] * get<2, 0>(rotation_matrix_),
-       x[0] * get<0, 1>(rotation_matrix_) + x[1] * get<1, 1>(rotation_matrix_) +
-           x[2] * get<2, 1>(rotation_matrix_),
-       x[0] * get<0, 2>(rotation_matrix_) + x[1] * get<1, 2>(rotation_matrix_) +
-           x[2] * get<2, 2>(rotation_matrix_)}};
+  return {{target_coords[0] * get<0, 0>(rotation_matrix_) +
+               target_coords[1] * get<1, 0>(rotation_matrix_) +
+               target_coords[2] * get<2, 0>(rotation_matrix_),
+           target_coords[0] * get<0, 1>(rotation_matrix_) +
+               target_coords[1] * get<1, 1>(rotation_matrix_) +
+               target_coords[2] * get<2, 1>(rotation_matrix_),
+           target_coords[0] * get<0, 2>(rotation_matrix_) +
+               target_coords[1] * get<1, 2>(rotation_matrix_) +
+               target_coords[2] * get<2, 2>(rotation_matrix_)}};
 }
 
 template <typename T>
@@ -148,13 +150,13 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::jacobian(const std::array<T, 3>& xi) const {
+Rotation<3>::jacobian(const std::array<T, 3>& source_coords) const {
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
       jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
-          dereference_wrapper(xi[0]), 0.0)};
+          dereference_wrapper(source_coords[0]), 0.0)};
   get<0, 0>(jac) = get<0, 0>(rotation_matrix_);
   get<1, 0>(jac) = get<1, 0>(rotation_matrix_);
   get<0, 1>(jac) = get<0, 1>(rotation_matrix_);
@@ -172,13 +174,13 @@ Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
        tmpl::integral_list<std::int32_t, 2, 1>,
        index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                   SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::inv_jacobian(const std::array<T, 3>& xi) const {
+Rotation<3>::inv_jacobian(const std::array<T, 3>& source_coords) const {
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
       inv_jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
-          dereference_wrapper(xi[0]), 0.0)};
+          dereference_wrapper(source_coords[0]), 0.0)};
   get<0, 0>(inv_jac) = get<0, 0>(rotation_matrix_);
   get<1, 0>(inv_jac) = get<0, 1>(rotation_matrix_);
   get<0, 1>(inv_jac) = get<1, 0>(rotation_matrix_);
@@ -209,119 +211,125 @@ bool operator!=(const Rotation<3>& lhs, const Rotation<3>& rhs) noexcept {
 }
 
 template std::array<double, 2> Rotation<2>::operator()(
-    const std::array<std::reference_wrapper<const double>, 2>& /*xi*/) const;
+    const std::array<std::reference_wrapper<const double>, 2>& source_coords)
+    const;
 template std::array<double, 2> Rotation<2>::operator()(
-    const std::array<double, 2>& /*xi*/) const;
+    const std::array<double, 2>& source_coords) const;
 template std::array<DataVector, 2> Rotation<2>::operator()(
-    const std::array<std::reference_wrapper<const DataVector>, 2>& /*xi*/)
-    const;
+    const std::array<std::reference_wrapper<const DataVector>, 2>&
+        source_coords) const;
 template std::array<DataVector, 2> Rotation<2>::operator()(
-    const std::array<DataVector, 2>& /*xi*/) const;
+    const std::array<DataVector, 2>& source_coords) const;
 
 template std::array<double, 2> Rotation<2>::inverse(
-    const std::array<std::reference_wrapper<const double>, 2>& /*xi*/) const;
-template std::array<double, 2> Rotation<2>::inverse(
-    const std::array<double, 2>& /*xi*/) const;
-template std::array<DataVector, 2> Rotation<2>::inverse(
-    const std::array<std::reference_wrapper<const DataVector>, 2>& /*xi*/)
+    const std::array<std::reference_wrapper<const double>, 2>& target_coords)
     const;
+template std::array<double, 2> Rotation<2>::inverse(
+    const std::array<double, 2>& target_coords) const;
 template std::array<DataVector, 2> Rotation<2>::inverse(
-    const std::array<DataVector, 2>& /*xi*/) const;
+    const std::array<std::reference_wrapper<const DataVector>, 2>&
+        target_coords) const;
+template std::array<DataVector, 2> Rotation<2>::inverse(
+    const std::array<DataVector, 2>& target_coords) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::jacobian(
-    const std::array<std::reference_wrapper<const double>, 2>& /*xi*/) const;
+Rotation<2>::jacobian(const std::array<std::reference_wrapper<const double>, 2>&
+                          source_coords) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::jacobian(const std::array<double, 2>& /*xi*/) const;
+Rotation<2>::jacobian(const std::array<double, 2>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
 Rotation<2>::jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                       2>& /*xi*/) const;
+                                       2>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::jacobian(const std::array<DataVector, 2>& /*xi*/) const;
+Rotation<2>::jacobian(const std::array<DataVector, 2>& source_coords) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::inv_jacobian(
-    const std::array<std::reference_wrapper<const double>, 2>& /*xi*/) const;
+Rotation<2>::inv_jacobian(const std::array<std::reference_wrapper<const double>,
+                                           2>& source_coords) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::inv_jacobian(const std::array<double, 2>& /*xi*/) const;
+Rotation<2>::inv_jacobian(const std::array<double, 2>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
 Rotation<2>::inv_jacobian(
-    const std::array<std::reference_wrapper<const DataVector>, 2>& /*xi*/)
+    const std::array<std::reference_wrapper<const DataVector>, 2>&
+        source_coords) const;
+template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
+                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
+                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
+Rotation<2>::inv_jacobian(const std::array<DataVector, 2>& source_coords) const;
+
+template std::array<double, 3> Rotation<3>::operator()(
+    const std::array<std::reference_wrapper<const double>, 3>& source_coords)
     const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::inv_jacobian(const std::array<DataVector, 2>& /*xi*/) const;
-
 template std::array<double, 3> Rotation<3>::operator()(
-    const std::array<std::reference_wrapper<const double>, 3>& xi) const;
-template std::array<double, 3> Rotation<3>::operator()(
-    const std::array<double, 3>& xi) const;
+    const std::array<double, 3>& source_coords) const;
 template std::array<DataVector, 3> Rotation<3>::operator()(
-    const std::array<std::reference_wrapper<const DataVector>, 3>& xi) const;
+    const std::array<std::reference_wrapper<const DataVector>, 3>&
+        source_coords) const;
 template std::array<DataVector, 3> Rotation<3>::operator()(
-    const std::array<DataVector, 3>& xi) const;
+    const std::array<DataVector, 3>& source_coords) const;
 
 template std::array<double, 3> Rotation<3>::inverse(
-    const std::array<std::reference_wrapper<const double>, 3>& xi) const;
+    const std::array<std::reference_wrapper<const double>, 3>& target_coords)
+    const;
 template std::array<double, 3> Rotation<3>::inverse(
-    const std::array<double, 3>& xi) const;
+    const std::array<double, 3>& target_coords) const;
 template std::array<DataVector, 3> Rotation<3>::inverse(
-    const std::array<std::reference_wrapper<const DataVector>, 3>& xi) const;
+    const std::array<std::reference_wrapper<const DataVector>, 3>&
+        target_coords) const;
 template std::array<DataVector, 3> Rotation<3>::inverse(
-    const std::array<DataVector, 3>& xi) const;
+    const std::array<DataVector, 3>& target_coords) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::jacobian(
-    const std::array<std::reference_wrapper<const double>, 3>& /*xi*/) const;
+Rotation<3>::jacobian(const std::array<std::reference_wrapper<const double>, 3>&
+                          source_coords) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::jacobian(const std::array<double, 3>& /*xi*/) const;
+Rotation<3>::jacobian(const std::array<double, 3>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
 Rotation<3>::jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                       3>& /*xi*/) const;
+                                       3>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::jacobian(const std::array<DataVector, 3>& /*xi*/) const;
+Rotation<3>::jacobian(const std::array<DataVector, 3>& source_coords) const;
 
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::inv_jacobian(
-    const std::array<std::reference_wrapper<const double>, 3>& /*xi*/) const;
+Rotation<3>::inv_jacobian(const std::array<std::reference_wrapper<const double>,
+                                           3>& source_coords) const;
 template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::inv_jacobian(const std::array<double, 3>& /*xi*/) const;
+Rotation<3>::inv_jacobian(const std::array<double, 3>& source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
 Rotation<3>::inv_jacobian(
-    const std::array<std::reference_wrapper<const DataVector>, 3>& /*xi*/)
-    const;
+    const std::array<std::reference_wrapper<const DataVector>, 3>&
+        source_coords) const;
 template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                 index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                            SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::inv_jacobian(const std::array<DataVector, 3>& /*xi*/) const;
+Rotation<3>::inv_jacobian(const std::array<DataVector, 3>& source_coords) const;
 
 }  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/Rotation.hpp
@@ -52,25 +52,25 @@ class Rotation<2> {
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> operator()(
-      const std::array<T, 2>& xi) const;
+      const std::array<T, 2>& source_coords) const;
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> inverse(
-      const std::array<T, 2>& x) const;
+      const std::array<T, 2>& target_coords) const;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 2>& /*xi*/) const;
+  jacobian(const std::array<T, 2>& source_coords) const;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 2>& /*xi*/) const;
+  inv_jacobian(const std::array<T, 2>& source_coords) const;
 
   void pup(PUP::er& p);  // NOLINT
 
@@ -130,25 +130,25 @@ class Rotation<3> {
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> operator()(
-      const std::array<T, 3>& xi) const;
+      const std::array<T, 3>& source_coords) const;
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> inverse(
-      const std::array<T, 3>& x) const;
+      const std::array<T, 3>& target_coords) const;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 3>& /*xi*/) const;
+  jacobian(const std::array<T, 3>& source_coords) const;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 3>& /*xi*/) const;
+  inv_jacobian(const std::array<T, 3>& source_coords) const;
 
   void pup(PUP::er& p);  // NOLINT
 

--- a/src/Domain/CoordinateMaps/Wedge2D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.hpp
@@ -40,25 +40,25 @@ class Wedge2D {
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> operator()(
-      const std::array<T, 2>& x) const noexcept;
+      const std::array<T, 2>& source_coords) const noexcept;
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> inverse(
-      const std::array<T, 2>& x) const noexcept;
+      const std::array<T, 2>& target_coords) const noexcept;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 2>& x) const noexcept;
+  jacobian(const std::array<T, 2>& source_coords) const noexcept;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 2>& x) const noexcept;
+  inv_jacobian(const std::array<T, 2>& source_coords) const noexcept;
 
   // clang-tidy: google runtime references
   void pup(PUP::er& p);  // NOLINT

--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -200,26 +200,25 @@ class Wedge3D {
 
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> operator()(
-      const std::array<T, 3>& x) const noexcept;
+      const std::array<T, 3>& source_coords) const noexcept;
 
-  // Currently unimplemented, hence the noreturn attribute
   template <typename T>
   std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> inverse(
-      const std::array<T, 3>& x) const noexcept;
+      const std::array<T, 3>& target_coords) const noexcept;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 3>& x) const noexcept;
+  jacobian(const std::array<T, 3>& source_coords) const noexcept;
 
   template <typename T>
   Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
          tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
                     SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 3>& xi) const noexcept;
+  inv_jacobian(const std::array<T, 3>& source_coords) const noexcept;
 
   // clang-tidy: google runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/Domain/DomainCreators/Brick.cpp
+++ b/src/Domain/DomainCreators/Brick.cpp
@@ -10,7 +10,7 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/BlockNeighbor.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Domain.hpp"
@@ -37,9 +37,8 @@ Brick<TargetFrame>::Brick(
 
 template <typename TargetFrame>
 Domain<3, TargetFrame> Brick<TargetFrame>::create_domain() const noexcept {
-  using AffineMap = CoordinateMaps::AffineMap;
-  using AffineMap3D =
-      CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   std::vector<PairOfFaces> identifications{};
   if (is_periodic_in_xyz_[0]) {
     identifications.push_back({{0, 4, 2, 6}, {1, 5, 3, 7}});
@@ -53,9 +52,9 @@ Domain<3, TargetFrame> Brick<TargetFrame>::create_domain() const noexcept {
 
   return Domain<3, TargetFrame>{
       make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
-          AffineMap3D{AffineMap{-1., 1., lower_xyz_[0], upper_xyz_[0]},
-                      AffineMap{-1., 1., lower_xyz_[1], upper_xyz_[1]},
-                      AffineMap{-1., 1., lower_xyz_[2], upper_xyz_[2]}}),
+          Affine3D{Affine{-1., 1., lower_xyz_[0], upper_xyz_[0]},
+                   Affine{-1., 1., lower_xyz_[1], upper_xyz_[1]},
+                   Affine{-1., 1., lower_xyz_[2], upper_xyz_[2]}}),
       std::vector<std::array<size_t, 8>>{{{0, 1, 2, 3, 4, 5, 6, 7}}},
       identifications};
 }

--- a/src/Domain/DomainCreators/Disk.cpp
+++ b/src/Domain/DomainCreators/Disk.cpp
@@ -7,7 +7,7 @@
 
 #include "Domain/Block.hpp"
 #include "Domain/BlockNeighbor.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
@@ -35,8 +35,8 @@ Disk<TargetFrame>::Disk(
 template <typename TargetFrame>
 Domain<2, TargetFrame> Disk<TargetFrame>::create_domain() const noexcept {
   using Wedge2DMap = CoordinateMaps::Wedge2D;
-  using AffineMap = CoordinateMaps::AffineMap;
-  using AffineMap2D = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+  using Affine = CoordinateMaps::Affine;
+  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
   using Equiangular = CoordinateMaps::Equiangular;
   using Equiangular2D =
       CoordinateMaps::ProductOf2Maps<Equiangular, Equiangular>;
@@ -72,10 +72,10 @@ Domain<2, TargetFrame> Disk<TargetFrame>::create_domain() const noexcept {
   } else {
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::Logical, TargetFrame>(
-            AffineMap2D{AffineMap(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
-                                  inner_radius_ / sqrt(2.0)),
-                        AffineMap(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
-                                  inner_radius_ / sqrt(2.0))}));
+            Affine2D{Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
+                            inner_radius_ / sqrt(2.0)),
+                     Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(2.0),
+                            inner_radius_ / sqrt(2.0))}));
   }
   return Domain<2, TargetFrame>{std::move(coord_maps), corners};
 }

--- a/src/Domain/DomainCreators/Interval.cpp
+++ b/src/Domain/DomainCreators/Interval.cpp
@@ -9,7 +9,7 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/BlockNeighbor.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Domain.hpp"
 #include "Options/Options.hpp"
@@ -37,7 +37,7 @@ template <typename TargetFrame>
 Domain<1, TargetFrame> Interval<TargetFrame>::create_domain() const noexcept {
   return Domain<1, TargetFrame>{
       make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
-          CoordinateMaps::AffineMap{-1., 1., lower_x_[0], upper_x_[0]}),
+          CoordinateMaps::Affine{-1., 1., lower_x_[0], upper_x_[0]}),
       std::vector<std::array<size_t, 2>>{{{1, 2}}},
       is_periodic_in_x_[0] ? std::vector<PairOfFaces>{{{1}, {2}}}
                            : std::vector<PairOfFaces>{}};

--- a/src/Domain/DomainCreators/Rectangle.cpp
+++ b/src/Domain/DomainCreators/Rectangle.cpp
@@ -10,7 +10,7 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/BlockNeighbor.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Domain.hpp"
@@ -37,8 +37,8 @@ Rectangle<TargetFrame>::Rectangle(
 
 template <typename TargetFrame>
 Domain<2, TargetFrame> Rectangle<TargetFrame>::create_domain() const noexcept {
-  using AffineMap = CoordinateMaps::AffineMap;
-  using AffineMap2D = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+  using Affine = CoordinateMaps::Affine;
+  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
   std::vector<PairOfFaces> identifications{};
   if (is_periodic_in_xy_[0]) {
     identifications.push_back({{0, 2}, {1, 3}});
@@ -49,8 +49,8 @@ Domain<2, TargetFrame> Rectangle<TargetFrame>::create_domain() const noexcept {
 
   return Domain<2, TargetFrame>{
       make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
-          AffineMap2D{AffineMap{-1., 1., lower_xy_[0], upper_xy_[0]},
-                      AffineMap{-1., 1., lower_xy_[1], upper_xy_[1]}}),
+          Affine2D{Affine{-1., 1., lower_xy_[0], upper_xy_[0]},
+                   Affine{-1., 1., lower_xy_[1], upper_xy_[1]}}),
       std::vector<std::array<size_t, 4>>{{{0, 1, 2, 3}}}, identifications};
 }
 

--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -1,7 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
@@ -17,16 +17,15 @@ void register_with_charm();
 template <>
 void register_with_charm<1>() {
   PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         CoordinateMaps::AffineMap>));
+                                         CoordinateMaps::Affine>));
 }
 
 template <>
 void register_with_charm<2>() {
-  PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<
-                 Frame::Logical, Frame::Inertial,
-                 CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
-                                                CoordinateMaps::AffineMap>>));
+  PUPable_reg(SINGLE_ARG(
+      ::CoordinateMap<Frame::Logical, Frame::Inertial,
+                      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                     CoordinateMaps::Affine>>));
   PUPable_reg(
       SINGLE_ARG(::CoordinateMap<
                  Frame::Logical, Frame::Inertial,
@@ -39,9 +38,9 @@ template <>
 void register_with_charm<3>() {
   PUPable_reg(SINGLE_ARG(
       ::CoordinateMap<Frame::Logical, Frame::Inertial,
-                      CoordinateMaps::ProductOf3Maps<
-                          CoordinateMaps::AffineMap, CoordinateMaps::AffineMap,
-                          CoordinateMaps::AffineMap>>));
+                      CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
+                                                     CoordinateMaps::Affine,
+                                                     CoordinateMaps::Affine>>));
   PUPable_reg(
       SINGLE_ARG(::CoordinateMap<
                  Frame::Logical, Frame::Inertial,

--- a/src/Domain/DomainCreators/Sphere.cpp
+++ b/src/Domain/DomainCreators/Sphere.cpp
@@ -6,7 +6,7 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/BlockNeighbor.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
@@ -35,9 +35,8 @@ Sphere<TargetFrame>::Sphere(
 template <typename TargetFrame>
 Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
   using Wedge3DMap = CoordinateMaps::Wedge3D;
-  using AffineMap = CoordinateMaps::AffineMap;
-  using AffineMap3D =
-      CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   using Equiangular = CoordinateMaps::Equiangular;
   using Equiangular3D =
       CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
@@ -77,12 +76,12 @@ Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
   } else {
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::Logical, TargetFrame>(
-            AffineMap3D{AffineMap(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
-                                  inner_radius_ / sqrt(3.0)),
-                        AffineMap(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
-                                  inner_radius_ / sqrt(3.0)),
-                        AffineMap(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
-                                  inner_radius_ / sqrt(3.0))}));
+            Affine3D{Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                            inner_radius_ / sqrt(3.0)),
+                     Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                            inner_radius_ / sqrt(3.0)),
+                     Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                            inner_radius_ / sqrt(3.0))}));
   }
   return Domain<3, TargetFrame>(std::move(coord_maps), corners);
 }

--- a/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
+++ b/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
@@ -9,7 +9,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/VariablesHelpers.hpp"
 #include "Domain/Block.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
@@ -19,15 +19,12 @@
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-using AffineMap = CoordinateMaps::AffineMap;
-using AffineMap2D = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
-using AffineMap3D =
-    CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
-using AffineCoordMap = CoordinateMap<Frame::Logical, Frame::Grid, AffineMap>;
-using AffineCoordMap2D =
-    CoordinateMap<Frame::Logical, Frame::Grid, AffineMap2D>;
-using AffineCoordMap3D =
-    CoordinateMap<Frame::Logical, Frame::Grid, AffineMap3D>;
+using Affine = CoordinateMaps::Affine;
+using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+using AffineCoordMap = CoordinateMap<Frame::Logical, Frame::Grid, Affine>;
+using AffineCoordMap2D = CoordinateMap<Frame::Logical, Frame::Grid, Affine2D>;
+using AffineCoordMap3D = CoordinateMap<Frame::Logical, Frame::Grid, Affine3D>;
 template <size_t Dim>
 using Rotation = CoordinateMaps::Rotation<Dim>;
 
@@ -82,13 +79,13 @@ void test_1d_aligned() {
       std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid, 1>>>(
       std::make_unique<AffineCoordMap>(
           make_coordinate_map<Frame::Logical, Frame::Grid>(
-              AffineMap{-1.0, 1.0, -2.0, 2.0})),
+              Affine{-1.0, 1.0, -2.0, 2.0})),
       std::make_unique<AffineCoordMap>(
           make_coordinate_map<Frame::Logical, Frame::Grid>(
-              AffineMap{-1.0, 1.0, 2.0, 5.0})),
+              Affine{-1.0, 1.0, 2.0, 5.0})),
       std::make_unique<AffineCoordMap>(
           make_coordinate_map<Frame::Logical, Frame::Grid>(
-              AffineMap{-1.0, 1.0, 5.0, 6.0})));
+              Affine{-1.0, 1.0, 5.0, 6.0})));
 
   std::vector<std::array<size_t, 2>> corners{{{0, 1}}, {{1, 2}}, {{2, 3}}};
 
@@ -112,13 +109,13 @@ void test_1d_flipped() {
       std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid, 1>>>(
       std::make_unique<AffineCoordMap>(
           make_coordinate_map<Frame::Logical, Frame::Grid>(
-              AffineMap{-1.0, 1.0, 2.0, -2.0})),
+              Affine{-1.0, 1.0, 2.0, -2.0})),
       std::make_unique<AffineCoordMap>(
           make_coordinate_map<Frame::Logical, Frame::Grid>(
-              AffineMap{-1.0, 1.0, 2.0, 5.0})),
+              Affine{-1.0, 1.0, 2.0, 5.0})),
       std::make_unique<AffineCoordMap>(
           make_coordinate_map<Frame::Logical, Frame::Grid>(
-              AffineMap{-1.0, 1.0, 6.0, 5.0})));
+              Affine{-1.0, 1.0, 6.0, 5.0})));
 
   std::vector<std::array<size_t, 2>> corners{{{1, 0}}, {{1, 2}}, {{3, 2}}};
 
@@ -140,25 +137,25 @@ void test_1d_flipped() {
 template <typename Map>
 void test_2d_rotated(const Map& my_map, const std::array<size_t, 4>& my_corners,
                      const Index<2>& my_extents) {
-  const AffineMap lower_x_map(-1.0, 1.0, -2.0, 2.0);
-  const AffineMap center_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap upper_x_map(-1.0, 1.0, 5.0, 6.0);
-  const AffineMap lower_y_map(-1.0, 1.0, -3.0, 0.0);
-  const AffineMap center_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap upper_y_map(-1.0, 1.0, 4.0, 9.0);
+  const Affine lower_x_map(-1.0, 1.0, -2.0, 2.0);
+  const Affine center_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine upper_x_map(-1.0, 1.0, 5.0, 6.0);
+  const Affine lower_y_map(-1.0, 1.0, -3.0, 0.0);
+  const Affine center_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine upper_y_map(-1.0, 1.0, 4.0, 9.0);
 
   const auto lower_eta_neighbor_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(
-          AffineMap2D{center_x_map, lower_y_map});
+          Affine2D{center_x_map, lower_y_map});
   const auto lower_xi_neighbor_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(
-          AffineMap2D{lower_x_map, center_y_map});
+          Affine2D{lower_x_map, center_y_map});
   const auto upper_xi_neighbor_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(
-          AffineMap2D{upper_x_map, center_y_map});
+          Affine2D{upper_x_map, center_y_map});
   const auto upper_eta_neighbor_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(
-          AffineMap2D{center_x_map, upper_y_map});
+          Affine2D{center_x_map, upper_y_map});
 
   auto maps = make_vector<
       std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid, 2>>>(
@@ -206,10 +203,10 @@ void test_2d_rotated(const Map& my_map, const std::array<size_t, 4>& my_corners,
 }
 
 void test_2d_aligned() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
   const Rotation<2> rotation(0.0);
-  const AffineMap2D product{my_x_map, my_y_map};
+  const Affine2D product{my_x_map, my_y_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 4> my_corners{{3, 4, 7, 8}};
@@ -218,10 +215,10 @@ void test_2d_aligned() {
 }
 
 void test_2d_flipped() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
   const Rotation<2> rotation(M_PI);
-  const AffineMap2D product{my_x_map, my_y_map};
+  const Affine2D product{my_x_map, my_y_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 4> my_corners{{8, 7, 4, 3}};
@@ -230,10 +227,10 @@ void test_2d_flipped() {
 }
 
 void test_2d_rotated_by_90() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
   const Rotation<2> rotation(M_PI_2);
-  const AffineMap2D product{my_x_map, my_y_map};
+  const Affine2D product{my_x_map, my_y_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 4> my_corners{{4, 8, 3, 7}};
@@ -242,10 +239,10 @@ void test_2d_rotated_by_90() {
 }
 
 void test_2d_rotated_by_270() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
   const Rotation<2> rotation(-M_PI_2);
-  const AffineMap2D product{my_x_map, my_y_map};
+  const Affine2D product{my_x_map, my_y_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 4> my_corners{{7, 3, 8, 4}};
@@ -256,34 +253,34 @@ void test_2d_rotated_by_270() {
 template <typename Map>
 void test_3d_rotated(const Map& my_map, const std::array<size_t, 8>& my_corners,
                      const Index<3>& my_extents) {
-  const AffineMap lower_x_map(-1.0, 1.0, -2.0, 2.0);
-  const AffineMap center_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap upper_x_map(-1.0, 1.0, 5.0, 6.0);
-  const AffineMap lower_y_map(-1.0, 1.0, -3.0, 0.0);
-  const AffineMap center_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap upper_y_map(-1.0, 1.0, 4.0, 9.0);
-  const AffineMap lower_z_map(-1.0, 1.0, -5.0, 1.0);
-  const AffineMap center_z_map(-1.0, 1.0, 1.0, 7.0);
-  const AffineMap upper_z_map(-1.0, 1.0, 7.0, 12.0);
+  const Affine lower_x_map(-1.0, 1.0, -2.0, 2.0);
+  const Affine center_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine upper_x_map(-1.0, 1.0, 5.0, 6.0);
+  const Affine lower_y_map(-1.0, 1.0, -3.0, 0.0);
+  const Affine center_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine upper_y_map(-1.0, 1.0, 4.0, 9.0);
+  const Affine lower_z_map(-1.0, 1.0, -5.0, 1.0);
+  const Affine center_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine upper_z_map(-1.0, 1.0, 7.0, 12.0);
 
   const auto lower_zeta_neighbor_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(
-          AffineMap3D{center_x_map, center_y_map, lower_z_map});
+          Affine3D{center_x_map, center_y_map, lower_z_map});
   const auto lower_eta_neighbor_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(
-          AffineMap3D{center_x_map, lower_y_map, center_z_map});
+          Affine3D{center_x_map, lower_y_map, center_z_map});
   const auto lower_xi_neighbor_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(
-          AffineMap3D{lower_x_map, center_y_map, center_z_map});
+          Affine3D{lower_x_map, center_y_map, center_z_map});
   const auto upper_xi_neighbor_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(
-          AffineMap3D{upper_x_map, center_y_map, center_z_map});
+          Affine3D{upper_x_map, center_y_map, center_z_map});
   const auto upper_eta_neighbor_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(
-          AffineMap3D{center_x_map, upper_y_map, center_z_map});
+          Affine3D{center_x_map, upper_y_map, center_z_map});
   const auto upper_zeta_neighbor_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(
-          AffineMap3D{center_x_map, center_y_map, upper_z_map});
+          Affine3D{center_x_map, center_y_map, upper_z_map});
 
   auto maps = make_vector<
       std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>(
@@ -341,12 +338,12 @@ void test_3d_rotated(const Map& my_map, const std::array<size_t, 8>& my_corners,
 }
 
 void test_3d_aligned() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, 0.0, 0.0);
 
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
 
@@ -356,12 +353,12 @@ void test_3d_aligned() {
 }
 
 void test_3d_rotated_by_90_0_0() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(M_PI_2, 0.0, 0.0);
 
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
 
@@ -371,12 +368,12 @@ void test_3d_rotated_by_90_0_0() {
 }
 
 void test_3d_rotated_by_180_0_0() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(M_PI, 0.0, 0.0);
 
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
 
@@ -386,11 +383,11 @@ void test_3d_rotated_by_180_0_0() {
 }
 
 void test_3d_rotated_by_270_0_0() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(-M_PI_2, 0.0, 0.0);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{11, 7, 12, 8, 23, 19, 24, 20}};
@@ -399,11 +396,11 @@ void test_3d_rotated_by_270_0_0() {
 }
 
 void test_3d_rotated_by_0_90_0() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, M_PI_2, 0.0);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{19, 7, 23, 11, 20, 8, 24, 12}};
@@ -412,11 +409,11 @@ void test_3d_rotated_by_0_90_0() {
 }
 
 void test_3d_rotated_by_0_90_90() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, M_PI_2, M_PI_2);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{7, 11, 19, 23, 8, 12, 20, 24}};
@@ -425,11 +422,11 @@ void test_3d_rotated_by_0_90_90() {
 }
 
 void test_3d_rotated_by_0_90_180() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, M_PI_2, M_PI);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{11, 23, 7, 19, 12, 24, 8, 20}};
@@ -438,11 +435,11 @@ void test_3d_rotated_by_0_90_180() {
 }
 
 void test_3d_rotated_by_0_90_270() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, M_PI_2, -M_PI_2);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{23, 19, 11, 7, 24, 20, 12, 8}};
@@ -451,11 +448,11 @@ void test_3d_rotated_by_0_90_270() {
 }
 
 void test_3d_rotated_by_0_180_0() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, M_PI, 0.0);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{20, 19, 24, 23, 8, 7, 12, 11}};
@@ -464,11 +461,11 @@ void test_3d_rotated_by_0_180_0() {
 }
 
 void test_3d_rotated_by_0_180_90() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, M_PI, M_PI_2);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{19, 23, 20, 24, 7, 11, 8, 12}};
@@ -477,11 +474,11 @@ void test_3d_rotated_by_0_180_90() {
 }
 
 void test_3d_rotated_by_0_180_180() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, M_PI, M_PI);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{23, 24, 19, 20, 11, 12, 7, 8}};
@@ -490,11 +487,11 @@ void test_3d_rotated_by_0_180_180() {
 }
 
 void test_3d_rotated_by_0_180_270() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, M_PI, -M_PI_2);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{24, 20, 23, 19, 12, 8, 11, 7}};
@@ -503,11 +500,11 @@ void test_3d_rotated_by_0_180_270() {
 }
 
 void test_3d_rotated_by_0_270_0() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, -M_PI_2, 0.0);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{8, 20, 12, 24, 7, 19, 11, 23}};
@@ -516,11 +513,11 @@ void test_3d_rotated_by_0_270_0() {
 }
 
 void test_3d_rotated_by_0_270_90() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, -M_PI_2, M_PI_2);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{20, 24, 8, 12, 19, 23, 7, 11}};
@@ -529,11 +526,11 @@ void test_3d_rotated_by_0_270_90() {
 }
 
 void test_3d_rotated_by_0_270_180() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, -M_PI_2, M_PI);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{24, 12, 20, 8, 23, 11, 19, 7}};
@@ -542,11 +539,11 @@ void test_3d_rotated_by_0_270_180() {
 }
 
 void test_3d_rotated_by_0_270_270() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(0.0, -M_PI_2, -M_PI_2);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{12, 8, 24, 20, 11, 7, 23, 19}};
@@ -555,11 +552,11 @@ void test_3d_rotated_by_0_270_270() {
 }
 
 void test_3d_rotated_by_90_90_0() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(M_PI_2, M_PI_2, 0.0);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{20, 8, 19, 7, 24, 12, 23, 11}};
@@ -568,11 +565,11 @@ void test_3d_rotated_by_90_90_0() {
 }
 
 void test_3d_rotated_by_90_90_90() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(M_PI_2, M_PI_2, M_PI_2);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{8, 7, 20, 19, 12, 11, 24, 23}};
@@ -581,11 +578,11 @@ void test_3d_rotated_by_90_90_90() {
 }
 
 void test_3d_rotated_by_90_90_180() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(M_PI_2, M_PI_2, M_PI);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{7, 19, 8, 20, 11, 23, 12, 24}};
@@ -594,11 +591,11 @@ void test_3d_rotated_by_90_90_180() {
 }
 
 void test_3d_rotated_by_90_90_270() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(M_PI_2, M_PI_2, -M_PI_2);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{19, 20, 7, 8, 23, 24, 11, 12}};
@@ -607,11 +604,11 @@ void test_3d_rotated_by_90_90_270() {
 }
 
 void test_3d_rotated_by_90_270_0() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(M_PI_2, -M_PI_2, 0.0);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{12, 24, 11, 23, 8, 20, 7, 19}};
@@ -620,11 +617,11 @@ void test_3d_rotated_by_90_270_0() {
 }
 
 void test_3d_rotated_by_90_270_90() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(M_PI_2, -M_PI_2, M_PI_2);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{24, 23, 12, 11, 20, 19, 8, 7}};
@@ -633,11 +630,11 @@ void test_3d_rotated_by_90_270_90() {
 }
 
 void test_3d_rotated_by_90_270_180() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(M_PI_2, -M_PI_2, M_PI);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{23, 11, 24, 12, 19, 7, 20, 8}};
@@ -646,11 +643,11 @@ void test_3d_rotated_by_90_270_180() {
 }
 
 void test_3d_rotated_by_90_270_270() {
-  const AffineMap my_x_map(-1.0, 1.0, 2.0, 5.0);
-  const AffineMap my_y_map(-1.0, 1.0, 0.0, 4.0);
-  const AffineMap my_z_map(-1.0, 1.0, 1.0, 7.0);
+  const Affine my_x_map(-1.0, 1.0, 2.0, 5.0);
+  const Affine my_y_map(-1.0, 1.0, 0.0, 4.0);
+  const Affine my_z_map(-1.0, 1.0, 1.0, 7.0);
   const Rotation<3> rotation(M_PI_2, -M_PI_2, -M_PI_2);
-  const AffineMap3D product{my_x_map, my_y_map, my_z_map};
+  const Affine3D product{my_x_map, my_y_map, my_z_map};
   const auto my_map =
       make_coordinate_map<Frame::Logical, Frame::Grid>(rotation, product);
   const std::array<size_t, 8> my_corners{{11, 12, 23, 24, 7, 8, 19, 20}};

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -2,7 +2,7 @@
 # See LICENSE.txt for details.
 
 set(DOMAIN_TESTS
-    Domain/CoordinateMaps/Test_AffineMap.cpp
+    Domain/CoordinateMaps/Test_Affine.cpp
     Domain/CoordinateMaps/Test_CoordinateMap.cpp
     Domain/CoordinateMaps/Test_Equiangular.cpp
     Domain/CoordinateMaps/Test_Identity.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
@@ -14,7 +14,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Affine", "[Domain][Unit]") {
   const double xa = -2.0;
   const double xb = 2.0;
 
-  CoordinateMaps::AffineMap affine_map(xA, xB, xa, xb);
+  CoordinateMaps::Affine affine_map(xA, xB, xa, xb);
 
   const double xi = 0.5 * (xA + xB);
   const double x = xb * (xi - xA) / (xB - xA) + xa * (xB - xi) / (xB - xA);

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -5,7 +5,7 @@
 
 #include "DataStructures/MakeWithValue.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
@@ -59,7 +59,7 @@ auto compose_inv_jacobians(const Map1& map1, const Map2& map2,
 }
 
 void test_single_coordinate_map() {
-  using affine_map1d = CoordinateMaps::AffineMap;
+  using affine_map1d = CoordinateMaps::Affine;
 
   const auto affine1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
       affine_map1d{-1.0, 1.0, 2.0, 8.0});
@@ -217,7 +217,7 @@ void test_single_coordinate_map() {
 }
 
 void test_coordinate_map_with_affine_map() {
-  using affine_map = CoordinateMaps::AffineMap;
+  using affine_map = CoordinateMaps::Affine;
   using affine_map_2d = CoordinateMaps::ProductOf2Maps<affine_map, affine_map>;
   using affine_map_3d =
       CoordinateMaps::ProductOf3Maps<affine_map, affine_map, affine_map>;
@@ -534,16 +534,16 @@ void test_coordinate_map_with_rotation_wedge() {
 }
 
 void test_make_vector_coordinate_map_base() {
-  using AffineMap = CoordinateMaps::AffineMap;
+  using Affine = CoordinateMaps::Affine;
 
   const auto affine1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      AffineMap{-1.0, 1.0, 2.0, 8.0});
+      Affine{-1.0, 1.0, 2.0, 8.0});
   const auto affine1d_base =
       make_coordinate_map_base<Frame::Logical, Frame::Grid>(
-          AffineMap{-1.0, 1.0, 2.0, 8.0});
+          Affine{-1.0, 1.0, 2.0, 8.0});
   const auto vector_of_affine1d =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Grid>(
-          AffineMap{-1.0, 1.0, 2.0, 8.0});
+          Affine{-1.0, 1.0, 2.0, 8.0});
 
   CHECK(affine1d == *affine1d_base);
   CHECK(*affine1d_base == affine1d);

--- a/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
@@ -5,7 +5,7 @@
 
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
@@ -13,7 +13,7 @@
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf2Maps",
                   "[Domain][Unit]") {
-  using affine_map = CoordinateMaps::AffineMap;
+  using affine_map = CoordinateMaps::Affine;
   using affine_map_2d = CoordinateMaps::ProductOf2Maps<affine_map, affine_map>;
 
   const double xA = -1.0;
@@ -126,7 +126,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf2Maps",
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf3Maps",
                   "[Domain][Unit]") {
-  using affine_map = CoordinateMaps::AffineMap;
+  using affine_map = CoordinateMaps::Affine;
   using affine_map_3d =
       CoordinateMaps::ProductOf3Maps<affine_map, affine_map, affine_map>;
 

--- a/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
@@ -3,7 +3,7 @@
 
 #include <catch.hpp>
 
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Brick.hpp"
@@ -15,9 +15,8 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
-using AffineMap = CoordinateMaps::AffineMap;
-using AffineMap3D =
-    CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+using Affine = CoordinateMaps::Affine;
+using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 void test_brick_construction(
     const DomainCreators::Brick<Frame::Inertial>& brick,
     const std::array<double, 3>& lower_bound,
@@ -40,9 +39,9 @@ void test_brick_construction(
   test_domain_construction(
       domain, expected_block_neighbors, expected_external_boundaries,
       make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          AffineMap3D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
-                      AffineMap{-1., 1., lower_bound[1], upper_bound[1]},
-                      AffineMap{-1., 1., lower_bound[2], upper_bound[2]}})));
+          Affine3D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
+                   Affine{-1., 1., lower_bound[1], upper_bound[1]},
+                   Affine{-1., 1., lower_bound[2], upper_bound[2]}})));
 
   test_initial_domain(domain, brick.initial_refinement_levels());
 }
@@ -176,15 +175,14 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
 
   const auto base_map =
       make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          AffineMap3D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
-                      AffineMap{-1., 1., lower_bound[1], upper_bound[1]},
-                      AffineMap{-1., 1., lower_bound[2], upper_bound[2]}});
-  are_maps_equal(
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(
-          AffineMap3D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
-                      AffineMap{-1., 1., lower_bound[1], upper_bound[1]},
-                      AffineMap{-1., 1., lower_bound[2], upper_bound[2]}}),
-      *serialize_and_deserialize(base_map));
+          Affine3D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
+                   Affine{-1., 1., lower_bound[1], upper_bound[1]},
+                   Affine{-1., 1., lower_bound[2], upper_bound[2]}});
+  are_maps_equal(make_coordinate_map<Frame::Logical, Frame::Inertial>(
+                     Affine3D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
+                              Affine{-1., 1., lower_bound[1], upper_bound[1]},
+                              Affine{-1., 1., lower_bound[2], upper_bound[2]}}),
+                 *serialize_and_deserialize(base_map));
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick.Factory",

--- a/tests/Unit/Domain/DomainCreators/Test_Disk.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Disk.cpp
@@ -3,7 +3,7 @@
 
 #include <catch.hpp>
 
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
@@ -67,8 +67,8 @@ void test_disk_construction(
   CHECK(disk.initial_refinement_levels() == expected_refinement_level);
   using TargetFrame = Frame::Inertial;
   using Wedge2DMap = CoordinateMaps::Wedge2D;
-  using AffineMap = CoordinateMaps::AffineMap;
-  using AffineMap2D = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+  using Affine = CoordinateMaps::Affine;
+  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
   using Equiangular = CoordinateMaps::Equiangular;
   using Equiangular2D =
       CoordinateMaps::ProductOf2Maps<Equiangular, Equiangular>;
@@ -94,10 +94,10 @@ void test_disk_construction(
   } else {
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::Logical, TargetFrame>(
-            AffineMap2D{AffineMap(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
-                                  inner_radius / sqrt(2.0)),
-                        AffineMap(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
-                                  inner_radius / sqrt(2.0))}));
+            Affine2D{Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
+                            inner_radius / sqrt(2.0)),
+                     Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(2.0),
+                            inner_radius / sqrt(2.0))}));
   }
   test_domain_construction(domain, expected_block_neighbors,
                            expected_external_boundaries, coord_maps);

--- a/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
@@ -3,7 +3,7 @@
 
 #include <catch.hpp>
 
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Interval.hpp"
 #include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
@@ -36,7 +36,7 @@ void test_interval_construction(
   test_domain_construction(
       domain, expected_block_neighbors, expected_external_boundaries,
       make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::AffineMap{-1., 1., lower_bound[0], upper_bound[0]})));
+          CoordinateMaps::Affine{-1., 1., lower_bound[0], upper_bound[0]})));
   test_initial_domain(domain, interval.initial_refinement_levels());
 }
 }  // namespace
@@ -73,13 +73,13 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval", "[Domain][Unit]") {
 
   const auto base_map =
       make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::AffineMap{-1., 1., lower_bound[0], upper_bound[0]});
+          CoordinateMaps::Affine{-1., 1., lower_bound[0], upper_bound[0]});
   const auto base_map_deserialized = serialize_and_deserialize(base_map);
   using MapType = const CoordinateMap<Frame::Logical, Frame::Inertial,
-                                      CoordinateMaps::AffineMap>*;
+                                      CoordinateMaps::Affine>*;
   REQUIRE(dynamic_cast<MapType>(base_map.get()) != nullptr);
   const auto coord_map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
-      CoordinateMaps::AffineMap{-1., 1., lower_bound[0], upper_bound[0]});
+      CoordinateMaps::Affine{-1., 1., lower_bound[0], upper_bound[0]});
   CHECK(*dynamic_cast<MapType>(base_map.get()) == coord_map);
 }
 

--- a/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
@@ -3,7 +3,7 @@
 
 #include <catch.hpp>
 
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Rectangle.hpp"
@@ -15,8 +15,8 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
-using AffineMap = CoordinateMaps::AffineMap;
-using AffineMap2D = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
+using Affine = CoordinateMaps::Affine;
+using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
 void test_rectangle_construction(
     const DomainCreators::Rectangle<Frame::Inertial>& rectangle,
     const std::array<double, 2>& lower_bound,
@@ -39,8 +39,8 @@ void test_rectangle_construction(
   test_domain_construction(
       domain, expected_block_neighbors, expected_external_boundaries,
       make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          AffineMap2D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
-                      AffineMap{-1., 1., lower_bound[1], upper_bound[1]}})));
+          Affine2D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
+                   Affine{-1., 1., lower_bound[1], upper_bound[1]}})));
   test_initial_domain(domain, rectangle.initial_refinement_levels());
 }
 }  // namespace
@@ -106,15 +106,15 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
 
   const auto base_map =
       make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          AffineMap2D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
-                      AffineMap{-1., 1., lower_bound[1], upper_bound[1]}});
+          Affine2D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
+                   Affine{-1., 1., lower_bound[1], upper_bound[1]}});
   const auto base_map_deserialized = serialize_and_deserialize(base_map);
   using MapType =
-      const CoordinateMap<Frame::Logical, Frame::Inertial, AffineMap2D>*;
+      const CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D>*;
   REQUIRE(dynamic_cast<MapType>(base_map.get()) != nullptr);
   const auto coord_map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
-      AffineMap2D{AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
-                  AffineMap{-1., 1., lower_bound[1], upper_bound[1]}});
+      Affine2D{Affine{-1., 1., lower_bound[0], upper_bound[0]},
+               Affine{-1., 1., lower_bound[1], upper_bound[1]}});
   CHECK(*dynamic_cast<MapType>(base_map.get()) == coord_map);
 }
 

--- a/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
@@ -7,7 +7,7 @@
 #include <vector>
 
 #include "Domain/Block.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
@@ -126,9 +126,8 @@ void test_sphere_construction(
   CHECK(sphere.initial_extents() == expected_extents);
   CHECK(sphere.initial_refinement_levels() == expected_refinement_level);
   using Wedge3DMap = CoordinateMaps::Wedge3D;
-  using AffineMap = CoordinateMaps::AffineMap;
-  using AffineMap3D =
-      CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   using Equiangular = CoordinateMaps::Equiangular;
   using Equiangular3D =
       CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
@@ -159,12 +158,12 @@ void test_sphere_construction(
   } else {
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            AffineMap3D{AffineMap(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                                  inner_radius / sqrt(3.0)),
-                        AffineMap(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                                  inner_radius / sqrt(3.0)),
-                        AffineMap(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
-                                  inner_radius / sqrt(3.0))}));
+            Affine3D{Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                            inner_radius / sqrt(3.0)),
+                     Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                            inner_radius / sqrt(3.0)),
+                     Affine(-1.0, 1.0, -1.0 * inner_radius / sqrt(3.0),
+                            inner_radius / sqrt(3.0))}));
   }
   test_domain_construction(domain, expected_block_neighbors,
                            expected_external_boundaries, coord_maps);

--- a/tests/Unit/Domain/Test_CoordinatesTag.cpp
+++ b/tests/Unit/Domain/Test_CoordinatesTag.cpp
@@ -5,7 +5,7 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/ElementId.hpp"
@@ -33,17 +33,16 @@ void test_coordinates_compute_item(Index<Dim> extents, T map) noexcept {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinatesTag", "[Unit][Domain]") {
-  using AffineMap = CoordinateMaps::AffineMap;
-  using AffineMap2d = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
-  using AffineMap3d =
-      CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+  using Affine = CoordinateMaps::Affine;
+  using Affine2d = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  using Affine3d = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
-  test_coordinates_compute_item(Index<1>{5}, AffineMap{-1.0, 1.0, -0.3, 0.7});
-  test_coordinates_compute_item(Index<2>{5, 7},
-                                AffineMap2d{AffineMap{-1.0, 1.0, -0.3, 0.7},
-                                            AffineMap{-1.0, 1.0, 0.3, 0.55}});
-  test_coordinates_compute_item(Index<3>{5, 6, 9},
-                                AffineMap3d{AffineMap{-1.0, 1.0, -0.3, 0.7},
-                                            AffineMap{-1.0, 1.0, 0.3, 0.55},
-                                            AffineMap{-1.0, 1.0, 2.3, 2.8}});
+  test_coordinates_compute_item(Index<1>{5}, Affine{-1.0, 1.0, -0.3, 0.7});
+  test_coordinates_compute_item(
+      Index<2>{5, 7},
+      Affine2d{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55}});
+  test_coordinates_compute_item(
+      Index<3>{5, 6, 9},
+      Affine3d{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
+               Affine{-1.0, 1.0, 2.3, 2.8}});
 }

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 #include <memory>
 
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Utilities/MakeVector.hpp"
@@ -15,20 +15,20 @@ namespace {
 void test_1d_domains() {
   {
     PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         CoordinateMaps::AffineMap>));
+                                         CoordinateMaps::Affine>));
 
     // Test construction of two intervals which have anti-aligned logical axes.
     const Domain<1, Frame::Inertial> domain(
         make_vector<std::unique_ptr<
             CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>(
             std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
-                                           CoordinateMaps::AffineMap>>(
+                                           CoordinateMaps::Affine>>(
                 make_coordinate_map<Frame::Logical, Frame::Inertial>(
-                    CoordinateMaps::AffineMap{-1., 1., -2., 0.})),
+                    CoordinateMaps::Affine{-1., 1., -2., 0.})),
             std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
-                                           CoordinateMaps::AffineMap>>(
+                                           CoordinateMaps::Affine>>(
                 make_coordinate_map<Frame::Logical, Frame::Inertial>(
-                    CoordinateMaps::AffineMap{-1., 1., 0., 2.}))),
+                    CoordinateMaps::Affine{-1., 1., 0., 2.}))),
         std::vector<std::array<size_t, 2>>{{{1, 2}}, {{3, 2}}});
 
     const OrientationMap<1> unaligned_orientation{{{Direction<1>::lower_xi()}},
@@ -45,9 +45,9 @@ void test_1d_domains() {
 
     const auto expected_maps =
         make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                        CoordinateMaps::AffineMap{-1., 1., -2., 0.}),
+                        CoordinateMaps::Affine{-1., 1., -2., 0.}),
                     make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                        CoordinateMaps::AffineMap{-1., 1., 0., 2.}));
+                        CoordinateMaps::Affine{-1., 1., 0., 2.}));
 
     test_domain_construction(domain, expected_neighbors, expected_boundaries,
                              expected_maps);
@@ -60,15 +60,15 @@ void test_1d_domains() {
       std::vector<Block<1, Frame::Inertial>> vec;
       vec.emplace_back(Block<1, Frame::Inertial>{
           std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         CoordinateMaps::AffineMap>>(
+                                         CoordinateMaps::Affine>>(
               make_coordinate_map<Frame::Logical, Frame::Inertial>(
-                  CoordinateMaps::AffineMap{-1., 1., -2., 0.})),
+                  CoordinateMaps::Affine{-1., 1., -2., 0.})),
           0, expected_neighbors[0]});
       vec.emplace_back(Block<1, Frame::Inertial>{
           std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         CoordinateMaps::AffineMap>>(
+                                         CoordinateMaps::Affine>>(
               make_coordinate_map<Frame::Logical, Frame::Inertial>(
-                  CoordinateMaps::AffineMap{-1., 1., 0., 2.})),
+                  CoordinateMaps::Affine{-1., 1., 0., 2.})),
           1, expected_neighbors[1]});
       return vec;
     }();
@@ -93,15 +93,15 @@ void test_1d_domains() {
     // Test construction of a periodic domain
     const auto expected_maps =
         make_vector(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            CoordinateMaps::AffineMap{-1., 1., -2., 2.}));
+            CoordinateMaps::Affine{-1., 1., -2., 2.}));
 
     const Domain<1, Frame::Inertial> domain{
         make_vector<std::unique_ptr<
             CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>(
             std::make_unique<CoordinateMap<Frame::Logical, Frame::Inertial,
-                                           CoordinateMaps::AffineMap>>(
+                                           CoordinateMaps::Affine>>(
                 make_coordinate_map<Frame::Logical, Frame::Inertial>(
-                    CoordinateMaps::AffineMap{-1., 1., -2., 2.}))),
+                    CoordinateMaps::Affine{-1., 1., -2., 2.}))),
         std::vector<std::array<size_t, 2>>{{{1, 2}}},
         std::vector<PairOfFaces>{{{1}, {2}}}};
 

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
@@ -85,7 +85,7 @@ void test_element_map();
 
 template <>
 void test_element_map<1>() {
-  using AffineMap = CoordinateMaps::AffineMap;
+  using Affine = CoordinateMaps::Affine;
 
   auto segment_ids = std::array<SegmentId, 1>({{SegmentId(2, 3)}});
   ElementId<1> element_id(0, segment_ids);
@@ -93,17 +93,17 @@ void test_element_map<1>() {
   const tnsr::I<DV, 1, Frame::Logical> logical_point_dv(
       DV{-1.0, -0.5, 0.0, 0.5, 1.0});
 
-  const AffineMap affine_map{-1.0, 1.0, 0.5, 1.0};
-  const AffineMap first_map{-1.0, 1.0, 2.0, 8.0};
+  const Affine affine_map{-1.0, 1.0, 0.5, 1.0};
+  const Affine first_map{-1.0, 1.0, 2.0, 8.0};
 
   // Aligned maps
   test_element_impl(true, element_id, affine_map, first_map,
-                    AffineMap{2.0, 8.0, -2.0, -1.0}, logical_point_double,
+                    Affine{2.0, 8.0, -2.0, -1.0}, logical_point_double,
                     logical_point_dv);
 
   // Flip axis in second map
   test_element_impl(true, element_id, affine_map, first_map,
-                    AffineMap{2.0, 8.0, 2.0, -1.0}, logical_point_double,
+                    Affine{2.0, 8.0, 2.0, -1.0}, logical_point_double,
                     logical_point_dv);
 }
 
@@ -111,7 +111,7 @@ template <>
 void test_element_map<2>() {
   using Rotate = CoordinateMaps::Rotation<2>;
   using Wedge2D = CoordinateMaps::Wedge2D;
-  using AffineMap = CoordinateMaps::AffineMap;
+  using Affine = CoordinateMaps::Affine;
 
   auto segment_ids =
       std::array<SegmentId, 2>({{SegmentId(2, 3), SegmentId(1, 0)}});
@@ -122,8 +122,8 @@ void test_element_map<2>() {
   const tnsr::I<DV, 2, Frame::Logical> logical_point_dv(std::array<DV, 2>{
       {DV{-1.0, 0.5, 0.0, 0.5, 1.0}, DV{-1.0, 0.5, 0.0, 0.5, 1.0}}});
 
-  const CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap> affine_map(
-      AffineMap{-1.0, 1.0, 0.5, 1.0}, AffineMap{-1.0, 1.0, -1.0, 0.0});
+  const CoordinateMaps::ProductOf2Maps<Affine, Affine> affine_map(
+      Affine{-1.0, 1.0, 0.5, 1.0}, Affine{-1.0, 1.0, -1.0, 0.0});
   const auto first_map = Rotate(2.);
 
   // Test with two rotations
@@ -139,7 +139,7 @@ void test_element_map<2>() {
 template <>
 void test_element_map<3>() {
   using Rotate = CoordinateMaps::Rotation<3>;
-  using AffineMap = CoordinateMaps::AffineMap;
+  using Affine = CoordinateMaps::Affine;
 
   auto segment_ids = std::array<SegmentId, 3>(
       {{SegmentId(2, 3), SegmentId(1, 0), SegmentId(2, 1)}});
@@ -151,10 +151,9 @@ void test_element_map<3>() {
       {{DV{-1.0, 0.5, 0.0, 0.5, 1.0}, DV{-1.0, 0.5, 0.0, 0.5, 1.0},
         DV{-1.0, 0.5, 0.0, 0.5, 1.0}}}};
 
-  const CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>
-      affine_map(AffineMap{-1.0, 1.0, 0.5, 1.0},
-                 AffineMap{-1.0, 1.0, -1.0, 0.0},
-                 AffineMap{-1.0, 1.0, -0.5, 0.0});
+  const CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine> affine_map(
+      Affine{-1.0, 1.0, 0.5, 1.0}, Affine{-1.0, 1.0, -1.0, 0.0},
+      Affine{-1.0, 1.0, -0.5, 0.0});
   const auto first_map = Rotate{M_PI_4, M_PI_4, M_PI_2};
 
   // test with 2 rotations

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -6,7 +6,7 @@
 
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
@@ -43,7 +43,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.CoordMap", "[Unit][Domain]") {
   /// [face_normal_example]
   const Index<0> extents_0d;
   const auto map_1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      CoordinateMaps::AffineMap(-1.0, 1.0, -3.0, 7.0));
+      CoordinateMaps::Affine(-1.0, 1.0, -3.0, 7.0));
   const auto normal_1d_lower =
       unnormalized_face_normal(extents_0d, map_1d, Direction<1>::lower_xi());
   /// [face_normal_example]
@@ -60,7 +60,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.CoordMap", "[Unit][Domain]") {
         {{{{0.6, 0.8}}, {{-0.8, 0.6}}}});
 
   check(make_coordinate_map<Frame::Logical, Frame::Grid>(
-            CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
+            CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                            CoordinateMaps::Rotation<2>>(
                 {-1., 1., 2., 7.}, CoordinateMaps::Rotation<2>(atan2(4., 3.)))),
         {{{{0.4, 0., 0.}}, {{0., 0.6, 0.8}}, {{0., -0.8, 0.6}}}});
@@ -72,7 +72,7 @@ void test_face_normal_element_map() {
   const Index<0> extents_0d;
   const auto map_1d = ElementMap<1, TargetFrame>(
       ElementId<1>{0}, make_coordinate_map_base<Frame::Logical, TargetFrame>(
-                           CoordinateMaps::AffineMap(-1.0, 1.0, -3.0, 7.0)));
+                           CoordinateMaps::Affine(-1.0, 1.0, -3.0, 7.0)));
   const auto normal_1d_lower =
       unnormalized_face_normal(extents_0d, map_1d, Direction<1>::lower_xi());
 
@@ -92,7 +92,7 @@ void test_face_normal_element_map() {
   check(ElementMap<3, TargetFrame>(
             ElementId<3>(0),
             make_coordinate_map_base<Frame::Logical, TargetFrame>(
-                CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
+                CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                                CoordinateMaps::Rotation<2>>(
                     {-1., 1., 2., 7.},
                     CoordinateMaps::Rotation<2>(atan2(4., 3.))))),

--- a/tests/Unit/Domain/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_LogicalCoordinates.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "DataStructures/Index.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
@@ -12,11 +12,10 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.LogicalCoordinates", "[Domain][Unit]") {
-  using AffineMap2d = CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
-                                                     CoordinateMaps::AffineMap>;
-  using AffineMap3d = CoordinateMaps::ProductOf3Maps<CoordinateMaps::AffineMap,
-                                                     CoordinateMaps::AffineMap,
-                                                     CoordinateMaps::AffineMap>;
+  using Affine2d = CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                  CoordinateMaps::Affine>;
+  using Affine3d = CoordinateMaps::ProductOf3Maps<
+      CoordinateMaps::Affine, CoordinateMaps::Affine, CoordinateMaps::Affine>;
 
   const Index<1> extents_1d(Index<1>(3));
   const Index<2> extents_2d(Index<2>(2, 3));
@@ -24,20 +23,20 @@ SPECTRE_TEST_CASE("Unit.Domain.LogicalCoordinates", "[Domain][Unit]") {
   /// [logical_coordinates_example]
   const Index<3> extents_3d(Index<3>(5, 3, 2));
 
-  const CoordinateMaps::AffineMap x_map{-1.0, 1.0, -3.0, 7.0};
-  const CoordinateMaps::AffineMap y_map{-1.0, 1.0, -13.0, 47.0};
-  const CoordinateMaps::AffineMap z_map{-1.0, 1.0, -32.0, 74.0};
+  const CoordinateMaps::Affine x_map{-1.0, 1.0, -3.0, 7.0};
+  const CoordinateMaps::Affine y_map{-1.0, 1.0, -13.0, 47.0};
+  const CoordinateMaps::Affine z_map{-1.0, 1.0, -32.0, 74.0};
 
   const auto map_3d = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      AffineMap3d{x_map, y_map, z_map});
+      Affine3d{x_map, y_map, z_map});
 
   const auto x_3d = map_3d(logical_coordinates(extents_3d));
   /// [logical_coordinates_example]
 
   const auto map_1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      CoordinateMaps::AffineMap{x_map});
-  const auto map_2d = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      AffineMap2d{x_map, y_map});
+      CoordinateMaps::Affine{x_map});
+  const auto map_2d =
+      make_coordinate_map<Frame::Logical, Frame::Grid>(Affine2d{x_map, y_map});
   const auto x_1d = map_1d(logical_coordinates(extents_1d));
   const auto x_2d = map_2d(logical_coordinates(extents_2d));
 
@@ -65,22 +64,21 @@ SPECTRE_TEST_CASE("Unit.Domain.LogicalCoordinates", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.InterfaceLogicalCoordinates", "[Domain][Unit]") {
-  using AffineMap2d = CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
-                                                     CoordinateMaps::AffineMap>;
-  using AffineMap3d = CoordinateMaps::ProductOf3Maps<CoordinateMaps::AffineMap,
-                                                     CoordinateMaps::AffineMap,
-                                                     CoordinateMaps::AffineMap>;
+  using Affine2d = CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                  CoordinateMaps::Affine>;
+  using Affine3d = CoordinateMaps::ProductOf3Maps<
+      CoordinateMaps::Affine, CoordinateMaps::Affine, CoordinateMaps::Affine>;
 
-  const CoordinateMaps::AffineMap x_map{-1.0, 1.0, -3.0, 7.0};
-  const CoordinateMaps::AffineMap y_map{-1.0, 1.0, -13.0, 47.0};
-  const CoordinateMaps::AffineMap z_map{-1.0, 1.0, -32.0, 74.0};
+  const CoordinateMaps::Affine x_map{-1.0, 1.0, -3.0, 7.0};
+  const CoordinateMaps::Affine y_map{-1.0, 1.0, -13.0, 47.0};
+  const CoordinateMaps::Affine z_map{-1.0, 1.0, -32.0, 74.0};
 
   const auto map_1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      CoordinateMaps::AffineMap{x_map});
-  const auto map_2d = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      AffineMap2d{x_map, y_map});
+      CoordinateMaps::Affine{x_map});
+  const auto map_2d =
+      make_coordinate_map<Frame::Logical, Frame::Grid>(Affine2d{x_map, y_map});
   const auto map_3d = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      AffineMap3d{x_map, y_map, z_map});
+      Affine3d{x_map, y_map, z_map});
 
   const Index<0> extents_0d;
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -9,7 +9,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/ElementId.hpp"
@@ -109,8 +109,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
       {{Direction<2>::upper_xi(), Direction<2>::upper_eta()}},
       {{Direction<2>::lower_eta(), Direction<2>::lower_xi()}});
 
-  const CoordinateMaps::AffineMap xi_map{-1., 1., 3., 7.};
-  const CoordinateMaps::AffineMap eta_map{-1., 1., -2., 4.};
+  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
+  const CoordinateMaps::Affine eta_map{-1., 1., -2., 4.};
 
   auto start_box =
       [&extents, &time_id, &self_id, &west_id, &east_id, &south_id,
@@ -124,9 +124,9 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
     auto map = ElementMap<2, Frame::Inertial>(
         ElementId<2>{0},
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
-                                           CoordinateMaps::AffineMap>(
-                xi_map, eta_map)));
+            CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                           CoordinateMaps::Affine>(xi_map,
+                                                                   eta_map)));
 
     Variables<tmpl::list<Var>> variables(extents.product());
     get<Var>(variables).get() = DataVector{1., 2., 3., 4., 5., 6., 7., 8., 9.};
@@ -293,8 +293,8 @@ SPECTRE_TEST_CASE(
 
   auto map = ElementMap<2, Frame::Inertial>(
       self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                   CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
-                                                  CoordinateMaps::AffineMap>(
+                   CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                  CoordinateMaps::Affine>(
                        {-1., 1., 3., 7.}, {-1., 1., -2., 4.})));
 
   Variables<tmpl::list<Var>> variables(extents.product());

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
@@ -9,7 +9,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/ElementId.hpp"
@@ -134,8 +134,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication2",
       {{Direction<2>::upper_xi(), Direction<2>::upper_eta()}},
       {{Direction<2>::lower_eta(), Direction<2>::lower_xi()}});
 
-  const CoordinateMaps::AffineMap xi_map{-1., 1., 3., 7.};
-  const CoordinateMaps::AffineMap eta_map{-1., 1., -2., 4.};
+  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
+  const CoordinateMaps::Affine eta_map{-1., 1., -2., 4.};
 
   auto start_box = [&extents, &time_id, &self_id, &west_id, &east_id, &south_id,
                     &block_orientation, &xi_map, &eta_map]() {
@@ -146,8 +146,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication2",
 
     auto map = ElementMap<2, Frame::Inertial>(
         self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
-                                                    CoordinateMaps::AffineMap>(
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                    CoordinateMaps::Affine>(
                          xi_map, eta_map)));
 
     Variables<tmpl::list<Var>> variables(extents.product());
@@ -236,8 +236,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication2",
 
     auto map = ElementMap<2, Frame::Inertial>(
         south_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                      CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
-                                                     CoordinateMaps::AffineMap>(
+                      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                     CoordinateMaps::Affine>(
                           xi_map, eta_map)));
 
     auto box =
@@ -263,8 +263,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication2",
 
     auto map = ElementMap<2, Frame::Inertial>(
         east_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
-                                                    CoordinateMaps::AffineMap>(
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                    CoordinateMaps::Affine>(
                          xi_map, eta_map)));
 
     auto box =
@@ -343,8 +343,8 @@ SPECTRE_TEST_CASE(
 
   auto map = ElementMap<2, Frame::Inertial>(
       self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                   CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
-                                                  CoordinateMaps::AffineMap>(
+                   CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                  CoordinateMaps::Affine>(
                        {-1., 1., 3., 7.}, {-1., 1., -2., 4.})));
 
   Variables<tmpl::list<Var>> variables(extents.product());

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -10,7 +10,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
@@ -30,12 +30,11 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.LiftFlux",
                   "[Unit][NumericalAlgorithms]") {
   const size_t perpendicular_extent = 5;
 
-  const CoordinateMaps::AffineMap xi_map(-1., 1., -5., 7.);
-  const CoordinateMaps::AffineMap eta_map(-1., 1., 2., 5.);
+  const CoordinateMaps::Affine xi_map(-1., 1., -5., 7.);
+  const CoordinateMaps::Affine eta_map(-1., 1., 2., 5.);
   const auto coordinate_map = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
-                                     CoordinateMaps::AffineMap>(
-      xi_map, eta_map));
+      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                     CoordinateMaps::Affine>(xi_map, eta_map));
   const double element_length = (eta_map(std::array<double, 1>{{1.}}) -
                                  eta_map(std::array<double, 1>{{-1.}}))[0];
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -9,7 +9,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/LogicalCoordinates.hpp"
@@ -214,9 +214,9 @@ void test_logical_partial_derivatives_3d(const Index<3>& extents) {
 template <typename VariableTags, typename GradientTags = VariableTags>
 void test_partial_derivatives_1d(const Index<1>& extents) {
   const size_t number_of_grid_points = extents.product();
-  const CoordinateMaps::AffineMap x_map{-1.0, 1.0, -0.3, 0.7};
+  const CoordinateMaps::Affine x_map{-1.0, 1.0, -0.3, 0.7};
   const auto map_1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      CoordinateMaps::AffineMap{x_map});
+      CoordinateMaps::Affine{x_map});
   const auto x = map_1d(logical_coordinates(extents));
   const InverseJacobian<1, Frame::Logical, Frame::Grid> inverse_jacobian(
       extents.product(), 2.0);
@@ -248,7 +248,7 @@ void test_partial_derivatives_1d(const Index<1>& extents) {
 
 template <typename VariableTags, typename GradientTags = VariableTags>
 void test_partial_derivatives_2d(const Index<2>& extents) {
-  using affine_map = CoordinateMaps::AffineMap;
+  using affine_map = CoordinateMaps::Affine;
   using affine_map_2d = CoordinateMaps::ProductOf2Maps<affine_map, affine_map>;
   const size_t number_of_grid_points = extents.product();
   const auto prod_map2d =
@@ -291,7 +291,7 @@ void test_partial_derivatives_2d(const Index<2>& extents) {
 
 template <typename VariableTags, typename GradientTags = VariableTags>
 void test_partial_derivatives_3d(const Index<3>& extents) {
-  using affine_map = CoordinateMaps::AffineMap;
+  using affine_map = CoordinateMaps::Affine;
   using affine_map_3d =
       CoordinateMaps::ProductOf3Maps<affine_map, affine_map, affine_map>;
   const size_t number_of_grid_points = extents.product();
@@ -501,10 +501,9 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs.ComputeItems",
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs.ComputeItems",
                   "[NumericalAlgorithms][LinearOperators][Unit]") {
-  using AffineMap = CoordinateMaps::AffineMap;
-  using AffineMap2d = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
-  using AffineMap3d =
-      CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+  using Affine = CoordinateMaps::Affine;
+  using Affine2d = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  using Affine3d = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
   Index<3> max_extents{10, 10, 5};
 
@@ -512,22 +511,20 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs.ComputeItems",
     test_partial_derivatives_compute_item(
         std::array<size_t, 1>{{a + 1}},
         make_coordinate_map<Frame::Logical, Frame::Grid>(
-            CoordinateMaps::AffineMap{-1.0, 1.0, -0.3, 0.7}));
+            CoordinateMaps::Affine{-1.0, 1.0, -0.3, 0.7}));
     for (size_t b = 1; b < max_extents[1]; ++b) {
       test_partial_derivatives_compute_item(
           std::array<size_t, 2>{{a + 1, b + 1}},
-          make_coordinate_map<Frame::Logical, Frame::Grid>(
-              AffineMap2d{AffineMap{-1.0, 1.0, -0.3, 0.7},
-                          AffineMap{-1.0, 1.0, 0.3, 0.55}}));
+          make_coordinate_map<Frame::Logical, Frame::Grid>(Affine2d{
+              Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55}}));
       for (size_t c = 1; a < max_extents[0] / 2 and b < max_extents[1] / 2 and
                          c < max_extents[2];
            ++c) {
         test_partial_derivatives_compute_item(
             std::array<size_t, 3>{{a + 1, b + 1, c + 1}},
-            make_coordinate_map<Frame::Logical, Frame::Grid>(
-                AffineMap3d{AffineMap{-1.0, 1.0, -0.3, 0.7},
-                            AffineMap{-1.0, 1.0, 0.3, 0.55},
-                            AffineMap{-1.0, 1.0, 2.3, 2.8}}));
+            make_coordinate_map<Frame::Logical, Frame::Grid>(Affine3d{
+                Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
+                Affine{-1.0, 1.0, 2.3, 2.8}}));
       }
     }
   }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
@@ -11,7 +11,7 @@
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/LogicalCoordinates.hpp"
@@ -50,14 +50,13 @@ void verify_time_independent_einstein_solution(
   const size_t data_size = pow<3>(grid_size_each_dimension);
   Index<3> extents(grid_size_each_dimension);
 
-  using AffineMap = CoordinateMaps::AffineMap;
-  using AffineMap3D =
-      CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(AffineMap3D{
-          AffineMap{-1., 1., lower_bound[0], upper_bound[0]},
-          AffineMap{-1., 1., lower_bound[1], upper_bound[1]},
-          AffineMap{-1., 1., lower_bound[2], upper_bound[2]},
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
       });
 
   // Set up coordinates

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -13,7 +13,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/LogicalCoordinates.hpp"
@@ -27,10 +27,9 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
-using AffineMap = CoordinateMaps::AffineMap;
-using AffineMap2D = CoordinateMaps::ProductOf2Maps<AffineMap, AffineMap>;
-using AffineMap3D =
-    CoordinateMaps::ProductOf3Maps<AffineMap, AffineMap, AffineMap>;
+using Affine = CoordinateMaps::Affine;
+using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
 template <size_t VolumeDim>
 auto make_affine_map() noexcept;
@@ -38,20 +37,20 @@ auto make_affine_map() noexcept;
 template <>
 auto make_affine_map<1>() noexcept {
   return make_coordinate_map<Frame::Logical, Frame::Inertial>(
-      AffineMap{-1.0, 1.0, -0.3, 0.7});
+      Affine{-1.0, 1.0, -0.3, 0.7});
 }
 
 template <>
 auto make_affine_map<2>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(AffineMap2D{
-      AffineMap{-1.0, 1.0, -0.3, 0.7}, AffineMap{-1.0, 1.0, 0.3, 0.55}});
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine2D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55}});
 }
 
 template <>
 auto make_affine_map<3>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(AffineMap3D{
-      AffineMap{-1.0, 1.0, -0.3, 0.7}, AffineMap{-1.0, 1.0, 0.3, 0.55},
-      AffineMap{-1.0, 1.0, 2.3, 2.8}});
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine3D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
+               Affine{-1.0, 1.0, 2.3, 2.8}});
 }
 
 template <typename T, size_t VolumeDim>


### PR DESCRIPTION
## Proposed changes

Addresses issue #420 
Also renames AffineMap to Affine

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
