### PR TITLE
Add code to compute Ricci tensor

### DIFF
--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -334,6 +334,41 @@ using ijaa = Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
                                SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
                                SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>,
                                SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
+
+// Rank 4 - generic (default spacetime)
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
+          IndexType Index = IndexType::Spacetime>
+using abcc = Tensor<
+    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
+    index_list<
+        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
+          IndexType Index = IndexType::Spacetime>
+using aBcc = Tensor<
+    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
+    index_list<
+        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+
+// Rank 4 - spatial
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using ijkk = Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
+                    index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using iJkk = Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
+                    index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Up, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                               SpatialIndex<SpatialDim, UpLo::Lo, Fr>>>;
+
 }  // namespace tnsr
 
 template <size_t Dim, typename SourceFrame, typename TargetFrame>

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
     ComputeGhQuantities.cpp
     ComputeSpacetimeQuantities.cpp
     IndexManipulation.cpp
+    Ricci.cpp
     )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.cpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/MakeWithValue.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace gr {
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
+    const tnsr::Abb<DataType, SpatialDim, Frame, Index>& christoffel_2nd_kind,
+    const tnsr::aBcc<DataType, SpatialDim, Frame, Index>&
+        d_christoffel_2nd_kind) noexcept {
+  auto ricci = make_with_value<tnsr::aa<DataType, SpatialDim, Frame, Index>>(
+      christoffel_2nd_kind, 0.);
+  constexpr auto dimensionality = index_dim<0>(ricci);
+  for (size_t i = 0; i < dimensionality; ++i) {
+    for (size_t j = i; j < dimensionality; ++j) {
+      for (size_t m = 0; m < dimensionality; ++m) {
+        ricci.get(i, j) += d_christoffel_2nd_kind.get(m, m, i, j) -
+                           0.5 * (d_christoffel_2nd_kind.get(i, m, m, j) +
+                                  d_christoffel_2nd_kind.get(j, m, m, i));
+
+        for (size_t n = 0; n < dimensionality; ++n) {
+          ricci.get(i, j) += christoffel_2nd_kind.get(m, i, j) *
+                                 christoffel_2nd_kind.get(n, n, m) -
+                             christoffel_2nd_kind.get(m, i, n) *
+                                 christoffel_2nd_kind.get(n, m, j);
+        }
+      }
+    }
+  }
+  return ricci;
+}
+} // namespace gr
+
+// Explicit Instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define INDEXTYPE(data) BOOST_PP_TUPLE_ELEM(3, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>     \
+  gr::ricci_tensor(                                                           \
+      const tnsr::Abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>&  \
+          christoffel_2nd_kind,                                               \
+      const tnsr::aBcc<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>& \
+          d_christoffel_2nd_kind) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial),
+                        (IndexType::Spatial, IndexType::Spacetime))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INDEXTYPE
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Ricci.hpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+///\file
+/// Declares function templates to calculate the Ricci tensor
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+namespace gr {
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes Ricci tensor from the (spatial or spacetime)
+ * Christoffel symbol of the second kind and its derivative.
+ *
+ * \details Computes Ricci tensor \f$R_{ab}\f$ as:
+ * \f$ R_{ab} = \frac{1}{2} ( \partial_c \Gamma^{c}_{ab} - \partial_{(b}
+ * \Gamma^{c}_{a)c}
+ * + \Gamma^{d}_{ab}\Gamma^{c}_{cd} - \Gamma^{d}_{ac} \Gamma^{c}_{bd}  ) \f$
+ * where \f$\Gamma^{a}_{bc}\f$ is the Christoffel symbol of the second kind.
+ */
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+tnsr::aa<DataType, SpatialDim, Frame, Index> ricci_tensor(
+    const tnsr::Abb<DataType, SpatialDim, Frame, Index>& christoffel_2nd_kind,
+    const tnsr::aBcc<DataType, SpatialDim, Frame, Index>&
+        d_christoffel_2nd_kind) noexcept;
+
+} // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SPECTRE_UNIT_GENERAL_RELATIVITY
     PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
     PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
     PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
