### PR TITLE
Add flux and numerical flux computation for ScalarWave

### DIFF
--- a/cmake/SetupDoxygen.cmake
+++ b/cmake/SetupDoxygen.cmake
@@ -20,7 +20,19 @@ if (DOXYGEN_FOUND)
       DEPENDS
       ${PROJECT_BINARY_DIR}/docs/DoxyfileHtml
       ${SPECTRE_DOXYGEN_GROUPS}
-  )
+      )
+
+  add_custom_target(
+    doc-check
+    # search for warnings and print out 6 lines after to make sure
+    # majority of warning is printed so the results are actually
+    # useful.
+    COMMAND ! ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/docs/DoxyfileHtml 2>&1
+    | grep -A 6 'warning'
+    DEPENDS
+    ${PROJECT_BINARY_DIR}/docs/DoxyfileHtml
+    ${SPECTRE_DOXYGEN_GROUPS}
+    )
 
   set(SPECTRE_DOX_GENERATE_HTML "NO")
   set(SPECTRE_DOX_GENERATE_XML "YES")

--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -11,11 +11,14 @@
 #include "Utilities/TMPL.hpp"
 
 namespace ScalarWave {
+// Doxygen is not good at templates and so we have to hide the definition.
+/// \cond
 template <size_t Dim>
 void ComputeDuDt<Dim>::apply(
-    gsl::not_null<Scalar<DataVector>*> dt_pi,
-    gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
-    gsl::not_null<Scalar<DataVector>*> dt_psi, const Scalar<DataVector>& pi,
+    const gsl::not_null<Scalar<DataVector>*> dt_pi,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
+    const gsl::not_null<Scalar<DataVector>*> dt_psi,
+    const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
     const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi) noexcept {
   get(*dt_psi) = -get(pi);
@@ -27,6 +30,7 @@ void ComputeDuDt<Dim>::apply(
     dt_phi->get(d) = -d_pi.get(d);
   }
 }
+/// \endcond
 
 template <size_t Dim>
 void ComputeNormalDotFluxes<Dim>::apply(

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -171,4 +171,10 @@ struct UpwindFlux {
       const tnsr::i<DataVector, Dim, Frame::Inertial>&
           normal_times_flux_pi_exterior) const noexcept;
 };
+
+/// Compute the maximum magnitude of the characteristic speeds.
+struct ComputeLargestCharacteristicSpeed {
+  using argument_tags = tmpl::list<>;
+  SPECTRE_ALWAYS_INLINE static constexpr double apply() noexcept { return 1.0; }
+};
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -68,4 +68,29 @@ struct ComputeDuDt {
       const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
       const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi) noexcept;
 };
+
+/*!
+ * \brief Compute normal component of flux on a boundary.
+ *
+ * \f{align}
+ * F(\Psi) =& 0 \\
+ * F(\Pi) =& n^i \Phi_i \\
+ * F(\Phi_i) =& n_i \Pi
+ * \f}
+ */
+template <size_t Dim>
+struct ComputeNormalDotFluxes {
+  using return_tags =
+      tmpl::list<Tags::NormalDotFlux<Pi>, Tags::NormalDotFlux<Phi<Dim>>,
+                 Tags::NormalDotFlux<Psi>>;
+  using argument_tags = tmpl::list<Pi, Phi<Dim>>;
+  static void apply(gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
+                    gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+                        phi_normal_dot_flux,
+                    gsl::not_null<Scalar<DataVector>*> psi_normal_dot_flux,
+                    const Scalar<DataVector>& pi,
+                    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+                    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+                        interface_unit_normal) noexcept;
+};
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -5,7 +5,9 @@
 
 #include <cstddef>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
 template <typename>
@@ -92,5 +94,81 @@ struct ComputeNormalDotFluxes {
                     const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
                     const tnsr::i<DataVector, Dim, Frame::Inertial>&
                         interface_unit_normal) noexcept;
