### PR TITLE
Add DiscreteRotation

### DIFF
--- a/src/Domain/OrientationMap.cpp
+++ b/src/Domain/OrientationMap.cpp
@@ -4,8 +4,21 @@
 #include "Domain/OrientationMap.hpp"
 
 #include <ostream>
+#include <set>
 
 #include "Domain/SegmentId.hpp"
+
+namespace {
+template <size_t VolumeDim>
+std::set<size_t> set_of_dimensions(
+    const std::array<Direction<VolumeDim>, VolumeDim>& directions) noexcept {
+  std::set<size_t> set_of_dims;
+  for (size_t j = 0; j < VolumeDim; j++) {
+    set_of_dims.insert(gsl::at(directions, j).dimension());
+  }
+  return set_of_dims;
+}
+}  // namespace
 
 template <size_t VolumeDim>
 OrientationMap<VolumeDim>::OrientationMap() {
@@ -13,6 +26,7 @@ OrientationMap<VolumeDim>::OrientationMap() {
     gsl::at(mapped_directions_, j) = Direction<VolumeDim>(j, Side::Upper);
   }
 }
+
 template <size_t VolumeDim>
 OrientationMap<VolumeDim>::OrientationMap(
     std::array<Direction<VolumeDim>, VolumeDim> mapped_directions)
@@ -23,6 +37,8 @@ OrientationMap<VolumeDim>::OrientationMap(
       is_aligned_ = false;
     }
   }
+  ASSERT(set_of_dimensions(mapped_directions).size() == VolumeDim,
+         "This OrientationMap fails to map Directions one-to-one.");
 }
 
 template <size_t VolumeDim>
@@ -38,6 +54,10 @@ OrientationMap<VolumeDim>::OrientationMap(
       is_aligned_ = false;
     }
   }
+  ASSERT(set_of_dimensions(directions_in_host).size() == VolumeDim,
+         "This OrientationMap fails to map Directions one-to-one.");
+  ASSERT(set_of_dimensions(directions_in_neighbor).size() == VolumeDim,
+         "This OrientationMap fails to map Directions one-to-one.");
 }
 
 template <size_t VolumeDim>

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -1296,6 +1296,19 @@ template <typename T>
 struct remove_reference_wrapper<std::reference_wrapper<T>> {
   using type = T;
 };
+template <typename T>
+struct remove_reference_wrapper<const std::reference_wrapper<T>> {
+  using type = T;
+};
+template <typename T>
+struct remove_reference_wrapper<volatile std::reference_wrapper<T>> {
+  using type = T;
+};
+template <typename T>
+struct remove_reference_wrapper<const volatile std::reference_wrapper<T>> {
+  using type = T;
+};
+
 /// \endcond
 
 template <typename T>

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -160,30 +160,6 @@ void test_refinement_levels_of_neighbors(
     }
   }
 }
-// Iterates over the logical corners of a VolumeDim-dimensional cube.
-template <size_t VolumeDim>
-class VolumeCornerIterator {
- public:
-  VolumeCornerIterator() noexcept = default;
-  void operator++() noexcept {
-    ++index_;
-    for (size_t i = 0; i < VolumeDim; i++) {
-      corner_[i] = 2 * static_cast<int>(get_nth_bit(index_, i)) - 1;
-    }
-  }
-  explicit operator bool() noexcept { return index_ < two_to_the(VolumeDim); }
-  tnsr::I<double, VolumeDim, Frame::Logical> operator()() noexcept {
-    return corner_;
-  }
-  tnsr::I<double, VolumeDim, Frame::Logical> operator*() noexcept {
-    return corner_;
-  }
-
- private:
-  size_t index_ = 0;
-  tnsr::I<double, VolumeDim, Frame::Logical> corner_ =
-      make_array<VolumeDim>(-1);
-};
 
 // Iterates over the 2^(VolumeDim-1) logical corners of the face of a
 // VolumeDim-dimensional cube in the given direction.

--- a/tests/Unit/Domain/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Test_OrientationMap.cpp
@@ -264,6 +264,55 @@ SPECTRE_TEST_CASE("Unit.Domain.OrientationMap", "[Domain][Unit]") {
   test_3d();
 }
 
