### PR TITLE
Add cons to prim for Newtonian Euler

### DIFF
--- a/src/Evolution/Systems/CMakeLists.txt
+++ b/src/Evolution/Systems/CMakeLists.txt
@@ -3,5 +3,6 @@
 
 add_subdirectory(CurvedScalarWave)
 add_subdirectory(GeneralizedHarmonic)
+add_subdirectory(NewtonianEuler)
 add_subdirectory(RelativisticEuler)
 add_subdirectory(ScalarWave)

--- a/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY NewtonianEuler)
+
+set(LIBRARY_SOURCES
+    PrimitiveFromConservative.cpp
+    )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  )

--- a/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/// \cond
+namespace NewtonianEuler {
+
+template <size_t Dim, typename DataType>
+void velocity(const gsl::not_null<tnsr::I<DataType, Dim>*> velocity,
+              const Scalar<DataType>& mass_density,
+              const tnsr::I<DataType, Dim>& momentum_density) noexcept {
+  const DataType one_over_mass_density = 1.0 / get(mass_density);
+  for (size_t i = 0; i < Dim; ++i) {
+    velocity->get(i) = momentum_density.get(i) * one_over_mass_density;
+  }
+}
+
+template <size_t Dim, typename DataType>
+tnsr::I<DataType, Dim> velocity(
+    const Scalar<DataType>& mass_density,
+    const tnsr::I<DataType, Dim>& momentum_density) noexcept {
+  auto velocity = make_with_value<tnsr::I<DataType, Dim>>(mass_density, 0.0);
+  NewtonianEuler::velocity(make_not_null(&velocity), mass_density,
+                           momentum_density);
+  return velocity;
+}
+
+template <size_t Dim, typename DataType>
+void primitive_from_conservative(
+    const gsl::not_null<tnsr::I<DataType, Dim>*> velocity,
+    const gsl::not_null<Scalar<DataType>*> specific_internal_energy,
+    const Scalar<DataType>& mass_density,
+    const tnsr::I<DataType, Dim>& momentum_density,
+    const Scalar<DataType>& energy_density) noexcept {
+  NewtonianEuler::velocity(velocity, mass_density, momentum_density);
+  get(*specific_internal_energy) = get(energy_density) / get(mass_density) -
+                                   0.5 * get(dot_product(*velocity, *velocity));
+}
+
+}  // namespace NewtonianEuler
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                              \
+  template void NewtonianEuler::velocity(                                 \
+      const gsl::not_null<tnsr::I<DTYPE(data), DIM(data)>*> velocity,     \
+      const Scalar<DTYPE(data)>& mass_density,                            \
+      const tnsr::I<DTYPE(data), DIM(data)>& momentum_density) noexcept;  \
+  template tnsr::I<DTYPE(data), DIM(data)> NewtonianEuler::velocity(      \
+      const Scalar<DTYPE(data)>& mass_density,                            \
+      const tnsr::I<DTYPE(data), DIM(data)>& momentum_density) noexcept;  \
+  template void NewtonianEuler::primitive_from_conservative(              \
+      const gsl::not_null<tnsr::I<DTYPE(data), DIM(data)>*> velocity,     \
+      const gsl::not_null<Scalar<DTYPE(data)>*> specific_internal_energy, \
+      const Scalar<DTYPE(data)>& mass_density,                            \
+      const tnsr::I<DTYPE(data), DIM(data)>& momentum_density,            \
+      const Scalar<DTYPE(data)>& energy_density) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))
+
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace NewtonianEuler {
+// @{
+/*!
+ * \brief Compute the velocity from the conservative variables.
+ */
+template <size_t Dim, typename DataType>
+void velocity(gsl::not_null<tnsr::I<DataType, Dim>*> velocity,
+              const Scalar<DataType>& mass_density,
+              const tnsr::I<DataType, Dim>& momentum_density) noexcept;
+
+template <size_t Dim, typename DataType>
+tnsr::I<DataType, Dim> velocity(
+    const Scalar<DataType>& mass_density,
+    const tnsr::I<DataType, Dim>& momentum_density) noexcept;
+// @}
+
+/*!
+ * \brief Compute the primitive variables from the conservative variables.
+ *
+ * \f{align*}
+ * v^i &= \frac{S^i}{\rho} \\
+ * \epsilon &= \frac{e}{\rho} - \frac{1}{2}\frac{S^2}{\rho^2}
+ * \f}
+ *
+ * where \f$v^i\f$ is the velocity, \f$\epsilon\f$ is the specific
+ * internal energy, \f$e\f$ is the energy density, \f$\rho\f$
+ * is the mass density, \f$S^i\f$ is the momentum density, and
+ * \f$S^2\f$ is the momentum density squared.
+ */
+template <size_t Dim, typename DataType>
+void primitive_from_conservative(
+    gsl::not_null<tnsr::I<DataType, Dim>*> velocity,
+    gsl::not_null<Scalar<DataType>*> specific_internal_energy,
+    const Scalar<DataType>& mass_density,
+    const tnsr::I<DataType, Dim>& momentum_density,
+    const Scalar<DataType>& energy_density) noexcept;
+
+}  // namespace NewtonianEuler

