### PR TITLE
Add Frustum CoordinateMap

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
     Affine.cpp
     BulgedCube.cpp
     Equiangular.cpp
+    Frustum.cpp
     Identity.cpp
     Rotation.cpp
     Wedge2D.cpp

--- a/src/Domain/CoordinateMaps/Frustum.cpp
+++ b/src/Domain/CoordinateMaps/Frustum.cpp
@@ -1,0 +1,218 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/Frustum.hpp"
+
+#include <pup.h>
+
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace CoordinateMaps {
+Frustum::Frustum(const std::array<std::array<double, 2>, 4>& face_vertices,
+                 const double lower_bound, const double upper_bound,
+                 OrientationMap<3> orientation_of_frustum) noexcept
+    // clang-tidy: trivially copyable
+    : orientation_of_frustum_(std::move(orientation_of_frustum)) {  // NOLINT
+  const double& lower_x_lower_base = face_vertices[0][0];
+  const double& lower_y_lower_base = face_vertices[0][1];
+  const double& upper_x_lower_base = face_vertices[1][0];
+  const double& upper_y_lower_base = face_vertices[1][1];
+  const double& lower_x_upper_base = face_vertices[2][0];
+  const double& lower_y_upper_base = face_vertices[2][1];
+  const double& upper_x_upper_base = face_vertices[3][0];
+  const double& upper_y_upper_base = face_vertices[3][1];
+  ASSERT(upper_x_lower_base > lower_x_lower_base,
+         "The lower bound for a coordinate must be numerically less"
+         " than the upper bound for that coordinate.");
+  ASSERT(upper_y_lower_base > lower_y_lower_base,
+         "The lower bound for a coordinate must be numerically less"
+         " than the upper bound for that coordinate.");
+  ASSERT(upper_x_upper_base > lower_x_upper_base,
+         "The lower bound for a coordinate must be numerically less"
+         " than the upper bound for that coordinate.");
+  ASSERT(upper_y_upper_base > lower_y_upper_base,
+         "The lower bound for a coordinate must be numerically less"
+         " than the upper bound for that coordinate.");
+  ASSERT(upper_bound > lower_bound,
+         "The lower bound for a coordinate must be numerically less"
+         " than the upper bound for that coordinate.");
+  sum_midpoint_x_ = 0.5 * (lower_x_upper_base + upper_x_upper_base +
+                           lower_x_lower_base + upper_x_lower_base);
+  dif_midpoint_x_ = 0.5 * (lower_x_upper_base + upper_x_upper_base -
+                           lower_x_lower_base - upper_x_lower_base);
+  sum_half_length_x_ = 0.5 * (upper_x_upper_base - lower_x_upper_base +
+                              upper_x_lower_base - lower_x_lower_base);
+  dif_half_length_x_ = 0.5 * (upper_x_upper_base - lower_x_upper_base -
+                              upper_x_lower_base + lower_x_lower_base);
+  sum_midpoint_y_ = 0.5 * (lower_y_upper_base + upper_y_upper_base +
+                           lower_y_lower_base + upper_y_lower_base);
+  dif_midpoint_y_ = 0.5 * (lower_y_upper_base + upper_y_upper_base -
+                           lower_y_lower_base - upper_y_lower_base);
+  sum_half_length_y_ = 0.5 * (upper_y_upper_base - lower_y_upper_base +
+                              upper_y_lower_base - lower_y_lower_base);
+  dif_half_length_y_ = 0.5 * (upper_y_upper_base - lower_y_upper_base -
+                              upper_y_lower_base + lower_y_lower_base);
+  midpoint_z_ = 0.5 * (upper_bound + lower_bound);
+  half_length_z_ = 0.5 * (upper_bound - lower_bound);
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> Frustum::operator()(
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  const ReturnType& xi = source_coords[0];
+  const ReturnType& eta = source_coords[1];
+  const ReturnType& zeta = source_coords[2];
+
+  ReturnType physical_x =
+      0.5 * ((sum_midpoint_x_ + sum_half_length_x_ * xi) +
+             (dif_midpoint_x_ + dif_half_length_x_ * xi) * zeta);
+  ReturnType physical_y =
+      0.5 * ((sum_midpoint_y_ + sum_half_length_y_ * eta) +
+             (dif_midpoint_y_ + dif_half_length_y_ * eta) * zeta);
+  ReturnType physical_z = midpoint_z_ + half_length_z_ * zeta;
+
+  std::array<ReturnType, 3> physical_coords{
+      {std::move(physical_x), std::move(physical_y), std::move(physical_z)}};
+  return discrete_rotation(orientation_of_frustum_, std::move(physical_coords));
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3> Frustum::inverse(
+    const std::array<T, 3>& target_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  // physical coords {x,y,z}
+  std::array<ReturnType, 3> coords =
+      discrete_rotation(orientation_of_frustum_.inverse_map(), target_coords);
+
+  // We reuse `coords` to avoid an allocation. This is now the
+  // logical coords {xi,eta,zeta}
+  coords[2] = (coords[2] - midpoint_z_) / half_length_z_;
+  coords[0] =
+      (2.0 * coords[0] - sum_midpoint_x_ - dif_midpoint_x_ * coords[2]) /
+      (sum_half_length_x_ + dif_half_length_x_ * coords[2]);
+  coords[1] =
+      (2.0 * coords[1] - sum_midpoint_y_ - dif_midpoint_y_ * coords[2]) /
+      (sum_half_length_y_ + dif_half_length_y_ * coords[2]);
+  return coords;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Frustum::jacobian(
+    const std::array<T, 3>& source_coords) const noexcept {
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+  const ReturnType& xi = source_coords[0];
+  const ReturnType& eta = source_coords[1];
+  const ReturnType& zeta = source_coords[2];
+  const auto zero = make_with_value<ReturnType>(xi, 0.0);
+
+  auto jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  // dX_dxi
+  std::array<ReturnType, 3> dX_dlogical = discrete_rotation(
+      orientation_of_frustum_,
+      std::array<ReturnType, 3>{
+          {0.5 * (sum_half_length_x_ + dif_half_length_x_ * zeta), zero,
+           zero}});
+  get<0, 0>(jacobian_matrix) = dX_dlogical[0];
+  get<1, 0>(jacobian_matrix) = dX_dlogical[1];
+  get<2, 0>(jacobian_matrix) = dX_dlogical[2];
+
+  // dX_deta
+  dX_dlogical = discrete_rotation(
+      orientation_of_frustum_,
+      std::array<ReturnType, 3>{
+          {zero, 0.5 * (sum_half_length_y_ + dif_half_length_y_ * zeta),
+           zero}});
+  get<0, 1>(jacobian_matrix) = dX_dlogical[0];
+  get<1, 1>(jacobian_matrix) = dX_dlogical[1];
+  get<2, 1>(jacobian_matrix) = dX_dlogical[2];
+
+  // dX_dzeta
+  dX_dlogical[0] = 0.5 * (dif_midpoint_x_ + dif_half_length_x_ * xi);
+  dX_dlogical[1] = 0.5 * (dif_midpoint_y_ + dif_half_length_y_ * eta);
+  dX_dlogical[2] = make_with_value<ReturnType>(xi, half_length_z_);
+  dX_dlogical =
+      discrete_rotation(orientation_of_frustum_, std::move(dX_dlogical));
+  get<0, 2>(jacobian_matrix) = dX_dlogical[0];
+  get<1, 2>(jacobian_matrix) = dX_dlogical[1];
+  get<2, 2>(jacobian_matrix) = dX_dlogical[2];
+  return jacobian_matrix;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Frustum::inv_jacobian(
+    const std::array<T, 3>& source_coords) const noexcept {
+  const auto jac = jacobian(source_coords);
+  return determinant_and_inverse(jac).second;
+}
+
+void Frustum::pup(PUP::er& p) noexcept {
+  p | orientation_of_frustum_;
+  p | sum_midpoint_x_;
+  p | dif_midpoint_x_;
+  p | sum_half_length_x_;
+  p | dif_half_length_x_;
+  p | sum_midpoint_y_;
+  p | dif_midpoint_y_;
+  p | sum_half_length_y_;
+  p | dif_half_length_y_;
+  p | midpoint_z_;
+  p | half_length_z_;
+}
+
+bool operator==(const Frustum& lhs, const Frustum& rhs) noexcept {
+  return lhs.orientation_of_frustum_ == rhs.orientation_of_frustum_ and
+         lhs.sum_midpoint_x_ == rhs.sum_midpoint_x_ and
+         lhs.dif_midpoint_x_ == rhs.dif_midpoint_x_ and
+         lhs.sum_half_length_x_ == rhs.sum_half_length_x_ and
+         lhs.dif_half_length_x_ == rhs.dif_half_length_x_ and
+         lhs.sum_midpoint_y_ == rhs.sum_midpoint_y_ and
+         lhs.dif_midpoint_y_ == rhs.dif_midpoint_y_ and
+         lhs.sum_half_length_y_ == lhs.sum_half_length_y_ and
+         lhs.dif_half_length_y_ == lhs.dif_half_length_y_ and
+         lhs.midpoint_z_ == rhs.midpoint_z_ and
+         lhs.half_length_z_ == rhs.half_length_z_;
+}
+
+bool operator!=(const Frustum& lhs, const Frustum& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// Explicit instantiations
+/// \cond
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3> Frustum::      \
+  operator()(const std::array<DTYPE(data), 3>& source_coords) const noexcept; \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>                \
+  Frustum::inverse(const std::array<DTYPE(data), 3>& target_coords)           \
+      const noexcept;                                                         \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>  \
+  Frustum::jacobian(const std::array<DTYPE(data), 3>& source_coords)          \
+      const noexcept;                                                         \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame>  \
+  Frustum::inv_jacobian(const std::array<DTYPE(data), 3>& source_coords)      \
+      const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+}  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <memory>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace CoordinateMaps {
+
+/// \ingroup CoordinateMapsGroup
+///
+/// Frustum map from the cube to a rectangular frustum where the bases of the
+/// frustum are perpendicular to the z-axis. The `lower_bound` and
+/// `upper_bound` values correspond to the locations of the bases along this
+/// axis. The `face_vertices` values determine the size of the two rectangular
+/// bases along the other two axes. For example, for a frustum along the z-axis,
+/// with the lower base starting at (x,y) = (-2.0,3.0) and extending to
+/// (2.0,5.0), and with the upper base extending from (0.0,1.0) to (1.0,3.0),
+/// the corresponding value for `face_vertices` is `{{{{-2.0,3.0}}, {{2.0,5.0}},
+/// {{0.0,1.0}}, {{1.0,3.0}}}}`. The user may reorient the frustum by passing
+/// an `OrientationMap` to the constructor.
+class Frustum {
+ public:
+  static constexpr size_t dim = 3;
+  Frustum(const std::array<std::array<double, 2>, 4>& face_vertices,
+          double lower_bound, double upper_bound,
+          OrientationMap<3> orientation_of_frustum) noexcept;
+  Frustum() = default;
+  ~Frustum() = default;
+  Frustum(Frustum&&) = default;
+  Frustum(const Frustum&) = default;
+  Frustum& operator=(const Frustum&) = default;
+  Frustum& operator=(Frustum&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> inverse(
+      const std::array<T, 3>& target_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
+
+  // clang-tidy: google runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  friend bool operator==(const Frustum& lhs, const Frustum& rhs) noexcept;
+
+  OrientationMap<3> orientation_of_frustum_{};
+  double sum_midpoint_x_{std::numeric_limits<double>::signaling_NaN()};
+  double dif_midpoint_x_{std::numeric_limits<double>::signaling_NaN()};
+  double sum_half_length_x_{std::numeric_limits<double>::signaling_NaN()};
+  double dif_half_length_x_{std::numeric_limits<double>::signaling_NaN()};
+  double sum_midpoint_y_{std::numeric_limits<double>::signaling_NaN()};
+  double dif_midpoint_y_{std::numeric_limits<double>::signaling_NaN()};
+  double sum_half_length_y_{std::numeric_limits<double>::signaling_NaN()};
+  double dif_half_length_y_{std::numeric_limits<double>::signaling_NaN()};
+  double midpoint_z_{std::numeric_limits<double>::signaling_NaN()};
+  double half_length_z_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+bool operator!=(const Frustum& lhs, const Frustum& rhs) noexcept;
+}  // namespace CoordinateMaps

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   CoordinateMaps/Test_BulgedCube.cpp
   CoordinateMaps/Test_CoordinateMap.cpp
   CoordinateMaps/Test_Equiangular.cpp
+  CoordinateMaps/Test_Frustum.cpp
   CoordinateMaps/Test_Identity.cpp
   CoordinateMaps/Test_ProductMaps.cpp
   CoordinateMaps/Test_Rotation.cpp

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <functional>
+#include <random>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -227,4 +228,52 @@ template <typename Map, typename T>
 void test_inverse_map(const Map& map,
                       const std::array<T, Map::dim>& test_point) {
   CHECK_ITERABLE_APPROX(test_point, map.inverse(map(test_point)));
+}
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Given a 3D Map `map`, tests the map functions, including map inverse,
+ * jacobian, and inverse jacobian, for a series of points.
+ */
+template <typename Map>
+void test_map3d(const Map& map) {
+  // Set up random number generator
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> real_dis(-1.0, 1.0);
+  const double xi = real_dis(gen);
+  CAPTURE_PRECISE(xi);
+  const double eta = real_dis(gen);
+  CAPTURE_PRECISE(eta);
+  const double zeta = real_dis(gen);
+  CAPTURE_PRECISE(zeta);
+
+  const std::array<std::array<double, 3>, 13> test_points{{{{0.0, 0.0, 0.0}},
+                                                          {{-1.0, -1.0, -1.0}},
+                                                          {{1.0, -1.0, -1.0}},
+                                                          {{-1.0, 1.0, -1.0}},
+                                                          {{1.0, 1.0, -1.0}},
+                                                          {{-1.0, -1.0, 1.0}},
+                                                          {{1.0, -1.0, 1.0}},
+                                                          {{-1.0, 1.0, 1.0}},
+                                                          {{1.0, 1.0, 1.0}},
+                                                          {{-0.1, 0.3, 0.1}},
+                                                          {{0.5, 0.7, -0.5}},
+                                                          {{0.9, -1.0, 0.4}},
+                                                          {{xi, eta, zeta}}}};
+  test_serialization(map);
+  CHECK_FALSE(map != map);
+  test_coordinate_map_argument_types(map, test_points[0]);
+  for (const auto& point : test_points) {
+    test_jacobian(map, point);
+    test_inv_jacobian(map, point);
+    test_inverse_map(map, point);
+  }
+  const auto map2 = serialize_and_deserialize(map);
+  CHECK(map2 == map);
+  for (const auto& point : test_points) {
+    test_jacobian(map2, point);
+    test_inv_jacobian(map2, point);
+    test_inverse_map(map2, point);
+  }
 }

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -321,3 +321,29 @@ class OrientationMapIterator {
   VolumeCornerIterator<VolumeDim> vci_{};
   OrientationMap<VolumeDim> map_ = OrientationMap<VolumeDim>{};
 };
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Wedge OrientationMap in each of the six directions used in the
+ * Shell and Sphere domain creators.
+ */
+inline std::array<OrientationMap<3>, 6> all_wedge_directions() {
+  const OrientationMap<3> upper_zeta_rotation{};
+  const OrientationMap<3> lower_zeta_rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+       Direction<3>::lower_zeta()}});
+  const OrientationMap<3> upper_eta_rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
+       Direction<3>::upper_xi()}});
+  const OrientationMap<3> lower_eta_rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
+       Direction<3>::lower_xi()}});
+  const OrientationMap<3> upper_xi_rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+       Direction<3>::upper_eta()}});
+  const OrientationMap<3> lower_xi_rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+       Direction<3>::upper_eta()}});
+  return {{upper_zeta_rotation, lower_zeta_rotation, upper_eta_rotation,
+           lower_eta_rotation, upper_xi_rotation, lower_xi_rotation}};
+}

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -1,0 +1,233 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <array>
+#include <catch.hpp>
+#include <random>
+
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Frustum.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
+  // Set up random number generator
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<> lower_bound_dis(-14, -2);
+  std::uniform_real_distribution<> upper_bound_dis(2, 14);
+
+  const double lower_x_lower_base = lower_bound_dis(gen);
+  CAPTURE_PRECISE(lower_x_lower_base);
+  const double lower_y_lower_base = lower_bound_dis(gen);
+  CAPTURE_PRECISE(lower_y_lower_base);
+  const double upper_x_lower_base = upper_bound_dis(gen);
+  CAPTURE_PRECISE(upper_x_lower_base);
+  const double upper_y_lower_base = upper_bound_dis(gen);
+  CAPTURE_PRECISE(upper_y_lower_base);
+  const double lower_x_upper_base = lower_bound_dis(gen);
+  CAPTURE_PRECISE(lower_x_upper_base);
+  const double lower_y_upper_base = lower_bound_dis(gen);
+  CAPTURE_PRECISE(lower_y_upper_base);
+  const double upper_x_upper_base = upper_bound_dis(gen);
+  CAPTURE_PRECISE(upper_x_upper_base);
+  const double upper_y_upper_base = upper_bound_dis(gen);
+  CAPTURE_PRECISE(upper_y_upper_base);
+
+  for (OrientationMapIterator<3> map_i{}; map_i; ++map_i) {
+    const std::array<std::array<double, 2>, 4> face_vertices{
+        {{{lower_x_lower_base, lower_y_lower_base}},
+         {{upper_x_lower_base, upper_y_lower_base}},
+         {{lower_x_upper_base, lower_y_upper_base}},
+         {{upper_x_upper_base, upper_y_upper_base}}}};
+    const CoordinateMaps::Frustum frustum_map(face_vertices, -1.0, 2.0,
+                                              map_i());
+    test_map3d(frustum_map);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Alignment",
+                  "[Domain][Unit]") {
+  // This test tests that the logical axes point along the expected directions
+  // in physical space
+
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+  const double lower_bound = 2.0;
+  const double upper_bound = 5.0;
+
+  const auto wedge_directions = all_wedge_directions();
+  const CoordinateMaps::Frustum map_upper_zeta(
+      face_vertices, lower_bound, upper_bound,
+      wedge_directions[0]);  // Upper Z frustum
+  const CoordinateMaps::Frustum map_upper_eta(
+      face_vertices, lower_bound, upper_bound,
+      wedge_directions[2]);  // Upper Y frustum
+  const CoordinateMaps::Frustum map_upper_xi(
+      face_vertices, lower_bound, upper_bound,
+      wedge_directions[4]);  // Upper X Frustum
+  const CoordinateMaps::Frustum map_lower_zeta(
+      face_vertices, lower_bound, upper_bound,
+      wedge_directions[1]);  // Lower Z frustum
+  const CoordinateMaps::Frustum map_lower_eta(
+      face_vertices, lower_bound, upper_bound,
+      wedge_directions[3]);  // Lower Y frustum
+  const CoordinateMaps::Frustum map_lower_xi(
+      face_vertices, lower_bound, upper_bound,
+      wedge_directions[5]);  // Lower X frustum
+  const std::array<double, 3> lowest_corner{{-1.0, -1.0, -1.0}};
+  const std::array<double, 3> along_xi{{1.0, -1.0, -1.0}};
+  const std::array<double, 3> along_eta{{-1.0, 1.0, -1.0}};
+  const std::array<double, 3> along_zeta{{-1.0, -1.0, 1.0}};
+
+  const std::array<double, 3> lowest_physical_corner_in_map_upper_zeta{
+      {-2.0, -2.0, 2.0}};
+  const std::array<double, 3> lowest_physical_corner_in_map_upper_eta{
+      {-2.0, 2.0, -2.0}};
+  const std::array<double, 3> lowest_physical_corner_in_map_upper_xi{
+      {2.0, -2.0, -2.0}};
+  const std::array<double, 3> lowest_physical_corner_in_map_lower_zeta{
+      {-2.0, 2.0, -2.0}};
+  const std::array<double, 3> lowest_physical_corner_in_map_lower_eta{
+      {-2.0, -2.0, 2.0}};
+  const std::array<double, 3> lowest_physical_corner_in_map_lower_xi{
+      {-2.0, 2.0, -2.0}};
+
+  // Test that this map's logical axes point along +X, +Y, +Z:
+  CHECK(map_upper_zeta(along_xi)[0] == approx(2.0));
+  CHECK(map_upper_zeta(along_eta)[1] == approx(2.0));
+  CHECK(map_upper_zeta(along_zeta)[2] == approx(5.0));
+  CHECK_ITERABLE_APPROX(map_upper_zeta(lowest_corner),
+                        lowest_physical_corner_in_map_upper_zeta);
+
+  // Test that this map's logical axes point along +Z, +X, +Y:
+  CHECK(map_upper_eta(along_xi)[2] == approx(2.0));
+  CHECK(map_upper_eta(along_eta)[0] == approx(2.0));
+  CHECK(map_upper_eta(along_zeta)[1] == approx(5.0));
+  CHECK_ITERABLE_APPROX(map_upper_eta(lowest_corner),
+                        lowest_physical_corner_in_map_upper_eta);
+
+  // Test that this map's logical axes point along +Y, +Z, +X:
+  CHECK(map_upper_xi(along_xi)[1] == approx(2.0));
+  CHECK(map_upper_xi(along_eta)[2] == approx(2.0));
+  CHECK(map_upper_xi(along_zeta)[0] == approx(5.0));
+  CHECK_ITERABLE_APPROX(map_upper_xi(lowest_corner),
+                        lowest_physical_corner_in_map_upper_xi);
+
+  // Test that this map's logical axes point along +X, -Y, -Z:
+  CHECK(map_lower_zeta(along_xi)[0] == approx(2.0));
+  CHECK(map_lower_zeta(along_eta)[1] == approx(-2.0));
+  CHECK(map_lower_zeta(along_zeta)[2] == approx(-5.0));
+  CHECK_ITERABLE_APPROX(map_lower_zeta(lowest_corner),
+                        lowest_physical_corner_in_map_lower_zeta);
+
+  // Test that this map's logical axes point along -Z, +X, -Y:
+  CHECK(map_lower_eta(along_xi)[2] == approx(-2.0));
+  CHECK(map_lower_eta(along_eta)[0] == approx(2.0));
+  CHECK(map_lower_eta(along_zeta)[1] == approx(-5.0));
+  CHECK_ITERABLE_APPROX(map_lower_eta(lowest_corner),
+                        lowest_physical_corner_in_map_lower_eta);
+
+  // Test that this map's logical axes point along -Y, +Z, -X:
+  CHECK(map_lower_xi(along_xi)[1] == approx(-2.0));
+  CHECK(map_lower_xi(along_eta)[2] == approx(2.0));
+  CHECK(map_lower_xi(along_zeta)[0] == approx(-5.0));
+  CHECK_ITERABLE_APPROX(map_lower_xi(lowest_corner),
+                        lowest_physical_corner_in_map_lower_xi);
+}
+
+// [[OutputRegex, The lower bound for a coordinate must be numerically less
+// than the upper bound for that coordinate.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert1",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{-3.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+  const double lower_bound = 2.0;
+  const double upper_bound = 5.0;
+
+  auto failed_frustum = CoordinateMaps::Frustum(
+      face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+  static_cast<void>(failed_frustum);
+
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The lower bound for a coordinate must be numerically less
+// than the upper bound for that coordinate.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert2",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{2.0, -3.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+  const double lower_bound = 2.0;
+  const double upper_bound = 5.0;
+
+  auto failed_frustum = CoordinateMaps::Frustum(
+      face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+  static_cast<void>(failed_frustum);
+
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The lower bound for a coordinate must be numerically less
+// than the upper bound for that coordinate.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert3",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{-5.0, 4.0}}}};
+  const double lower_bound = 2.0;
+  const double upper_bound = 5.0;
+
+  auto failed_frustum = CoordinateMaps::Frustum(
+      face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+  static_cast<void>(failed_frustum);
+
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The lower bound for a coordinate must be numerically less
+// than the upper bound for that coordinate.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert4",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, -5.0}}}};
+  const double lower_bound = 2.0;
+  const double upper_bound = 5.0;
+
+  auto failed_frustum = CoordinateMaps::Frustum(
+      face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+  static_cast<void>(failed_frustum);
+
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The lower bound for a coordinate must be numerically less
+// than the upper bound for that coordinate.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Assert5",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+  const double lower_bound = 2.0;
+  const double upper_bound = -2.0;
+
+  auto failed_frustum = CoordinateMaps::Frustum(
+      face_vertices, lower_bound, upper_bound, OrientationMap<3>{});
+  static_cast<void>(failed_frustum);
+
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -41,16 +41,9 @@ void test_wedge3d_all_directions(const bool with_equiangular_map) {
   // Set up random number generator
   std::random_device rd;
   std::mt19937 gen(rd());
-  std::uniform_real_distribution<> real_dis(-1, 1);
   std::uniform_real_distribution<> unit_dis(0, 1);
   std::uniform_real_distribution<> inner_dis(1, 3);
   std::uniform_real_distribution<> outer_dis(4, 7);
-  const double xi = real_dis(gen);
-  CAPTURE_PRECISE(xi);
-  const double eta = real_dis(gen);
-  CAPTURE_PRECISE(eta);
-  const double zeta = real_dis(gen);
-  CAPTURE_PRECISE(zeta);
   const double inner_radius = inner_dis(gen);
   CAPTURE_PRECISE(inner_radius);
   const double outer_radius = outer_dis(gen);
@@ -58,36 +51,19 @@ void test_wedge3d_all_directions(const bool with_equiangular_map) {
   const double sphericity = unit_dis(gen);
   CAPTURE_PRECISE(sphericity);
 
-  const std::array<std::array<double, 3>, 4> test_points{{{{-0.1, 0.3, 0.1}},
-                                                          {{0.5, 0.7, -0.5}},
-                                                          {{0.9, -1.0, 0.4}},
-                                                          {{xi, eta, zeta}}}};
-
   using WedgeHalves = CoordinateMaps::Wedge3D::WedgeHalves;
   const std::array<WedgeHalves, 3> halves_array = {
       {WedgeHalves::UpperOnly, WedgeHalves::LowerOnly, WedgeHalves::Both}};
   for (const auto& halves : halves_array) {
     for (const auto& direction : all_wedge_directions()) {
-      const CoordinateMaps::Wedge3D map(inner_radius, outer_radius, direction,
-                                        sphericity, with_equiangular_map,
-                                        halves);
-      test_serialization(map);
-      CHECK_FALSE(map != map);
-      test_coordinate_map_argument_types(map, test_points[0]);
-      for (const auto& point : test_points) {
-        test_jacobian(map, point);
-        test_inv_jacobian(map, point);
-        test_inverse_map(map, point);
-      }
-      const auto map2 = serialize_and_deserialize(map);
-      for (const auto& point : test_points) {
-        test_jacobian(map2, point);
-        test_inv_jacobian(map2, point);
-        test_inverse_map(map2, point);
-      }
+      const CoordinateMaps::Wedge3D wedge_map(inner_radius, outer_radius,
+                                              direction, sphericity,
+                                              with_equiangular_map, halves);
+      test_map3d(wedge_map);
     }
   }
 }
+
 void test_wedge3d_alignment(const bool with_equiangular_map) {
   // This test tests that the logical axes point along the expected directions
   // in physical space

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -15,28 +15,6 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 namespace {
-// Wedge OrientationMap in each of the six directions.
-std::array<OrientationMap<3>, 6> all_wedge_directions() {
-  const OrientationMap<3> upper_zeta_rotation{};
-  const OrientationMap<3> lower_zeta_rotation(std::array<Direction<3>, 3>{
-      {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-       Direction<3>::lower_zeta()}});
-  const OrientationMap<3> upper_eta_rotation(std::array<Direction<3>, 3>{
-      {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
-       Direction<3>::upper_xi()}});
-  const OrientationMap<3> lower_eta_rotation(std::array<Direction<3>, 3>{
-      {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
-       Direction<3>::lower_xi()}});
-  const OrientationMap<3> upper_xi_rotation(std::array<Direction<3>, 3>{
-      {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
-       Direction<3>::upper_eta()}});
-  const OrientationMap<3> lower_xi_rotation(std::array<Direction<3>, 3>{
-      {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
-       Direction<3>::upper_eta()}});
-  return {{upper_zeta_rotation, lower_zeta_rotation, upper_eta_rotation,
-           lower_eta_rotation, upper_xi_rotation, lower_xi_rotation}};
-}
-
 void test_wedge3d_all_directions(const bool with_equiangular_map) {
   // Set up random number generator
   std::random_device rd;


### PR DESCRIPTION
## Proposed changes

The map obtained by linearly interpolating between rectangles that are parallel to each other. The rectangles are confined to lie perpendicular to one of the three Cartesian axes.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- [ ] Code has documentation and unit tests
- [ ] Private member variables have a trailing underscore
- [ ] Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- [ ] Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- [ ] File lists in CMake are alphabetical
- [ ] Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- [ ] Mark objects `const` whenever possible
- [ ] Almost always `auto`, except with expression templates, i.e. `DataVector`
- [ ] All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- [ ] Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- [ ] Prefix commits addressing PR requests with `fixup`


### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