+// [[OutputRegex, This OrientationMap fails to map Directions one-to-one.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.OrientationMap.Bijective",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_orientationmap = OrientationMap<2>{std::array<Direction<2>, 2>{
+      {Direction<2>::upper_xi(), Direction<2>::lower_xi()}}};
+  static_cast<void>(failed_orientationmap);
+
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, This OrientationMap fails to map Directions one-to-one.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.OrientationMap.BijectiveHost",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_orientationmap = OrientationMap<2>{
+      std::array<Direction<2>, 2>{
+          {Direction<2>::upper_xi(), Direction<2>::lower_xi()}},
+      std::array<Direction<2>, 2>{
+          {Direction<2>::upper_xi(), Direction<2>::upper_eta()}},
+  };
+  static_cast<void>(failed_orientationmap);
+
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, This OrientationMap fails to map Directions one-to-one.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.OrientationMap.BijectiveNeighbor",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_orientationmap = OrientationMap<3>{
+      std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                   Direction<3>::lower_eta(),
+                                   Direction<3>::lower_zeta()}},
+      std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                   Direction<3>::upper_eta(),
+                                   Direction<3>::lower_eta()}},
+  };
+  static_cast<void>(failed_orientationmap);
+
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
 namespace {
 template <size_t VolumeDim>
 OrientationMap<VolumeDim> generate_orientation_map(

--- a/tests/Unit/Domain/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Test_OrientationMap.cpp
@@ -2,10 +2,14 @@
 // See LICENSE.txt for details.
 
 #include <catch.hpp>
+#include <functional>
+#include <numeric>
 
+#include "DataStructures/DataVector.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Utilities/StdHelpers.hpp"
+#include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Unit/TestingFramework.hpp"
 
@@ -258,4 +262,135 @@ SPECTRE_TEST_CASE("Unit.Domain.OrientationMap", "[Domain][Unit]") {
   test_1d();
   test_2d();
   test_3d();
+}
+
+namespace {
+template <size_t VolumeDim>
+OrientationMap<VolumeDim> generate_orientation_map(
+    const VolumeCornerIterator<VolumeDim>& vci,
+    const std::array<size_t, VolumeDim>& dimensions) {
+  std::array<Direction<VolumeDim>, VolumeDim> array_of_directions{};
+  for (size_t i = 0; i < VolumeDim; i++) {
+    gsl::at(array_of_directions, i) =
+        Direction<VolumeDim>{gsl::at(dimensions, i), gsl::at(vci(), i)};
+  }
+  return OrientationMap<VolumeDim>{array_of_directions};
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.AllOrientations",
+                  "[Domain][Unit]") {
+  std::array<size_t, 2> dimensions_2d{};
+  std::iota(dimensions_2d.begin(), dimensions_2d.end(), 0);
+  do {
+    for (VolumeCornerIterator<2> vci{}; vci; ++vci) {
+      const OrientationMap<2> map_2d =
+          generate_orientation_map<2>(vci, dimensions_2d);
+      const std::array<double, 2> original_point{{0.5, -2.0}};
+      const std::array<double, 2> new_point =
+          discrete_rotation(map_2d, original_point);
+      for (size_t d = 0; d < 2; d++) {
+        CHECK(gsl::at(new_point, d) ==
+              (map_2d(Direction<2>{d, Side::Upper}).side() == Side::Upper
+                   ? gsl::at(original_point, map_2d(d))
+                   : -1.0 * gsl::at(original_point, map_2d(d))));
+      }
+    }
+  } while (std::next_permutation(dimensions_2d.begin(), dimensions_2d.end()));
+  std::array<size_t, 3> dimensions_3d{};
+  std::iota(dimensions_3d.begin(), dimensions_3d.end(), 0);
+  do {
+    for (VolumeCornerIterator<3> vci{}; vci; ++vci) {
+      const OrientationMap<3> map_3d =
+          generate_orientation_map<3>(vci, dimensions_3d);
+      const std::array<double, 3> original_point{{0.5, -2.0, 1.5}};
+      const std::array<double, 3> new_point =
+          discrete_rotation(map_3d, original_point);
+      for (size_t d = 0; d < 3; d++) {
+        CHECK(gsl::at(new_point, d) ==
+              (map_3d(Direction<3>{d, Side::Upper}).side() == Side::Upper
+                   ? gsl::at(original_point, map_3d(d))
+                   : -1.0 * gsl::at(original_point, map_3d(d))));
+      }
+    }
+  } while (std::next_permutation(dimensions_3d.begin(), dimensions_3d.end()));
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.Rotation", "[Domain][Unit]") {
+  const OrientationMap<1> rotation1(
+      std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}});
+  const std::array<DataVector, 1> test_points1{
+      {DataVector{-1.0, 1.0, 0.7, 0.0}}};
+  const std::array<DataVector, 1> expected_rotated_points1{
+      {DataVector{1.0, -1.0, -0.7, 0.0}}};
+  CHECK(discrete_rotation(rotation1, test_points1) == expected_rotated_points1);
+  CHECK(discrete_rotation(rotation1, std::array<double, 1>{{-0.2}}) ==
+        std::array<double, 1>{{0.2}});
+
+  const OrientationMap<2> rotation2(std::array<Direction<2>, 2>{
+      {Direction<2>::upper_eta(), Direction<2>::upper_xi()}});
+  const std::array<DataVector, 2> test_points2{
+      {DataVector{-1.0, 1.0, 0.7, 0.0}, DataVector{0.25, 1.0, -0.2, 0.0}}};
+  const std::array<DataVector, 2> expected_rotated_points2{
+      {DataVector{0.25, 1.0, -0.2, 0.0}, DataVector{-1.0, 1.0, 0.7, 0.0}}};
+  CHECK(discrete_rotation(rotation2, test_points2) == expected_rotated_points2);
+  CHECK(discrete_rotation(rotation2, std::array<double, 2>{{-1.0, 0.5}}) ==
+        std::array<double, 2>{{0.5, -1.0}});
+
+  const OrientationMap<3> rotation3(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
+       Direction<3>::lower_xi()}});
+  const std::array<DataVector, 3> test_points3{
+      {DataVector{-1.0, 1.0, 0.7, 0.0}, DataVector{0.25, 1.0, -0.2, 0.0},
+       DataVector{0.0, -0.5, 0.4, 0.0}}};
+  const std::array<DataVector, 3> expected_rotated_points3{
+      {DataVector{0.25, 1.0, -0.2, 0.0}, DataVector{0.0, 0.5, -0.4, 0.0},
+       DataVector{1.0, -1.0, -0.7, 0.0}}};
+  CHECK(discrete_rotation(rotation3, test_points3) == expected_rotated_points3);
+  CHECK(discrete_rotation(rotation3, std::array<double, 3>{{-1.0, 0.5, 1.0}}) ==
+        std::array<double, 3>{{0.5, -1.0, 1.0}});
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.ReferenceWrapper",
+                  "[Domain][Unit]") {
+  const OrientationMap<3> rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
+       Direction<3>::lower_xi()}});
+
+  // This test will check that these points are not modified.
+  DataVector x_points{-1.0, 1.0, 0.7, 0.0};
+  DataVector y_points{0.25, 1.0, -0.2, 0.0};
+  DataVector z_points{0.0, -0.5, 0.4, 0.0};
+
+  // These variables are not passed to any functions;
+  // they will not be modified by construction.
+  // clang-tidy: local copy is never modified
+  const DataVector x_points_proof = x_points;  // NOLINT
+  const DataVector y_points_proof = y_points;  // NOLINT
+  const DataVector z_points_proof = z_points;  // NOLINT
+
+  // References to the points to be tested:
+  const auto ref_x_points = std::cref(x_points);
+  const auto ref_y_points = std::cref(y_points);
+  const auto ref_z_points = std::cref(z_points);
+
+  // Array of references to the points to be tested.
+  const std::array<const std::reference_wrapper<const DataVector>, 3>
+      test_points{{ref_x_points, ref_y_points, ref_z_points}};
+
+  // The value of new_points is irrelevant to this test.
+  auto new_points = discrete_rotation(rotation, test_points);
+  CHECK(test_points[0] == x_points_proof);
+  CHECK(test_points[1] == y_points_proof);
+  CHECK(test_points[2] == z_points_proof);
+
+  const DataVector new_pt{0.0, 0.5, -0.4, 0.0};
+  new_points[0] = new_pt;
+  new_points[1] = new_pt;
+  new_points[2] = new_pt;
+
+  // Check that modifying new_points does not modify the test points.
+  CHECK(test_points[0] == x_points_proof);
+  CHECK(test_points[1] == y_points_proof);
+  CHECK(test_points[2] == z_points_proof);
 }

