### PR TITLE
Add pypp library, allow calling python functions from C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ include(SetupHdf5)
 include(SetupJemalloc)
 include(SetupLIBXSMM)
 include(SetupPapi)
+include(SetupPythonLibs)
 include(SetupYamlCpp)
 
 # The precompiled header must be setup after all libraries have been found

--- a/cmake/SetupPythonLibs.cmake
+++ b/cmake/SetupPythonLibs.cmake
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+find_package(PythonLibs REQUIRED)
+include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
+list(APPEND SPECTRE_LIBRARIES ${PYTHON_LIBRARIES})
+
+message(STATUS "Python libs: " ${PYTHON_LIBRARIES})
+message(STATUS "Python incl: " ${PYTHON_INCLUDE_DIRS})

--- a/cmake/SpectreParseTests.py
+++ b/cmake/SpectreParseTests.py
@@ -23,6 +23,7 @@ allowed_tags = [
                 "Options",
                 "Parallel",
                 "PointwiseFunctions",
+                "Pypp",
                 "RelativisticEuler",
                 "RootFinding",
                 "Serialization",

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -82,6 +82,9 @@ INPUT += @PROJECT_SOURCE_DIR@/docs
 INPUT += @PROJECT_SOURCE_DIR@/tests/Unit/ActionTesting.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/DataStructures/TestHelpers.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp \
+         @PROJECT_SOURCE_DIR@/tests/Unit/Pypp/Pypp.hpp  \
+         @PROJECT_SOURCE_DIR@/tests/Unit/Pypp/PyppFundamentals.hpp  \
+         @PROJECT_SOURCE_DIR@/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/TestCreation.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/TestHelpers.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/TestingFramework.hpp

--- a/src/Informer/InfoFromBuild.cpp
+++ b/src/Informer/InfoFromBuild.cpp
@@ -39,3 +39,7 @@ std::string info_from_build() {
   }();
   return info;
 }
+
+std::string unit_test_path() noexcept {
+  return "@CMAKE_SOURCE_DIR@/tests/Unit/";
+}

--- a/src/Informer/InfoFromBuild.hpp
+++ b/src/Informer/InfoFromBuild.hpp
@@ -41,3 +41,9 @@ int spectre_minor_version();
  * \brief Returns patch version
  */
 int spectre_patch_version();
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Returns the path to the Unit test directory.
+ */
+std::string unit_test_path() noexcept;

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(NumericalAlgorithms)
 add_subdirectory(Options)
 add_subdirectory(Parallel)
 add_subdirectory(PointwiseFunctions)
+add_subdirectory(Pypp)
 add_subdirectory(Time)
 add_subdirectory(Utilities)
 

