### PR TITLE
Changes to RootFinding and BulgedCube fixes

### DIFF
--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -71,18 +71,24 @@ template <typename DType>
 DType scaling_factor(RootFunction<DType>&& rootfunction) noexcept {
   const DType& x_sq = rootfunction.get_x_sq();
   const DType& physical_r_squared = rootfunction.get_r_sq();
-  DType rho = find_root_of_function(
-      rootfunction, make_with_value<DType>(x_sq, 0.0),
-      make_with_value<DType>(x_sq, sqrt(3.0)), 1.0e-16, 1.0e-16);
-  for (size_t i = 0; i < get_size(rho); i++) {
-    if (not(equal_within_roundoff(get_element(physical_r_squared, i), 0.0))) {
-      get_element(rho, i) /= sqrt(get_element(physical_r_squared, i));
-    } else {
-      ASSERT(equal_within_roundoff(get_element(rho, i), 0.0),
-             "r == 0 must imply rho == 0. This has failed.");
+  try {
+    DType rho =
+        find_root_of_function(rootfunction, make_with_value<DType>(x_sq, 0.0),
+                              make_with_value<DType>(x_sq, sqrt(3.0)),
+                              10.0 * std::numeric_limits<double>::epsilon(),
+                              10.0 * std::numeric_limits<double>::epsilon());
+    for (size_t i = 0; i < get_size(rho); i++) {
+      if (not(equal_within_roundoff(get_element(physical_r_squared, i), 0.0))) {
+        get_element(rho, i) /= sqrt(get_element(physical_r_squared, i));
+      } else {
+        ASSERT(equal_within_roundoff(get_element(rho, i), 0.0),
+               "r == 0 must imply rho == 0. This has failed.");
+      }
     }
+    return rho;
+  } catch (std::exception& exception) {
+    ERROR("Error in BulgedCube root find:" << exception.what());
   }
-  return rho;
 }
 }  // namespace
 

--- a/src/NumericalAlgorithms/RootFinding/RootFinder.hpp
+++ b/src/NumericalAlgorithms/RootFinding/RootFinder.hpp
@@ -31,6 +31,9 @@ double find_root_of_function(const Function& f, const double lower_bound,
                              const double absolute_tolerance,
                              const double relative_tolerance,
                              const size_t max_iterations = 100) {
+  ASSERT(relative_tolerance > std::numeric_limits<double>::epsilon(),
+         "The relative tolerance is too small.");
+
   boost::uintmax_t max_iter = max_iterations;
 
   // This solver requires tol to be passed as a termination condition. This
@@ -74,6 +77,8 @@ DataVector find_root_of_function(const Function& f,
                                  const double absolute_tolerance,
                                  const double relative_tolerance,
                                  const size_t max_iterations = 100) {
+  ASSERT(relative_tolerance > std::numeric_limits<double>::epsilon(),
+         "The relative tolerance is too small.");
   // This solver requires tol to be passed as a termination condition. This
   // termination condition is equivalent to the convergence criteria used by the
   // GSL

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_OneDRootFinder.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_OneDRootFinder.cpp
@@ -82,3 +82,41 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.DataVector",
   CHECK(std::abs(root[3] + 2.0) < abs_tol);
   CHECK(std::abs(root[3] + 2.0) / 2.0 < rel_tol);
 }
+
+// [[OutputRegex, The relative tolerance is too small.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.RootFinding.TOMS748RootSolver.RelativeTol.DataVector",
+    "[NumericalAlgorithms][RootFinding][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const double abs_tol = 1e-15;
+  const double rel_tol = 0.5 * std::numeric_limits<double>::epsilon();
+  const DataVector upper{2.0, 3.0, -sqrt(2.0), -sqrt(2.0)};
+  const DataVector lower{sqrt(2.), sqrt(2.0), -2.0, -3.0};
+
+  const DataVector constant{2.0, 4.0, 2.0, 4.0};
+  const auto f_lambda = [&constant](const double x, const size_t i) noexcept {
+    return constant[i] - x * x;
+  };
+
+  find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The relative tolerance is too small.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.RootFinding.TOMS748RootSolver.RelativeTol.Double",
+    "[NumericalAlgorithms][RootFinding][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const double abs_tol = 1e-15;
+  const double rel_tol = 0.5 * std::numeric_limits<double>::epsilon();
+  double upper = 2.0;
+  double lower = sqrt(2.);
+  const auto f_lambda = [](double x) { return 2.0 - x * x; };
+
+  find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}


### PR DESCRIPTION
## Proposed changes

Add ASSERTs to RootFinding to make sure the tolerance is set in the appropriate range.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