--- a/tests/Unit/Evolution/Systems/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(CurvedScalarWave)
 add_subdirectory(GeneralizedHarmonic)
+add_subdirectory(NewtonianEuler)
 add_subdirectory(RelativisticEuler)
 add_subdirectory(ScalarWave)
 

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(NEWTONIAN_EULER_TESTS
+    Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
+    )
+
+set(SYSTEM_TESTS "${SYSTEM_TESTS};${NEWTONIAN_EULER_TESTS}" PARENT_SCOPE)
+set(LIBRARIES_TO_LINK "${LIBRARIES_TO_LINK};NewtonianEuler" PARENT_SCOPE)

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
@@ -1,0 +1,114 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"  // delete when py
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "tests/Unit/DataStructures/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
+
+namespace {
+
+template <size_t Dim, typename DataType>
+tnsr::I<DataType, Dim> expected_velocity(
+    const Scalar<DataType>& mass_density,
+    const tnsr::I<DataType, Dim>& momentum_density) noexcept {
+  auto result = make_with_value<tnsr::I<DataType, Dim>>(mass_density, 0.0);
+  const DataType one_over_mass_density = 1.0 / get(mass_density);
+  for (size_t i = 0; i < Dim; ++i) {
+    result.get(i) = momentum_density.get(i) * one_over_mass_density;
+  }
+  return result;
+}
+
+template <size_t Dim, typename DataType>
+Scalar<DataType> expected_specific_internal_energy(
+    const Scalar<DataType>& mass_density,
+    const tnsr::I<DataType, Dim>& momentum_density,
+    const Scalar<DataType>& energy_density) noexcept {
+  const auto velocity =
+      NewtonianEuler::velocity(mass_density, momentum_density);
+  return Scalar<DataType>{-0.5 * get(dot_product(velocity, velocity)) +
+                          get(energy_density) / get(mass_density)};
+}
+
+template <size_t Dim, typename DataType>
+void test_velocity(
+    const gsl::not_null<std::mt19937*> generator,
+    const gsl::not_null<std::uniform_real_distribution<>*> distribution,
+    const DataType& used_for_size) noexcept {
+  const auto mass_density = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto momentum_density = make_with_random_values<tnsr::I<DataType, Dim>>(
+      generator, distribution, used_for_size);
+
+  const auto velocity =
+      NewtonianEuler::velocity(mass_density, momentum_density);
+  const auto exp_velocity = expected_velocity(mass_density, momentum_density);
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK_ITERABLE_APPROX(exp_velocity.get(i), velocity.get(i));
+  }
+}
+
+template <size_t Dim, typename DataType>
+void test_primitive_from_conservative(
+    const gsl::not_null<std::mt19937*> generator,
+    const gsl::not_null<std::uniform_real_distribution<>*> distribution,
+    const DataType& used_for_size) noexcept {
+  const auto mass_density = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto momentum_density = make_with_random_values<tnsr::I<DataType, Dim>>(
+      generator, distribution, used_for_size);
+  const auto energy_density = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+
+  auto velocity = make_with_value<tnsr::I<DataType, Dim>>(used_for_size, 0.0);
+  auto specific_internal_energy =
+      make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+  NewtonianEuler::primitive_from_conservative(
+      make_not_null(&velocity), make_not_null(&specific_internal_energy),
+      mass_density, momentum_density, energy_density);
+
+  const auto exp_velocity = expected_velocity(mass_density, momentum_density);
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK_ITERABLE_APPROX(exp_velocity.get(i), velocity.get(i));
+  }
+  CHECK_ITERABLE_APPROX(expected_specific_internal_energy(
+                            mass_density, momentum_density, energy_density),
+                        specific_internal_energy);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.NewtonianEuler.PrimitiveFromConservative",
+    "[Unit][Evolution]") {
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed = " << seed);
+  std::uniform_real_distribution<> distribution(0.0, 1.0);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  const double d = std::numeric_limits<double>::signaling_NaN();
+  test_velocity<1>(nn_generator, nn_distribution, d);
+  test_velocity<2>(nn_generator, nn_distribution, d);
+  test_velocity<3>(nn_generator, nn_distribution, d);
+  test_primitive_from_conservative<1>(nn_generator, nn_distribution, d);
+  test_primitive_from_conservative<2>(nn_generator, nn_distribution, d);
+  test_primitive_from_conservative<3>(nn_generator, nn_distribution, d);
+
+  const DataVector dv(5);
+  test_velocity<1>(nn_generator, nn_distribution, dv);
+  test_velocity<2>(nn_generator, nn_distribution, dv);
+  test_velocity<3>(nn_generator, nn_distribution, dv);
+  test_primitive_from_conservative<1>(nn_generator, nn_distribution, dv);
+  test_primitive_from_conservative<2>(nn_generator, nn_distribution, dv);
+  test_primitive_from_conservative<3>(nn_generator, nn_distribution, dv);
+}


### PR DESCRIPTION
## Proposed changes

Add the functions to obtain the primitive quantities in terms of the conserved quantities for Newtonian Euler.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