--- a/tests/Unit/Pypp/CMakeLists.txt
+++ b/tests/Unit/Pypp/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(PYPP_TESTS
+    Pypp/Test_Pypp.cpp
+  )
+
+set(SPECTRE_TESTS "${SPECTRE_TESTS};${PYPP_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/Pypp/Pypp.hpp
+++ b/tests/Unit/Pypp/Pypp.hpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines function pypp::call<R,Args...>
+
+#pragma once
+
+#include <Python.h>
+#include <stdexcept>
+#include <string>
+
+#include "tests/Unit/Pypp/PyppFundamentals.hpp"
+
+/// \ingroup TestingFrameworkGroup
+/// Contains all functions for calling python from C++
+namespace pypp {
+
+/// Calls a Python function from a module/file with given parameters
+///
+/// \param module_name name of module the function is in
+/// \param function_name name of Python function in module
+/// \param t the arguments to be passed to the Python function
+/// \return the object returned by the Python function converted to a C++ type
+///
+/// Custom classes can be converted between Python and C++ by overloading the
+/// `pypp::ToPythonObject<T>` and `pypp::FromPythonObject<T>` structs for your
+/// own types. This tells C++ how to deconstruct the Python object into
+/// fundamental types and reconstruct the C++ object and vice-versa.
+///
+/// \note In order to setup the python interpreter and add the local directories
+/// to the path, a SetupLocalPythonEnvironment object needs to be constructed
+/// in the local scope.
+///
+/// \example
+/// The following example calls the function `test_numeric` from the module
+/// `pypp_py_tests` which multiplies two integers.
+/// \snippet Test_Pypp.cpp pypp_int_test
+/// Alternatively, this examples calls `test_vector` from `pypp_py_tests` which
+/// converts two vectors to python lists and multiplies them pointwise.
+/// \snippet Test_Pypp.cpp pypp_vector_test
+template <typename R, typename... Args>
+R call(const std::string& module_name, const std::string& function_name,
+       const Args&... t) {
+  PyObject* module = PyImport_ImportModule(module_name.c_str());
+  if (module == nullptr) {
+    PyErr_Print();
+    throw std::runtime_error{std::string("Could not find python module.\n") +
+                             module_name};
+  }
+  PyObject* func = PyObject_GetAttrString(module, function_name.c_str());
+  if (func == nullptr or not PyCallable_Check(func)) {
+    if (PyErr_Occurred()) {
+      PyErr_Print();
+    }
+    throw std::runtime_error{"Could not find python function in module.\n"};
+  }
+  PyObject* args = make_py_tuple(t...);
+  PyObject* value = PyObject_CallObject(func, args);
+  Py_DECREF(args);  // NOLINT
+  if (value == nullptr) {
+    Py_DECREF(func);    // NOLINT
+    Py_DECREF(module);  // NOLINT
+    PyErr_Print();
+    throw std::runtime_error{"Function returned null"};
+  }
+  auto ret = from_py_object<R>(value);
+  Py_DECREF(value);   // NOLINT
+  Py_DECREF(func);    // NOLINT
+  Py_DECREF(module);  // NOLINT
+  return ret;
+}
+}  // namespace pypp

--- a/tests/Unit/Pypp/PyppFundamentals.hpp
+++ b/tests/Unit/Pypp/PyppFundamentals.hpp
@@ -1,0 +1,324 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines classes for converting to and from Python objects
+
+#pragma once
+
+#include <Python.h>
+#include <array>
+#include <cstddef>
+#include <initializer_list>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace pypp {
+/// \cond
+using None = void*;
+
+template <typename T, typename = std::nullptr_t>
+struct ToPyObject;
+
+template <typename T>
+PyObject* to_py_object(const T& t) {
+  PyObject* value = ToPyObject<T>::convert(t);
+  if (value == nullptr) {
+    throw std::runtime_error{"Failed to convert argument."};
+  }
+  return value;
+}
+
+template <typename T, typename = std::nullptr_t>
+struct FromPyObject;
+
+template <typename T>
+T from_py_object(PyObject* t) {
+  return FromPyObject<T>::convert(t);
+}
+/// \endcond
+
+/// Create a python tuple from Args
+///
+/// \tparam Args the types of the arguments to be put in the tuple (deducible)
+/// \param t the arguments to put into the tuple
+/// \return PyObject* containing a Python tuple
+template <typename... Args>
+PyObject* make_py_tuple(const Args&... t) {
+  PyObject* py_tuple = PyTuple_New(sizeof...(Args));
+  int entry = 0;
+  const auto add_entry = [&entry, &py_tuple](const auto& arg) {
+    PyObject* value = to_py_object(arg);
+    PyTuple_SetItem(py_tuple, entry, value);
+    entry++;
+    return '0';
+  };
+  (void)add_entry; // GCC warns that add_entry is unused
+  (void)std::initializer_list<char>{add_entry(t)...};
+  return  py_tuple;
+}
+
+///\cond
+template <>
+struct ToPyObject<void, std::nullptr_t> {
+  static PyObject* convert() { return Py_None; }
+};
+
+template <typename T>
+struct ToPyObject<
+    T, Requires<cpp17::is_same_v<typename std::decay<T>::type, std::string>>> {
+  static PyObject* convert(const T& t) {
+#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
+    return PyString_FromString(t.c_str());
+#elif PY_MAJOR_VERSION == 3
+    return PyUnicode_FromString(t.c_str());
+#else
+    static_assert(false, "Only works on Python 2.7 and 3.x")
+#endif
+  }
+};
+
+template <typename T>
+struct ToPyObject<
+    T, Requires<cpp17::is_same_v<typename std::decay<T>::type, bool>>> {
+  static PyObject* convert(const T& t) {
+    return PyBool_FromLong(static_cast<long>(t));
+  }
+};
+
+template <typename T>
+struct ToPyObject<
+    T, Requires<cpp17::is_same_v<typename std::decay<T>::type, int> or
+                cpp17::is_same_v<typename std::decay<T>::type, short>>> {
+  static PyObject* convert(const T& t) {
+#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
+    return PyInt_FromLong(t);
+#elif PY_MAJOR_VERSION == 3
+    return PyLong_FromLong(t);
+#else
+    static_assert(false, "Only works on Python 2.7 and 3.x")
+#endif
+  }
+};
+
+template <typename T>
+struct ToPyObject<
+    T, Requires<cpp17::is_same_v<typename std::decay<T>::type, long>>> {
+  static PyObject* convert(const T& t) { return PyLong_FromLong(t); }
+};
+
+template <typename T>
+struct ToPyObject<
+    T, Requires<cpp17::is_same_v<typename std::decay<T>::type, unsigned long> or
+                cpp17::is_same_v<typename std::decay<T>::type, unsigned int>>> {
+  static PyObject* convert(const T& t) { return PyLong_FromUnsignedLong(t); }
+};
+
+template <typename T>
+struct ToPyObject<
+    T, Requires<
+           cpp17::is_same_v<typename std::decay<T>::type, size_t> and
+           not cpp17::is_same_v<typename std::decay<T>::type, unsigned long> and
+           not cpp17::is_same_v<typename std::decay<T>::type, unsigned int>>> {
+  static PyObject* convert(const T& t) { return PyLong_FromSize_t(t); }
+};
+
+template <typename T>
+struct ToPyObject<
+    T, Requires<std::is_floating_point<typename std::decay<T>::type>::value>> {
+  static PyObject* convert(const T& t) { return PyFloat_FromDouble(t); }
+};
+
+template <typename T, typename A>
+struct ToPyObject<std::vector<T, A>, std::nullptr_t> {
+  static PyObject* convert(const std::vector<T, A>& t) {
+    PyObject* list = PyList_New(static_cast<long>(t.size()));
+    if (list == nullptr) {
+      throw std::runtime_error{"Failed to convert argument."};
+    }
+    for (size_t i = 0; i < t.size(); ++i) {
+      if (-1 ==
+          PyList_SetItem(list, static_cast<long>(i), to_py_object<T>(t[i]))) {
+        throw std::runtime_error{"Failed to add to PyList."};
+      }
+    }
+    return list;
+  }
+};
+
+template <typename T, size_t Size>
+struct ToPyObject<std::array<T, Size>, std::nullptr_t> {
+  static PyObject* convert(const std::array<T, Size>& t) {
+    PyObject* list = PyList_New(static_cast<long>(t.size()));
+    if (list == nullptr) {
+      throw std::runtime_error{"Failed to convert argument."};
+    }
+    for (size_t i = 0; i < Size; ++i) {
+      PyObject* value =
+          ToPyObject<T>::convert(gsl::at(t, i));
+      if (value == nullptr) {
+        throw std::runtime_error{"Failed to convert argument."};
+      }
+      if (-1 == PyList_SetItem(list, static_cast<long>(i), value)) {
+        throw std::runtime_error{"Failed to add to PyList."};
+      }
+    }
+    return list;
+  }
+};
+
+template <>
+struct FromPyObject<long, std::nullptr_t> {
+  static long convert(PyObject* t) {
+    if (t == nullptr) {
+      throw std::runtime_error{"Received null PyObject."};
+#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
+    } else if (not PyInt_Check(t) and not PyLong_Check(t)) {
+#elif PY_MAJOR_VERSION == 3
+    } else if (not PyLong_Check(t)) {
+#else
+    } else {
+      static_assert(false, "Only works on Python 2.7 and 3.x")
+#endif
+      throw std::runtime_error{"Cannot convert non-long/int type to long."};
+    }
+    return PyLong_AsLong(t);
+  }
+};
+
+template <>
+struct FromPyObject<unsigned long, std::nullptr_t> {
+  static unsigned long convert(PyObject* t) {
+    if (t == nullptr) {
+      throw std::runtime_error{"Received null PyObject."};
+#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
+    } else if (not PyInt_Check(t) and not PyLong_Check(t)) {
+#elif PY_MAJOR_VERSION == 3
+    } else if (not PyLong_Check(t)) {
+#else
+    } else {
+      static_assert(false, "Only works on Python 2.7 and 3.x");
+#endif
+      throw std::runtime_error{"Cannot convert non-long/int type to long."};
+    }
+    return PyLong_AsUnsignedLong(t);
+  }
+};
+
+template <>
+struct FromPyObject<double, std::nullptr_t> {
+  static double convert(PyObject* t) {
+    if (t == nullptr) {
+      throw std::runtime_error{"Received null PyObject."};
+    } else if (not PyFloat_Check(t)) {
+      throw std::runtime_error{"Cannot convert non-double type to double."};
+    }
+    return PyFloat_AsDouble(t);
+  }
+};
+
+template <>
+struct FromPyObject<bool, std::nullptr_t> {
+  static bool convert(PyObject* t) {
+    if (t == nullptr) {
+      throw std::runtime_error{"Received null PyObject."};
+    } else if (not PyBool_Check(t)) {
+      throw std::runtime_error{"Cannot convert non-bool type to bool."};
+    }
+    return static_cast<bool>(PyLong_AsLong(t));
+  }
+};
+
+template <>
+struct FromPyObject<std::string, std::nullptr_t> {
+  static std::string convert(PyObject* t) {
+    if (t == nullptr) {
+      throw std::runtime_error{"Received null PyObject."};
+#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
+    } else if (not PyString_CheckExact(t)) {
+#elif PY_MAJOR_VERSION == 3
+    } else if (not PyUnicode_CheckExact(t)) {
+#else
+    } else {
+      static_assert(false, "Only works on Python 2.7 and 3.x")
+#endif
+      throw std::runtime_error{"Cannot convert non-string type to string."};
+    }
+#if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
+    return std::string(PyString_AsString(t));
+#elif PY_MAJOR_VERSION == 3
+    PyObject* tascii = PyUnicode_AsASCIIString(t);
+    if (nullptr == tascii) {
+      throw std::runtime_error{"Cannot convert to ASCII string."};
+    }
+    std::string str = PyBytes_AsString(tascii);
+    Py_DECREF(tascii);  // NOLINT
+    return str;
+#else
+    static_assert(false, "Only works on Python 2.7 and 3.x")
+#endif
+  }
+};
+
+// This overload handles the case of converting from a python type of None to a
+// void*
+template <>
+struct FromPyObject<void*, std::nullptr_t> {
+  static void* convert(PyObject* t) {
+    if (t == nullptr) {
+      throw std::runtime_error{"Received null PyObject."};
+    } else if (t != Py_None) {
+      throw std::runtime_error{"Cannot convert non-None type to void."};
+    }
+    return nullptr;
+  }
+};
+
+template <typename T>
+struct FromPyObject<T, Requires<tt::is_a_v<std::vector, T>>> {
+  static T convert(PyObject* p) {
+    if (p == nullptr) {
+      throw std::runtime_error{"Received null PyObject."};
+    } else if (not PyList_CheckExact(p)) {
+      throw std::runtime_error{"Cannot convert non-list type to vector."};
+    }
+    T t(static_cast<size_t>(PyList_Size(p)));
+    for (size_t i = 0; i < t.size(); ++i) {
+      PyObject* value = PyList_GetItem(p, static_cast<long>(i));
+      if (value == nullptr) {
+        throw std::runtime_error{"Failed to get argument from list."};
+      }
+      t[i] = from_py_object<typename T::value_type>(value);
+    }
+    return t;
+  }
+};
+
+template <typename T>
+struct FromPyObject<T, Requires<tt::is_std_array_v<T>>> {
+  static T convert(PyObject* p) {
+    if (p == nullptr) {
+      throw std::runtime_error{"Received null PyObject."};
+    } else if (not PyList_CheckExact(p)) {
+      throw std::runtime_error{"Cannot convert non-list type to array."};
+    }
+    T t{};
+    // clang-tidy: Do no implicitly decay an array into a pointer
+    assert(PyList_Size(p) == static_cast<long>(t.size()));  // NOLINT
+    for (size_t i = 0; i < t.size(); ++i) {
+      PyObject* value = PyList_GetItem(p, static_cast<long>(i));
+      if (value == nullptr) {
+        throw std::runtime_error{"Failed to get argument from list."};
+      }
+      gsl::at(t, i) = from_py_object<typename T::value_type>(value);
+    }
+    return t;
+  }
+};
+///\endcond
+}  // namespace pypp

