### PR TITLE
Add scalar wave rhs

### DIFF
--- a/cmake/SpectreParseTests.py
+++ b/cmake/SpectreParseTests.py
@@ -14,6 +14,7 @@ allowed_tags = [
                 "DataStructures",
                 "Domain",
                 "ErrorHandling",
+                "Evolution",
                 "GeneralizedHarmonic",
                 "H5",
                 "IO",

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -308,11 +308,6 @@ into two classes:
  */
 
 /*!
- * \defgroup ParallelComponentsGroup ParallelComponents
- * Information about which ParallelComponents are available and how to use them
- */
-
-/*!
  * \defgroup TestingFrameworkGroup Testing Framework
  * \brief Classes, functions, macros, and instructions for developing tests
  *

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -91,6 +91,11 @@
  */
 
 /*!
+ * \defgroup EvolutionSystemsGroup Evolution Systems
+ * \brief Contains the namespaces of all the available evolution systems.
+ */
+
+/*!
  * \defgroup ExecutablesGroup Executables
  * \brief A list of executables and how to use them
  *

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -439,7 +439,7 @@ template <typename... Args,
                                         std::decay_t<Args>>...> and
                        sizeof...(Args) == 1)>>
 Tensor<X, Symm, IndexList<Indices...>>::Tensor(Args&&... args)
-    : data_(make_array<size()>(X(std::forward<Args>(args)...))) {}
+    : data_(make_array<size(), X>(std::forward<Args>(args)...)) {}
 
 template <typename X, typename Symm, template <typename...> class IndexList,
           typename... Indices>

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -129,7 +129,7 @@ Direction<VolumeDim> get_direction_normal_to_face(
                      two_to_the(VolumeDim - 1)>& face_pts) {
   const auto summed_point = std::accumulate(
       face_pts.begin(), face_pts.end(),
-      tnsr::I<double, VolumeDim, Frame::Logical>(0),
+      tnsr::I<double, VolumeDim, Frame::Logical>(0.0),
       [](tnsr::I<double, VolumeDim, Frame::Logical>& prior,
          const tnsr::I<double, VolumeDim, Frame::Logical>& point) {
         for (size_t i = 0; i < prior.size(); i++) {

--- a/src/Evolution/Systems/CMakeLists.txt
+++ b/src/Evolution/Systems/CMakeLists.txt
@@ -2,3 +2,4 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(GeneralizedHarmonic)
+add_subdirectory(ScalarWave)

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -26,6 +26,13 @@ class not_null;
 }  // namespace gsl
 
 namespace GeneralizedHarmonic {
+  /*!
+   * \brief Compute the RHS of the Generalized Harmonic formulation of
+   * Einstein's equations.
+   *
+   * \details For the full form of the equations see "A New Generalized Harmonic
+   * Evolution System" by Lindblom et. al, arxiv.org/abs/gr-qc/0512093.
+   */
 template <size_t Dim>
 struct ComputeDuDt {
  public:
@@ -43,13 +50,6 @@ struct ComputeDuDt {
       SpacetimeChristoffelFirstKind<Dim>, SpacetimeChristoffelSecondKind<Dim>,
       SpacetimeNormalVector<Dim>, SpacetimeNormalOneForm<Dim>>;
 
-  /*!
-   * /brief Compute the RHS of the Generalized Harmonic formulation of
-   * Einstein's equations.
-   *
-   * /details For the full form of the equations see "A New Generalized Harmonic
-   * Evolution System" by Lindblom et. al, arxiv.org/abs/gr-qc/0512093.
-   */
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_pi,

--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -13,6 +13,10 @@ struct list;
 template <class>
 class Variables;
 
+/*!
+ * \ingroup EvolutionSystemsGroup
+ * \brief Items related to evolving the first-order generalized harmonic system.
+ */
 namespace GeneralizedHarmonic {
 template <size_t Dim>
 struct System {

--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY ScalarWave)
+
+set(LIBRARY_SOURCES
+    Equations.cpp
+    )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  )

--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/ScalarWave/Equations.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/ScalarWave/System.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarWave {
+template <size_t Dim>
+void ComputeDuDt<Dim>::apply(
+    gsl::not_null<Scalar<DataVector>*> dt_pi,
+    gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
+    gsl::not_null<Scalar<DataVector>*> dt_psi, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
+    const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi) noexcept {
+  get(*dt_psi) = -get(pi);
+  get(*dt_pi) = -get<0, 0>(d_phi);
+  for (size_t d = 1; d < Dim; ++d) {
+    get(*dt_pi) -= d_phi.get(d, d);
+  }
+  for (size_t d = 0; d < Dim; ++d) {
+    dt_phi->get(d) = -d_pi.get(d);
+  }
+}
+}  // namespace ScalarWave
+
+// Generate explicit instantiations of partial_derivatives function as well as
+// all other functions in Equations.cpp
+
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp"
+
+template <size_t Dim>
+using derivative_tags = typename ScalarWave::System<Dim>::gradients_tags;
+
+template <size_t Dim>
+using variables_tags = typename ScalarWave::System<Dim>::variables_tags;
+
+using derivative_frame = Frame::Inertial;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                                               \
+  template class ScalarWave::ComputeDuDt<DIM(data)>;                         \
+  template Variables<                                                        \
+      db::wrap_tags_in<Tags::deriv, derivative_tags<DIM(data)>,              \
+                       tmpl::size_t<DIM(data)>, derivative_frame>>           \
+  partial_derivatives<derivative_tags<DIM(data)>, variables_tags<DIM(data)>, \
+                      DIM(data), derivative_frame>(                          \
+      const Variables<variables_tags<DIM(data)>>& u,                         \
+      const Index<DIM(data)>& extents,                                       \
+      const Tensor<                                                          \
+          DataVector, tmpl::integral_list<std::int32_t, 2, 1>,               \
+          tmpl::list<SpatialIndex<DIM(data), UpLo::Up, Frame::Logical>,      \
+                     SpatialIndex<DIM(data), UpLo::Lo, derivative_frame>>>&  \
+          inverse_jacobian) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TMPL.hpp"
+
+template <typename>
+class Variables;
+
+class DataVector;
+
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+namespace Tags {
+template <typename, typename, typename>
+struct deriv;
+template <typename>
+struct dt;
+template <typename>
+struct NormalDotFlux;
+template <typename>
+struct NormalDotNumericalFlux;
+template <typename>
+struct Variables;
+}  // namespace Tags
+
+namespace ScalarWave {
+struct Psi;
+struct Pi;
+template <size_t Dim>
+struct Phi;
+}  // namespace ScalarWave
+
+namespace ScalarWave {
+/*!
+ * \brief Compute the time derivative of the evolved variables of the
+ * first-order scalar wave system.
+ *
+ * The evolution equations for the first-order scalar wave system are given by:
+ * \f{align}
+ * \partial_t\psi = & -\pi \\
+ * \partial_t\Phi_i = & -\partial_i \pi \\
+ * \partial_t\pi = & - \delta^{ij}\partial_i\Phi_j
+ * \f}
+ *
+ * where \f$\psi\f$ is the scalar field, \f$\pi=-\partial_t\psi\f$ is the
+ * conjugate momentum to \f$\psi\f$, and \f$\Phi_i=\partial_i\psi\f$ is an
+ * auxiliary variable.
+ */
+template <size_t Dim>
+struct ComputeDuDt {
+  using return_tags = typelist<Tags::dt<Pi>, Tags::dt<Phi<Dim>>, Tags::dt<Psi>>;
+
+  using argument_tags =
+      tmpl::list<Pi, Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,
+                 Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
+  static void apply(
+      gsl::not_null<Scalar<DataVector>*> dt_pi,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
+      gsl::not_null<Scalar<DataVector>*> dt_psi, const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
+      const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi) noexcept;
+};
+}  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -1,0 +1,32 @@
+
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines class ScalarWaveSystem.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Evolution/Systems/ScalarWave/Equations.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/*!
+ * \ingroup EvolutionSystemsGroup
+ * \brief Items related to evolving the scalar wave equation:
+ */
+namespace ScalarWave {
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+
+  using variables_tags = tmpl::list<Pi, Phi<Dim>, Psi>;
+  // Typelist of which subset of the variables to take the gradient of.
+  using gradients_tags = tmpl::list<Pi, Phi<Dim>>;
+
+  using du_dt = ComputeDuDt<Dim>;
+};
+}  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines DataBox tags for scalar wave system
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+class DataVector;
+
+namespace ScalarWave {
+struct Psi : db::DataBoxTag {
+  using type = Scalar<DataVector>;
+  static constexpr db::DataBoxString label = "Psi";
+};
+
+struct Pi : db::DataBoxTag {
+  using type = Scalar<DataVector>;
+  static constexpr db::DataBoxString label = "Pi";
+};
+
+template <size_t Dim>
+struct Phi : db::DataBoxTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+  static constexpr db::DataBoxString label = "Phi";
+};
+}  // namespace ScalarWave

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(
   IO
   LinearOperators
   RootFinding
+  ScalarWave
   Time
   WaveEquation
   ${SPECTRE_LIBRARIES}

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
@@ -117,7 +117,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
 
   {
     // Check for doubles
-    const tnsr::i<double, 1, Frame::Grid> one_d_covector{2};
+    const tnsr::i<double, 1, Frame::Grid> one_d_covector{2.0};
     const tnsr::II<double, 1, Frame::Grid> inv_h = []() {
       tnsr::II<double, 1, Frame::Grid> tensor{};
       get<0, 0>(tensor) = 4.;
@@ -126,7 +126,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
 
     CHECK(magnitude(one_d_covector, inv_h) == 4.0);
 
-    const tnsr::i<double, 3, Frame::Grid> three_d_covector{{{-3, 12, 4}}};
+    const tnsr::i<double, 3, Frame::Grid> three_d_covector{{{-3.0, 12.0, 4.0}}};
     const tnsr::II<double, 3, Frame::Grid> inv_g = []() {
       tnsr::II<double, 3, Frame::Grid> tensor{};
       get<0, 0>(tensor) = 2;

--- a/tests/Unit/Evolution/Systems/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CMakeLists.txt
@@ -2,5 +2,6 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(GeneralizedHarmonic)
+add_subdirectory(ScalarWave)
 
 set(EVOLUTION_TESTS "${EVOLUTION_TESTS};${SYSTEM_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(SCALAR_WAVE_TESTS
+    Evolution/Systems/ScalarWave/Test_Equations.cpp
+    )
+
+set(SYSTEM_TESTS "${SYSTEM_TESTS};${SCALAR_WAVE_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <memory>
+
+#include "DataStructures/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Evolution/Systems/ScalarWave/Equations.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+template <size_t Dim>
+void check_du_dt(const size_t npts, const double time) {
+  ScalarWave::Solutions::PlaneWave<Dim> solution(
+      make_array<Dim>(0.1), make_array<Dim>(0.0),
+      std::make_unique<MathFunctions::Gaussian>(1.0, 1.0, 0.0));
+
+  tnsr::I<DataVector, Dim> x = [npts]() {
+    auto logical_coords = logical_coordinates(Index<Dim>(3));
+    tnsr::I<DataVector, Dim> coords{pow<Dim>(npts)};
+    for (size_t i = 0; i < Dim; ++i) {
+      coords.get(i) = std::move(logical_coords.get(i));
+    }
+    return coords;
+  }();
+
+  auto box = db::create<db::AddTags<
+      Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+      Tags::dt<ScalarWave::Psi>, ScalarWave::Pi,
+      Tags::deriv<ScalarWave::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
+      Tags::deriv<ScalarWave::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>>(
+      Scalar<DataVector>(pow<Dim>(npts), 0.0),
+      tnsr::i<DataVector, Dim, Frame::Inertial>(pow<Dim>(npts), 0.0),
+      Scalar<DataVector>(pow<Dim>(npts), 0.0),
+      Scalar<DataVector>(-1.0 * solution.dpsi_dt(x, time).get()),
+      [&x, &time, &solution ]() noexcept {
+        auto dpi_dx = solution.d2psi_dtdx(x, time);
+        for (size_t i = 0; i < Dim; ++i) {
+          dpi_dx.get(i) *= -1.0;
+        }
+        return dpi_dx;
+      }(),
+      [&npts, &x, &time, &solution ]() noexcept {
+        tnsr::ij<DataVector, Dim, Frame::Inertial> d2psi_dxdx{pow<Dim>(npts),
+                                                              0.0};
+        const tnsr::ii<DataVector, Dim, Frame::Inertial> ddpsi_soln =
+            solution.d2psi_dxdx(x, time);
+        for (size_t i = 0; i < Dim; ++i) {
+          for (size_t j = 0; j < Dim; ++j) {
+            d2psi_dxdx.get(i, j) = ddpsi_soln.get(i, j);
+          }
+        }
+        return d2psi_dxdx;
+      }());
+
+  db::mutate_apply<typename ScalarWave::ComputeDuDt<Dim>::return_tags,
+                   typename ScalarWave::ComputeDuDt<Dim>::argument_tags>(
+      ScalarWave::ComputeDuDt<Dim>{}, box);
+
+  CHECK_ITERABLE_APPROX(
+      db::get<Tags::dt<ScalarWave::Pi>>(box),
+      Scalar<DataVector>(-1.0 * solution.d2psi_dt2(x, time).get()));
+  CHECK_ITERABLE_APPROX(db::get<Tags::dt<ScalarWave::Phi<Dim>>>(box),
+                        solution.d2psi_dtdx(x, time));
+  CHECK_ITERABLE_APPROX(db::get<Tags::dt<ScalarWave::Psi>>(box),
+                        solution.dpsi_dt(x, time));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.DuDt",
+                  "[Unit][Evolution]") {
+  constexpr double time = 0.7;
+  check_du_dt<1>(3, time);
+  check_du_dt<2>(3, time);
+  check_du_dt<3>(3, time);
+}


### PR DESCRIPTION
## Proposed changes

- Add ability to call specific constructor via `make_array`
- Change to the new `make_array` call in `Tensor`
- Add ScalarWave tags
- Add ScalarWave RHS

I'm planning on adding the flux equations in a separate PR that will be dependent on this PR.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
