### PR TITLE
Plane wave changes

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -161,6 +161,19 @@ class Variables<tmpl::list<Tags...>> {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p);  // NOLINT
 
+  /// \brief Assign a subset of the `Tensor`s from another Variables
+  ///
+  /// \note There is no need for an rvalue overload because we need to copy into
+  /// the contiguous array anyway
+  template <typename... SubsetOfTags,
+            Requires<tmpl2::flat_all_v<tmpl::list_contains_v<
+                tmpl::list<Tags...>, SubsetOfTags>...>> = nullptr>
+  void assign_subset(
+      const Variables<tmpl::list<SubsetOfTags...>>& vars) noexcept {
+    (void)std::initializer_list<char>{
+        (get<SubsetOfTags>(*this) = get<SubsetOfTags>(vars), '0')...};
+  }
+
   /// Converting constructor for an expression to a Variables class
   // clang-tidy: mark as explicit (we want conversion to Variables)
   template <typename VT, bool VF>

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -27,6 +27,10 @@ constexpr size_t map_dim = FirstMap::dim;
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase : public PUP::able {
  public:
+  static constexpr size_t dim = Dim;
+  using source_frame = SourceFrame;
+  using target_frame = TargetFrame;
+
   WRAPPED_PUPable_abstract(CoordinateMapBase);  // NOLINT
 
   CoordinateMapBase() = default;

--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -27,6 +27,8 @@ template <size_t Dim, typename TargetFrame>
 class ElementMap {
  public:
   static constexpr size_t dim = Dim;
+  using source_frame = Frame::Logical;
+  using target_frame = TargetFrame;
 
   /// \cond HIDDEN_SYMBOLS
   ElementMap() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -12,7 +12,7 @@ namespace Solutions {
 template <size_t Dim>
 PlaneWave<Dim>::PlaneWave(std::array<double, Dim> wave_vector,
                           std::array<double, Dim> center,
-                          std::unique_ptr<MathFunction<1>>&& profile) noexcept
+                          std::unique_ptr<MathFunction<1>> profile) noexcept
     : wave_vector_(std::move(wave_vector)),
       center_(std::move(center)),
       profile_(std::move(profile)),

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -80,6 +80,34 @@ tnsr::ii<T, Dim> PlaneWave<Dim>::d2psi_dxdx(const tnsr::I<T, Dim>& x,
 }
 
 template <size_t Dim>
+Variables<tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>>
+PlaneWave<Dim>::evolution_variables(const tnsr::I<DataVector, Dim>& x,
+                                    double t) const noexcept {
+  Variables<tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>>
+      variables{x.begin()->size()};
+  get<ScalarWave::Psi>(variables) = psi(x, t);
+  get<ScalarWave::Pi>(variables) = dpsi_dt(x, t);
+  get<ScalarWave::Pi>(variables).get() *= -1.0;
+  get<ScalarWave::Phi<Dim>>(variables) = dpsi_dx(x, t);
+  return variables;
+}
+
+template <size_t Dim>
+Variables<tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                     Tags::dt<ScalarWave::Psi>>>
+PlaneWave<Dim>::dt_evolution_variables(const tnsr::I<DataVector, Dim>& x,
+                                       double t) const noexcept {
+  Variables<tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                       Tags::dt<ScalarWave::Psi>>>
+      dt_variables{x.begin()->size()};
+  get<Tags::dt<ScalarWave::Psi>>(dt_variables) = dpsi_dt(x, t);
+  get<Tags::dt<ScalarWave::Pi>>(dt_variables) = d2psi_dt2(x, t);
+  get<Tags::dt<ScalarWave::Pi>>(dt_variables).get() *= -1.0;
+  get<Tags::dt<ScalarWave::Phi<Dim>>>(dt_variables) = d2psi_dtdx(x, t);
+  return dt_variables;
+}
+
+template <size_t Dim>
 void PlaneWave<Dim>::pup(PUP::er& p) noexcept {
   p | wave_vector_;
   p | center_;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -3,6 +3,7 @@
 
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
 
+#include "Parallel/PupStlCpp11.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"
 
@@ -76,6 +77,14 @@ tnsr::ii<T, Dim> PlaneWave<Dim>::d2psi_dxdx(const tnsr::I<T, Dim>& x,
     }
   }
   return result;
+}
+
+template <size_t Dim>
+void PlaneWave<Dim>::pup(PUP::er& p) noexcept {
+  p | wave_vector_;
+  p | center_;
+  p | profile_;
+  p | omega_;
 }
 
 template <size_t Dim>

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -9,8 +9,11 @@
 #include <array>
 #include <memory>
 
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/MakeWithValue.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -90,6 +93,21 @@ class PlaneWave {
   /// The second spatial derivatives of the scalar field
   template <typename T>
   tnsr::ii<T, Dim> d2psi_dxdx(const tnsr::I<T, Dim>& x, double t) const
+      noexcept;
+
+  /// Retrieve the evolution variables at time `t` and spatial coordinates `x`
+  Variables<tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>>
+  evolution_variables(const tnsr::I<DataVector, Dim>& x, double t) const
+      noexcept;
+
+  /// Retrieve the time derivative of the evolution variables at time `t` and
+  /// spatial coordinates `x`
+  ///
+  /// \note This function's expected use case is setting the past time
+  /// derivative values for Adams-Bashforth-like steppers.
+  Variables<tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                       Tags::dt<ScalarWave::Psi>>>
+  dt_evolution_variables(const tnsr::I<DataVector, Dim>& x, double t) const
       noexcept;
 
   // clang-tidy: no pass by reference

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -54,9 +54,9 @@ class PlaneWave {
   static constexpr OptionString help = {
       "A plane wave solution of the Euclidean wave equation"};
 
-  PlaneWave(std::array<double, Dim> wave_vector, std::array<double, Dim> center,
-            std::unique_ptr<MathFunction<1>>&& profile) noexcept;
   PlaneWave() = default;
+  PlaneWave(std::array<double, Dim> wave_vector, std::array<double, Dim> center,
+            std::unique_ptr<MathFunction<1>> profile) noexcept;
   PlaneWave(const PlaneWave&) noexcept = delete;
   PlaneWave& operator=(const PlaneWave&) noexcept = delete;
   PlaneWave(PlaneWave&&) noexcept = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -15,6 +15,10 @@
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/MakeArray.hpp"
 
+namespace PUP {
+class er;
+}  // namespace PUP
+
 namespace ScalarWave {
 namespace Solutions {
 /*!
@@ -87,6 +91,9 @@ class PlaneWave {
   template <typename T>
   tnsr::ii<T, Dim> d2psi_dxdx(const tnsr::I<T, Dim>& x, double t) const
       noexcept;
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
 
  private:
   template <typename T>

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -369,6 +369,65 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.Serialization",
   test_serialization(v);
 }
 
+SPECTRE_TEST_CASE("Unit.DataStructures.Variables.assign_subset",
+                  "[DataStructures][Unit]") {
+  constexpr size_t size = 3;
+  Variables<tmpl::list<VariablesTestTags_detail::vector>> vars_subset0(size,
+                                                                       8.0);
+  Variables<tmpl::list<VariablesTestTags_detail::scalar>> vars_subset1(size,
+                                                                       4.0);
+
+  Variables<tmpl::list<VariablesTestTags_detail::vector,
+                       VariablesTestTags_detail::scalar>>
+      vars_set0(size, 3.0);
+  CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
+        db::item_type<VariablesTestTags_detail::vector>(size, 3.0));
+  CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
+        db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
+  vars_set0.assign_subset(vars_subset0);
+  CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
+        db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+  CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
+        db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
+  vars_set0.assign_subset(vars_subset1);
+  CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
+        db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+  CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
+        db::item_type<VariablesTestTags_detail::scalar>(size, 4.0));
+
+  Variables<tmpl::list<VariablesTestTags_detail::vector,
+                       VariablesTestTags_detail::scalar,
+                       VariablesTestTags_detail::scalar2>>
+      vars_set1(size, 3.0);
+  CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
+        db::item_type<VariablesTestTags_detail::vector>(size, 3.0));
+  CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
+        db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
+  CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
+        db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
+  vars_set1.assign_subset(vars_subset0);
+  CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
+        db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+  CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
+        db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
+  CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
+        db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
+  vars_set1.assign_subset(vars_subset1);
+  CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
+        db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+  CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
+        db::item_type<VariablesTestTags_detail::scalar>(size, 4.0));
+  CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
+        db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
+
+  Variables<tmpl::list<VariablesTestTags_detail::vector>> vars_set2(size, -7.0);
+  CHECK(get<VariablesTestTags_detail::vector>(vars_set2) ==
+        db::item_type<VariablesTestTags_detail::vector>(size, -7.0));
+  vars_set2.assign_subset(vars_subset0);
+  CHECK(get<VariablesTestTags_detail::vector>(vars_set2) ==
+        db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+}
+
 SPECTRE_TEST_CASE("Unit.DataStructures.Variables.SliceVariables",
                   "[DataStructures][Unit]") {
   Variables<typelist<VariablesTestTags_detail::vector>> vars(24, 0.);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -56,6 +56,23 @@ void check_solution_x(const double kx, const double omega, const DataVector& u,
     CHECK(approx(d2psi_dtdx[s]) == pw.d2psi_dtdx(p, t).get(0));
     CHECK(approx(d2psi_dxdx[s]) == pw.d2psi_dxdx(p, t).get(0, 0));
   }
+
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Psi>(pw.evolution_variables(x, t)),
+                        pw.psi(x, t));
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Phi<Dim>>(pw.evolution_variables(x, t)),
+                        pw.dpsi_dx(x, t));
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Pi>(pw.evolution_variables(x, t)),
+                        Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
+
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Psi>>(pw.dt_evolution_variables(x, t)),
+      pw.dpsi_dt(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Phi<Dim>>>(pw.dt_evolution_variables(x, t)),
+      pw.d2psi_dtdx(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Pi>>(pw.dt_evolution_variables(x, t)),
+      Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
 }
 
 template <size_t Dim>
@@ -80,6 +97,23 @@ void check_solution_y(const double kx, const double ky, const double omega,
     CHECK(approx(d2psi_dxdy[s]) == pw.d2psi_dxdx(p, t).get(1, 0));
     CHECK(approx(d2psi_dydy[s]) == pw.d2psi_dxdx(p, t).get(1, 1));
   }
+
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Psi>(pw.evolution_variables(x, t)),
+                        pw.psi(x, t));
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Phi<Dim>>(pw.evolution_variables(x, t)),
+                        pw.dpsi_dx(x, t));
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Pi>(pw.evolution_variables(x, t)),
+                        Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
+
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Psi>>(pw.dt_evolution_variables(x, t)),
+      pw.dpsi_dt(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Phi<Dim>>>(pw.dt_evolution_variables(x, t)),
+      pw.d2psi_dtdx(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Pi>>(pw.dt_evolution_variables(x, t)),
+      Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
 }
 
 void check_solution_z(const double kx, const double ky, const double kz,
@@ -108,6 +142,23 @@ void check_solution_z(const double kx, const double ky, const double kz,
     CHECK(approx(d2psi_dydz[s]) == pw.d2psi_dxdx(p, t).get(1, 2));
     CHECK(approx(d2psi_dzdz[s]) == pw.d2psi_dxdx(p, t).get(2, 2));
   }
+
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Psi>(pw.evolution_variables(x, t)),
+                        pw.psi(x, t));
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Phi<3>>(pw.evolution_variables(x, t)),
+                        pw.dpsi_dx(x, t));
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Pi>(pw.evolution_variables(x, t)),
+                        Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
+
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Psi>>(pw.dt_evolution_variables(x, t)),
+      pw.dpsi_dt(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Phi<3>>>(pw.dt_evolution_variables(x, t)),
+      pw.d2psi_dtdx(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Pi>>(pw.dt_evolution_variables(x, t)),
+      Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
 }
 
 void test_1d() {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cmath>
 
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -123,6 +124,10 @@ void test_1d() {
       {{k}}, {{center_x}}, std::make_unique<MathFunctions::PowX>(3));
   check_solution_x(k, omega, u, pw, x, t);
 
+  Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+  const auto deserialized_pw = serialize_and_deserialize(pw);
+  check_solution_x(k, omega, u, deserialized_pw, x, t);
+
   test_creation<ScalarWave::Solutions::PlaneWave<1>>(
       "  WaveVector: [3.5]\n"
       "  Center: [3.5]\n"
@@ -151,6 +156,11 @@ void test_2d() {
       std::make_unique<MathFunctions::PowX>(3));
   check_solution_x(kx, omega, u, pw, x, t);
   check_solution_y(kx, ky, omega, u, pw, x, t);
+
+  Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+  const auto deserialized_pw = serialize_and_deserialize(pw);
+  check_solution_x(kx, omega, u, deserialized_pw, x, t);
+  check_solution_y(kx, ky, omega, u, deserialized_pw, x, t);
 
   test_creation<ScalarWave::Solutions::PlaneWave<2>>(
       "  WaveVector: [-2, 3.5]\n"
@@ -187,6 +197,12 @@ void test_3d() {
   check_solution_x(kx, omega, u, pw, x, t);
   check_solution_y(kx, ky, omega, u, pw, x, t);
   check_solution_z(kx, ky, kz, omega, u, pw, x, t);
+
+  Parallel::register_derived_classes_with_charm<MathFunction<1>>();
+  const auto deserialized_pw = serialize_and_deserialize(pw);
+  check_solution_x(kx, omega, u, deserialized_pw, x, t);
+  check_solution_y(kx, ky, omega, u, deserialized_pw, x, t);
+  check_solution_z(kx, ky, kz, omega, u, deserialized_pw, x, t);
 
   test_creation<ScalarWave::Solutions::PlaneWave<3>>(
       "  WaveVector: [-1, -2, 3.5]\n"


### PR DESCRIPTION
## Proposed changes

- Allow assigning `Variables<Tag0, Tag2>` to `Variables<Tag0, Tag1, Tag2, Tag3,...>` via a `.assign_subset` method
- Make ScalarWave::Solutions::PlaneWave serializable
- Add functions to ScalarWave::Solutions::PlaneWave that allow retrieving a `Variables<Pi, Phi<Dim>, Psi>` and their time derivatives. This is useful for setting initial data from analytic solutions and comparing to them for error measures.
- Make public type aliases between CoordinateMap, CoordinateMapBase, and ElementMap consistent by adding some to the latter two.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