+    PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
     )
 
 set(SPECTRE_UNIT_POINTWISE_FUNCTIONS

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.cpp
@@ -229,6 +229,43 @@ tnsr::Ijj<DataType, SpatialDim> make_spatial_christoffel_second_kind(
 }
 
 template <size_t SpatialDim, typename DataType>
+tnsr::aBcc<DataType, SpatialDim> make_deriv_spacetime_christoffel_second_kind(
+    const DataType& used_for_size) {
+  auto deriv_christoffel =
+      make_with_value<tnsr::aBcc<DataType, SpatialDim>>(used_for_size, 0.);
+  for (size_t i = 0; i < SpatialDim + 1; i++) {
+    for (size_t j = i; j < SpatialDim + 1; j++) {
+      for (size_t k = 0; k < SpatialDim + 1; k++) {
+        for (size_t l = 0; l < SpatialDim + 1; ++l) {
+          deriv_christoffel.get(k, l, i, j) = make_with_value<DataType>(
+              used_for_size, (i + 2.) * (j + 1.) * (k + 2.) * (l + 4.));
+        }
+      }
+    }
+  }
+  return deriv_christoffel;
+}
+
+template <size_t SpatialDim, typename DataType>
+tnsr::iJkk<DataType, SpatialDim> make_deriv_spatial_christoffel_second_kind(
+    const DataType& used_for_size){
+  auto deriv_christoffel =
+      make_with_value<tnsr::iJkk<DataType, SpatialDim>>(used_for_size, 0.);
+  for (size_t i = 0; i < SpatialDim; i++) {
+    for (size_t j = i; j < SpatialDim; j++) {
+      for (size_t k = 0; k < SpatialDim; k++) {
+        for (size_t l = 0; l < SpatialDim; ++l) {
+          deriv_christoffel.get(k, l, i, j) = make_with_value<DataType>(
+              used_for_size, 4. * (i + 1.) * (j + 1.) - k * (l + 4.));
+        }
+      }
+    }
+  }
+  return deriv_christoffel;
+}
+
+
+template <size_t SpatialDim, typename DataType>
 tnsr::aa<DataType, SpatialDim> make_spacetime_metric(
     const DataType& used_for_size) {
   auto spacetime_metric =
@@ -322,6 +359,12 @@ tnsr::I<DataType, SpatialDim> make_trace_spatial_christoffel_second_kind(
   make_spacetime_christoffel_second_kind(const DTYPE(data) & used_for_size); \
   template tnsr::Ijj<DTYPE(data), DIM(data)>                                 \
   make_spatial_christoffel_second_kind(const DTYPE(data) & used_for_size);   \
+  template tnsr::iJkk<DTYPE(data), DIM(data)>                                \
+  make_deriv_spatial_christoffel_second_kind(                                \
+      const DTYPE(data) & used_for_size);                                    \
+  template tnsr::aBcc<DTYPE(data), DIM(data)>                                \
+  make_deriv_spacetime_christoffel_second_kind(                              \
+      const DTYPE(data) & used_for_size);                                    \
   template tnsr::aa<DTYPE(data), DIM(data)> make_spacetime_metric(           \
       const DTYPE(data) & used_for_size);                                    \
   template tnsr::AA<DTYPE(data), DIM(data)> make_inverse_spacetime_metric(   \

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
@@ -89,6 +89,10 @@ tnsr::Ijj<DataType, SpatialDim> make_spatial_christoffel_second_kind(
     const DataType& used_for_size);
 
 template <size_t SpatialDim, typename DataType>
+tnsr::iJkk<DataType, SpatialDim> make_deriv_spatial_christoffel_second_kind(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
 tnsr::abb<DataType, SpatialDim> make_spacetime_deriv_spacetime_metric(
     const DataType& used_for_size);
 
@@ -102,6 +106,10 @@ tnsr::iaa<DataType, SpatialDim> make_spatial_deriv_spacetime_metric(
 
 template <size_t SpatialDim, typename DataType>
 tnsr::Abb<DataType, SpatialDim> make_spacetime_christoffel_second_kind(
+    const DataType& used_for_size);
+
+template <size_t SpatialDim, typename DataType>
+tnsr::aBcc<DataType, SpatialDim> make_deriv_spacetime_christoffel_second_kind(
     const DataType& used_for_size);
 
 template <size_t SpatialDim, typename DataType>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <limits>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+template <typename DataType>
+void test_1d_spatial_ricci(const DataType& used_for_size) {
+  constexpr size_t spatial_dim = 1;
+  const auto ricci = gr::ricci_tensor(
+      make_spatial_christoffel_second_kind<spatial_dim>(
+          used_for_size),
+      make_deriv_spatial_christoffel_second_kind<spatial_dim>(
+          used_for_size));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
+                        make_with_value<DataType>(used_for_size, 0.));
+}
+
+template <typename DataType>
+void test_2d_spatial_ricci(const DataType& used_for_size) {
+  constexpr size_t spatial_dim = 2;
+  const auto ricci = gr::ricci_tensor(
+      make_spatial_christoffel_second_kind<spatial_dim>(
+          used_for_size),
+      make_deriv_spatial_christoffel_second_kind<spatial_dim>(
+          used_for_size));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
+                        make_with_value<DataType>(used_for_size, -9.));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 1),
+                        make_with_value<DataType>(used_for_size, 5.5));
+  CHECK_ITERABLE_APPROX(ricci.get(1, 1),
+                        make_with_value<DataType>(used_for_size, 20.));
+}
+
+template <typename DataType>
+void test_3d_spatial_ricci(const DataType& used_for_size) {
+  constexpr size_t spatial_dim = 3;
+  const auto ricci = gr::ricci_tensor(
+      make_spatial_christoffel_second_kind<spatial_dim>(
+          used_for_size),
+      make_deriv_spatial_christoffel_second_kind<spatial_dim>(
+          used_for_size));
+
+  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
+                        make_with_value<DataType>(used_for_size, -65.));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 1),
+                        make_with_value<DataType>(used_for_size, 2.5));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 2),
+                        make_with_value<DataType>(used_for_size, 70.));
+  CHECK_ITERABLE_APPROX(ricci.get(1, 1),
+                        make_with_value<DataType>(used_for_size, 46.));
+  CHECK_ITERABLE_APPROX(ricci.get(1, 2),
+                        make_with_value<DataType>(used_for_size, 89.5));
+  CHECK_ITERABLE_APPROX(ricci.get(2, 2),
+                        make_with_value<DataType>(used_for_size, 109.));
+}
+
+template <typename DataType>
+void test_1d_spacetime_ricci(const DataType& used_for_size) {
+  constexpr size_t spatial_dim = 1;
+  const auto ricci = gr::ricci_tensor(
+      make_spacetime_christoffel_second_kind<spatial_dim>(
+          used_for_size),
+      make_deriv_spacetime_christoffel_second_kind<spatial_dim>(
+          used_for_size));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
+                        make_with_value<DataType>(used_for_size, -46.));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 1),
+                        make_with_value<DataType>(used_for_size, 28.));
+  CHECK_ITERABLE_APPROX(ricci.get(1, 1),
+                        make_with_value<DataType>(used_for_size, -16.));
+}
+
+template <typename DataType>
+void test_2d_spacetime_ricci(const DataType& used_for_size) {
+  constexpr size_t spatial_dim = 2;
+  const auto ricci = gr::ricci_tensor(
+      make_spacetime_christoffel_second_kind<spatial_dim>(
+          used_for_size),
+      make_deriv_spacetime_christoffel_second_kind<spatial_dim>(
+          used_for_size));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
+                        make_with_value<DataType>(used_for_size, -406.));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 1),
+                        make_with_value<DataType>(used_for_size, -32.));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 2),
+                        make_with_value<DataType>(used_for_size, 217.));
+  CHECK_ITERABLE_APPROX(ricci.get(1, 1),
+                        make_with_value<DataType>(used_for_size, -178.));
+  CHECK_ITERABLE_APPROX(ricci.get(1, 2),
+                        make_with_value<DataType>(used_for_size, 143.5));
+  CHECK_ITERABLE_APPROX(ricci.get(2, 2),
+                        make_with_value<DataType>(used_for_size, -201.));
+}
+
+template <typename DataType>
+void test_3d_spacetime_ricci(const DataType& used_for_size) {
+  constexpr size_t spatial_dim = 3;
+  const auto ricci = gr::ricci_tensor(
+      make_spacetime_christoffel_second_kind<spatial_dim>(
+          used_for_size),
+      make_deriv_spacetime_christoffel_second_kind<spatial_dim>(
+          used_for_size));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
+                        make_with_value<DataType>(used_for_size, -1928.));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 1),
+                        make_with_value<DataType>(used_for_size, -700.));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 2),
+                        make_with_value<DataType>(used_for_size, 283.));
+  CHECK_ITERABLE_APPROX(ricci.get(0, 3),
+                        make_with_value<DataType>(used_for_size, 940.));
+  CHECK_ITERABLE_APPROX(ricci.get(1, 1),
+                        make_with_value<DataType>(used_for_size, -1300.));
+  CHECK_ITERABLE_APPROX(ricci.get(1, 2),
+                        make_with_value<DataType>(used_for_size, 82.5));
+  CHECK_ITERABLE_APPROX(ricci.get(1, 3),
+                        make_with_value<DataType>(used_for_size, 968.));
+  CHECK_ITERABLE_APPROX(ricci.get(2, 2),
+                        make_with_value<DataType>(used_for_size, -629.));
+  CHECK_ITERABLE_APPROX(ricci.get(2, 3),
+                        make_with_value<DataType>(used_for_size, 335.5));
+  CHECK_ITERABLE_APPROX(ricci.get(3, 3),
+                        make_with_value<DataType>(used_for_size, -1176.));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Ricci.",
+                  "[PointwiseFunctions][Unit]") {
+  const double d(std::numeric_limits<double>::signaling_NaN());
+  test_1d_spatial_ricci(d);
+  test_2d_spatial_ricci(d);
+  test_3d_spatial_ricci(d);
+  test_1d_spacetime_ricci(d);
+  test_2d_spacetime_ricci(d);
+  test_3d_spacetime_ricci(d);
+
+  const DataVector dv(5);
+  test_1d_spatial_ricci(dv);
+  test_2d_spatial_ricci(dv);
+  test_3d_spatial_ricci(dv);
+  test_1d_spacetime_ricci(dv);
+  test_2d_spacetime_ricci(dv);
+  test_3d_spacetime_ricci(dv);
+}


### PR DESCRIPTION
## Proposed changes

This pull request adds code in PointwiseFunctions/GeneralRelativity to compute the Ricci scalar from Christoffel2ndKind and its derivative. 

Supporting this functionality, I also do the following:

  - Add necessary tensor aliases for derivatives of Christoffel2ndKind

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

I based my code for Ricci*pp on Christoffel*pp. Similarly, when I changed other files, I based my changes on prior functionality.