### PR TITLE
Treat tpp files like cpp in CheckFiles.sh

### DIFF
--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -34,7 +34,7 @@ pretty_grep() {
 
 # Utility functions for checks classifying a file based on its name
 is_hpp() { [[ $1 =~ \.hpp$ ]] ; }
-is_c++() { [[ $1 =~ \.cpp$ ]] || [[ $1 =~ \.hpp$ ]] ; }
+is_c++() { [[ $1 =~ \.cpp$ ]] || [[ $1 =~ \.hpp$ ]] || [[ $1 =~ \.tpp$ ]] ; }
 
 # Utility function for checks that returns false if the first argument
 # matches any of the shell regexes passed as subsequent arguments.
@@ -145,6 +145,8 @@ long_lines_test() {
     local eighty=${ten}${ten}${ten}${ten}${ten}${ten}${ten}${ten}
     test_check pass foo.cpp "${eighty}"$'\n'
     test_check fail foo.cpp "${eighty}x"$'\n'
+    test_check fail foo.hpp "${eighty}x"$'\n'
+    test_check fail foo.tpp "${eighty}x"$'\n'
     test_check pass foo.yaml "${eighty}x"$'\n'
     test_check pass foo.cpp "#include ${eighty}x"$'\n'
     test_check pass foo.cpp "xxx http://${eighty}x"$'\n'


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