--- a/tests/Unit/Pypp/PyppPyTests.py
+++ b/tests/Unit/Pypp/PyppPyTests.py
@@ -1,0 +1,41 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+def test_none():
+    return None
+
+
+def test_numeric(a, b):
+    return a * b
+
+
+def test_vector(a, b):
+    test = list()
+    test.append(a[0] * b[0])
+    test.append(a[1] * b[1])
+    return test
+
+
+def test_unordered_map(a, b):
+    test = {}
+    test["0"] = a["0"] * b["0"]
+    test["1"] = a["1"] * b["1"]
+    return test
+
+
+def test_tuple(a, b):
+    if a[0] != 0.35 or a[1] != "test 1" or b[0] != "test 2" or b[1] != 100:
+        raise RuntimeError('Failed test_tuple')
+    return 0.48, "test 3"
+
+
+def test_tuple_list(a, b):
+    if a[0] != 0.35 or a[1] != "test 1" or b[0] != "test 2" or b[1] != 100:
+        raise RuntimeError('Failed test_tuple')
+    return 0.48, [0.98, "test 4"]
+
+
+def test_string(a):
+    if a != "test string":
+        raise RuntimeError('Failed string test')
+    return "back test string"

--- a/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp
+++ b/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <codecvt>
+#include <string>
+
+#include "Informer/InfoFromBuild.hpp"
+#include "tests/Unit/Pypp/PyppFundamentals.hpp"
+
+/// Contains all functions for pypp
+namespace pypp {
+
+/// Enable calling of python in the local scope, and add directory(ies) to the
+/// front of the search path for modules. The directory which is appended to the
+/// path is relative to the `tests/Unit` directory.
+struct SetupLocalPythonEnvironment {
+  explicit SetupLocalPythonEnvironment(
+      const std::string& cur_dir_relative_to_unit_test_path) {
+    Py_Initialize();
+    // clang-tidy: Do not use const-cast
+    PyObject* pyob_old_paths =
+        PySys_GetObject(const_cast<char*>("path"));  // NOLINT
+    const auto old_paths =
+        pypp::from_py_object<std::vector<std::string>>(pyob_old_paths);
+    std::string new_path =
+        unit_test_path() + cur_dir_relative_to_unit_test_path;
+    for (const auto& p : old_paths) {
+      new_path += ":";
+      new_path += p;
+    }
+
+#if PY_MAJOR_VERSION == 3
+    PySys_SetPath(std::wstring_convert<std::codecvt_utf8<wchar_t>>()
+                      .from_bytes(new_path)
+                      .c_str());
+#else
+    // clang-tidy: Do not use const-cast
+    PySys_SetPath(const_cast<char*>(new_path.c_str()));  // NOLINT
+#endif
+  }
+  ~SetupLocalPythonEnvironment() { Py_Finalize(); }
+
+  SetupLocalPythonEnvironment(const SetupLocalPythonEnvironment&) = delete;
+  SetupLocalPythonEnvironment& operator=(const SetupLocalPythonEnvironment&) =
+      delete;
+  SetupLocalPythonEnvironment(const SetupLocalPythonEnvironment&&) = delete;
+  SetupLocalPythonEnvironment& operator=(const SetupLocalPythonEnvironment&&) =
+      delete;
+};
+}  // namespace pypp

