### PR TITLE
Add cartesian axes to Direction

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -13,7 +13,7 @@ Block<VolumeDim, TargetFrame>::Block(
     : map_(std::move(map)), id_(id), neighbors_(std::move(neighbors)) {
   // Loop over Directions to search which Directions were not set to neighbors_,
   // set these Directions to external_boundaries_.
-  for (const auto& direction : Direction<VolumeDim>::all_directions()) {
+  for (const auto& direction : Direction<VolumeDim>::all_logical_directions()) {
     if (neighbors_.find(direction) == neighbors_.end()) {
       external_boundaries_.emplace(std::move(direction));
     }

--- a/src/Domain/Direction.cpp
+++ b/src/Domain/Direction.cpp
@@ -6,39 +6,88 @@
 #include <ostream>
 
 #include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
 
 template <>
 Direction<1>::Direction(const size_t dimension, const Side side) noexcept {
-  ASSERT(
-      0 == dimension,
-      "dim = " << dimension << ", for Direction<1> only dim = 0 is allowed.");
-  axis_ = Axis::Xi;
+  ASSERT(0 == dimension or 3 == dimension or 4 == dimension or 5 == dimension,
+         "dim = " << dimension
+                  << ", for Direction<1> only dim = 0, 3, 4, or 5 is allowed.");
+  switch (dimension) {
+    case 0:
+      axis_ = Axis::Xi;
+      break;
+    case 3:
+      axis_ = Axis::X;
+      break;
+    case 4:
+      axis_ = Axis::Y;
+      break;
+    case 5:
+      axis_ = Axis::Z;
+      break;
+    default:
+      ERROR("For Direction<1> only dim = 0, 3, 4, or 5 are allowed.");
+  }
   side_ = side;
 }
 
 /// \cond NEVER
 template <>
 Direction<2>::Direction(const size_t dimension, const Side side) noexcept {
-  ASSERT(0 == dimension or 1 == dimension,
-         "dim = " << dimension
-                  << ", for Direction<2> only dim = 0 or dim = 1 are allowed.");
-  axis_ = 0 == dimension ? Axis::Xi : Axis::Eta;
+  ASSERT(0 == dimension or 1 == dimension or 3 == dimension or 4 == dimension or
+             5 == dimension,
+         "dim = "
+             << dimension
+             << ", for Direction<2> only dim = 0, 1, 3, 4, or 5 are allowed.");
+  switch (dimension) {
+    case 0:
+      axis_ = Axis::Xi;
+      break;
+    case 1:
+      axis_ = Axis::Eta;
+      break;
+    case 3:
+      axis_ = Axis::X;
+      break;
+    case 4:
+      axis_ = Axis::Y;
+      break;
+    case 5:
+      axis_ = Axis::Z;
+      break;
+    default:
+      ERROR("For Direction<2> only dim = 0, 1, 3, 4, or 5 are allowed.");
+  }
   side_ = side;
 }
 
 template <>
 Direction<3>::Direction(const size_t dimension, const Side side) noexcept {
-  ASSERT(0 == dimension or 1 == dimension or 2 == dimension,
-         "dim = " << dimension << ", for Direction<3> only dim = 0, dim = 1, "
-                                  "or dim = 2 are allowed.");
-  if (0 == dimension) {
-    axis_ = Axis::Xi;
-  }
-  if (1 == dimension) {
-    axis_ = Axis::Eta;
-  }
-  if (2 == dimension) {
-    axis_ = Axis::Zeta;
+  ASSERT(dimension < 6, "dim = " << dimension
+                                 << ", for Direction<3> only dim = 0, 1, "
+                                    "2, 3, 4, or 5 are allowed.");
+  switch (dimension) {
+    case 0:
+      axis_ = Axis::Xi;
+      break;
+    case 1:
+      axis_ = Axis::Eta;
+      break;
+    case 2:
+      axis_ = Axis::Zeta;
+      break;
+    case 3:
+      axis_ = Axis::X;
+      break;
+    case 4:
+      axis_ = Axis::Y;
+      break;
+    case 5:
+      axis_ = Axis::Z;
+      break;
+    default:
+      ERROR("For Direction<3> only dim = 0, 1, 2, 3, 4, or 5 are allowed.");
   }
   side_ = side;
 }

--- a/src/Domain/Direction.cpp
+++ b/src/Domain/Direction.cpp
@@ -9,65 +9,34 @@
 #include "ErrorHandling/Error.hpp"
 
 template <>
-Direction<1>::Direction(const size_t dimension, const Side side) noexcept {
-  ASSERT(0 == dimension or 3 == dimension or 4 == dimension or 5 == dimension,
-         "dim = " << dimension
-                  << ", for Direction<1> only dim = 0, 3, 4, or 5 is allowed.");
-  switch (dimension) {
-    case 0:
-      axis_ = Axis::Xi;
-      break;
-    case 3:
-      axis_ = Axis::X;
-      break;
-    case 4:
-      axis_ = Axis::Y;
-      break;
-    case 5:
-      axis_ = Axis::Z;
-      break;
-    default:
-      ERROR("For Direction<1> only dim = 0, 3, 4, or 5 are allowed.");
-  }
+Direction<1>::Direction(const size_t logical_dimension,
+                        const Side side) noexcept {
+  ASSERT(0 == logical_dimension,
+         "dim = " << logical_dimension
+                  << ", for Direction<1> only dim = 0 is allowed.");
+  axis_ = Axis::Xi;
   side_ = side;
 }
 
 /// \cond NEVER
 template <>
-Direction<2>::Direction(const size_t dimension, const Side side) noexcept {
-  ASSERT(0 == dimension or 1 == dimension or 3 == dimension or 4 == dimension or
-             5 == dimension,
-         "dim = "
-             << dimension
-             << ", for Direction<2> only dim = 0, 1, 3, 4, or 5 are allowed.");
-  switch (dimension) {
-    case 0:
-      axis_ = Axis::Xi;
-      break;
-    case 1:
-      axis_ = Axis::Eta;
-      break;
-    case 3:
-      axis_ = Axis::X;
-      break;
-    case 4:
-      axis_ = Axis::Y;
-      break;
-    case 5:
-      axis_ = Axis::Z;
-      break;
-    default:
-      ERROR("For Direction<2> only dim = 0, 1, 3, 4, or 5 are allowed.");
-  }
+Direction<2>::Direction(const size_t logical_dimension,
+                        const Side side) noexcept {
+  ASSERT(logical_dimension < 2,
+         "dim = " << logical_dimension
+                  << ", for Direction<2> only dim = 0 or dim = 1 are allowed.");
+  axis_ = 0 == logical_dimension ? Axis::Xi : Axis ::Eta;
   side_ = side;
 }
 
 template <>
-Direction<3>::Direction(const size_t dimension, const Side side) noexcept {
-  ASSERT(dimension < 6, "dim = " << dimension
-                                 << ", for Direction<3> only dim = 0, 1, "
-                                    "2, 3, 4, or 5 are allowed.");
-  switch (dimension) {
+Direction<3>::Direction(const size_t logical_dimension,
+                        const Side side) noexcept {
+  ASSERT(logical_dimension < 3,
+         "dim = " << logical_dimension
+                  << ", for Direction<3> only dim = 0, dim = 1, "
+                     "or dim = 2 are allowed.");
+  switch (logical_dimension) {
     case 0:
       axis_ = Axis::Xi;
       break;
@@ -76,15 +45,6 @@ Direction<3>::Direction(const size_t dimension, const Side side) noexcept {
       break;
     case 2:
       axis_ = Axis::Zeta;
-      break;
-    case 3:
-      axis_ = Axis::X;
-      break;
-    case 4:
-      axis_ = Axis::Y;
-      break;
-    case 5:
-      axis_ = Axis::Z;
       break;
     default:
       ERROR("For Direction<3> only dim = 0, 1, 2, 3, 4, or 5 are allowed.");
@@ -101,7 +61,7 @@ std::ostream& operator<<(std::ostream& os,
   } else {
     os << "+";
   }
-  os << direction.dimension();
+  os << direction.logical_dimension();
   return os;
 }
 

--- a/src/Domain/Direction.hpp
+++ b/src/Domain/Direction.hpp
@@ -10,7 +10,6 @@
 #include <iosfwd>
 #include <pup.h>
 
-#include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Side.hpp"
 #include "Parallel/PupStlCpp11.hpp"
 
@@ -19,20 +18,22 @@
 template <size_t VolumeDim>
 class Direction {
  public:
-  /// The logical-coordinate names of each dimension
+  /// The logical-coordinate names of each logical_dimension
   enum class Axis;
 
   /// Construct by specifying an Axis and a Side.
   Direction(Axis axis, Side side) noexcept : axis_(axis), side_(side) {}
 
-  /// Construct by specifying a dimension and a Side.
-  Direction<VolumeDim>(size_t dimension, Side side) noexcept;
+  /// Construct by specifying a logical_dimension and a Side.
+  Direction<VolumeDim>(size_t logical_dimension, Side side) noexcept;
 
   /// Default constructor for Charm++ serialization.
   Direction() noexcept;
 
-  /// The dimension of the Direction
-  size_t dimension() const noexcept { return static_cast<size_t>(axis_); }
+  /// The logical_dimension of the Direction
+  size_t logical_dimension() const noexcept {
+    return static_cast<size_t>(axis_);
+  }
 
   /// The Axis of the Direction
   Axis axis() const noexcept { return axis_; }
@@ -46,7 +47,7 @@ class Direction {
   /// The opposite Direction.
   Direction<VolumeDim> opposite() const noexcept;
 
-  // An array of all logical Directions for a given dimensionality.
+  // An array of all logical Directions for a given logical_dimensionality.
   static const std::array<Direction<VolumeDim>, 2 * VolumeDim>&
   all_logical_directions() noexcept;
 
@@ -97,10 +98,10 @@ Direction<VolumeDim>::Direction() noexcept = default;  // NOLINT
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 template <>
-enum class Direction<1>::Axis{Xi = 0, X = 3, Y = 4, Z = 5};
+enum class Direction<1>::Axis{Xi = 0, X = 3};
 
 template <>
-enum class Direction<2>::Axis{Xi = 0, Eta = 1, X = 3, Y = 4, Z = 5};
+enum class Direction<2>::Axis{Xi = 0, Eta = 1, X = 3, Y = 4};
 
 template <>
 enum class Direction<3>::Axis{Xi = 0, Eta = 1, Zeta = 2, X = 3, Y = 4, Z = 5};
@@ -152,21 +153,25 @@ inline Direction<VolumeDim> Direction<VolumeDim>::upper_x() noexcept {
 
 template <size_t VolumeDim>
 inline Direction<VolumeDim> Direction<VolumeDim>::lower_y() noexcept {
+  static_assert(VolumeDim == 2 or VolumeDim == 3, "VolumeDim must be 2 or 3.");
   return Direction(Direction<VolumeDim>::Axis::Y, Side::Lower);
 }
 
 template <size_t VolumeDim>
 inline Direction<VolumeDim> Direction<VolumeDim>::upper_y() noexcept {
+  static_assert(VolumeDim == 2 or VolumeDim == 3, "VolumeDim must be 2 or 3.");
   return Direction(Direction<VolumeDim>::Axis::Y, Side::Upper);
 }
 
 template <size_t VolumeDim>
 inline Direction<VolumeDim> Direction<VolumeDim>::lower_z() noexcept {
+  static_assert(VolumeDim == 3, "VolumeDim must be 3.");
   return Direction(Direction<VolumeDim>::Axis::Z, Side::Lower);
 }
 
 template <size_t VolumeDim>
 inline Direction<VolumeDim> Direction<VolumeDim>::upper_z() noexcept {
+  static_assert(VolumeDim == 3, "VolumeDim must be 3.");
   return Direction(Direction<VolumeDim>::Axis::Z, Side::Upper);
 }
 template <size_t VolumeDim>
@@ -212,7 +217,8 @@ void Direction<VolumeDim>::pup(PUP::er& p) {
 template <size_t VolumeDim>
 inline bool operator==(const Direction<VolumeDim>& lhs,
                        const Direction<VolumeDim>& rhs) {
-  return lhs.dimension() == rhs.dimension() and lhs.sign() == rhs.sign();
+  return lhs.logical_dimension() == rhs.logical_dimension() and
+         lhs.sign() == rhs.sign();
 }
 
 template <size_t VolumeDim>
@@ -223,7 +229,8 @@ inline bool operator!=(const Direction<VolumeDim>& lhs,
 
 template <size_t VolumeDim>
 size_t hash_value(const Direction<VolumeDim>& d) noexcept {
-  return std::hash<size_t>{}(d.dimension()) xor std::hash<double>{}(d.sign());
+  return std::hash<size_t>{}(d.logical_dimension()) xor
+         std::hash<double>{}(d.sign());
 }
 
 namespace std {

--- a/src/Domain/Direction.hpp
+++ b/src/Domain/Direction.hpp
@@ -10,6 +10,7 @@
 #include <iosfwd>
 #include <pup.h>
 
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Side.hpp"
 #include "Parallel/PupStlCpp11.hpp"
 
@@ -47,7 +48,7 @@ class Direction {
 
   // An array of all logical Directions for a given dimensionality.
   static const std::array<Direction<VolumeDim>, 2 * VolumeDim>&
-  all_directions() noexcept;
+  all_logical_directions() noexcept;
 
   // {@
   /// Helper functions for creating specific Directions.
@@ -59,6 +60,13 @@ class Direction {
   static Direction<VolumeDim> upper_eta() noexcept;
   static Direction<VolumeDim> lower_zeta() noexcept;
   static Direction<VolumeDim> upper_zeta() noexcept;
+  static Direction<VolumeDim> lower_x() noexcept;
+  static Direction<VolumeDim> upper_x() noexcept;
+  static Direction<VolumeDim> lower_y() noexcept;
+  static Direction<VolumeDim> upper_y() noexcept;
+  static Direction<VolumeDim> lower_z() noexcept;
+  static Direction<VolumeDim> upper_z() noexcept;
+
   // @}
 
   /// Serialization for Charm++
@@ -89,13 +97,13 @@ Direction<VolumeDim>::Direction() noexcept = default;  // NOLINT
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 template <>
-enum class Direction<1>::Axis{Xi = 0};
+enum class Direction<1>::Axis{Xi = 0, X = 3, Y = 4, Z = 5};
 
 template <>
-enum class Direction<2>::Axis{Xi = 0, Eta = 1};
+enum class Direction<2>::Axis{Xi = 0, Eta = 1, X = 3, Y = 4, Z = 5};
 
 template <>
-enum class Direction<3>::Axis{Xi = 0, Eta = 1, Zeta = 2};
+enum class Direction<3>::Axis{Xi = 0, Eta = 1, Zeta = 2, X = 3, Y = 4, Z = 5};
 #pragma GCC diagnostic pop
 
 template <size_t VolumeDim>
@@ -133,22 +141,51 @@ inline Direction<VolumeDim> Direction<VolumeDim>::upper_zeta() noexcept {
 }
 
 template <size_t VolumeDim>
+inline Direction<VolumeDim> Direction<VolumeDim>::lower_x() noexcept {
+  return Direction(Direction<VolumeDim>::Axis::X, Side::Lower);
+}
+
+template <size_t VolumeDim>
+inline Direction<VolumeDim> Direction<VolumeDim>::upper_x() noexcept {
+  return Direction(Direction<VolumeDim>::Axis::X, Side::Upper);
+}
+
+template <size_t VolumeDim>
+inline Direction<VolumeDim> Direction<VolumeDim>::lower_y() noexcept {
+  return Direction(Direction<VolumeDim>::Axis::Y, Side::Lower);
+}
+
+template <size_t VolumeDim>
+inline Direction<VolumeDim> Direction<VolumeDim>::upper_y() noexcept {
+  return Direction(Direction<VolumeDim>::Axis::Y, Side::Upper);
+}
+
+template <size_t VolumeDim>
+inline Direction<VolumeDim> Direction<VolumeDim>::lower_z() noexcept {
+  return Direction(Direction<VolumeDim>::Axis::Z, Side::Lower);
+}
+
+template <size_t VolumeDim>
+inline Direction<VolumeDim> Direction<VolumeDim>::upper_z() noexcept {
+  return Direction(Direction<VolumeDim>::Axis::Z, Side::Upper);
+}
+template <size_t VolumeDim>
 inline Direction<VolumeDim> Direction<VolumeDim>::opposite() const noexcept {
   return Direction<VolumeDim>(axis_, ::opposite(side_));
 }
 
 /// \cond NEVER
 template <>
-inline const std::array<Direction<1>, 2>& Direction<1>::all_directions()
-    noexcept {
+inline const std::array<Direction<1>, 2>&
+Direction<1>::all_logical_directions() noexcept {
   const static auto directions = std::array<Direction<1>, 2>{
       {Direction<1>::upper_xi(), Direction<1>::lower_xi()}};
   return directions;
 }
 
 template <>
-inline const std::array<Direction<2>, 4>& Direction<2>::all_directions()
-    noexcept {
+inline const std::array<Direction<2>, 4>&
+Direction<2>::all_logical_directions() noexcept {
   const static auto directions = std::array<Direction<2>, 4>{
       {Direction<2>::upper_xi(), Direction<2>::lower_xi(),
        Direction<2>::upper_eta(), Direction<2>::lower_eta()}};
@@ -156,8 +193,8 @@ inline const std::array<Direction<2>, 4>& Direction<2>::all_directions()
 }
 
 template <>
-inline const std::array<Direction<3>, 6>& Direction<3>::all_directions()
-    noexcept {
+inline const std::array<Direction<3>, 6>&
+Direction<3>::all_logical_directions() noexcept {
   const static auto directions = std::array<Direction<3>, 6>{
       {Direction<3>::upper_xi(), Direction<3>::lower_xi(),
        Direction<3>::upper_eta(), Direction<3>::lower_eta(),

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -183,9 +183,9 @@ std::vector<Direction<VolumeDim>> get_directions_along_face(
            "the edge is parallel to the xi, eta, or zeta axis, respectively. "
            "This ASSERT is triggered when the two corners passed do not make "
            "up an edge of the n-cube.");
-    const size_t dimension = std::round(log2(abs(direction_pow2)));
+    const size_t logical_dimension = std::round(log2(abs(direction_pow2)));
     const Side side = direction_pow2 > 0 ? Side::Upper : Side::Lower;
-    result.push_back(Direction<VolumeDim>(dimension, side));
+    result.push_back(Direction<VolumeDim>(logical_dimension, side));
   }
   return result;
 }
@@ -199,7 +199,8 @@ Direction<VolumeDim> mapped(
   const auto correspondence = obtain_correspondence_between_blocks(
       block_id1, block_id2, corners_of_all_blocks);
   for (size_t i = 0; i < VolumeDim; i++) {
-    if (dir_in_block1.dimension() == (correspondence.first)[i].dimension()) {
+    if (dir_in_block1.logical_dimension() ==
+        (correspondence.first)[i].logical_dimension()) {
       return dir_in_block1.side() == (correspondence.first)[i].side()
                  ? (correspondence.second)[i]
                  : (correspondence.second)[i].opposite();

--- a/src/Domain/Element.cpp
+++ b/src/Domain/Element.cpp
@@ -12,17 +12,17 @@ Element<VolumeDim>::Element(ElementId<VolumeDim> id,
                             Neighbors_t neighbors) noexcept
     : id_(std::move(id)),
       neighbors_(std::move(neighbors)),
-      number_of_neighbors_([this](){
+      number_of_neighbors_([this]() {
         size_t number_of_neighbors = 0;
         for (const auto& p : neighbors_) {
           number_of_neighbors += p.second.size();
         }
         return number_of_neighbors;
       }()),
-      external_boundaries_([this](){
+      external_boundaries_([this]() {
         std::unordered_set<Direction<VolumeDim>> external_boundaries(
-            Direction<VolumeDim>::all_directions().begin(),
-            Direction<VolumeDim>::all_directions().end());
+            Direction<VolumeDim>::all_logical_directions().begin(),
+            Direction<VolumeDim>::all_logical_directions().end());
         for (const auto& neighbor_direction : neighbors_) {
           external_boundaries.erase(neighbor_direction.first);
         }

--- a/src/Domain/FaceNormal.cpp
+++ b/src/Domain/FaceNormal.cpp
@@ -22,7 +22,7 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal_impl(
   const auto inv_jacobian_on_interface =
       map.inv_jacobian(std::move(interface_coords));
 
-  const auto sliced_away_dim = direction.dimension();
+  const auto sliced_away_dim = direction.logical_dimension();
   const double sign = direction.sign();
 
   tnsr::i<DataVector, VolumeDim, TargetFrame> face_normal(

--- a/src/Domain/LogicalCoordinates.cpp
+++ b/src/Domain/LogicalCoordinates.cpp
@@ -32,7 +32,7 @@ template <size_t VolumeDim>
 tnsr::I<DataVector, VolumeDim, Frame::Logical> interface_logical_coordinates(
     const Index<VolumeDim - 1>& extents,
     const Direction<VolumeDim>& direction) {
-  const size_t sliced_away_dim = direction.dimension();
+  const size_t sliced_away_dim = direction.logical_dimension();
   tnsr::I<DataVector, VolumeDim, Frame::Logical> logical_x(extents.product());
 
   std::array<DataVector, VolumeDim - 1> collocation_points_in_each_dim{};

--- a/src/Domain/OrientationMap.cpp
+++ b/src/Domain/OrientationMap.cpp
@@ -18,7 +18,7 @@ OrientationMap<VolumeDim>::OrientationMap(
     std::array<Direction<VolumeDim>, VolumeDim> mapped_directions)
     : mapped_directions_(std::move(mapped_directions)) {
   for (size_t j = 0; j < VolumeDim; j++) {
-    if (gsl::at(mapped_directions_, j).dimension() != j or
+    if (gsl::at(mapped_directions_, j).logical_dimension() != j or
         gsl::at(mapped_directions_, j).side() != Side::Upper) {
       is_aligned_ = false;
     }
@@ -30,7 +30,8 @@ OrientationMap<VolumeDim>::OrientationMap(
     const std::array<Direction<VolumeDim>, VolumeDim>& directions_in_host,
     const std::array<Direction<VolumeDim>, VolumeDim>& directions_in_neighbor) {
   for (size_t j = 0; j < VolumeDim; j++) {
-    gsl::at(mapped_directions_, gsl::at(directions_in_host, j).dimension()) =
+    gsl::at(mapped_directions_,
+            gsl::at(directions_in_host, j).logical_dimension()) =
         (gsl::at(directions_in_host, j).side() == Side::Upper
              ? gsl::at(directions_in_neighbor, j)
              : gsl::at(directions_in_neighbor, j).opposite());
@@ -45,7 +46,7 @@ std::array<SegmentId, VolumeDim> OrientationMap<VolumeDim>::operator()(
     const std::array<SegmentId, VolumeDim>& segmentIds) const {
   std::array<SegmentId, VolumeDim> result = segmentIds;
   for (size_t d = 0; d < VolumeDim; d++) {
-    gsl::at(result, gsl::at(mapped_directions_, d).dimension()) =
+    gsl::at(result, gsl::at(mapped_directions_, d).logical_dimension()) =
         gsl::at(mapped_directions_, d).side() == Side::Upper
             ? gsl::at(segmentIds, d)
             : gsl::at(segmentIds, d).id_if_flipped();
@@ -58,7 +59,7 @@ OrientationMap<VolumeDim> OrientationMap<VolumeDim>::inverse_map() const
     noexcept {
   std::array<Direction<VolumeDim>, VolumeDim> result;
   for (size_t i = 0; i < VolumeDim; i++) {
-    gsl::at(result, gsl::at(mapped_directions_, i).dimension()) =
+    gsl::at(result, gsl::at(mapped_directions_, i).logical_dimension()) =
         Direction<VolumeDim>(i, gsl::at(mapped_directions_, i).side());
   }
   return OrientationMap<VolumeDim>{result};

--- a/src/Domain/OrientationMap.hpp
+++ b/src/Domain/OrientationMap.hpp
@@ -17,9 +17,9 @@
  * \ingroup DomainCreators
  * \brief A mapping of the logical coordinate axes of a host to the logical
  * coordinate axes of a neighbor of the host.
- * \usage Given a `size_t dimension`, a `Direction`, or a `SegmentId` of the
- * host, an `OrientationMap` will give the corresponding value in the neighbor.
- * \tparam VolumeDim the dimension of the blocks.
+ * \usage Given a `size_t logical_dimension`, a `Direction`, or a `SegmentId` of
+ * the host, an `OrientationMap` will give the corresponding value in the
+ * neighbor. \tparam VolumeDim the logical_dimension of the blocks.
  */
 template <size_t VolumeDim>
 class OrientationMap {
@@ -42,16 +42,17 @@ class OrientationMap {
   /// True when mapped(Direction) == Direction
   bool is_aligned() const noexcept { return is_aligned_; }
 
-  /// The corresponding dimension in the neighbor.
+  /// The corresponding logical_dimension in the neighbor.
   size_t operator()(const size_t dim) const noexcept {
-    return gsl::at(mapped_directions_, dim).dimension();
+    return gsl::at(mapped_directions_, dim).logical_dimension();
   }
 
   /// The corresponding direction in the neighbor.
   Direction<VolumeDim> operator()(const Direction<VolumeDim>& direction) const {
     return direction.side() == Side::Upper
-               ? gsl::at(mapped_directions_, direction.dimension())
-               : gsl::at(mapped_directions_, direction.dimension()).opposite();
+               ? gsl::at(mapped_directions_, direction.logical_dimension())
+               : gsl::at(mapped_directions_, direction.logical_dimension())
+                     .opposite();
   }
 
   /// The corresponding SegmentIds in the neighbor.

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -124,8 +124,8 @@ auto make_unnormalized_face_normals(
                      tnsr::i<DataVector, VolumeDim, Frame::Inertial>>
       result;
   for (const auto& d : Direction<VolumeDim>::all_logical_directions()) {
-    result.emplace(
-        d, unnormalized_face_normal(extents.slice_away(d.dimension()), map, d));
+    result.emplace(d, unnormalized_face_normal(
+                          extents.slice_away(d.logical_dimension()), map, d));
   }
   return result;
 }

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -123,7 +123,7 @@ auto make_unnormalized_face_normals(
   std::unordered_map<Direction<VolumeDim>,
                      tnsr::i<DataVector, VolumeDim, Frame::Inertial>>
       result;
-  for (const auto& d : Direction<VolumeDim>::all_directions()) {
+  for (const auto& d : Direction<VolumeDim>::all_logical_directions()) {
     result.emplace(
         d, unnormalized_face_normal(extents.slice_away(d.dimension()), map, d));
   }

--- a/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
+++ b/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
@@ -41,7 +41,7 @@ void check_orient_variables_on_slice(
     const Direction<SpatialDim>& direction_to_neighbor,
     const Index<SpatialDim>& my_extents,
     const Index<SpatialDim>& neighbor_extents) {
-  const size_t my_sliced_dim = direction_to_neighbor.dimension();
+  const size_t my_sliced_dim = direction_to_neighbor.logical_dimension();
   const Index<SpatialDim - 1> extents_on_my_slice(
       my_extents.slice_away(my_sliced_dim));
   Variables<tmpl::list<PhysicalCoords<SpatialDim>>> coords_on_my_slice(

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -104,7 +104,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equidistant",
   CAPTURE_PRECISE(outer_radius);
   const std::array<double, 2> test_point{{xi, eta}};
 
-  for (const auto& direction : Direction<2>::all_directions()) {
+  for (const auto& direction : Direction<2>::all_logical_directions()) {
     const CoordinateMaps::Wedge2D map{inner_radius, outer_radius, direction,
                                       false};
     test_jacobian(map, test_point);
@@ -215,7 +215,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equiangular",
   CAPTURE_PRECISE(outer_radius);
   const std::array<double, 2> test_point{{xi, eta}};
 
-  for (const auto& direction : Direction<2>::all_directions()) {
+  for (const auto& direction : Direction<2>::all_logical_directions()) {
     const CoordinateMaps::Wedge2D map{inner_radius, outer_radius, direction,
                                       true};
     test_jacobian(map, test_point);

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -19,7 +19,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Sphere.Equiangular",
   const std::array<double, 3> test_point2{{0.5, 0.7, -0.5}};
   const std::array<double, 3> test_point3{{0.9, -1.0, 0.4}};
 
-  for (const auto& direction : Direction<3>::all_directions()) {
+  for (const auto& direction : Direction<3>::all_logical_directions()) {
     const CoordinateMaps::Wedge3D map(sqrt(3.0), 2.0 * sqrt(3.0), direction, 1,
                                       true);
     test_jacobian(map, test_point1);
@@ -61,7 +61,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Sphere.Equidistant",
   const std::array<double, 3> test_point2{{0.5, 0.7, -0.5}};
   const std::array<double, 3> test_point3{{0.9, -1.0, 0.4}};
 
-  for (const auto& direction : Direction<3>::all_directions()) {
+  for (const auto& direction : Direction<3>::all_logical_directions()) {
     const CoordinateMaps::Wedge3D map(sqrt(3.0), 2.0 * sqrt(3.0), direction, 1,
                                       false);
     test_jacobian(map, test_point1);
@@ -472,7 +472,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Jacobian.Equiangular",
   const double sphericity = unit_dis(gen);
   CAPTURE_PRECISE(sphericity);
 
-  for (const auto direction : Direction<3>::all_directions()) {
+  for (const auto direction : Direction<3>::all_logical_directions()) {
     const CoordinateMaps::Wedge3D map{inner_radius, outer_radius, direction,
                                       sphericity, true};
     const CoordinateMaps::Wedge3D map_spheres{inner_radius, outer_radius,
@@ -509,7 +509,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Jacobian.Equidistant",
   const double sphericity = unit_dis(gen);
   CAPTURE_PRECISE(sphericity);
 
-  for (const auto direction : Direction<3>::all_directions()) {
+  for (const auto direction : Direction<3>::all_logical_directions()) {
     const CoordinateMaps::Wedge3D map{inner_radius, outer_radius, direction,
                                       sphericity, false};
     const CoordinateMaps::Wedge3D map_spheres{inner_radius, outer_radius,

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -30,7 +30,7 @@ boost::rational<size_t> fraction_of_block_face_area(
     const Direction<VolumeDim>& direction) noexcept {
   const auto& segment_ids = element_id.segment_ids();
   size_t sum_of_refinement_levels = 0;
-  const size_t dim_normal_to_face = direction.dimension();
+  const size_t dim_normal_to_face = direction.logical_dimension();
   for (size_t d = 0; d < VolumeDim; ++d) {
     if (dim_normal_to_face != d) {
       sum_of_refinement_levels += gsl::at(segment_ids, d).refinement_level();
@@ -159,7 +159,7 @@ void test_refinement_levels_of_neighbors(
     }
   }
 }
-// Iterates over the logical corners of a VolumeDim-dimensional cube.
+// Iterates over the logical corners of a VolumeDim-logical_dimensional cube.
 template <size_t VolumeDim>
 class VolumeCornerIterator {
  public:
@@ -185,7 +185,7 @@ class VolumeCornerIterator {
 };
 
 // Iterates over the 2^(VolumeDim-1) logical corners of the face of a
-// VolumeDim-dimensional cube in the given direction.
+// VolumeDim-logical_dimensional cube in the given direction.
 template <size_t VolumeDim>
 class FaceCornerIterator {
  public:
@@ -194,7 +194,7 @@ class FaceCornerIterator {
     face_index_++;
     do {
       index_++;
-    } while (get_nth_bit(index_, direction_.dimension()) ==
+    } while (get_nth_bit(index_, direction_.logical_dimension()) ==
              (direction_.side() == Side::Upper ? 0 : 1));
     for (size_t i = 0; i < VolumeDim; ++i) {
       corner_[i] = 2 * static_cast<int>(get_nth_bit(index_, i)) - 1;
@@ -227,7 +227,7 @@ FaceCornerIterator<VolumeDim>::FaceCornerIterator(
     Direction<VolumeDim> direction) noexcept
     : direction_(std::move(direction)),
       index_(direction.side() == Side::Upper
-                 ? two_to_the(direction_.dimension())
+                 ? two_to_the(direction_.logical_dimension())
                  : 0) {
   for (size_t i = 0; i < VolumeDim; ++i) {
     corner_[i] = 2 * static_cast<int>(get_nth_bit(index_, i)) - 1;
@@ -290,7 +290,7 @@ tnsr::I<double, VolumeDim, Frame::Logical> get_corner_of_orthant(
     const std::array<Direction<VolumeDim>, VolumeDim>& directions) noexcept {
   tnsr::I<double, VolumeDim, Frame::Logical> result{};
   for (size_t i = 0; i < VolumeDim; i++) {
-    result[gsl::at(directions, i).dimension()] =
+    result[gsl::at(directions, i).logical_dimension()] =
         gsl::at(directions, i).side() == Side::Upper ? 1.0 : -1.0;
   }
   return result;

--- a/tests/Unit/Domain/Test_Direction.cpp
+++ b/tests/Unit/Domain/Test_Direction.cpp
@@ -8,191 +8,151 @@
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction1D", "[Domain][Unit]") {
-  auto upper_xi_1 = Direction<1>::upper_xi();
+  const auto upper_xi_1 = Direction<1>::upper_xi();
   CHECK(upper_xi_1.opposite() == Direction<1>::lower_xi());
   CHECK(upper_xi_1.opposite().sign() == -1.0);
   CHECK(upper_xi_1.axis() == Direction<1>::Axis::Xi);
   test_serialization(upper_xi_1);
 
-  auto lower_xi_1 = Direction<1>(0, Side::Lower);
+  const auto lower_xi_1 = Direction<1>(0, Side::Lower);
   CHECK(lower_xi_1 == Direction<1>::lower_xi());
   CHECK(lower_xi_1.axis() == Direction<1>::Axis::Xi);
   CHECK(lower_xi_1.side() == Side::Lower);
   test_serialization(lower_xi_1);
 
-  auto upper_x_1 = Direction<1>::upper_x();
+  const auto upper_x_1 = Direction<1>::upper_x();
   CHECK(upper_x_1 != Direction<1>::upper_xi());
   CHECK(upper_x_1.opposite() == Direction<1>::lower_x());
   CHECK(upper_x_1.opposite().sign() == -1.0);
   CHECK(upper_x_1.axis() == Direction<1>::Axis::X);
   test_serialization(upper_x_1);
 
-  auto lower_x_1 = Direction<1>(3, Side::Lower);
+  const auto lower_x_1 = Direction<1>(Direction<1>::Axis::X, Side::Lower);
   CHECK(lower_x_1 != Direction<1>::lower_xi());
   CHECK(lower_x_1 == Direction<1>::lower_x());
   CHECK(lower_x_1.axis() == Direction<1>::Axis::X);
   CHECK(lower_x_1.side() == Side::Lower);
   test_serialization(lower_x_1);
-
-  auto upper_y_1 = Direction<1>::upper_y();
-  CHECK(upper_y_1 != Direction<1>::upper_xi());
-  CHECK(upper_y_1.opposite() == Direction<1>::lower_y());
-  CHECK(upper_y_1.opposite().sign() == -1.0);
-  CHECK(upper_y_1.axis() == Direction<1>::Axis::Y);
-  test_serialization(upper_y_1);
-
-  auto lower_y_1 = Direction<1>(4, Side::Lower);
-  CHECK(lower_y_1 != Direction<1>::lower_xi());
-  CHECK(lower_y_1 == Direction<1>::lower_y());
-  CHECK(lower_y_1.axis() == Direction<1>::Axis::Y);
-  CHECK(lower_y_1.side() == Side::Lower);
-  test_serialization(lower_y_1);
-
-  auto upper_z_1 = Direction<1>::upper_z();
-  CHECK(upper_z_1 != Direction<1>::upper_xi());
-  CHECK(upper_z_1.opposite() == Direction<1>::lower_z());
-  CHECK(upper_z_1.opposite().sign() == -1.0);
-  CHECK(upper_z_1.axis() == Direction<1>::Axis::Z);
-  test_serialization(upper_z_1);
-
-  auto lower_z_1 = Direction<1>(5, Side::Lower);
-  CHECK(lower_z_1 != Direction<1>::lower_xi());
-  CHECK(lower_z_1 == Direction<1>::lower_z());
-  CHECK(lower_z_1.axis() == Direction<1>::Axis::Z);
-  CHECK(lower_z_1.side() == Side::Lower);
-  test_serialization(lower_z_1);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction2D", "[Domain][Unit]") {
-  auto upper_xi_2 = Direction<2>(0, Side::Upper);
+  const auto upper_xi_2 = Direction<2>(0, Side::Upper);
   CHECK(upper_xi_2 == Direction<2>::upper_xi());
   CHECK(upper_xi_2.axis() == Direction<2>::Axis::Xi);
   CHECK(upper_xi_2.side() == Side::Upper);
   test_serialization(upper_xi_2);
 
-  auto upper_eta_2 = Direction<2>(1, Side::Upper);
+  const auto upper_eta_2 = Direction<2>(1, Side::Upper);
   CHECK(upper_eta_2 == Direction<2>::upper_eta());
   CHECK(upper_eta_2.axis() == Direction<2>::Axis::Eta);
   CHECK(upper_eta_2.side() == Side::Upper);
   test_serialization(upper_eta_2);
 
-  auto lower_xi_2 = Direction<2>(0, Side::Lower);
+  const auto lower_xi_2 = Direction<2>(0, Side::Lower);
   CHECK(lower_xi_2 == Direction<2>::lower_xi());
   CHECK(lower_xi_2.axis() == Direction<2>::Axis::Xi);
   CHECK(lower_xi_2.side() == Side::Lower);
   test_serialization(lower_xi_2);
 
-  auto lower_eta_2 = Direction<2>(1, Side::Lower);
+  const auto lower_eta_2 = Direction<2>(1, Side::Lower);
   CHECK(lower_eta_2 == Direction<2>::lower_eta());
   CHECK(lower_eta_2.axis() == Direction<2>::Axis::Eta);
   CHECK(lower_eta_2.side() == Side::Lower);
   test_serialization(lower_eta_2);
 
-  auto upper_x_2 = Direction<2>(3, Side::Upper);
+  const auto upper_x_2 = Direction<2>(Direction<2>::Axis::X, Side::Upper);
   CHECK(upper_x_2 == Direction<2>::upper_x());
   CHECK(upper_x_2.axis() == Direction<2>::Axis::X);
   CHECK(upper_x_2.side() == Side::Upper);
   test_serialization(upper_x_2);
 
-  auto lower_x_2 = Direction<2>(3, Side::Lower);
+  const auto lower_x_2 = Direction<2>(Direction<2>::Axis::X, Side::Lower);
   CHECK(lower_x_2 == Direction<2>::lower_x());
   CHECK(lower_x_2.axis() == Direction<2>::Axis::X);
   CHECK(lower_x_2.side() == Side::Lower);
   test_serialization(lower_x_2);
 
-  auto upper_y_2 = Direction<2>(4, Side::Upper);
+  const auto upper_y_2 = Direction<2>(Direction<2>::Axis::Y, Side::Upper);
   CHECK(upper_y_2 == Direction<2>::upper_y());
   CHECK(upper_y_2.axis() == Direction<2>::Axis::Y);
   CHECK(upper_y_2.side() == Side::Upper);
   test_serialization(upper_y_2);
 
-  auto lower_y_2 = Direction<2>(4, Side::Lower);
+  const auto lower_y_2 = Direction<2>(Direction<2>::Axis::Y, Side::Lower);
   CHECK(lower_y_2 == Direction<2>::lower_y());
   CHECK(lower_y_2.axis() == Direction<2>::Axis::Y);
   CHECK(lower_y_2.side() == Side::Lower);
   test_serialization(lower_y_2);
-
-  auto upper_z_2 = Direction<2>(5, Side::Upper);
-  CHECK(upper_z_2 == Direction<2>::upper_z());
-  CHECK(upper_z_2.axis() == Direction<2>::Axis::Z);
-  CHECK(upper_z_2.side() == Side::Upper);
-  test_serialization(upper_z_2);
-
-  auto lower_z_2 = Direction<2>(5, Side::Lower);
-  CHECK(lower_z_2 == Direction<2>::lower_z());
-  CHECK(lower_z_2.axis() == Direction<2>::Axis::Z);
-  CHECK(lower_z_2.side() == Side::Lower);
-  test_serialization(lower_z_2);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction3D", "[Domain][Unit]") {
-  auto upper_xi = Direction<3>(0, Side::Upper);
+  const auto upper_xi = Direction<3>(0, Side::Upper);
   CHECK(upper_xi == Direction<3>::upper_xi());
   CHECK(upper_xi.axis() == Direction<3>::Axis::Xi);
   CHECK(upper_xi.side() == Side::Upper);
   test_serialization(upper_xi);
 
-  auto upper_eta = Direction<3>(1, Side::Upper);
+  const auto upper_eta = Direction<3>(1, Side::Upper);
   CHECK(upper_eta == Direction<3>::upper_eta());
   CHECK(upper_eta.axis() == Direction<3>::Axis::Eta);
   CHECK(upper_eta.side() == Side::Upper);
   test_serialization(upper_eta);
 
-  auto lower_xi = Direction<3>(0, Side::Lower);
+  const auto lower_xi = Direction<3>(0, Side::Lower);
   CHECK(lower_xi == Direction<3>::lower_xi());
   CHECK(lower_xi.axis() == Direction<3>::Axis::Xi);
   CHECK(lower_xi.side() == Side::Lower);
   test_serialization(lower_xi);
 
-  auto lower_eta = Direction<3>(1, Side::Lower);
+  const auto lower_eta = Direction<3>(1, Side::Lower);
   CHECK(lower_eta == Direction<3>::lower_eta());
   CHECK(lower_eta.axis() == Direction<3>::Axis::Eta);
   CHECK(lower_eta.side() == Side::Lower);
   test_serialization(lower_eta);
 
-  auto upper_zeta = Direction<3>(2, Side::Upper);
+  const auto upper_zeta = Direction<3>(2, Side::Upper);
   CHECK(upper_zeta == Direction<3>::upper_zeta());
   CHECK(upper_zeta.axis() == Direction<3>::Axis::Zeta);
   CHECK(upper_zeta.side() == Side::Upper);
   test_serialization(upper_zeta);
 
-  auto lower_zeta = Direction<3>(2, Side::Lower);
+  const auto lower_zeta = Direction<3>(2, Side::Lower);
   CHECK(lower_zeta == Direction<3>::lower_zeta());
   CHECK(lower_zeta.axis() == Direction<3>::Axis::Zeta);
   CHECK(lower_zeta.side() == Side::Lower);
   test_serialization(lower_zeta);
 
-  auto upper_x = Direction<3>(3, Side::Upper);
+  const auto upper_x = Direction<3>(Direction<3>::Axis::X, Side::Upper);
   CHECK(upper_x == Direction<3>::upper_x());
   CHECK(upper_x.axis() == Direction<3>::Axis::X);
   CHECK(upper_x.side() == Side::Upper);
   test_serialization(upper_x);
 
-  auto upper_y = Direction<3>(4, Side::Upper);
+  const auto upper_y = Direction<3>(Direction<3>::Axis::Y, Side::Upper);
   CHECK(upper_y == Direction<3>::upper_y());
   CHECK(upper_y.axis() == Direction<3>::Axis::Y);
   CHECK(upper_y.side() == Side::Upper);
   test_serialization(upper_y);
 
-  auto lower_x = Direction<3>(3, Side::Lower);
+  const auto lower_x = Direction<3>(Direction<3>::Axis::X, Side::Lower);
   CHECK(lower_x == Direction<3>::lower_x());
   CHECK(lower_x.axis() == Direction<3>::Axis::X);
   CHECK(lower_x.side() == Side::Lower);
   test_serialization(lower_x);
 
-  auto lower_y = Direction<3>(4, Side::Lower);
+  const auto lower_y = Direction<3>(Direction<3>::Axis::Y, Side::Lower);
   CHECK(lower_y == Direction<3>::lower_y());
   CHECK(lower_y.axis() == Direction<3>::Axis::Y);
   CHECK(lower_y.side() == Side::Lower);
   test_serialization(lower_y);
 
-  auto upper_z = Direction<3>(5, Side::Upper);
+  const auto upper_z = Direction<3>(Direction<3>::Axis::Z, Side::Upper);
   CHECK(upper_z == Direction<3>::upper_z());
   CHECK(upper_z.axis() == Direction<3>::Axis::Z);
   CHECK(upper_z.side() == Side::Upper);
   test_serialization(upper_z);
 
-  auto lower_z = Direction<3>(5, Side::Lower);
+  const auto lower_z = Direction<3>(Direction<3>::Axis::Z, Side::Lower);
   CHECK(lower_z == Direction<3>::lower_z());
   CHECK(lower_z.axis() == Direction<3>::Axis::Z);
   CHECK(lower_z.side() == Side::Lower);
@@ -200,27 +160,27 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction3D", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Direction.HelperFunctions", "[Domain][Unit]") {
-  auto upper_xi_3 = Direction<3>::upper_xi();
+  const auto upper_xi_3 = Direction<3>::upper_xi();
   CHECK(upper_xi_3.axis() == Direction<3>::Axis::Xi);
   CHECK(upper_xi_3.side() == Side::Upper);
 
-  auto lower_xi_3 = Direction<3>::lower_xi();
+  const auto lower_xi_3 = Direction<3>::lower_xi();
   CHECK(lower_xi_3.axis() == Direction<3>::Axis::Xi);
   CHECK(lower_xi_3.side() == Side::Lower);
 
-  auto upper_eta_3 = Direction<3>::upper_eta();
+  const auto upper_eta_3 = Direction<3>::upper_eta();
   CHECK(upper_eta_3.axis() == Direction<3>::Axis::Eta);
   CHECK(upper_eta_3.side() == Side::Upper);
 
-  auto lower_eta_3 = Direction<3>::lower_eta();
+  const auto lower_eta_3 = Direction<3>::lower_eta();
   CHECK(lower_eta_3.axis() == Direction<3>::Axis::Eta);
   CHECK(lower_eta_3.side() == Side::Lower);
 
-  auto upper_zeta_3 = Direction<3>::upper_zeta();
+  const auto upper_zeta_3 = Direction<3>::upper_zeta();
   CHECK(upper_zeta_3.axis() == Direction<3>::Axis::Zeta);
   CHECK(upper_zeta_3.side() == Side::Upper);
 
-  auto lower_zeta_3 = Direction<3>::lower_zeta();
+  const auto lower_zeta_3 = Direction<3>::lower_zeta();
   CHECK(lower_zeta_3.axis() == Direction<3>::Axis::Zeta);
   CHECK(lower_zeta_3.side() == Side::Lower);
 }
@@ -266,70 +226,70 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Hash", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Direction.Output", "[Domain][Unit]") {
-  auto upper_xi = Direction<1>(0, Side::Upper);
+  const auto upper_xi = Direction<1>(0, Side::Upper);
   CHECK(get_output(upper_xi) == "+0");
 
-  auto lower_xi = Direction<2>(0, Side::Lower);
+  const auto lower_xi = Direction<2>(0, Side::Lower);
   CHECK(get_output(lower_xi) == "-0");
 
-  auto upper_eta = Direction<2>(1, Side::Upper);
+  const auto upper_eta = Direction<2>(1, Side::Upper);
   CHECK(get_output(upper_eta) == "+1");
 
-  auto lower_eta = Direction<2>(1, Side::Lower);
+  const auto lower_eta = Direction<2>(1, Side::Lower);
   CHECK(get_output(lower_eta) == "-1");
 
-  auto upper_xi_3 = Direction<3>(0, Side::Upper);
+  const auto upper_xi_3 = Direction<3>(0, Side::Upper);
   CHECK(get_output(upper_xi_3) == "+0");
 
-  auto lower_xi_3 = Direction<3>(0, Side::Lower);
+  const auto lower_xi_3 = Direction<3>(0, Side::Lower);
   CHECK(get_output(lower_xi_3) == "-0");
 
-  auto upper_eta_3 = Direction<3>(1, Side::Upper);
+  const auto upper_eta_3 = Direction<3>(1, Side::Upper);
   CHECK(get_output(upper_eta_3) == "+1");
 
-  auto lower_eta_3 = Direction<3>(1, Side::Lower);
+  const auto lower_eta_3 = Direction<3>(1, Side::Lower);
   CHECK(get_output(lower_eta_3) == "-1");
 
-  auto upper_zeta_3 = Direction<3>(2, Side::Upper);
+  const auto upper_zeta_3 = Direction<3>(2, Side::Upper);
   CHECK(get_output(upper_zeta_3) == "+2");
 
-  auto lower_zeta_3 = Direction<3>(2, Side::Lower);
+  const auto lower_zeta_3 = Direction<3>(2, Side::Lower);
   CHECK(get_output(lower_zeta_3) == "-2");
 }
 
-// [[OutputRegex, dim = 1, for Direction<1> only dim = 0, 3, 4, or 5 is
+// [[OutputRegex, dim = 1, for Direction<1> only dim = 0 is
 // allowed.]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Direction.FirstDimension",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto failed_direction = Direction<1>(1, Side::Upper);
+  const auto failed_direction = Direction<1>(1, Side::Upper);
   static_cast<void>(failed_direction);
 
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
-// [[OutputRegex, dim = 2, for Direction<2> only dim = 0, 1, 3, 4, or 5 are
+// [[OutputRegex, dim = 2, for Direction<2> only dim = 0 or dim = 1 are
 // allowed.]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Direction.SecondDimension",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto failed_direction = Direction<2>(2, Side::Upper);
+  const auto failed_direction = Direction<2>(2, Side::Upper);
   static_cast<void>(failed_direction);
 
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
-// [[OutputRegex, dim = 6, for Direction<3> only dim = 0, 1, 2, 3, 4, or 5
+// [[OutputRegex, dim = 3, for Direction<3> only dim = 0, dim = 1, or dim = 2
 // are allowed.]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Direction.ThirdDimension",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto failed_direction = Direction<3>(6, Side::Upper);
+  const auto failed_direction = Direction<3>(3, Side::Upper);
   static_cast<void>(failed_direction);
 
   ERROR("Failed to trigger ASSERT in an assertion test");

--- a/tests/Unit/Domain/Test_Direction.cpp
+++ b/tests/Unit/Domain/Test_Direction.cpp
@@ -19,6 +19,48 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction1D", "[Domain][Unit]") {
   CHECK(lower_xi_1.axis() == Direction<1>::Axis::Xi);
   CHECK(lower_xi_1.side() == Side::Lower);
   test_serialization(lower_xi_1);
+
+  auto upper_x_1 = Direction<1>::upper_x();
+  CHECK(upper_x_1 != Direction<1>::upper_xi());
+  CHECK(upper_x_1.opposite() == Direction<1>::lower_x());
+  CHECK(upper_x_1.opposite().sign() == -1.0);
+  CHECK(upper_x_1.axis() == Direction<1>::Axis::X);
+  test_serialization(upper_x_1);
+
+  auto lower_x_1 = Direction<1>(3, Side::Lower);
+  CHECK(lower_x_1 != Direction<1>::lower_xi());
+  CHECK(lower_x_1 == Direction<1>::lower_x());
+  CHECK(lower_x_1.axis() == Direction<1>::Axis::X);
+  CHECK(lower_x_1.side() == Side::Lower);
+  test_serialization(lower_x_1);
+
+  auto upper_y_1 = Direction<1>::upper_y();
+  CHECK(upper_y_1 != Direction<1>::upper_xi());
+  CHECK(upper_y_1.opposite() == Direction<1>::lower_y());
+  CHECK(upper_y_1.opposite().sign() == -1.0);
+  CHECK(upper_y_1.axis() == Direction<1>::Axis::Y);
+  test_serialization(upper_y_1);
+
+  auto lower_y_1 = Direction<1>(4, Side::Lower);
+  CHECK(lower_y_1 != Direction<1>::lower_xi());
+  CHECK(lower_y_1 == Direction<1>::lower_y());
+  CHECK(lower_y_1.axis() == Direction<1>::Axis::Y);
+  CHECK(lower_y_1.side() == Side::Lower);
+  test_serialization(lower_y_1);
+
+  auto upper_z_1 = Direction<1>::upper_z();
+  CHECK(upper_z_1 != Direction<1>::upper_xi());
+  CHECK(upper_z_1.opposite() == Direction<1>::lower_z());
+  CHECK(upper_z_1.opposite().sign() == -1.0);
+  CHECK(upper_z_1.axis() == Direction<1>::Axis::Z);
+  test_serialization(upper_z_1);
+
+  auto lower_z_1 = Direction<1>(5, Side::Lower);
+  CHECK(lower_z_1 != Direction<1>::lower_xi());
+  CHECK(lower_z_1 == Direction<1>::lower_z());
+  CHECK(lower_z_1.axis() == Direction<1>::Axis::Z);
+  CHECK(lower_z_1.side() == Side::Lower);
+  test_serialization(lower_z_1);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction2D", "[Domain][Unit]") {
@@ -45,6 +87,42 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction2D", "[Domain][Unit]") {
   CHECK(lower_eta_2.axis() == Direction<2>::Axis::Eta);
   CHECK(lower_eta_2.side() == Side::Lower);
   test_serialization(lower_eta_2);
+
+  auto upper_x_2 = Direction<2>(3, Side::Upper);
+  CHECK(upper_x_2 == Direction<2>::upper_x());
+  CHECK(upper_x_2.axis() == Direction<2>::Axis::X);
+  CHECK(upper_x_2.side() == Side::Upper);
+  test_serialization(upper_x_2);
+
+  auto lower_x_2 = Direction<2>(3, Side::Lower);
+  CHECK(lower_x_2 == Direction<2>::lower_x());
+  CHECK(lower_x_2.axis() == Direction<2>::Axis::X);
+  CHECK(lower_x_2.side() == Side::Lower);
+  test_serialization(lower_x_2);
+
+  auto upper_y_2 = Direction<2>(4, Side::Upper);
+  CHECK(upper_y_2 == Direction<2>::upper_y());
+  CHECK(upper_y_2.axis() == Direction<2>::Axis::Y);
+  CHECK(upper_y_2.side() == Side::Upper);
+  test_serialization(upper_y_2);
+
+  auto lower_y_2 = Direction<2>(4, Side::Lower);
+  CHECK(lower_y_2 == Direction<2>::lower_y());
+  CHECK(lower_y_2.axis() == Direction<2>::Axis::Y);
+  CHECK(lower_y_2.side() == Side::Lower);
+  test_serialization(lower_y_2);
+
+  auto upper_z_2 = Direction<2>(5, Side::Upper);
+  CHECK(upper_z_2 == Direction<2>::upper_z());
+  CHECK(upper_z_2.axis() == Direction<2>::Axis::Z);
+  CHECK(upper_z_2.side() == Side::Upper);
+  test_serialization(upper_z_2);
+
+  auto lower_z_2 = Direction<2>(5, Side::Lower);
+  CHECK(lower_z_2 == Direction<2>::lower_z());
+  CHECK(lower_z_2.axis() == Direction<2>::Axis::Z);
+  CHECK(lower_z_2.side() == Side::Lower);
+  test_serialization(lower_z_2);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction3D", "[Domain][Unit]") {
@@ -83,6 +161,42 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction3D", "[Domain][Unit]") {
   CHECK(lower_zeta.axis() == Direction<3>::Axis::Zeta);
   CHECK(lower_zeta.side() == Side::Lower);
   test_serialization(lower_zeta);
+
+  auto upper_x = Direction<3>(3, Side::Upper);
+  CHECK(upper_x == Direction<3>::upper_x());
+  CHECK(upper_x.axis() == Direction<3>::Axis::X);
+  CHECK(upper_x.side() == Side::Upper);
+  test_serialization(upper_x);
+
+  auto upper_y = Direction<3>(4, Side::Upper);
+  CHECK(upper_y == Direction<3>::upper_y());
+  CHECK(upper_y.axis() == Direction<3>::Axis::Y);
+  CHECK(upper_y.side() == Side::Upper);
+  test_serialization(upper_y);
+
+  auto lower_x = Direction<3>(3, Side::Lower);
+  CHECK(lower_x == Direction<3>::lower_x());
+  CHECK(lower_x.axis() == Direction<3>::Axis::X);
+  CHECK(lower_x.side() == Side::Lower);
+  test_serialization(lower_x);
+
+  auto lower_y = Direction<3>(4, Side::Lower);
+  CHECK(lower_y == Direction<3>::lower_y());
+  CHECK(lower_y.axis() == Direction<3>::Axis::Y);
+  CHECK(lower_y.side() == Side::Lower);
+  test_serialization(lower_y);
+
+  auto upper_z = Direction<3>(5, Side::Upper);
+  CHECK(upper_z == Direction<3>::upper_z());
+  CHECK(upper_z.axis() == Direction<3>::Axis::Z);
+  CHECK(upper_z.side() == Side::Upper);
+  test_serialization(upper_z);
+
+  auto lower_z = Direction<3>(5, Side::Lower);
+  CHECK(lower_z == Direction<3>::lower_z());
+  CHECK(lower_z.axis() == Direction<3>::Axis::Z);
+  CHECK(lower_z.side() == Side::Lower);
+  test_serialization(lower_z);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Direction.HelperFunctions", "[Domain][Unit]") {
@@ -183,7 +297,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Output", "[Domain][Unit]") {
   CHECK(get_output(lower_zeta_3) == "-2");
 }
 
-// [[OutputRegex, dim = 1, for Direction<1> only dim = 0 is allowed.]]
+// [[OutputRegex, dim = 1, for Direction<1> only dim = 0, 3, 4, or 5 is
+// allowed.]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Direction.FirstDimension",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
@@ -195,7 +310,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Output", "[Domain][Unit]") {
 #endif
 }
 
-// [[OutputRegex, dim = 2, for Direction<2> only dim = 0 or dim = 1 are
+// [[OutputRegex, dim = 2, for Direction<2> only dim = 0, 1, 3, 4, or 5 are
 // allowed.]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Direction.SecondDimension",
                                "[Domain][Unit]") {
@@ -208,13 +323,13 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Output", "[Domain][Unit]") {
 #endif
 }
 
-// [[OutputRegex, dim = 3, for Direction<3> only dim = 0, dim = 1, or dim = 2
+// [[OutputRegex, dim = 6, for Direction<3> only dim = 0, 1, 2, 3, 4, or 5
 // are allowed.]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Direction.ThirdDimension",
                                "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  auto failed_direction = Direction<3>(3, Side::Upper);
+  auto failed_direction = Direction<3>(6, Side::Upper);
   static_cast<void>(failed_direction);
 
   ERROR("Failed to trigger ASSERT in an assertion test");

--- a/tests/Unit/Domain/Test_Element.cpp
+++ b/tests/Unit/Domain/Test_Element.cpp
@@ -30,7 +30,7 @@ void check_element() {
   CHECK(element.id() == id);
   CHECK(element.neighbors() == two_neighbors);
   CHECK(element.number_of_neighbors() == 4);
-  for (const auto& direction : Direction<VolumeDim>::all_directions()) {
+  for (const auto& direction : Direction<VolumeDim>::all_logical_directions()) {
     // Either a xi direction or an external boundary, but not both.
     CHECK((direction.axis() == Direction<VolumeDim>::Axis::Xi) !=
           (element.external_boundaries().count(direction) == 1));


### PR DESCRIPTION
## Proposed changes

Extends Direction from logical to logical and cartesian axes.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
