### PR TITLE
Add new flux communication actions

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -76,10 +76,10 @@ struct LogicalCoordinates : db::ComputeItemTag {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// The coordinate map from logical to grid coordinate
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct ElementMap : db::DataBoxTag {
   static constexpr db::DataBoxString label = "ElementMap";
-  using type = ::ElementMap<VolumeDim, Frame::Grid>;
+  using type = ::ElementMap<VolumeDim, Frame>;
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -119,9 +119,9 @@ namespace detail {
 template <size_t VolumeDim>
 auto make_unnormalized_face_normals(
     const Index<VolumeDim>& extents,
-    const ::ElementMap<VolumeDim, Frame::Grid>& map) noexcept {
+    const ::ElementMap<VolumeDim, Frame::Inertial>& map) noexcept {
   std::unordered_map<Direction<VolumeDim>,
-                     tnsr::i<DataVector, VolumeDim, Frame::Grid>>
+                     tnsr::i<DataVector, VolumeDim, Frame::Inertial>>
       result;
   for (const auto& d : Direction<VolumeDim>::all_directions()) {
     result.emplace(

--- a/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
@@ -1,0 +1,163 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/Tuple.hpp"
+
+namespace dg {
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief Initialize a dG element with analytic initial data
+///
+/// Uses:
+/// - ConstGlobalCache:
+///   * A tag deriving off of Cache::AnalyticSolutionBase
+///   * CacheTags::TimeStepper
+///
+/// DataBox changes:
+/// - Adds:
+///   * Tags::TimeId
+///   * Tags::Time
+///   * Tags::TimeStep
+///   * Tags::LogicalCoordinates<Dim>
+///   * Tags::Extents<Dim>
+///   * Tags::Element<Dim>
+///   * Tags::ElementMap<Dim>
+///   * System::variables_tag
+///   * Tags::HistoryEvolvedVariables<System::variables_tag,
+///                  db::add_tag_prefix<Tags::dt, System::variables_tag>>
+///   * Tags::Coordinates<Tags::ElementMap<Dim>,
+///                       Tags::LogicalCoordinates<Dim>>
+///   * Tags::InverseJacobian<Tags::ElementMap<Dim>,
+///                           Tags::LogicalCoordinates<Dim>>
+///   * Tags::deriv<System::variables_tag::tags_list,
+///                 System::gradients_tags,
+///                 Tags::InverseJacobian<Tags::ElementMap<Dim>,
+///                                       Tags::LogicalCoordinates<Dim>>>
+///   * db::add_tag_prefix<Tags::dt, System::variables_tag>
+///   * Tags::UnnormalizedFaceNormal<Dim>
+/// - Removes: nothing
+/// - Modifies: nothing
+template <size_t Dim>
+struct InitializeElement {
+  using apply_args =
+      tmpl::list<std::vector<std::array<size_t, Dim>>,
+                 Domain<Dim, Frame::Inertial>, ::Time, ::TimeDelta>;
+
+  template <class System>
+  using return_tag_list = tmpl::list<
+      Tags::TimeId, Tags::Time, Tags::TimeStep, Tags::LogicalCoordinates<Dim>,
+      Tags::Extents<Dim>, Tags::Element<Dim>, Tags::ElementMap<Dim>,
+      typename System::variables_tag,
+      Tags::HistoryEvolvedVariables<
+          typename System::variables_tag,
+          db::add_tag_prefix<Tags::dt, typename System::variables_tag>>,
+      Tags::Coordinates<Tags::ElementMap<Dim>, Tags::LogicalCoordinates<Dim>>,
+      Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                            Tags::LogicalCoordinates<Dim>>,
+      Tags::deriv<typename System::variables_tag::tags_list,
+                  typename System::gradients_tags,
+                  Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                                        Tags::LogicalCoordinates<Dim>>>,
+      db::add_tag_prefix<Tags::dt, typename System::variables_tag>,
+      Tags::UnnormalizedFaceNormal<Dim>>;
+
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ElementIndex<Dim>& array_index,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    std::vector<std::array<size_t, Dim>> initial_extents,
+                    Domain<Dim, Frame::Inertial> domain, Time initial_time,
+                    TimeDelta initial_dt) noexcept {
+    using solution_tag = CacheTags::AnalyticSolutionBase;
+    using variables_tags =
+        typename Metavariables::system::variables_tag::tags_list;
+
+    ElementId<Dim> element_id{array_index};
+
+    const auto& my_block = domain.blocks()[element_id.block_id()];
+
+    ElementMap<Dim, Frame::Inertial> map{element_id,
+                                         my_block.coordinate_map().get_clone()};
+
+    Element<Dim> element = create_initial_element(element_id, my_block);
+
+    ::Index<Dim> mesh{initial_extents[element_id.block_id()]};
+    const auto num_grid_points = mesh.product();
+    auto logical_coords = logical_coordinates(mesh);
+    auto inertial_coords = map(logical_coords);
+
+    // Set initial data from analytic solution
+    auto vars = Parallel::get<solution_tag>(cache).evolution_variables(
+        inertial_coords, initial_time.value());
+
+    typename Tags::HistoryEvolvedVariables<
+        Tags::Variables<variables_tags>,
+        Tags::dt<Tags::Variables<db::wrap_tags_in<Tags::dt, variables_tags>>>>::
+        type history_dt_vars;
+    const auto& time_stepper = Parallel::get<CacheTags::TimeStepper>(cache);
+    if (not time_stepper.is_self_starting()) {
+      // We currently just put initial points at past slab boundaries.
+      Time past_t = initial_time;
+      TimeDelta past_dt = initial_dt;
+      for (size_t i = time_stepper.number_of_past_steps(); i > 0; --i) {
+        past_dt = past_dt.with_slab(past_dt.slab().advance_towards(-past_dt));
+        past_t -= past_dt;
+
+        history_dt_vars.emplace_front(
+            past_t,
+            Parallel::get<solution_tag>(cache).evolution_variables(
+                inertial_coords, past_t.value()),
+            Parallel::get<solution_tag>(cache).dt_evolution_variables(
+                inertial_coords, past_t.value()));
+      }
+    }
+
+    // Set up initial time
+    TimeId time_id{};
+    time_id.time = initial_time;
+
+    db::compute_databox_type<return_tag_list<typename Metavariables::system>>
+        outbox = db::create<
+            db::get_items<return_tag_list<typename Metavariables::system>>,
+            db::get_compute_items<
+                return_tag_list<typename Metavariables::system>>>(
+            time_id, initial_dt, std::move(mesh), std::move(element),
+            std::move(map), std::move(vars), std::move(history_dt_vars),
+            Variables<db::wrap_tags_in<Tags::dt, variables_tags>>{
+                num_grid_points, 0.0});
+
+    return std::make_tuple(std::move(outbox));
+  }
+};
+}  // namespace Actions
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -143,8 +143,9 @@ struct ComputeBoundaryFlux {
 
       // Using this instead of auto prevents incomprehensible errors
       // if the return type of compute_flux is wrong.
-      using FluxType = db::item_type<db::add_tag_prefix<
-          Tags::Flux, variables_tag, tmpl::size_t<volume_dim>, Frame::Grid>>;
+      using FluxType = db::item_type<
+          db::add_tag_prefix<Tags::Flux, variables_tag,
+                             tmpl::size_t<volume_dim>, Frame::Inertial>>;
       const FluxType local_boundary_flux =
           System::compute_flux::apply(local_value);
       const FluxType neighbor_boundary_flux =
@@ -160,7 +161,7 @@ struct ComputeBoundaryFlux {
         &neighbor_boundary_flux, &unit_face_normal
       ](auto tag) noexcept {
         using Tag = tmpl::type_from<decltype(tag)>;
-        using flux_tag = Tags::Flux<Tag, tmpl::size_t<2>, Frame::Grid>;
+        using flux_tag = Tags::Flux<Tag, tmpl::size_t<2>, Frame::Inertial>;
 
         const auto& local_bf = get<flux_tag>(local_boundary_flux);
         auto& local_nf = get<Tags::NormalDotFlux<Tag>>(local_normal_flux);

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication2.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication2.hpp
@@ -1,0 +1,350 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines actions ComputeBoundaryFlux and SendDataForFluxes
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/DataOnSlice.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/SliceIterator.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/Neighbors.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Domain/Side.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace dg {
+namespace Actions {
+
+namespace DgActions_detail {
+template <size_t volume_dim, typename Tag>
+using mortars_tag = Tags::HistoryBoundaryVariables<
+    std::pair<Direction<volume_dim>, ElementId<volume_dim>>, Tag,
+    boost::hash<std::pair<Direction<volume_dim>, ElementId<volume_dim>>>>;
+}  // namespace DgActions_detail
+
+template <typename Metavariables>
+struct ComputeBoundaryFlux {
+  using PackagedData = Variables<
+      typename Metavariables::normal_dot_numerical_flux::type::package_tags>;
+  using system = typename Metavariables::system;
+  static constexpr size_t volume_dim = system::volume_dim;
+
+  struct FluxesTag {
+    using temporal_id = TimeId;
+    using type = std::unordered_map<
+        TimeId, std::unordered_map<
+                    std::pair<Direction<volume_dim>, ElementId<volume_dim>>,
+                    PackagedData,
+                    boost::hash<std::pair<Direction<volume_dim>,
+                                          ElementId<volume_dim>>>>>;
+  };
+
+  using inbox_tags = tmpl::list<FluxesTag>;
+
+ private:
+  template <typename Flux, typename... NumericalFluxTags, typename... Tags,
+            typename... ArgumentTags, typename... Args>
+  static void apply_normal_dot_numerical_flux(
+      const gsl::not_null<Variables<tmpl::list<NumericalFluxTags...>>*>
+          numerical_fluxes,
+      const Flux& flux,
+      const Variables<tmpl::list<Tags...>>& self_packaged_data,
+      const Variables<tmpl::list<Tags...>>& neighbor_packaged_data) noexcept {
+    flux(make_not_null(&get<NumericalFluxTags>(*numerical_fluxes))...,
+         get<Tags>(self_packaged_data)...,
+         get<Tags>(neighbor_packaged_data)...);
+  }
+
+ public:
+  template <typename DbTags, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<DbTags>& box,
+                    tuples::TaggedTuple<InboxTags...>& inboxes,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using variables_tag = typename system::variables_tag;
+    using dt_variables_tag = db::add_tag_prefix<Tags::dt, variables_tag>;
+
+    using normal_dot_flux_tag =
+        db::add_tag_prefix<Tags::NormalDotFlux, variables_tag>;
+    using normal_dot_numerical_flux_tag =
+        db::add_tag_prefix<Tags::NormalDotNumericalFlux, variables_tag>;
+    using mortars_normal_dot_fluxes_tag =
+        DgActions_detail::mortars_tag<volume_dim, normal_dot_flux_tag>;
+    using mortars_packaged_data_tag = DgActions_detail::mortars_tag<
+        volume_dim,
+        Tags::Variables<typename Metavariables::normal_dot_numerical_flux::
+                            type::package_tags>>;
+
+    const auto& normal_dot_numerical_flux_computer =
+        get<typename Metavariables::normal_dot_numerical_flux>(cache);
+    const auto& extents = db::get<Tags::Extents<volume_dim>>(box);
+    const auto& local_mortar_data = db::get<mortars_packaged_data_tag>(box);
+    const auto& local_normal_dot_flux =
+        db::get<mortars_normal_dot_fluxes_tag>(box);
+
+    const auto& element = db::get<Tags::Element<volume_dim>>(box);
+
+    auto& inbox = tuples::get<FluxesTag>(inboxes);
+    const auto& time_id = db::get<Tags::TimeId>(box);
+    auto remote_data = std::move(inbox[time_id]);
+    inbox.erase(time_id);
+
+    for (const auto& direction_neighbors : element.neighbors()) {
+      const auto& direction = direction_neighbors.first;
+      const size_t dimension = direction.dimension();
+      const auto& neighbors_in_direction = direction_neighbors.second;
+      ASSERT(neighbors_in_direction.size() == 1,
+             "Complex mortars unimplemented");
+      const auto& neighbor = *neighbors_in_direction.begin();
+      const auto neighbor_data_it =
+          remote_data.find(std::make_pair(direction, neighbor));
+      ASSERT(remote_data.end() != neighbor_data_it,
+             "Attempting to access neighbor flux data that does not exist. "
+             "The neighbor attempting to be accessed is: "
+                 << neighbor << " in direction " << direction
+                 << ". The known keys are " << keys_of(remote_data) << ".");
+      const PackagedData& self_packaged_data =
+          local_mortar_data.at(std::make_pair(direction, neighbor));
+      const PackagedData& neighbor_packaged_data = neighbor_data_it->second;
+
+      // All of this needs to be fixed for hp-adaptivity to handle
+      // projections correctly
+      const auto& face_normal =
+          db::get<Tags::UnnormalizedFaceNormal<volume_dim>>(box).at(direction);
+
+      // Compute numerical flux
+      db::item_type<normal_dot_numerical_flux_tag> normal_dot_numerical_fluxes(
+          face_normal.begin()->size(), 0.0);
+      apply_normal_dot_numerical_flux(
+          make_not_null(&normal_dot_numerical_fluxes),
+          normal_dot_numerical_flux_computer, self_packaged_data,
+          neighbor_packaged_data);
+
+      // Needs fixing for GH/curved
+      db::item_type<dt_variables_tag> lifted_data(dg::lift_flux(
+          local_normal_dot_flux.at(std::make_pair(direction, neighbor)),
+          std::move(normal_dot_numerical_fluxes), extents[dimension],
+          magnitude(face_normal)));
+
+      db::mutate<dt_variables_tag>(box, [
+        &lifted_data, &extents, &dimension, &direction
+      ](db::item_type<dt_variables_tag> & dt_vars) noexcept {
+        add_slice_to_data(
+            make_not_null(&dt_vars), lifted_data, extents, dimension,
+            direction.side() == Side::Lower ? 0 : extents[dimension] - 1);
+      });
+    }
+
+    return std::make_tuple(
+        db::create_from<db::RemoveTags<mortars_normal_dot_fluxes_tag,
+                                       mortars_packaged_data_tag>>(
+            std::move(box)));
+  }
+
+  template <typename DbTags, typename... InboxTags, typename ArrayIndex>
+  static bool is_ready(
+      const db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& inboxes,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/) noexcept {
+    const auto& time_id = db::get<Tags::TimeId>(box);
+    const auto& inbox = tuples::get<FluxesTag>(inboxes);
+    auto receives = inbox.find(time_id);
+    const auto number_of_neighbors =
+        db::get<Tags::Element<volume_dim>>(box).number_of_neighbors();
+    const size_t num_receives =
+        receives == inbox.end() ? 0 : receives->second.size();
+    return num_receives == number_of_neighbors;
+  }
+};
+
+struct SendDataForFluxes {
+ private:
+  template <typename PackagedData, typename NumericalFluxComputer,
+            typename... NormalDotFluxTags, typename TagsList, typename... Args,
+            typename... SliceTags>
+  static void get_packaged_data_from_numerical_flux(
+      const gsl::not_null<PackagedData*> packaged_data,
+      const NumericalFluxComputer& numerical_flux_computer,
+      const Variables<tmpl::list<NormalDotFluxTags...>>& boundary_flux,
+      const Variables<TagsList>& sliced_variables,
+      const tmpl::list<SliceTags...>& /*meta*/, Args&&... args) noexcept {
+    numerical_flux_computer.package_data(
+        packaged_data, get<NormalDotFluxTags>(boundary_flux)...,
+        get<SliceTags>(sliced_variables)..., std::forward<Args>(args)...);
+  }
+
+  template <typename Metavariables, typename... NormalDotFluxTags,
+            typename... VariablesTags, size_t Dim, typename Frame,
+            typename... ArgumentTags>
+  static void apply_flux(
+      gsl::not_null<Variables<tmpl::list<NormalDotFluxTags...>>*> boundary_flux,
+      const Variables<tmpl::list<VariablesTags...>>& boundary_variables,
+      const tnsr::i<DataVector, Dim, Frame>& unit_face_normal,
+      tmpl::list<ArgumentTags...> /*meta*/) noexcept {
+    Metavariables::system::normal_dot_fluxes::apply(
+        make_not_null(&get<NormalDotFluxTags>(*boundary_flux))...,
+        get<ArgumentTags>(boundary_variables)..., unit_face_normal);
+  }
+
+ public:
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTags>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using system = typename Metavariables::system;
+    constexpr size_t volume_dim = system::volume_dim;
+    using variables_tag = typename system::variables_tag;
+    using PackagedData = Variables<
+        typename Metavariables::normal_dot_numerical_flux::type::package_tags>;
+
+    const auto& normal_dot_numerical_flux_computer =
+        get<typename Metavariables::normal_dot_numerical_flux>(cache);
+
+    auto& receiver_proxy =
+        Parallel::get_parallel_component<ParallelComponent>(cache);
+
+    const auto& element = db::get<Tags::Element<volume_dim>>(box);
+    const auto& extents = db::get<Tags::Extents<volume_dim>>(box);
+    const auto& time_id = db::get<Tags::TimeId>(box);
+
+    using normal_dot_flux_tag =
+        db::add_tag_prefix<Tags::NormalDotFlux, variables_tag>;
+    using NormalDotFluxType = db::item_type<normal_dot_flux_tag>;
+
+    std::unordered_map<
+        std::pair<Direction<volume_dim>, ElementId<volume_dim>>, PackagedData,
+        boost::hash<std::pair<Direction<volume_dim>, ElementId<volume_dim>>>>
+        mortars_packaged_data;
+    std::unordered_map<
+        std::pair<Direction<volume_dim>, ElementId<volume_dim>>,
+        NormalDotFluxType,
+        boost::hash<std::pair<Direction<volume_dim>, ElementId<volume_dim>>>>
+        mortars_normal_dot_fluxes;
+
+    for (const auto& direction_neighbors : element.neighbors()) {
+      const auto& direction = direction_neighbors.first;
+      const size_t dimension = direction.dimension();
+      const auto& neighbors_in_direction = direction_neighbors.second;
+      ASSERT(neighbors_in_direction.size() == 1,
+             "h-adaptivity is not supported yet.\nDirection: "
+                 << direction << "\nDimension: " << dimension
+                 << "\nNeighbors:\n"
+                 << neighbors_in_direction);
+      const auto& orientation = neighbors_in_direction.orientation();
+      const auto boundary_extents = extents.slice_away(dimension);
+      auto boundary_variables = db::data_on_slice(
+          box, extents, dimension,
+          direction.side() == Side::Lower ? 0 : extents[dimension] - 1,
+          tmpl::remove_duplicates<
+              tmpl::append<typename Metavariables::normal_dot_numerical_flux::
+                               type::slice_tags,
+                           typename Metavariables::system::normal_dot_fluxes::
+                               argument_tags>>{});
+
+      // Everything in the loop over neighbors needs to be fixed for
+      // hp-adaptivity to handle projections correctly
+      for (const auto& neighbor : neighbors_in_direction) {
+        const auto& face_normal =
+            db::get<Tags::UnnormalizedFaceNormal<volume_dim>>(box).at(
+                direction);
+        DataVector magnitude_of_face_normal = magnitude(face_normal);
+        std::decay_t<decltype(face_normal)> unit_face_normal(
+            magnitude_of_face_normal.size(), 0.0);
+        for (size_t d = 0; d < volume_dim; ++d) {
+          unit_face_normal.get(d) =
+              face_normal.get(d) / magnitude_of_face_normal;
+        }
+
+        // This needs to be updated for conservative systems where we can just
+        // slice the flux from the volume.
+        NormalDotFluxType local_boundary_flux(face_normal.begin()->size(), 0.0);
+        apply_flux<Metavariables>(
+            make_not_null(&local_boundary_flux), boundary_variables,
+            unit_face_normal,
+            typename system::normal_dot_fluxes::argument_tags{});
+
+        // We compute the parts of the numerical flux that only depend on data
+        // from this side of the mortar now, then package it into a Variables.
+        // We store one copy of the Variables and send another, since we need
+        // the data on both sides of the mortar.
+        PackagedData packaged_data(face_normal.begin()->size(), 0.0);
+        get_packaged_data_from_numerical_flux(
+            make_not_null(&packaged_data), normal_dot_numerical_flux_computer,
+            local_boundary_flux, boundary_variables,
+            typename Metavariables::normal_dot_numerical_flux::type::
+                slice_tags{},
+            unit_face_normal);
+
+        const auto direction_from_neighbor = orientation(direction.opposite());
+
+        // orient_variables_on_slice only needs to be done in the case where
+        // the data is oriented differently. This needs to improved later.
+        // Note: avoiding the same-orientation-on-both-sides copy is possible
+        // even with AMR since the quantities are already on the mortar at this
+        // point
+        auto neighbor_packaged_data = orient_variables_on_slice(
+            packaged_data, boundary_extents, dimension, orientation);
+
+        receiver_proxy[neighbor]
+            .template receive_data<
+                typename ComputeBoundaryFlux<Metavariables>::FluxesTag>(
+                time_id, std::make_pair(std::make_pair(direction_from_neighbor,
+                                                       element.id()),
+                                        std::move(neighbor_packaged_data)));
+
+        mortars_packaged_data.emplace(std::make_pair(direction, neighbor),
+                                      std::move(packaged_data));
+        mortars_normal_dot_fluxes.emplace(std::make_pair(direction, neighbor),
+                                          std::move(local_boundary_flux));
+      }  // loop over neighbors_in_direction
+    }    // loop over element.neighbors()
+
+    using mortars_normal_dot_fluxes_tag =
+        DgActions_detail::mortars_tag<volume_dim, normal_dot_flux_tag>;
+    using mortars_packaged_data_tag = DgActions_detail::mortars_tag<
+        volume_dim,
+        Tags::Variables<typename Metavariables::normal_dot_numerical_flux::
+                            type::package_tags>>;
+    return std::make_tuple(
+        db::create_from<db::RemoveTags<>,
+                        db::AddTags<mortars_packaged_data_tag,
+                                    mortars_normal_dot_fluxes_tag>>(
+            box, std::move(mortars_packaged_data),
+            std::move(mortars_normal_dot_fluxes)));
+  }
+};
+}  // namespace Actions
+}  // namespace dg

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Options/Options.hpp"
+
+namespace CacheTags {
+/// \ingroup CacheTagsGroup
+/// Can be used to retrieve the analytic solution from the cache without having
+/// to know the template parameters of AnalyticSolution.
+struct AnalyticSolutionBase {};
+
+/// \ingroup CacheTagsGroup
+/// The analytic solution, with the type of the analytic solution set as the
+/// template parameter
+template <typename SolutionType>
+struct AnalyticSolution : AnalyticSolutionBase {
+  static constexpr OptionString help =
+      "Analytic solution used for the initial data and errors";
+  using type = SolutionType;
+};
+}  // namespace CacheTags

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -69,11 +69,11 @@ struct HistoryEvolvedVariables : db::DataBoxPrefix {
 ///
 /// \tparam Key type identifying a boundary
 /// \tparam Tag tag for boundary variables
-template <typename Key, typename Tag>
+template <typename Key, typename Tag, typename Hash = std::hash<Key>>
 struct HistoryBoundaryVariables : db::DataBoxPrefix {
   static constexpr db::DataBoxString label = "HistoryBoundaryVariables";
   using tag = Tag;
-  using type = std::unordered_map<Key, db::item_type<Tag>>;
+  using type = std::unordered_map<Key, db::item_type<Tag>, Hash>;
 };
 
 }  // namespace Tags

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -114,12 +114,15 @@ class ActionRunner {
 
   /// Call Action::apply as if on the portion of Component labeled by
   /// array_index.
-  template <typename Component, typename Action, typename DbTags>
+  template <typename Component, typename Action, typename DbTags,
+            typename... Args>
   decltype(auto) apply(db::DataBox<DbTags>& box,
-                       const typename Component::index& array_index) noexcept {
+                       const typename Component::index& array_index,
+                       Args&&... args) noexcept {
     return Action::apply(box, inboxes<Component>()[array_index], cache_,
                          array_index, typename Component::action_list{},
-                         std::add_pointer_t<Component>{nullptr});
+                         std::add_pointer_t<Component>{nullptr},
+                         std::forward<Args>(args)...);
   }
 
   /// Call Action::is_ready as if on the portion of Component labeled

--- a/tests/Unit/Domain/Test_CoordinatesTag.cpp
+++ b/tests/Unit/Domain/Test_CoordinatesTag.cpp
@@ -16,7 +16,7 @@
 namespace {
 template <size_t Dim, typename T>
 void test_coordinates_compute_item(Index<Dim> extents, T map) noexcept {
-  using map_tag = Tags::ElementMap<Dim>;
+  using map_tag = Tags::ElementMap<Dim, Frame::Grid>;
   const auto box = db::create<
       db::AddTags<Tags::Extents<Dim>, map_tag>,
       db::AddComputeItemsTags<

--- a/tests/Unit/Evolution/CMakeLists.txt
+++ b/tests/Unit/Evolution/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Actions)
+add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Systems)
 
 set(SPECTRE_TESTS "${SPECTRE_TESTS};${EVOLUTION_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(EVOLUTION_DG_TESTS
+  Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+  )
+
+set(SPECTRE_TESTS "${SPECTRE_TESTS};${EVOLUTION_DG_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -1,0 +1,201 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+#include <deque>
+#include <memory>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/DomainCreators/Brick.hpp"
+#include "Domain/DomainCreators/Interval.hpp"
+#include "Domain/DomainCreators/Rectangle.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Time/TimeSteppers/AdamsBashforthN.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+struct Var : db::DataBoxTag {
+  using type = Scalar<DataVector>;
+  static constexpr db::DataBoxString label = "Var";
+};
+
+struct SystemAnalyticSolution {
+  template <size_t Dim>
+  Variables<tmpl::list<Var>> evolution_variables(
+      const tnsr::I<DataVector, Dim>& x, double t) const noexcept {
+    Variables<tmpl::list<Var>> variables(x.begin()->size());
+    get(get<Var>(variables)) = x.get(0) + t;
+    for (size_t d = 1; d < Dim; ++d) {
+      get(get<Var>(variables)) += x.get(d) + t;
+    }
+    return variables;
+  }
+
+  template <size_t Dim>
+  Variables<tmpl::list<Tags::dt<Var>>> dt_evolution_variables(
+      const tnsr::I<DataVector, Dim>& x, double t) const noexcept {
+    Variables<tmpl::list<Tags::dt<Var>>> variables(x.begin()->size());
+    get(get<Tags::dt<Var>>(variables)) = 2.0 * x.get(0) + t;
+    for (size_t d = 1; d < Dim; ++d) {
+      get(get<Tags::dt<Var>>(variables)) += 2.0 * x.get(d) + t;
+    }
+    return variables;
+  }
+};
+
+struct System {
+  using variables_tag = Tags::Variables<tmpl::list<Var>>;
+  using gradients_tags = tmpl::list<Var>;
+};
+
+template <size_t Dim>
+struct Metavariables;
+
+template <size_t Dim>
+using component = ActionTesting::MockArrayComponent<
+    Metavariables<Dim>, ElementIndex<Dim>,
+    tmpl::list<CacheTags::TimeStepper,
+               CacheTags::AnalyticSolution<SystemAnalyticSolution>>,
+    tmpl::list<dg::Actions::InitializeElement<Dim>>>;
+
+template <size_t Dim>
+struct Metavariables {
+  using component_list = tmpl::list<component<Dim>>;
+  using system = System;
+};
+
+template <size_t Dim, typename DomainCreatorType>
+void test_initialize_element(const ElementId<Dim>& element_id,
+                             const DomainCreatorType& domain_creator) {
+  ActionTesting::ActionRunner<Metavariables<Dim>> runner{
+      {std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
+       SystemAnalyticSolution{}}};
+
+  const Slab slab = Slab::with_duration_from_start(0.3, 0.01);
+
+  const auto domain = domain_creator.create_domain();
+
+  db::DataBox<tmpl::list<>> empty_box{};
+  auto box = std::get<0>(
+      runner
+          .template apply<component<Dim>, dg::Actions::InitializeElement<Dim>>(
+              empty_box, element_id, domain_creator.initial_extents(),
+              domain_creator.create_domain(), slab.start(), slab.duration()));
+  CHECK(db::get<Tags::TimeId>(box) == [&slab]() {
+    TimeId time_id{};
+    time_id.time = slab.start();
+    return time_id;
+  }());
+  CHECK(db::get<Tags::Time>(box) == slab.start());
+  CHECK(db::get<Tags::TimeStep>(box) == slab.duration());
+
+  const auto& my_block = domain.blocks()[element_id.block_id()];
+  ElementMap<Dim, Frame::Inertial> map{element_id,
+                                       my_block.coordinate_map().get_clone()};
+  Element<Dim> element = create_initial_element(element_id, my_block);
+  Index<Dim> extents{domain_creator.initial_extents()[element_id.block_id()]};
+  const auto num_grid_points = extents.product();
+  auto logical_coords = logical_coordinates(extents);
+  auto inertial_coords = map(logical_coords);
+  CHECK(db::get<Tags::LogicalCoordinates<Dim>>(box) == logical_coords);
+  CHECK(db::get<Tags::Extents<Dim>>(box) == extents);
+  CHECK(db::get<Tags::Element<Dim>>(box) == element);
+  // Can't test ElementMap directly, only via inverse jacobian and grid
+  // coordinates. We can check that we can retrieve it.
+  (void)db::get<Tags::ElementMap<Dim>>(box);
+  CHECK(db::get<Var>(box) == ([&inertial_coords, &slab]() {
+          double time = slab.start().value();
+          Scalar<DataVector> var{inertial_coords.get(0) + time};
+          for (size_t d = 1; d < Dim; ++d) {
+            get(var) += inertial_coords.get(d) + time;
+          }
+          return var;
+        }()));
+  CHECK(
+      (db::get<Tags::HistoryEvolvedVariables<
+           typename System::variables_tag,
+           db::add_tag_prefix<Tags::dt, typename System::variables_tag>>>(
+          box)) == ([&slab, &inertial_coords]() {
+        std::deque<std::tuple<::Time, Variables<tmpl::list<Var>>,
+                              Variables<tmpl::list<Tags::dt<Var>>>>>
+            history{};
+        TimeSteppers::AdamsBashforthN stepper(4, false);
+        SystemAnalyticSolution solution{};
+
+        Time past_t{slab.start()};
+        TimeDelta past_dt{slab.duration()};
+        for (size_t i = stepper.number_of_past_steps(); i > 0; --i) {
+          past_dt = past_dt.with_slab(past_dt.slab().advance_towards(-past_dt));
+          past_t -= past_dt;
+
+          history.emplace_front(
+              past_t,
+              solution.evolution_variables(inertial_coords, past_t.value()),
+              solution.dt_evolution_variables(inertial_coords, past_t.value()));
+        }
+        return history;
+      }()));
+  CHECK((db::get<Tags::Coordinates<Tags::ElementMap<Dim>,
+                                   Tags::LogicalCoordinates<Dim>>>(box)) ==
+        inertial_coords);
+  CHECK((db::get<Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                                       Tags::LogicalCoordinates<Dim>>>(box)) ==
+        map.inv_jacobian(logical_coords));
+  CHECK((db::get<
+            Tags::deriv<typename System::variables_tag::tags_list,
+                        typename System::gradients_tags,
+                        Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                                              Tags::LogicalCoordinates<Dim>>>>(
+            box)) ==
+        partial_derivatives<tmpl::list<Var>>(
+            SystemAnalyticSolution{}.evolution_variables(inertial_coords, 0.),
+            extents, map.inv_jacobian(logical_coords)));
+  CHECK((db::get<db::add_tag_prefix<Tags::dt, typename System::variables_tag>>(
+            box)) ==
+        Variables<tmpl::list<Tags::dt<Var>>>(extents.product(), 0.0));
+  CHECK(db::get<Tags::UnnormalizedFaceNormal<Dim>>(box) ==
+        Tags::UnnormalizedFaceNormal<Dim>::function(extents, map));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.dG.InitializeElement",
+                  "[Unit][Evolution][Actions]") {
+  test_initialize_element(ElementId<1>{0, {{SegmentId{2, 1}}}},
+                          DomainCreators::Interval<Frame::Inertial>{
+                              {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}});
+
+  test_initialize_element(
+      ElementId<2>{0, {{SegmentId{2, 1}, SegmentId{3, 2}}}},
+      DomainCreators::Rectangle<Frame::Inertial>{
+          {{-0.5, -0.75}}, {{1.5, 2.4}}, {{false, false}}, {{2, 3}}, {{4, 5}}});
+
+  test_initialize_element(
+      ElementId<3>{0, {{SegmentId{2, 1}, SegmentId{3, 2}, SegmentId{1, 0}}}},
+      DomainCreators::Brick<Frame::Inertial>{{{-0.5, -0.75, -1.2}},
+                                             {{1.5, 2.4, 1.2}},
+                                             {{false, false, true}},
+                                             {{2, 3, 1}},
+                                             {{4, 5, 3}}});
+}
+
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -2,7 +2,8 @@
 # See LICENSE.txt for details.
 
 set(SPECTRE_UNIT_ACTIONS
-    NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+  NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+  NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
    )
 
 set(SPECTRE_UNIT_DISCONTINUOUS_GALERKIN

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -40,7 +40,7 @@ struct System {
 
   struct compute_flux {
     static auto apply(const Variables<tmpl::list<Var>>& value) noexcept {
-      using flux_tag = Tags::Flux<Var, tmpl::size_t<2>, Frame::Grid>;
+      using flux_tag = Tags::Flux<Var, tmpl::size_t<2>, Frame::Inertial>;
       Variables<tmpl::list<flux_tag>> result(value.number_of_grid_points());
       get<0>(get<flux_tag>(result)) = 10. * value;
       get<1>(get<flux_tag>(result)) = 20. * value;
@@ -121,9 +121,9 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
         {Direction<2>::upper_xi(), {{east_id}, {}}},
         {Direction<2>::upper_eta(), {{south_id}, {}}}});
 
-    auto map = ElementMap<2, Frame::Grid>(
+    auto map = ElementMap<2, Frame::Inertial>(
         ElementId<2>{0},
-        make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
                                            CoordinateMaps::AffineMap>(
                 xi_map, eta_map)));
@@ -291,8 +291,8 @@ SPECTRE_TEST_CASE(
 
   const Element<2> element(self_id, {});
 
-  auto map = ElementMap<2, Frame::Grid>(
-      self_id, make_coordinate_map_base<Frame::Logical, Frame::Grid>(
+  auto map = ElementMap<2, Frame::Inertial>(
+      self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
                    CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
                                                   CoordinateMaps::AffineMap>(
                        {-1., 1., 3., 7.}, {-1., 1., -2., 4.})));

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
@@ -1,0 +1,379 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+#include <memory>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/AffineMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication2.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+constexpr size_t volume_dim = 2;
+
+struct Var : db::DataBoxTag {
+  static constexpr db::DataBoxString label = "Var";
+  using type = Scalar<DataVector>;
+};
+
+struct System {
+  static constexpr const size_t volume_dim = ::volume_dim;
+  using variables_tag = Tags::Variables<tmpl::list<Var>>;
+  using dt_variables_tag = Tags::dt<Tags::Variables<tmpl::list<Tags::dt<Var>>>>;
+  static constexpr const size_t number_of_independent_components =
+      db::item_type<variables_tag>::number_of_independent_components;
+
+  struct normal_dot_fluxes {
+    using return_tags = tmpl::list<Tags::NormalDotFlux<Var>>;
+    using argument_tags = tmpl::list<Var>;
+    static void apply(
+        const gsl::not_null<Scalar<DataVector>*> var_normal_dot_flux,
+        const Scalar<DataVector>& var,
+        const tnsr::i<DataVector, volume_dim, Frame::Inertial>&
+        /*interface_unit_normal*/) noexcept {
+      var_normal_dot_flux->get() = 0.25 * var.get();
+    }
+  };
+};
+
+class NumericalFlux {
+ public:
+  using flux_tag =
+      db::add_tag_prefix<Tags::NormalDotFlux, System::variables_tag>;
+  using argument_tags = tmpl::list<flux_tag>;
+  using package_tags = tmpl::list<Var>;
+  using slice_tags = tmpl::list<Var>;
+
+  void package_data(const gsl::not_null<Variables<package_tags>*> packaged_var,
+                    const Scalar<DataVector>& var_flux,
+                    const Scalar<DataVector>& var,
+                    const tnsr::i<DataVector, 2, Frame::Inertial>&
+                    /*interface_unit_normal*/) const noexcept {
+    get<Var>(*packaged_var).get() = 0.5 * var.get() + var_flux.get();
+  }
+
+  void operator()(
+      const gsl::not_null<Scalar<DataVector>*> normal_dot_numerical_flux,
+      const Scalar<DataVector>& packaged_var_interior,
+      const Scalar<DataVector>& packaged_var_exterior) const noexcept {
+    normal_dot_numerical_flux->get() = 11.0 * packaged_var_interior.get() +
+                                       1000. * packaged_var_exterior.get();
+  }
+};
+
+struct NumericalFluxTag {
+  using type = NumericalFlux;
+};
+
+struct Metavariables;
+
+using CharmIndexType = ElementIndex<volume_dim>;
+
+using component = ActionTesting::MockArrayComponent<
+    Metavariables, CharmIndexType, tmpl::list<NumericalFluxTag>,
+    tmpl::list<dg::Actions::ComputeBoundaryFlux<Metavariables>>>;
+
+struct Metavariables {
+  using system = System;
+  using component_list = tmpl::list<component>;
+  using normal_dot_numerical_flux = NumericalFluxTag;
+};
+
+using fluxes_tag = dg::Actions::ComputeBoundaryFlux<Metavariables>::FluxesTag;
+using mortars_normal_dot_fluxes_tag =
+    dg::Actions::DgActions_detail::mortars_tag<
+        2, db::add_tag_prefix<Tags::NormalDotFlux,
+                              typename System::variables_tag>>;
+using mortars_packaged_data_tag = dg::Actions::DgActions_detail::mortars_tag<
+    2,
+    Tags::Variables<
+        typename Metavariables::normal_dot_numerical_flux::type::package_tags>>;
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication2",
+                  "[Unit][NumericalAlgorithms][Actions]") {
+  ActionTesting::ActionRunner<Metavariables> runner{{}};
+
+  const Slab slab(1., 3.);
+  const TimeId time_id{8, slab.start(), 0};
+
+  const Index<2> extents{{{3, 3}}};
+
+  //      xi  Block   +- xi
+  //      |   0   1   |
+  // eta -+ +---+-+-+ eta
+  //        |   |X| |
+  //        |   +-+-+
+  //        |   | | |
+  //        +---+-+-+
+  // We run the send action on the indicated element.
+  const ElementId<2> self_id(1, {{{1, 0}, {1, 0}}});
+  const ElementId<2> west_id(0);
+  const ElementId<2> east_id(1, {{{1, 1}, {1, 0}}});
+  const ElementId<2> south_id(1, {{{1, 0}, {1, 1}}});
+
+  // OrientationMap from block 1 to block 0
+  const OrientationMap<2> block_orientation(
+      {{Direction<2>::upper_xi(), Direction<2>::upper_eta()}},
+      {{Direction<2>::lower_eta(), Direction<2>::lower_xi()}});
+
+  const CoordinateMaps::AffineMap xi_map{-1., 1., 3., 7.};
+  const CoordinateMaps::AffineMap eta_map{-1., 1., -2., 4.};
+
+  auto start_box = [&extents, &time_id, &self_id, &west_id, &east_id, &south_id,
+                    &block_orientation, &xi_map, &eta_map]() {
+    const Element<2> element(
+        self_id, {{Direction<2>::lower_xi(), {{west_id}, block_orientation}},
+                  {Direction<2>::upper_xi(), {{east_id}, {}}},
+                  {Direction<2>::upper_eta(), {{south_id}, {}}}});
+
+    auto map = ElementMap<2, Frame::Inertial>(
+        self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
+                                                    CoordinateMaps::AffineMap>(
+                         xi_map, eta_map)));
+
+    Variables<tmpl::list<Var>> variables(extents.product());
+    get<Var>(variables).get() = DataVector{1., 2., 3., 4., 5., 6., 7., 8., 9.};
+    db::item_type<db::add_tag_prefix<Tags::dt, System::variables_tag>>
+        dt_variables(extents.product(), 0.0);
+
+    return db::create<
+        db::AddTags<Tags::TimeId, Tags::Extents<2>, Tags::Element<2>,
+                    Tags::ElementMap<2>, System::variables_tag,
+                    db::add_tag_prefix<Tags::dt, System::variables_tag>>,
+        db::AddComputeItemsTags<Tags::UnnormalizedFaceNormal<2>>>(
+        time_id, extents, element, std::move(map), std::move(variables),
+        std::move(dt_variables));
+  }();
+
+  auto sent_box =
+      std::get<0>(runner.apply<component, dg::Actions::SendDataForFluxes>(
+          start_box, CharmIndexType(self_id)));
+
+  // Check local state
+  auto local_mortar_fluxes = db::get<mortars_normal_dot_fluxes_tag>(sent_box);
+  auto local_mortar_packaged_data =
+      db::get<mortars_packaged_data_tag>(sent_box);
+  CHECK(local_mortar_fluxes.size() == 3);
+  CHECK(get<Tags::NormalDotFlux<Var>>(local_mortar_fluxes[std::make_pair(
+                                          Direction<2>::lower_xi(), west_id)])
+            .get() == (DataVector{0.25, 1., 1.75}));
+  CHECK(get<Tags::NormalDotFlux<Var>>(local_mortar_fluxes[std::make_pair(
+                                          Direction<2>::upper_xi(), east_id)])
+            .get() == (DataVector{0.75, 1.5, 2.25}));
+  CHECK(get<Tags::NormalDotFlux<Var>>(local_mortar_fluxes[std::make_pair(
+                                          Direction<2>::upper_eta(), south_id)])
+            .get() == (DataVector{1.75, 2., 2.25}));
+
+  CHECK(local_mortar_packaged_data.size() == 3);
+  CHECK(get<Var>(local_mortar_packaged_data[std::make_pair(
+                     Direction<2>::lower_xi(), west_id)])
+            .get() == (DataVector{0.75, 3., 5.25}));
+  CHECK(get<Var>(local_mortar_packaged_data[std::make_pair(
+                     Direction<2>::upper_xi(), east_id)])
+            .get() == (DataVector{2.25, 4.5, 6.75}));
+  CHECK(get<Var>(local_mortar_packaged_data[std::make_pair(
+                     Direction<2>::upper_eta(), south_id)])
+            .get() == (DataVector{5.25, 6., 6.75}));
+
+  // Check sent data
+  CHECK((runner.nonempty_inboxes<component, fluxes_tag>()) ==
+        (std::unordered_set<CharmIndexType>{CharmIndexType(west_id),
+                                            CharmIndexType(east_id),
+                                            CharmIndexType(south_id)}));
+  auto& inboxes = runner.inboxes<component>();
+  const auto flux_inbox =
+      [&inboxes, &time_id ](const ElementId<2>& id) noexcept {
+    return tuples::get<fluxes_tag>(inboxes[CharmIndexType(id)])[time_id];
+  };
+  CHECK(flux_inbox(west_id).size() == 1);
+  CHECK(get<Var>(flux_inbox(west_id).at({Direction<2>::lower_eta(), self_id}))
+            .get() == (DataVector{5.25, 3., 0.75}));
+  CHECK(flux_inbox(east_id).size() == 1);
+  CHECK(get<Var>(flux_inbox(east_id).at({Direction<2>::lower_xi(), self_id}))
+            .get() == (DataVector{2.25, 4.5, 6.75}));
+  CHECK(flux_inbox(south_id).size() == 1);
+  CHECK(get<Var>(flux_inbox(south_id).at({Direction<2>::lower_eta(), self_id}))
+            .get() == (DataVector{5.25, 6., 6.75}));
+
+  // Now check ComputeBoundaryFlux
+  db::mutate<Tags::Element<2>>(sent_box, [](auto& element) {
+    auto neighbors = element.neighbors();
+    neighbors.erase(Direction<2>::lower_xi());
+    element = Element<2>(element.id(), std::move(neighbors));
+  });
+
+  CHECK_FALSE((runner.is_ready<component,
+                               dg::Actions::ComputeBoundaryFlux<Metavariables>>(
+      sent_box, CharmIndexType(self_id))));
+
+  // Send from south neighbor
+  {
+    const Element<2> element(south_id,
+                             {{Direction<2>::lower_eta(), {{self_id}, {}}}});
+
+    Variables<tmpl::list<Var>> variables(extents.product());
+    get<Var>(variables).get() =
+        DataVector{11., 12., 13., 14., 15., 16., 17., 18., 19.};
+
+    auto map = ElementMap<2, Frame::Inertial>(
+        south_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+                      CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
+                                                     CoordinateMaps::AffineMap>(
+                          xi_map, eta_map)));
+
+    auto box =
+        db::create<db::AddTags<Tags::TimeId, Tags::Extents<2>, Tags::Element<2>,
+                               System::variables_tag, Tags::ElementMap<2>>,
+                   db::AddComputeItemsTags<Tags::UnnormalizedFaceNormal<2>>>(
+            time_id, extents, element, std::move(variables), std::move(map));
+    runner.apply<component, dg::Actions::SendDataForFluxes>(
+        box, CharmIndexType(south_id));
+  }
+  CHECK_FALSE((runner.is_ready<component,
+                               dg::Actions::ComputeBoundaryFlux<Metavariables>>(
+      sent_box, CharmIndexType(self_id))));
+
+  // Send from east neighbor
+  {
+    const Element<2> element(east_id,
+                             {{Direction<2>::lower_xi(), {{self_id}, {}}}});
+
+    Variables<tmpl::list<Var>> variables(extents.product());
+    get<Var>(variables).get() =
+        DataVector{21., 22., 23., 24., 25., 26., 27., 28., 29.};
+
+    auto map = ElementMap<2, Frame::Inertial>(
+        east_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
+                                                    CoordinateMaps::AffineMap>(
+                         xi_map, eta_map)));
+
+    auto box =
+        db::create<db::AddTags<Tags::TimeId, Tags::Extents<2>, Tags::Element<2>,
+                               System::variables_tag, Tags::ElementMap<2>>,
+                   db::AddComputeItemsTags<Tags::UnnormalizedFaceNormal<2>>>(
+            time_id, extents, element, std::move(variables), std::move(map));
+    runner.apply<component, dg::Actions::SendDataForFluxes>(
+        box, CharmIndexType(east_id));
+  }
+  CHECK((runner.is_ready<component,
+                         dg::Actions::ComputeBoundaryFlux<Metavariables>>(
+      sent_box, CharmIndexType(self_id))));
+
+  auto received_box = std::get<0>(
+      runner.apply<component, dg::Actions::ComputeBoundaryFlux<Metavariables>>(
+          sent_box, CharmIndexType(self_id)));
+
+  CHECK(tuples::get<fluxes_tag>(
+            runner.inboxes<component>().at(CharmIndexType(self_id)))
+            .empty());
+
+  const double xi_lift = -12. / (xi_map(std::array<double, 1>{{1.}}) -
+                                 xi_map(std::array<double, 1>{{-1.}}))[0];
+  const double eta_lift = -12. / (eta_map(std::array<double, 1>{{1.}}) -
+                                  eta_map(std::array<double, 1>{{-1.}}))[0];
+
+  const DataVector xi_boundaries{
+      0.,
+      0.,
+      15774. / magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+                   Direction<2>::lower_xi()))[0],
+      0.,
+      0.,
+      18048. / magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+                   Direction<2>::lower_xi()))[1],
+      0.,
+      0.,
+      20322. / magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+                   Direction<2>::lower_xi()))[2]};
+  const DataVector eta_boundaries{
+      0.,
+      0.,
+      0.,
+      0.,
+      0.,
+      0.,
+      16612. / 3. /
+          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::upper_eta()))[0],
+      18128. / 3. /
+          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::upper_eta()))[1],
+      19644. / 3. /
+          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::upper_eta()))[2]};
+
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<Var>>(db::get<System::dt_variables_tag>(received_box)).get(),
+      xi_lift * xi_boundaries + eta_lift * eta_boundaries);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.DiscontinuousGalerkin.Actions.FluxCommunication2.NoNeighbors",
+    "[Unit][NumericalAlgorithms][Actions]") {
+  ActionTesting::ActionRunner<Metavariables> runner{{}};
+
+  const Slab slab(1., 3.);
+  const TimeId time_id{8, slab.start(), 0};
+
+  const Index<2> extents{{{3, 3}}};
+
+  const ElementId<2> self_id(1, {{{1, 0}, {1, 0}}});
+
+  const Element<2> element(self_id, {});
+
+  auto map = ElementMap<2, Frame::Inertial>(
+      self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+                   CoordinateMaps::ProductOf2Maps<CoordinateMaps::AffineMap,
+                                                  CoordinateMaps::AffineMap>(
+                       {-1., 1., 3., 7.}, {-1., 1., -2., 4.})));
+
+  Variables<tmpl::list<Var>> variables(extents.product());
+  get<Var>(variables).get() = DataVector{1., 2., 3., 4., 5., 6., 7., 8., 9.};
+  db::item_type<db::add_tag_prefix<Tags::dt, System::variables_tag>>
+      dt_variables(extents.product(), 0.0);
+  auto start_box = db::create<
+      db::AddTags<Tags::TimeId, Tags::Extents<2>, Tags::Element<2>,
+                  Tags::ElementMap<2>, System::variables_tag,
+                  db::add_tag_prefix<Tags::dt, System::variables_tag>>,
+      db::AddComputeItemsTags<Tags::UnnormalizedFaceNormal<2>>>(
+      time_id, extents, element, std::move(map), std::move(variables),
+      std::move(dt_variables));
+
+  auto sent_box =
+      std::get<0>(runner.apply<component, dg::Actions::SendDataForFluxes>(
+          start_box, CharmIndexType(self_id)));
+
+  CHECK(db::get<mortars_packaged_data_tag>(sent_box).empty());
+  CHECK((runner.nonempty_inboxes<component, fluxes_tag>().empty()));
+
+  CHECK((runner.is_ready<component,
+                         dg::Actions::ComputeBoundaryFlux<Metavariables>>(
+      sent_box, CharmIndexType(self_id))));
+
+  auto received_box = std::get<0>(
+      runner.apply<component, dg::Actions::ComputeBoundaryFlux<Metavariables>>(
+          sent_box, CharmIndexType(self_id)));
+
+  CHECK(get<Tags::dt<Var>>(db::get<System::dt_variables_tag>(received_box))
+            .get() == (DataVector{0., 0., 0., 0., 0., 0., 0., 0., 0.}));
+}

