### PR TITLE
Add Expansion.

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
     SpherepackIterator.cpp
     Strahlkorper.cpp
     StrahlkorperDataBox.cpp
+    StrahlkorperGr.cpp
     YlmSpherepack.cpp
     YlmSpherepackHelper.cpp
     )

--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ApparentHorizons/StrahlkorperGr.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+
+namespace StrahlkorperGr {
+
+template <typename Frame>
+tnsr::i<DataVector, 3, Frame> unit_normal_one_form(
+    const tnsr::i<DataVector, 3, Frame>& normal_one_form,
+    const DataVector& one_over_one_form_magnitude) noexcept {
+  auto unit_normal_one_form = normal_one_form;
+  for (size_t i = 0; i < 3; ++i) {
+    unit_normal_one_form.get(i) *= one_over_one_form_magnitude;
+  }
+  return unit_normal_one_form;
+}
+
+template <typename Frame>
+tnsr::ii<DataVector, 3, Frame> grad_unit_normal_one_form(
+    const tnsr::i<DataVector, 3, Frame>& r_hat, const DataVector& radius,
+    const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, 3, Frame>& d2x_radius,
+    const DataVector& one_over_one_form_magnitude,
+    const tnsr::Ijj<DataVector, 3, Frame>& christoffel_2nd_kind) noexcept {
+  const DataVector one_over_radius = 1.0 / radius;
+  tnsr::ii<DataVector, 3, Frame> grad_normal(radius.size(), 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {  // symmetry
+      grad_normal.get(i, j) = -one_over_one_form_magnitude *
+                              (r_hat.get(i) * r_hat.get(j) * one_over_radius +
+                               d2x_radius.get(i, j));
+      for (size_t k = 0; k < 3; ++k) {
+        grad_normal.get(i, j) -=
+            unit_normal_one_form.get(k) * christoffel_2nd_kind.get(k, i, j);
+      }
+    }
+    grad_normal.get(i, i) += one_over_radius * one_over_one_form_magnitude;
+  }
+  return grad_normal;
+}
+
+template <typename Frame>
+Scalar<DataVector> expansion(
+    const tnsr::ii<DataVector, 3, Frame>& grad_normal,
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept {
+  // Form inverse surface metric
+  tnsr::II<DataVector, 3, Frame> inv_surf_metric(
+      get<0>(unit_normal_vector).size(), 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      inv_surf_metric.get(i, j) =
+          upper_spatial_metric.get(i, j) -
+          unit_normal_vector.get(i) * unit_normal_vector.get(j);
+    }
+  }
+
+  // If you want the future *ingoing* null expansion,
+  // the formula is the same as here except you
+  // change the sign on grad_normal just before you
+  // subtract the extrinsic curvature.
+  // That is, if GsBar is the value of grad_normal
+  // at this point in the code, and S^i is the unit
+  // spatial normal to the surface,
+  // the outgoing expansion is
+  // (g^ij - S^i S^j) (GsBar_ij - K_ij)
+  // and the ingoing expansion is
+  // (g^ij - S^i S^j) (-GsBar_ij - K_ij)
+
+  Scalar<DataVector> expansion(get<0>(unit_normal_vector).size(), 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      get(expansion) += inv_surf_metric.get(i, j) *
+                        (grad_normal.get(i, j) - extrinsic_curvature.get(i, j));
+    }
+  }
+
+  return expansion;
+}
+
+}  // namespace StrahlkorperGr
+
+template tnsr::i<DataVector, 3, Frame::Inertial>
+StrahlkorperGr::unit_normal_one_form<Frame::Inertial>(
+    const tnsr::i<DataVector, 3, Frame::Inertial>& normal_one_form,
+    const DataVector& one_over_one_form_magnitude) noexcept;
+
+template tnsr::ii<DataVector, 3, Frame::Inertial>
+StrahlkorperGr::grad_unit_normal_one_form<Frame::Inertial>(
+    const tnsr::i<DataVector, 3, Frame::Inertial>& r_hat,
+    const DataVector& radius,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& unit_normal_one_form,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& d2x_radius,
+    const DataVector& one_over_one_form_magnitude,
+    const tnsr::Ijj<DataVector, 3, Frame::Inertial>&
+        christoffel_2nd_kind) noexcept;
+
+template Scalar<DataVector> StrahlkorperGr::expansion<Frame::Inertial>(
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& grad_normal,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& upper_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>&
+        extrinsic_curvature) noexcept;

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+class DataVector;
+
+/// \ingroup SurfacesGroup
+/// Contains functions that depend both on a Strahlkorper and a metric.
+namespace StrahlkorperGr {
+
+/// \ingroup SurfacesGroup
+/// \brief Computes normalized unit normal one-form to a Strahlkorper.
+///
+/// \details The input argument `normal_one_form` \f$n_i\f$ is the
+/// unnormalized surface one-form; it depends on a Strahlkorper but
+/// not on a metric.  The input argument `one_over_one_form_magnitude`
+/// is \f$1/\sqrt{g^{ij}n_i n_j}\f$, which can be computed using (one
+/// over) the `magnitude` function.
+template <typename Frame>
+tnsr::i<DataVector, 3, Frame> unit_normal_one_form(
+    const tnsr::i<DataVector, 3, Frame>& normal_one_form,
+    const DataVector& one_over_one_form_magnitude) noexcept;
+
+/// \ingroup SurfacesGroup
+/// \brief Computes 3-covariant gradient \f$D_i S_j\f$ of a
+/// Strahlkorper's normal.
+///
+/// \details See Eqs. (1--9) of https://arxiv.org/abs/gr-qc/9606010.
+/// Here \f$S_j\f$ is the (normalized) unit one-form to the surface,
+/// and \f$D_i\f$ is the spatial covariant derivative.  Note that this
+/// object is symmetric, even though this is not obvious from the
+/// definition.  The input arguments `r_hat`, `radius`, and
+/// `d2x_radius` depend on the Strahlkorper but not on the metric, and
+/// can be computed from a Strahlkorper using ComputeItems in
+/// `StrahlkorperTags`.  The input argument
+/// `one_over_one_form_magnitude` is \f$1/\sqrt{g^{ij}n_i n_j}\f$,
+/// where \f$n_i\f$ is `StrahlkorperTags::NormalOneForm` (i.e.  the
+/// unnormalized one-form to the Strahlkorper); it can be computed
+/// using (one over) the `magnitude` function.  The input argument
+/// `unit_normal_one_form` is \f$S_j\f$,the normalized one-form.
+template <typename Frame>
+tnsr::ii<DataVector, 3, Frame> grad_unit_normal_one_form(
+    const tnsr::i<DataVector, 3, Frame>& r_hat, const DataVector& radius,
+    const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
+    const tnsr::ii<DataVector, 3, Frame>& d2x_radius,
+    const DataVector& one_over_one_form_magnitude,
+    const tnsr::Ijj<DataVector, 3, Frame>& christoffel_2nd_kind) noexcept;
+
+/// \ingroup SurfacesGroup
+/// \brief Expansion of a `Strahlkorper`. Should be zero on apparent horizons.
+///
+/// \details Implements Eq. (5) in
+/// https://arxiv.org/abs/gr-qc/9606010.  The input argument
+/// `grad_normal` is the quantity returned by
+/// `StrahlkorperGr::grad_unit_normal_one_form`, and `unit_normal_vector` is
+/// \f$S^i = g^{ij} S_j\f$ where \f$S_j\f$ is the unit normal one form.
+template <typename Frame>
+Scalar<DataVector> expansion(
+    const tnsr::ii<DataVector, 3, Frame>& grad_normal,
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
+
+}  // namespace StrahlkorperGr

--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp
@@ -30,6 +30,26 @@ raise_or_lower_first_index(
 
 /*!
  * \ingroup GeneralRelativityGroup
+ * \brief Raises or lowers the index of a rank 1 tensor.
+ *
+ * \details If \f$T_{a}\f$ is a tensor and the
+ * index \f$a\f$ can represent either a spatial or spacetime index,
+ * then the tensor \f$ T^a = g^{ad} T_{d} \f$ is computed, where \f$
+ * g^{ab}\f$ is the inverse metric, which is either a spatial or spacetime
+ * metric. If a tensor \f$ S^a \f$ is passed as an argument than the
+ * corresponding tensor \f$ S_{a} \f$ is calculated with respect to the metric
+ * \f$g_{ab}\f$.
+ */
+template <typename DataType, typename Index0>
+Tensor<DataType, Symmetry<1>, index_list<change_index_up_lo<Index0>>>
+raise_or_lower_index(
+    const Tensor<DataType, Symmetry<1>, index_list<Index0>>& tensor,
+    const Tensor<DataType, Symmetry<1, 1>,
+                 index_list<change_index_up_lo<Index0>,
+                            change_index_up_lo<Index0>>>& metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
  * \brief Computes trace of a rank 3 tensor, which is symmetric in its last two
  * indices with all indices lower.
  *

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 set(APPARENT_HORIZONS_TESTS
+    ApparentHorizons/Test_Expansion.cpp
     ApparentHorizons/Test_SpherepackIterator.cpp
     ApparentHorizons/Test_Strahlkorper.cpp
     ApparentHorizons/Test_StrahlkorperDataBox.cpp

--- a/tests/Unit/ApparentHorizons/Test_Expansion.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Expansion.cpp
@@ -1,0 +1,138 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "ApparentHorizons/StrahlkorperDataBox.hpp"
+#include "ApparentHorizons/StrahlkorperGr.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/MakeWithValue.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GrTags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+void test_schwarzschild() {
+  // Make surface of radius 2.
+  const auto box =
+      db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
+                 db::AddComputeItemsTags<
+                     StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
+          Strahlkorper<Frame::Inertial>(10, 10, 2.0, {{0, 0, 0}}));
+
+  const double t = 0.0;
+  const auto& cart_coords =
+      db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
+
+  // Schwarzschild solution
+  const double mass = 1.0;
+  const std::array<double, 3> spin{{0.0, 0.0, 0.0}};
+  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
+  EinsteinSolutions::KerrSchild solution(mass, spin, center);
+  const auto vars = solution.solution(cart_coords, t);
+
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);
+  const auto& deriv_spatial_metric =
+      get<EinsteinSolutions::KerrSchild::deriv_spatial_metric<DataVector>>(
+          vars);
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+
+  const DataVector one_over_one_form_magnitude =
+      1.0 /
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric);
+  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
+      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+      one_over_one_form_magnitude);
+  const auto unit_normal_vector =
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
+  const auto grad_unit_normal_one_form =
+      StrahlkorperGr::grad_unit_normal_one_form(
+          db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
+          db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box),
+          unit_normal_one_form,
+          db::get<StrahlkorperTags::D2xRadius<Frame::Inertial>>(box),
+          one_over_one_form_magnitude,
+          raise_or_lower_first_index(
+              compute_christoffel_first_kind(deriv_spatial_metric),
+              inverse_spatial_metric));
+
+  const auto residual = StrahlkorperGr::expansion(
+      grad_unit_normal_one_form, unit_normal_vector, inverse_spatial_metric,
+      gr::extrinsic_curvature(
+          get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
+          get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
+          get<EinsteinSolutions::KerrSchild::deriv_shift<DataVector>>(vars),
+          spatial_metric,
+          get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataVector>>(vars),
+          deriv_spatial_metric));
+
+  Approx custom_approx = Approx::custom().epsilon(1.e-12);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(residual), DataVector(get(residual).size(), 0.0), custom_approx);
+}
+
+void test_minkowski() {
+  // Make surface of radius 2.
+  const auto box =
+      db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
+                 db::AddComputeItemsTags<
+                     StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
+          Strahlkorper<Frame::Inertial>(10, 10, 2.0, {{0, 0, 0}}));
+
+  const double t = 0.0;
+  const auto& cart_coords =
+      db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
+
+  EinsteinSolutions::Minkowski<3> solution{};
+
+  const auto deriv_spatial_metric =
+      solution.deriv_spatial_metric(cart_coords, t);
+  const auto inverse_spatial_metric =
+      solution.inverse_spatial_metric(cart_coords, t);
+
+  const DataVector one_over_one_form_magnitude =
+      1.0 /
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric);
+  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
+      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+      one_over_one_form_magnitude);
+  const auto unit_normal_vector =
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
+  const auto grad_unit_normal_one_form =
+      StrahlkorperGr::grad_unit_normal_one_form(
+          db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
+          db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box),
+          unit_normal_one_form,
+          db::get<StrahlkorperTags::D2xRadius<Frame::Inertial>>(box),
+          one_over_one_form_magnitude,
+          raise_or_lower_first_index(
+              compute_christoffel_first_kind(deriv_spatial_metric),
+              inverse_spatial_metric));
+
+  const auto residual = StrahlkorperGr::expansion(
+      grad_unit_normal_one_form, unit_normal_vector, inverse_spatial_metric,
+      solution.extrinsic_curvature(cart_coords, t));
+
+  Approx custom_approx = Approx::custom().epsilon(1.e-12);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(residual), DataVector(get(residual).size(), 1.0), custom_approx);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.ConstantExpansion",
+                  "[ApparentHorizons][Unit]") {
+  test_schwarzschild();
+  test_minkowski();
+}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
@@ -17,7 +17,7 @@ tnsr::I<DataType, SpatialDim> make_shift(const DataType& used_for_size) {
   auto shift =
       make_with_value<tnsr::I<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
-    shift.get(i) = make_with_value<DataType>(used_for_size, i + 1);
+    shift.get(i) = make_with_value<DataType>(used_for_size, i + 1.);
   }
   return shift;
 }
