### PR TITLE
Print types in parsing messages in YAML-like form

### DIFF
--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -96,7 +96,8 @@ T Option::parse_as() const {
     error_context.line = e.mark.line;
     error_context.column = e.mark.column;
     std::ostringstream ss;
-    ss << "Failed to convert value to type " << pretty_type::get_name<T>()
+    ss << "Failed to convert value to type "
+       << Options_detail::yaml_type<T>::value()
        << ":";
 
     const std::string value_text = YAML::Dump(node());

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -176,3 +176,13 @@ SPECTRE_TEST_CASE("Unit.Options.Factory.missing_arg", "[Unit][Options]") {
              "  TestWithArg:");
   CHECK(opts.get<OptionType>()->name() == "TestWithArg(stuff)");
 }
+
+SPECTRE_TEST_CASE("Unit.Options.Factory.Format", "[Unit][Options]") {
+  Options<tmpl::list<OptionType>> opts("");
+  INFO(opts.help());
+  // The compiler puts "(anonymous namespace)::" before the type, but
+  // I don't want to rely on that, so just check that the type is at
+  // the end of the line, which should ensure it is not in a template
+  // parameter or something.
+  CHECK(opts.help().find("OptionTest\n") != std::string::npos);
+}


### PR DESCRIPTION
## Proposed changes

The main changes are sequence containers displaying as `[Type, ...]`, associative containers displaying as `{Key: Value}`, and the `std::unique_ptr`s around Factory classes being dropped.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
