### PR TITLE
Fix some array-related bugs

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -42,17 +42,17 @@ class CoordinateMapBase : public PUP::able {
   // @{
   /// Apply the `Maps` to the point(s) `source_point`
   virtual tnsr::I<double, Dim, TargetFrame> operator()(
-      const tnsr::I<double, Dim, SourceFrame>& source_point) const = 0;
+      tnsr::I<double, Dim, SourceFrame> source_point) const = 0;
   virtual tnsr::I<DataVector, Dim, TargetFrame> operator()(
-      const tnsr::I<DataVector, Dim, SourceFrame>& source_point) const = 0;
+      tnsr::I<DataVector, Dim, SourceFrame> source_point) const = 0;
   // @}
 
   // @{
   /// Apply the inverse `Maps` to the point(s) `target_point`
   virtual tnsr::I<double, Dim, SourceFrame> inverse(
-      const tnsr::I<double, Dim, TargetFrame>& target_point) const = 0;
+      tnsr::I<double, Dim, TargetFrame> target_point) const = 0;
   virtual tnsr::I<DataVector, Dim, SourceFrame> inverse(
-      const tnsr::I<DataVector, Dim, TargetFrame>& target_point) const = 0;
+      tnsr::I<DataVector, Dim, TargetFrame> target_point) const = 0;
   // @}
 
   // @{