--- a/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
@@ -73,7 +73,9 @@ class Square : public Shape {
 };
 #pragma GCC diagnostic pop
 
-struct shape_of_nametag {
+struct shape_of_nametag_base {};
+
+struct shape_of_nametag : shape_of_nametag_base {
   using type = std::unique_ptr<Shape>;
 };
 
@@ -149,6 +151,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
     CHECK(178 == Parallel::get<age>(cache));
     CHECK(2.2 == Parallel::get<height>(cache));
     CHECK(4 == Parallel::get<shape_of_nametag>(cache).number_of_sides());
+    CHECK(4 == Parallel::get<shape_of_nametag_base>(cache).number_of_sides());
   }
 
   {
@@ -171,6 +174,8 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
     CHECK(178 == Parallel::get<age>(local_cache));
     CHECK(2.2 == Parallel::get<height>(local_cache));
     CHECK(4 == Parallel::get<shape_of_nametag>(local_cache).number_of_sides());
+    CHECK(4 ==
+          Parallel::get<shape_of_nametag_base>(local_cache).number_of_sides());
   }
 }
 


### PR DESCRIPTION
## Proposed changes

This is on top of #491 
- The only new commit in this is "Add new flux communication Actions", which does as it says. This currently only works for hyperbolic (non-conservative) systems but will be pretty straight forward to generalize and merge the code from the current flux communication actions that does the slicing of the volume fluxes for conservative systems.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
