### PR TITLE
Add FunctionOfTime base class and tests

### DIFF
--- a/src/ControlSystem/FunctionOfTime.hpp
+++ b/src/ControlSystem/FunctionOfTime.hpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+
+/// \ingroup ControlSystemGroup
+/// Base class for FunctionsOfTime
+class FunctionOfTime {
+ public:
+  FunctionOfTime() = default;
+  FunctionOfTime(FunctionOfTime&&) noexcept = default;
+  FunctionOfTime& operator=(FunctionOfTime&&) noexcept = default;
+  FunctionOfTime(const FunctionOfTime&) = delete;
+  FunctionOfTime& operator=(const FunctionOfTime&) = delete;
+  virtual ~FunctionOfTime() = default;
+
+  virtual std::array<double, 2> time_bounds() const noexcept = 0;
+
+  virtual std::array<DataVector, 1> func(double t) const noexcept = 0;
+  virtual std::array<DataVector, 2> func_and_deriv(double t) const noexcept = 0;
+  virtual std::array<DataVector, 3> func_and_2_derivs(double t) const
+      noexcept = 0;
+};

--- a/src/ControlSystem/PiecewisePolynomial.cpp
+++ b/src/ControlSystem/PiecewisePolynomial.cpp
@@ -19,8 +19,8 @@ FunctionsOfTime::PiecewisePolynomial<MaxDeriv>::PiecewisePolynomial(
 template <size_t MaxDeriv>
 template <size_t MaxDerivReturned>
 std::array<DataVector, MaxDerivReturned + 1>
-FunctionsOfTime::PiecewisePolynomial<MaxDeriv>::operator()(const double t) const
-    noexcept {
+FunctionsOfTime::PiecewisePolynomial<MaxDeriv>::func_and_derivs(
+    const double t) const noexcept {
   const auto& deriv_info_at_t = deriv_info_from_upper_bound(t);
   const double dt = t - deriv_info_at_t.time;
   const value_type& coefs = deriv_info_at_t.derivs_coefs;
@@ -59,7 +59,7 @@ void FunctionsOfTime::PiecewisePolynomial<MaxDeriv>::update(
   }
 
   // get the current values, before updating the `MaxDeriv'th deriv
-  value_type func = this->operator()(time_of_update);
+  value_type func = func_and_derivs(time_of_update);
 
   if (updated_max_deriv.size() != func.back().size()) {
     ERROR("the number of components trying to be updated ("
@@ -126,8 +126,8 @@ template class FunctionsOfTime::PiecewisePolynomial<4_st>;
 
 #define INSTANTIATE(_, data)                             \
   template std::array<DataVector, DIMRETURNED(data) + 1> \
-  FunctionsOfTime::PiecewisePolynomial<DIM(data)>::      \
-  operator()<DIMRETURNED(data)>(const double) const noexcept;
+  FunctionsOfTime::PiecewisePolynomial<DIM(              \
+      data)>::func_and_derivs<DIMRETURNED(data)>(const double) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (2), (0, 1, 2))
 GENERATE_INSTANTIATIONS(INSTANTIATE, (3), (0, 1, 2, 3))

--- a/tests/Unit/ControlSystem/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/ControlSystem/Test_PiecewisePolynomial.cpp
@@ -18,28 +18,31 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
   // test two component system (x**3 and x**2)
   const std::array<DataVector, deriv_order + 1> init_func{
       {{0.0, 0.0}, {0.0, 0.0}, {0.0, 2.0}, {6.0, 0.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(t, init_func);
+  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(t,
+                                                                   init_func);
+  FunctionOfTime& f_of_t = f_of_t_derived;
 
   while (t < final_time) {
-    const auto& lambdas0 = f_of_t(t);
+    const auto& lambdas0 = f_of_t.func_and_2_derivs(t);
     CHECK(approx(lambdas0[0][0]) == cube(t));
     CHECK(approx(lambdas0[0][1]) == square(t));
     CHECK(approx(lambdas0[1][0]) == 3.0 * square(t));
     CHECK(approx(lambdas0[1][1]) == 2.0 * t);
     CHECK(approx(lambdas0[2][0]) == 6.0 * t);
     CHECK(approx(lambdas0[2][1]) == 2.0);
-    CHECK(approx(lambdas0[3][0]) == 6.0);
-    CHECK(approx(lambdas0[3][1]) == 0.0);
 
-    const auto& lambdas1 = f_of_t.operator()<ret_deriv_order>(t);
-    CHECK(lambdas1.size() == ret_deriv_order + 1);
+    const auto& lambdas1 = f_of_t.func_and_deriv(t);
     CHECK(approx(lambdas1[0][0]) == cube(t));
     CHECK(approx(lambdas1[0][1]) == square(t));
     CHECK(approx(lambdas1[1][0]) == 3.0 * square(t));
     CHECK(approx(lambdas1[1][1]) == 2.0 * t);
 
+    const auto& lambdas2 = f_of_t.func(t);
+    CHECK(approx(lambdas2[0][0]) == cube(t));
+    CHECK(approx(lambdas2[0][1]) == square(t));
+
     t += dt;
-    f_of_t.update(t, {6.0, 0.0});
+    f_of_t_derived.update(t, {6.0, 0.0});
   }
   // test time_bounds function
   const auto& t_bounds = f_of_t.time_bounds();
@@ -58,16 +61,27 @@ SPECTRE_TEST_CASE(
   // initally x**2, but update with non-constant 2nd deriv
   const std::array<DataVector, deriv_order + 1> init_func{
       {{0.0}, {0.0}, {2.0}}};
-  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(t, init_func);
+  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(t,
+                                                                   init_func);
+  FunctionOfTime& f_of_t = f_of_t_derived;
 
   while (t < final_time) {
     t += dt;
-    f_of_t.update(t, {3.0 + t});
+    f_of_t_derived.update(t, {3.0 + t});
   }
-  const auto& lambdas = f_of_t(t);
-  CHECK(approx(lambdas[0][0]) == 33.948);
-  CHECK(approx(lambdas[1][0]) == 19.56);
-  CHECK(approx(lambdas[2][0]) == 7.2);
+  const auto& lambdas0 = f_of_t.func_and_2_derivs(t);
+  CHECK(approx(lambdas0[0][0]) == 33.948);
+  CHECK(approx(lambdas0[1][0]) == 19.56);
+  CHECK(approx(lambdas0[2][0]) == 7.2);
+  const auto& lambdas1 = f_of_t.func_and_deriv(t);
+  CHECK(approx(lambdas1[0][0]) == 33.948);
+  CHECK(approx(lambdas1[1][0]) == 19.56);
+  const auto& lambdas2 = f_of_t.func(t);
+  CHECK(approx(lambdas2[0][0]) == 33.948);
+
+  CHECK(lambdas0.size() == 3);
+  CHECK(lambdas1.size() == 2);
+  CHECK(lambdas2.size() == 1);
 }
 
 SPECTRE_TEST_CASE(
@@ -79,8 +93,22 @@ SPECTRE_TEST_CASE(
       {{1.0, 1.0}, {3.0, 2.0}, {6.0, 2.0}, {6.0, 0.0}}};
   FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func);
   f_of_t.update(2.0, {6.0, 0.0});
-  const auto& lambdas = f_of_t(1.0 - 5.0e-16);
-  CHECK_ITERABLE_APPROX(lambdas, init_func);
+
+  const auto& lambdas0 = f_of_t.func_and_2_derivs(1.0 - 5.0e-16);
+  CHECK(approx(lambdas0[0][0]) == 1.0);
+  CHECK(approx(lambdas0[1][0]) == 3.0);
+  CHECK(approx(lambdas0[2][0]) == 6.0);
+  CHECK(approx(lambdas0[0][1]) == 1.0);
+  CHECK(approx(lambdas0[1][1]) == 2.0);
+  CHECK(approx(lambdas0[2][1]) == 2.0);
+  const auto& lambdas1 = f_of_t.func_and_deriv(1.0 - 5.0e-16);
+  CHECK(approx(lambdas1[0][0]) == 1.0);
+  CHECK(approx(lambdas1[1][0]) == 3.0);
+  CHECK(approx(lambdas1[0][1]) == 1.0);
+  CHECK(approx(lambdas1[1][1]) == 2.0);
+  const auto& lambdas2 = f_of_t.func(1.0 - 5.0e-16);
+  CHECK(approx(lambdas2[0][0]) == 1.0);
+  CHECK(approx(lambdas2[0][1]) == 1.0);
 }
 
 // [[OutputRegex, t must be increasing from call to call. Attempted to update at
@@ -124,5 +152,5 @@ SPECTRE_TEST_CASE(
       {{1.0, 1.0}, {3.0, 2.0}, {6.0, 2.0}, {6.0, 0.0}}};
   FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func);
   f_of_t.update(2.0, {6.0, 0.0});
-  const auto& lambdas = f_of_t(0.5);
+  const auto& lambdas = f_of_t.func(0.5);
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
Add base class for FunctionsOfTime

### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
