### PR TITLE
Add time-dependent translation map

### DIFF
--- a/cmake/SetupClangTidy.cmake
+++ b/cmake/SetupClangTidy.cmake
@@ -10,13 +10,14 @@
 # -cppcoreguidelines-c-copy-assignment-signature: false positives
 # -cert-err58-cpp: many static variables we use do not throw, and if they do
 #                  we want to terminate anyway
+# -google-default-arguments: defaulting virtual functions in CoordinateMap
 #
 # Notes:
 # misc-move-const-arg: we keep this check because even though this gives
 #                      a lot of annoying warnings about moving trivially
 #                      copyable types, it warns about moving const objects,
 #                      which can have severe performance impacts.
-set(CLANG_TIDY_IGNORE_CHECKS "*,-llvm-header-guard,-google-runtime-int,-readability-else-after-return,-misc-noexcept-move-constructor,-misc-unconventional-assign-operator,-cppcoreguidelines-c-copy-assignment-signature,-modernize-raw-string-literal,-hicpp-noexcept-move,-hicpp-no-assembler,-android-*,-cert-err58-cpp")
+set(CLANG_TIDY_IGNORE_CHECKS "*,-llvm-header-guard,-google-runtime-int,-readability-else-after-return,-misc-noexcept-move-constructor,-misc-unconventional-assign-operator,-cppcoreguidelines-c-copy-assignment-signature,-modernize-raw-string-literal,-hicpp-noexcept-move,-hicpp-no-assembler,-android-*,-cert-err58-cpp,-google-default-arguments")
 
 if(NOT CMAKE_CXX_CLANG_TIDY AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   string(

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -59,6 +59,16 @@
  */
 
 /*!
+ * \defgroup CoordMapsTimeDependentGroup  Coordinate Maps, Time-dependent
+ * \brief Functions for mapping time-dependent coordinates between different
+ * frames
+ *
+ * Coordinate maps provide the maps themselves, the inverse maps, the Jacobian
+ * and inverse Jacobian of the maps, and the frame velocity (time derivative of
+ * the map)
+ */
+
+/*!
  * \defgroup DataBoxGroup DataBox
  * \brief Contains (meta)functions used for manipulating DataBoxes
  */

--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
     Equiangular.cpp
     Identity.cpp
     Rotation.cpp
+    Translation.cpp
     Wedge2D.cpp
     Wedge3D.cpp
     )

--- a/src/Domain/CoordinateMaps/Translation.cpp
+++ b/src/Domain/CoordinateMaps/Translation.cpp
@@ -1,0 +1,95 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/Translation.hpp"
+
+#include "ControlSystem/FunctionOfTime.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Identity.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace CoordMapsTimeDependent {
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::operator()(
+    const std::array<T, 1>& source_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  return {{source_coords[0] + map_list.at(f_of_t_name_).func(time)[0][0]}};
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::inverse(
+    const std::array<T, 1>& target_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  return {{target_coords[0] - map_list.at(f_of_t_name_).func(time)[0][0]}};
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::frame_velocity(
+    const std::array<T, 1>& source_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  return {{make_with_value<tt::remove_cvref_wrap_t<T>>(
+      dereference_wrapper(source_coords[0]),
+      map_list.at(f_of_t_name_).func_and_deriv(time)[1][0])}};
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> Translation::jacobian(
+    const std::array<T, 1>& source_coords) const noexcept {
+  return identity<1>(dereference_wrapper(source_coords[0]));
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>
+Translation::inv_jacobian(const std::array<T, 1>& source_coords) const
+    noexcept {
+  return identity<1>(dereference_wrapper(source_coords[0]));
+}
+
+void Translation::pup(PUP::er& p) noexcept { p | f_of_t_name_; }
+
+bool operator==(const CoordMapsTimeDependent::Translation& lhs,
+                const CoordMapsTimeDependent::Translation& rhs) noexcept {
+  return lhs.f_of_t_name_ == rhs.f_of_t_name_;
+}
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1> Translation::   \
+  operator()(const std::array<DTYPE(data), 1>& source_coords,                  \
+             const double time,                                                \
+             const std::unordered_map<std::string, FunctionOfTime&>& map_list) \
+      const noexcept;                                                          \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
+  Translation::inverse(                                                        \
+      const std::array<DTYPE(data), 1>& target_coords, const double time,      \
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
+      const noexcept;                                                          \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
+  Translation::frame_velocity(                                                 \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
+  Translation::jacobian(const std::array<DTYPE(data), 1>& source_coords)       \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
+  Translation::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords)   \
+      const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+}  // namespace CoordMapsTimeDependent

--- a/src/Domain/CoordinateMaps/Translation.hpp
+++ b/src/Domain/CoordinateMaps/Translation.hpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+class FunctionOfTime;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace CoordMapsTimeDependent {
+/*!
+ * \ingroup CoordMapsTimeDependentGroup
+ * \brief Translation map defined by \f$x = \xi+T(t)\f$.
+ *
+ * The map adds a translation, \f$T(t)\f$, to the coordinates \f$\xi\f$,
+ * where \f$T(t)\f$ is a FunctionOfTime.
+ */
+class Translation {
+ public:
+  static constexpr size_t dim = 1;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
+      const std::array<T, 1>& source_coords, double time,
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+      noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 1> inverse(
+      const std::array<T, 1>& target_coords, double time,
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+      noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 1> frame_velocity(
+      const std::array<T, 1>& source_coords, double time,
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+      noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 1>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
+      const std::array<T, 1>& source_coords) const noexcept;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  friend bool operator==(const Translation& lhs,
+                         const Translation& rhs) noexcept;
+
+  std::string f_of_t_name_ = "trans";
+};
+
+inline bool operator!=(
+    const CoordMapsTimeDependent::Translation& lhs,
+    const CoordMapsTimeDependent::Translation& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace CoordMapsTimeDependent

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   CoordinateMaps/Test_Identity.cpp
   CoordinateMaps/Test_ProductMaps.cpp
   CoordinateMaps/Test_Rotation.cpp
+  CoordinateMaps/Test_Translation.cpp
   CoordinateMaps/Test_Wedge2D.cpp
   CoordinateMaps/Test_Wedge3D.cpp
   PARENT_SCOPE

--- a/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <catch.hpp>
+#include <unordered_map>
+
+#include "ControlSystem/PiecewisePolynomial.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Translation.hpp"
+#include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.Translation",
+                  "[Domain][Unit]") {
+  // define vars for FunctionOfTime::PiecewisePolynomial f(t) = t**2.
+  double t = -1.0;
+  const double dt = 0.6;
+  const double final_time = 4.0;
+  constexpr size_t deriv_order = 3;
+
+  const std::array<DataVector, deriv_order + 1> init_func{
+      {{1.0}, {-2.0}, {2.0}, {0.0}}};
+  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t_derived(t,
+                                                                   init_func);
+  FunctionOfTime& f_of_t = f_of_t_derived;
+
+  const std::unordered_map<std::string, FunctionOfTime&> f_of_t_list = {
+      {"trans", f_of_t}};
+  const CoordMapsTimeDependent::Translation trans_map{};
+  // test serialized/deserialized map
+  const auto trans_map_deserialized = serialize_and_deserialize(trans_map);
+
+  const std::array<double, 1> point_xi{{3.2}};
+  const std::array<double, 1> point_x{{3.2}};
+
+  while (t < final_time) {
+    const std::array<double, 1> trans_x{{square(t)}};
+    const std::array<double, 1> frame_vel{{f_of_t.func_and_deriv(t)[1][0]}};
+
+    CHECK_ITERABLE_APPROX(trans_map(point_xi, t, f_of_t_list),
+                          point_x + trans_x);
+    CHECK_ITERABLE_APPROX(trans_map.inverse(point_x + trans_x, t, f_of_t_list),
+                          point_xi);
+    CHECK_ITERABLE_APPROX(
+        trans_map.frame_velocity(point_x + trans_x, t, f_of_t_list), frame_vel);
+
+    CHECK_ITERABLE_APPROX(trans_map_deserialized(point_xi, t, f_of_t_list),
+                          point_x + trans_x);
+    CHECK_ITERABLE_APPROX(
+        trans_map_deserialized.inverse(point_x + trans_x, t, f_of_t_list),
+        point_xi);
+    CHECK_ITERABLE_APPROX(trans_map_deserialized.frame_velocity(
+                              point_x + trans_x, t, f_of_t_list),
+                          frame_vel);
+
+    t += dt;
+  }
+
+  // time-independent checks
+  CHECK(trans_map.inv_jacobian(point_xi).get(0, 0) == 1.0);
+  CHECK(trans_map_deserialized.inv_jacobian(point_xi).get(0, 0) == 1.0);
+  CHECK(trans_map.jacobian(point_xi).get(0, 0) == 1.0);
+  CHECK(trans_map_deserialized.jacobian(point_xi).get(0, 0) == 1.0);
+
+  // Check inequivalence operator
+  CHECK_FALSE(trans_map != trans_map);
+  CHECK_FALSE(trans_map_deserialized != trans_map_deserialized);
+
+  // Check serialization
+  CHECK(trans_map == trans_map_deserialized);
+  CHECK_FALSE(trans_map != trans_map_deserialized);
+
+  test_coordinate_map_argument_types(trans_map, point_xi, t, f_of_t_list);
+}


### PR DESCRIPTION
## Proposed changes

### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
