### PR TITLE
Add FunctionOfTime SettleToConstant

### DIFF
--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY ControlSystem)
 
 set(LIBRARY_SOURCES
     PiecewisePolynomial.cpp
+    SettleToConstant.cpp
    )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/ControlSystem/SettleToConstant.cpp
+++ b/src/ControlSystem/SettleToConstant.cpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/SettleToConstant.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/MakeArray.hpp"
+
+FunctionsOfTime::SettleToConstant::SettleToConstant(
+    const std::array<DataVector, 3>& initial_func_and_derivs,
+    const double match_time, const double decay_time) noexcept
+    : match_time_(match_time),
+      inv_decay_time_(1.0 / decay_time) {
+  // F = f(t0)
+  // the constants are then computed from F and its derivs:
+  // C = -dtF-dt2F*decay_time;
+  // B = (C-dtF)*decay_time;
+  // A = F-B;
+  coef_c_ =
+      -initial_func_and_derivs[1] - initial_func_and_derivs[2] * decay_time;
+  coef_b_ = (coef_c_ - initial_func_and_derivs[1]) * decay_time;
+  coef_a_ = initial_func_and_derivs[0] - coef_b_;
+}
+
+template <size_t MaxDerivReturned>
+std::array<DataVector, MaxDerivReturned + 1>
+FunctionsOfTime::SettleToConstant::func_and_derivs(const double t) const
+    noexcept {
+  static_assert(MaxDerivReturned < 3, "The maximum available derivative is 2.");
+
+  // initialize result for the number of derivs requested
+  std::array<DataVector, MaxDerivReturned + 1> result =
+      make_array<MaxDerivReturned + 1>(DataVector(coef_a_.size(), 0.0));
+
+  const double dt = t - match_time_;
+  const double ex = exp(-dt * inv_decay_time_);
+
+  gsl::at(result, 0) = coef_a_ + (coef_b_ + coef_c_ * dt) * ex;
+  if (MaxDerivReturned > 0) {
+    gsl::at(result, 1) = ex * (coef_c_ * (1.0 - dt * inv_decay_time_) -
+                               coef_b_ * inv_decay_time_);
+    if (MaxDerivReturned > 1) {
+      gsl::at(result, 2) =
+          ex * inv_decay_time_ *
+          (coef_c_ * (inv_decay_time_ * dt - 2.0) + inv_decay_time_ * coef_b_);
+    }
+  }
+
+  return result;
+}
+
+/// \cond
+template std::array<DataVector, 1>
+FunctionsOfTime::SettleToConstant::func_and_derivs<0>(const double) const
+    noexcept;
+template std::array<DataVector, 2>
+FunctionsOfTime::SettleToConstant::func_and_derivs<1>(const double) const
+    noexcept;
+template std::array<DataVector, 3>
+FunctionsOfTime::SettleToConstant::func_and_derivs<2>(const double) const
+    noexcept;
+/// \endcond

