### PR TITLE
Allow periodic boundary conditions across multiple blocks

### DIFF
--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -7,28 +7,59 @@
 #include "Domain/DomainHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-// Tests that get_common_global_corners is an order-sensitive intersection.
-SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Boundaries", "[Domain][Unit]") {
-  std::vector<std::array<size_t, 8>> corners_of_all_blocks{
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.SameBlock",
+                  "[Domain][Unit]") {
+  const std::vector<std::array<size_t, 8>> corners_of_all_blocks{
       {{0, 1, 2, 3, 4, 5, 6, 7}}, {{8, 9, 10, 11, 0, 1, 2, 3}}};
   std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
       neighbors_of_all_blocks;
   set_internal_boundaries<3>(corners_of_all_blocks, &neighbors_of_all_blocks);
 
-  std::array<Direction<3>, 3> mapped_directions{{Direction<3>::upper_xi(),
-                                                 Direction<3>::upper_eta(),
-                                                 Direction<3>::upper_zeta()}};
-  OrientationMap<3> expected_orientation(mapped_directions);
-  CHECK(
-      (neighbors_of_all_blocks)[0][Direction<3>::lower_zeta()].orientation() ==
-      expected_orientation);
+  const OrientationMap<3> aligned{};
+  CHECK(neighbors_of_all_blocks[0][Direction<3>::lower_zeta()].orientation() ==
+        aligned);
 
   const PairOfFaces x_faces{{1, 3, 5, 7}, {0, 2, 4, 6}};
 
-  std::vector<PairOfFaces> identifications{x_faces};
+  const std::vector<PairOfFaces> identifications{x_faces};
   set_periodic_boundaries<3>(identifications, corners_of_all_blocks,
                              &neighbors_of_all_blocks);
-  OrientationMap<3> expected_identification(mapped_directions);
-  CHECK((neighbors_of_all_blocks)[0][Direction<3>::upper_xi()].orientation() ==
-        expected_identification);
+  CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
+        aligned);
+
+  const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
+      expected_block_neighbors{{{Direction<3>::upper_xi(), {0, aligned}},
+                                {Direction<3>::lower_xi(), {0, aligned}},
+                                {Direction<3>::lower_zeta(), {1, aligned}}},
+                               {{Direction<3>::upper_zeta(), {0, aligned}}}};
+
+  CHECK(neighbors_of_all_blocks == expected_block_neighbors);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.DifferentBlocks",
+                  "[Domain][Unit]") {
+  const std::vector<std::array<size_t, 8>> corners_of_all_blocks{
+      {{0, 1, 2, 3, 4, 5, 6, 7}}, {{8, 9, 10, 11, 0, 1, 2, 3}}};
+  std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
+      neighbors_of_all_blocks;
+  set_internal_boundaries<3>(corners_of_all_blocks, &neighbors_of_all_blocks);
+
+  const OrientationMap<3> aligned{};
+  CHECK(neighbors_of_all_blocks[0][Direction<3>::lower_zeta()].orientation() ==
+        aligned);
+
+  const PairOfFaces x_faces_on_different_blocks{{1, 3, 5, 7}, {8, 10, 0, 2}};
+
+  const std::vector<PairOfFaces> identifications{x_faces_on_different_blocks};
+  set_periodic_boundaries<3>(identifications, corners_of_all_blocks,
+                             &neighbors_of_all_blocks);
+  CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
+        aligned);
+  const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
+      expected_block_neighbors{{{Direction<3>::upper_xi(), {1, aligned}},
+                                {Direction<3>::lower_zeta(), {1, aligned}}},
+                               {{Direction<3>::lower_xi(), {0, aligned}},
+                                {Direction<3>::upper_zeta(), {0, aligned}}}};
+
+  CHECK(neighbors_of_all_blocks == expected_block_neighbors);
 }


### PR DESCRIPTION
## Proposed changes

Allows the user to identify the face of one block with the face of another block in setting up
periodic boundary conditions.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
