### PR TITLE
Fix building with clang-tidy and not a PCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,14 +33,9 @@ include(SetupGoldOrLldLinker)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(SetupLIBCXX)
-include(SetupClangFormat)
-include(SetupClangTidy)
-include(SetupCppCheck)
 include(SetupCxxFlags)
 include(SetupSanitizers)
 include(SetupListTargets)
-include(SetupDoxygen)
-include(CodeCoverageDetection)
 
 include(SetupBlas)
 include(SetupBlaze)
@@ -57,6 +52,15 @@ include(SetupYamlCpp)
 
 # The precompiled header must be setup after all libraries have been found
 include(SetupPch)
+
+# The ClangFormat, clang-tidy, CppCheck, Doxygen, and CodeCov are intentionally
+# after the PCH setup because that way they are able to change their
+# dependencies on the PCH if necessary.
+include(SetupClangFormat)
+include(SetupClangTidy)
+include(SetupCppCheck)
+include(SetupDoxygen)
+include(CodeCoverageDetection)
 
 # Generate Charm++ files
 generate_algorithms(${CMAKE_BINARY_DIR}/src/Parallel/Algorithms)

--- a/cmake/SetupClangTidy.cmake
+++ b/cmake/SetupClangTidy.cmake
@@ -38,8 +38,10 @@ if (CLANG_TIDY_BIN)
     module_ConstGlobalCache
     module_Main
     module_Test_ConstGlobalCache
-    pch
     )
+  if (TARGET pch)
+    list(APPEND MODULES_TO_DEPEND_ON pch)
+  endif()
   configure_file(
     ${CMAKE_SOURCE_DIR}/tools/ClangTidyAll.sh
     ${CMAKE_BINARY_DIR}/ClangTidyAll.sh


### PR DESCRIPTION
## Proposed changes

- Building with no PCH and clang fails if clang-tidy is present because it tries to depend on the PCH target.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
