### PR TITLE
Add CHECK_ITERABLE_CUSTOM_APPROX.

### DIFF
--- a/tests/Unit/Test_TestHelpers.cpp
+++ b/tests/Unit/Test_TestHelpers.cpp
@@ -26,25 +26,31 @@ SPECTRE_TEST_CASE("Test.TestHelpers", "[Unit]") {
   u_set.insert(0);
   test_iterators(u_set);
 
+  Approx larger_approx =
+      Approx::custom().epsilon(std::numeric_limits<double>::epsilon() * 1.e4);
+
   const std::vector<double> vec_a{1., 2., 3.5};
   CHECK_ITERABLE_APPROX(vec_a, vec_a);
   auto vec_b = vec_a;
   vec_b[1] += 1e-15;
   CHECK(vec_a != vec_b);
   CHECK_ITERABLE_APPROX(vec_a, vec_b);
+  vec_b[1] += 1e-12;
+  CHECK_ITERABLE_CUSTOM_APPROX(vec_a, vec_b, larger_approx);
 
   const std::vector<std::map<int, double>> vecmap_a{
-    {{1, 1.}, {2, 2.}},
-    {{1, 1.23}, {3, 4.56}, {5, 7.89}}};
+      {{1, 1.}, {2, 2.}}, {{1, 1.23}, {3, 4.56}, {5, 7.89}}};
   CHECK_ITERABLE_APPROX(vecmap_a, vecmap_a);
   auto vecmap_b = vecmap_a;
   vecmap_b[1][1] += 1e-15;
   CHECK(vecmap_a != vecmap_b);
   CHECK_ITERABLE_APPROX(vecmap_a, vecmap_b);
+  vecmap_b[1][1] += 1e-12;
+  CHECK_ITERABLE_CUSTOM_APPROX(vecmap_a, vecmap_b, larger_approx);
 }
 
 SPECTRE_TEST_CASE("Test.TestHelpers.Derivative", "[Unit]") {
-  { // 3D Test
+  {  // 3D Test
     const std::array<double, 3> x{{1.2, -3.4, 1.3}};
     const double delta = 1.e-2;
 
@@ -60,7 +66,7 @@ SPECTRE_TEST_CASE("Test.TestHelpers.Derivative", "[Unit]") {
             approx(gsl::at(dfunc(x), i)));
     }
   }
-  { // 2D Test
+  {  // 2D Test
     const std::array<double, 2> x{{1.2, -2.4}};
     const double delta = 1.e-2;
 


### PR DESCRIPTION
## Proposed changes

Adds a version of CHECK_ITERABLE_APPROX that works for user-defined Approx.
### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
