### PR TITLE
Events and Triggers

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -91,6 +91,11 @@
  */
 
 /*!
+ * \defgroup EventsAndTriggersGroup Events and Triggers
+ * \brief Classes and functions related to events and triggers
+ */
+
+/*!
  * \defgroup EvolutionSystemsGroup Evolution Systems
  * \brief Contains the namespaces of all the available evolution systems.
  */

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1451,7 +1451,7 @@ struct Apply;
 template <template <typename...> class TagsList, typename... Tags>
 struct Apply<TagsList<Tags...>> {
   template <typename F, typename... BoxTags, typename... Args>
-  static constexpr auto apply(F f, const DataBox<BoxTags...>& box,
+  static constexpr auto apply(F&& f, const DataBox<BoxTags...>& box,
                               Args&&... args) {
     static_assert(
         tt::is_callable_v<
@@ -1462,11 +1462,12 @@ struct Apply<TagsList<Tags...>> {
         "Cannot call the function f with the list of tags and "
         "arguments specified. Check that the Tags::type and the "
         "types of the Args match the function f.");
-    return f(::db::get<Tags>(box)..., std::forward<Args>(args)...);
+    return std::forward<F>(f)(::db::get<Tags>(box)...,
+                              std::forward<Args>(args)...);
   }
 
   template <typename F, typename... BoxTags, typename... Args>
-  static constexpr auto apply_with_box(F f, const DataBox<BoxTags...>& box,
+  static constexpr auto apply_with_box(F&& f, const DataBox<BoxTags...>& box,
                                        Args&&... args) {
     static_assert(
         tt::is_callable_v<
@@ -1478,7 +1479,8 @@ struct Apply<TagsList<Tags...>> {
         "arguments specified. Check that the Tags::type and the "
         "types of the Args match the function f and that f is "
         "receiving the correct type of DataBox.");
-    return f(box, ::db::get<Tags>(box)..., std::forward<Args>(args)...);
+    return std::forward<F>(f)(box, ::db::get<Tags>(box)...,
+                              std::forward<Args>(args)...);
   }
 };
 }  // namespace detail
@@ -1522,9 +1524,10 @@ struct Apply<TagsList<Tags...>> {
  * DataBox, `box`
  */
 template <typename TagsList, typename F, typename... BoxTags, typename... Args>
-inline constexpr auto apply(F f, const DataBox<BoxTags...>& box,
+inline constexpr auto apply(F&& f, const DataBox<BoxTags...>& box,
                             Args&&... args) {
-  return detail::Apply<TagsList>::apply(f, box, std::forward<Args>(args)...);
+  return detail::Apply<TagsList>::apply(std::forward<F>(f), box,
+                                        std::forward<Args>(args)...);
 }
 
 namespace databox_detail {
@@ -1692,9 +1695,9 @@ mutate_apply(F f, DataBox<BoxTags...>& box, Args&&... args) noexcept(
  * DataBox, `box`
  */
 template <typename TagsList, typename F, typename... BoxTags, typename... Args>
-inline constexpr auto apply_with_box(F f, const DataBox<BoxTags...>& box,
+inline constexpr auto apply_with_box(F&& f, const DataBox<BoxTags...>& box,
                                      Args&&... args) {
-  return detail::Apply<TagsList>::apply_with_box(f, box,
+  return detail::Apply<TagsList>::apply_with_box(std::forward<F>(f), box,
                                                  std::forward<Args>(args)...);
 }
 

--- a/src/Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp
+++ b/src/Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \ingroup EventsAndTriggersGroup
+/// \brief Run the events and triggers
+///
+/// Uses:
+/// - ConstGlobalCache: the EventsAndTriggers tag, as required by
+///   events and triggers
+/// - DataBox: as required by events and triggers
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies: nothing
+struct RunEventsAndTriggers {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(const db::DataBox<DbTags>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const component) noexcept {
+    get<Tags::EventsAndTriggersTagBase>(cache).run_events(
+        box, cache, array_index, component);
+
+    return std::forward_as_tuple(box);
+  }
+};
+}  // namespace Actions

--- a/src/Evolution/EventsAndTriggers/Completion.hpp
+++ b/src/Evolution/EventsAndTriggers/Completion.hpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Evolution/EventsAndTriggers/Event.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Events {
+/// \ingroup EventsAndTriggersGroup
+/// Sets the termination flag for the code to exit.
+template <typename KnownEvents>
+class Completion : public Event<KnownEvents> {
+ public:
+  /// \cond
+  explicit Completion(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Completion);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {
+    "Sets the termination flag for the code to exit."};
+
+  Completion() = default;
+
+  using argument_tags = tmpl::list<>;
+
+  template <typename Metavariables, typename ArrayIndex, typename Component>
+  void operator()(Parallel::ConstGlobalCache<Metavariables>& cache,
+                  const ArrayIndex& array_index,
+                  const Component* const /*meta*/) const noexcept {
+    auto al_gore =
+        Parallel::get_parallel_component<Component>(cache)[array_index]
+        .ckLocal();
+    al_gore->set_terminate(true);
+  }
+};
+
+/// \cond
+template <typename KnownEvents>
+PUP::able::PUP_ID Completion<KnownEvents>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace Events

--- a/src/Evolution/EventsAndTriggers/Event.hpp
+++ b/src/Evolution/EventsAndTriggers/Event.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/FakeVirtual.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \ingroup EventsAndTriggersGroup
+namespace Events {
+template <typename>
+class Completion;
+}  // namespace Events
+
+namespace Event_detail {
+template <typename KnownEvents>
+using default_events = tmpl::list<Events::Completion<KnownEvents>>;
+}  // namespace Event_detail
+
+/// \ingroup EventsAndTriggersGroup
+/// Base class for something that can happen during a simulation (such
+/// as an observation).
+template <typename KnownEvents>
+class Event : public PUP::able {
+ protected:
+  /// \cond
+  Event() = default;
+  Event(const Event&) = default;
+  Event(Event&&) = default;
+  Event& operator=(const Event&) = default;
+  Event& operator=(Event&&) = default;
+  /// \endcond
+
+ public:
+  ~Event() override = default;
+
+  WRAPPED_PUPable_abstract(Event);  // NOLINT
+
+  using creatable_classes = tmpl::remove_duplicates<tmpl::append<
+      Event_detail::default_events<KnownEvents>,
+      typename KnownEvents::template type<KnownEvents>>>;
+
+  template <typename DbTags, typename Metavariables, typename ArrayIndex,
+            typename ComponentPointer>
+  void run(const db::DataBox<DbTags>& box,
+           Parallel::ConstGlobalCache<Metavariables>& cache,
+           const ArrayIndex& array_index,
+           const ComponentPointer /*meta*/) noexcept {
+    call_with_dynamic_type<void, creatable_classes>(
+        this,
+        [&box, &cache, &array_index](auto* const event) noexcept {
+          using EventType = std::decay_t<decltype(*event)>;
+          db::apply<typename EventType::argument_tags>(
+              *event, box, cache, array_index, ComponentPointer{});
+        });
+  }
+};
+
+#include "Evolution/EventsAndTriggers/Completion.hpp"

--- a/src/Evolution/EventsAndTriggers/EventsAndTriggers.hpp
+++ b/src/Evolution/EventsAndTriggers/EventsAndTriggers.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/EventsAndTriggers/Event.hpp"
+#include "Evolution/EventsAndTriggers/Trigger.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+
+/// \ingroup EventsAndTriggersGroup
+/// Class that checks triggers and runs events
+template <typename KnownEvents, typename KnownTriggers>
+class EventsAndTriggers {
+ public:
+  using Storage =
+      std::unordered_map<std::unique_ptr<Trigger<KnownTriggers>>,
+                         std::vector<std::unique_ptr<Event<KnownEvents>>>>;
+
+  EventsAndTriggers() = default;
+  explicit EventsAndTriggers(Storage events_and_triggers) noexcept
+      : events_and_triggers_(std::move(events_and_triggers)) {}
+
+  template <typename DbTags, typename Metavariables, typename ArrayIndex,
+            typename Component>
+  void run_events(const db::DataBox<DbTags>& box,
+                  Parallel::ConstGlobalCache<Metavariables>& cache,
+                  const ArrayIndex& array_index,
+                  const Component* component) const noexcept {
+    for (const auto& trigger_and_events : events_and_triggers_) {
+      const auto& trigger = trigger_and_events.first;
+      const auto& events = trigger_and_events.second;
+      if (trigger->is_triggered(box)) {
+        for (const auto& event : events) {
+          event->run(box, cache, array_index, component);
+        }
+      }
+    }
+  }
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | events_and_triggers_;
+  }
+
+ private:
+  // The unique pointer contents *must* be treated as const everywhere
+  // in order to make the const global cache behave sanely.  They are
+  // only non-const to make pup work.
+  Storage events_and_triggers_;
+};
+
+template <typename KnownEvents, typename KnownTriggers>
+struct create_from_yaml<EventsAndTriggers<KnownEvents, KnownTriggers>> {
+  using type = EventsAndTriggers<KnownEvents, KnownTriggers>;
+  static type create(const Option& options) {
+    return type(options.parse_as<typename type::Storage>());
+  }
+};
+
+namespace Tags {
+/// \cond
+struct EventsAndTriggersTagBase {};
+/// \endcond
+
+/// \ingroup CacheTagsGroup
+/// \ingroup EventsAndTriggersGroup
+/// Contains the events and triggers
+template <typename KnownEvents, typename KnownTriggers>
+struct EventsAndTriggers : EventsAndTriggersTagBase {
+  using type = ::EventsAndTriggers<KnownEvents, KnownTriggers>;
+};
+}  // namespace Tags

--- a/src/Evolution/EventsAndTriggers/LogicalTriggers.hpp
+++ b/src/Evolution/EventsAndTriggers/LogicalTriggers.hpp
@@ -1,0 +1,184 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+
+#include "Evolution/EventsAndTriggers/Trigger.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Triggers {
+/// \ingroup EventsAndTriggersGroup
+/// Always triggers.
+template <typename KnownTriggers>
+class Always : public Trigger<KnownTriggers> {
+ public:
+  /// \cond
+  explicit Always(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Always);  // NOLINT
+  /// \endcond
+
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {"Always trigger."};
+
+  Always() = default;
+
+  using argument_tags = tmpl::list<>;
+
+  bool operator()() const noexcept { return true; }
+};
+
+/// \ingroup EventsAndTriggersGroup
+/// Negates another trigger
+template <typename KnownTriggers>
+class Not : public Trigger<KnownTriggers> {
+ public:
+  /// \cond
+  Not() = default;
+  explicit Not(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Not);  // NOLINT
+  /// \endcond
+
+  static constexpr OptionString help = {"Negates another trigger."};
+
+  explicit Not(std::unique_ptr<Trigger<KnownTriggers>> negated_trigger) noexcept
+      : negated_trigger_(std::move(negated_trigger)) {}
+
+  using argument_tags = tmpl::list<Tags::DataBox>;
+
+  template <typename DbTags>
+  bool operator()(const db::DataBox<DbTags>& box) noexcept {
+    return not negated_trigger_->is_triggered(box);
+  }
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | negated_trigger_;
+  }
+
+ private:
+  std::unique_ptr<Trigger<KnownTriggers>> negated_trigger_;
+};
+
+/// \ingroup EventsAndTriggersGroup
+/// Short-circuiting logical AND of other triggers.
+template <typename KnownTriggers>
+class And : public Trigger<KnownTriggers> {
+ public:
+  /// \cond
+  And() = default;
+  explicit And(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(And);  // NOLINT
+  /// \endcond
+
+  static constexpr OptionString help = {
+      "Short-circuiting logical AND of other triggers."};
+
+  explicit And(std::vector<std::unique_ptr<Trigger<KnownTriggers>>>
+                   combined_triggers) noexcept
+      : combined_triggers_(std::move(combined_triggers)) {}
+
+  using argument_tags = tmpl::list<Tags::DataBox>;
+
+  template <typename DbTags>
+  bool operator()(const db::DataBox<DbTags>& box) noexcept {
+    for (auto& trigger : combined_triggers_) {
+      if (not trigger->is_triggered(box)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | combined_triggers_;
+  }
+
+ private:
+  std::vector<std::unique_ptr<Trigger<KnownTriggers>>> combined_triggers_;
+};
+
+/// \ingroup EventsAndTriggersGroup
+/// Short-circuiting logical OR of other triggers.
+template <typename KnownTriggers>
+class Or : public Trigger<KnownTriggers> {
+ public:
+  /// \cond
+  Or() = default;
+  explicit Or(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Or);  // NOLINT
+  /// \endcond
+
+  static constexpr OptionString help = {
+      "Short-circuiting logical OR of other triggers."};
+
+  explicit Or(std::vector<std::unique_ptr<Trigger<KnownTriggers>>>
+                  combined_triggers) noexcept
+      : combined_triggers_(std::move(combined_triggers)) {}
+
+  using argument_tags = tmpl::list<Tags::DataBox>;
+
+  template <typename DbTags>
+  bool operator()(const db::DataBox<DbTags>& box) noexcept {
+    for (auto& trigger : combined_triggers_) {
+      if (trigger->is_triggered(box)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | combined_triggers_;
+  }
+
+ private:
+  std::vector<std::unique_ptr<Trigger<KnownTriggers>>> combined_triggers_;
+};
+
+/// \cond
+template <typename KnownTriggers>
+PUP::able::PUP_ID Always<KnownTriggers>::my_PUP_ID = 0;  // NOLINT
+template <typename KnownTriggers>
+PUP::able::PUP_ID Not<KnownTriggers>::my_PUP_ID = 0;  // NOLINT
+template <typename KnownTriggers>
+PUP::able::PUP_ID And<KnownTriggers>::my_PUP_ID = 0;  // NOLINT
+template <typename KnownTriggers>
+PUP::able::PUP_ID Or<KnownTriggers>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace Triggers
+
+template <typename KnownTriggers>
+struct create_from_yaml<Triggers::Not<KnownTriggers>> {
+  static Triggers::Not<KnownTriggers> create(const Option& options) {
+    return Triggers::Not<KnownTriggers>(
+        options.parse_as<std::unique_ptr<Trigger<KnownTriggers>>>());
+  }
+};
+
+template <typename KnownTriggers>
+struct create_from_yaml<Triggers::And<KnownTriggers>> {
+  static Triggers::And<KnownTriggers> create(const Option& options) {
+    return Triggers::And<KnownTriggers>(
+        options
+            .parse_as<std::vector<std::unique_ptr<Trigger<KnownTriggers>>>>());
+  }
+};
+
+template <typename KnownTriggers>
+struct create_from_yaml<Triggers::Or<KnownTriggers>> {
+  static Triggers::Or<KnownTriggers> create(const Option& options) {
+    return Triggers::Or<KnownTriggers>(
+        options
+            .parse_as<std::vector<std::unique_ptr<Trigger<KnownTriggers>>>>());
+  }
+};

--- a/src/Evolution/EventsAndTriggers/Trigger.hpp
+++ b/src/Evolution/EventsAndTriggers/Trigger.hpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/FakeVirtual.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \ingroup EventsAndTriggersGroup
+namespace Triggers {
+template <typename>
+class Always;
+template <typename>
+class And;
+template <typename>
+class Not;
+template <typename>
+class Or;
+}  // namespace Triggers
+
+namespace Trigger_detail {
+template <typename KnownTriggers>
+using logical_triggers =
+    tmpl::list<Triggers::Always<KnownTriggers>, Triggers::And<KnownTriggers>,
+               Triggers::Not<KnownTriggers>, Triggers::Or<KnownTriggers>>;
+}  // namespace Trigger_detail
+
+/// \ingroup EventsAndTriggersGroup
+/// Base class for checking whether to run an Event.
+template <typename KnownTriggers>
+class Trigger : public PUP::able {
+ protected:
+  /// \cond
+  Trigger() = default;
+  Trigger(const Trigger&) = default;
+  Trigger(Trigger&&) = default;
+  Trigger& operator=(const Trigger&) = default;
+  Trigger& operator=(Trigger&&) = default;
+  /// \endcond
+
+ public:
+  ~Trigger() override = default;
+
+  WRAPPED_PUPable_abstract(Trigger);  // NOLINT
+
+  using creatable_classes = tmpl::remove_duplicates<tmpl::append<
+      Trigger_detail::logical_triggers<KnownTriggers>,
+      typename KnownTriggers::template type<KnownTriggers>>>;
+
+  template <typename DbTags>
+  bool is_triggered(const db::DataBox<DbTags>& box) noexcept {
+    return call_with_dynamic_type<bool, creatable_classes>(
+        this,
+        [&box](auto* const trigger) noexcept {
+          using TriggerType = std::decay_t<decltype(*trigger)>;
+          return db::apply<typename TriggerType::argument_tags>(
+              *trigger, box);
+        });
+  }
+};
+
+#include "Evolution/EventsAndTriggers/LogicalTriggers.hpp"

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -52,6 +52,15 @@ struct Time : db::ComputeItemTag {
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
+/// \brief Tag for compute item for current time as a double
+struct TimeValue : db::ComputeItemTag {
+  static constexpr db::DataBoxString label = "TimeValue";
+  static auto function(const ::Time& t) noexcept { return t.value(); }
+  using argument_tags = tmpl::list<Time>;
+};
+
+/// \ingroup DataBoxTags
+/// \ingroup TimeGroup
 /// \brief Prefix for TimeStepper history
 ///
 /// \tparam Tag tag for the variables

--- a/src/Time/Triggers/EveryNSlabs.hpp
+++ b/src/Time/Triggers/EveryNSlabs.hpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <unordered_set>
+#include <vector>
+
+#include "Evolution/EventsAndTriggers/Trigger.hpp"
+#include "Options/Options.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Triggers {
+/// \ingroup EventsAndTriggersGroup
+/// \ingroup TimeGroup
+/// Trigger every N time slabs after a given offset.
+template <typename KnownTriggers>
+class EveryNSlabs : public Trigger<KnownTriggers> {
+ public:
+  /// \cond
+  EveryNSlabs() = default;
+  explicit EveryNSlabs(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(EveryNSlabs);  // NOLINT
+  /// \endcond
+
+  struct N {
+    using type = size_t;
+    static constexpr OptionString help{"How frequently to trigger."};
+    static type lower_bound() { return 1; }
+  };
+  struct Offset {
+    using type = size_t;
+    static constexpr OptionString help{"First slab to trigger on."};
+    static type default_value() { return 0; }
+  };
+
+  using options = tmpl::list<N, Offset>;
+  static constexpr OptionString help{
+    "Trigger every N time slabs after a given offset."};
+
+  EveryNSlabs(const size_t interval, const size_t offset) noexcept
+      : interval_(interval), offset_(offset) {}
+
+  using argument_tags = tmpl::list<Tags::TimeId>;
+
+  bool operator()(const TimeId& time_id) const noexcept {
+    const size_t slab_number = time_id.slab_number;
+    return slab_number >= offset_ and (slab_number - offset_) % interval_ == 0;
+  }
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | interval_;
+    p | offset_;
+  }
+
+ private:
+  size_t interval_{0};
+  size_t offset_{0};
+};
+
+/// \cond
+template <typename KnownTriggers>
+PUP::able::PUP_ID EveryNSlabs<KnownTriggers>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace Triggers

--- a/src/Time/Triggers/PastTime.hpp
+++ b/src/Time/Triggers/PastTime.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+
+#include "Evolution/EventsAndTriggers/Trigger.hpp"
+#include "Options/Options.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Triggers {
+/// \ingroup EventsAndTriggersGroup
+/// \ingroup TimeGroup
+/// Trigger when the simulation is past a certain time (after that
+/// time if time is running forward, before that time if time is
+/// running backward).
+template <typename KnownTriggers>
+class PastTime : public Trigger<KnownTriggers> {
+ public:
+  /// \cond
+  PastTime() = default;
+  explicit PastTime(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(PastTime);  // NOLINT
+  /// \endcond
+
+  static constexpr OptionString help{
+      "Trigger if the simulation is past a given time."};
+
+  explicit PastTime(const double trigger_time) noexcept
+      : trigger_time_(trigger_time) {}
+
+  using argument_tags = tmpl::list<Tags::TimeValue, Tags::TimeStep>;
+
+  bool operator()(const double time, const TimeDelta& time_step) const
+      noexcept {
+    if (time_step.is_positive()) {
+      return time > trigger_time_;
+    } else {
+      return time < trigger_time_;
+    }
+  }
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | trigger_time_;
+  }
+
+ private:
+  double trigger_time_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+/// \cond
+template <typename KnownTriggers>
+PUP::able::PUP_ID PastTime<KnownTriggers>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace Triggers
+
+template <typename KnownTriggers>
+struct create_from_yaml<Triggers::PastTime<KnownTriggers>> {
+  static Triggers::PastTime<KnownTriggers> create(const Option& options) {
+    return Triggers::PastTime<KnownTriggers>(options.parse_as<double>());
+  }
+};

--- a/src/Time/Triggers/SpecifiedSlabs.hpp
+++ b/src/Time/Triggers/SpecifiedSlabs.hpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <unordered_set>
+#include <vector>
+
+#include "Evolution/EventsAndTriggers/Trigger.hpp"
+#include "Options/Options.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Triggers {
+/// \ingroup EventsAndTriggersGroup
+/// \ingroup TimeGroup
+/// Trigger at specified numbers of slabs after the simulation start.
+template <typename KnownTriggers>
+class SpecifiedSlabs : public Trigger<KnownTriggers> {
+ public:
+  /// \cond
+  SpecifiedSlabs() = default;
+  explicit SpecifiedSlabs(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(SpecifiedSlabs);  // NOLINT
+  /// \endcond
+
+  struct Slabs {
+    using type = std::vector<size_t>;
+    static constexpr OptionString help{
+      "List of slab numbers on which to trigger."};
+  };
+
+  using options = tmpl::list<Slabs>;
+  static constexpr OptionString help{
+    "Trigger at specified numbers of slabs after the simulation start."};
+
+  explicit SpecifiedSlabs(const std::vector<size_t>& slabs) noexcept
+      : slabs_(slabs.begin(), slabs.end()) {}
+
+  using argument_tags = tmpl::list<Tags::TimeId>;
+
+  bool operator()(const TimeId& time_id) const noexcept {
+    return slabs_.count(time_id.slab_number) == 1;
+  }
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | slabs_;
+  }
+
+ private:
+  std::unordered_set<size_t> slabs_;
+};
+
+/// \cond
+template <typename KnownTriggers>
+PUP::able::PUP_ID SpecifiedSlabs<KnownTriggers>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace Triggers

--- a/src/Time/Triggers/TimeTriggers.hpp
+++ b/src/Time/Triggers/TimeTriggers.hpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Time/Triggers/EveryNSlabs.hpp"
+#include "Time/Triggers/PastTime.hpp"
+#include "Time/Triggers/SpecifiedSlabs.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Triggers {
+/// \ingroup EventsAndTriggersGroup
+/// Typelist of Time triggers
+template <typename T>
+using time_triggers =
+    tmpl::list<EveryNSlabs<T>, PastTime<T>, SpecifiedSlabs<T>>;
+}  // namespace Triggers

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -140,6 +140,7 @@ class ActionRunner {
 
   /// Call Action::apply as if on the portion of Component labeled by
   /// array_index.
+  //@{
   template <typename Component, typename Action, typename DbTags,
             typename... Args>
   decltype(auto) apply(db::DataBox<DbTags>& box,
@@ -150,6 +151,18 @@ class ActionRunner {
                          std::add_pointer_t<Component>{nullptr},
                          std::forward<Args>(args)...);
   }
+
+  template <typename Component, typename Action, typename DbTags,
+            typename... Args>
+  decltype(auto) apply(const db::DataBox<DbTags>& box,
+                       const typename Component::index& array_index,
+                       Args&&... args) noexcept {
+    return Action::apply(box, inboxes<Component>()[array_index], cache_,
+                         array_index, typename Component::action_list{},
+                         std::add_pointer_t<Component>{nullptr},
+                         std::forward<Args>(args)...);
+  }
+  //@}
 
   /// Call Action::is_ready as if on the portion of Component labeled
   /// by array_index.

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(Actions)
 add_subdirectory(DiscontinuousGalerkin)
+add_subdirectory(EventsAndTriggers)
 add_subdirectory(Systems)
 
 set(SPECTRE_TESTS "${SPECTRE_TESTS};${EVOLUTION_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/Evolution/EventsAndTriggers/CMakeLists.txt
+++ b/tests/Unit/Evolution/EventsAndTriggers/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(EVENTS_AND_TRIGGERS_TESTS
+    Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+   )
+
+set(EVOLUTION_TESTS "${EVOLUTION_TESTS};${EVENTS_AND_TRIGGERS_TESTS}"
+    PARENT_SCOPE)

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -1,0 +1,145 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// This file checks the Completion event and the basic logical
+// triggers (Always, And, Not, and Or).
+
+#include <catch.hpp>
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
+#include "Evolution/EventsAndTriggers/Completion.hpp"
+#include "Evolution/EventsAndTriggers/Event.hpp"
+#include "Evolution/EventsAndTriggers/LogicalTriggers.hpp"
+#include "Evolution/EventsAndTriggers/Trigger.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/MakeVector.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+struct DefaultClasses {
+  template <typename T>
+  using type = tmpl::list<>;
+};
+
+using events_and_triggers_tag =
+    Tags::EventsAndTriggers<DefaultClasses, DefaultClasses>;
+
+struct Metavariables;
+using component =
+    ActionTesting::MockArrayComponent<Metavariables, int,
+                                      tmpl::list<events_and_triggers_tag>>;
+
+struct Metavariables {
+  using component_list = tmpl::list<component>;
+};
+
+using EventsAndTriggersType = EventsAndTriggers<DefaultClasses, DefaultClasses>;
+
+void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
+                             const bool expected) {
+  // Test pup
+  Parallel::register_derived_classes_with_charm<Event<DefaultClasses>>();
+  Parallel::register_derived_classes_with_charm<Trigger<DefaultClasses>>();
+  ActionTesting::ActionRunner<Metavariables> runner{{
+    serialize_and_deserialize(events_and_triggers)}};
+
+  const auto box = db::create<db::AddTags<>>();
+
+  runner.apply<component, Actions::RunEventsAndTriggers>(box, 0);
+
+  CHECK(runner.algorithms<component>()[0].get_terminate() == expected);
+}
+
+void check_trigger(const bool expected, const std::string& trigger_string) {
+  // Test factory
+  std::unique_ptr<Trigger<DefaultClasses>> trigger =
+      test_factory_creation<Trigger<DefaultClasses>>(trigger_string);
+
+  EventsAndTriggersType::Storage events_and_triggers_map;
+  events_and_triggers_map.emplace(
+      std::move(trigger),
+      make_vector<std::unique_ptr<Event<DefaultClasses>>>(
+          std::make_unique<Events::Completion<DefaultClasses>>()));
+  const EventsAndTriggersType events_and_triggers(
+      std::move(events_and_triggers_map));
+
+  run_events_and_triggers(events_and_triggers, expected);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers", "[Unit][Evolution]") {
+  test_factory_creation<Event<DefaultClasses>>("  Completion");
+
+  check_trigger(true,
+                "  Always");
+  check_trigger(false,
+                "  Not: Always");
+  check_trigger(true,
+                "  Not:\n"
+                "    Not: Always");
+
+  check_trigger(true,
+                "  And:\n"
+                "    - Always\n"
+                "    - Always");
+  check_trigger(false,
+                "  And:\n"
+                "    - Always\n"
+                "    - Not: Always");
+  check_trigger(false,
+                "  And:\n"
+                "    - Not: Always\n"
+                "    - Always");
+  check_trigger(false,
+                "  And:\n"
+                "    - Not: Always\n"
+                "    - Not: Always");
+  check_trigger(false,
+                "  And:\n"
+                "    - Always\n"
+                "    - Always\n"
+                "    - Not: Always");
+
+  check_trigger(true,
+                "  Or:\n"
+                "    - Always\n"
+                "    - Always");
+  check_trigger(true,
+                "  Or:\n"
+                "    - Always\n"
+                "    - Not: Always");
+  check_trigger(true,
+                "  Or:\n"
+                "    - Not: Always\n"
+                "    - Always");
+  check_trigger(false,
+                "  Or:\n"
+                "    - Not: Always\n"
+                "    - Not: Always");
+  check_trigger(true,
+                "  Or:\n"
+                "    - Not: Always\n"
+                "    - Not: Always\n"
+                "    - Always");
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.EventsAndTriggers.creation",
+                  "[Unit][Evolution]") {
+  const auto events_and_triggers = test_creation<EventsAndTriggersType>(
+      "  ? Not: Always\n"
+      "  : - Completion\n"
+      "  ? Or:\n"
+      "    - Not: Always\n"
+      "    - Always\n"
+      "  : - Completion\n"
+      "    - Completion\n"
+      "  ? Not: Always\n"
+      "  : - Completion\n");
+
+  run_events_and_triggers(events_and_triggers, true);
+}

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -564,8 +564,13 @@ struct FormatPair {
   static constexpr OptionString help = {"halp"};
   static constexpr const char* const expected = "[[int x0], [double x0]]";
 };
+struct ArrayHash {
+  size_t operator()(const std::array<int, 0>& /*unused*/) const noexcept {
+    return 0;
+  }
+};
 struct FormatUnorderedMap {
-  using type = std::unordered_map<In<int>, In<double>>;
+  using type = std::unordered_map<In<int>, In<double>, ArrayHash>;
   static constexpr OptionString help = {"halp"};
   static constexpr const char* const expected = "{[int x0]: [double x0]}";
 };
@@ -585,4 +590,13 @@ SPECTRE_TEST_CASE("Unit.Options.Format", "[Unit][Options]") {
   check(FormatArray{});
   check(FormatPair{});
   check(FormatUnorderedMap{});
+}
+
+// [[OutputRegex, Failed to convert value to type
+// {\[int x0\]: \[double x0\]}:]]
+SPECTRE_TEST_CASE("Unit.Options.Format.UnorderedMap.Error", "[Unit][Options]") {
+  ERROR_TEST();
+  Options<tmpl::list<FormatUnorderedMap>> opts("");
+  opts.parse("FormatUnorderedMap: X");
+  opts.get<FormatUnorderedMap>();
 }

--- a/tests/Unit/Time/CMakeLists.txt
+++ b/tests/Unit/Time/CMakeLists.txt
@@ -2,8 +2,11 @@
 # See LICENSE.txt for details.
 
 set(TIME_TESTS
+    Time/Test_EveryNSlabs.cpp
     Time/Test_History.cpp
+    Time/Test_PastTime.cpp
     Time/Test_Slab.cpp
+    Time/Test_SpecifiedSlabs.cpp
     Time/Test_StepControllers.cpp
     Time/Test_Time.cpp
     Time/Test_TimeId.cpp

--- a/tests/Unit/Time/Test_EveryNSlabs.cpp
+++ b/tests/Unit/Time/Test_EveryNSlabs.cpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/EventsAndTriggers/Trigger.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeId.hpp"
+#include "Time/Triggers/TimeTriggers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+struct TimeTriggers {
+  template <typename T>
+  using type = Triggers::time_triggers<T>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.Triggers.EveryNSlabs", "[Unit][Time]") {
+  Parallel::register_derived_classes_with_charm<Trigger<TimeTriggers>>();
+
+  const auto trigger = test_factory_creation<Trigger<TimeTriggers>>(
+      "  EveryNSlabs:\n"
+      "    N: 3\n"
+      "    Offset: 5");
+
+  const auto sent_trigger = serialize_and_deserialize(trigger);
+
+  const Slab slab(0., 1.);
+  auto box = db::create<db::AddTags<Tags::TimeId, Tags::TimeStep>,
+                        db::AddComputeItemsTags<Tags::Time, Tags::TimeValue>>(
+      TimeId{0, slab.start(), 0}, slab.duration());
+  for (const bool expected :
+       {false, false, false, false, false, true, false, false, true, false}) {
+    CHECK(sent_trigger->is_triggered(box) == expected);
+    db::mutate<Tags::TimeId>(box,
+                             [](TimeId& time_id) { ++time_id.slab_number; });
+  }
+}

--- a/tests/Unit/Time/Test_PastTime.cpp
+++ b/tests/Unit/Time/Test_PastTime.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/EventsAndTriggers/Trigger.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeId.hpp"
+#include "Time/Triggers/TimeTriggers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+struct TimeTriggers {
+  template <typename T>
+  using type = Triggers::time_triggers<T>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.Triggers.PastTime", "[Unit][Time]") {
+  Parallel::register_derived_classes_with_charm<Trigger<TimeTriggers>>();
+
+  const auto trigger =
+      test_factory_creation<Trigger<TimeTriggers>>("  PastTime: -7.");
+
+  const auto sent_trigger = serialize_and_deserialize(trigger);
+
+  const Slab slab(-10., 10.);
+
+  const auto check = [&sent_trigger](const Time& time, const TimeDelta& step,
+                                     const bool expected) noexcept {
+    const auto box = db::create<
+        db::AddTags<Tags::TimeId, Tags::TimeStep>,
+        db::AddComputeItemsTags<Tags::Time, Tags::TimeValue>>(
+        TimeId{0, time, 0}, step);
+    CHECK(sent_trigger->is_triggered(box) == expected);
+  };
+  check(slab.start(), slab.duration(), false);
+  check(slab.start(), -slab.duration(), true);
+  check(slab.end(), slab.duration(), true);
+  check(slab.end(), -slab.duration(), false);
+}

--- a/tests/Unit/Time/Test_SpecifiedSlabs.cpp
+++ b/tests/Unit/Time/Test_SpecifiedSlabs.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Evolution/EventsAndTriggers/Trigger.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/TimeId.hpp"
+#include "Time/Triggers/TimeTriggers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+struct TimeTriggers {
+  template <typename T>
+  using type = Triggers::time_triggers<T>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Time.Triggers.SpecifiedSlabs", "[Unit][Time]") {
+  Parallel::register_derived_classes_with_charm<Trigger<TimeTriggers>>();
+
+  const auto trigger = test_factory_creation<Trigger<TimeTriggers>>(
+      "  SpecifiedSlabs:\n"
+      "    Slabs: [3, 6, 8]");
+
+  const auto sent_trigger = serialize_and_deserialize(trigger);
+
+  const Slab slab(0., 1.);
+  auto box = db::create<db::AddTags<Tags::TimeId, Tags::TimeStep>,
+                        db::AddComputeItemsTags<Tags::Time, Tags::TimeValue>>(
+      TimeId{0, slab.start(), 0}, slab.duration());
+  for (const bool expected :
+       {false, false, false, true, false, false, true, false, true, false}) {
+    CHECK(sent_trigger->is_triggered(box) == expected);
+    db::mutate<Tags::TimeId>(box,
+                             [](TimeId& time_id) { ++time_id.slab_number; });
+  }
+}


### PR DESCRIPTION
### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

I've gone with putting the Events and Triggers in the global cache, and as a result they cannot have state.  If we want stateful triggers moving them to the DataBox would not be difficult.