+};
+
+/*!
+ * \brief Computes the upwind flux
+ *
+ * The upwind flux is given by:
+ * \f{align}
+ * F^*(\Psi) =& 0 \\
+ * F^*(\Pi) =& \frac{1}{2}\left(F(\Pi)_{\mathrm{int}} + F(\Pi)_{\mathrm{ext}}
+ *                    + \Pi_{\mathrm{int}} - \Pi_{\mathrm{ext}}\right) \\
+ * F^*(\Phi_i) =& \frac{1}{2} \left(F(\Phi_i)_{\mathrm{int}}
+ *                   + F(\Phi_i)_{\mathrm{ext}}
+ *                   + (n_i)_{\mathrm{int}} F(\Pi)_{\mathrm{int}}
+ *                   - (n_i)_{\mathrm{ext}} F(\Pi)_{\mathrm{ext}}\right)
+ * \f}
+ * where \f$F^*\f$ is the normal dotted with the numerical flux and \f$F\f$ is
+ * the normal dotted with the flux, which is computed in
+ * ScalarWave::ComputeNormalDotFluxes
+ */
+template <size_t Dim>
+struct UpwindFlux {
+ private:
+  struct NormalTimesFluxPi {
+    using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+    static constexpr db::DataBoxString label = "NormalTimesFluxPi";
+  };
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {
+      "Computes the upwind flux for a scalar wave system. It requires no "
+      "options."};
+
+  // clang-tidy: non-const reference
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+
+  using return_tags = tmpl::list<Tags::NormalDotNumericalFlux<Pi>,
+                                 Tags::NormalDotNumericalFlux<Phi<Dim>>,
+                                 Tags::NormalDotNumericalFlux<Psi>>;
+
+  using package_tags =
+      tmpl::list<Tags::NormalDotFlux<Pi>, Tags::NormalDotFlux<Phi<Dim>>, Pi,
+                 NormalTimesFluxPi>;
+
+  using slice_tags = tmpl::list<Pi>;
+
+  // pseudo-interface: used internally by Algorithm infrastructure, not
+  // user-level code
+  void package_data(
+      gsl::not_null<Variables<package_tags>*> packaged_data,
+      const Scalar<DataVector>& normal_dot_flux_pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_dot_flux_phi,
+      const Scalar<DataVector>& /*normal_dot_flux_psi*/,
+      const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+      const noexcept;
+
+  // pseudo-interface: used internally by Algorithm infrastructure, not
+  // user-level code
+  void operator()(
+      gsl::not_null<Scalar<DataVector>*> pi_normal_dot_numerical_flux,
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          phi_normal_dot_numerical_flux,
+      gsl::not_null<Scalar<DataVector>*> psi_normal_dot_numerical_flux,
+      const Scalar<DataVector>& normal_dot_flux_pi_interior,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          normal_dot_flux_phi_interior,
+      const Scalar<DataVector>& pi_interior,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          normal_times_flux_pi_interior,
+      const Scalar<DataVector>& minus_normal_dot_flux_pi_exterior,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          minus_normal_dot_flux_phi_exterior,
+      const Scalar<DataVector>& pi_exterior,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+          normal_times_flux_pi_exterior) const noexcept;
 };
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -34,5 +34,7 @@ struct System {
 
   using du_dt = ComputeDuDt<Dim>;
   using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
+  using compute_largest_characteristic_speed =
+      ComputeLargestCharacteristicSpeed;
 };
 }  // namespace ScalarWave

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -33,5 +33,6 @@ struct System {
   using gradients_tags = tmpl::list<Pi, Phi<Dim>>;
 
   using du_dt = ComputeDuDt<Dim>;
+  using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
 };
 }  // namespace ScalarWave

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -144,3 +144,89 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.NormalDotFluxes",
   check_normal_dot_fluxes<2>(3, time);
   check_normal_dot_fluxes<3>(3, time);
 }