--- a/tests/Unit/Pypp/Test_Pypp.cpp
+++ b/tests/Unit/Pypp/Test_Pypp.cpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for detai
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include "tests/Unit/Pypp/Pypp.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestingFramework.hpp"
+
+SPECTRE_TEST_CASE("Unit.Pypp.none", "[Pypp][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};
+  pypp::call<pypp::None>("PyppPyTests", "test_none");
+  CHECK_THROWS(pypp::call<pypp::None>("PyppPyTests", "test_numeric", 1, 2));
+  CHECK_THROWS(pypp::call<std::string>("PyppPyTests", "test_none"));
+}
+
+SPECTRE_TEST_CASE("Unit.Pypp.std::string", "[Pypp][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};
+  const auto ret = pypp::call<std::string>("PyppPyTests", "test_string",
+                                           std::string("test string"));
+  CHECK(ret == std::string("back test string"));
+  CHECK_THROWS(pypp::call<std::string>("PyppPyTests", "test_string",
+                                       std::string("test string_")));
+  CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_string",
+                                  std::string("test string")));
+}
+
+SPECTRE_TEST_CASE("Unit.Pypp.int", "[Pypp][Unit]") {
+  /// [pypp_int_test]
+  pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};
+  const auto ret = pypp::call<long>("PyppPyTests", "test_numeric", 3, 4);
+  CHECK(ret == 3 * 4);
+  /// [pypp_int_test]
+  CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_numeric", 3, 4));
+  CHECK_THROWS(pypp::call<void*>("PyppPyTests", "test_numeric", 3, 4));
+  CHECK_THROWS(pypp::call<long>("PyppPyTests", "test_none"));
+}
+
+SPECTRE_TEST_CASE("Unit.Pypp.long", "[Pypp][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};
+  const auto ret = pypp::call<long>("PyppPyTests", "test_numeric", 3l, 4l);
+  CHECK(ret == 3l * 4l);
+  CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_numeric", 3l, 4l));
+  CHECK_THROWS(pypp::call<long>("PyppPyTests", "test_numeric", 3.0, 3.74));
+}
+
+SPECTRE_TEST_CASE("Unit.Pypp.unsigned_long", "[Pypp][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};
+  const auto ret =
+      pypp::call<unsigned long>("PyppPyTests", "test_numeric", 3ul, 4ul);
+  CHECK(ret == 3ul * 4ul);
+  CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_numeric", 3ul, 4ul));
+  CHECK_THROWS(
+      pypp::call<unsigned long>("PyppPyTests", "test_numeric", 3.0, 3.74));
+}
+
+SPECTRE_TEST_CASE("Unit.Pypp.double", "[Pypp][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};
+  const auto ret =
+      pypp::call<double>("PyppPyTests", "test_numeric", 3.49582, 3);
+  CHECK(ret == 3.0 * 3.49582);
+  CHECK_THROWS(pypp::call<long>("PyppPyTests", "test_numeric", 3.8, 3.9));
+  CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_numeric", 3ul, 3ul));
+}
+
+SPECTRE_TEST_CASE("Unit.Pypp.std::vector", "[Pypp][Unit]") {
+  /// [pypp_vector_test]
+  pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};
+  const auto ret = pypp::call<std::vector<double>>(
+      "PyppPyTests", "test_vector", std::vector<double>{1.3, 4.9},
+      std::vector<double>{4.2, 6.8});
+  CHECK(approx(ret[0]) == 1.3 * 4.2);
+  CHECK(approx(ret[1]) == 4.9 * 6.8);
+  /// [pypp_vector_test]
+  CHECK_THROWS(pypp::call<std::string>("PyppPyTests", "test_vector",
+                                       std::vector<double>{1.3, 4.9},
+                                       std::vector<double>{4.2, 6.8}));
+}
+
+SPECTRE_TEST_CASE("Unit.Pypp.std::array", "[Pypp][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};
+  // std::arrays and std::vectors should both convert to lists in python so this
+  // test calls the same python function as the vector test
+  const auto ret = pypp::call<std::array<double, 2>>(
+      "PyppPyTests", "test_vector", std::array<double, 2>{{1.3, 4.9}},
+      std::array<double, 2>{{4.2, 6.8}});
+  CHECK(approx(ret[0]) == 1.3 * 4.2);
+  CHECK(approx(ret[1]) == 4.9 * 6.8);
+  CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_vector",
+                                  std::array<double, 2>{{1.3, 4.9}},
+                                  std::array<double, 2>{{4.2, 6.8}}));
+}


### PR DESCRIPTION
## Proposed changes

Add's pypp library to call python functions from c++. This will be used to simplify and standardise how we test pointwise functions. 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

Currently before calling a python module in the same folder, one has to call `prepend` with the path to the current directory within tests/Unit. This is not ideal but I'm not sure of a better way. 