--- a/src/ControlSystem/SettleToConstant.hpp
+++ b/src/ControlSystem/SettleToConstant.hpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "ControlSystem/FunctionOfTime.hpp"
+#include "DataStructures/DataVector.hpp"
+
+namespace FunctionsOfTime {
+/// \ingroup ControlSystemGroup
+/// Given an initial function \f$f(t)\f$ and its first two derivatives
+/// at the matching time \f$t_0\f$, the constant coefficients \f$A,B,C\f$
+/// are computed such that the resulting function of time
+/// \f$g(t)\f$ satisfies \f$g(t=t_0)=f(t=t_0)\f$ and
+/// approaches a constant value for \f$t > t_0\f$ on a timescale
+/// of \f$\tau\f$. The resultant
+/// function is \f[ g(t) = A + (B+C(t-t_0)) e^{-(t-t_0)/\tau} \f]
+/// where \f$\tau\f$=`decay_time` and \f$t_0\f$=`match_time`.
+
+class SettleToConstant : public FunctionOfTime {
+ public:
+  SettleToConstant(const std::array<DataVector, 3>& initial_func_and_derivs,
+                   double match_time, double decay_time) noexcept;
+
+  ~SettleToConstant() override = default;
+  SettleToConstant(SettleToConstant&&) noexcept = default;
+  SettleToConstant& operator=(SettleToConstant&&) noexcept = default;
+  SettleToConstant(const SettleToConstant&) = delete;
+  SettleToConstant& operator=(const SettleToConstant&) = delete;
+
+  /// Returns the function at an arbitrary time `t`.
+  std::array<DataVector, 1> func(double t) const noexcept override {
+    return func_and_derivs<0>(t);
+  }
+  /// Returns the function and its first derivative at an arbitrary time `t`.
+  std::array<DataVector, 2> func_and_deriv(double t) const noexcept override {
+    return func_and_derivs<1>(t);
+  }
+  /// Returns the function and the first two derivatives at an arbitrary time
+  /// `t`.
+  std::array<DataVector, 3> func_and_2_derivs(double t) const
+      noexcept override {
+    return func_and_derivs<2>(t);
+  }
+
+  /// Returns the domain of validity of the function.
+  std::array<double, 2> time_bounds() const noexcept override {
+    return {{match_time_, std::numeric_limits<double>::max()}};
+  }
+
+ private:
+  template <size_t MaxDerivReturned = 2>
+  std::array<DataVector, MaxDerivReturned + 1> func_and_derivs(double t) const
+      noexcept;
+
+  DataVector coef_a_, coef_b_, coef_c_;
+  double match_time_;
+  double inv_decay_time_;
+};
+}  // namespace FunctionsOfTime

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(CONTROL_SYSTEM_TESTS
     ControlSystem/Test_PiecewisePolynomial.cpp
+    ControlSystem/Test_SettleToConstant.cpp
     )
 
 set(SPECTRE_TESTS "${SPECTRE_TESTS};${CONTROL_SYSTEM_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/ControlSystem/Test_SettleToConstant.cpp
+++ b/tests/Unit/ControlSystem/Test_SettleToConstant.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "ControlSystem/SettleToConstant.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.SettleToConstant",
+                  "[ControlSystem][Unit]") {
+  const double match_time = 10.0;
+  const double decay_time = 5.0;
+  // set init_func to f(t) = 5 + 2t + 3t^2
+  const double f_t0 = 5.0 + 2.0 * match_time + 3.0 * square(match_time);
+  const double dtf_t0 = 2.0 + 6.0 * match_time;
+  const double d2tf_t0 = 6.0;
+  // compute coefficients for check
+  const double C = -(decay_time * d2tf_t0 + dtf_t0);
+  const double B = decay_time * (C - dtf_t0);
+  const double A = f_t0 - B;
+  const std::array<DataVector, 3> init_func{{{f_t0}, {dtf_t0}, {d2tf_t0}}};
+  const FunctionsOfTime::SettleToConstant f_of_t_derived(init_func, match_time,
+                                                         decay_time);
+  const FunctionOfTime& f_of_t = f_of_t_derived;
+
+  // check that values agree at the matching time
+  const auto& lambdas0 = f_of_t.func_and_2_derivs(match_time);
+  CHECK(approx(lambdas0[0][0]) == f_t0);
+  CHECK(approx(lambdas0[1][0]) == dtf_t0);
+  CHECK(approx(lambdas0[2][0]) == d2tf_t0);
+
+  const auto& lambdas1 = f_of_t.func_and_deriv(match_time);
+  CHECK(approx(lambdas1[0][0]) == f_t0);
+  CHECK(approx(lambdas1[1][0]) == dtf_t0);
+
+  const auto& lambdas2 = f_of_t.func(match_time);
+  CHECK(approx(lambdas2[0][0]) == f_t0);
+
+  // check that asymptotic values approach f = A = const.
+  const auto& lambdas3 = f_of_t.func_and_2_derivs(1.0e5);
+  CHECK(approx(lambdas3[0][0]) == A);
+  CHECK(approx(lambdas3[1][0]) == 0.0);
+  CHECK(approx(lambdas3[2][0]) == 0.0);
+
+  const auto& lambdas4 = f_of_t.func_and_deriv(1.0e5);
+  CHECK(approx(lambdas4[0][0]) == A);
+  CHECK(approx(lambdas4[1][0]) == 0.0);
+
+  const auto& lambdas5 = f_of_t.func(1.0e5);
+  CHECK(approx(lambdas5[0][0]) == A);
+
+  // test time_bounds function
+  const auto& t_bounds = f_of_t.time_bounds();
+  CHECK(t_bounds[0] == 10.0);
+}


### PR DESCRIPTION
## Proposed changes

Add SettleToConstant, another FunctionOfTime.

### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
