### PR TITLE
Additions for evolutions 5

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -76,10 +76,10 @@ struct LogicalCoordinates : db::ComputeItemTag {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The coordinate map from logical to grid coordinate
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct ElementMap : db::DataBoxTag {
   static constexpr db::DataBoxString label = "ElementMap";
-  using type = ::ElementMap<VolumeDim, Frame::Grid>;
+  using type = ::ElementMap<VolumeDim, Frame>;
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -119,9 +119,9 @@ namespace detail {
 template <size_t VolumeDim>
 auto make_unnormalized_face_normals(
     const Index<VolumeDim>& extents,
-    const ::ElementMap<VolumeDim, Frame::Grid>& map) noexcept {
+    const ::ElementMap<VolumeDim, Frame::Inertial>& map) noexcept {
   std::unordered_map<Direction<VolumeDim>,
-                     tnsr::i<DataVector, VolumeDim, Frame::Grid>>
+                     tnsr::i<DataVector, VolumeDim, Frame::Inertial>>
       result;
   for (const auto& d : Direction<VolumeDim>::all_directions()) {
     result.emplace(

--- a/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
@@ -1,0 +1,163 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/Tuple.hpp"
+
+namespace dg {
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief Initialize a dG element with analytic initial data
+///
+/// Uses:
+/// - ConstGlobalCache:
+///   * A tag deriving off of Cache::AnalyticSolutionBase
+///   * CacheTags::TimeStepper
+///
+/// DataBox changes:
+/// - Adds:
+///   * Tags::TimeId
+///   * Tags::Time
+///   * Tags::TimeStep
+///   * Tags::LogicalCoordinates<Dim>
+///   * Tags::Extents<Dim>
+///   * Tags::Element<Dim>
+///   * Tags::ElementMap<Dim>
+///   * System::variables_tag
+///   * Tags::HistoryEvolvedVariables<System::variables_tag,
+///                  db::add_tag_prefix<Tags::dt, System::variables_tag>>
+///   * Tags::Coordinates<Tags::ElementMap<Dim>,
+///                       Tags::LogicalCoordinates<Dim>>
+///   * Tags::InverseJacobian<Tags::ElementMap<Dim>,
+///                           Tags::LogicalCoordinates<Dim>>
+///   * Tags::deriv<System::variables_tag::tags_list,
+///                 System::gradients_tags,
+///                 Tags::InverseJacobian<Tags::ElementMap<Dim>,
+///                                       Tags::LogicalCoordinates<Dim>>>
+///   * db::add_tag_prefix<Tags::dt, System::variables_tag>
+///   * Tags::UnnormalizedFaceNormal<Dim>
+/// - Removes: nothing
+/// - Modifies: nothing
+template <size_t Dim>
+struct InitializeElement {
+  using apply_args =
+      tmpl::list<std::vector<std::array<size_t, Dim>>,
+                 Domain<Dim, Frame::Inertial>, ::Time, ::TimeDelta>;
+
+  template <class System>
+  using return_tag_list = tmpl::list<
+      Tags::TimeId, Tags::Time, Tags::TimeStep, Tags::LogicalCoordinates<Dim>,
+      Tags::Extents<Dim>, Tags::Element<Dim>, Tags::ElementMap<Dim>,
+      typename System::variables_tag,
+      Tags::HistoryEvolvedVariables<
+          typename System::variables_tag,
+          db::add_tag_prefix<Tags::dt, typename System::variables_tag>>,
+      Tags::Coordinates<Tags::ElementMap<Dim>, Tags::LogicalCoordinates<Dim>>,
+      Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                            Tags::LogicalCoordinates<Dim>>,
+      Tags::deriv<typename System::variables_tag::tags_list,
+                  typename System::gradients_tags,
+                  Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                                        Tags::LogicalCoordinates<Dim>>>,
+      db::add_tag_prefix<Tags::dt, typename System::variables_tag>,
+      Tags::UnnormalizedFaceNormal<Dim>>;
+
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ElementIndex<Dim>& array_index,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    std::vector<std::array<size_t, Dim>> initial_extents,
+                    Domain<Dim, Frame::Inertial> domain, Time initial_time,
+                    TimeDelta initial_dt) noexcept {
+    using solution_tag = CacheTags::AnalyticSolutionBase;
+    using variables_tags =
+        typename Metavariables::system::variables_tag::tags_list;
+
+    ElementId<Dim> element_id{array_index};
+
+    const auto& my_block = domain.blocks()[element_id.block_id()];
+
+    ElementMap<Dim, Frame::Inertial> map{element_id,
+                                         my_block.coordinate_map().get_clone()};
+
+    Element<Dim> element = create_initial_element(element_id, my_block);
+
+    ::Index<Dim> mesh{initial_extents[element_id.block_id()]};
+    const auto num_grid_points = mesh.product();
+    auto logical_coords = logical_coordinates(mesh);
+    auto inertial_coords = map(logical_coords);
+
+    // Set initial data from analytic solution
+    auto vars = Parallel::get<solution_tag>(cache).evolution_variables(
+        inertial_coords, initial_time.value());
+
+    typename Tags::HistoryEvolvedVariables<
+        Tags::Variables<variables_tags>,
+        Tags::dt<Tags::Variables<db::wrap_tags_in<Tags::dt, variables_tags>>>>::
+        type history_dt_vars;
+    const auto& time_stepper = Parallel::get<CacheTags::TimeStepper>(cache);
+    if (not time_stepper.is_self_starting()) {
+      // We currently just put initial points at past slab boundaries.
+      Time past_t = initial_time;
+      TimeDelta past_dt = initial_dt;
+      for (size_t i = time_stepper.number_of_past_steps(); i > 0; --i) {
+        past_dt = past_dt.with_slab(past_dt.slab().advance_towards(-past_dt));
+        past_t -= past_dt;
+
+        history_dt_vars.emplace_front(
+            past_t,
+            Parallel::get<solution_tag>(cache).evolution_variables(
+                inertial_coords, past_t.value()),
+            Parallel::get<solution_tag>(cache).dt_evolution_variables(
+                inertial_coords, past_t.value()));
+      }
+    }
+
+    // Set up initial time
+    TimeId time_id{};
+    time_id.time = initial_time;
+
+    db::compute_databox_type<return_tag_list<typename Metavariables::system>>
+        outbox = db::create<
+            db::get_items<return_tag_list<typename Metavariables::system>>,
+            db::get_compute_items<
+                return_tag_list<typename Metavariables::system>>>(
+            time_id, initial_dt, std::move(mesh), std::move(element),
+            std::move(map), std::move(vars), std::move(history_dt_vars),
+            Variables<db::wrap_tags_in<Tags::dt, variables_tags>>{
+                num_grid_points, 0.0});
+
+    return std::make_tuple(std::move(outbox));
+  }
+};
+}  // namespace Actions
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -143,8 +143,9 @@ struct ComputeBoundaryFlux {
 
       // Using this instead of auto prevents incomprehensible errors
       // if the return type of compute_flux is wrong.
-      using FluxType = db::item_type<db::add_tag_prefix<
-          Tags::Flux, variables_tag, tmpl::size_t<volume_dim>, Frame::Grid>>;
+      using FluxType = db::item_type<
+          db::add_tag_prefix<Tags::Flux, variables_tag,
+                             tmpl::size_t<volume_dim>, Frame::Inertial>>;
       const FluxType local_boundary_flux =
           System::compute_flux::apply(local_value);
       const FluxType neighbor_boundary_flux =
@@ -160,7 +161,7 @@ struct ComputeBoundaryFlux {
         &neighbor_boundary_flux, &unit_face_normal
       ](auto tag) noexcept {
         using Tag = tmpl::type_from<decltype(tag)>;
-        using flux_tag = Tags::Flux<Tag, tmpl::size_t<2>, Frame::Grid>;
+        using flux_tag = Tags::Flux<Tag, tmpl::size_t<2>, Frame::Inertial>;
 
         const auto& local_bf = get<flux_tag>(local_boundary_flux);
         auto& local_nf = get<Tags::NormalDotFlux<Tag>>(local_normal_flux);

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Options/Options.hpp"
+
+namespace CacheTags {
+/// \ingroup CacheTagsGroup
+/// Can be used to retrieve the analytic solution from the cache without having
+/// to know the template parameters of AnalyticSolution.
+struct AnalyticSolutionBase {};
+
+/// \ingroup CacheTagsGroup
+/// The analytic solution, with the type of the analytic solution set as the
+/// template parameter
+template <typename SolutionType>
+struct AnalyticSolution : AnalyticSolutionBase {
+  static constexpr OptionString help =
+      "Analytic solution used for the initial data and errors";
+  using type = SolutionType;
+};
+}  // namespace CacheTags

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -69,11 +69,11 @@ struct HistoryEvolvedVariables : db::DataBoxPrefix {
 ///
 /// \tparam Key type identifying a boundary
 /// \tparam Tag tag for boundary variables
-template <typename Key, typename Tag>
+template <typename Key, typename Tag, typename Hash = std::hash<Key>>
 struct HistoryBoundaryVariables : db::DataBoxPrefix {
   static constexpr db::DataBoxString label = "HistoryBoundaryVariables";
   using tag = Tag;
-  using type = std::unordered_map<Key, db::item_type<Tag>>;
+  using type = std::unordered_map<Key, db::item_type<Tag>, Hash>;
 };
 
 }  // namespace Tags

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -114,12 +114,15 @@ class ActionRunner {
 
   /// Call Action::apply as if on the portion of Component labeled by
   /// array_index.
-  template <typename Component, typename Action, typename DbTags>
+  template <typename Component, typename Action, typename DbTags,
+            typename... Args>
   decltype(auto) apply(db::DataBox<DbTags>& box,
-                       const typename Component::index& array_index) noexcept {
+                       const typename Component::index& array_index,
+                       Args&&... args) noexcept {
     return Action::apply(box, inboxes<Component>()[array_index], cache_,
                          array_index, typename Component::action_list{},
-                         std::add_pointer_t<Component>{nullptr});
+                         std::add_pointer_t<Component>{nullptr},
+                         std::forward<Args>(args)...);
   }
 
   /// Call Action::is_ready as if on the portion of Component labeled

--- a/tests/Unit/Domain/Test_CoordinatesTag.cpp
+++ b/tests/Unit/Domain/Test_CoordinatesTag.cpp
@@ -16,7 +16,7 @@
 namespace {
 template <size_t Dim, typename T>
 void test_coordinates_compute_item(Index<Dim> extents, T map) noexcept {
-  using map_tag = Tags::ElementMap<Dim>;
+  using map_tag = Tags::ElementMap<Dim, Frame::Grid>;
   const auto box = db::create<
       db::AddTags<Tags::Extents<Dim>, map_tag>,
       db::AddComputeItemsTags<

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Actions)
+add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Systems)
 
 set(SPECTRE_TESTS "${SPECTRE_TESTS};${EVOLUTION_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(EVOLUTION_DG_TESTS
+  Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+  )
+
+set(SPECTRE_TESTS "${SPECTRE_TESTS};${EVOLUTION_DG_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -1,0 +1,201 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+#include <deque>
+#include <memory>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/DomainCreators/Brick.hpp"
+#include "Domain/DomainCreators/Interval.hpp"
+#include "Domain/DomainCreators/Rectangle.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Time/TimeSteppers/AdamsBashforthN.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+struct Var : db::DataBoxTag {
+  using type = Scalar<DataVector>;
+  static constexpr db::DataBoxString label = "Var";
+};
+
+struct SystemAnalyticSolution {
+  template <size_t Dim>
+  Variables<tmpl::list<Var>> evolution_variables(
+      const tnsr::I<DataVector, Dim>& x, double t) const noexcept {
+    Variables<tmpl::list<Var>> variables(x.begin()->size());
+    get(get<Var>(variables)) = x.get(0) + t;
+    for (size_t d = 1; d < Dim; ++d) {
+      get(get<Var>(variables)) += x.get(d) + t;
+    }
+    return variables;
+  }
+
+  template <size_t Dim>
+  Variables<tmpl::list<Tags::dt<Var>>> dt_evolution_variables(
+      const tnsr::I<DataVector, Dim>& x, double t) const noexcept {
+    Variables<tmpl::list<Tags::dt<Var>>> variables(x.begin()->size());
+    get(get<Tags::dt<Var>>(variables)) = 2.0 * x.get(0) + t;
+    for (size_t d = 1; d < Dim; ++d) {
+      get(get<Tags::dt<Var>>(variables)) += 2.0 * x.get(d) + t;
+    }
+    return variables;
+  }
+};
+
+struct System {
+  using variables_tag = Tags::Variables<tmpl::list<Var>>;
+  using gradients_tags = tmpl::list<Var>;
+};
+
+template <size_t Dim>
+struct Metavariables;
+
+template <size_t Dim>
+using component = ActionTesting::MockArrayComponent<
+    Metavariables<Dim>, ElementIndex<Dim>,
+    tmpl::list<CacheTags::TimeStepper,
+               CacheTags::AnalyticSolution<SystemAnalyticSolution>>,
+    tmpl::list<dg::Actions::InitializeElement<Dim>>>;
+
+template <size_t Dim>
+struct Metavariables {
+  using component_list = tmpl::list<component<Dim>>;
+  using system = System;
+};
+
+template <size_t Dim, typename DomainCreatorType>
+void test_initialize_element(const ElementId<Dim>& element_id,
+                             const DomainCreatorType& domain_creator) {
+  ActionTesting::ActionRunner<Metavariables<Dim>> runner{
+      {std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
+       SystemAnalyticSolution{}}};
+
+  const Slab slab = Slab::with_duration_from_start(0.3, 0.01);
+
+  const auto domain = domain_creator.create_domain();
+
+  db::DataBox<tmpl::list<>> empty_box{};
+  auto box = std::get<0>(
+      runner
+          .template apply<component<Dim>, dg::Actions::InitializeElement<Dim>>(
+              empty_box, element_id, domain_creator.initial_extents(),
+              domain_creator.create_domain(), slab.start(), slab.duration()));
+  CHECK(db::get<Tags::TimeId>(box) == [&slab]() {
+    TimeId time_id{};
+    time_id.time = slab.start();
+    return time_id;
+  }());
+  CHECK(db::get<Tags::Time>(box) == slab.start());
+  CHECK(db::get<Tags::TimeStep>(box) == slab.duration());
+
+  const auto& my_block = domain.blocks()[element_id.block_id()];
+  ElementMap<Dim, Frame::Inertial> map{element_id,
+                                       my_block.coordinate_map().get_clone()};
+  Element<Dim> element = create_initial_element(element_id, my_block);
+  Index<Dim> extents{domain_creator.initial_extents()[element_id.block_id()]};
+  const auto num_grid_points = extents.product();
+  auto logical_coords = logical_coordinates(extents);
+  auto inertial_coords = map(logical_coords);
+  CHECK(db::get<Tags::LogicalCoordinates<Dim>>(box) == logical_coords);
+  CHECK(db::get<Tags::Extents<Dim>>(box) == extents);
+  CHECK(db::get<Tags::Element<Dim>>(box) == element);
+  // Can't test ElementMap directly, only via inverse jacobian and grid
+  // coordinates. We can check that we can retrieve it.
+  (void)db::get<Tags::ElementMap<Dim>>(box);
+  CHECK(db::get<Var>(box) == ([&inertial_coords, &slab]() {
+          double time = slab.start().value();
+          Scalar<DataVector> var{inertial_coords.get(0) + time};
+          for (size_t d = 1; d < Dim; ++d) {
+            get(var) += inertial_coords.get(d) + time;
+          }
+          return var;
+        }()));
+  CHECK(
+      (db::get<Tags::HistoryEvolvedVariables<
+           typename System::variables_tag,
+           db::add_tag_prefix<Tags::dt, typename System::variables_tag>>>(
+          box)) == ([&slab, &inertial_coords]() {
+        std::deque<std::tuple<::Time, Variables<tmpl::list<Var>>,
+                              Variables<tmpl::list<Tags::dt<Var>>>>>
+            history{};
+        TimeSteppers::AdamsBashforthN stepper(4, false);
+        SystemAnalyticSolution solution{};
+
+        Time past_t{slab.start()};
+        TimeDelta past_dt{slab.duration()};
+        for (size_t i = stepper.number_of_past_steps(); i > 0; --i) {
+          past_dt = past_dt.with_slab(past_dt.slab().advance_towards(-past_dt));
+          past_t -= past_dt;
+
+          history.emplace_front(
+              past_t,
+              solution.evolution_variables(inertial_coords, past_t.value()),
+              solution.dt_evolution_variables(inertial_coords, past_t.value()));
+        }
+        return history;
+      }()));
+  CHECK((db::get<Tags::Coordinates<Tags::ElementMap<Dim>,
+                                   Tags::LogicalCoordinates<Dim>>>(box)) ==
+        inertial_coords);
+  CHECK((db::get<Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                                       Tags::LogicalCoordinates<Dim>>>(box)) ==
+        map.inv_jacobian(logical_coords));
+  CHECK((db::get<
+            Tags::deriv<typename System::variables_tag::tags_list,
+                        typename System::gradients_tags,
+                        Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                                              Tags::LogicalCoordinates<Dim>>>>(
+            box)) ==
+        partial_derivatives<tmpl::list<Var>>(
+            SystemAnalyticSolution{}.evolution_variables(inertial_coords, 0.),
+            extents, map.inv_jacobian(logical_coords)));
+  CHECK((db::get<db::add_tag_prefix<Tags::dt, typename System::variables_tag>>(
+            box)) ==
+        Variables<tmpl::list<Tags::dt<Var>>>(extents.product(), 0.0));
+  CHECK(db::get<Tags::UnnormalizedFaceNormal<Dim>>(box) ==
+        Tags::UnnormalizedFaceNormal<Dim>::function(extents, map));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.dG.InitializeElement",
+                  "[Unit][Evolution][Actions]") {
+  test_initialize_element(ElementId<1>{0, {{SegmentId{2, 1}}}},
+                          DomainCreators::Interval<Frame::Inertial>{
+                              {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}});
+
+  test_initialize_element(
+      ElementId<2>{0, {{SegmentId{2, 1}, SegmentId{3, 2}}}},
+      DomainCreators::Rectangle<Frame::Inertial>{
+          {{-0.5, -0.75}}, {{1.5, 2.4}}, {{false, false}}, {{2, 3}}, {{4, 5}}});
+
+  test_initialize_element(
+      ElementId<3>{0, {{SegmentId{2, 1}, SegmentId{3, 2}, SegmentId{1, 0}}}},
+      DomainCreators::Brick<Frame::Inertial>{{{-0.5, -0.75, -1.2}},
+                                             {{1.5, 2.4, 1.2}},
+                                             {{false, false, true}},
+                                             {{2, 3, 1}},
+                                             {{4, 5, 3}}});
+}
+
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -40,7 +40,7 @@ struct System {
 
   struct compute_flux {
     static auto apply(const Variables<tmpl::list<Var>>& value) noexcept {
-      using flux_tag = Tags::Flux<Var, tmpl::size_t<2>, Frame::Grid>;
+      using flux_tag = Tags::Flux<Var, tmpl::size_t<2>, Frame::Inertial>;
       Variables<tmpl::list<flux_tag>> result(value.number_of_grid_points());
       get<0>(get<flux_tag>(result)) = 10. * value;
       get<1>(get<flux_tag>(result)) = 20. * value;
@@ -121,9 +121,9 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
         {Direction<2>::upper_xi(), {{east_id}, {}}},
         {Direction<2>::upper_eta(), {{south_id}, {}}}});
 
-    auto map = ElementMap<2, Frame::Grid>(
+    auto map = ElementMap<2, Frame::Inertial>(
         ElementId<2>{0},
-        make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
                                            CoordinateMaps::AffineMap>(
                 xi_map, eta_map)));
@@ -291,8 +291,8 @@ SPECTRE_TEST_CASE(
 
   const Element<2> element(self_id, {});
 
-  auto map = ElementMap<2, Frame::Grid>(
-      self_id, make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+  auto map = ElementMap<2, Frame::Inertial>(
+      self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
                    CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
                                                   CoordinateMaps::AffineMap>(
                        {-1., 1., 3., 7.}, {-1., 1., -2., 4.})));

--- a/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
@@ -73,7 +73,9 @@ class Square : public Shape {
 };
 #pragma GCC diagnostic pop
 
-struct shape_of_nametag {
+struct shape_of_nametag_base {};
+
+struct shape_of_nametag : shape_of_nametag_base {
   using type = std::unique_ptr<Shape>;
 };
 
@@ -149,6 +151,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
     CHECK(178 == Parallel::get<age>(cache));
     CHECK(2.2 == Parallel::get<height>(cache));
     CHECK(4 == Parallel::get<shape_of_nametag>(cache).number_of_sides());
+    CHECK(4 == Parallel::get<shape_of_nametag_base>(cache).number_of_sides());
   }
 
   {
@@ -171,6 +174,8 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
     CHECK(178 == Parallel::get<age>(local_cache));
     CHECK(2.2 == Parallel::get<height>(local_cache));
     CHECK(4 == Parallel::get<shape_of_nametag>(local_cache).number_of_sides());
+    CHECK(4 ==
+          Parallel::get<shape_of_nametag_base>(local_cache).number_of_sides());
   }
 }
 


### PR DESCRIPTION
## Proposed changes

*Note:* this is on top of #482 

- Use inertial frame everywhere for now. Once we have dual frames (not necessarily control systems) we will have to revisit how to deal with dual frames. It's not clear Saul's paper is correct based off some test simulations Saul did.
- Allow retrieving tags from the global cache via a base class the tag derives off of. This allows "template parameter erasure"
- Add a tag for the analytic solution, stored in the global cache. This uses the template parameter erasure introduced in the previous commit
- Add Action that initializes the DataBox of the dG element's Parallal Component.
- Allow the HistoryBoundaryVariables to have a non-default hash. I'm expecting this tag to be changed once LTS is worked on more.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
