### PR TITLE
Changes to Actions::UpdateU

### DIFF
--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -55,16 +55,14 @@ struct UpdateU {
           const auto& time_stepper =
               Parallel::get<CacheTags::TimeStepper>(cache);
 
-          history.emplace_back(time, vars, std::move(dt_vars));
+          history.emplace_back(time, vars, dt_vars);
           time_stepper.update_u(make_not_null(&vars), history, time_step);
           history.erase(history.begin(), time_stepper.needed_history(history));
         },
         db::get<Tags::Time>(box),
         db::get<Tags::TimeStep>(box));
 
-    return std::make_tuple(
-        db::create_from<db::RemoveTags<dt_variables_tag>, db::AddTags<>>(
-            std::move(box)));
+    return std::forward_as_tuple(std::move(box));
   }
 };
 }  // namespace Actions

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
@@ -46,7 +47,7 @@ struct UpdateU {
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     using variables_tag = typename Metavariables::system::variables_tag;
-    using dt_variables_tag = typename Metavariables::system::dt_variables_tag;
+    using dt_variables_tag = db::add_tag_prefix<Tags::dt, variables_tag>;
 
     db::mutate<variables_tag, dt_variables_tag,
                Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>>(

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -43,20 +43,24 @@ struct Metavariables {
 SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
   ActionTesting::ActionRunner<Metavariables> runner{
     {std::make_unique<TimeSteppers::RungeKutta3>()}};
+  using variables_tag = Var;
+  using dt_variables_tag = Tags::dt<Var>;
 
   const Slab slab(1., 3.);
   const TimeDelta time_step = slab.duration() / 2;
   TimeId time_id{8, slab.start(), 0};
 
-  using history_tag = Tags::HistoryEvolvedVariables<Var, Tags::dt<Var>>;
+  using history_tag =
+      Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>;
 
   const auto rhs =
       [](const double t, const double y) { return 2. * t - 2. * (y - t * t); };
 
-  auto result_box = db::create<
-    db::AddTags<Tags::TimeId, Tags::TimeStep, Var, history_tag>,
+  auto box = db::create<
+    db::AddTags<Tags::TimeId, Tags::TimeStep, variables_tag, dt_variables_tag,
+                history_tag>,
     db::AddComputeItemsTags<Tags::Time>>(
-        time_id, time_step, 1., history_tag::type{});
+        time_id, time_step, 1., 0., history_tag::type{});
 
   const std::array<Time, 3> substep_times{
     {slab.start(), slab.start() + time_step, slab.start() + time_step / 2}};
@@ -65,17 +69,21 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
   const std::array<double, 3> expected_values{{3., 3., 10./3.}};
 
   for (size_t substep = 0; substep < 3; ++substep) {
-    time_id.time = gsl::at(substep_times, substep);
-    time_id.substep = substep;
+    db::mutate<dt_variables_tag, Tags::TimeId>(
+        box,
+        [&rhs, &substep, &substep_times ](double& dt_vars,
+                                          TimeId& local_time_id,
+                                          const double& vars) noexcept {
+          local_time_id.time = gsl::at(substep_times, substep);
+          local_time_id.substep = substep;
 
-    auto box = db::create_from<db::RemoveTags<Tags::TimeId>,
-                               db::AddTags<Tags::TimeId, Tags::dt<Var>>>(
-        result_box, time_id,
-        rhs(time_id.time.value(), db::get<Var>(result_box)));
+          dt_vars = rhs(local_time_id.time.value(), vars);
+        },
+        db::get<variables_tag>(box));
 
-    result_box = std::get<0>(runner.apply<component, Actions::UpdateU>(box, 0));
+    box = std::get<0>(runner.apply<component, Actions::UpdateU>(box, 0));
 
-    CHECK(db::get<Var>(result_box) ==
+    CHECK(db::get<variables_tag>(box) ==
           approx(gsl::at(expected_values, substep)));
   }
 }


### PR DESCRIPTION
## Proposed changes

- UpdateU no longer removes dt_vars from the DataBox. Basically we don't want to have to re-allocate every time step.
- UpdateU uses `Tags::dt<system::variables_tag>` instead of `system::dt_variables_tag`.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
