### PR TITLE
Add Strahlkörper::ricci_scalar

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -93,13 +93,13 @@ tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
   // Form projector
   tnsr::Ij<DataVector, 3, Frame> projector(
       get<0>(unit_normal_one_form).size(), 0.0);
+  const auto& unit_normal_vector = raise_or_lower_index(unit_normal_one_form,
+                                                        upper_spatial_metric);
   for (size_t i = 0; i < 3; ++i) {
     projector.get(i,i) += 1.0;
     for (size_t j = 0; j < 3; ++j) {
       projector.get(i, j) -=
-          raise_or_lower_index(
-              unit_normal_one_form, upper_spatial_metric).get(i)
-          * unit_normal_one_form.get(j);
+          unit_normal_vector.get(i) * unit_normal_one_form.get(j);
     }
   }
 
@@ -130,14 +130,9 @@ Scalar<DataVector> ricci_scalar(
     const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept {
 
   Scalar<DataVector> ricci_scalar(get<0>(unit_normal_vector).size(), 0.0);
-  Scalar<DataVector> tr_extrinsic_curvature(get<0>(unit_normal_vector).size(),
-                                            0.0);
 
   for(size_t i = 0; i < 3; ++i) {
     for(size_t j = 0; j < 3; ++j) {
-      tr_extrinsic_curvature.get() += upper_spatial_metric.get(i,j)
-                                     * extrinsic_curvature.get(i,j);
-
       ricci_scalar.get() -= 2.0 * spatial_ricci_tensor.get(i,j)
                             * unit_normal_vector.get(i)
                             * unit_normal_vector.get(j);
@@ -154,8 +149,8 @@ Scalar<DataVector> ricci_scalar(
     }
   }
 
-  get(ricci_scalar) += tr_extrinsic_curvature.get()
-                       * tr_extrinsic_curvature.get();
+  get(ricci_scalar) += square(get(trace(extrinsic_curvature,
+                                        upper_spatial_metric)));
   get(ricci_scalar) += get(trace(spatial_ricci_tensor, upper_spatial_metric));
   return ricci_scalar;
 }

--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -5,6 +5,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 
 namespace StrahlkorperGr {
 
@@ -83,6 +84,81 @@ Scalar<DataVector> expansion(
   return expansion;
 }
 
+template <typename Frame>
+tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
+    const tnsr::ii<DataVector, 3, Frame>& grad_normal,
+    const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept {
+
+  // Form projector
+  tnsr::Ij<DataVector, 3, Frame> projector(
+      get<0>(unit_normal_one_form).size(), 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    projector.get(i,i) += 1.0;
+    for (size_t j = 0; j < 3; ++j) {
+      projector.get(i, j) -=
+          raise_or_lower_index(
+              unit_normal_one_form, upper_spatial_metric).get(i)
+          * unit_normal_one_form.get(j);
+    }
+  }
+
+  // Project symmetrized gradient
+  tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
+      get<0>(unit_normal_one_form).size(), 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j ) {
+      for (size_t k = 0; k < 3; ++k ) {
+        for (size_t l =0; l < 3; ++l ) {
+          extrinsic_curvature.get(i,j) +=
+              //Note: grad_normal is already symmetric, so
+              //no need to symmetrize it
+              projector.get(k,i) * projector.get(l,j) * grad_normal.get(k,l);
+        }
+      }
+    }
+  }
+
+  return extrinsic_curvature;
+}
+
+template <typename Frame>
+Scalar<DataVector> ricci_scalar(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci_tensor,
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept {
+
+  Scalar<DataVector> ricci_scalar(get<0>(unit_normal_vector).size(), 0.0);
+  Scalar<DataVector> tr_extrinsic_curvature(get<0>(unit_normal_vector).size(),
+                                            0.0);
+
+  for(size_t i = 0; i < 3; ++i) {
+    for(size_t j = 0; j < 3; ++j) {
+      tr_extrinsic_curvature.get() += upper_spatial_metric.get(i,j)
+                                     * extrinsic_curvature.get(i,j);
+
+      ricci_scalar.get() -= 2.0 * spatial_ricci_tensor.get(i,j)
+                            * unit_normal_vector.get(i)
+                            * unit_normal_vector.get(j);
+
+      for(size_t k = 0; k < 3; ++k) {
+        for(size_t l = 0; l < 3; ++l) {
+          // K^{ij} K_{ij} = g^{ik} g^{jl} K_{kl} K_{ij}
+          get(ricci_scalar) -= upper_spatial_metric.get(i,k)
+                               * upper_spatial_metric.get(j,l)
+                               * extrinsic_curvature.get(k,l)
+                               * extrinsic_curvature.get(i,j);
+        }
+      }
+    }
+  }
+
+  get(ricci_scalar) += tr_extrinsic_curvature.get()
+                       * tr_extrinsic_curvature.get();
+  get(ricci_scalar) += get(trace(spatial_ricci_tensor, upper_spatial_metric));
+  return ricci_scalar;
+}
 }  // namespace StrahlkorperGr
 
 template tnsr::i<DataVector, 3, Frame::Inertial>
@@ -106,3 +182,18 @@ template Scalar<DataVector> StrahlkorperGr::expansion<Frame::Inertial>(
     const tnsr::II<DataVector, 3, Frame::Inertial>& upper_spatial_metric,
     const tnsr::ii<DataVector, 3, Frame::Inertial>&
         extrinsic_curvature) noexcept;
+
+template tnsr::ii<DataVector, 3, Frame::Inertial>
+StrahlkorperGr::extrinsic_curvature<Frame::Inertial>(
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& grad_normal,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& unit_normal_one_form,
+    const tnsr::II<DataVector, 3, Frame::Inertial>&
+    upper_spatial_metric) noexcept;
+
+
+template Scalar<DataVector> StrahlkorperGr::ricci_scalar<Frame::Inertial>(
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_ricci_tensor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature,
+    const tnsr::II<DataVector, 3, Frame::Inertial>&
+    upper_spatial_metric) noexcept;

--- a/src/ApparentHorizons/StrahlkorperGr.cpp
+++ b/src/ApparentHorizons/StrahlkorperGr.cpp
@@ -89,14 +89,13 @@ tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
     const tnsr::ii<DataVector, 3, Frame>& grad_normal,
     const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
     const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept {
-
   // Form projector
-  tnsr::Ij<DataVector, 3, Frame> projector(
-      get<0>(unit_normal_one_form).size(), 0.0);
-  const auto& unit_normal_vector = raise_or_lower_index(unit_normal_one_form,
-                                                        upper_spatial_metric);
+  tnsr::Ij<DataVector, 3, Frame> projector(get<0>(unit_normal_one_form).size(),
+                                           0.0);
+  const auto& unit_normal_vector =
+      raise_or_lower_index(unit_normal_one_form, upper_spatial_metric);
   for (size_t i = 0; i < 3; ++i) {
-    projector.get(i,i) += 1.0;
+    projector.get(i, i) += 1.0;
     for (size_t j = 0; j < 3; ++j) {
       projector.get(i, j) -=
           unit_normal_vector.get(i) * unit_normal_one_form.get(j);
@@ -107,13 +106,13 @@ tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
   tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
       get<0>(unit_normal_one_form).size(), 0.0);
   for (size_t i = 0; i < 3; ++i) {
-    for (size_t j = i; j < 3; ++j ) {
-      for (size_t k = 0; k < 3; ++k ) {
-        for (size_t l =0; l < 3; ++l ) {
-          extrinsic_curvature.get(i,j) +=
-              //Note: grad_normal is already symmetric, so
-              //no need to symmetrize it
-              projector.get(k,i) * projector.get(l,j) * grad_normal.get(k,l);
+    for (size_t j = i; j < 3; ++j) {
+      for (size_t k = 0; k < 3; ++k) {
+        for (size_t l = 0; l < 3; ++l) {
+          // Note: grad_normal is already symmetric, so
+          // no need to symmetrize it
+          extrinsic_curvature.get(i, j) +=
+              projector.get(k, i) * projector.get(l, j) * grad_normal.get(k, l);
         }
       }
     }
@@ -128,30 +127,28 @@ Scalar<DataVector> ricci_scalar(
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
     const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept {
+  auto ricci_scalar = trace(spatial_ricci_tensor, upper_spatial_metric);
 
-  Scalar<DataVector> ricci_scalar(get<0>(unit_normal_vector).size(), 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      ricci_scalar.get() -= 2.0 * spatial_ricci_tensor.get(i, j) *
+                            unit_normal_vector.get(i) *
+                            unit_normal_vector.get(j);
 
-  for(size_t i = 0; i < 3; ++i) {
-    for(size_t j = 0; j < 3; ++j) {
-      ricci_scalar.get() -= 2.0 * spatial_ricci_tensor.get(i,j)
-                            * unit_normal_vector.get(i)
-                            * unit_normal_vector.get(j);
-
-      for(size_t k = 0; k < 3; ++k) {
-        for(size_t l = 0; l < 3; ++l) {
+      for (size_t k = 0; k < 3; ++k) {
+        for (size_t l = 0; l < 3; ++l) {
           // K^{ij} K_{ij} = g^{ik} g^{jl} K_{kl} K_{ij}
-          get(ricci_scalar) -= upper_spatial_metric.get(i,k)
-                               * upper_spatial_metric.get(j,l)
-                               * extrinsic_curvature.get(k,l)
-                               * extrinsic_curvature.get(i,j);
+          get(ricci_scalar) -=
+              upper_spatial_metric.get(i, k) * upper_spatial_metric.get(j, l) *
+              extrinsic_curvature.get(k, l) * extrinsic_curvature.get(i, j);
         }
       }
     }
   }
 
-  get(ricci_scalar) += square(get(trace(extrinsic_curvature,
-                                        upper_spatial_metric)));
-  get(ricci_scalar) += get(trace(spatial_ricci_tensor, upper_spatial_metric));
+  get(ricci_scalar) +=
+      square(get(trace(extrinsic_curvature, upper_spatial_metric)));
+
   return ricci_scalar;
 }
 }  // namespace StrahlkorperGr
@@ -183,12 +180,11 @@ StrahlkorperGr::extrinsic_curvature<Frame::Inertial>(
     const tnsr::ii<DataVector, 3, Frame::Inertial>& grad_normal,
     const tnsr::i<DataVector, 3, Frame::Inertial>& unit_normal_one_form,
     const tnsr::II<DataVector, 3, Frame::Inertial>&
-    upper_spatial_metric) noexcept;
-
+        upper_spatial_metric) noexcept;
 
 template Scalar<DataVector> StrahlkorperGr::ricci_scalar<Frame::Inertial>(
     const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_ricci_tensor,
     const tnsr::I<DataVector, 3, Frame::Inertial>& unit_normal_vector,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature,
     const tnsr::II<DataVector, 3, Frame::Inertial>&
-    upper_spatial_metric) noexcept;
+        upper_spatial_metric) noexcept;

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -64,4 +64,43 @@ Scalar<DataVector> expansion(
     const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
 
+/// \ingroup SurfacesGroup
+/// \brief Extrinsic curvature of a 2D `Strahlkorper` embedded in a 3D space.
+///
+/// \details Implements Eq. (D.43) of Carroll's Spacetime and Geometry text.
+/// Specifically,
+/// \f$ K_{ij} = P^k_i P^l_j \nabla_{(k} S_{l)} \f$, where
+/// \f$ P^k_i = \delta^k_i - S^k S_i \f$,
+/// `grad_normal` is the quantity \f$ \nabla_k S_l \f$ returned by
+/// `StrahlkorperGr::grad_unit_normal_one_form`, and `unit_normal_vector` is
+/// \f$S^i = g^{ij} S_j\f$ where \f$S_j\f$ is the unit normal one form.
+/// Not to be confused with the extrinsic curvature of a 3D spatial slice
+/// embedded in 3+1 spacetime.
+template <typename Frame>
+tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
+    const tnsr::ii<DataVector, 3, Frame>& grad_normal,
+    const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
+
+/// \ingroup SurfacesGroup
+/// \brief Intrinsic Ricci scalar curvature of a 2D `Strahlkorper`.
+///
+/// \details Implements Eq. (D.51) of
+/// Sean Carroll's Spacetime and Geometry textbook (except correcting
+/// sign errors: both extrinsic curvature terms are off by a minus sign
+/// in Carroll's text but correct in Carroll's errata).
+/// \f$ \hat{R}=R - 2 R_{ij} S^i S^j + K^2-K^{ij}K_{ij}.\f$
+/// Here \f$\hat{R}\f$ is the intrinsic Ricci scalar curavture of
+/// the Strahlkorper, \f$R\f$ and \f$R_{ij}\f$ are the Ricci scalar and
+/// Ricci tensor of the 3D space that contains the Strahlkorper,
+/// \f$ K_{ij} \f$ the output of StrahlkorperGr::extrinsic_curvature,
+/// \f$ K \f$ is the trace of \f$K_{ij}\f$,
+/// and `unit_normal_vector` is
+/// \f$S^i = g^{ij} S_j\f$ where \f$S_j\f$ is the unit normal one form.
+template <typename Frame>
+Scalar<DataVector> ricci_scalar(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci_tensor,
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
 }  // namespace StrahlkorperGr

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -83,14 +83,14 @@ tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
     const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
 
 /// \ingroup SurfacesGroup
-/// \brief Intrinsic Ricci scalar curvature of a 2D `Strahlkorper`.
+/// \brief Intrinsic Ricci scalar of a 2D `Strahlkorper`.
 ///
 /// \details Implements Eq. (D.51) of
 /// Sean Carroll's Spacetime and Geometry textbook (except correcting
 /// sign errors: both extrinsic curvature terms are off by a minus sign
 /// in Carroll's text but correct in Carroll's errata).
 /// \f$ \hat{R}=R - 2 R_{ij} S^i S^j + K^2-K^{ij}K_{ij}.\f$
-/// Here \f$\hat{R}\f$ is the intrinsic Ricci scalar curavture of
+/// Here \f$\hat{R}\f$ is the intrinsic Ricci scalar curvature of
 /// the Strahlkorper, \f$R\f$ and \f$R_{ij}\f$ are the Ricci scalar and
 /// Ricci tensor of the 3D space that contains the Strahlkorper,
 /// \f$ K_{ij} \f$ the output of StrahlkorperGr::extrinsic_curvature,

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 set(APPARENT_HORIZONS_TESTS
+    ApparentHorizons/StrahlkorperGrTestHelpers.cpp
     ApparentHorizons/Test_SpherepackIterator.cpp
     ApparentHorizons/Test_Strahlkorper.cpp
     ApparentHorizons/Test_StrahlkorperDataBox.cpp

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -2,10 +2,10 @@
 # See LICENSE.txt for details.
 
 set(APPARENT_HORIZONS_TESTS
-    ApparentHorizons/Test_Expansion.cpp
     ApparentHorizons/Test_SpherepackIterator.cpp
     ApparentHorizons/Test_Strahlkorper.cpp
     ApparentHorizons/Test_StrahlkorperDataBox.cpp
+    ApparentHorizons/Test_StrahlkorperGr.cpp
     ApparentHorizons/Test_YlmSpherepack.cpp
     ApparentHorizons/YlmTestFunctions.cpp
     )

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp"
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
@@ -11,27 +12,23 @@ template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
 tnsr::aa<DataType, SpatialDim, Frame, Index> make_spatial_ricci_schwarzschild(
     const tnsr::A<DataType, SpatialDim, Frame, Index>& x,
     const double& mass) noexcept {
-
   auto r = make_with_value<Scalar<DataType>>(x, 0.);
-  auto ricci = make_with_value<tnsr::aa<DataType, SpatialDim, Frame, Index>>(
-      x, 0.);
+  auto ricci =
+      make_with_value<tnsr::aa<DataType, SpatialDim, Frame, Index>>(x, 0.);
 
   constexpr auto dimensionality = index_dim<0>(ricci);
 
-  for (size_t i=0; i < dimensionality; ++i) {
-    r.get() += x.get(i)*x.get(i);
-  }
-  r.get() = sqrt(r.get());
+  r.get() = magnitude(x);
 
-  for (size_t i=0; i < dimensionality; ++i) {
-    for (size_t j=i; j < dimensionality; ++j ) {
-      ricci.get(i,j) -= (8.0 * mass + 3.0 * r.get()) * x.get(i) * x.get(j);
+  for (size_t i = 0; i < dimensionality; ++i) {
+    for (size_t j = i; j < dimensionality; ++j) {
+      ricci.get(i, j) -= (8.0 * mass + 3.0 * r.get()) * x.get(i) * x.get(j);
       if (i == j) {
-        ricci.get(i,j) += r.get() * r.get() * (4.0 * mass + r.get());
+        ricci.get(i, j) += r.get() * r.get() * (4.0 * mass + r.get());
       }
-      ricci.get(i,j) *= mass;
-      ricci.get(i,j) /= r.get() * r.get() * r.get() * r.get()
-                        * (2.0 * mass + r.get()) * (2.0 * mass + r.get());
+      ricci.get(i, j) *= mass;
+      ricci.get(i, j) /= r.get() * r.get() * r.get() * r.get() *
+                         (2.0 * mass + r.get()) * (2.0 * mass + r.get());
     }
   }
 
@@ -43,15 +40,14 @@ tnsr::aa<DataType, SpatialDim, Frame, Index> make_spatial_ricci_schwarzschild(
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 #define INDEXTYPE(data) BOOST_PP_TUPLE_ELEM(3, data)
 
-#define INSTANTIATE(_, data)                                                 \
-  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>    \
-  make_spatial_ricci_schwarzschild(                                          \
-      const tnsr::A<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>& x,\
+#define INSTANTIATE(_, data)                                                  \
+  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>     \
+  make_spatial_ricci_schwarzschild(                                           \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>& x, \
       const double& mass) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (3), (double, DataVector),
-                        (Frame::Grid, Frame::Inertial),
-                        (IndexType::Spatial))
+                        (Frame::Grid, Frame::Inertial), (IndexType::Spatial))
 
 #undef DIM
 #undef DTYPE

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+tnsr::aa<DataType, SpatialDim, Frame, Index> make_spatial_ricci_schwarzschild(
+    const tnsr::A<DataType, SpatialDim, Frame, Index>& x,
+    const double& mass) noexcept {
+
+  auto r = make_with_value<Scalar<DataType>>(x, 0.);
+  auto ricci = make_with_value<tnsr::aa<DataType, SpatialDim, Frame, Index>>(
+      x, 0.);
+
+  constexpr auto dimensionality = index_dim<0>(ricci);
+
+  for (size_t i=0; i < dimensionality; ++i) {
+    r.get() += x.get(i)*x.get(i);
+  }
+  r.get() = sqrt(r.get());
+
+  for (size_t i=0; i < dimensionality; ++i) {
+    for (size_t j=i; j < dimensionality; ++j ) {
+      ricci.get(i,j) -= (8.0 * mass + 3.0 * r.get()) * x.get(i) * x.get(j);
+      if (i == j) {
+        ricci.get(i,j) += r.get() * r.get() * (4.0 * mass + r.get());
+      }
+      ricci.get(i,j) *= mass;
+      ricci.get(i,j) /= r.get() * r.get() * r.get() * r.get()
+                        * (2.0 * mass + r.get()) * (2.0 * mass + r.get());
+    }
+  }
+
+  return ricci;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define INDEXTYPE(data) BOOST_PP_TUPLE_ELEM(3, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>    \
+  make_spatial_ricci_schwarzschild(                                          \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data), INDEXTYPE(data)>& x,\
+      const double& mass) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial),
+                        (IndexType::Spatial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INDEXTYPE
+#undef INSTANTIATE

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines functions useful for testing general relativity
+
+#pragma once
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+/*!
+ * \brief Schwarzschild (Kerr-Schild) spatial ricci tensor
+ *
+ * \details
+ * Computes \f$R_{ij} = M \frac{r^2(4M+r)\delta_{ij}-(8M+3r)x_i x_j}
+ * {r^4(2M+r^2)},\f$
+ * where \f$r = x_i x_j \delta^{ij}\f$, \f$x_i\f$ is the
+ * position vector in Cartesian coordinates, and M is the mass.
+ */
+template <size_t SpatialDim, typename Frame, IndexType Index, typename DataType>
+tnsr::aa<DataType, SpatialDim, Frame, Index> make_spatial_ricci_schwarzschild(
+    const tnsr::A<DataType, SpatialDim, Frame, Index>& x,
+    const double& mass) noexcept;

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
@@ -1,13 +1,14 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-/// \file
-/// Defines functions useful for testing general relativity
+/// Defines functions useful for testing StrahlkorperGr.
 
 #pragma once
 
+#include <cstddef>
+
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 /*!

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -131,7 +131,7 @@ void test_minkowski() {
 
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.ApparentHorizons.ConstantExpansion",
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr",
                   "[ApparentHorizons][Unit]") {
   test_schwarzschild();
   test_minkowski();

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -16,6 +16,7 @@
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
@@ -79,6 +80,17 @@ void test_schwarzschild() {
   Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
   CHECK_ITERABLE_CUSTOM_APPROX(
       get(residual), DataVector(get(residual).size(), 0.0), custom_approx);
+
+  const auto ricci_scalar = StrahlkorperGr::ricci_scalar(
+      make_spatial_ricci_schwarzschild(cart_coords, mass),
+      unit_normal_vector,
+      StrahlkorperGr::extrinsic_curvature(grad_unit_normal_one_form,
+                                          unit_normal_one_form,
+                                          inverse_spatial_metric),
+      inverse_spatial_metric);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(ricci_scalar), DataVector(get(ricci_scalar).size(), 0.5/(mass*mass)),
+      custom_approx);
 }
 
 void test_minkowski() {
@@ -127,6 +139,19 @@ void test_minkowski() {
   Approx custom_approx = Approx::custom().epsilon(1.e-12);
   CHECK_ITERABLE_CUSTOM_APPROX(
       get(residual), DataVector(get(residual).size(), 1.0), custom_approx);
+
+  const auto ricci_scalar = StrahlkorperGr::ricci_scalar(
+      make_with_value<tnsr::aa<DataVector, 3, Frame::Inertial,
+                      IndexType::Spatial>>(inverse_spatial_metric,
+                                           0.0),
+      unit_normal_vector,
+      StrahlkorperGr::extrinsic_curvature(grad_unit_normal_one_form,
+                                          unit_normal_one_form,
+                                          inverse_spatial_metric),
+      inverse_spatial_metric);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      get(ricci_scalar), DataVector(get(ricci_scalar).size(), 0.5),
+      custom_approx);
 }
 
 }  // namespace

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -26,7 +26,7 @@ void test_schwarzschild() {
       db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
                  db::AddComputeItemsTags<
                      StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
-          Strahlkorper<Frame::Inertial>(10, 10, 2.0, {{0, 0, 0}}));
+          Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0, 0, 0}}));
 
   const double t = 0.0;
   const auto& cart_coords =
@@ -82,15 +82,14 @@ void test_schwarzschild() {
       get(residual), DataVector(get(residual).size(), 0.0), custom_approx);
 
   const auto ricci_scalar = StrahlkorperGr::ricci_scalar(
-      make_spatial_ricci_schwarzschild(cart_coords, mass),
-      unit_normal_vector,
+      make_spatial_ricci_schwarzschild(cart_coords, mass), unit_normal_vector,
       StrahlkorperGr::extrinsic_curvature(grad_unit_normal_one_form,
                                           unit_normal_one_form,
                                           inverse_spatial_metric),
       inverse_spatial_metric);
-  CHECK_ITERABLE_CUSTOM_APPROX(
-      get(ricci_scalar), DataVector(get(ricci_scalar).size(), 0.5/(mass*mass)),
-      custom_approx);
+
+  CHECK_ITERABLE_APPROX(get(ricci_scalar), DataVector(get(ricci_scalar).size(),
+                                                      0.5 / (mass * mass)));
 }
 
 void test_minkowski() {
@@ -99,7 +98,7 @@ void test_minkowski() {
       db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
                  db::AddComputeItemsTags<
                      StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
-          Strahlkorper<Frame::Inertial>(10, 10, 2.0, {{0, 0, 0}}));
+          Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0, 0, 0}}));
 
   const double t = 0.0;
   const auto& cart_coords =
@@ -141,17 +140,16 @@ void test_minkowski() {
       get(residual), DataVector(get(residual).size(), 1.0), custom_approx);
 
   const auto ricci_scalar = StrahlkorperGr::ricci_scalar(
-      make_with_value<tnsr::aa<DataVector, 3, Frame::Inertial,
-                      IndexType::Spatial>>(inverse_spatial_metric,
-                                           0.0),
-      unit_normal_vector,
-      StrahlkorperGr::extrinsic_curvature(grad_unit_normal_one_form,
-                                          unit_normal_one_form,
-                                          inverse_spatial_metric),
+      make_with_value<
+          tnsr::aa<DataVector, 3, Frame::Inertial, IndexType::Spatial>>(
+          inverse_spatial_metric, 0.0),
+      unit_normal_vector, StrahlkorperGr::extrinsic_curvature(
+                              grad_unit_normal_one_form, unit_normal_one_form,
+                              inverse_spatial_metric),
       inverse_spatial_metric);
-  CHECK_ITERABLE_CUSTOM_APPROX(
-      get(ricci_scalar), DataVector(get(ricci_scalar).size(), 0.5),
-      custom_approx);
+
+  CHECK_ITERABLE_APPROX(get(ricci_scalar),
+                        DataVector(get(ricci_scalar).size(), 0.5));
 }
 
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Adds StrahlkorperGr::ricci_scalar(), which computes the intrinsic Ricci scalar curvature of a Strahlkorper using Gauss's equation. There are four terms in Gauss's equation: two involve the Ricci tensor of the 3D space containing the Strahlkorper, and two involve the extrinsic curvature of the Strahlkorper embedded in the 3D space (not to be confused with the extrinsic curvature of the space embedded in 3+1 spacetime).

The test i) verifies that the scalar curvature of a sphere in flat space is 2/R^2 for a sphere of radius 2, testing the extrinsic curvature terms only, and ii) verifies that the scalar curvature of a Schwarzschild black hole is 1/(2 M^2) for a hole of unit mass, which tests all four terms (the Ricci and extrinsic curvature terms each are nonzero). 

Does not depend on #495. For the Schwarzschild test, I simply implement the Ricci tensor for Schwarzschild in Kerr-Schild slicing in a new "helpers" file. Generalizing to Kerr would be a big pain and would not make the test more thorough.

Because StrahlkorperGr now does more than expansion, I renamed TestExpansion -> TestStrahlkorperGr. This is in a separate commit.
<!--

-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->