### PR TITLE
Add HalfWedge functionality to Wedge3D

### DIFF
--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -174,6 +174,14 @@ namespace CoordinateMaps {
 class Wedge3D {
  public:
   static constexpr size_t dim = 3;
+  enum class WedgeHalves {
+    /// Use the entire wedge
+    Both,
+    /// Use only the upper logical half
+    UpperOnly,
+    /// Use only the lower logical half
+    LowerOnly
+  };
 
   /*!
    * Constructs a 3D wedge.
@@ -189,12 +197,17 @@ class Wedge3D {
    * whether the other surface is flat (value of 0), spherical (value of 1) or
    * somewhere in between
    * \param with_equiangular_map Determines whether to apply a tangent function
-   * mapping to the logical coordinates (for 'true') or not (for 'false').
+   * mapping to the logical coordinates (for `true`) or not (for `false`).
+   * \param halves_to_use Determines whether to use the logical xi
+   * coordinates in the [0,1] interval (value of `UpperOnly`) of the full wedge,
+   * the coordinates in the [-1,0] interval (value of `LowerOnly`) of the
+   * full wedge, or the full wedge entirely (value of `Both`). Half wedges are
+   * currently only useful in constructing domains for binary systems.
    */
   Wedge3D(double radius_of_other_surface, double radius_of_spherical_surface,
           OrientationMap<3> orientation_of_wedge,
-          double sphericity_of_other_surface,
-          bool with_equiangular_map) noexcept;
+          double sphericity_of_other_surface, bool with_equiangular_map,
+          WedgeHalves halves_to_use = WedgeHalves::Both) noexcept;
 
   Wedge3D() = default;
   ~Wedge3D() = default;
@@ -232,6 +245,7 @@ class Wedge3D {
   double sphericity_of_other_surface_{
       std::numeric_limits<double>::signaling_NaN()};
   bool with_equiangular_map_ = false;
+  WedgeHalves halves_to_use_ = WedgeHalves::Both;
 };
 bool operator!=(const Wedge3D& lhs, const Wedge3D& rhs) noexcept;
 }  // namespace CoordinateMaps

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -63,26 +63,31 @@ void test_wedge3d_all_directions(const bool with_equiangular_map) {
                                                           {{0.9, -1.0, 0.4}},
                                                           {{xi, eta, zeta}}}};
 
-  for (const auto& direction : all_wedge_directions()) {
-    const CoordinateMaps::Wedge3D map(inner_radius, outer_radius, direction,
-                                      sphericity, with_equiangular_map);
-    test_serialization(map);
-    CHECK_FALSE(map != map);
-    test_coordinate_map_argument_types(map, test_points[0]);
-    for (const auto& point : test_points) {
-      test_jacobian(map, point);
-      test_inv_jacobian(map, point);
-      test_inverse_map(map, point);
-    }
-    const auto map2 = serialize_and_deserialize(map);
-    for (const auto& point : test_points) {
-      test_jacobian(map2, point);
-      test_inv_jacobian(map2, point);
-      test_inverse_map(map2, point);
+  using WedgeHalves = CoordinateMaps::Wedge3D::WedgeHalves;
+  const std::array<WedgeHalves, 3> halves_array = {
+      {WedgeHalves::UpperOnly, WedgeHalves::LowerOnly, WedgeHalves::Both}};
+  for (const auto& halves : halves_array) {
+    for (const auto& direction : all_wedge_directions()) {
+      const CoordinateMaps::Wedge3D map(inner_radius, outer_radius, direction,
+                                        sphericity, with_equiangular_map,
+                                        halves);
+      test_serialization(map);
+      CHECK_FALSE(map != map);
+      test_coordinate_map_argument_types(map, test_points[0]);
+      for (const auto& point : test_points) {
+        test_jacobian(map, point);
+        test_inv_jacobian(map, point);
+        test_inverse_map(map, point);
+      }
+      const auto map2 = serialize_and_deserialize(map);
+      for (const auto& point : test_points) {
+        test_jacobian(map2, point);
+        test_inv_jacobian(map2, point);
+        test_inverse_map(map2, point);
+      }
     }
   }
 }
-
 void test_wedge3d_alignment(const bool with_equiangular_map) {
   // This test tests that the logical axes point along the expected directions
   // in physical space


### PR DESCRIPTION
## Proposed changes

Adds a constructor to Wedge3D allowing for the construction of half wedges.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
