### PR TITLE
Use DiscreteRotation in Wedge3D

### DIFF
--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -9,6 +9,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/OrientationMap.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 namespace PUP {
@@ -180,8 +181,10 @@ class Wedge3D {
    * \param radius_of_other_surface Distance from the origin to one of the
    * corners which lie on the other surface, which may be anything between flat
    * and spherical.
-   * \param direction_of_wedge The axis on which the
-   * wedge is centred.
+   * \param orientation_of_wedge The orientation of the desired wedge relative
+   * to the orientation of the default wedge which is a wedge that has its
+   * curved surfaces pierced by the upper-z axis. The logical xi and eta
+   * coordinates point in the cartesian x and y directions, respectively.
    * \param sphericity_of_other_surface Value between 0 and 1 which determines
    * whether the other surface is flat (value of 0), spherical (value of 1) or
    * somewhere in between
@@ -189,7 +192,8 @@ class Wedge3D {
    * mapping to the logical coordinates (for 'true') or not (for 'false').
    */
   Wedge3D(double radius_of_other_surface, double radius_of_spherical_surface,
-          Direction<3> direction_of_wedge, double sphericity_of_other_surface,
+          OrientationMap<3> orientation_of_wedge,
+          double sphericity_of_other_surface,
           bool with_equiangular_map) noexcept;
 
   Wedge3D() = default;
@@ -224,7 +228,7 @@ class Wedge3D {
   double radius_of_other_surface_{std::numeric_limits<double>::signaling_NaN()};
   double radius_of_spherical_surface_{
       std::numeric_limits<double>::signaling_NaN()};
-  Direction<3> direction_of_wedge_{};
+  OrientationMap<3> orientation_of_wedge_{};
   double sphericity_of_other_surface_{
       std::numeric_limits<double>::signaling_NaN()};
   bool with_equiangular_map_ = false;

--- a/src/Domain/DomainCreators/Shell.cpp
+++ b/src/Domain/DomainCreators/Shell.cpp
@@ -32,8 +32,6 @@ Shell<TargetFrame>::Shell(
 
 template <typename TargetFrame>
 Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
-  using Wedge3DMap = CoordinateMaps::Wedge3D;
-
   std::vector<std::array<size_t, 8>> corners{
       {{7, 5, 8, 6, 15, 13, 16, 14}},   // Upper z
       {{4, 2, 3, 1, 12, 10, 11, 9}},    // Lower z
@@ -41,22 +39,11 @@ Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
       {{7, 3, 5, 1, 15, 11, 13, 9}},    // Lower y
       {{1, 2, 5, 6, 9, 10, 13, 14}},    // Upper x
       {{4, 3, 8, 7, 12, 11, 16, 15}}};  // Lower x
-
-  return Domain<3, TargetFrame>{
-      make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::upper_zeta(),
-                     1.0, use_equiangular_map_},
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::lower_zeta(),
-                     1.0, use_equiangular_map_},
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::upper_eta(),
-                     1.0, use_equiangular_map_},
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::lower_eta(),
-                     1.0, use_equiangular_map_},
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::upper_xi(),
-                     1.0, use_equiangular_map_},
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::lower_xi(),
-                     1.0, use_equiangular_map_}),
-      corners};
+  std::vector<
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+      coord_maps = wedge_coordinate_maps<TargetFrame>(
+          inner_radius_, outer_radius_, 1.0, use_equiangular_map_);
+  return Domain<3, TargetFrame>{std::move(coord_maps), corners};
 }
 
 template <typename TargetFrame>

--- a/src/Domain/DomainCreators/Sphere.cpp
+++ b/src/Domain/DomainCreators/Sphere.cpp
@@ -34,7 +34,6 @@ Sphere<TargetFrame>::Sphere(
 
 template <typename TargetFrame>
 Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
-  using Wedge3DMap = CoordinateMaps::Wedge3D;
   using Affine = CoordinateMaps::Affine;
   using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   using Equiangular = CoordinateMaps::Equiangular;
@@ -50,20 +49,10 @@ Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
       {{4, 3, 8, 7, 12, 11, 16, 15}},  // Lower x
       {{3, 1, 4, 2, 7, 5, 8, 6}}};     // center cube
 
