### PR TITLE
Scalar wave executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -290,6 +290,7 @@ script:
              -D MACOSX_MIN=10.11
              ${TRAVIS_BUILD_DIR}
     && make -j2
+    && ${TRAVIS_BUILD_DIR}/.travis/FindAndBuildExecutables.sh ${TRAVIS_BUILD_DIR}/tests/InputFiles/
     && ctest --output-on-failure
     && ccache -s;
   else

--- a/.travis/FindAndBuildExecutables.sh
+++ b/.travis/FindAndBuildExecutables.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# This script searches for executables that the input
+# file tests depend on and then builds them.
+# The first argument passed in is the directory in
+# which to search
+input_files=`find $1 -name '*.yaml'`
+
+executables=()
+for input_file in $input_files; do
+    executables+=(`grep 'Executable' $input_file \
+                   | sed s/\#[[:space:]]*Executable:[[:space:]]*//g`)
+done
+echo "Found: ${executables[@]}"
+echo "Removing duplicate executables"
+executables=`echo "${executables[@]}" | xargs -n1 | sort -u`
+
+for executable in $executables; do
+    echo "Building $executable"
+    make $executable
+done

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ generate_algorithms(${CMAKE_BINARY_DIR}/src/Parallel/Algorithms)
 
 enable_testing(true)
 include(SpectreAddCatchTests)
+include(AddInputFileTests)
 include(SetupCompilationFailureTests)
 
 include_directories(${CMAKE_SOURCE_DIR}/external)

