### PR TITLE
Databox TMP cleanup

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1295,10 +1295,8 @@ constexpr auto DataBox<TagsList<Tags...>>::create_from(const Box& box,
   using sorted_tags = ::db::get_databox_list<new_tags>;
   // List of tags that were both removed and added, and therefore were mutated
   using mutated_tags =
-      tmpl::filter<AddTags,
-                   tmpl::bind<tmpl::found, tmpl::pin<RemoveTags>,
-                              tmpl::bind<std::is_same, tmpl::pin<tmpl::_1>,
-                                         tmpl::parent<tmpl::_1>>>>;
+      tmpl::filter<AddTags, tmpl::bind<tmpl::list_contains,
+                                       tmpl::pin<RemoveTags>, tmpl::_1>>;
   return DataBox<sorted_tags>(box, remaining_tags{}, AddTags{},
                               AddComputeItems{}, compute_items_to_keep{},
                               mutated_tags{}, std::forward<Args>(args)...);

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1700,21 +1700,6 @@ inline constexpr auto apply_with_box(F f, const DataBox<BoxTags...>& box,
 
 /*!
  * \ingroup DataBoxGroup
- * \brief Get typelist of tags to remove from a DataBox so as to keep only
- * desired tags
- *
- * \metareturns a typelist of tags that need to be removed from the DataBox
- * with tags `DataBoxTagsList` in order to keep the tags in `KeepTagsList`
- *
- * \example
- * \snippet Test_DataBox.cpp remove_tags_from_keep_tags
- */
-template <typename DataBoxTagsList, typename KeepTagsList>
-using remove_tags_from_keep_tags =
-    tmpl::list_difference<DataBoxTagsList, KeepTagsList>;
-
-/*!
- * \ingroup DataBoxGroup
  * \brief Get all the Tags that are compute items from the `TagList`
  */
 template <class TagList>

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1074,18 +1074,14 @@ void mutate(DataBox<TagList>& box, Invokable&& invokable,
   // For all the variable tags in the DataBox, check if one of their Tags is
   // being mutated and if so add it to the list of tags being mutated. Then,
   // remove any Variables tags that would be passed multiple times.
-  using variables_tags = tmpl::filter<
+  using variables_tags = tmpl::list_difference<
       tmpl::filter<
           typename DataBox<TagList>::variables_item_tags,
           tmpl::bind<
               tmpl::found, databox_detail::get_tags_list<tmpl::_1>,
-              tmpl::bind<tmpl::found, tmpl::pin<tmpl::list<MutateTags...>>,
-                         tmpl::bind<std::is_same, tmpl::pin<tmpl::_1>,
-                                    tmpl::parent<tmpl::_1>>>>>,
-      tmpl::bind<tmpl::not_found, tmpl::pin<mutate_tags_list>,
-                 tmpl::bind<std::is_same, tmpl::bind<tmpl::pin, tmpl::_1>,
-                            tmpl::parent<tmpl::_1>>>>;
-
+              tmpl::pin<tmpl::bind<tmpl::list_contains,
+                                   tmpl::pin<mutate_tags_list>, tmpl::_1>>>>,
+      mutate_tags_list>;
   // Since MutateTags could contain Variables Tags we need to extract the Tags
   // inside the Variables class and reset compute items depending on those too.
   using mutated_items_including_variables =

--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -554,4 +554,9 @@ using list_contains =
 
 template <typename Sequence, typename Item>
 constexpr const bool list_contains_v = list_contains<Sequence, Item>::value;
+
+/// Obtain the elements of `Sequence1` that are not in `Sequence2`.
+template <typename Sequence1, typename Sequence2>
+using list_difference =
+    remove_if<Sequence1, bind<list_contains, pin<Sequence2>, _1>>;
 }  // namespace brigand

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -91,22 +91,6 @@ struct TagPrefix : db::DataBoxPrefix {
 }  // namespace test_databox_tags
 
 namespace {
-template <typename T>
-struct X {};
-/// [remove_tags_from_keep_tags]
-using full_list = tmpl::list<double, char, int, bool, X<int>>;
-using keep_list = tmpl::list<double, bool>;
-static_assert(
-    std::is_same<typelist<char, int, X<int>>,
-                 db::remove_tags_from_keep_tags<full_list, keep_list>>::value,
-    "Failed testing db::remove_tags_from_keep_tags");
-using keep_list2 = tmpl::list<double, bool, X<int>>;
-static_assert(
-    std::is_same<typelist<char, int>,
-                 db::remove_tags_from_keep_tags<full_list, keep_list2>>::value,
-    "Failed testing db::remove_tags_from_keep_tags");
-/// [remove_tags_from_keep_tags]
-
 using Box_t = db::DataBox<db::get_databox_list<typelist<
     test_databox_tags::Tag0, test_databox_tags::Tag1, test_databox_tags::Tag2,
     test_databox_tags::TagPrefix<test_databox_tags::Tag0>,

--- a/tests/Unit/Utilities/Test_TMPL.cpp
+++ b/tests/Unit/Utilities/Test_TMPL.cpp
@@ -46,3 +46,17 @@ static_assert(not tmpl::list_contains_v<tmpl::list<Templated<int>,
                                                    Templated<double>>,
                                         double>,
               "Failed testing list_contains");
+
+static_assert(cpp17::is_same_v<
+                  tmpl::list_difference<
+                      tmpl::list<Templated<int>, Templated<double>>,
+                      tmpl::list<double>>,
+                  tmpl::list<Templated<int>, Templated<double>>>,
+              "Failed testing list_difference");
+
+static_assert(cpp17::is_same_v<
+                  tmpl::list_difference<
+                      tmpl::list<Templated<int>, Templated<double>>,
+                      tmpl::list<Templated<double>>>,
+                  tmpl::list<Templated<int>>>,
+              "Failed testing list_difference");


### PR DESCRIPTION
There are a few changes that remove parameter pack expansions that I am not certain I understand the implications of in terms of compilation time/resources, so I'd like comments on them.  These have been collected into the fixup commit.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
