### PR TITLE
Fix CAPTURE_PRECISE for STL types

### DIFF
--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -432,13 +432,22 @@ std::string get_output(const Container& c) {
   return os.str();
 }
 
+namespace TestHelpers_detail {
+template <typename T>
+std::string format_capture_precise(const T& t) noexcept {
+  std::ostringstream os;
+  os << std::scientific << std::setprecision(18) << t;
+  return os.str();
+}
+}  // namespace TestHelpers_detail
+
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief Alternative to Catch's CAPTURE that prints more digits.
  */
 #define CAPTURE_PRECISE(variable)                                    \
-  INFO(std::scientific << std::setprecision(18) << #variable << ": " \
-                       << (variable));
+  INFO(#variable << ": "                                             \
+       << TestHelpers_detail::format_capture_precise(variable))
 
 /*!
  * \ingroup TestingFrameworkGroup

--- a/tests/Unit/Test_TestHelpers.cpp
+++ b/tests/Unit/Test_TestHelpers.cpp
@@ -47,6 +47,11 @@ SPECTRE_TEST_CASE("Test.TestHelpers", "[Unit]") {
   CHECK_ITERABLE_APPROX(vecmap_a, vecmap_b);
   vecmap_b[1][1] += 1e-12;
   CHECK_ITERABLE_CUSTOM_APPROX(vecmap_a, vecmap_b, larger_approx);
+
+  // Check that CAPTURE_PRECISE accepts an STL type (we cannot test
+  // the output because that is only produced on a Catch failure,
+  // which would fail the test.
+  CAPTURE_PRECISE((std::array<double, 1>{{1.5}}));
 }
 
 SPECTRE_TEST_CASE("Test.TestHelpers.Derivative", "[Unit]") {


### PR DESCRIPTION
Catch (correctly) defines an operator<< in the Catch namespace, but
that hides operators in other namespaces.  For our custom types the
operator<< is in the same namespace as the type and so can be found
using ADL, but for our custom STL operators the operator<< is in a
different namespace (the global one) from all its arguments (std), and
so cannot be found.

This commit causes the lookup to occur in the global namespace (or
actually a detail namespace with no operator<< functions in it) so our
custom operators can be found.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [X] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