--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -1,0 +1,107 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+function(add_single_input_file_test INPUT_FILE EXECUTABLE CHECK_TYPE TIMEOUT)
+  # Extract just the name of the input file
+  get_filename_component(INPUT_FILE_NAME "${INPUT_FILE}" NAME)
+
+  # Extract the main subdirectory name
+  string(FIND "${INPUT_FILE}" "tests/InputFiles/" POSITION_OF_INPUT_FILE_DIR)
+  math(EXPR
+    POSITION_OF_INPUT_FILE_DIR
+    ${POSITION_OF_INPUT_FILE_DIR}+17
+    # 17 is the length of "tests/InputFiles/"
+    )
+  string(SUBSTRING "${INPUT_FILE}" ${POSITION_OF_INPUT_FILE_DIR}
+    -1 TEMP)
+  string(FIND "${TEMP}" "/" POSITION_OF_SLASH)
+  string(SUBSTRING "${TEMP}" 0 ${POSITION_OF_SLASH}
+      EXECUTABLE_DIR_NAME)
+
+  # Set tags for the test
+  set(TAGS "InputFiles;${EXECUTABLE_DIR_NAME};${CHECK_TYPE}")
+  string(TOLOWER "${TAGS}" TAGS)
+
+  set(
+    CTEST_NAME
+    "\"InputFiles.${EXECUTABLE_DIR_NAME}.${INPUT_FILE_NAME}.${CHECK_TYPE}\""
+    )
+  if ("${CHECK_TYPE}" STREQUAL "parse")
+    add_test(
+      NAME "${CTEST_NAME}"
+      COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE}
+      --check-options --input-file ${INPUT_FILE}
+      )
+  elseif("${CHECK_TYPE}" STREQUAL "execute")
+    add_test(
+      NAME "${CTEST_NAME}"
+      COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE}
+      --input-file ${INPUT_FILE}
+      )
+  else()
+    message(FATAL_ERROR "Unknown Check for input file: ${CHECK_TYPE}."
+      "Known checks are: execute")
+  endif()
+
+  set_tests_properties(
+    "${CTEST_NAME}"
+    PROPERTIES
+    FAIL_REGULAR_EXPRESSION "ERROR"
+    TIMEOUT ${TIMEOUT}
+    LABELS "${TAGS}"
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+endfunction()
+
+# Searches the directory INPUT_FILE_DIR for .yaml files and adds a
+# test for each one. The input files must contain a line of the form:
+# '# Executable: EvolveScalarWave1D'
+# with the name of the executable that should be able to parse and run
+# using the input file, and a line of the form:
+# '# Check: execute'
+# OR
+# '# Check:'
+# If 'execute' is present then the input file will not just be parsed,
+# but the simulation will be run.
+function(add_input_file_tests INPUT_FILE_DIR)
+  set(INPUT_FILE_LIST "")
+  file(GLOB_RECURSE INPUT_FILE_LIST ${INPUT_FILE_DIR} "${INPUT_FILE_DIR}*.yaml")
+  set(TIMEOUT 2)
+
+  foreach(INPUT_FILE ${INPUT_FILE_LIST})
+    file(READ ${INPUT_FILE} INPUT_FILE_CONTENTS)
+    # Check if the executable name is present
+    string(REGEX MATCH "#[ ]*Executable:[^\n]+"
+      INPUT_FILE_EXECUTABLE "${INPUT_FILE_CONTENTS}")
+    if("${INPUT_FILE_EXECUTABLE}" STREQUAL "")
+      message(FATAL_ERROR "Could not find the executable in input "
+        "file ${INPUT_FILE}. You must supply a line of the form:"
+        "'# Executable: EXECUTABLE_NAME'")
+    endif()
+    # Extract executable name, and remove trailing white space
+    string(REGEX REPLACE "#[ ]*Executable:[ ]*" ""
+      INPUT_FILE_EXECUTABLE "${INPUT_FILE_EXECUTABLE}")
+    string(STRIP "${INPUT_FILE_EXECUTABLE}" INPUT_FILE_EXECUTABLE)
+
+    # Read what tests to do. Currently only "execute" is available
+    # "parse" is ignored because it's always run, empty is accepted.
+    string(REGEX MATCH "#[ ]*Check:[^\n]+"
+      INPUT_FILE_CHECKS "${INPUT_FILE_CONTENTS}")
+    # Extract list of checks to perform
+    string(REGEX REPLACE "#[ ]*Check:[ ]*" ""
+      INPUT_FILE_CHECKS "${INPUT_FILE_CHECKS}")
+    string(STRIP "${INPUT_FILE_CHECKS}" INPUT_FILE_CHECKS)
+    set(INPUT_FILE_CHECKS "parse;${INPUT_FILE_CHECKS}")
+    list(REMOVE_DUPLICATES "INPUT_FILE_CHECKS")
+
+    foreach(CHECK_TYPE ${INPUT_FILE_CHECKS})
+      add_single_input_file_test(
+        ${INPUT_FILE}
+        ${INPUT_FILE_EXECUTABLE}
+        ${CHECK_TYPE}
+        ${TIMEOUT}
+        )
+    endforeach()
+  endforeach()
+endfunction()
+
+add_input_file_tests("${CMAKE_SOURCE_DIR}/tests/InputFiles/")

--- a/containers/Dockerfile.travis
+++ b/containers/Dockerfile.travis
@@ -113,6 +113,12 @@ RUN if [ ${SONARQUBE} ] \
     && [ -z "${RUN_CLANG_TIDY}" ]; then \
       make -j2; \
     fi
+# Find and build the executables used for input file tests
+RUN if [ -z "${RUN_CPPCHECK}" ] \
+    && [ -z "${RUN_CLANG_TIDY}" ]; then \
+      /work/spectre/.travis/FindAndBuildExecutables.sh \
+      /work/spectre/tests/InputFiles; \
+    fi
 RUN ccache -s
 
 RUN if [ -z "${RUN_CPPCHECK}" ] \

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1106,6 +1106,11 @@ void mutate(DataBox<TagList>& box, Invokable&& invokable,
                          tmpl::bind<tmpl::pin, tmpl::get_source<tmpl::_1>>,
                          tmpl::parent<tmpl::_1>>>>,
       tmpl::get_destination<tmpl::_1>>;
+  (void)std::initializer_list<char>{
+      ((void)databox_detail::add_variables_item_tags_to_box<MutateTags>(
+           box.data_,
+           typename databox_detail::select_if_variables<MutateTags>::type{}),
+       '0')...};
   databox_detail::reset_compute_items_after_mutate<
       tmpl::size<first_compute_items_to_reset>::value == 0,
       typename DataBox<TagList>::edge_list,

--- a/src/Domain/ElementId.cpp
+++ b/src/Domain/ElementId.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 
 #include "Domain/ElementIndex.hpp"
+#include "Parallel/ArrayIndex.hpp"
 #include "Parallel/PupStlCpp11.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -31,6 +32,14 @@ ElementId<VolumeDim>::ElementId(const ElementIndex<VolumeDim>& index) noexcept {
         SegmentId{gsl::at(index.segments(), d).refinement_level(),
                   gsl::at(index.segments(), d).index()};
   }
+}
+
+// clang-tidy: mark explicit, we want implicit conversion
+template <size_t VolumeDim>
+ElementId<VolumeDim>::
+operator Parallel::ArrayIndex<ElementIndex<VolumeDim>>()  // NOLINT
+    const {
+  return {ElementIndex<VolumeDim>{*this}};
 }
 
 template <size_t VolumeDim>
