### PR TITLE
Make History::insert leave deriv in a usable state

### DIFF
--- a/src/Time/History.hpp
+++ b/src/Time/History.hpp
@@ -39,10 +39,10 @@ class History {
   ~History() = default;
 
   /// Add a new set of values to the end of the history.  `deriv` is
-  /// left in an unspecified state.  The different argument types for
-  /// `value` and `deriv` reflect the common use of this class, which
-  /// wants `value` to remain unchanged but does not care about
-  /// `deriv`.
+  /// either left unchanged or set to a previously inserted `deriv`
+  /// value.  The different argument types for `value` and `deriv`
+  /// reflect the common use of this class, which wants `value` to
+  /// remain unchanged but does not care about `deriv`.
   void insert(Time time, const Vars& value, DerivVars&& deriv) noexcept;
 
   /// Add a new set of values to the front of the history.  This is
@@ -168,7 +168,7 @@ void History<Vars, DerivVars>::insert(Time time, const Vars& value,
                                       DerivVars&& deriv) noexcept {
   if (first_needed_entry_ == 0) {
     // clang-tidy: move of trivially-copyable type
-    data_.emplace_back(std::move(time), value, std::move(deriv));  // NOLINT
+    data_.emplace_back(std::move(time), value, deriv);  // NOLINT
   } else {
     // Move an unneeded entry into the arguments so the caller can
     // reuse any resources the entry contained.

--- a/tests/Unit/ApparentHorizons/Test_Expansion.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Expansion.cpp
@@ -76,7 +76,7 @@ void test_schwarzschild() {
           get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataVector>>(vars),
           deriv_spatial_metric));
 
-  Approx custom_approx = Approx::custom().epsilon(1.e-12);
+  Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(
       get(residual), DataVector(get(residual).size(), 0.0), custom_approx);
 }

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -77,7 +77,12 @@ SPECTRE_TEST_CASE("Unit.Time.History", "[Unit][Time]") {
 
   history.insert(make_time(0.), 0., get_output(0));
   history.insert_initial(make_time(-1.), -1., get_output(-1));
-  history.insert(make_time(1.), 1., get_output(1));
+  {
+    auto tmp = get_output(1);
+    history.insert(make_time(1.), 1., std::move(tmp));
+    // clang-tidy: misc-use-after-move
+    CHECK(tmp == get_output(1));  // NOLINT
+  }
   history.insert_initial(make_time(-2.), -2., get_output(-2));
   history.insert_initial(make_time(-3.), -3., get_output(-3));
 
@@ -88,10 +93,12 @@ SPECTRE_TEST_CASE("Unit.Time.History", "[Unit][Time]") {
   CHECK(history.size() == 3);
   CHECK(history.capacity() == 5);
 
-  auto tmp = get_output(2);
-  history.insert(make_time(2.), 2., std::move(tmp));
-  // clang-tidy: misc-use-after-move
-  CHECK(tmp == get_output(-3));  // NOLINT
+  {
+    auto tmp = get_output(2);
+    history.insert(make_time(2.), 2., std::move(tmp));
+    // clang-tidy: misc-use-after-move
+    CHECK(tmp == get_output(-3));  // NOLINT
+  }
   CHECK(history.size() == 4);
   CHECK(history.capacity() == 5);
 


### PR DESCRIPTION
### Types of changes:

- [X] Bugfix
- [ ] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
