### PR TITLE
Add StrahlkorperGr::ricci_scalar

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -79,4 +79,49 @@ Scalar<DataVector> expansion(
     const tnsr::II<DataVector, 3, Frame>& inverse_surface_metric,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
 
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Extrinsic curvature of a 2D `Strahlkorper` embedded in a 3D space.
+ *
+ * \details Implements Eq. (D.43) of Carroll's Spacetime and Geometry text.
+ * Specifically,
+ * \f$ K_{ij} = P^k_i P^l_j \nabla_{(k} S_{l)} \f$, where
+ * \f$ P^k_i = \delta^k_i - S^k S_i \f$,
+ * `grad_normal` is the quantity \f$ \nabla_k S_l \f$ returned by
+ * `StrahlkorperGr::grad_unit_normal_one_form`, and `unit_normal_vector` is
+ * \f$S^i = g^{ij} S_j\f$ where \f$S_j\f$ is the unit normal one form.
+ * Not to be confused with the extrinsic curvature of a 3D spatial slice
+ * embedded in 3+1 spacetime.
+ * Because StrahlkorperGr::grad_unit_normal_one_form is symmetric, this
+ * can be expanded into
+ * \f$ K_{ij} = \nabla_{i}S_{j} - 2 S^k S_{(i}\nabla_{j)}S_k
+ * + S_i S_j S^k S^l \nabla_{k} n_{l}\f$.
+ */
+template <typename Frame>
+tnsr::ii<DataVector, 3, Frame> extrinsic_curvature(
+    const tnsr::ii<DataVector, 3, Frame>& grad_normal,
+    const tnsr::i<DataVector, 3, Frame>& unit_normal_one_form,
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector) noexcept;
+
+/// \ingroup SurfacesGroup
+/// \brief Intrinsic Ricci scalar of a 2D `Strahlkorper`.
+///
+/// \details Implements Eq. (D.51) of
+/// Sean Carroll's Spacetime and Geometry textbook (except correcting
+/// sign errors: both extrinsic curvature terms are off by a minus sign
+/// in Carroll's text but correct in Carroll's errata).
+/// \f$ \hat{R}=R - 2 R_{ij} S^i S^j + K^2-K^{ij}K_{ij}.\f$
+/// Here \f$\hat{R}\f$ is the intrinsic Ricci scalar curvature of
+/// the Strahlkorper, \f$R\f$ and \f$R_{ij}\f$ are the Ricci scalar and
+/// Ricci tensor of the 3D space that contains the Strahlkorper,
+/// \f$ K_{ij} \f$ the output of StrahlkorperGr::extrinsic_curvature,
+/// \f$ K \f$ is the trace of \f$K_{ij}\f$,
+/// and `unit_normal_vector` is
+/// \f$S^i = g^{ij} S_j\f$ where \f$S_j\f$ is the unit normal one form.
+template <typename Frame>
+Scalar<DataVector> ricci_scalar(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_ricci_tensor,
+    const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
+    const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
+    const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
 }  // namespace StrahlkorperGr

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE.txt for details.
 
 set(APPARENT_HORIZONS_TESTS
+    ApparentHorizons/StrahlkorperGrTestHelpers.cpp
     ApparentHorizons/Test_FastFlow.cpp
     ApparentHorizons/Test_SpherepackIterator.cpp
     ApparentHorizons/Test_Strahlkorper.cpp

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace TestHelpers {
+namespace Schwarzschild {
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> spatial_ricci(
+    const tnsr::I<DataType, SpatialDim, Frame>& x,
+    const double& mass) noexcept {
+  auto ricci = make_with_value<tnsr::ii<DataType, SpatialDim, Frame>>(x, 0.);
+
+  constexpr auto dimensionality = index_dim<0>(ricci);
+
+  const DataType r = magnitude(x);
+
+  for (size_t i = 0; i < dimensionality; ++i) {
+    for (size_t j = i; j < dimensionality; ++j) {
+      ricci.get(i, j) -= (8.0 * mass + 3.0 * r) * x.get(i) * x.get(j);
+      if (i == j) {
+        ricci.get(i, j) += square(r) * (4.0 * mass + r);
+      }
+      ricci.get(i, j) *= mass;
+      ricci.get(i, j) /= pow<4>(r) * square(2.0 * mass + r);
+    }
+  }
+
+  return ricci;
+}
+}  // namespace Schwarzschild
+
+namespace Minkowski {
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature_sphere(
+    const tnsr::I<DataType, SpatialDim, Frame>& x) noexcept {
+  auto extrinsic_curvature =
+      make_with_value<tnsr::ii<DataType, SpatialDim, Frame>>(x, 0.);
+
+  constexpr auto dimensionality = index_dim<0>(extrinsic_curvature);
+
+  const DataType one_over_r = 1.0 / magnitude(x);
+
+  for (size_t i = 0; i < dimensionality; ++i) {
+    extrinsic_curvature.get(i, i) += 1.0;
+    for (size_t j = i; j < dimensionality; ++j) {
+      extrinsic_curvature.get(i, j) -= x.get(i) * x.get(j) * square(one_over_r);
+      extrinsic_curvature.get(i, j) *= one_over_r;
+    }
+  }
+
+  return extrinsic_curvature;
+}
+}  // namespace Minkowski
+}  // namespace TestHelpers
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define INDEXTYPE(data) BOOST_PP_TUPLE_ELEM(3, data)
+
+#define INSTANTIATE(_, data)                                 \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>     \
+  TestHelpers::Schwarzschild::spatial_ricci(                 \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x, \
+      const double& mass) noexcept;                          \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>     \
+  TestHelpers::Minkowski::extrinsic_curvature_sphere(        \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& x) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INDEXTYPE
+#undef INSTANTIATE

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+namespace TestHelpers {
+namespace Schwarzschild {
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Schwarzschild (Kerr-Schild) spatial ricci tensor
+ *
+ * \details
+ * Computes \f$R_{ij} = M \frac{r^2(4M+r)\delta_{ij}-(8M+3r)x_i x_j}
+ * {r^4(2M+r^2)},\f$
+ * where \f$r = x_i x_j \delta^{ij}\f$, \f$x_i\f$ is the
+ * position vector in Cartesian coordinates, and M is the mass.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> spatial_ricci(
+    const tnsr::I<DataType, SpatialDim, Frame>& x, const double& mass) noexcept;
+} //namespace Schwarzschild
+
+namespace Minkowski {
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Extrinsic curvature of 2D sphere in 3D flat space
+ *
+ * \details
+ * Computes \f$K_{ij} = \frac{1}{r}\left(\delta_{ij} -
+ * \frac{x_i x_j}{r}\right),\f$
+ * where \f$r = x_i x_j \delta^{ij}\f$ and \f$x_i\f$ is the
+ * position vector in Cartesian coordinates.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature_sphere(
+    const tnsr::I<DataType, SpatialDim, Frame>& x) noexcept;
+} //namespace Minkowski
+} //namespace TestHelpers

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -16,16 +16,18 @@
 #include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
+namespace TestExpansion {
 void test_schwarzschild() {
   // Make surface of radius 2.
   const auto box =
       db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
                  db::AddComputeItemsTags<
                      StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
-          Strahlkorper<Frame::Inertial>(10, 10, 2.0, {{0, 0, 0}}));
+          Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
 
   const double t = 0.0;
   const auto& cart_coords =
@@ -88,7 +90,7 @@ void test_minkowski() {
       db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
                  db::AddComputeItemsTags<
                      StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
-          Strahlkorper<Frame::Inertial>(10, 10, 2.0, {{0, 0, 0}}));
+          Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
 
   const double t = 0.0;
   const auto& cart_coords =
@@ -130,11 +132,186 @@ void test_minkowski() {
   CHECK_ITERABLE_CUSTOM_APPROX(
       get(residual), DataVector(get(residual).size(), 1.0), custom_approx);
 }
+}  // namespace TestExpansion
 
+namespace TestExtrinsicCurvature {
+void test_minkowski() {
+  // Make surface of radius 2.
+  const auto box =
+      db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
+                 db::AddComputeItemsTags<
+                     StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
+          Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
+
+  const double t = 0.0;
+  const auto& cart_coords =
+      db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
+
+  EinsteinSolutions::Minkowski<3> solution{};
+
+  const auto deriv_spatial_metric =
+      solution.deriv_spatial_metric(cart_coords, t);
+  const auto inverse_spatial_metric =
+      solution.inverse_spatial_metric(cart_coords, t);
+
+  const DataVector one_over_one_form_magnitude =
+      1.0 /
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric);
+  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
+      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+      one_over_one_form_magnitude);
+  const auto grad_unit_normal_one_form =
+      StrahlkorperGr::grad_unit_normal_one_form(
+          db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
+          db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box),
+          unit_normal_one_form,
+          db::get<StrahlkorperTags::D2xRadius<Frame::Inertial>>(box),
+          one_over_one_form_magnitude,
+          raise_or_lower_first_index(
+              gr::christoffel_first_kind(deriv_spatial_metric),
+              inverse_spatial_metric));
+
+  const auto unit_normal_vector =
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
+  const auto extrinsic_curvature = StrahlkorperGr::extrinsic_curvature(
+      grad_unit_normal_one_form, unit_normal_one_form, unit_normal_vector);
+  const auto extrinsic_curvature_minkowski =
+      TestHelpers::Minkowski::extrinsic_curvature_sphere(cart_coords);
+
+  CHECK_ITERABLE_APPROX(extrinsic_curvature, extrinsic_curvature_minkowski);
+}
+}  // namespace TestExtrinsicCurvature
+
+namespace TestRicciScalar {
+void test_schwarzschild() {
+  // Make surface of radius 2.
+  const auto box =
+      db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
+                 db::AddComputeItemsTags<
+                     StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
+          Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
+
+  const double t = 0.0;
+  const auto& cart_coords =
+      db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
+
+  // Schwarzschild solution
+  const double mass = 1.0;
+  const std::array<double, 3> spin{{0.0, 0.0, 0.0}};
+  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
+  EinsteinSolutions::KerrSchild solution(mass, spin, center);
+  const auto vars = solution.solution(cart_coords, t);
+
+  const auto& spatial_metric =
+      get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);
+  const auto& deriv_spatial_metric =
+      get<EinsteinSolutions::KerrSchild::deriv_spatial_metric<DataVector>>(
+          vars);
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+
+  const DataVector one_over_one_form_magnitude =
+      1.0 /
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric);
+  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
+      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+      one_over_one_form_magnitude);
+  const auto grad_unit_normal_one_form =
+      StrahlkorperGr::grad_unit_normal_one_form(
+          db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
+          db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box),
+          unit_normal_one_form,
+          db::get<StrahlkorperTags::D2xRadius<Frame::Inertial>>(box),
+          one_over_one_form_magnitude,
+          raise_or_lower_first_index(
+              gr::christoffel_first_kind(deriv_spatial_metric),
+              inverse_spatial_metric));
+
+  const auto unit_normal_vector =
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
+  const auto ricci_scalar = StrahlkorperGr::ricci_scalar(
+      TestHelpers::Schwarzschild::spatial_ricci(cart_coords, mass),
+      unit_normal_vector,
+      StrahlkorperGr::extrinsic_curvature(
+          grad_unit_normal_one_form, unit_normal_one_form, unit_normal_vector),
+      inverse_spatial_metric);
+
+  CHECK_ITERABLE_APPROX(get(ricci_scalar), DataVector(get(ricci_scalar).size(),
+                                                      0.5 / square(mass)));
+}
+
+void test_minkowski() {
+  // Make surface of radius 2.
+  const auto box =
+      db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
+                 db::AddComputeItemsTags<
+                     StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
+          Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
+
+  const double t = 0.0;
+  const auto& cart_coords =
+      db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
+
+  EinsteinSolutions::Minkowski<3> solution{};
+
+  const auto deriv_spatial_metric =
+      solution.deriv_spatial_metric(cart_coords, t);
+  const auto inverse_spatial_metric =
+      solution.inverse_spatial_metric(cart_coords, t);
+
+  const DataVector one_over_one_form_magnitude =
+      1.0 /
+      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric);
+  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
+      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+      one_over_one_form_magnitude);
+  const auto grad_unit_normal_one_form =
+      StrahlkorperGr::grad_unit_normal_one_form(
+          db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
+          db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box),
+          unit_normal_one_form,
+          db::get<StrahlkorperTags::D2xRadius<Frame::Inertial>>(box),
+          one_over_one_form_magnitude,
+          raise_or_lower_first_index(
+              gr::christoffel_first_kind(deriv_spatial_metric),
+              inverse_spatial_metric));
+
+  const auto unit_normal_vector =
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
+  const auto extrinsic_curvature = StrahlkorperGr::extrinsic_curvature(
+      grad_unit_normal_one_form, unit_normal_one_form, unit_normal_vector);
+
+  const auto ricci_scalar = StrahlkorperGr::ricci_scalar(
+      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(
+          inverse_spatial_metric, 0.0),
+      unit_normal_vector, extrinsic_curvature, inverse_spatial_metric);
+
+  CHECK_ITERABLE_APPROX(get(ricci_scalar),
+                        DataVector(get(ricci_scalar).size(), 0.5));
+}
+}  // namespace TestRicciScalar
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.ApparentHorizons.ConstantExpansion",
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.Expansion",
                   "[ApparentHorizons][Unit]") {
-  test_schwarzschild();
-  test_minkowski();
+  TestExpansion::test_schwarzschild();
+  TestExpansion::test_minkowski();
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.ExtrinsicCurvature",
+                  "[ApparentHorizons][Unit]") {
+  // N.B.: test_minkowski() fully tests the extrinsic curvature function.
+  // All components of extrinsic curvature of a sphere in flat space
+  // are nontrivial; cf. extrinsic_curvature_sphere()
+  // in StrahlkorperGrTestHelpers.cpp).
+  TestExtrinsicCurvature::test_minkowski();
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.RicciScalar",
+                  "[ApparentHorizons][Unit]") {
+  TestRicciScalar::test_schwarzschild();
+  TestRicciScalar::test_minkowski();
 }


