### PR TITLE
Use the GNU Gold or LLVM LLD linker if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ include(SetupCharm)
 include(SetupCharmProjections)
 include(SetupMacOsx)
 include(EnableWarnings)
+include(SetupGoldOrLldLinker)
 
 # In order to use certain code analysis tools like clang-tidy and cppcheck the
 # compile commands need to be accessible. CMake can write these to a

--- a/cmake/SetupGoldOrLldLinker.cmake
+++ b/cmake/SetupGoldOrLldLinker.cmake
@@ -1,0 +1,50 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+option(USE_LD
+  "Override the default linker. Options are: ld, gold, lld"
+  OFF)
+
+if (USE_LD)
+  if("${USE_LD}" STREQUAL "gold")
+    find_program(GNU_GOLD_LINKER "ld.gold")
+    if ("${GNU_GOLD_LINKER}" STREQUAL "")
+      message(FATAL_ERROR
+        "ld.gold requested but could not find executable")
+    endif()
+    check_and_add_cxx_link_flag("-fuse-ld=gold")
+  elseif("${USE_LD}" STREQUAL "lld")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+      message(FATAL_ERROR "GCC does not support linking with LLD. "
+        "If this has changed please remove this error message "
+        "and submit a pull request.")
+    endif()
+    find_program(LLD_LINKER "ld.lld")
+    if ("${LLD_LINKER}" STREQUAL "")
+      message(FATAL_ERROR
+        "ld.lld requested but could not find executable")
+    endif()
+    check_and_add_cxx_link_flag("-fuse-ld=lld")
+  elseif(NOT "${USE_LD}" STREQUAL "ld")
+    message(FATAL_ERROR
+      "USE_LD must be one of 'ld', 'gold' or 'lld' but got '${USE_LD}'")
+  endif()
+else()
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    # GCC currently only supports linking with ld.gold, not ld.lld
+    find_program(GNU_GOLD_LINKER "ld.gold")
+    if (NOT "${GNU_GOLD_LINKER}" STREQUAL "")
+      check_and_add_cxx_link_flag("-fuse-ld=gold")
+    endif()
+  else()
+    find_program(LLD_LINKER "ld.lld")
+    if (NOT "${LLD_LINKER}" STREQUAL "")
+      check_and_add_cxx_link_flag("-fuse-ld=lld")
+    else()
+      find_program(GNU_GOLD_LINKER "ld.gold")
+      if (NOT "${GNU_GOLD_LINKER}" STREQUAL "")
+        check_and_add_cxx_link_flag("-fuse-ld=gold")
+      endif()
+    endif()
+  endif()
+endif()


### PR DESCRIPTION
## Proposed changes

Use the GNU Gold and LLVM LLD linkers if they're available.

These linkers are quite a bit faster than LD. On my machine I get:
ld: 11.7 s
ld.gold: 6.5 s
ld.lld: 4.9 s

when linking RunTests

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