@@ -27,7 +27,7 @@ tnsr::i<DataType, SpatialDim> make_lower_shift(const DataType& used_for_size) {
   auto shift =
       make_with_value<tnsr::i<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
-    shift.get(i) = make_with_value<DataType>(used_for_size, i + 1);
+    shift.get(i) = make_with_value<DataType>(used_for_size, i + 1.);
   }
   return shift;
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
@@ -23,6 +23,16 @@ tnsr::I<DataType, SpatialDim> make_shift(const DataType& used_for_size) {
 }
 
 template <size_t SpatialDim, typename DataType>
+tnsr::i<DataType, SpatialDim> make_lower_shift(const DataType& used_for_size) {
+  auto shift =
+      make_with_value<tnsr::i<DataType, SpatialDim>>(used_for_size, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    shift.get(i) = make_with_value<DataType>(used_for_size, i + 1);
+  }
+  return shift;
+}
+
+template <size_t SpatialDim, typename DataType>
 tnsr::ii<DataType, SpatialDim> make_spatial_metric(
     const DataType& used_for_size) {
   auto metric =
@@ -48,6 +58,27 @@ tnsr::II<DataType, SpatialDim> make_inverse_spatial_metric(
     }
   }
   return metric;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::A<DataType, SpatialDim> make_dummy_vector(const DataType& used_for_size) {
+  auto result =
+      make_with_value<tnsr::A<DataType, SpatialDim>>(used_for_size, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    result.get(a) = make_with_value<DataType>(used_for_size, a + 1.);
+  }
+  return result;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::a<DataType, SpatialDim> make_dummy_one_form(
+    const DataType& used_for_size) {
+  auto one_form =
+      make_with_value<tnsr::a<DataType, SpatialDim>>(used_for_size, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    one_form.get(a) = make_with_value<DataType>(used_for_size, a + 1.);
+  }
+  return one_form;
 }
 
 template <typename DataType>
@@ -153,7 +184,7 @@ tnsr::iaa<DataType, SpatialDim> make_spatial_deriv_spacetime_metric(
 
 template <size_t SpatialDim, typename DataType>
 tnsr::aa<DataType, SpatialDim> make_dt_spacetime_metric(
-    const DataType& used_for_size){
+    const DataType& used_for_size) {
   auto dt_spacetime_metric =
       make_with_value<tnsr::aa<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim + 1; i++) {
@@ -183,7 +214,7 @@ tnsr::Abb<DataType, SpatialDim> make_spacetime_christoffel_second_kind(
 
 template <size_t SpatialDim, typename DataType>
 tnsr::Ijj<DataType, SpatialDim> make_spatial_christoffel_second_kind(
-    const DataType& used_for_size){
+    const DataType& used_for_size) {
   auto christoffel =
       make_with_value<tnsr::Ijj<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t i = 0; i < SpatialDim; i++) {
@@ -199,7 +230,7 @@ tnsr::Ijj<DataType, SpatialDim> make_spatial_christoffel_second_kind(
 
 template <size_t SpatialDim, typename DataType>
 tnsr::aa<DataType, SpatialDim> make_spacetime_metric(
-    const DataType& used_for_size){
+    const DataType& used_for_size) {
   auto spacetime_metric =
       make_with_value<tnsr::aa<DataType, SpatialDim>>(used_for_size, 0.);
   for (size_t mu = 0; mu < SpatialDim + 1; ++mu) {
@@ -248,9 +279,15 @@ tnsr::i<DataType, SpatialDim> make_trace_spatial_christoffel(
 #define INSTANTIATE(_, data)                                                 \
   template tnsr::I<DTYPE(data), DIM(data)> make_shift(const DTYPE(data) &    \
                                                       used_for_size);        \
+  template tnsr::i<DTYPE(data), DIM(data)> make_lower_shift(                 \
+      const DTYPE(data) & used_for_size);                                    \
   template tnsr::ii<DTYPE(data), DIM(data)> make_spatial_metric(             \
       const DTYPE(data) & used_for_size);                                    \
   template tnsr::II<DTYPE(data), DIM(data)> make_inverse_spatial_metric(     \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::A<DTYPE(data), DIM(data)> make_dummy_vector(                \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::a<DTYPE(data), DIM(data)> make_dummy_one_form(              \
       const DTYPE(data) & used_for_size);                                    \
   template tnsr::I<DTYPE(data), DIM(data)> make_dt_shift(const DTYPE(data) & \
                                                          used_for_size);     \

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
@@ -47,11 +47,21 @@ template <size_t SpatialDim, typename DataType>
 tnsr::I<DataType, SpatialDim> make_shift(const DataType& used_for_size);
 
 template <size_t SpatialDim, typename DataType>
+tnsr::i<DataType, SpatialDim> make_lower_shift(const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
 tnsr::ii<DataType, SpatialDim> make_spatial_metric(
     const DataType& used_for_size);
 
 template <size_t SpatialDim, typename DataType>
 tnsr::II<DataType, SpatialDim> make_inverse_spatial_metric(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::A<DataType, SpatialDim> make_dummy_vector(const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::a<DataType, SpatialDim> make_dummy_one_form(
     const DataType& used_for_size);
 
 template <typename DataType>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
@@ -20,6 +20,15 @@ void test_1d_spatial_raise(const DataVector& used_for_size) {
           make_deriv_spatial_metric<dim>(used_for_size),
           make_inverse_spatial_metric<dim>(used_for_size)),
       raised_tensor);
+
+  const tnsr::I<double, dim> shift = raise_or_lower_index(
+      make_lower_shift<dim>(0.), make_inverse_spatial_metric<dim>(0.));
+  CHECK(get<0>(shift) == approx(1.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_index(make_lower_shift<dim>(used_for_size),
+                           make_inverse_spatial_metric<dim>(used_for_size)),
+      shift);
 }
 
 void test_1d_spatial_lower(const DataVector& used_for_size) {
@@ -35,6 +44,15 @@ void test_1d_spatial_lower(const DataVector& used_for_size) {
           make_spatial_christoffel_second_kind<dim>(used_for_size),
           make_spatial_metric<dim>(used_for_size)),
       lowered_tensor);
+
+  const tnsr::i<double, dim> lowered_shift =
+      raise_or_lower_index(make_shift<dim>(0.), make_spatial_metric<dim>(0.));
+  CHECK(get<0>(lowered_shift) == approx(1.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_index(make_shift<dim>(used_for_size),
+                           make_spatial_metric<dim>(used_for_size)),
+      lowered_shift);
 }
 
 void test_2d_spatial_raise(const DataVector& used_for_size) {
@@ -55,6 +73,16 @@ void test_2d_spatial_raise(const DataVector& used_for_size) {
           make_deriv_spatial_metric<dim>(used_for_size),
           make_inverse_spatial_metric<dim>(used_for_size)),
       raised_tensor);
+
+  const tnsr::I<double, dim> shift = raise_or_lower_index(
+      make_lower_shift<dim>(0.), make_inverse_spatial_metric<dim>(0.));
+  CHECK(get<0>(shift) == approx(5.));
+  CHECK(get<1>(shift) == approx(10.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_index(make_lower_shift<dim>(used_for_size),
+                           make_inverse_spatial_metric<dim>(used_for_size)),
+      shift);
 }
 
 void test_2d_spatial_lower(const DataVector& used_for_size) {
@@ -76,6 +104,16 @@ void test_2d_spatial_lower(const DataVector& used_for_size) {
           make_spatial_christoffel_second_kind<dim>(used_for_size),
           make_spatial_metric<dim>(used_for_size)),
       lowered_tensor);
+
+  const tnsr::i<double, dim> lowered_shift =
+      raise_or_lower_index(make_shift<dim>(0.), make_spatial_metric<dim>(0.));
+  CHECK(get<0>(lowered_shift) == approx(5.));
+  CHECK(get<1>(lowered_shift) == approx(10.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_index(make_shift<dim>(used_for_size),
+                           make_spatial_metric<dim>(used_for_size)),
+      lowered_shift);
 }
 
 void test_3d_spatial_raise(const DataVector& used_for_size) {
@@ -107,7 +145,19 @@ void test_3d_spatial_raise(const DataVector& used_for_size) {
           make_deriv_spatial_metric<dim>(used_for_size),
           make_inverse_spatial_metric<dim>(used_for_size)),
       raised_tensor);
+
+  const tnsr::I<double, dim> shift = raise_or_lower_index(
+      make_lower_shift<dim>(0.), make_inverse_spatial_metric<dim>(0.));
+  CHECK(get<0>(shift) == approx(14.));
+  CHECK(get<1>(shift) == approx(28.));
+  CHECK(get<2>(shift) == approx(42.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_index(make_lower_shift<dim>(used_for_size),
+                           make_inverse_spatial_metric<dim>(used_for_size)),
+      shift);
 }
+
 void test_3d_spatial_lower(const DataVector& used_for_size) {
   const size_t dim = 3;
   const tnsr::ijj<double, dim> lowered_tensor =
@@ -138,6 +188,17 @@ void test_3d_spatial_lower(const DataVector& used_for_size) {
           make_spatial_christoffel_second_kind<dim>(used_for_size),
           make_spatial_metric<dim>(used_for_size)),
       lowered_tensor);
+
+  const tnsr::i<double, dim> lowered_shift =
+      raise_or_lower_index(make_shift<dim>(0.), make_spatial_metric<dim>(0.));
+  CHECK(get<0>(lowered_shift) == approx(14.));
+  CHECK(get<1>(lowered_shift) == approx(28.));
+  CHECK(get<2>(lowered_shift) == approx(42.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_index(make_shift<dim>(used_for_size),
+                           make_spatial_metric<dim>(used_for_size)),
+      lowered_shift);
 }
 
 void test_3d_spacetime_raise(const DataVector& used_for_size) {
@@ -192,6 +253,18 @@ void test_3d_spacetime_raise(const DataVector& used_for_size) {
           make_spacetime_deriv_spacetime_metric<dim>(used_for_size),
           make_inverse_spacetime_metric<dim>(used_for_size)),
       raised_tensor);
+
+  const tnsr::A<double, dim> raised_one_form = raise_or_lower_index(
+      make_dummy_one_form<dim>(0.), make_inverse_spacetime_metric<dim>(0.));
+  CHECK(get<0>(raised_one_form) == approx(-160.));
+  CHECK(get<1>(raised_one_form) == approx(-240.));
+  CHECK(get<2>(raised_one_form) == approx(-320.));
+  CHECK(get<3>(raised_one_form) == approx(-400.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_index(make_dummy_one_form<dim>(used_for_size),
+                           make_inverse_spacetime_metric<dim>(used_for_size)),
+      raised_one_form);
 }
 
 void test_3d_spacetime_lower(const DataVector& used_for_size) {
@@ -246,6 +319,18 @@ void test_3d_spacetime_lower(const DataVector& used_for_size) {
           make_spacetime_christoffel_second_kind<dim>(used_for_size),
           make_spacetime_metric<dim>(used_for_size)),
       lowered_tensor);
+
+  const tnsr::a<double, dim> lowered_vector = raise_or_lower_index(
+      make_dummy_vector<dim>(0.), make_spacetime_metric<dim>(0.));
+  CHECK(get<0>(lowered_vector) == approx(-160.));
+  CHECK(get<1>(lowered_vector) == approx(-240.));
+  CHECK(get<2>(lowered_vector) == approx(-320.));
+  CHECK(get<3>(lowered_vector) == approx(-400.));
+
+  check_tensor_doubles_equals_tensor_datavectors(
+      raise_or_lower_index(make_dummy_vector<dim>(used_for_size),
+                           make_spacetime_metric<dim>(used_for_size)),
+      lowered_vector);
 }
 void test_1d_spatial_trace(const DataVector& used_for_size) {
   const size_t dim = 1;


### PR DESCRIPTION
## Proposed changes

Adds a function to compute the expansion of a Strahlkorper.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