+
+namespace {
+template <class... Tags, class FluxType, class... NormalDotNumericalFluxTypes>
+void apply_numerical_flux(
+    const FluxType& flux,
+    const Variables<tmpl::list<Tags...>>& packaged_data_int,
+    const Variables<tmpl::list<Tags...>>& packaged_data_ext,
+    NormalDotNumericalFluxTypes&&... normal_dot_numerical_flux) {
+  flux(std::forward<NormalDotNumericalFluxTypes>(normal_dot_numerical_flux)...,
+       get<Tags>(packaged_data_int)..., get<Tags>(packaged_data_ext)...);
+}
+
+template <size_t Dim>
+void check_upwind_flux(const size_t npts, const double t) {
+  const ScalarWave::Solutions::PlaneWave<Dim> solution(
+      make_array<Dim>(0.1), make_array<Dim>(0.0),
+      std::make_unique<MathFunctions::Gaussian>(1.0, 1.0, 0.0));
+
+  const tnsr::I<DataVector, Dim> x = [npts]() {
+    auto logical_coords = logical_coordinates(Index<Dim>(3));
+    tnsr::I<DataVector, Dim> coords{pow<Dim>(npts)};
+    for (size_t i = 0; i < Dim; ++i) {
+      coords.get(i) = std::move(logical_coords.get(i));
+    }
+    return coords;
+  }();
+
+  // Any numbers are fine, doesn't have anything to do with unit normal
+  tnsr::i<DataVector, Dim, Frame::Inertial> unit_normal(pow<Dim>(npts), 0.0);
+  for (size_t d = 0; d < Dim; ++d) {
+    unit_normal.get(d) = x.get(d);
+  }
+
+  Variables<typename ScalarWave::UpwindFlux<Dim>::package_tags>
+      packaged_data_int(pow<Dim>(npts), 0.0);
+  Variables<typename ScalarWave::UpwindFlux<Dim>::package_tags>
+      packaged_data_ext(pow<Dim>(npts), 0.0);
+
+  ScalarWave::UpwindFlux<Dim> flux_computer{};
+  flux_computer.package_data(
+      make_not_null(&packaged_data_int), solution.dpsi_dt(x, t + 1.0),
+      solution.dpsi_dx(x, t + 2.0), solution.psi(x, t + 3.0),
+      solution.psi(x, t + 4.0), unit_normal);
+  flux_computer.package_data(
+      make_not_null(&packaged_data_ext), solution.dpsi_dt(x, 2.0 * t + 10.0),
+      solution.dpsi_dx(x, 2.0 * t + 9.0), solution.psi(x, 2.0 * t + 8.0),
+      solution.psi(x, 2.0 * t + 7.0), unit_normal);
+
+  Scalar<DataVector> normal_dot_numerical_flux_pi(pow<Dim>(npts), 0.0);
+  Scalar<DataVector> normal_dot_numerical_flux_psi(pow<Dim>(npts), 0.0);
+  tnsr::i<DataVector, Dim, Frame::Inertial> normal_dot_numerical_flux_phi(
+      pow<Dim>(npts), 0.0);
+  apply_numerical_flux(flux_computer, packaged_data_int, packaged_data_ext,
+                       make_not_null(&normal_dot_numerical_flux_pi),
+                       make_not_null(&normal_dot_numerical_flux_phi),
+                       make_not_null(&normal_dot_numerical_flux_psi));
+
+  CHECK(normal_dot_numerical_flux_psi ==
+        Scalar<DataVector>(pow<Dim>(npts), 0.0));
+  CHECK(normal_dot_numerical_flux_pi ==
+        Scalar<DataVector>(0.5 * (get(solution.psi(x, t + 4.0)) -
+                                  get(solution.psi(x, 2.0 * t + 7.0)) +
+                                  get(solution.dpsi_dt(x, t + 1.0)) -
+                                  get(solution.dpsi_dt(x, 2.0 * t + 10.0)))));
+
+  tnsr::i<DataVector, Dim> normal_dot_numerical_flux_phi_expected(
+      pow<Dim>(npts), 0.0);
+  for (size_t d = 0; d < Dim; ++d) {
+    normal_dot_numerical_flux_phi_expected.get(d) =
+        0.5 * (solution.dpsi_dx(x, t + 2.0).get(d) -
+               solution.dpsi_dx(x, 2.0 * t + 9.0).get(d) +
+               unit_normal.get(d) * solution.dpsi_dt(x, t + 1.0).get() -
+               unit_normal.get(d) * solution.dpsi_dt(x, 2.0 * t + 10.0).get());
+  }
+  CHECK(normal_dot_numerical_flux_phi ==
+        normal_dot_numerical_flux_phi_expected);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.UpwindFlux",
+                  "[Unit][Evolution]") {
+  constexpr double time = 0.7;
+  check_upwind_flux<1>(3, time);
+  check_upwind_flux<2>(3, time);
+  check_upwind_flux<3>(3, time);
+}

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -230,3 +230,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.UpwindFlux",
   check_upwind_flux<2>(3, time);
   check_upwind_flux<3>(3, time);
 }
+
+static_assert(1.0 == ScalarWave::ComputeLargestCharacteristicSpeed::apply(),
+              "Failed testing ScalarWave::ComputeLargestCharacteristicSpeed.");


### PR DESCRIPTION
## Proposed changes

- Add flux computation for the scalar wave system
- Add numerical flux computation for scalar wave system. The numerical flux is computed in two steps. First the `package_data` function is called to compute the contribution from one side of the interface. The call operator of the class is passed the data from each side of the interface and then computes the numerical fluxes.
- Add compute largest characteristic
- Add `doc-check` target to check warnings in documentation. Fix #255 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
