### PR TITLE
Add fast flow

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY ApparentHorizons)
 
 set(LIBRARY_SOURCES
+    FastFlow.cpp
     SpherepackIterator.cpp
     Strahlkorper.cpp
     StrahlkorperDataBox.cpp

--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -1,0 +1,357 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ApparentHorizons/FastFlow.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <pup.h>
+#include <utility>
+
+#include "ApparentHorizons/SpherepackIterator.hpp"
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "ApparentHorizons/StrahlkorperDataBox.hpp"
+#include "ApparentHorizons/StrahlkorperGr.hpp"
+#include "ApparentHorizons/YlmSpherepack.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Options/ParseOptions.hpp"
+#include "Parallel/Abort.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+
+FastFlow::FastFlow(FastFlow::Flow::type flow, FastFlow::Alpha::type alpha,
+                   FastFlow::Beta::type beta, FastFlow::AbsTol::type abs_tol,
+                   FastFlow::TruncationTol::type trunc_tol,
+                   FastFlow::DivergenceTol::type divergence_tol,
+                   FastFlow::DivergenceIter::type divergence_iter,
+                   FastFlow::MaxIts::type max_its) noexcept
+    : alpha_(alpha),
+      beta_(beta),
+      abs_tol_(abs_tol),
+      trunc_tol_(trunc_tol),
+      divergence_tol_(divergence_tol),
+      divergence_iter_(divergence_iter),
+      max_its_(max_its),
+      flow_(flow),
+      current_iter_(0),
+      previous_residual_mesh_norm_(0.0),
+      min_residual_mesh_norm_(std::numeric_limits<double>::max()),
+      iter_at_min_residual_mesh_norm_(0) {}
+
+template <typename Frame>
+size_t FastFlow::current_l_mesh(const Strahlkorper<Frame>& strahlkorper) const
+    noexcept {
+  const size_t l_max = strahlkorper.ylm_spherepack().l_max();
+  // This is the formula used in SpEC (if l_max>=4). We may want to make this
+  // formula an option in the future, if we want to experiment with it.
+  return static_cast<size_t>(std::floor(1.5 * l_max));
+}
+
+namespace {
+template <typename Frame>
+DataVector fast_flow_weight(
+    const DataVector& one_form_magnitude,
+    const db::item_type<StrahlkorperTags::Rhat<Frame>>& r_hat,
+    const db::item_type<StrahlkorperTags::Radius<Frame>>& radius,
+    const tnsr::II<DataVector, 3, Frame>& inverse_surface_metric) noexcept {
+  // Form Euclidean surface metric
+  auto flat_metric =
+      make_with_value<tnsr::ii<DataVector, 3, Frame>>(radius, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    flat_metric.get(i, i) = 1.0;
+    for (size_t j = i; j < 3; ++j) {
+      flat_metric.get(i, j) -= r_hat.get(i) * r_hat.get(j);
+    }
+  }
+
+  auto denominator = make_with_value<DataVector>(radius, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      denominator += inverse_surface_metric.get(i, j) * flat_metric.get(i, j);
+    }
+  }
+
+  return 2.0 * one_form_magnitude * square(radius) / denominator;
+}
+}  // namespace
+
+template <typename Frame>
+std::pair<FastFlow::Status, FastFlow::IterInfo>
+FastFlow::iterate_horizon_finder(
+    const gsl::not_null<Strahlkorper<Frame>*> current_strahlkorper,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::Ijj<DataVector, 3, Frame>& christoffel_2nd_kind) noexcept {
+  const size_t l_surface = current_strahlkorper->l_max();
+  const size_t l_mesh = current_l_mesh(*current_strahlkorper);
+
+  // Evaluate the Strahlkorper on a higher resolution mesh
+  const Strahlkorper<Frame> strahlkorper(l_mesh, l_mesh, *current_strahlkorper);
+
+  // Make a DataBox with this strahlkorper.
+  // Do we want to define ComputeItems for expansion, normalized
+  // unit norms, etc in this DataBox? So far we do not.
+  auto box = db::create<
+      db::AddTags<StrahlkorperTags::items_tags<Frame>>,
+      db::AddComputeItemsTags<StrahlkorperTags::compute_items_tags<Frame>>>(
+      strahlkorper);
+
+  // Get minimum radius.
+  const auto& radius = db::get<StrahlkorperTags::Radius<Frame>>(box);
+  const auto r_minmax = std::minmax_element(radius.begin(), radius.end());
+  const auto r_min = *r_minmax.first;
+  const auto r_max = *r_minmax.second;
+
+  if (r_min < 0.0) {
+    return std::make_pair(Status::NegativeRadius,
+                          IterInfo{current_iter_, r_min, r_max});
+  }
+
+  // Evaluate the current residual on the surface
+  const auto one_form_magnitude =
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame>>(box),
+                upper_spatial_metric);
+  const DataVector one_over_one_form_magnitude = 1.0 / one_form_magnitude;
+  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
+      db::get<StrahlkorperTags::NormalOneForm<Frame>>(box),
+      one_over_one_form_magnitude);
+  const auto inverse_surface_metric = StrahlkorperGr::inverse_surface_metric(
+      raise_or_lower_index(unit_normal_one_form, upper_spatial_metric),
+      upper_spatial_metric);
+
+  const auto surface_residual = StrahlkorperGr::expansion(
+      StrahlkorperGr::grad_unit_normal_one_form(
+          db::get<StrahlkorperTags::Rhat<Frame>>(box),
+          db::get<StrahlkorperTags::Radius<Frame>>(box), unit_normal_one_form,
+          db::get<StrahlkorperTags::D2xRadius<Frame>>(box),
+          one_over_one_form_magnitude, christoffel_2nd_kind),
+      inverse_surface_metric, extrinsic_curvature);
+
+  auto weighted_residual = get(surface_residual);
+  switch (flow_) {
+    case FlowType::Jacobi:
+      // Do nothing
+      break;
+    case FlowType::Curvature: {
+      weighted_residual *= one_form_magnitude;
+    } break;
+    case FlowType::Fast: {
+      weighted_residual *= fast_flow_weight<Frame>(
+          one_form_magnitude, db::get<StrahlkorperTags::Rhat<Frame>>(box),
+          db::get<StrahlkorperTags::Radius<Frame>>(box),
+          inverse_surface_metric);
+    } break;
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("Cannot find the specified value of FlowType, need to add a case?");
+      // LCOV_EXCL_STOP
+  }
+
+  // Norm of the residual on the surface of size l_mesh.
+  // Note: In SpEC, this norm is computed as a pointwise L2 norm.  But
+  // here we compute the L2 integral norm.  The integral should be
+  // more accurate, but if it turns out that this integral is
+  // expensive, we can switch back to the pointwise L2 norm.
+  const double residual_mesh_norm = sqrt(strahlkorper.ylm_spherepack().average(
+      strahlkorper.ylm_spherepack().phys_to_spec(square(weighted_residual))));
+
+  if (residual_mesh_norm < min_residual_mesh_norm_) {
+    min_residual_mesh_norm_ = residual_mesh_norm;
+    iter_at_min_residual_mesh_norm_ = current_iter_;
+  }
+
+  // Transform the weighted residual
+  const auto weighted_residual_coefs =
+      strahlkorper.ylm_spherepack().phys_to_spec(weighted_residual);
+
+  // Restrict to the basis of the surface
+  const auto residual_on_surface =
+      strahlkorper.ylm_spherepack().prolong_or_restrict(
+          weighted_residual_coefs, current_strahlkorper->ylm_spherepack());
+
+  // Evaluate the norm of the residual on the surface of size l_surface.
+  // See comment on pointwise norm vs integral norm above.
+  const auto residual_ylm_norm =
+      sqrt(current_strahlkorper->ylm_spherepack().average(
+          current_strahlkorper->ylm_spherepack().phys_to_spec(
+              square(current_strahlkorper->ylm_spherepack().spec_to_phys(
+                  residual_on_surface)))));
+
+  // Fill iter_info
+  const auto minmax_residual =
+      std::minmax_element(weighted_residual.begin(), weighted_residual.end());
+  IterInfo iter_info{current_iter_,
+                     r_min,
+                     r_max,
+                     *minmax_residual.first,
+                     *minmax_residual.second,
+                     residual_ylm_norm,
+                     residual_mesh_norm};
+
+  // Exit if converged.
+  // What should happen is that as iterations proceed,
+  // residual_mesh_norm approaches a constant (the truncation error), and
+  // residual_ylm_norm decreases to roundoff.
+  //
+  // The first convergence condition is just
+  // residual_ylm_norm<abs_tol_.  The second convergence condition has
+  // two parts: First, we require that residual_ylm_norm <
+  // trunc_tol_*residual_mesh_norm.  But this may happen because
+  // residual_mesh_norm grows quickly, rather than because
+  // residual_ylm_norm shrinks.  So we require also that
+  // residual_mesh_norm-previous_residual_mesh_norm_ is small; that
+  // is, that residual_mesh_norm is converging to something.  But we
+  // can't require that
+  // residual_mesh_norm-previous_residual_mesh_norm_ is small on the
+  // first step, since previous_residual_mesh_norm_ is not defined, so
+  // we skip this part of the check on the first iteration.
+  if (residual_ylm_norm < abs_tol_) {
+    // clang-tidy: std::move of trivially-copyable type
+    return std::make_pair(Status::AbsTol, std::move(iter_info));  // NOLINT
+  } else if (residual_ylm_norm < trunc_tol_ * residual_mesh_norm) {
+    // This may be convergence by TruncationTol, but first make sure
+    // that either residual_mesh_norm is converging, or that it is the
+    // first step (i.e. previous_residual_mesh_norm_ == 0) so that we
+    // don't know yet if residual_mesh_norm is converging.
+    if (previous_residual_mesh_norm_ == 0 or
+        equal_within_roundoff(residual_mesh_norm, previous_residual_mesh_norm_,
+                              divergence_tol_ - 1.0, 0.0)) {
+      // clang-tidy: std::move of trivially-copyable type
+      return std::make_pair(Status::TruncationTol,
+                            std::move(iter_info));  // NOLINT
+    }
+  }
+
+  // Treat the case in which residual_mesh_norm is increasing
+  if (residual_mesh_norm > divergence_tol_ * min_residual_mesh_norm_ and
+      iter_at_min_residual_mesh_norm_ <= current_iter_ - divergence_iter_) {
+    // clang-tidy: std::move of trivially-copyable type
+    return std::make_pair(Status::DivergenceError,
+                          std::move(iter_info));  // NOLINT
+  }
+
+  if (current_iter_ == max_its_) {
+    // clang-tidy: std::move of trivially-copyable type
+    return std::make_pair(Status::MaxIts, std::move(iter_info));  // NOLINT
+  }
+
+  // We have succeeded in an iteration.  So return the next guess.
+  ++current_iter_;
+
+  // Construct new coefs.  Parameters flow_A and flow_B are from
+  // Gundlach, PRD 57, 863 (1998), eq. 44.
+  const double flow_A = alpha_ / (l_surface * (l_surface + 1)) + beta_;
+  const double flow_B = beta_ / alpha_;
+  auto coefs = current_strahlkorper->coefficients();
+  for (auto cit = SpherepackIterator(current_strahlkorper->l_max(),
+                                     current_strahlkorper->l_max());
+       cit; ++cit) {
+    coefs[cit()] -= flow_A / (1.0 + flow_B * cit.l() * (cit.l() + 1)) *
+                    residual_on_surface[cit()];
+  }
+  *current_strahlkorper = Strahlkorper<Frame>(coefs, *current_strahlkorper);
+
+  // Set up for next iter
+  previous_residual_mesh_norm_ = residual_mesh_norm;
+
+  // clang-tidy: std::move of trivially-copyable type
+  return std::make_pair(Status::SuccessfulIteration,
+                        std::move(iter_info));  // NOLINT
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const FastFlow::FlowType& flow_type) noexcept {
+  switch (flow_type) {
+    case FastFlow::FlowType::Jacobi:
+      return os << "Jacobi";
+    case FastFlow::FlowType::Curvature:
+      return os << "Curvature";
+    case FastFlow::FlowType::Fast:
+      return os << "Fast";
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("Unknown FastFlow::FlowType");
+      // LCOV_EXCL_STOP
+  }
+}
+
+void FastFlow::pup(PUP::er& p) noexcept {
+  p | alpha_;
+  p | beta_;
+  p | abs_tol_;
+  p | trunc_tol_;
+  p | divergence_tol_;
+  p | divergence_iter_;
+  p | max_its_;
+  p | flow_;
+  p | current_iter_;
+  p | previous_residual_mesh_norm_;
+  p | min_residual_mesh_norm_;
+  p | iter_at_min_residual_mesh_norm_;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const FastFlow::Status& status) noexcept {
+  switch (status) {
+    case FastFlow::Status::SuccessfulIteration:
+      return os << "Still iterating";
+    case FastFlow::Status::AbsTol:
+      return os << "Converged: Absolute tolerance";
+    case FastFlow::Status::TruncationTol:
+      return os << "Converged: Truncation tolerance";
+    case FastFlow::Status::MaxIts:
+      return os << "Failed: Too many iterations";
+    case FastFlow::Status::NegativeRadius:
+      return os << "Failed: Negative radius";
+    case FastFlow::Status::DivergenceError:
+      return os << "Failed: Diverging";
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("Need to add another case, don't understand value of 'status'");
+      // LCOV_EXCL_STOP
+  }
+}
+
+bool operator==(const FastFlow& lhs, const FastFlow& rhs) noexcept {
+  return lhs.alpha_ == rhs.alpha_ and lhs.beta_ == rhs.beta_ and
+         lhs.abs_tol_ == rhs.abs_tol_ and lhs.trunc_tol_ == rhs.trunc_tol_ and
+         lhs.divergence_tol_ == rhs.divergence_tol_ and
+         lhs.divergence_iter_ == rhs.divergence_iter_ and
+         lhs.max_its_ == rhs.max_its_ and lhs.flow_ == rhs.flow_ and
+         lhs.current_iter_ == rhs.current_iter_ and
+         lhs.previous_residual_mesh_norm_ ==
+             rhs.previous_residual_mesh_norm_ and
+         lhs.min_residual_mesh_norm_ == rhs.min_residual_mesh_norm_ and
+         lhs.iter_at_min_residual_mesh_norm_ ==
+             rhs.iter_at_min_residual_mesh_norm_;
+}
+
+FastFlow::FlowType create_from_yaml<FastFlow::FlowType>::create(
+    const Option& options) {
+  const std::string flow_type_read = options.parse_as<std::string>();
+  if ("Jacobi" == flow_type_read) {
+    return FastFlow::FlowType::Jacobi;
+  } else if ("Curvature" == flow_type_read) {
+    return FastFlow::FlowType::Curvature;
+  } else if ("Fast" == flow_type_read) {
+    return FastFlow::FlowType::Fast;
+  }
+  PARSE_ERROR(options.context(), "Failed to convert \""
+                                     << flow_type_read
+                                     << "\" to FastFlow::FlowType. Must be "
+                                        "one of Jacobi, Curvature, Fast.");
+}
+
+template size_t FastFlow::current_l_mesh(
+    const Strahlkorper<Frame::Inertial>& strahlkorper) const noexcept;
+
+template std::pair<FastFlow::Status, FastFlow::IterInfo>
+FastFlow::iterate_horizon_finder<Frame::Inertial>(
+    const gsl::not_null<Strahlkorper<Frame::Inertial>*> current_strahlkorper,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& upper_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature,
+    const tnsr::Ijj<DataVector, 3, Frame::Inertial>&
+        christoffel_2nd_kind) noexcept;