-  auto coord_maps =
-      make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::upper_zeta(),
-                     0.0, use_equiangular_map_},
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::lower_zeta(),
-                     0.0, use_equiangular_map_},
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::upper_eta(),
-                     0.0, use_equiangular_map_},
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::lower_eta(),
-                     0.0, use_equiangular_map_},
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::upper_xi(),
-                     0.0, use_equiangular_map_},
-          Wedge3DMap{inner_radius_, outer_radius_, Direction<3>::lower_xi(),
-                     0.0, use_equiangular_map_});
+  std::vector<
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+      coord_maps = wedge_coordinate_maps<TargetFrame>(
+          inner_radius_, outer_radius_, 0.0, use_equiangular_map_);
   if (use_equiangular_map_) {
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::Logical, TargetFrame>(Equiangular3D{

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -3,6 +3,8 @@
 
 #include "Domain/DomainHelpers.hpp"
 
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/OrientationMap.hpp"
 
@@ -309,6 +311,42 @@ void set_periodic_boundaries(
   }
 }
 
+template <typename TargetFrame>
+std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+wedge_coordinate_maps(const double inner_radius, const double outer_radius,
+                      const double sphericity,
+                      const bool use_equiangular_map) noexcept {
+  using Wedge3DMap = CoordinateMaps::Wedge3D;
+  return make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
+      Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{}, sphericity,
+                 use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius,
+                 OrientationMap<3>(std::array<Direction<3>, 3>{
+                     {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                      Direction<3>::lower_zeta()}}),
+                 sphericity, use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius,
+                 OrientationMap<3>(std::array<Direction<3>, 3>{
+                     {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
+                      Direction<3>::upper_xi()}}),
+                 sphericity, use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius,
+                 OrientationMap<3>(std::array<Direction<3>, 3>{
+                     {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
+                      Direction<3>::lower_xi()}}),
+                 sphericity, use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius,
+                 OrientationMap<3>(std::array<Direction<3>, 3>{
+                     {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                      Direction<3>::upper_eta()}}),
+                 sphericity, use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius,
+                 OrientationMap<3>(std::array<Direction<3>, 3>{
+                     {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                      Direction<3>::upper_eta()}}),
+                 sphericity, use_equiangular_map});
+}
+
 template void set_internal_boundaries(
     const std::vector<std::array<size_t, 2>>& corners_of_all_blocks,
     gsl::not_null<
@@ -343,3 +381,13 @@ template void set_periodic_boundaries(
     gsl::not_null<
         std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>*>
         neighbors_of_all_blocks);
+template std::vector<
+    std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+wedge_coordinate_maps(const double inner_radius, const double outer_radius,
+                      const double sphericity,
+                      const bool use_equiangular_map) noexcept;
+template std::vector<
+    std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
+wedge_coordinate_maps(const double inner_radius, const double outer_radius,
+                      const double sphericity,
+                      const bool use_equiangular_map) noexcept;

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -7,10 +7,14 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <numeric>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockNeighbor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/OrientationMap.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 
 /// \ingroup ComputationalDomainGroup
@@ -47,3 +51,10 @@ void set_periodic_boundaries(
     gsl::not_null<std::vector<
         std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks);
+
+/// \ingroup ComputationalDomainGroup
+/// These are the six Wedge3Ds used in the DomainCreators for Sphere and Shell.
+template <typename TargetFrame>
+std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+wedge_coordinate_maps(double inner_radius, double outer_radius,
+                      double sphericity, bool use_equiangular_map) noexcept;

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -7,6 +7,7 @@
 
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
+#include "Domain/DomainHelpers.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
@@ -14,6 +15,28 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 namespace {
+// Wedge OrientationMap in each of the six directions.
+std::array<OrientationMap<3>, 6> all_wedge_directions() {
+  const OrientationMap<3> upper_zeta_rotation{};
+  const OrientationMap<3> lower_zeta_rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+       Direction<3>::lower_zeta()}});
+  const OrientationMap<3> upper_eta_rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
+       Direction<3>::upper_xi()}});
+  const OrientationMap<3> lower_eta_rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
+       Direction<3>::lower_xi()}});
+  const OrientationMap<3> upper_xi_rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+       Direction<3>::upper_eta()}});
+  const OrientationMap<3> lower_xi_rotation(std::array<Direction<3>, 3>{
+      {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+       Direction<3>::upper_eta()}});
+  return {{upper_zeta_rotation, lower_zeta_rotation, upper_eta_rotation,
+           lower_eta_rotation, upper_xi_rotation, lower_xi_rotation}};
+}
+
 void test_wedge3d_all_directions(const bool with_equiangular_map) {
   // Set up random number generator
   std::random_device rd;
@@ -40,7 +63,7 @@ void test_wedge3d_all_directions(const bool with_equiangular_map) {
                                                           {{0.9, -1.0, 0.4}},
                                                           {{xi, eta, zeta}}}};
 