@@ -61,12 +61,11 @@ class CoordinateMapBase : public PUP::able {
   virtual Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                  index_list<SpatialIndex<Dim, UpLo::Up, SourceFrame>,
                             SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>
-  inv_jacobian(const tnsr::I<double, Dim, SourceFrame>& source_point) const = 0;
+  inv_jacobian(tnsr::I<double, Dim, SourceFrame> source_point) const = 0;
   virtual Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                  index_list<SpatialIndex<Dim, UpLo::Up, SourceFrame>,
                             SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>
-  inv_jacobian(
-      const tnsr::I<DataVector, Dim, SourceFrame>& source_point) const = 0;
+  inv_jacobian(tnsr::I<DataVector, Dim, SourceFrame> source_point) const = 0;
   // @}
 
   // @{
@@ -74,11 +73,11 @@ class CoordinateMapBase : public PUP::able {
   virtual Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                  index_list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
                             SpatialIndex<Dim, UpLo::Lo, SourceFrame>>>
-  jacobian(const tnsr::I<double, Dim, SourceFrame>& source_point) const = 0;
+  jacobian(tnsr::I<double, Dim, SourceFrame> source_point) const = 0;
   virtual Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                  index_list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
                             SpatialIndex<Dim, UpLo::Lo, SourceFrame>>>
-  jacobian(const tnsr::I<DataVector, Dim, SourceFrame>& source_point) const = 0;
+  jacobian(tnsr::I<DataVector, Dim, SourceFrame> source_point) const = 0;
   // @}
  private:
   virtual bool is_equal_to(const CoordinateMapBase& other) const = 0;
@@ -146,26 +145,24 @@ class CoordinateMap
   // @{
   /// Apply the `Maps...` to the point(s) `source_point`
   constexpr tnsr::I<double, dim, TargetFrame> operator()(
-      const tnsr::I<double, dim, SourceFrame>& source_point) const override {
-    return call_impl(source_point);
+      tnsr::I<double, dim, SourceFrame> source_point) const override {
+    return call_impl(std::move(source_point));
   }
   constexpr tnsr::I<DataVector, dim, TargetFrame> operator()(
-      const tnsr::I<DataVector, dim, SourceFrame>& source_point)
-      const override {
-    return call_impl(source_point);
+      tnsr::I<DataVector, dim, SourceFrame> source_point) const override {
+    return call_impl(std::move(source_point));
   }
   // @}
 
   // @{
   /// Apply the inverse `Maps...` to the point(s) `target_point`
   constexpr tnsr::I<double, dim, SourceFrame> inverse(
-      const tnsr::I<double, dim, TargetFrame>& target_point) const override {
-    return inverse_impl(target_point);
+      tnsr::I<double, dim, TargetFrame> target_point) const override {
+    return inverse_impl(std::move(target_point));
   }
   constexpr tnsr::I<DataVector, dim, SourceFrame> inverse(
-      const tnsr::I<DataVector, dim, TargetFrame>& target_point)
-      const override {
-    return inverse_impl(target_point);
+      tnsr::I<DataVector, dim, TargetFrame> target_point) const override {
+    return inverse_impl(std::move(target_point));
   }
   // @}
 
@@ -175,16 +172,15 @@ class CoordinateMap
   constexpr Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                    index_list<SpatialIndex<dim, UpLo::Up, SourceFrame>,
                               SpatialIndex<dim, UpLo::Lo, TargetFrame>>>
-  inv_jacobian(
-      const tnsr::I<double, dim, SourceFrame>& source_point) const override {
-    return inv_jacobian_impl(source_point);
+  inv_jacobian(tnsr::I<double, dim, SourceFrame> source_point) const override {
+    return inv_jacobian_impl(std::move(source_point));
   }
   constexpr Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                    index_list<SpatialIndex<dim, UpLo::Up, SourceFrame>,
                               SpatialIndex<dim, UpLo::Lo, TargetFrame>>>
-  inv_jacobian(const tnsr::I<DataVector, dim, SourceFrame>& source_point)
+  inv_jacobian(tnsr::I<DataVector, dim, SourceFrame> source_point)
       const override {
-    return inv_jacobian_impl(source_point);
+    return inv_jacobian_impl(std::move(source_point));
   }
   // @}
 
@@ -193,16 +189,14 @@ class CoordinateMap
   constexpr Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
                    index_list<SpatialIndex<dim, UpLo::Up, TargetFrame>,
                               SpatialIndex<dim, UpLo::Lo, SourceFrame>>>
-  jacobian(
-      const tnsr::I<double, dim, SourceFrame>& source_point) const override {
-    return jacobian_impl(source_point);
+  jacobian(tnsr::I<double, dim, SourceFrame> source_point) const override {
+    return jacobian_impl(std::move(source_point));
   }
   constexpr Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
                    index_list<SpatialIndex<dim, UpLo::Up, TargetFrame>,
                               SpatialIndex<dim, UpLo::Lo, SourceFrame>>>
-  jacobian(const tnsr::I<DataVector, dim, SourceFrame>& source_point)
-      const override {
-    return jacobian_impl(source_point);
+  jacobian(tnsr::I<DataVector, dim, SourceFrame> source_point) const override {
+    return jacobian_impl(std::move(source_point));
   }
   // @}
 
@@ -232,25 +226,25 @@ class CoordinateMap
 
   template <typename T>
   constexpr SPECTRE_ALWAYS_INLINE tnsr::I<T, dim, TargetFrame> call_impl(
-      const tnsr::I<T, dim, SourceFrame>& source_point) const;
+      tnsr::I<T, dim, SourceFrame>&& source_point) const;
 
   template <typename T>
   constexpr SPECTRE_ALWAYS_INLINE tnsr::I<T, dim, SourceFrame> inverse_impl(
-      const tnsr::I<T, dim, TargetFrame>& target_point) const;
+      tnsr::I<T, dim, TargetFrame>&& target_point) const;
 
   template <typename T>
   constexpr SPECTRE_ALWAYS_INLINE
       Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
              index_list<SpatialIndex<dim, UpLo::Up, SourceFrame>,
                         SpatialIndex<dim, UpLo::Lo, TargetFrame>>>
-      inv_jacobian_impl(const tnsr::I<T, dim, SourceFrame>& source_point) const;
+      inv_jacobian_impl(tnsr::I<T, dim, SourceFrame>&& source_point) const;
 
   template <typename T>
   constexpr SPECTRE_ALWAYS_INLINE
       Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
              index_list<SpatialIndex<dim, UpLo::Up, TargetFrame>,
                         SpatialIndex<dim, UpLo::Lo, SourceFrame>>>
-      jacobian_impl(const tnsr::I<T, dim, SourceFrame>& source_point) const;
+      jacobian_impl(tnsr::I<T, dim, SourceFrame>&& source_point) const;
 
   std::tuple<Maps...> maps_;
 };
@@ -269,8 +263,8 @@ template <typename T>
 constexpr SPECTRE_ALWAYS_INLINE tnsr::I<
     T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, TargetFrame>
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::call_impl(
-    const tnsr::I<T, dim, SourceFrame>& source_point) const {
-  std::array<T, dim> mapped_point = make_array<T, dim>(source_point);
+    tnsr::I<T, dim, SourceFrame>&& source_point) const {
+  std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
   tuple_fold(maps_, [](const auto& map,
                        std::array<T, dim>& point) { point = map(point); },
              mapped_point);
@@ -282,8 +276,8 @@ template <typename T>
 constexpr SPECTRE_ALWAYS_INLINE tnsr::I<
     T, CoordinateMap<SourceFrame, TargetFrame, Maps...>::dim, SourceFrame>
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::inverse_impl(
-    const tnsr::I<T, dim, TargetFrame>& target_point) const {
-  std::array<T, dim> mapped_point = make_array<T, dim>(target_point);
+    tnsr::I<T, dim, TargetFrame>&& target_point) const {
+  std::array<T, dim> mapped_point = make_array<T, dim>(std::move(target_point));
   tuple_fold<true>(maps_,
                    [](const auto& map, std::array<T, dim>& point) {
                      point = map.inverse(point);
@@ -296,11 +290,11 @@ template <typename SourceFrame, typename TargetFrame, typename... Maps>
 template <typename T>
 constexpr SPECTRE_ALWAYS_INLINE auto
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
-    const tnsr::I<T, dim, SourceFrame>& source_point) const
+    tnsr::I<T, dim, SourceFrame>&& source_point) const
     -> Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
               index_list<SpatialIndex<dim, UpLo::Up, SourceFrame>,
                          SpatialIndex<dim, UpLo::Lo, TargetFrame>>> {
-  std::array<T, dim> mapped_point = make_array<T, dim>(source_point);
+  std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
 
   Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<dim, UpLo::Up, SourceFrame>,
@@ -349,11 +343,11 @@ template <typename SourceFrame, typename TargetFrame, typename... Maps>
 template <typename T>
 constexpr SPECTRE_ALWAYS_INLINE auto
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
-    const tnsr::I<T, dim, SourceFrame>& source_point) const
+    tnsr::I<T, dim, SourceFrame>&& source_point) const
     -> Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
               index_list<SpatialIndex<dim, UpLo::Up, TargetFrame>,
                          SpatialIndex<dim, UpLo::Lo, SourceFrame>>> {
-  std::array<T, dim> mapped_point = make_array<T, dim>(source_point);
+  std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
   Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
          index_list<SpatialIndex<dim, UpLo::Up, TargetFrame>,
                     SpatialIndex<dim, UpLo::Lo, SourceFrame>>>

--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -48,13 +48,13 @@ class ElementMap {
   tnsr::I<T, Dim, TargetFrame> operator()(
       tnsr::I<T, Dim, Frame::Logical> source_point) const noexcept {
     apply_affine_transformation_to_point(source_point);
-    return block_map_->operator()(source_point);
+    return block_map_->operator()(std::move(source_point));
   }
 
   template <typename T>
   tnsr::I<T, Dim, Frame::Logical> inverse(
-      const tnsr::I<T, Dim, TargetFrame>& target_point) const noexcept {
-    auto source_point{block_map_->inverse(target_point)};
+      tnsr::I<T, Dim, TargetFrame> target_point) const noexcept {
+    auto source_point{block_map_->inverse(std::move(target_point))};
     // Apply the affine map to the points
     for (size_t d = 0; d < Dim; ++d) {
       source_point.get(d) =
@@ -70,7 +70,7 @@ class ElementMap {
                     SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>
   inv_jacobian(tnsr::I<T, Dim, Frame::Logical> source_point) const noexcept {
     apply_affine_transformation_to_point(source_point);
-    auto inv_jac = block_map_->inv_jacobian(source_point);
+    auto inv_jac = block_map_->inv_jacobian(std::move(source_point));
     for (size_t d = 0; d < Dim; ++d) {
       for (size_t i = 0; i < Dim; ++i) {
         inv_jac.get(d, i) *= gsl::at(inverse_jacobian_, d);
@@ -85,7 +85,7 @@ class ElementMap {
                     SpatialIndex<Dim, UpLo::Lo, Frame::Logical>>>
   jacobian(tnsr::I<T, Dim, Frame::Logical> source_point) const noexcept {
     apply_affine_transformation_to_point(source_point);
-    auto jac = block_map_->jacobian(source_point);
+    auto jac = block_map_->jacobian(std::move(source_point));
     for (size_t d = 0; d < Dim; ++d) {
       for (size_t i = 0; i < Dim; ++i) {
         jac.get(i, d) *= gsl::at(jacobian_, d);

--- a/src/Domain/FaceNormal.cpp
+++ b/src/Domain/FaceNormal.cpp
@@ -17,9 +17,10 @@ template <typename TargetFrame, size_t VolumeDim, typename Map>
 tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal_impl(
     const Index<VolumeDim - 1>& interface_extents, const Map& map,
     const Direction<VolumeDim>& direction) noexcept {
-  const auto interface_coords =
+  auto interface_coords =
       interface_logical_coordinates(interface_extents, direction);
-  const auto inv_jacobian_on_interface = map.inv_jacobian(interface_coords);
+  const auto inv_jacobian_on_interface =
+      map.inv_jacobian(std::move(interface_coords));
 
   const auto sliced_away_dim = direction.dimension();
   const double sign = direction.sign();

--- a/src/Domain/LogicalCoordinates.cpp
+++ b/src/Domain/LogicalCoordinates.cpp
@@ -10,7 +10,6 @@
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Direction.hpp"
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
 

--- a/tests/Unit/Utilities/Test_MakeArray.cpp
+++ b/tests/Unit/Utilities/Test_MakeArray.cpp
@@ -101,4 +101,26 @@ SPECTRE_TEST_CASE("Unit.Utilities.MakeArray", "[Unit][Utilities]") {
   for (size_t i = 0; i < 3; i++) {
     CHECK(gsl::at(vector_array2, i) == (std::vector<int>{3, 9, 12, -10}));
   }
+
+  // Check make_array with an rvalue sequence
+  {
+    std::vector<MyNonCopyable<int>> vector;
+    for (int i = 0; i < 3; ++i) {
+      vector.emplace_back(i);
+    }
+    const auto array = make_array<MyNonCopyable<int>, 3>(std::move(vector));
+    for (size_t i = 0; i < 3; ++i) {
+      CHECK(gsl::at(array, i).get() == i);
+    }
+  }
+
+  // Check that make_array does not move from an lvalue sequence
+  {
+    std::vector<std::vector<int>> vector(3, std::vector<int>{1, 2, 3});
+    make_array<std::vector<int>, 3>(vector);
+    CHECK(vector.size() == 3);
+    for (size_t i = 0; i < 3; ++i) {
+      CHECK(vector[i] == (std::vector<int>{1, 2, 3}));
+    }
+  }
 }


### PR DESCRIPTION
Fixes #380 and #382.

### Types of changes:

- [X] Bugfix
- [ ] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`
