### PR TITLE
Have docs include parts of testing framework

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -71,9 +71,20 @@ STRIP_CODE_COMMENTS    = NO
 # configuration options related to the input files
 #---------------------------------------------------------------------------
 
-INPUT                  = @SPECTRE_DOXYGEN_GROUPS@ \
-                         @PROJECT_SOURCE_DIR@/docs/MainSite/Main.md \
-                         @PROJECT_SOURCE_DIR@
+INPUT = @SPECTRE_DOXYGEN_GROUPS@ \
+        @PROJECT_SOURCE_DIR@/docs/MainSite/Main.md \
+        @PROJECT_SOURCE_DIR@/src
+
+# Add tutorials directory
+INPUT += @PROJECT_SOURCE_DIR@/docs
+
+# Add files to scan that explain testing framework
+INPUT += @PROJECT_SOURCE_DIR@/tests/Unit/ActionTesting.hpp \
+         @PROJECT_SOURCE_DIR@/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp \
+         @PROJECT_SOURCE_DIR@/tests/Unit/TestCreation.hpp \
+         @PROJECT_SOURCE_DIR@/tests/Unit/TestHelpers.hpp
+
+
 
 FILE_PATTERNS          = *.cpp \
                          *.hpp \
@@ -85,11 +96,7 @@ EXCLUDE                =
 
 EXCLUDE_SYMLINKS       = NO
 
-EXCLUDE_PATTERNS       = @PROJECT_SOURCE_DIR@/build*                  \
-                         @PROJECT_SOURCE_DIR@/cmake/*                 \
-                         @PROJECT_SOURCE_DIR@/README.md               \
-                         @PROJECT_SOURCE_DIR@/support/*               \
-                         @PROJECT_SOURCE_DIR@/tests/*
+EXCLUDE_PATTERNS       =
 
 EXCLUDE_SYMBOLS        = *brigand*                                    \
                          charm*                                       \

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -368,7 +368,7 @@ into two classes:
  * specified as follows:
  * \code
  * // [[TimeOut, 10]]
- * // [[ErrorRegex, The error message expected from the test]]
+ * // [[OutputRegex, The error message expected from the test]]
  * SPECTRE_TEST_CASE("Unit.Blah", "[Unit]") {
  * \endcode
  *
@@ -398,7 +398,7 @@ into two classes:
  * </table>
  *
  * \example
- * snippet Test_H5.cpp willfail_example_for_dev_doc
+ * \snippet Test_H5.cpp willfail_example_for_dev_doc
  *
  * ### Testing static assert
  *

--- a/tests/Unit/Parallel/Test_PupStlCpp11.cpp
+++ b/tests/Unit/Parallel/Test_PupStlCpp11.cpp
@@ -100,12 +100,14 @@ SPECTRE_TEST_CASE("Unit.Serialization.unique_ptr.double",
   CHECK(3.8273 == *serialize_and_deserialize(test_unique_ptr));  // NOLINT
 }
 
+/// [example_serialize_derived]
 SPECTRE_TEST_CASE("Unit.Serialization.unique_ptr.abstract_base",
                   "[Serialization][Unit]") {
   test_serialization_via_base<Test_Classes::Base,
                               Test_Classes::DerivedInPupStlCpp11>(
       std::vector<double>{-1, 12.3, -7, 8});
 }
+/// [example_serialize_derived]
 
 SPECTRE_TEST_CASE("Unit.Serialization.unique_ptr.nullptr",
                   "[Serialization][Unit]") {


### PR DESCRIPTION
## Proposed changes

The Doxygen file is improved to include only the src dir, and then
include the several files in tests that has documentation for the
testing framework.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