-  for (const auto& direction : Direction<3>::all_directions()) {
+  for (const auto& direction : all_wedge_directions()) {
     const CoordinateMaps::Wedge3D map(inner_radius, outer_radius, direction,
                                       sphericity, with_equiangular_map);
     test_serialization(map);
@@ -67,23 +90,24 @@ void test_wedge3d_alignment(const bool with_equiangular_map) {
   const double inner_r = sqrt(3.0);
   const double outer_r = 2.0 * sqrt(3.0);
 
+  const auto wedge_directions = all_wedge_directions();
   const CoordinateMaps::Wedge3D map_upper_zeta(
-      inner_r, outer_r, Direction<3>::upper_zeta(), 0,
+      inner_r, outer_r, wedge_directions[0], 0,
       with_equiangular_map);  // Upper Z wedge
   const CoordinateMaps::Wedge3D map_upper_eta(
-      inner_r, outer_r, Direction<3>::upper_eta(), 0,
+      inner_r, outer_r, wedge_directions[2], 0,
       with_equiangular_map);  // Upper Y wedge
   const CoordinateMaps::Wedge3D map_upper_xi(
-      inner_r, outer_r, Direction<3>::upper_xi(), 0,
+      inner_r, outer_r, wedge_directions[4], 0,
       with_equiangular_map);  // Upper X Wedge
   const CoordinateMaps::Wedge3D map_lower_zeta(
-      inner_r, outer_r, Direction<3>::lower_zeta(), 0,
+      inner_r, outer_r, wedge_directions[1], 0,
       with_equiangular_map);  // Lower Z wedge
   const CoordinateMaps::Wedge3D map_lower_eta(
-      inner_r, outer_r, Direction<3>::lower_eta(), 0,
+      inner_r, outer_r, wedge_directions[3], 0,
       with_equiangular_map);  // Lower Y wedge
   const CoordinateMaps::Wedge3D map_lower_xi(
-      inner_r, outer_r, Direction<3>::lower_xi(), 0,
+      inner_r, outer_r, wedge_directions[5], 0,
       with_equiangular_map);  // Lower X wedge
   const std::array<double, 3> lowest_corner{{-1.0, -1.0, -1.0}};
   const std::array<double, 3> along_xi{{1.0, -1.0, -1.0}};
@@ -184,24 +208,25 @@ void test_wedge3d_random_radii(const bool with_equiangular_map) {
   const double random_outer_radius_upper_zeta = outer_dis(gen);
   CAPTURE_PRECISE(random_outer_radius_upper_zeta);
 
+  const auto wedge_directions = all_wedge_directions();
   const CoordinateMaps::Wedge3D map_lower_xi(
       random_inner_radius_lower_xi, random_outer_radius_lower_xi,
-      Direction<3>::lower_xi(), 0, with_equiangular_map);
+      wedge_directions[5], 0, with_equiangular_map);
   const CoordinateMaps::Wedge3D map_lower_eta(
       random_inner_radius_lower_eta, random_outer_radius_lower_eta,
-      Direction<3>::lower_eta(), 0, with_equiangular_map);
+      wedge_directions[3], 0, with_equiangular_map);
   const CoordinateMaps::Wedge3D map_lower_zeta(
       random_inner_radius_lower_zeta, random_outer_radius_lower_zeta,
-      Direction<3>::lower_zeta(), 0, with_equiangular_map);
+      wedge_directions[1], 0, with_equiangular_map);
   const CoordinateMaps::Wedge3D map_upper_xi(
       random_inner_radius_upper_xi, random_outer_radius_upper_xi,
-      Direction<3>::upper_xi(), 0, with_equiangular_map);
+      wedge_directions[4], 0, with_equiangular_map);
   const CoordinateMaps::Wedge3D map_upper_eta(
       random_inner_radius_upper_eta, random_outer_radius_upper_eta,
-      Direction<3>::upper_eta(), 0, with_equiangular_map);
+      wedge_directions[2], 0, with_equiangular_map);
   const CoordinateMaps::Wedge3D map_upper_zeta(
       random_inner_radius_upper_zeta, random_outer_radius_upper_zeta,
-      Direction<3>::upper_zeta(), 0, with_equiangular_map);
+      wedge_directions[0], 0, with_equiangular_map);
   CHECK(map_lower_xi(outer_corner)[0] ==
         approx(-random_outer_radius_lower_xi / sqrt(3.0)));
   CHECK(map_lower_eta(outer_corner)[1] ==

--- a/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
@@ -81,18 +81,35 @@ void test_shell_construction(
   test_domain_construction(
       domain, expected_block_neighbors, expected_external_boundaries,
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::upper_zeta(),
+          Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{}, 1.0,
+                     use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                          Direction<3>::lower_zeta()}}},
                      1.0, use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::lower_zeta(),
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
+                          Direction<3>::upper_xi()}}},
                      1.0, use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::upper_eta(), 1.0,
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::lower_eta(), 1.0,
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::upper_xi(), 1.0,
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::lower_xi(), 1.0,
-                     use_equiangular_map}));
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
+                          Direction<3>::lower_xi()}}},
+                     1.0, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                          Direction<3>::upper_eta()}}},
+                     1.0, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                          Direction<3>::upper_eta()}}},
+                     1.0, use_equiangular_map}
+
+          ));
 
   test_initial_domain(domain, shell.initial_refinement_levels());
 }