--- a/tests/Unit/Utilities/Test_TypeTraits.cpp
+++ b/tests/Unit/Utilities/Test_TypeTraits.cpp
@@ -550,6 +550,56 @@ static_assert(cpp17::is_same_v<
               "Failed testing remove_reference_wrapper");
 static_assert(cpp17::is_same_v<A, tt::remove_reference_wrapper_t<A>>,
               "Failed testing remove_reference_wrapper");
+static_assert(
+    cpp17::is_same_v<double, tt::remove_reference_wrapper_t<
+                                 const std::reference_wrapper<double>>>,
+    "Failed testing remove_reference_wrapper");
+static_assert(
+    cpp17::is_same_v<double, tt::remove_reference_wrapper_t<
+                                 volatile std::reference_wrapper<double>>>,
+    "Failed testing remove_reference_wrapper");
+static_assert(cpp17::is_same_v<
+                  double, tt::remove_reference_wrapper_t<
+                              const volatile std::reference_wrapper<double>>>,
+              "Failed testing remove_reference_wrapper");
+static_assert(cpp17::is_same_v<const double,
+                               tt::remove_reference_wrapper_t<
+                                   const std::reference_wrapper<const double>>>,
+              "Failed testing remove_reference_wrapper");
+static_assert(
+    cpp17::is_same_v<const double,
+                     tt::remove_reference_wrapper_t<
+                         volatile std::reference_wrapper<const double>>>,
+    "Failed testing remove_reference_wrapper");
+static_assert(
+    cpp17::is_same_v<const double,
+                     tt::remove_reference_wrapper_t<
+                         const volatile std::reference_wrapper<const double>>>,
+    "Failed testing remove_reference_wrapper");
+static_assert(
+    cpp17::is_same_v<
+        A, tt::remove_reference_wrapper_t<const std::reference_wrapper<A>>>,
+    "Failed testing remove_reference_wrapper");
+static_assert(
+    cpp17::is_same_v<
+        A, tt::remove_reference_wrapper_t<volatile std::reference_wrapper<A>>>,
+    "Failed testing remove_reference_wrapper");
+static_assert(
+    cpp17::is_same_v<A, tt::remove_reference_wrapper_t<
+                            const volatile std::reference_wrapper<A>>>,
+    "Failed testing remove_reference_wrapper");
+static_assert(
+    cpp17::is_same_v<const A, tt::remove_reference_wrapper_t<
+                                  const std::reference_wrapper<const A>>>,
+    "Failed testing remove_reference_wrapper");
+static_assert(
+    cpp17::is_same_v<const A, tt::remove_reference_wrapper_t<
+                                  volatile std::reference_wrapper<const A>>>,
+    "Failed testing remove_reference_wrapper");
+static_assert(cpp17::is_same_v<
+                  const A, tt::remove_reference_wrapper_t<
+                               const volatile std::reference_wrapper<const A>>>,
+              "Failed testing remove_reference_wrapper");
 /// [remove_reference_wrapper_example]
 
 /// [remove_cvref_wrap]
@@ -600,11 +650,15 @@ static_assert(
     "Failed testing remove_cvref_wrap");
 static_assert(
     cpp17::is_same_v<tt::remove_cvref_wrap_t<const std::reference_wrapper<int>>,
-                     std::reference_wrapper<int>>,
+                     int>,
+    "Failed testing remove_cvref_wrap");
+static_assert(
+    cpp17::is_same_v<
+        tt::remove_cvref_wrap_t<volatile std::reference_wrapper<int>>, int>,
     "Failed testing remove_cvref_wrap");
 static_assert(
     cpp17::is_same_v<
         tt::remove_cvref_wrap_t<const volatile std::reference_wrapper<int>>,
-        std::reference_wrapper<int>>,
+        int>,
     "Failed testing remove_cvref_wrap");
 /// [remove_cvref_wrap]


### PR DESCRIPTION
## Proposed changes

Adds helper functions that will be useful for Wedge3D and Frustum and other CoordinateMaps requiring discrete rotations.
### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
