### PR TITLE
Add ComputeVolumeDuDt Action

### DIFF
--- a/src/Evolution/Actions/ComputeVolumeDuDt.hpp
+++ b/src/Evolution/Actions/ComputeVolumeDuDt.hpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Utilities/Requires.hpp"
+
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \brief Compute the volume time derivative of the variables
+///
+/// \note The DataBox items holding the time derivatives are not zeroed
+///
+/// Uses:
+/// - DataBox:
+///   - All elements in `system::du_dt::return_tags`
+///   - All elements in `system::du_dt::argument_tags`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies: db::add_tag_prefix<Tags::dt, typename system::variables_tag>
+template <size_t Dim>
+struct ComputeVolumeDuDt {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::size<DbTagsList>::value != 0> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using system = typename Metavariables::system;
+    // Note: dt_variables is not zeroed and du_dt cannot assume this.
+    db::mutate_apply<typename system::du_dt::return_tags,
+                     typename system::du_dt::argument_tags>(
+        typename system::du_dt{}, box);
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions

--- a/tests/Unit/Evolution/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Actions/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(EVOLUTION_ACTION_TESTS
+  Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+  )
+
+set(SPECTRE_TESTS "${SPECTRE_TESTS};${EVOLUTION_ACTION_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Evolution/Actions/ComputeVolumeDuDt.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+struct var_tag : db::DataBoxTag {
+  using type = int;
+  static constexpr db::DataBoxString label = "var_tag";
+};
+struct dt_var_tag : db::DataBoxTag {
+  using type = int;
+  static constexpr db::DataBoxString label = "dt_var_tag";
+};
+
+struct ComputeDuDt {
+  using return_tags = tmpl::list<dt_var_tag>;
+  using argument_tags = tmpl::list<var_tag>;
+  static void apply(const gsl::not_null<int*> dt_var, const int& var) {
+    *dt_var = var * 2;
+  }
+};
+
+struct System {
+  using du_dt = ComputeDuDt;
+};
+
+using ElementIndexType = ElementIndex<2>;
+
+struct Metavariables;
+using component = ActionTesting::MockArrayComponent<
+    Metavariables, ElementIndexType, tmpl::list<>,
+    tmpl::list<Actions::ComputeVolumeDuDt<2>>>;
+
+struct Metavariables {
+  using component_list = tmpl::list<component>;
+  using system = System;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeDuDt",
+                  "[Unit][Evolution][Actions]") {
+  ActionTesting::ActionRunner<Metavariables> runner{{}};
+  const ElementId<2> self_id(1, {{{1, 0}, {1, 0}}});
+  auto start_box = db::create<db::AddTags<var_tag, dt_var_tag>>(3, -100);
+
+  CHECK(db::get<var_tag>(start_box) == 3);
+  CHECK(db::get<dt_var_tag>(start_box) == -100);
+  runner.apply<component, Actions::ComputeVolumeDuDt<2>>(
+      start_box, ElementIndexType(self_id));
+  CHECK(db::get<var_tag>(start_box) == 3);
+  CHECK(db::get<dt_var_tag>(start_box) == 6);
+}

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Actions)
 add_subdirectory(Systems)
 
 set(SPECTRE_TESTS "${SPECTRE_TESTS};${EVOLUTION_TESTS}" PARENT_SCOPE)


### PR DESCRIPTION
## Proposed changes

- Adds Action that computes the RHS of the evolution equations.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