--- a/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
@@ -133,18 +133,33 @@ void test_sphere_construction(
 
   auto coord_maps =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::upper_zeta(),
+          Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{}, 0.0,
+                     use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                          Direction<3>::lower_zeta()}}},
                      0.0, use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::lower_zeta(),
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
+                          Direction<3>::upper_xi()}}},
                      0.0, use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::upper_eta(), 0.0,
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::lower_eta(), 0.0,
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::upper_xi(), 0.0,
-                     use_equiangular_map},
-          Wedge3DMap{inner_radius, outer_radius, Direction<3>::lower_xi(), 0.0,
-                     use_equiangular_map});
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
+                          Direction<3>::lower_xi()}}},
+                     0.0, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                          Direction<3>::upper_eta()}}},
+                     0.0, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                          Direction<3>::upper_eta()}}},
+                     0.0, use_equiangular_map});
   if (use_equiangular_map) {
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(Equiangular3D{

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -3,6 +3,7 @@
 
 #include <catch.hpp>
 
+#include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "tests/Unit/TestingFramework.hpp"
@@ -62,4 +63,51 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.DifferentBlocks",
                                 {Direction<3>::upper_zeta(), {0, aligned}}}};
 
   CHECK(neighbors_of_all_blocks == expected_block_neighbors);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.AllWedgeDirections",
+                  "[Domain][Unit]") {
+  using Wedge3DMap = CoordinateMaps::Wedge3D;
+  const double inner_radius = 1.0;
+  const double outer_radius = 2.0;
+  const double sphericity = 1.0;
+  const bool use_equiangular_map = true;
+
+  const auto expected_coord_maps =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
+                     sphericity, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                          Direction<3>::lower_zeta()}}},
+                     sphericity, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
+                          Direction<3>::upper_xi()}}},
+                     sphericity, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
+                          Direction<3>::lower_xi()}}},
+                     sphericity, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                          Direction<3>::upper_eta()}}},
+                     sphericity, use_equiangular_map},
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                          Direction<3>::upper_eta()}}},
+                     sphericity, use_equiangular_map});
+  const auto maps = wedge_coordinate_maps<Frame::Inertial>(
+      inner_radius, outer_radius, sphericity, use_equiangular_map);
+  CHECK(*expected_coord_maps[0] == *maps[0]);
+  CHECK(*expected_coord_maps[1] == *maps[1]);
+  CHECK(*expected_coord_maps[2] == *maps[2]);
+  CHECK(*expected_coord_maps[3] == *maps[3]);
+  CHECK(*expected_coord_maps[4] == *maps[4]);
+  CHECK(*expected_coord_maps[5] == *maps[5]);
 }

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -165,7 +165,7 @@ void test_element_map<3>() {
   // test with rotation and wedge
   test_element_impl(
       true, element_id, affine_map, first_map,
-      CoordinateMaps::Wedge3D{3.0, 7.0, Direction<3>::lower_eta(), 0.8, true},
+      CoordinateMaps::Wedge3D{3.0, 7.0, OrientationMap<3>{}, 0.8, true},
       logical_point_double, logical_point_dv);
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes
Factors out the rotations done in Wedge3D.
### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
