### PR TITLE
compute_christoffel_first_kind -> gr::christoffel_first_kind

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -7,8 +7,9 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
+namespace gr {
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
-tnsr::abb<DataType, SpatialDim, Frame, Index> compute_christoffel_first_kind(
+tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
     const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric) {
   auto christoffel =
       make_with_value<tnsr::abb<DataType, SpatialDim, Frame, Index>>(d_metric,
@@ -25,6 +26,7 @@ tnsr::abb<DataType, SpatialDim, Frame, Index> compute_christoffel_first_kind(
   }
   return christoffel;
 }
+} // namespace gr
 
 // Explicit Instantiations
 /// \cond
@@ -35,7 +37,7 @@ tnsr::abb<DataType, SpatialDim, Frame, Index> compute_christoffel_first_kind(
 
 #define INSTANTIATE(_, data)                                                 \
   template tnsr::abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>   \
-  compute_christoffel_first_kind(                                            \
+  gr::christoffel_first_kind(                                                \
       const tnsr::abb<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>& \
           d_metric);
 

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.hpp
@@ -8,16 +8,18 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
+namespace gr {
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes Christoffel symbol of the first kind from derivative of
  * metric
  *
  * \details Computes Christoffel symbol \f$\Gamma_{abc}\f$ as:
- * \f$ \Gamma_{cab} = 1/2 ( \partial_a g_{bc} + \partial_b g_{ac} -  \partial_c
- *    g_{ab}) \f$
+ * \f$ \Gamma_{cab} = \frac{1}{2} ( \partial_a g_{bc} + \partial_b g_{ac}
+ *  -  \partial_c g_{ab}) \f$
  * where \f$g_{bc}\f$ is either a spatial or spacetime metric
  */
 template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
-tnsr::abb<DataType, SpatialDim, Frame, Index> compute_christoffel_first_kind(
+tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
     const tnsr::abb<DataType, SpatialDim, Frame, Index>& d_metric);
+} // namespace gr

--- a/tests/Unit/ApparentHorizons/Test_Expansion.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Expansion.cpp
@@ -63,7 +63,7 @@ void test_schwarzschild() {
           db::get<StrahlkorperTags::D2xRadius<Frame::Inertial>>(box),
           one_over_one_form_magnitude,
           raise_or_lower_first_index(
-              compute_christoffel_first_kind(deriv_spatial_metric),
+              gr::christoffel_first_kind(deriv_spatial_metric),
               inverse_spatial_metric));
 
   const auto residual = StrahlkorperGr::expansion(
@@ -117,7 +117,7 @@ void test_minkowski() {
           db::get<StrahlkorperTags::D2xRadius<Frame::Inertial>>(box),
           one_over_one_form_magnitude,
           raise_or_lower_first_index(
-              compute_christoffel_first_kind(deriv_spatial_metric),
+              gr::christoffel_first_kind(deriv_spatial_metric),
               inverse_spatial_metric));
 
   const auto residual = StrahlkorperGr::expansion(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
@@ -106,7 +106,7 @@ void verify_time_independent_einstein_solution(
       lapse, dt_lapse, d_lapse, shift, dt_shift, d_shift, g,
       trace(gr::extrinsic_curvature(lapse, shift, d_shift, g, dt_g, d_g),
             upper_spatial_metric),
-      trace_last_indices(compute_christoffel_first_kind(d_g),
+      trace_last_indices(gr::christoffel_first_kind(d_g),
                          upper_spatial_metric));
 
   // Compute numerical derivatives of psi,pi,phi,H.
@@ -157,7 +157,7 @@ void verify_time_independent_einstein_solution(
   // Compute derived spacetime quantities
   const auto upper_psi =
       gr::inverse_spacetime_metric(lapse, shift, upper_spatial_metric);
-  const auto christoffel_first_kind = compute_christoffel_first_kind(d4_psi);
+  const auto christoffel_first_kind = gr::christoffel_first_kind(d4_psi);
   const auto christoffel_second_kind =
       raise_or_lower_first_index(christoffel_first_kind, upper_psi);
   const auto trace_christoffel_first_kind =

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -9,19 +9,19 @@
 namespace {
 void test_1d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
   const size_t spatial_dim = 1;
-  const auto christoffel = compute_christoffel_first_kind(
+  const auto christoffel = gr::christoffel_first_kind(
       make_deriv_spatial_metric<spatial_dim>(0.));
   CHECK(christoffel.get(0, 0, 0) == approx(1.5));
 
   check_tensor_doubles_equals_tensor_datavectors(
-      compute_christoffel_first_kind(
+      gr::christoffel_first_kind(
           make_deriv_spatial_metric<spatial_dim>(used_for_size)),
       christoffel);
 }
 
 void test_2d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
   const size_t spatial_dim = 2;
-  const auto christoffel = compute_christoffel_first_kind(
+  const auto christoffel = gr::christoffel_first_kind(
       make_deriv_spatial_metric<spatial_dim>(0.));
   CHECK(christoffel.get(0, 0, 0) == approx(1.5));
   CHECK(christoffel.get(0, 0, 1) == approx(2.0));
@@ -31,14 +31,14 @@ void test_2d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
   CHECK(christoffel.get(1, 1, 1) == approx(6.5));
 
   check_tensor_doubles_equals_tensor_datavectors(
-      compute_christoffel_first_kind(
+      gr::christoffel_first_kind(
           make_deriv_spatial_metric<spatial_dim>(used_for_size)),
       christoffel);
 }
 
 void test_3d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
   const size_t spatial_dim = 3;
-  const auto christoffel = compute_christoffel_first_kind(
+  const auto christoffel = gr::christoffel_first_kind(
       make_deriv_spatial_metric<spatial_dim>(0.));
   CHECK(christoffel.get(0, 0, 0) == approx(1.5));
   CHECK(christoffel.get(0, 0, 1) == approx(2.0));
@@ -60,14 +60,14 @@ void test_3d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
   CHECK(christoffel.get(2, 2, 2) == approx(14.5));
 
   check_tensor_doubles_equals_tensor_datavectors(
-      compute_christoffel_first_kind(
+      gr::christoffel_first_kind(
           make_deriv_spatial_metric<spatial_dim>(used_for_size)),
       christoffel);
 }
 
 void test_1d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
   const size_t spatial_dim = 1;
-  const auto christoffel = compute_christoffel_first_kind(
+  const auto christoffel = gr::christoffel_first_kind(
       make_spacetime_deriv_spacetime_metric<spatial_dim>(0.));
   CHECK(christoffel.get(0, 0, 0) == approx(1.5));
   CHECK(christoffel.get(0, 0, 1) == approx(2.0));
@@ -78,14 +78,14 @@ void test_1d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
 
 
   check_tensor_doubles_equals_tensor_datavectors(
-      compute_christoffel_first_kind(
+      gr::christoffel_first_kind(
           make_spacetime_deriv_spacetime_metric<spatial_dim>(used_for_size)),
       christoffel);
 }
 
 void test_2d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
   const size_t spatial_dim = 2;
-  const auto christoffel = compute_christoffel_first_kind(
+  const auto christoffel = gr::christoffel_first_kind(
       make_spacetime_deriv_spacetime_metric<spatial_dim>(0.));
   CHECK(christoffel.get(0, 0, 0) == approx(1.5));
   CHECK(christoffel.get(0, 0, 1) == approx(2.0));
@@ -108,14 +108,14 @@ void test_2d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
 
 
   check_tensor_doubles_equals_tensor_datavectors(
-      compute_christoffel_first_kind(
+      gr::christoffel_first_kind(
           make_spacetime_deriv_spacetime_metric<spatial_dim>(used_for_size)),
       christoffel);
 }
 
 void test_3d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
   const size_t spatial_dim = 3;
-  const auto christoffel = compute_christoffel_first_kind(
+  const auto christoffel = gr::christoffel_first_kind(
       make_spacetime_deriv_spacetime_metric<spatial_dim>(0.));
   CHECK(christoffel.get(0, 0, 0) == approx(1.5));
   CHECK(christoffel.get(0, 0, 1) == approx(2.));
@@ -159,7 +159,7 @@ void test_3d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
   CHECK(christoffel.get(3, 3, 3) == approx(48.));
 
   check_tensor_doubles_equals_tensor_datavectors(
-      compute_christoffel_first_kind(
+      gr::christoffel_first_kind(
           make_spacetime_deriv_spacetime_metric<spatial_dim>(used_for_size)),
       christoffel);
 }


### PR DESCRIPTION
## Proposed changes

<!--
Change compute_christoffel_first_kind() - > gr::christoffel_first_kind(), i.e. remove compute_ prefix from function name and move to namespace gr.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