--- a/src/ApparentHorizons/FastFlow.hpp
+++ b/src/ApparentHorizons/FastFlow.hpp
@@ -1,0 +1,207 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <ostream>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
+
+template <typename>
+class Strahlkorper;
+
+/// \ingroup SurfacesGroup
+/// \brief Fast flow method for finding apparent horizons.
+///
+/// \details Based on https://arxiv.org/abs/gr-qc/9707050
+//  The method is iterative.
+class FastFlow {
+ public:
+  enum class FlowType { Jacobi, Curvature, Fast };
+
+  // Error conditions are negative, successes are nonnegative
+  enum class Status {
+    // SuccessfulIteration means we should iterate again.
+    SuccessfulIteration = 0,
+    // The following indicate convergence, can stop iterating.
+    AbsTol = 1,
+    TruncationTol = 2,
+    // The following indicate errors.
+    MaxIts = -1,
+    NegativeRadius = -2,
+    DivergenceError = -3
+  };
+
+  /// Holds information about an iteration of the algorithm.
+  struct IterInfo {
+    size_t iteration{std::numeric_limits<size_t>::max()};
+    double r_min{std::numeric_limits<double>::signaling_NaN()},
+        r_max{std::numeric_limits<double>::signaling_NaN()},
+        min_residual{std::numeric_limits<double>::signaling_NaN()},
+        max_residual{std::numeric_limits<double>::signaling_NaN()},
+        residual_ylm{std::numeric_limits<double>::signaling_NaN()},
+        residual_mesh{std::numeric_limits<double>::signaling_NaN()};
+  };
+
+  struct Flow {
+    using type = FlowType;
+    static constexpr OptionString help = {
+        "Flow method: Jacobi, Curvature, or Fast"};
+    static type default_value() { return FlowType::Fast; }
+  };
+
+  struct Alpha {
+    using type = double;
+    static constexpr OptionString help = {
+        "Alpha parameter in PRD 57, 863 (1998)"};
+    static type default_value() { return 1.0; }
+  };
+
+  struct Beta {
+    using type = double;
+    static constexpr OptionString help = {
+        "Beta parameter in PRD 57, 863 (1998)"};
+    static type default_value() { return 0.5; }
+  };
+
+  struct AbsTol {
+    using type = double;
+    static constexpr OptionString help = {
+        "Convergence found if R_{Y_lm}<AbsTol"};
+    static type default_value() { return 1.e-12; }
+  };
+
+  struct TruncationTol {
+    using type = double;
+    static constexpr OptionString help = {
+        "Convergence found if R_{Y_lm}< TruncationTol*R_{mesh}"};
+    static type default_value() { return 1.e-2; }
+  };
+
+  struct DivergenceTol {
+    using type = double;
+    static constexpr OptionString help = {
+        "Fraction that residual can increase before dying"};
+    static type default_value() { return 1.2; }
+    static type lower_bound() { return 1.0; }
+  };
+
+  struct DivergenceIter {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Num iterations residual can increase before dying"};
+    static type default_value() { return 5; }
+  };
+
+  struct MaxIts {
+    using type = size_t;
+    static constexpr OptionString help = {"Maximum number of iterations."};
+    static type default_value() { return 100; }
+  };
+
+  using options = tmpl::list<Flow, Alpha, Beta, AbsTol, TruncationTol,
+                             DivergenceTol, DivergenceIter, MaxIts>;
+
+  static constexpr OptionString help{
+      "Find a Strahlkorper using a 'fast flow' method.\n"
+      "Based on Gundlach, PRD 57, 863 (1998).\n"
+      "Expands the surface in terms of spherical harmonics Y_lm up to a given\n"
+      "l_surface, and varies the coefficients S_lm where 0<=l<=l_surface to\n"
+      "minimize the residual of the apparent horizon equation.  Also keeps\n"
+      "another representation of the surface that is expanded up to\n"
+      "l_mesh > l_surface.  Let R_{Y_lm} be the residual computed using the\n"
+      "surface represented up to l_surface; this residual can in principle be\n"
+      "lowered to machine roundoff by enough iterations. Let R_{mesh} be the\n"
+      "residual computed using the surface represented up to l_mesh; this\n"
+      "residual represents the truncation error, since l_mesh>l_surface and\n"
+      "since coefficients S_lm with l>l_surface are not modified in the\n"
+      "iteration.\n\n"
+      "Convergence is achieved if R_{Y_lm}< TruncationTol*R_{mesh}, or if\n"
+      "R_{Y_lm}<AbsTol, where TruncationTol and AbsTol are input parameters.\n"
+      "If instead |R_{mesh}|_i > DivergenceTol * min_{j}(|R_{mesh}|_j) where\n"
+      "i is the iteration index and j runs from 0 to i-DivergenceIter, then\n"
+      "FastFlow exits with Status::DivergenceError.  Here DivergenceIter and\n"
+      "DivergenceTol are input parameters."};
+
+  FastFlow(Flow::type flow, Alpha::type alpha, Beta::type beta,
+           AbsTol::type abs_tol, TruncationTol::type trunc_tol,
+           DivergenceTol::type divergence_tol,
+           DivergenceIter::type divergence_iter, MaxIts::type max_its) noexcept;
+
+  FastFlow() noexcept
+      : FastFlow(FlowType::Fast, 1.0, 0.5, 1.e-12, 1.e-2, 1.2, 5, 100) {}
+
+  FastFlow(const FastFlow& /*rhs*/) = default;
+  FastFlow& operator=(const FastFlow& /*rhs*/) = default;
+  FastFlow(FastFlow&& /*rhs*/) noexcept = default;
+  FastFlow& operator=(FastFlow&& /*rhs*/) noexcept = default;
+  ~FastFlow() = default;
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  /// Evaluate residuals and compute the next iteration.  If
+  /// Status==SuccessfulIteration, then `current_strahlkorper` is
+  /// modified and `current_iteration()` is incremented.  Otherwise, we
+  /// end with success or failure, and neither `current_strahlkorper`
+  /// nor `current_iteration()` is changed.
+  template <typename Frame>
+  std::pair<Status, IterInfo> iterate_horizon_finder(
+      gsl::not_null<Strahlkorper<Frame>*> current_strahlkorper,
+      const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric,
+      const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+      const tnsr::Ijj<DataVector, 3, Frame>& christoffel_2nd_kind) noexcept;
+
+  size_t current_iteration() const noexcept { return current_iter_; }
+
+  /// Given a Strahlkorper defined up to some maximum Y_lm l called
+  /// l_surface, returns a larger value of l, l_mesh, that is used for
+  /// evaluating convergence.
+  template <typename Frame>
+  size_t current_l_mesh(const Strahlkorper<Frame>& strahlkorper) const noexcept;
+
+  /// Resets the finder.
+  SPECTRE_ALWAYS_INLINE void reset_for_next_find() noexcept {
+    current_iter_ = 0;
+  }
+
+ private:
+  friend bool operator==(const FastFlow& /*lhs*/,
+                         const FastFlow& /*rhs*/) noexcept;
+  double alpha_, beta_, abs_tol_, trunc_tol_, divergence_tol_;
+  size_t divergence_iter_, max_its_;
+  FlowType flow_;
+  size_t current_iter_;
+  double previous_residual_mesh_norm_, min_residual_mesh_norm_;
+  size_t iter_at_min_residual_mesh_norm_;
+};
+
+SPECTRE_ALWAYS_INLINE bool converged(const FastFlow::Status& status) noexcept {
+  return static_cast<int>(status) > 0;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const FastFlow::FlowType& flow_type) noexcept;
+
+std::ostream& operator<<(std::ostream& os,
+                         const FastFlow::Status& status) noexcept;
+
+SPECTRE_ALWAYS_INLINE bool operator!=(const FastFlow& lhs,
+                                      const FastFlow& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template <>
+struct create_from_yaml<FastFlow::FlowType> {
+  static FastFlow::FlowType create(const Option& options);
+};

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -50,18 +50,33 @@ tnsr::ii<DataVector, 3, Frame> grad_unit_normal_one_form(
     const tnsr::Ijj<DataVector, 3, Frame>& christoffel_2nd_kind) noexcept;
 
 /// \ingroup SurfacesGroup
+/// \brief Computes inverse 2-metric \f$g^{ij}-S^i S^j\f$ of a Strahlkorper.
+///
+/// \details See Eqs. (1--9) of https://arxiv.org/abs/gr-qc/9606010.
+/// Here \f$S^i\f$ is the (normalized) unit vector to the surface,
+/// and \f$g^{ij}\f$ is the 3-metric.  This object is expressed in the
+/// usual 3-d Cartesian basis, so it is written as a 3-dimensional tensor.
+/// But because it is orthogonal to \f$S_i\f$, it has only 3 independent
+/// degrees of freedom, and could be expressed as a 2-d tensor with an
+/// appropriate choice of basis. The input argument `unit_normal_vector` is
+/// \f$S^i = g^{ij} S_j\f$, where \f$S_j\f$ is the unit normal one form.
+template <typename Frame>
+tnsr::II<DataVector, 3, Frame> inverse_surface_metric(
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
+
+/// \ingroup SurfacesGroup
 /// \brief Expansion of a `Strahlkorper`. Should be zero on apparent horizons.
 ///
 /// \details Implements Eq. (5) in
 /// https://arxiv.org/abs/gr-qc/9606010.  The input argument
 /// `grad_normal` is the quantity returned by
-/// `StrahlkorperGr::grad_unit_normal_one_form`, and `unit_normal_vector` is
-/// \f$S^i = g^{ij} S_j\f$ where \f$S_j\f$ is the unit normal one form.
+/// `StrahlkorperGr::grad_unit_normal_one_form`, and `inverse_surface_metric`
+/// is the quantity returned by `StrahlkorperGr::inverse_surface_metric`.
 template <typename Frame>
 Scalar<DataVector> expansion(
     const tnsr::ii<DataVector, 3, Frame>& grad_normal,
-    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
-    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric,
+    const tnsr::II<DataVector, 3, Frame>& inverse_surface_metric,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
 
 }  // namespace StrahlkorperGr

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(APPARENT_HORIZONS_TESTS
     ApparentHorizons/Test_Expansion.cpp
+    ApparentHorizons/Test_FastFlow.cpp
     ApparentHorizons/Test_SpherepackIterator.cpp
     ApparentHorizons/Test_Strahlkorper.cpp
     ApparentHorizons/Test_StrahlkorperDataBox.cpp

--- a/tests/Unit/ApparentHorizons/Test_Expansion.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Expansion.cpp
@@ -53,8 +53,6 @@ void test_schwarzschild() {
   const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
       one_over_one_form_magnitude);
-  const auto unit_normal_vector =
-      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
   const auto grad_unit_normal_one_form =
       StrahlkorperGr::grad_unit_normal_one_form(
           db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
@@ -65,9 +63,12 @@ void test_schwarzschild() {
           raise_or_lower_first_index(
               gr::christoffel_first_kind(deriv_spatial_metric),
               inverse_spatial_metric));
+  const auto inverse_surface_metric = StrahlkorperGr::inverse_surface_metric(
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric),
+      inverse_spatial_metric);
 
   const auto residual = StrahlkorperGr::expansion(
-      grad_unit_normal_one_form, unit_normal_vector, inverse_spatial_metric,
+      grad_unit_normal_one_form, inverse_surface_metric,
       gr::extrinsic_curvature(
           get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
           get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
@@ -107,8 +108,6 @@ void test_minkowski() {
   const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
       one_over_one_form_magnitude);
-  const auto unit_normal_vector =
-      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
   const auto grad_unit_normal_one_form =
       StrahlkorperGr::grad_unit_normal_one_form(
           db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
@@ -119,9 +118,12 @@ void test_minkowski() {
           raise_or_lower_first_index(
               gr::christoffel_first_kind(deriv_spatial_metric),
               inverse_spatial_metric));
+  const auto inverse_surface_metric = StrahlkorperGr::inverse_surface_metric(
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric),
+      inverse_spatial_metric);
 
   const auto residual = StrahlkorperGr::expansion(
-      grad_unit_normal_one_form, unit_normal_vector, inverse_spatial_metric,
+      grad_unit_normal_one_form, inverse_surface_metric,
       solution.extrinsic_curvature(cart_coords, t));
 
   Approx custom_approx = Approx::custom().epsilon(1.e-12);

--- a/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
+++ b/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
@@ -1,0 +1,305 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <catch.hpp>
+
+#include "ApparentHorizons/FastFlow.hpp"
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "ApparentHorizons/StrahlkorperDataBox.hpp"
+#include "ApparentHorizons/StrahlkorperGr.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/MakeWithValue.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+FastFlow::Status do_iteration(
+    const gsl::not_null<Strahlkorper<Frame::Inertial>*> strahlkorper,
+    const gsl::not_null<FastFlow*> flow,
+    const EinsteinSolutions::KerrSchild& solution) {
+  FastFlow::Status status = FastFlow::Status::SuccessfulIteration;
+
+  while (status == FastFlow::Status::SuccessfulIteration) {
+    const auto l_mesh = flow->current_l_mesh(*strahlkorper);
+    const auto prolonged_strahlkorper =
+        Strahlkorper<Frame::Inertial>(l_mesh, l_mesh, *strahlkorper);
+
+    const auto box =
+        db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
+                   db::AddComputeItemsTags<
+                       StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
+            prolonged_strahlkorper);
+
+    const double t = 0.0;
+    const auto& cart_coords =
+        db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
+    const auto vars = solution.solution(cart_coords, t);
+
+    const auto& spatial_metric =
+        get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);
+    const auto& deriv_spatial_metric =
+        get<EinsteinSolutions::KerrSchild::deriv_spatial_metric<DataVector>>(
+            vars);
+    const auto inverse_spatial_metric =
+        determinant_and_inverse(spatial_metric).second;
+
+    const auto status_and_info = flow->iterate_horizon_finder<Frame::Inertial>(
+        strahlkorper, inverse_spatial_metric,
+        gr::extrinsic_curvature(
+            get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
+            get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
+            get<EinsteinSolutions::KerrSchild::deriv_shift<DataVector>>(vars),
+            spatial_metric,
+            get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataVector>>(
+                vars),
+            deriv_spatial_metric),
+        raise_or_lower_first_index(
+            gr::christoffel_first_kind(deriv_spatial_metric),
+            inverse_spatial_metric));
+    status = status_and_info.first;
+  }
+  return status;
+}
+
+struct FastFlowFromOpts {
+  using type = FastFlow;
+  static constexpr OptionString help{"FastFlow horizon-finder"};
+};
+
+void test_construct_from_options_fast() {
+  Options<tmpl::list<FastFlowFromOpts>> opts("");
+  opts.parse(
+      "FastFlowFromOpts:\n"
+      "  Flow: Fast\n"
+      "  Alpha: 1.1\n"
+      "  Beta: 0.6\n"
+      "  AbsTol: 1.e-10\n"
+      "  TruncationTol: 1.e-3\n"
+      "  DivergenceTol: 1.1\n"
+      "  DivergenceIter: 6\n"
+      "  MaxIts: 200");
+  CHECK(opts.get<FastFlowFromOpts>() ==
+        FastFlow(FastFlow::FlowType::Fast, 1.1, 0.6, 1e-10, 1e-3, 1.1, 6, 200));
+}
+
+void test_construct_from_options_jacobi() {
+  Options<tmpl::list<FastFlowFromOpts>> opts("");
+  opts.parse(
+      "FastFlowFromOpts:\n"
+      "  Flow: Jacobi\n"
+      "  Alpha: 1.1\n"
+      "  Beta: 0.6\n"
+      "  AbsTol: 1.e-10\n"
+      "  TruncationTol: 1.e-3\n"
+      "  DivergenceTol: 1.1\n"
+      "  DivergenceIter: 6\n"
+      "  MaxIts: 200");
+  CHECK(opts.get<FastFlowFromOpts>() == FastFlow(FastFlow::FlowType::Jacobi,
+                                                 1.1, 0.6, 1e-10, 1e-3, 1.1, 6,
+                                                 200));
+}
+
+void test_construct_from_options_curvature() {
+  Options<tmpl::list<FastFlowFromOpts>> opts("");
+  opts.parse(
+      "FastFlowFromOpts:\n"
+      "  Flow: Curvature\n"
+      "  Alpha: 1.1\n"
+      "  Beta: 0.6\n"
+      "  AbsTol: 1.e-10\n"
+      "  TruncationTol: 1.e-3\n"
+      "  DivergenceTol: 1.1\n"
+      "  DivergenceIter: 6\n"
+      "  MaxIts: 200");
+  CHECK(opts.get<FastFlowFromOpts>() == FastFlow(FastFlow::FlowType::Curvature,
+                                                 1.1, 0.6, 1e-10, 1e-3, 1.1, 6,
+                                                 200));
+}
+
+void test_serialize() noexcept {
+  FastFlow fastflow(FastFlow::FlowType::Jacobi, 1.1, 0.6, 1e-10, 1e-3, 1.1, 6,
+                    200);
+  test_serialization(fastflow);
+}
+
+void test_copy_and_move() noexcept {
+  FastFlow fastflow(FastFlow::FlowType::Curvature, 1.1, 0.6, 1e-10, 1e-3, 1.1,
+                    6, 200);
+  test_copy_semantics(fastflow);
+  auto fastflow_copy = fastflow;
+  // clang-tidy: std::move of triviable-copyable type
+  test_move_semantics(std::move(fastflow), fastflow_copy);  // NOLINT
+}
+
+void test_ostream() noexcept {
+  CHECK(get_output(FastFlow::FlowType::Curvature) == "Curvature");
+  CHECK(get_output(FastFlow::FlowType::Jacobi) == "Jacobi");
+  CHECK(get_output(FastFlow::FlowType::Fast) == "Fast");
+  CHECK(get_output(FastFlow::Status::SuccessfulIteration) == "Still iterating");
+  CHECK(get_output(FastFlow::Status::AbsTol) ==
+        "Converged: Absolute tolerance");
+  CHECK(get_output(FastFlow::Status::TruncationTol) ==
+        "Converged: Truncation tolerance");
+  CHECK(get_output(FastFlow::Status::MaxIts) == "Failed: Too many iterations");
+  CHECK(get_output(FastFlow::Status::NegativeRadius) ==
+        "Failed: Negative radius");
+  CHECK(get_output(FastFlow::Status::DivergenceError) == "Failed: Diverging");
+}
+
+void test_negative_radius_error() {
+  // Set initial Strahlkorper radius to negative on purpose to get
+  // error exit status.
+  Strahlkorper<Frame::Inertial> strahlkorper(5, 5, -1.0, {{0, 0, 0}});
+  FastFlow flow(FastFlow::FlowType::Fast, 1.0, 0.5, 1e-12, 1e-10, 1.2, 5, 100);
+
+  const EinsteinSolutions::KerrSchild solution(1.0, {{0., 0., 0.}},
+                                               {{0., 0., 0.}});
+
+  const auto status = do_iteration(&strahlkorper, &flow, solution);
+  CHECK(status == FastFlow::Status::NegativeRadius);
+}
+
+void test_too_many_iterations_error() {
+  Strahlkorper<Frame::Inertial> strahlkorper(5, 5, 3.0, {{0, 0, 0}});
+  // Set number of iterations to 1 on purpose to get error exit status.
+  FastFlow flow(FastFlow::FlowType::Fast, 1.0, 0.5, 1e-12, 1e-10, 1.2, 5, 1);
+
+  const EinsteinSolutions::KerrSchild solution(1.0, {{0., 0., 0.}},
+                                               {{0., 0., 0.}});
+
+  const auto status = do_iteration(&strahlkorper, &flow, solution);
+  CHECK(status == FastFlow::Status::MaxIts);
+}
+
+void test_schwarzschild(FastFlow::Flow::type type_of_flow,
+                        const size_t max_iterations) {
+  Strahlkorper<Frame::Inertial> strahlkorper(5, 5, 3.0, {{0, 0, 0}});
+  FastFlow flow(type_of_flow, 1.0, 0.5, 1e-12, 1e-10, 1.2, 5, max_iterations);
+
+  const EinsteinSolutions::KerrSchild solution(1.0, {{0., 0., 0.}},
+                                               {{0., 0., 0.}});
+
+  const auto status = do_iteration(&strahlkorper, &flow, solution);
+  CHECK(converged(status));
+
+  const auto box =
+      db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
+                 db::AddComputeItemsTags<
+                     StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
+          strahlkorper);
+  const auto& rad = db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box);
+  const auto r_minmax = std::minmax_element(rad.begin(), rad.end());
+  Approx custom_approx = Approx::custom().epsilon(1.e-11);
+  CHECK(*r_minmax.first == custom_approx(2.0));
+  CHECK(*r_minmax.second == custom_approx(2.0));
+}
+
+void test_kerr(FastFlow::Flow::type type_of_flow, const size_t max_iterations) {
+  Strahlkorper<Frame::Inertial> strahlkorper(8, 8, 2.0, {{0, 0, 0}});
+  FastFlow flow(type_of_flow, 1.0, 0.5, 1e-12, 1e-2, 1.2, 5, max_iterations);
+
+  const std::array<double, 3> spin = {{0.1, 0.2, 0.3}};
+  const EinsteinSolutions::KerrSchild solution(1.0, spin, {{0., 0., 0.}});
+
+  const auto status = do_iteration(&strahlkorper, &flow, solution);
+  CHECK(converged(status));
+
+  const double spin_magnitude =
+      sqrt(square(spin[0]) + square(spin[1]) + square(spin[2]));
+  // Once we switch to c++17, use std::hypot(spin[0],spin[1],spin[2]);
+
+  // minimal radius of kerr horizon is M + sqrt(M^2-a^2) (obtained in
+  // direction parallel to Spin)
+  const double r_min_pt = strahlkorper.radius(acos(spin[2] / spin_magnitude),
+                                              atan2(spin[1], spin[0]));
+  const double r_min_val = 1.0 + sqrt(1.0 - square(spin_magnitude));
+
+  const std::array<double, 3> vector_normal_to_spin = {{0.0, -0.3, 0.2}};
+  const double vector_magnitude =
+      sqrt(square(vector_normal_to_spin[0]) + square(vector_normal_to_spin[1]) +
+           square(vector_normal_to_spin[2]));
+  // Once we switch to c++17, use std::hypot
+
+  // maximal radius of kerr horizon is sqrt(2M^2 + 2M sqrt(M^2-a^2))
+  // (obtained in direction orthogonal to spin)
+  const double r_max_pt = strahlkorper.radius(
+      acos(vector_normal_to_spin[2] / vector_magnitude),
+      atan2(vector_normal_to_spin[1], vector_normal_to_spin[0]));
+  const double r_max_val = sqrt(2.0 + 2.0 * sqrt(1.0 - square(spin_magnitude)));
+
+  Approx custom_approx = Approx::custom().epsilon(1.e-10);
+  CHECK(r_min_pt == custom_approx(r_min_val));
+  CHECK(r_max_pt == custom_approx(r_max_val));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.FastFlowSchwarzschild",
+                  "[Utilities][Unit]") {
+  test_schwarzschild(FastFlow::FlowType::Fast, 100);
+  test_schwarzschild(FastFlow::FlowType::Jacobi, 200);
+  test_schwarzschild(FastFlow::FlowType::Curvature, 200);
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.FastFlowKerr", "[Utilities][Unit]") {
+  test_kerr(FastFlow::FlowType::Fast, 100);
+  test_kerr(FastFlow::FlowType::Jacobi, 200);
+  test_kerr(FastFlow::FlowType::Curvature, 200);
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.FastFlowMisc", "[Utilities][Unit]") {
+  test_negative_radius_error();
+  test_too_many_iterations_error();
+  test_construct_from_options_fast();
+  test_construct_from_options_jacobi();
+  test_construct_from_options_curvature();
+  test_copy_and_move();
+  test_serialize();
+  test_ostream();
+}
+
+// [[OutputRegex, Value 0.5 is below the lower bound of 1.]
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.FastFlowOptFail",
+                  "[Utilities][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<FastFlowFromOpts>> opts("");
+  opts.parse(
+      "FastFlowFromOpts:\n"
+      "  Flow: Fast\n"
+      "  Alpha: 1.1\n"
+      "  Beta: 0.6\n"
+      "  AbsTol: 1.e-10\n"
+      "  TruncationTol: 1.e-3\n"
+      "  DivergenceTol: 0.5\n"
+      "  DivergenceIter: 6\n"
+      "  MaxIts: 200");
+  opts.get<FastFlowFromOpts>();
+}
+
+// [[OutputRegex, Failed to convert "Crud" to FastFlow::FlowType]]
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.FastFlowOptFail2",
+                  "[Utilities][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<FastFlowFromOpts>> opts("");
+  opts.parse(
+      "FastFlowFromOpts:\n"
+      "  Flow: Crud\n"
+      "  Alpha: 1.1\n"
+      "  Beta: 0.6\n"
+      "  AbsTol: 1.e-10\n"
+      "  TruncationTol: 1.e-3\n"
+      "  DivergenceTol: 1.1\n"
+      "  DivergenceIter: 6\n"
+      "  MaxIts: 200");
+  opts.get<FastFlowFromOpts>();
+}


### PR DESCRIPTION
## Proposed changes

Adds the FastFlow method for finding apparent horizons.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
