### PR TITLE
Minor changes to Domain tests

### DIFF
--- a/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
@@ -28,11 +28,7 @@ void test_brick_construction(
     const std::vector<std::unordered_set<Direction<3>>>&
         expected_external_boundaries) {
   const auto domain = brick.create_domain();
-  const auto& block = domain.blocks()[0];
-  const auto& neighbors = block.neighbors();
-  const auto& external_boundaries = block.external_boundaries();
 
-  CHECK(block.id() == 0);
   CHECK(brick.initial_extents() == expected_extents);
   CHECK(brick.initial_refinement_levels() == expected_refinement_level);
 

--- a/tests/Unit/Domain/DomainCreators/Test_Disk.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Disk.cpp
@@ -23,7 +23,6 @@ void test_disk_construction(
     const std::vector<std::array<size_t, 2>>& expected_refinement_level,
     const bool use_equiangular_map) {
   const auto domain = disk.create_domain();
-  const auto& blocks = domain.blocks();
   const OrientationMap<2> aligned_orientation{};
   const OrientationMap<2> quarter_turn_ccw(std::array<Direction<2>, 2>{
       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}});

--- a/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
@@ -25,11 +25,7 @@ void test_interval_construction(
     const std::vector<std::unordered_set<Direction<1>>>&
         expected_external_boundaries) noexcept {
   const auto domain = interval.create_domain();
-  const auto& block = domain.blocks()[0];
-  const auto& neighbors = block.neighbors();
-  const auto& external_boundaries = block.external_boundaries();
 
-  CHECK(block.id() == 0);
   CHECK(interval.initial_extents() == expected_extents);
   CHECK(interval.initial_refinement_levels() == expected_refinement_level);
 

--- a/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
@@ -28,11 +28,7 @@ void test_rectangle_construction(
     const std::vector<std::unordered_set<Direction<2>>>&
         expected_external_boundaries) {
   const auto domain = rectangle.create_domain();
-  const auto& block = domain.blocks()[0];
-  const auto& neighbors = block.neighbors();
-  const auto& external_boundaries = block.external_boundaries();
 
-  CHECK(block.id() == 0);
   CHECK(rectangle.initial_extents() == expected_extents);
   CHECK(rectangle.initial_refinement_levels() == expected_refinement_level);
 

--- a/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
@@ -22,7 +22,6 @@ void test_shell_construction(
     const std::array<size_t, 2>& expected_shell_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level) {
   const auto domain = shell.create_domain();
-  const auto& blocks = domain.blocks();
   const OrientationMap<3> aligned_orientation{};
   const OrientationMap<3> quarter_turn_ccw_about_zeta(
       std::array<Direction<3>, 3>{{Direction<3>::lower_eta(),

--- a/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
@@ -30,7 +30,6 @@ void test_sphere_construction(
     const std::array<size_t, 2>& expected_sphere_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level) {
   const auto domain = sphere.create_domain();
-  const auto& blocks = domain.blocks();
   const OrientationMap<3> aligned_orientation{};
   const OrientationMap<3> quarter_turn_ccw_about_zeta(
       std::array<Direction<3>, 3>{{Direction<3>::lower_eta(),

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -403,6 +403,7 @@ void test_initial_domain(const Domain<VolumeDim, Frame::Inertial>& domain,
                              initial_refinement_levels) noexcept {
   const auto element_ids = initial_element_ids(initial_refinement_levels);
   const auto& blocks = domain.blocks();
+  CHECK(blocks.size() == initial_refinement_levels.size());
   std::unordered_map<ElementId<VolumeDim>, Element<VolumeDim>> elements;
   for (const auto& element_id : element_ids) {
     elements.emplace(


### PR DESCRIPTION
## Proposed changes

Cleans up some code in the tests for Domain creation.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
