### PR TITLE
Time stepper interface adjustments

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
@@ -133,7 +133,7 @@ struct InitializeElement {
         past_dt = past_dt.with_slab(past_dt.slab().advance_towards(-past_dt));
         past_t -= past_dt;
 
-        history_dt_vars.emplace_front(
+        history_dt_vars.insert_initial(
             past_t,
             Parallel::get<solution_tag>(cache).evolution_variables(
                 inertial_coords, past_t.value()),

--- a/src/Parallel/PupStlCpp11.hpp
+++ b/src/Parallel/PupStlCpp11.hpp
@@ -2,12 +2,14 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// PUP routines for new C+11 STL containers
+/// PUP routines for new C+11 STL containers and other standard
+/// library objects Charm does not provide implementations for
 
 #pragma once
 
 #include <algorithm>
 #include <array>
+#include <deque>
 #include <memory>
 #include <pup_stl.h>
 #include <tuple>
@@ -39,6 +41,32 @@ inline void pup(PUP::er& p, std::array<T, N>& a) {  // NOLINT
 template <typename T, std::size_t N>
 inline void operator|(er& p, std::array<T, N>& a) {  // NOLINT
   pup(p, a);
+}
+
+/// \ingroup ParallelGroup
+/// Serialization of std::deque for Charm++
+template <typename T>
+inline void pup(PUP::er& p, std::deque<T>& d) {  // NOLINT
+  size_t number_elem = PUP_stl_container_size(p, d);
+
+  if (p.isUnpacking()) {
+    for (size_t i = 0; i < number_elem; ++i) {
+      T v;
+      p | v;
+      d.emplace_back(std::move(v));
+    }
+  } else {
+    for (auto& v : d) {
+      p | v;
+    }
+  }
+}
+
+/// \ingroup ParallelGroup
+/// Serialization of std::deque for Charm++
+template <typename T>
+inline void operator|(er& p, std::deque<T>& d) {  // NOLINT
+  pup(p, d);
 }
 
 /// \ingroup ParallelGroup

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -56,9 +56,9 @@ struct UpdateU {
           const auto& time_stepper =
               Parallel::get<CacheTags::TimeStepper>(cache);
 
-          history.emplace_back(time, vars, dt_vars);
-          time_stepper.update_u(make_not_null(&vars), history, time_step);
-          history.erase(history.begin(), time_stepper.needed_history(history));
+          history.insert(time, vars, dt_vars);
+          time_stepper.update_u(make_not_null(&vars), make_not_null(&history),
+                                time_step);
         },
         db::get<Tags::Time>(box),
         db::get<Tags::TimeStep>(box));

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -56,7 +56,7 @@ struct UpdateU {
           const auto& time_stepper =
               Parallel::get<CacheTags::TimeStepper>(cache);
 
-          history.insert(time, vars, dt_vars);
+          history.insert(time, vars, std::move(dt_vars));
           time_stepper.update_u(make_not_null(&vars), make_not_null(&history),
                                 time_step);
         },

--- a/src/Time/History.hpp
+++ b/src/Time/History.hpp
@@ -1,0 +1,196 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <deque>
+#include <iterator>
+#include <pup.h>
+#include <tuple>
+#include <utility>
+
+#include "Parallel/PupStlCpp11.hpp"
+#include "Time/Time.hpp"
+
+namespace TimeSteppers {
+
+template <typename Vars, typename DerivVars>
+class HistoryIterator;
+
+/// \ingroup TimeSteppersGroup
+/// History data used by a TimeStepper.
+/// \tparam Vars type of variables being integrated
+/// \tparam DerivVars type of derivative variables
+template <typename Vars, typename DerivVars>
+class History {
+ public:
+  using value_type = Time;
+  using const_reference = const value_type&;
+  using const_iterator = HistoryIterator<Vars, DerivVars>;
+  using difference_type =
+      typename std::iterator_traits<const_iterator>::difference_type;
+  using size_type = size_t;
+
+  History() = default;
+  History(const History&) = delete;
+  History(History&&) = default;
+  History& operator=(const History&) = delete;
+  History& operator=(History&&) = default;
+  ~History() = default;
+
+  /// Add a new set of values to the end of the history.
+  void insert(Time time, Vars value, DerivVars deriv) noexcept;
+
+  /// Add a new set of values to the front of the history.  This is
+  /// often convenient for setting initial data.
+  void insert_initial(Time time, Vars value, DerivVars deriv) noexcept;
+
+  /// Mark all data before the passed point in history as unneeded so
+  /// it can be removed.  Calling this directly should not often be
+  /// necessary, as it is handled internally by the time steppers.
+  void mark_unneeded(const const_iterator& first_needed) noexcept;
+
+  /// These iterators directly return the Time of the past values.
+  /// The other data can be accessed through the iterators using
+  /// HistoryIterator::value() and HistoryIterator::derivative().
+  //@{
+  const_iterator begin() const noexcept { return data_.begin(); }
+  const_iterator end() const noexcept { return data_.end(); }
+  const_iterator cbegin() const noexcept { return begin(); }
+  const_iterator cend() const noexcept { return end(); }
+  //@}
+
+  size_type size() const noexcept { return data_.size(); }
+
+  /// These return the past times.  The other data can be accessed
+  /// through HistoryIterator methods.
+  //@{
+  const_reference operator[](size_type n) const noexcept {
+    return std::get<0>(data_[n]);
+  }
+
+  const_reference front() const noexcept { return std::get<0>(data_.front()); }
+  const_reference back() const noexcept { return std::get<0>(data_.back()); }
+  //@}
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | data_;
+  }
+
+ private:
+  std::deque<std::tuple<Time, Vars, DerivVars>> data_;
+};
+
+/// \ingroup TimeSteppersGroup
+/// Iterator over history data used by a TimeStepper.  See History for
+/// details.
+template <typename Vars, typename DerivVars>
+class HistoryIterator {
+  using Base =
+      typename std::deque<std::tuple<Time, Vars, DerivVars>>::const_iterator;
+
+ public:
+  using iterator_category =
+      typename std::iterator_traits<Base>::iterator_category;
+  using value_type = Time;
+  using difference_type = typename std::iterator_traits<Base>::difference_type;
+  using pointer = const value_type*;
+  using reference = const value_type&;
+
+  HistoryIterator() = default;
+
+  reference operator*() const noexcept { return std::get<0>(*base_); }
+  pointer operator->() const noexcept { return &std::get<0>(*base_); }
+  reference operator[](difference_type n) const noexcept {
+    return std::get<0>(base_[n]);
+  }
+  HistoryIterator& operator++() noexcept { ++base_; return *this; }
+  HistoryIterator operator++(int) noexcept { return base_++; }
+  HistoryIterator& operator--() noexcept { --base_; return *this; }
+  HistoryIterator operator--(int) noexcept { return base_--; }
+  HistoryIterator& operator+=(difference_type n) noexcept {
+    base_ += n;
+    return *this;
+  }
+  HistoryIterator& operator-=(difference_type n) noexcept {
+    base_ -= n;
+    return *this;
+  }
+
+  const Vars& value() const noexcept { return std::get<1>(*base_); }
+  const DerivVars& derivative() const noexcept { return std::get<2>(*base_); }
+
+ private:
+  friend class History<Vars, DerivVars>;
+
+  friend difference_type operator-(const HistoryIterator& a,
+                                   const HistoryIterator& b) noexcept {
+    return a.base_ - b.base_;
+  }
+
+#define FORWARD_HISTORY_ITERATOR_OP(op)                        \
+  friend bool operator op(const HistoryIterator& a,            \
+                          const HistoryIterator& b) noexcept { \
+    return a.base_ op b.base_;                                 \
+  }
+  FORWARD_HISTORY_ITERATOR_OP(==)
+  FORWARD_HISTORY_ITERATOR_OP(!=)
+  FORWARD_HISTORY_ITERATOR_OP(<)
+  FORWARD_HISTORY_ITERATOR_OP(>)
+  FORWARD_HISTORY_ITERATOR_OP(<=)
+  FORWARD_HISTORY_ITERATOR_OP(>=)
+#undef FORWARD_HISTORY_ITERATOR_OP
+
+  // clang-tidy: google-explicit-constructor - private
+  HistoryIterator(Base base) noexcept : base_(std::move(base)) {}  // NOLINT
+
+  Base base_{};
+};
+
+// ================================================================
+
+template <typename Vars, typename DerivVars>
+inline void History<Vars, DerivVars>::insert(Time time, Vars value,
+                                             DerivVars deriv) noexcept {
+  // clang-tidy: move of trivially-copyable type
+  data_.emplace_back(std::move(time), // NOLINT
+                     std::move(value), std::move(deriv));
+}
+
+template <typename Vars, typename DerivVars>
+inline void History<Vars, DerivVars>::insert_initial(Time time, Vars value,
+                                                     DerivVars deriv) noexcept {
+  // clang-tidy: move of trivially-copyable type
+  data_.emplace_front(std::move(time), // NOLINT
+                      std::move(value), std::move(deriv));
+}
+
+template <typename Vars, typename DerivVars>
+inline void History<Vars, DerivVars>::mark_unneeded(
+    const const_iterator& first_needed) noexcept {
+  data_.erase(data_.begin(), first_needed.base_);
+}
+
+template <typename Vars, typename DerivVars>
+inline HistoryIterator<Vars, DerivVars> operator+(
+    HistoryIterator<Vars, DerivVars> it,
+    typename HistoryIterator<Vars, DerivVars>::difference_type n) noexcept {
+  it += n;
+  return it;
+}
+
+template <typename Vars, typename DerivVars>
+inline HistoryIterator<Vars, DerivVars> operator+(
+    typename HistoryIterator<Vars, DerivVars>::difference_type n,
+    HistoryIterator<Vars, DerivVars> it) noexcept {
+  return std::move(it) + n;
+}
+
+template <typename Vars, typename DerivVars>
+inline HistoryIterator<Vars, DerivVars> operator-(
+    HistoryIterator<Vars, DerivVars> it,
+    typename HistoryIterator<Vars, DerivVars>::difference_type n) noexcept {
+  return std::move(it) + (-n);
+}
+}  // namespace TimeSteppers

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -12,6 +12,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Options/Options.hpp"
+#include "Time/History.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
 #include "Utilities/TMPL.hpp"
@@ -59,8 +60,7 @@ template <typename Tag, typename DtTag>
 struct HistoryEvolvedVariables : db::DataBoxPrefix {
   static constexpr db::DataBoxString label = "HistoryEvolvedVariables";
   using tag = Tag;
-  using type =
-      std::deque<std::tuple<::Time, db::item_type<Tag>, db::item_type<DtTag>>>;
+  using type = TimeSteppers::History<db::item_type<Tag>, db::item_type<DtTag>>;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -11,6 +11,7 @@
 #include <type_traits>
 
 #include "Parallel/CharmPupable.hpp"
+#include "Time/History.hpp"
 #include "Time/Time.hpp"
 #include "Utilities/FakeVirtual.hpp"
 #include "Utilities/Gsl.hpp"
@@ -27,8 +28,6 @@ class RungeKutta3;
 
 namespace TimeStepper_detail {
 DEFINE_FAKE_VIRTUAL(compute_boundary_delta)
-DEFINE_FAKE_VIRTUAL(needed_boundary_history)
-DEFINE_FAKE_VIRTUAL(needed_history)
 DEFINE_FAKE_VIRTUAL(update_u)
 }  // namespace TimeStepper_detail
 
@@ -39,10 +38,7 @@ class TimeStepper : public PUP::able {
  public:
   using Inherit =
       TimeStepper_detail::FakeVirtualInherit_compute_boundary_delta<
-          TimeStepper_detail::FakeVirtualInherit_needed_boundary_history<
-              TimeStepper_detail::FakeVirtualInherit_needed_history<
-                  TimeStepper_detail::FakeVirtualInherit_update_u<
-                      TimeStepper>>>>;
+          TimeStepper_detail::FakeVirtualInherit_update_u<TimeStepper>>;
   using creatable_classes = typelist<
       TimeSteppers::AdamsBashforthN,
       TimeSteppers::RungeKutta3>;
@@ -58,14 +54,12 @@ class TimeStepper : public PUP::able {
   ~TimeStepper() noexcept override = default;
   /// \endcond
 
-  /// Add the change for the current substep to u.  New values should
-  /// be pushed onto the end of the history when evaluated and
-  /// obsolete values should be removed from the front, in a manner
-  /// similar to a queue.
+  /// Add the change for the current substep to u.
   template <typename Vars, typename DerivVars>
-  void update_u(const gsl::not_null<Vars*> u,
-                const std::deque<std::tuple<Time, Vars, DerivVars>>& history,
-                const TimeDelta& time_step) const noexcept {
+  void update_u(
+      const gsl::not_null<Vars*> u,
+      const gsl::not_null<TimeSteppers::History<Vars, DerivVars>*> history,
+      const TimeDelta& time_step) const noexcept {
     return TimeStepper_detail::fake_virtual_update_u<creatable_classes>(
         this, u, history, time_step);
   }
@@ -87,7 +81,8 @@ class TimeStepper : public PUP::able {
   template <typename BoundaryVars, typename FluxVars, typename Coupling>
   BoundaryVars compute_boundary_delta(
       const Coupling& coupling,
-      const std::vector<std::deque<std::tuple<Time, BoundaryVars, FluxVars>>>&
+      const gsl::not_null<std::vector<std::deque<std::tuple<
+          Time, BoundaryVars, FluxVars>>>*>
           history,
       const TimeDelta& time_step) const noexcept {
     static_assert(
@@ -98,32 +93,6 @@ class TimeStepper : public PUP::able {
         "Coupling function returns wrong type");
     return TimeStepper_detail::fake_virtual_compute_boundary_delta<
         creatable_classes>(this, coupling, history, time_step);
-  }
-
-  /// Return iterator to the first entry in `history` that is still
-  /// needed after the current step.  Entries up to that point must be
-  /// removed before the next call to `update_u`.
-  template <typename Vars, typename DerivVars>
-  typename std::deque<std::tuple<Time, Vars, DerivVars>>::const_iterator
-  needed_history(const std::deque<std::tuple<Time, Vars, DerivVars>>& history)
-      const noexcept {
-    return TimeStepper_detail::fake_virtual_needed_history<creatable_classes>(
-        this, history);
-  }
-
-  /// Return iterators to the first entry for each element of
-  /// `history` that is still needed after the current step.  Entries
-  /// up to that point must be removed before the next call to
-  /// `compute_boundary_delta`.
-  template <typename BoundaryVars, typename FluxVars>
-  typename std::vector<typename std::deque<
-      std::tuple<Time, BoundaryVars, FluxVars>>::const_iterator>
-  needed_boundary_history(
-      const std::vector<
-          std::deque<std::tuple<Time, BoundaryVars, FluxVars>>>& history,
-      const TimeDelta& time_step) const noexcept {
-    return TimeStepper_detail::fake_virtual_needed_boundary_history<
-        creatable_classes>(this, history, time_step);
   }
 
   /// Number of substeps in this TimeStepper

--- a/src/Utilities/ConstantExpressions.hpp
+++ b/src/Utilities/ConstantExpressions.hpp
@@ -174,6 +174,28 @@ constexpr T min_by_magnitude(std::initializer_list<T> ilist) {
 }
 //@}
 
+/// \ingroup ConstantExpressionsGroup
+/// \brief Returns `f(ic<0>{}) + f(ic<1>{}) + ... + f(ic<NumTerms-1>{})`
+/// where `ic<N>` stands for `std::integral_constant<size_t, N>`.
+/// This function allows the result types of each operation to be
+/// different, and so works efficiently with expression templates.
+/// \note When summing expression templates one must be careful of
+/// referring to temporaries in `f`.
+template <size_t NumTerms, typename Function,
+          Requires<NumTerms == 1> = nullptr>
+constexpr decltype(auto) constexpr_sum(Function&& f) noexcept {
+  return f(std::integral_constant<size_t, 0>{});
+}
+
+/// \cond HIDDEN_SYMBOLS
+template <size_t NumTerms, typename Function,
+          Requires<(NumTerms > 1)> = nullptr>
+constexpr decltype(auto) constexpr_sum(Function&& f) noexcept {
+  return constexpr_sum<NumTerms - 1>(f) +
+      f(std::integral_constant<size_t, NumTerms - 1>{});
+}
+/// \endcond
+
 namespace detail {
 template <typename List, size_t... indices,
           Requires<not tt::is_a_v<tmpl::list, tmpl::front<List>>> = nullptr>

--- a/src/Utilities/ConstantExpressions.hpp
+++ b/src/Utilities/ConstantExpressions.hpp
@@ -297,7 +297,9 @@ inline constexpr bool array_equal(const std::array<T, size>& lhs,
                   : true;
 }
 
+namespace cpp17 {
 /// \ingroup ConstantExpressionsGroup
 /// \brief Returns a const reference to its argument.
 template <typename T>
 constexpr const T& as_const(const T& t) noexcept { return t; }
+}  // namespace cpp17

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -130,7 +130,8 @@ class ActionRunner {
   template <typename Component, typename Action, typename DbTags>
   bool is_ready(const db::DataBox<DbTags>& box,
                 const typename Component::index& array_index) noexcept {
-    return Action::is_ready(box, as_const(inboxes<Component>()[array_index]),
+    return Action::is_ready(box,
+                            cpp17::as_const(inboxes<Component>()[array_index]),
                             cache_, array_index);
   }
 

--- a/tests/Unit/Parallel/Test_PupStlCpp11.cpp
+++ b/tests/Unit/Parallel/Test_PupStlCpp11.cpp
@@ -82,6 +82,11 @@ SPECTRE_TEST_CASE("Unit.Serialization.array", "[Serialization][Unit]") {
   test_serialization(t2);
 }
 
+SPECTRE_TEST_CASE("Unit.Serialization.deque", "[Serialization][Unit]") {
+  std::deque<double> t{1.0, 3.64, 9.23};
+  test_serialization(t);
+}
+
 SPECTRE_TEST_CASE("Unit.Serialization.unordered_set", "[Serialization][Unit]") {
   std::unordered_set<size_t> test_set = {1, 2, 5, 100};
   test_serialization(test_set);

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 set(TIME_TESTS
+    Time/Test_History.cpp
     Time/Test_Slab.cpp
     Time/Test_StepControllers.cpp
     Time/Test_Time.cpp

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -1,0 +1,131 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <string>
+
+#include "Time/History.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+Time make_time(const double t) noexcept {
+  return Slab(t, t + 0.5).start();
+}
+
+// Requires `it` to point at 0. in the sequence of times -1., 0., 1., 2.
+template <typename Iterator>
+void check_iterator(Iterator it) noexcept {
+  CHECK(*it == make_time(0.));
+  CHECK(it->value() == 0.);
+  CHECK(it[0] == make_time(0.));
+  CHECK(it[1] == make_time(1.));
+  CHECK(it[-1] == make_time(-1.));
+
+  CHECK(*++it == make_time(1.));
+  CHECK(*it == make_time(1.));
+  CHECK(*--it == make_time(0.));
+  CHECK(*it == make_time(0.));
+  CHECK(*it++ == make_time(0.));
+  CHECK(*it == make_time(1.));
+  CHECK(*it-- == make_time(1.));
+  CHECK(*it == make_time(0.));
+
+  CHECK(*(it += 0) == make_time(0.));
+  CHECK(*it == make_time(0.));
+  CHECK(*(it += 2) == make_time(2.));
+  CHECK(*it == make_time(2.));
+  CHECK(*(it += -2) == make_time(0.));
+  CHECK(*it == make_time(0.));
+
+  CHECK(*(it -= 0) == make_time(0.));
+  CHECK(*it == make_time(0.));
+  CHECK(*(it -= -2) == make_time(2.));
+  CHECK(*it == make_time(2.));
+  CHECK(*(it -= 2) == make_time(0.));
+  CHECK(*it == make_time(0.));
+
+  auto next_it = it;
+  ++next_it;
+  CHECK(it + 0 == it);
+  CHECK(it + 1 == next_it);
+  CHECK(it - (-1) == next_it);
+  CHECK(next_it - 0 == next_it);
+  CHECK(next_it - 1 == it);
+  CHECK(next_it + (-1) == it);
+  CHECK(0 + it == it);
+  CHECK(1 + it == next_it);
+  CHECK((-1) + next_it == it);
+
+  CHECK(it - it == 0);
+  CHECK(next_it - it == 1);
+  CHECK(it - next_it == -1);
+
+  check_cmp(it, it + 1);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.History", "[Unit][Time]") {
+  using HistoryType = TimeSteppers::History<double, std::string>;
+  HistoryType history;
+
+  CHECK(history.size() == 0);
+  CHECK(history.begin() == history.end());
+  CHECK(history.begin() == history.cbegin());
+  CHECK(history.end() == history.cend());
+
+  history.insert(make_time(0.), 0., get_output(0));
+  history.insert(make_time(1.), 1., get_output(1));
+  history.insert_initial(make_time(-1.), -1., get_output(-1));
+  history.insert(make_time(2.), 2., get_output(2));
+
+  const auto check_state = [](const HistoryType& hist) noexcept {
+    CHECK(hist.size() == 4);
+    {
+      auto it = hist.begin();
+      for (size_t i = 0; i < hist.size(); ++i) {
+        CHECK(*it == hist[i]);
+        const auto entry_num = static_cast<ssize_t>(i) - 1;
+        CHECK((*it).value() == entry_num);
+        CHECK(it->value() == entry_num);
+        CHECK(it.value() == entry_num);
+        CHECK(it.derivative() == get_output(entry_num));
+        ++it;
+      }
+      CHECK(it == hist.end());
+    }
+
+    CHECK(hist.front() == hist[0]);
+    CHECK(hist.back() == hist[3]);
+  };
+  check_state(history);
+
+  // We check this later, to make sure we don't somehow depend on the
+  // original object.
+  const auto copy = serialize_and_deserialize(history);
+
+  history.mark_unneeded(history.begin());
+  CHECK(history.size() == 4);
+  history.mark_unneeded(history.begin() + 2);
+  CHECK(history.size() == 2);
+
+  {
+    auto it = history.begin();
+    for (size_t i = 0; i < 2; ++i) {
+      CHECK(*it == history[i]);
+      const auto entry_num = static_cast<ssize_t>(i) + 1;
+      CHECK((*it).value() == entry_num);
+      CHECK(it->value() == entry_num);
+      CHECK(it.value() == entry_num);
+      CHECK(it.derivative() == get_output(entry_num));
+      ++it;
+    }
+    CHECK(it == history.end());
+  }
+
+  history.mark_unneeded(history.end());
+  CHECK(history.size() == 0);
+
+  check_state(copy);
+  check_iterator(copy.begin() + 1);
+}

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -208,9 +208,8 @@ SPECTRE_TEST_CASE(
     }
 
     t += dt;
-    y += ab4.compute_boundary_delta(quartic_coupling, history, dt)();
-    TimeStepperTestUtils::erase_boundary_history(
-        ab4, make_not_null(&history), dt);
+    y += ab4.compute_boundary_delta(
+        quartic_coupling, make_not_null(&history), dt)();
     CHECK(y == approx(quartic_answer(t.value())));
   }
 }
@@ -260,9 +259,8 @@ void do_lts_test(const std::array<TimeDelta, 3>& dt) noexcept {
 
     ASSERT(not simulation_less(next_check, t), "Screwed up arithmetic");
     if (t == next_check) {
-      y += ab4.compute_boundary_delta(quartic_coupling, history, dt[0])();
-      TimeStepperTestUtils::erase_boundary_history(
-          ab4, make_not_null(&history), dt[0]);
+      y += ab4.compute_boundary_delta(
+          quartic_coupling, make_not_null(&history), dt[0])();
       CHECK(y == approx(quartic_answer(t.value())));
       if (t.is_at_slab_boundary()) {
         break;
@@ -368,10 +366,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.Variable",
     gsl::at(next, side) += this_dt;
 
     if (*std::min_element(next.cbegin(), next.cend()) == next_check) {
-      y += ab4.compute_boundary_delta(quartic_coupling, history,
-                                      next_check - t)();
-      TimeStepperTestUtils::erase_boundary_history(
-          ab4, make_not_null(&history), next_check - t);
+      y += ab4.compute_boundary_delta(
+          quartic_coupling, make_not_null(&history), next_check - t)();
       CHECK(y == approx(quartic_answer(next_check.value())));
       if (next_check.is_at_slab_boundary()) {
         break;

--- a/tests/Unit/Utilities/Test_ConstantExpressions.cpp
+++ b/tests/Unit/Utilities/Test_ConstantExpressions.cpp
@@ -108,6 +108,12 @@ static_assert(min_by_magnitude({1, -1}) == 1,
 static_assert(min_by_magnitude({-1, 1}) == -1,
               "Failed testing min_by_magnitude");
 
+struct TwoN {
+  template <typename T>
+  constexpr size_t operator()(T n) noexcept { return 2 * n; }
+};
+static_assert(constexpr_sum<5>(TwoN{}) == 20, "Failed testing constexpr_sum");
+
 // Test string manipulation
 constexpr const char *const dummy_string1 = "test 1";
 constexpr const char *const dummy_string2 = "test 1";

--- a/tests/Unit/Utilities/Test_ConstantExpressions.cpp
+++ b/tests/Unit/Utilities/Test_ConstantExpressions.cpp
@@ -136,13 +136,13 @@ static_assert(
     "Failed testing make_array_from_list");
 
 // Test as_const
-static_assert(cpp17::is_same_v<const double&,
-                               decltype(as_const(std::declval<double>()))>,
+static_assert(cpp17::is_same_v<const double&, decltype(cpp17::as_const(
+                                                  std::declval<double>()))>,
               "Failed testing as_const");
-static_assert(cpp17::is_same_v<const double&,
-                               decltype(as_const(std::declval<double&>()))>,
+static_assert(cpp17::is_same_v<const double&, decltype(cpp17::as_const(
+                                                  std::declval<double&>()))>,
               "Failed testing as_const");
-static_assert(5 == as_const(5), "Failed testing as_const");
+static_assert(5 == cpp17::as_const(5), "Failed testing as_const");
 
 SPECTRE_TEST_CASE("Unit.Utilities.ConstantExpressions", "[Unit][Utilities]") {
   CHECK((std::array<std::array<size_t, 3>, 3>{

--- a/tests/Unit/Utilities/Test_FakeVirtual.cpp
+++ b/tests/Unit/Utilities/Test_FakeVirtual.cpp
@@ -238,11 +238,11 @@ SPECTRE_TEST_CASE("Unit.Utilities.call_with_dynamic_type",
 
   CHECK(11 ==
         (call_with_dynamic_type<int, tmpl::list<D1, D2>>(
-             &as_const(*d1),
+             &cpp17::as_const(*d1),
              [](const auto* const p) { return p->const_func(); })));
   CHECK(12 ==
         (call_with_dynamic_type<int, tmpl::list<D1, D2>>(
-             &as_const(*d2),
+             &cpp17::as_const(*d2),
              [](const auto* const p) { return p->const_func(); })));
 
   // Test void return type


### PR DESCRIPTION
## Proposed changes

* Adds dedicated classes for storing time stepper history
* Restricts boundary calculations to two sides

### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

The volume history class (History) does not have many features beyond a deque and could be dropped if people prefer.  I added it mostly for consistency with the boundary interface and as a possible place to do allocation caching if we end up wanting that.