### PR DESCRIPTION
## Proposed changes

(Note: replaces #523, which had conflicts I couldn't figure out how to resolve. So the quickest way forward was to make a new branch with a new pull request.)

Adds StrahlkorperGr::ricci_scalar(), which computes the intrinsic Ricci scalar curvature of a Strahlkorper using Gauss's equation. There are four terms in Gauss's equation: two involve the Ricci tensor of the 3D space containing the Strahlkorper, and two involve the extrinsic curvature of the Strahlkorper embedded in the 3D space (not to be confused with the extrinsic curvature of the space embedded in 3+1 spacetime).

The test i) verifies that the scalar curvature of a sphere in flat space is 2/R^2 for a sphere of radius 2, testing the extrinsic curvature terms only, and ii) verifies that the scalar curvature of a Schwarzschild black hole is 1/(2 M^2) for a hole of unit mass, which tests all four terms (the Ricci and extrinsic curvature terms each are nonzero). 

Does not depend on #495. For the Schwarzschild test, I simply implement the Ricci tensor for Schwarzschild in Kerr-Schild slicing in a new "helpers" file. Generalizing to Kerr would be a big pain and would not make the test more thorough.

Because StrahlkorperGr now does more than expansion, I renamed TestExpansion -> TestStrahlkorperGr. This is in a separate commit.
<!--

-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->