@@ -72,7 +81,8 @@ size_t hash_value(const ElementId<VolumeDim>& c) noexcept {
   return h;
 }
 
-namespace std {
+// clang-tidy: do not modify namespace std
+namespace std {  // NOLINT
 template <size_t VolumeDim>
 size_t hash<ElementId<VolumeDim>>::operator()(
     const ElementId<VolumeDim>& c) const noexcept {
@@ -93,7 +103,8 @@ template size_t hash_value(const ElementId<1>&) noexcept;
 template size_t hash_value(const ElementId<2>&) noexcept;
 template size_t hash_value(const ElementId<3>&) noexcept;
 
-namespace std {
+// clang-tidy: do not modify namespace std
+namespace std {  // NOLINT
 template struct hash<ElementId<1>>;
 template struct hash<ElementId<2>>;
 template struct hash<ElementId<3>>;

--- a/src/Domain/ElementId.hpp
+++ b/src/Domain/ElementId.hpp
@@ -18,6 +18,10 @@
 
 template <size_t>
 class ElementIndex;
+namespace Parallel {
+template <class>
+class ArrayIndex;
+}  // namespace Parallel
 
 /// \ingroup ComputationalDomainGroup
 /// An ElementId uniquely labels a Element.
@@ -36,6 +40,10 @@ class ElementId {
   /// Convert an ElementIndex to an ElementId
   // clang-tidy: mark explicit: we want to allow conversion
   ElementId(const ElementIndex<VolumeDim>& index) noexcept;  // NOLINT
+
+  /// Conversion operator needed to index `proxy`s using `ElementId`
+  // clang-tidy: mark explicit, we want implicit conversion
+  operator Parallel::ArrayIndex<ElementIndex<VolumeDim>>() const;  // NOLINT
 
   /// Create an arbitrary ElementId.
   ElementId(size_t block_id,
@@ -81,7 +89,8 @@ bool operator!=(const ElementId<VolumeDim>& lhs,
 template <size_t VolumeDim>
 size_t hash_value(const ElementId<VolumeDim>& c) noexcept;
 
-namespace std {
+// clang-tidy: do not modify namespace std
+namespace std {  // NOLINT
 template <size_t VolumeDim>
 struct hash<ElementId<VolumeDim>> {
   size_t operator()(const ElementId<VolumeDim>& c) const noexcept;

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "AlgorithmArray.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/InitialElementIds.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"
+#include "Parallel/Info.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+template <class Metavariables, class ActionList>
+struct DgElementArray {
+  static constexpr size_t volume_dim = Metavariables::system::volume_dim;
+
+  using chare_type = Parallel::Algorithms::Array;
+  using const_global_cache_tag_list = tmpl::flatten<
+      typelist<CacheTags::FinalTime, CacheTags::TimeStepper,
+               typename Metavariables::dg_element_array_add_to_cache>>;
+  using metavariables = Metavariables;
+  using action_list = ActionList;
+  using array_index = ElementIndex<volume_dim>;
+
+  using explicit_single_actions_list =
+      tmpl::list<dg::Actions::InitializeElement<volume_dim>>;
+
+  using initial_databox = db::compute_databox_type<
+      typename dg::Actions::InitializeElement<volume_dim>::
+          template return_tag_list<typename Metavariables::system>>;
+
+  using options = typelist<typename Metavariables::domain_creator_tag,
+                           OptionTags::InitialTime, OptionTags::DeltaT>;
+
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+      std::unique_ptr<DomainCreator<volume_dim, Frame::Inertial>>
+          domain_creator,
+      double initial_time, double initial_dt) noexcept;
+
+  static void execute_next_global_actions(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    if (next_phase == Metavariables::Phase::Evolve) {
+      Parallel::get_parallel_component<DgElementArray>(local_cache)
+          .perform_algorithm();
+    }
+  }
+};
+
+template <class Metavariables, class ActionList>
+void DgElementArray<Metavariables, ActionList>::initialize(
+    Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+    const std::unique_ptr<DomainCreator<volume_dim, Frame::Inertial>>
+        domain_creator,
+    const double initial_time, const double initial_dt) noexcept {
+  auto& dg_element_array = Parallel::get_parallel_component<DgElementArray>(
+      *(global_cache.ckLocalBranch()));
+
+  auto domain = domain_creator->create_domain();
+  for (const auto& block : domain.blocks()) {
+    const auto initial_ref_levs =
+        domain_creator->initial_refinement_levels()[block.id()];
+    const std::vector<ElementId<volume_dim>> element_ids =
+        initial_element_ids(block.id(), initial_ref_levs);
+    for (size_t i = 0, which_proc = 0,
+                number_of_procs =
+                    static_cast<size_t>(Parallel::number_of_procs());
+         i < element_ids.size(); ++i) {
+      dg_element_array(ElementIndex<volume_dim>(element_ids[i]))
+          .insert(global_cache, which_proc);
+      which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+    }
+  }
+  dg_element_array.doneInserting();
+
+  // Set time and DeltaT allowing for integration backwards in time
+  const bool time_reversed = initial_dt < 0;
+  const Slab slab =
+      time_reversed ? Slab::with_duration_to_end(initial_time, -initial_dt)
+                    : Slab::with_duration_from_start(initial_time, initial_dt);
+  const Time time = time_reversed ? slab.end() : slab.start();
+  const TimeDelta dt = time_reversed ? -slab.duration() : slab.duration();
+
+  dg_element_array.template explicit_single_action<
+      dg::Actions::InitializeElement<volume_dim>>(
+      std::make_tuple(domain_creator->initial_extents(),
+                      std::move(domain), time, dt));
+}

--- a/src/Evolution/Executables/CMakeLists.txt
+++ b/src/Evolution/Executables/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(Executables)
-add_subdirectory(Systems)
+add_subdirectory(ScalarWave)

--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+function(add_scalar_wave_executable DIM)
+  set(EXECUTABLE_NAME "EvolveScalarWave${DIM}D")
+
+  set(SUBDIR_NAME "src/Evolution/Executables/ScalarWave/")
+  set(BUILD_TARGET_FILENAME
+    "${CMAKE_BINARY_DIR}/${SUBDIR_NAME}${EXECUTABLE_NAME}.cpp"
+    )
+  file(WRITE
+    ${BUILD_TARGET_FILENAME}
+    "// Distributed under the MIT License.\n"
+    "// See LICENSE.txt for details.\n"
+    "\n"
+    "#include \"Evolution/Executables/ScalarWave/EvolveScalarWave.hpp\"\n"
+    "\n"
+    "using charm_metavariables = EvolutionMetavars<${DIM}>;\n"
+    "\n"
+    "#include \"Parallel/CharmMain.cpp\"\n"
+    )
+
+  add_executable(
+    ${EXECUTABLE_NAME}
+    EXCLUDE_FROM_ALL
+    ${BUILD_TARGET_FILENAME}
+    )
+
+  add_dependencies(
+    ${EXECUTABLE_NAME}
+    module_ConstGlobalCache
+    module_Main
+    )
+
+  target_link_libraries(
+    ${EXECUTABLE_NAME}
+    CoordinateMaps
+    DomainCreators
+    Informer
+    ScalarWave
+    Time
+    Utilities
+    WaveEquation
+    ${SPECTRE_LIBRARIES}
+    )
+endfunction(add_scalar_wave_executable)
+
+add_scalar_wave_executable(1)
+add_scalar_wave_executable(2)
+add_scalar_wave_executable(3)

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "AlgorithmArray.hpp"
+#include "AlgorithmGroup.hpp"
+#include "AlgorithmNodegroup.hpp"
+#include "AlgorithmSingleton.hpp"
+#include "Domain/DomainCreators/DomainCreator.hpp"
+#include "Domain/DomainCreators/RegisterDerivedWithCharm.cpp"
+#include "Evolution/Actions/ComputeVolumeDuDt.hpp"
+#include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
+#include "Evolution/Systems/ScalarWave/System.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication2.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Printf.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Time/Actions/AdvanceTime.hpp"
+#include "Time/Actions/FinalTime.hpp"
+#include "Time/Actions/UpdateU.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/TMPL.hpp"
+
+template <size_t Dim>
+struct EvolutionMetavars {
+  // Customization/"input options" to simulation
+  using system = ScalarWave::System<Dim>;
+  using analytic_solution_tag =
+      CacheTags::AnalyticSolution<ScalarWave::Solutions::PlaneWave<Dim>>;
+  using normal_dot_numerical_flux =
+      CacheTags::NumericalFluxParams<ScalarWave::UpwindFlux<Dim>>;
+  using dg_element_array_add_to_cache =
+      tmpl::list<analytic_solution_tag, normal_dot_numerical_flux>;
+  using domain_creator_tag = OptionTags::DomainCreator<Dim, Frame::Inertial>;
+
+  using component_list = tmpl::list<DgElementArray<
+      EvolutionMetavars,
+      tmpl::list<Actions::ComputeVolumeDuDt<Dim>,
+                 dg::Actions::SendDataForFluxes,
+                 dg::Actions::ComputeBoundaryFlux<EvolutionMetavars>,
+                 Actions::UpdateU, Actions::AdvanceTime, Actions::FinalTime>>>;
+
+  static constexpr OptionString help{
+      "Evolve a Scalar Wave in Dim spatial dimension.\n\n"
+      "The analytic solution is: PlaneWave\n"
+      "The numerical flux is:    UpwindFlux\n"};
+
+  enum class Phase {
+    Initialization,
+    Evolve,
+    Exit
+  };
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          EvolutionMetavars>& /*cache_proxy*/) noexcept {
+    return current_phase == Phase::Initialization ? Phase::Evolve : Phase::Exit;
+  }
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling, &DomainCreators::register_derived_with_charm,
+    &Parallel::register_derived_classes_with_charm<MathFunction<1>>,
+    &Parallel::register_derived_classes_with_charm<TimeStepper>};
+static const std::vector<void (*)()> charm_init_proc_funcs{};

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -1,4 +1,3 @@
-
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Options/Options.hpp"
+
+namespace CacheTags {
+/*!
+ * \ingroup CacheTagsGroup
+ * \brief The global cache tag that retrieves the parameters for the numerical
+ * flux from the input file
+ */
+template <typename NumericalFluxType>
+struct NumericalFluxParams {
+  static constexpr OptionString help = "The options for the numerical flux";
+  using type = NumericalFluxType;
+};
+}  // namespace CacheTags

--- a/src/Parallel/ConstGlobalCache.hpp
+++ b/src/Parallel/ConstGlobalCache.hpp
@@ -32,7 +32,7 @@ struct type_for_get_helper<std::unique_ptr<T, D>> {
 template <class ConstGlobalCacheTag, class Metavariables>
 using get_list_of_matching_tags =
     tmpl::filter<typename ConstGlobalCache<Metavariables>::tag_list,
-                 std::is_base_of<ConstGlobalCacheTag, tmpl::_1>>;
+                 std::is_base_of<tmpl::pin<ConstGlobalCacheTag>, tmpl::_1>>;
 
 template <class ConstGlobalCacheTag, class Metavariables>
 using type_for_get = typename type_for_get_helper<

--- a/src/Parallel/InitializationFunctions.hpp
+++ b/src/Parallel/InitializationFunctions.hpp
@@ -6,7 +6,10 @@
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 
 inline void setup_error_handling() {
-  std::set_terminate(
-      []() { Parallel::abort("Called terminate. Aborting..."); });
+  std::set_terminate([]() {
+    Parallel::abort(
+        "Terminate was called, calling Charm++'s abort function to properly "
+        "terminate execution.");
+  });
   enable_floating_point_exceptions();
 }

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -1,0 +1,32 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveScalarWave1D
+# Check: execute
+
+AnalyticSolution:
+  WaveVector: [1.0]
+  Center: [0.0]
+  Profile:
+    Sinusoid:
+      Amplitude: 1.0
+      Wavenumber: 1.0
+      Phase: 0.0
+
+InitialTime: 0.0
+FinalTime: 0.1
+DeltaT: 0.01
+
+DomainCreator:
+  Interval:
+    LowerBound: [0.0]
+    UpperBound: [6.283185307179586]
+    IsPeriodicIn: [true]
+    InitialRefinement: [2]
+    InitialGridPoints: [7]
+
+TimeStepper:
+  AdamsBashforthN:
+    TargetOrder: 3
+
+NumericalFluxParams:

--- a/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
@@ -1,0 +1,32 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveScalarWave2D
+# Check: execute
+
+AnalyticSolution:
+  WaveVector: [1.0, 1.0]
+  Center: [0.0, 0.0]
+  Profile:
+    Sinusoid:
+      Amplitude: 1.0
+      Wavenumber: 1.0
+      Phase: 0.0
+
+InitialTime: 0.0
+FinalTime: 0.1
+DeltaT: 0.01
+
+DomainCreator:
+  Rectangle:
+    LowerBound: [0.0, 0.0]
+    UpperBound: [6.283185307179586, 6.283185307179586]
+    IsPeriodicIn: [true, true]
+    InitialRefinement: [2, 2]
+    InitialGridPoints: [4, 4]
+
+TimeStepper:
+  AdamsBashforthN:
+    TargetOrder: 3
+
+NumericalFluxParams:

--- a/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
@@ -1,0 +1,32 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: EvolveScalarWave3D
+# Check: execute
+
+AnalyticSolution:
+  WaveVector: [1.0, 1.0, 1.0]
+  Center: [0.0, 0.0, 0.0]
+  Profile:
+    Sinusoid:
+      Amplitude: 1.0
+      Wavenumber: 1.0
+      Phase: 0.0
+
+InitialTime: 0.0
+FinalTime: 0.05
+DeltaT: 0.01
+
+DomainCreator:
+  Brick:
+    LowerBound: [0.0, 0.0, 0.0]
+    UpperBound: [6.283185307179586, 6.283185307179586, 6.283185307179586]
+    IsPeriodicIn: [true, true, true]
+    InitialRefinement: [1, 1, 1]
+    InitialGridPoints: [5, 5, 5]
+
+TimeStepper:
+  AdamsBashforthN:
+    TargetOrder: 3
+
+NumericalFluxParams:

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -846,6 +846,27 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Variables",
   }
 }
 
+namespace {
+struct Tag1 : db::DataBoxTag {
+  using type = Scalar<DataVector>;
+  static constexpr db::DataBoxString label = "Tag1";
+};
+struct Tag2 : db::DataBoxTag {
+  using type = Scalar<DataVector>;
+  static constexpr db::DataBoxString label = "Tag2";
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Variables2",
+                  "[Unit][DataStructures]") {
+  auto box = db::create<db::AddTags<Tags::Variables<tmpl::list<Tag1, Tag2>>>>(
+      Variables<tmpl::list<Tag1, Tag2>>(1, 1.));
+
+  db::mutate<Tags::Variables<tmpl::list<Tag1, Tag2>>>(
+      box, [](auto& vars) { vars = Variables<tmpl::list<Tag1, Tag2>>(1, 2.); });
+  CHECK(db::get<Tag1>(box) == Scalar<DataVector>(DataVector(1, 2.)));
+}
+
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.reset_compute_items",
                   "[Unit][DataStructures]") {
   auto box = db::create<


### PR DESCRIPTION
## Proposed changes

Note: Depends on #493 (which depends on #491). This means only the commits "Add tests for input files", "Add Parallel Compenent DgElementArray", and "Add 1D, 2D and 3D ScalarWave executables" are new.

- Close #505
- Adds testing infrastructure for input files. This should be flexible enough to allow easy extension of it in the future. Currently all input files are tested for parsing, this is not optional. It is possible to opt-in to having the executable run. Output is not checked, though.
- Add what is expected to be the core DgElementArray parallel component. I expect this to grow a bit as more features are added to the code, but this is enough for what we need right now.
- Add ScalarWave executables in 1D, 2D and 3D.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
