### PR TITLE
Add identity matrix and test

### DIFF
--- a/src/DataStructures/Tensor/Identity.hpp
+++ b/src/DataStructures/Tensor/Identity.hpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/// \ingroup TensorGroup
+/// \brief returns the Identity matrix
+template <size_t Dim, typename DataType>
+tnsr::Ij<DataType, Dim, Frame::NoFrame> identity(
+    const DataType& used_for_type) noexcept {
+  auto identity_matrix{make_with_value<tnsr::Ij<DataType, Dim, Frame::NoFrame>>(
+      used_for_type, 0.0)};
+
+  for (size_t i = 0; i < Dim; ++i) {
+    identity_matrix.get(i, i) = 1.0;
+  }
+  return identity_matrix;
+}

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -6,6 +6,7 @@ set(DATA_STRUCTURES_TESTS
     DataStructures/Test_DataBoxTag.cpp
     DataStructures/Test_DataVector.cpp
     DataStructures/Test_GeneralIndexIterator.cpp
+    DataStructures/Test_Identity.cpp
     DataStructures/Test_Index.cpp
     DataStructures/Test_IndexIterator.cpp
     DataStructures/Test_MakeWithValue.cpp

--- a/tests/Unit/DataStructures/Test_Identity.cpp
+++ b/tests/Unit/DataStructures/Test_Identity.cpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Identity.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+template <size_t Dim, typename DataType>
+void test_identity(const DataType& used_for_size) {
+  const auto identity_matrix{identity<Dim>(used_for_size)};
+
+  for (size_t i = 0; i < Dim; i++) {
+    for (size_t j = 0; j < Dim; j++) {
+      if (i == j) {
+        CHECK_ITERABLE_APPROX(identity_matrix.get(i, j),
+                              make_with_value<DataType>(used_for_size, 1.0));
+      } else {
+        CHECK_ITERABLE_APPROX(identity_matrix.get(i, j),
+                              make_with_value<DataType>(used_for_size, 0.0));
+      }
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Identity",
+                  "[DataStructures][Unit]") {
+  const double d(std::numeric_limits<double>::signaling_NaN());
+  test_identity<1>(d);
+  test_identity<2>(d);
+  test_identity<3>(d);
+
+  const DataVector dv(5);
+  test_identity<1>(dv);
+  test_identity<2>(dv);
+  test_identity<3>(dv);
+}


### PR DESCRIPTION
## Proposed changes

Add identity matrix and tests

### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
