### PR TITLE
Move namespace Basis to SpectralGroup

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
@@ -26,9 +26,6 @@ DataVector integrate_over_last_dimension(const DataVector& integrand,
 }
 }  // namespace
 
-namespace Basis {
-namespace lgl {
-
 template <size_t Dim>
 double definite_integral(const DataVector& integrand,
                          const Index<Dim>& extents) noexcept {
@@ -48,12 +45,9 @@ double definite_integral<1>(const DataVector& integrand,
   return ddot_(num_points, weights.data(), 1, integrand.data(), 1);
 }
 
-}  // namespace lgl
-}  // namespace Basis
-
 /// \cond
-template double Basis::lgl::definite_integral<2>(const DataVector&,
-                                                 const Index<2>&) noexcept;
-template double Basis::lgl::definite_integral<3>(const DataVector&,
-                                                 const Index<3>&) noexcept;
+template double definite_integral<2>(const DataVector&,
+                                     const Index<2>&) noexcept;
+template double definite_integral<3>(const DataVector&,
+                                     const Index<3>&) noexcept;
 /// \endcond

--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp
@@ -12,9 +12,6 @@ class DataVector;
 template <size_t>
 class Index;
 
-namespace Basis {
-namespace lgl {
-
 /*!
  * \ingroup NumericalAlgorithmsGroup
  * \brief Compute the definite integral of a grid-function over a manifold.
@@ -30,6 +27,3 @@ namespace lgl {
 template <size_t Dim>
 double definite_integral(const DataVector& integrand,
                          const Index<Dim>& extents) noexcept;
-
-}  // namespace lgl
-}  // namespace Basis

--- a/src/NumericalAlgorithms/LinearOperators/MeanValue.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/MeanValue.cpp
@@ -26,7 +26,7 @@ double mean_value_on_boundary(const DataVector& f, const Index<Dim>& extents,
        ++si) {
     f_on_boundary[si.slice_offset()] = f[si.volume_offset()];
   }
-  return Basis::lgl::definite_integral(f_on_boundary, extents_on_boundary) /
+  return definite_integral(f_on_boundary, extents_on_boundary) /
          two_to_the(Dim - 1);
 }
 

--- a/src/NumericalAlgorithms/LinearOperators/MeanValue.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/MeanValue.hpp
@@ -26,7 +26,7 @@
  */
 template <size_t Dim>
 double mean_value(const DataVector& f, const Index<Dim>& extents) {
-  return Basis::lgl::definite_integral(f, extents) / two_to_the(Dim);
+  return definite_integral(f, extents) / two_to_the(Dim);
 }
 
 /*!

--- a/src/NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp
+++ b/src/NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp
@@ -11,10 +11,10 @@
 class DataVector;
 class Matrix;
 
-/// \ingroup NumericalAlgorithmsGroup
+/// \ingroup SpectralGroup
 /// Basis functions, derivative matrices, etc. for spectral-type methods
 namespace Basis {
-/// \ingroup NumericalAlgorithmsGroup
+/// \ingroup SpectralGroup
 /// Functions for using Legendre-Gauss-Lobatto basis
 namespace lgl {
 /// Collocation points.

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
@@ -22,10 +22,9 @@ void test_definite_integral_1d(const Index<1>& extents) {
       integrand[s] = pow(x[s], a);
     }
     if (0 == a % 2) {
-      CHECK(2.0 / (a + 1.0) ==
-            approx(Basis::lgl::definite_integral(integrand, extents)));
+      CHECK(2.0 / (a + 1.0) == approx(definite_integral(integrand, extents)));
     } else {
-      CHECK(0.0 == approx(Basis::lgl::definite_integral(integrand, extents)));
+      CHECK(0.0 == approx(definite_integral(integrand, extents)));
     }
   }
 }
@@ -44,9 +43,9 @@ void test_definite_integral_2d(const Index<2>& extents) {
       }
       if (0 == a % 2 and 0 == b % 2) {
         CHECK(4.0 / ((a + 1.0) * (b + 1.0)) ==
-              approx(Basis::lgl::definite_integral(integrand, extents)));
+              approx(definite_integral(integrand, extents)));
       } else {
-        CHECK(0.0 == approx(Basis::lgl::definite_integral(integrand, extents)));
+        CHECK(0.0 == approx(definite_integral(integrand, extents)));
       }
     }
   }
@@ -70,10 +69,9 @@ void test_definite_integral_3d(const Index<3>& extents) {
         }
         if (0 == a % 2 and 0 == b % 2 and 0 == c % 2) {
           CHECK(8.0 / ((a + 1.0) * (b + 1.0) * (c + 1.0)) ==
-                approx(Basis::lgl::definite_integral(integrand, extents)));
+                approx(definite_integral(integrand, extents)));
         } else {
-          CHECK(0.0 ==
-                approx(Basis::lgl::definite_integral(integrand, extents)));
+          CHECK(0.0 == approx(definite_integral(integrand, extents)));
         }
       }
     }


### PR DESCRIPTION
## Proposed changes

Fix #247 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
