### PR TITLE
Clean up from dt_variables_tag removal from systems

### DIFF
--- a/cmake/SetupCompilationFailureTests.cmake
+++ b/cmake/SetupCompilationFailureTests.cmake
@@ -137,7 +137,7 @@ function(compilation_tests_parse_file SOURCE_FILE TEST_TARGET)
     set_tests_properties(
       "${TEST_NAME}"
       PROPERTIES
-      TIMEOUT 5
+      TIMEOUT 10
       LABELS "${TEST_TAGS}"
       PASS_REGULAR_EXPRESSION ${OUTPUT_REGEX}
       )

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -51,7 +51,7 @@ namespace Actions {
 ///   Tags::UnnormalizedFaceNormal<volume_dim>
 ///
 /// DataBox changes:
-/// - Adds: system::dt_variables_tag
+/// - Adds: db::add_tag_prefix<Tags::dt, variables_tag>
 /// - Removes: Tags::HistoryBoundaryVariables<Direction<volume_dim>,
 ///       system::variables_tag>
 /// - Modifies: nothing
@@ -94,7 +94,7 @@ struct ComputeBoundaryFlux {
                   "Inconsistent systems");
     constexpr const size_t volume_dim = System::volume_dim;
     using variables_tag = typename System::variables_tag;
-    using dt_variables_tag = typename System::dt_variables_tag;
+    using dt_variables_tag = db::add_tag_prefix<Tags::dt, variables_tag>;
 
     const auto& flux_computer =
         get<typename Metavariables::numerical_flux>(cache);

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -23,19 +23,20 @@ namespace Actions {
 /// \ingroup TimeGroup
 /// \brief Perform variable updates for one substep
 ///
+/// With `dt_variables_tag =
+/// db::add_tag_prefix<Tags::dt, system::variables_tag>`:
+///
 /// Uses:
 /// - ConstGlobalCache: CacheTags::TimeStepper
-/// - DataBox: system::variables_tag, system::dt_variables_tag,
-///   Tags::HistoryEvolvedVariables<system::variables_tag,
-///                                 system::dt_variables_tag>,
+/// - DataBox: system::variables_tag, dt_variables_tag,
+///   Tags::HistoryEvolvedVariables<system::variables_tag, dt_variables_tag>,
 ///   Tags::Time, Tags::TimeStep
 ///
 /// DataBox changes:
 /// - Adds: nothing
-/// - Removes: system::dt_variables_tag
-/// - Modifies: system::variables_tag,
-///   Tags::HistoryEvolvedVariables<system::variables_tag,
-///                                 system::dt_variables_tag>
+/// - Removes: nothing
+/// - Modifies: system::variables_tag, dt_variables_tag,
+///   Tags::HistoryEvolvedVariables<system::variables_tag, dt_variables_tag>
 struct UpdateU {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -34,7 +34,6 @@ struct Var : db::DataBoxTag {
 struct System {
   static constexpr const size_t volume_dim = 2;
   using variables_tag = Tags::Variables<tmpl::list<Var>>;
-  using dt_variables_tag = Tags::dt<Tags::Variables<tmpl::list<Tags::dt<Var>>>>;
   static constexpr const size_t number_of_independent_components =
       db::item_type<variables_tag>::number_of_independent_components;
 
@@ -48,6 +47,8 @@ struct System {
     }
   };
 };
+
+using dt_variables_tag = Tags::dt<Tags::Variables<tmpl::list<Tags::dt<Var>>>>;
 
 class NumericalFlux {
  public:
@@ -255,7 +256,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
                                   221400., 241600., 261800.};
 
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<Var>>(db::get<System::dt_variables_tag>(received_box)).get(),
+      get<Tags::dt<Var>>(db::get<dt_variables_tag>(received_box)).get(),
       xi_lift * xi_boundaries + eta_lift * eta_boundaries);
 }
 
@@ -305,6 +306,6 @@ SPECTRE_TEST_CASE(
       std::get<0>(runner.apply<component, Actions::ComputeBoundaryFlux<System>>(
           sent_box, self_id));
 
-  CHECK(get<Tags::dt<Var>>(db::get<System::dt_variables_tag>(received_box))
+  CHECK(get<Tags::dt<Var>>(db::get<dt_variables_tag>(received_box))
             .get() == (DataVector{0., 0., 0., 0., 0., 0., 0., 0., 0.}));
 }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
@@ -36,7 +36,6 @@ struct Var : db::DataBoxTag {
 struct System {
   static constexpr const size_t volume_dim = ::volume_dim;
   using variables_tag = Tags::Variables<tmpl::list<Var>>;
-  using dt_variables_tag = Tags::dt<Tags::Variables<tmpl::list<Tags::dt<Var>>>>;
   static constexpr const size_t number_of_independent_components =
       db::item_type<variables_tag>::number_of_independent_components;
 
@@ -52,6 +51,8 @@ struct System {
     }
   };
 };
+
+using dt_variables_tag = Tags::dt<Tags::Variables<tmpl::list<Tags::dt<Var>>>>;
 
 class NumericalFlux {
  public:
@@ -323,7 +324,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication2",
               Direction<2>::upper_eta()))[2]};
 
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<Var>>(db::get<System::dt_variables_tag>(received_box)).get(),
+      get<Tags::dt<Var>>(db::get<dt_variables_tag>(received_box)).get(),
       xi_lift * xi_boundaries + eta_lift * eta_boundaries);
 }
 
@@ -374,6 +375,6 @@ SPECTRE_TEST_CASE(
       runner.apply<component, dg::Actions::ComputeBoundaryFlux<Metavariables>>(
           sent_box, CharmIndexType(self_id)));
 
-  CHECK(get<Tags::dt<Var>>(db::get<System::dt_variables_tag>(received_box))
+  CHECK(get<Tags::dt<Var>>(db::get<dt_variables_tag>(received_box))
             .get() == (DataVector{0., 0., 0., 0., 0., 0., 0., 0., 0.}));
 }

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -26,7 +26,6 @@ struct Var : db::DataBoxTag {
 
 struct System {
   using variables_tag = Var;
-  using dt_variables_tag = Tags::dt<Var>;
 };
 
 struct Metavariables;


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
