### PR TITLE
Parallel::printf prints double precision for classes

### DIFF
--- a/src/Parallel/Printf.hpp
+++ b/src/Parallel/Printf.hpp
@@ -42,7 +42,8 @@ inline std::string stream_object_to_string(T&& t) {
                 "Cannot stream type and therefore it cannot be printed. Please "
                 "define a stream operator for the type.");
   std::stringstream ss;
-  ss << t;
+  ss << std::setprecision(std::numeric_limits<long double>::digits10 + 1)
+     << std::scientific << t;
   return ss.str();
 }
 

--- a/tests/Unit/Parallel/Test_Parallel.cpp
+++ b/tests/Unit/Parallel/Test_Parallel.cpp
@@ -9,7 +9,7 @@
 
 namespace {
 struct TestStream {
-  double a{3.4};
+  double a{1.0};
   std::vector<int> b{0, 4, 8, -7};
 };
 
@@ -23,7 +23,8 @@ std::ostream& operator<<(std::ostream& os, const TestStream& t) {
 }
 }  // namespace
 
-// [[OutputRegex, -100 3000000000 3.4 \(0,4,8,-7\) test 1 2 3 abf a o e u]]
+// [[OutputRegex, -100 3000000000 1.0000000000000000000e\+00 \(0,4,8,-7\) test 1
+// 2 3 abf a o e u]]
 SPECTRE_TEST_CASE("Unit.Parallel.printf", "[Unit][Parallel]") {
   const char c_string0[40] = {"test 1 2 3"};
   auto* c_string1 = new char[80];


### PR DESCRIPTION
## Proposed changes

Have classes that print doubles print to full precision when using `Parallel::printf`. This is useful for debugging purposes, I think.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
