### PR TITLE
Clean up concrete CoordinateMaps

### DIFF
--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -371,13 +371,15 @@ using iJkk = Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
 
 }  // namespace tnsr
 
-template <size_t Dim, typename SourceFrame, typename TargetFrame>
+template <typename DataType, size_t Dim, typename SourceFrame,
+          typename TargetFrame>
 using InverseJacobian =
-    Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-           tmpl::list<SpatialIndex<Dim, UpLo::Up, SourceFrame>,
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+           index_list<SpatialIndex<Dim, UpLo::Up, SourceFrame>,
                       SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>;
 
-template <size_t Dim, typename SourceFrame, typename TargetFrame>
-using Jacobian = Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                        tmpl::list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
+template <typename DataType, size_t Dim, typename SourceFrame,
+          typename TargetFrame>
+using Jacobian = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+                        index_list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
                                    SpatialIndex<Dim, UpLo::Lo, SourceFrame>>>;

--- a/src/Domain/CoordinateMaps/Affine.hpp
+++ b/src/Domain/CoordinateMaps/Affine.hpp
@@ -10,8 +10,11 @@
 #include <memory>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Parallel/CharmPupable.hpp"
 #include "Utilities/TypeTraits.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
 
 namespace CoordinateMaps {
 
@@ -41,26 +44,20 @@ class Affine {
   Affine& operator=(Affine&&) = default;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> operator()(
-      const std::array<T, 1>& source_coords) const;
+  std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
+      const std::array<T, 1>& source_coords) const noexcept;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> inverse(
-      const std::array<T, 1>& target_coords) const;
+  std::array<tt::remove_cvref_wrap_t<T>, 1> inverse(
+      const std::array<T, 1>& target_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 1>& source_coords) const;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
+      const std::array<T, 1>& source_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 1>& source_coords) const;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 1>& source_coords) const noexcept;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p);  // NOLINT

--- a/src/Domain/CoordinateMaps/BulgedCube.hpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.hpp
@@ -473,33 +473,27 @@ class BulgedCube {
   BulgedCube& operator=(BulgedCube&&) noexcept = default;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> operator()(
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> inverse(
+  std::array<tt::remove_cvref_wrap_t<T>, 3> inverse(
       const std::array<T, 3>& target_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 3>& source_coords) const noexcept;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 3>& source_coords) const noexcept;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
 
   // clang-tidy: google runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
  private:
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> xi_derivative(
+  std::array<tt::remove_cvref_wrap_t<T>, 3> xi_derivative(
       const std::array<T, 3>& source_coords) const noexcept;
   friend bool operator==(const BulgedCube& lhs, const BulgedCube& rhs) noexcept;
   double radius_;

--- a/src/Domain/CoordinateMaps/Equiangular.hpp
+++ b/src/Domain/CoordinateMaps/Equiangular.hpp
@@ -8,7 +8,8 @@
 
 #include <array>
 
-#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 namespace PUP {
 class er;
@@ -57,26 +58,20 @@ class Equiangular {
   Equiangular& operator=(Equiangular&&) = default;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> operator()(
+  std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords) const noexcept;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 1> inverse(
+  std::array<tt::remove_cvref_wrap_t<T>, 1> inverse(
       const std::array<T, 1>& target_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 1>& source_coords) const noexcept;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
+      const std::array<T, 1>& source_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 1>& source_coords) const noexcept;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 1>& source_coords) const noexcept;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/Domain/CoordinateMaps/Identity.cpp
+++ b/src/Domain/CoordinateMaps/Identity.cpp
@@ -3,65 +3,43 @@
 
 #include "Domain/CoordinateMaps/Identity.hpp"
 
+#include "DataStructures/Tensor/Identity.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace CoordinateMaps {
 
 template <size_t Dim>
 template <typename T>
-std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim> Identity<Dim>::
-operator()(const std::array<T, Dim>& source_coords) const {
-  return make_array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim>(
-      source_coords);
+std::array<tt::remove_cvref_wrap_t<T>, Dim> Identity<Dim>::operator()(
+    const std::array<T, Dim>& source_coords) const noexcept {
+  return make_array<tt::remove_cvref_wrap_t<T>, Dim>(source_coords);
 }
 
 template <size_t Dim>
 template <typename T>
-std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim>
-Identity<Dim>::inverse(const std::array<T, Dim>& target_coords) const {
-  return make_array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim>(
-      target_coords);
+std::array<tt::remove_cvref_wrap_t<T>, Dim> Identity<Dim>::inverse(
+    const std::array<T, Dim>& target_coords) const noexcept {
+  return make_array<tt::remove_cvref_wrap_t<T>, Dim>(target_coords);
 }
 
 template <size_t Dim>
 template <typename T>
-Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-       tmpl::integral_list<std::int32_t, 2, 1>,
-       index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
-                  SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
-Identity<Dim>::jacobian(const std::array<T, Dim>& source_coords) const {
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
-      jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
-          dereference_wrapper(source_coords[0]), 0.0)};
-  for (size_t i = 0; i < Dim; ++i) {
-    jac.get(i, i) = 1.0;
-  }
-  return jac;
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+Identity<Dim>::jacobian(const std::array<T, Dim>& source_coords) const
+    noexcept {
+  return identity<Dim>(dereference_wrapper(source_coords[0]));
 }
 
 template <size_t Dim>
 template <typename T>
-Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-       tmpl::integral_list<std::int32_t, 2, 1>,
-       index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
-                  SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
-Identity<Dim>::inv_jacobian(const std::array<T, Dim>& source_coords) const {
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
-      inv_jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
-          dereference_wrapper(source_coords[0]), 0.0)};
-  for (size_t i = 0; i < Dim; ++i) {
-    inv_jac.get(i, i) = 1.0;
-  }
-  return inv_jac;
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame>
+Identity<Dim>::inv_jacobian(const std::array<T, Dim>& source_coords) const
+    noexcept {
+  return identity<Dim>(dereference_wrapper(source_coords[0]));
 }
 
 template class Identity<1>;
@@ -70,127 +48,35 @@ template class Identity<2>;
 // unaffected.  So if the largest dim we do is 3, then you should never use
 // Identity<3>
 
-/// \cond HIDDEN_SYMBOLS
-template std::array<double, 1> Identity<1>::operator()(
-    const std::array<std::reference_wrapper<const double>, 1>& source_coords)
-    const;
-template std::array<double, 1> Identity<1>::operator()(
-    const std::array<double, 1>& source_coords) const;
-template std::array<DataVector, 1> Identity<1>::operator()(
-    const std::array<std::reference_wrapper<const DataVector>, 1>&
-        source_coords) const;
-template std::array<DataVector, 1> Identity<1>::operator()(
-    const std::array<DataVector, 1>& source_coords) const;
+// Explicit instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-template std::array<double, 1> Identity<1>::inverse(
-    const std::array<std::reference_wrapper<const double>, 1>& target_coords)
-    const;
-template std::array<double, 1> Identity<1>::inverse(
-    const std::array<double, 1>& target_coords) const;
-template std::array<DataVector, 1> Identity<1>::inverse(
-    const std::array<std::reference_wrapper<const DataVector>, 1>&
-        target_coords) const;
-template std::array<DataVector, 1> Identity<1>::inverse(
-    const std::array<DataVector, 1>& target_coords) const;
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
+  Identity<DIM(data)>::operator()(                                             \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept; \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
+  Identity<DIM(data)>::inverse(                                                \
+      const std::array<DTYPE(data), DIM(data)>& target_coords) const noexcept; \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
+                    Frame::NoFrame>                                            \
+  Identity<DIM(data)>::jacobian(                                               \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept; \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
+                    Frame::NoFrame>                                            \
+  Identity<DIM(data)>::inv_jacobian(                                           \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept;
 
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::jacobian(const std::array<std::reference_wrapper<const double>, 1>&
-                          source_coords) const;
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::jacobian(const std::array<double, 1>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                       1>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::jacobian(const std::array<DataVector, 1>& source_coords) const;
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
 
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::inv_jacobian(const std::array<std::reference_wrapper<const double>,
-                                           1>& source_coords) const;
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::inv_jacobian(const std::array<double, 1>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::inv_jacobian(
-    const std::array<std::reference_wrapper<const DataVector>, 1>&
-        source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<1, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<1, UpLo::Lo, Frame::NoFrame>>>
-Identity<1>::inv_jacobian(const std::array<DataVector, 1>& source_coords) const;
-
-template std::array<double, 2> Identity<2>::operator()(
-    const std::array<std::reference_wrapper<const double>, 2>& source_coords)
-    const;
-template std::array<double, 2> Identity<2>::operator()(
-    const std::array<double, 2>& source_coords) const;
-template std::array<DataVector, 2> Identity<2>::operator()(
-    const std::array<std::reference_wrapper<const DataVector>, 2>&
-        source_coords) const;
-template std::array<DataVector, 2> Identity<2>::operator()(
-    const std::array<DataVector, 2>& source_coords) const;
-
-template std::array<double, 2> Identity<2>::inverse(
-    const std::array<std::reference_wrapper<const double>, 2>& target_coords)
-    const;
-template std::array<double, 2> Identity<2>::inverse(
-    const std::array<double, 2>& target_coords) const;
-template std::array<DataVector, 2> Identity<2>::inverse(
-    const std::array<std::reference_wrapper<const DataVector>, 2>&
-        target_coords) const;
-template std::array<DataVector, 2> Identity<2>::inverse(
-    const std::array<DataVector, 2>& target_coords) const;
-
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::jacobian(const std::array<std::reference_wrapper<const double>, 2>&
-                          source_coords) const;
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::jacobian(const std::array<double, 2>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                       2>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::jacobian(const std::array<DataVector, 2>& source_coords) const;
-
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::inv_jacobian(const std::array<std::reference_wrapper<const double>,
-                                           2>& source_coords) const;
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::inv_jacobian(const std::array<double, 2>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::inv_jacobian(
-    const std::array<std::reference_wrapper<const DataVector>, 2>&
-        source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Identity<2>::inv_jacobian(const std::array<DataVector, 2>& source_coords) const;
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
 /// \endcond
+
 }  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/Identity.hpp
+++ b/src/Domain/CoordinateMaps/Identity.hpp
@@ -9,8 +9,12 @@
 #include <array>
 #include <memory>
 
-#include "DataStructures/Tensor/Tensor.hpp"
-#include "Parallel/CharmPupable.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
 
 namespace CoordinateMaps {
 
@@ -29,26 +33,20 @@ class Identity {
   Identity& operator=(Identity&&) = default;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim> operator()(
-      const std::array<T, Dim>& source_coords) const;
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
+      const std::array<T, Dim>& source_coords) const noexcept;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, Dim> inverse(
-      const std::array<T, Dim>& target_coords) const;
+  std::array<tt::remove_cvref_wrap_t<T>, Dim> inverse(
+      const std::array<T, Dim>& target_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, Dim>& source_coords) const;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jacobian(
+      const std::array<T, Dim>& source_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<Dim, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<Dim, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, Dim>& source_coords) const;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> inv_jacobian(
+      const std::array<T, Dim>& source_coords) const noexcept;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& /*p*/) {}  // NOLINT

--- a/src/Domain/CoordinateMaps/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/Rotation.cpp
@@ -4,6 +4,7 @@
 #include "Domain/CoordinateMaps/Rotation.hpp"
 
 #include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace CoordinateMaps {
@@ -20,8 +21,8 @@ Rotation<2>::Rotation(const double rotation_angle)
 }
 
 template <typename T>
-std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> Rotation<2>::
-operator()(const std::array<T, 2>& source_coords) const {
+std::array<tt::remove_cvref_wrap_t<T>, 2> Rotation<2>::operator()(
+    const std::array<T, 2>& source_coords) const noexcept {
   return {{source_coords[0] * get<0, 0>(rotation_matrix_) +
                source_coords[1] * get<0, 1>(rotation_matrix_),
            source_coords[0] * get<1, 0>(rotation_matrix_) +
@@ -29,8 +30,8 @@ operator()(const std::array<T, 2>& source_coords) const {
 }
 
 template <typename T>
-std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2>
-Rotation<2>::inverse(const std::array<T, 2>& target_coords) const {
+std::array<tt::remove_cvref_wrap_t<T>, 2> Rotation<2>::inverse(
+    const std::array<T, 2>& target_coords) const noexcept {
   return {{target_coords[0] * get<0, 0>(rotation_matrix_) +
                target_coords[1] * get<1, 0>(rotation_matrix_),
            target_coords[0] * get<0, 1>(rotation_matrix_) +
@@ -38,41 +39,30 @@ Rotation<2>::inverse(const std::array<T, 2>& target_coords) const {
 }
 
 template <typename T>
-Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-       tmpl::integral_list<std::int32_t, 2, 1>,
-       index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                  SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::jacobian(const std::array<T, 2>& source_coords) const {
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-      jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> Rotation<2>::jacobian(
+    const std::array<T, 2>& source_coords) const noexcept {
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> jacobian_matrix{
+      make_with_value<tt::remove_cvref_wrap_t<T>>(
           dereference_wrapper(source_coords[0]), 0.0)};
-  get<0, 0>(jac) = get<0, 0>(rotation_matrix_);
-  get<1, 0>(jac) = get<1, 0>(rotation_matrix_);
-  get<0, 1>(jac) = get<0, 1>(rotation_matrix_);
-  get<1, 1>(jac) = get<1, 1>(rotation_matrix_);
-  return jac;
+  get<0, 0>(jacobian_matrix) = get<0, 0>(rotation_matrix_);
+  get<1, 0>(jacobian_matrix) = get<1, 0>(rotation_matrix_);
+  get<0, 1>(jacobian_matrix) = get<0, 1>(rotation_matrix_);
+  get<1, 1>(jacobian_matrix) = get<1, 1>(rotation_matrix_);
+  return jacobian_matrix;
 }
 
 template <typename T>
-Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-       tmpl::integral_list<std::int32_t, 2, 1>,
-       index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                  SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::inv_jacobian(const std::array<T, 2>& source_coords) const {
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-      inv_jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame>
+Rotation<2>::inv_jacobian(const std::array<T, 2>& source_coords) const
+    noexcept {
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> inv_jacobian_matrix{
+      make_with_value<tt::remove_cvref_wrap_t<T>>(
           dereference_wrapper(source_coords[0]), 0.0)};
-  get<0, 0>(inv_jac) = get<0, 0>(rotation_matrix_);
-  get<1, 0>(inv_jac) = get<0, 1>(rotation_matrix_);
-  get<0, 1>(inv_jac) = get<1, 0>(rotation_matrix_);
-  get<1, 1>(inv_jac) = get<1, 1>(rotation_matrix_);
-  return inv_jac;
+  get<0, 0>(inv_jacobian_matrix) = get<0, 0>(rotation_matrix_);
+  get<1, 0>(inv_jacobian_matrix) = get<0, 1>(rotation_matrix_);
+  get<0, 1>(inv_jacobian_matrix) = get<1, 0>(rotation_matrix_);
+  get<1, 1>(inv_jacobian_matrix) = get<1, 1>(rotation_matrix_);
+  return inv_jacobian_matrix;
 }
 
 void Rotation<2>::pup(PUP::er& p) {
@@ -117,8 +107,8 @@ Rotation<3>::Rotation(const double rotation_about_z,
 }
 
 template <typename T>
-std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> Rotation<3>::
-operator()(const std::array<T, 3>& source_coords) const {
+std::array<tt::remove_cvref_wrap_t<T>, 3> Rotation<3>::operator()(
+    const std::array<T, 3>& source_coords) const noexcept {
   return {{source_coords[0] * get<0, 0>(rotation_matrix_) +
                source_coords[1] * get<0, 1>(rotation_matrix_) +
                source_coords[2] * get<0, 2>(rotation_matrix_),
@@ -131,8 +121,8 @@ operator()(const std::array<T, 3>& source_coords) const {
 }
 
 template <typename T>
-std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3>
-Rotation<3>::inverse(const std::array<T, 3>& target_coords) const {
+std::array<tt::remove_cvref_wrap_t<T>, 3> Rotation<3>::inverse(
+    const std::array<T, 3>& target_coords) const noexcept {
   // Inverse rotation matrix is the same as the transpose.
   return {{target_coords[0] * get<0, 0>(rotation_matrix_) +
                target_coords[1] * get<1, 0>(rotation_matrix_) +
@@ -146,51 +136,40 @@ Rotation<3>::inverse(const std::array<T, 3>& target_coords) const {
 }
 
 template <typename T>
-Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-       tmpl::integral_list<std::int32_t, 2, 1>,
-       index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                  SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::jacobian(const std::array<T, 3>& source_coords) const {
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-      jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Rotation<3>::jacobian(
+    const std::array<T, 3>& source_coords) const noexcept {
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian_matrix{
+      make_with_value<tt::remove_cvref_wrap_t<T>>(
           dereference_wrapper(source_coords[0]), 0.0)};
-  get<0, 0>(jac) = get<0, 0>(rotation_matrix_);
-  get<1, 0>(jac) = get<1, 0>(rotation_matrix_);
-  get<0, 1>(jac) = get<0, 1>(rotation_matrix_);
-  get<1, 1>(jac) = get<1, 1>(rotation_matrix_);
-  get<2, 0>(jac) = get<2, 0>(rotation_matrix_);
-  get<2, 1>(jac) = get<2, 1>(rotation_matrix_);
-  get<0, 2>(jac) = get<0, 2>(rotation_matrix_);
-  get<1, 2>(jac) = get<1, 2>(rotation_matrix_);
-  get<2, 2>(jac) = get<2, 2>(rotation_matrix_);
-  return jac;
+  get<0, 0>(jacobian_matrix) = get<0, 0>(rotation_matrix_);
+  get<1, 0>(jacobian_matrix) = get<1, 0>(rotation_matrix_);
+  get<0, 1>(jacobian_matrix) = get<0, 1>(rotation_matrix_);
+  get<1, 1>(jacobian_matrix) = get<1, 1>(rotation_matrix_);
+  get<2, 0>(jacobian_matrix) = get<2, 0>(rotation_matrix_);
+  get<2, 1>(jacobian_matrix) = get<2, 1>(rotation_matrix_);
+  get<0, 2>(jacobian_matrix) = get<0, 2>(rotation_matrix_);
+  get<1, 2>(jacobian_matrix) = get<1, 2>(rotation_matrix_);
+  get<2, 2>(jacobian_matrix) = get<2, 2>(rotation_matrix_);
+  return jacobian_matrix;
 }
 
 template <typename T>
-Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-       tmpl::integral_list<std::int32_t, 2, 1>,
-       index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                  SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::inv_jacobian(const std::array<T, 3>& source_coords) const {
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-      inv_jac{make_with_value<std::decay_t<tt::remove_reference_wrapper_t<T>>>(
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+Rotation<3>::inv_jacobian(const std::array<T, 3>& source_coords) const
+    noexcept {
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian_matrix{
+      make_with_value<tt::remove_cvref_wrap_t<T>>(
           dereference_wrapper(source_coords[0]), 0.0)};
-  get<0, 0>(inv_jac) = get<0, 0>(rotation_matrix_);
-  get<1, 0>(inv_jac) = get<0, 1>(rotation_matrix_);
-  get<0, 1>(inv_jac) = get<1, 0>(rotation_matrix_);
-  get<1, 1>(inv_jac) = get<1, 1>(rotation_matrix_);
-  get<2, 0>(inv_jac) = get<0, 2>(rotation_matrix_);
-  get<2, 1>(inv_jac) = get<1, 2>(rotation_matrix_);
-  get<0, 2>(inv_jac) = get<2, 0>(rotation_matrix_);
-  get<1, 2>(inv_jac) = get<2, 1>(rotation_matrix_);
-  get<2, 2>(inv_jac) = get<2, 2>(rotation_matrix_);
-  return inv_jac;
+  get<0, 0>(inv_jacobian_matrix) = get<0, 0>(rotation_matrix_);
+  get<1, 0>(inv_jacobian_matrix) = get<0, 1>(rotation_matrix_);
+  get<0, 1>(inv_jacobian_matrix) = get<1, 0>(rotation_matrix_);
+  get<1, 1>(inv_jacobian_matrix) = get<1, 1>(rotation_matrix_);
+  get<2, 0>(inv_jacobian_matrix) = get<0, 2>(rotation_matrix_);
+  get<2, 1>(inv_jacobian_matrix) = get<1, 2>(rotation_matrix_);
+  get<0, 2>(inv_jacobian_matrix) = get<2, 0>(rotation_matrix_);
+  get<1, 2>(inv_jacobian_matrix) = get<2, 1>(rotation_matrix_);
+  get<2, 2>(inv_jacobian_matrix) = get<2, 2>(rotation_matrix_);
+  return inv_jacobian_matrix;
 }
 
 void Rotation<3>::pup(PUP::er& p) {  // NOLINT
@@ -209,127 +188,35 @@ bool operator==(const Rotation<3>& lhs, const Rotation<3>& rhs) noexcept {
 bool operator!=(const Rotation<3>& lhs, const Rotation<3>& rhs) noexcept {
   return not(lhs == rhs);
 }
+// Explicit instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-template std::array<double, 2> Rotation<2>::operator()(
-    const std::array<std::reference_wrapper<const double>, 2>& source_coords)
-    const;
-template std::array<double, 2> Rotation<2>::operator()(
-    const std::array<double, 2>& source_coords) const;
-template std::array<DataVector, 2> Rotation<2>::operator()(
-    const std::array<std::reference_wrapper<const DataVector>, 2>&
-        source_coords) const;
-template std::array<DataVector, 2> Rotation<2>::operator()(
-    const std::array<DataVector, 2>& source_coords) const;
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
+  Rotation<DIM(data)>::operator()(                                             \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept; \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
+  Rotation<DIM(data)>::inverse(                                                \
+      const std::array<DTYPE(data), DIM(data)>& target_coords) const noexcept; \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
+                    Frame::NoFrame>                                            \
+  Rotation<DIM(data)>::jacobian(                                               \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept; \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
+                    Frame::NoFrame>                                            \
+  Rotation<DIM(data)>::inv_jacobian(                                           \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept;
 
-template std::array<double, 2> Rotation<2>::inverse(
-    const std::array<std::reference_wrapper<const double>, 2>& target_coords)
-    const;
-template std::array<double, 2> Rotation<2>::inverse(
-    const std::array<double, 2>& target_coords) const;
-template std::array<DataVector, 2> Rotation<2>::inverse(
-    const std::array<std::reference_wrapper<const DataVector>, 2>&
-        target_coords) const;
-template std::array<DataVector, 2> Rotation<2>::inverse(
-    const std::array<DataVector, 2>& target_coords) const;
+GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
 
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::jacobian(const std::array<std::reference_wrapper<const double>, 2>&
-                          source_coords) const;
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::jacobian(const std::array<double, 2>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                       2>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::jacobian(const std::array<DataVector, 2>& source_coords) const;
-
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::inv_jacobian(const std::array<std::reference_wrapper<const double>,
-                                           2>& source_coords) const;
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::inv_jacobian(const std::array<double, 2>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::inv_jacobian(
-    const std::array<std::reference_wrapper<const DataVector>, 2>&
-        source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-Rotation<2>::inv_jacobian(const std::array<DataVector, 2>& source_coords) const;
-
-template std::array<double, 3> Rotation<3>::operator()(
-    const std::array<std::reference_wrapper<const double>, 3>& source_coords)
-    const;
-template std::array<double, 3> Rotation<3>::operator()(
-    const std::array<double, 3>& source_coords) const;
-template std::array<DataVector, 3> Rotation<3>::operator()(
-    const std::array<std::reference_wrapper<const DataVector>, 3>&
-        source_coords) const;
-template std::array<DataVector, 3> Rotation<3>::operator()(
-    const std::array<DataVector, 3>& source_coords) const;
-
-template std::array<double, 3> Rotation<3>::inverse(
-    const std::array<std::reference_wrapper<const double>, 3>& target_coords)
-    const;
-template std::array<double, 3> Rotation<3>::inverse(
-    const std::array<double, 3>& target_coords) const;
-template std::array<DataVector, 3> Rotation<3>::inverse(
-    const std::array<std::reference_wrapper<const DataVector>, 3>&
-        target_coords) const;
-template std::array<DataVector, 3> Rotation<3>::inverse(
-    const std::array<DataVector, 3>& target_coords) const;
-
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::jacobian(const std::array<std::reference_wrapper<const double>, 3>&
-                          source_coords) const;
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::jacobian(const std::array<double, 3>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::jacobian(const std::array<std::reference_wrapper<const DataVector>,
-                                       3>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::jacobian(const std::array<DataVector, 3>& source_coords) const;
-
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::inv_jacobian(const std::array<std::reference_wrapper<const double>,
-                                           3>& source_coords) const;
-template Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::inv_jacobian(const std::array<double, 3>& source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::inv_jacobian(
-    const std::array<std::reference_wrapper<const DataVector>, 3>&
-        source_coords) const;
-template Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                           SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-Rotation<3>::inv_jacobian(const std::array<DataVector, 3>& source_coords) const;
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
 
 }  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/Rotation.hpp
@@ -10,7 +10,11 @@
 #include <memory>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Parallel/CharmPupable.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
 
 namespace CoordinateMaps {
 
@@ -51,26 +55,20 @@ class Rotation<2> {
   Rotation& operator=(Rotation&&) = default;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> operator()(
-      const std::array<T, 2>& source_coords) const;
+  std::array<tt::remove_cvref_wrap_t<T>, 2> operator()(
+      const std::array<T, 2>& source_coords) const noexcept;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> inverse(
-      const std::array<T, 2>& target_coords) const;
+  std::array<tt::remove_cvref_wrap_t<T>, 2> inverse(
+      const std::array<T, 2>& target_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 2>& source_coords) const;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> jacobian(
+      const std::array<T, 2>& source_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 2>& source_coords) const;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 2>& source_coords) const noexcept;
 
   void pup(PUP::er& p);  // NOLINT
 
@@ -129,26 +127,20 @@ class Rotation<3> {
   Rotation& operator=(Rotation&&) = default;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> operator()(
-      const std::array<T, 3>& source_coords) const;
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const noexcept;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 3> inverse(
-      const std::array<T, 3>& target_coords) const;
+  std::array<tt::remove_cvref_wrap_t<T>, 3> inverse(
+      const std::array<T, 3>& target_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 3>& source_coords) const;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<3, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<3, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 3>& source_coords) const;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const noexcept;
 
   void pup(PUP::er& p);  // NOLINT
 

--- a/src/Domain/CoordinateMaps/Wedge2D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.hpp
@@ -12,6 +12,7 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Direction.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 namespace CoordinateMaps {
 
@@ -39,26 +40,20 @@ class Wedge2D {
   Wedge2D& operator=(const Wedge2D&) = default;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> operator()(
+  std::array<tt::remove_cvref_wrap_t<T>, 2> operator()(
       const std::array<T, 2>& source_coords) const noexcept;
 
   template <typename T>
-  std::array<std::decay_t<tt::remove_reference_wrapper_t<T>>, 2> inverse(
+  std::array<tt::remove_cvref_wrap_t<T>, 2> inverse(
       const std::array<T, 2>& target_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-  jacobian(const std::array<T, 2>& source_coords) const noexcept;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> jacobian(
+      const std::array<T, 2>& source_coords) const noexcept;
 
   template <typename T>
-  Tensor<std::decay_t<tt::remove_reference_wrapper_t<T>>,
-         tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                    SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-  inv_jacobian(const std::array<T, 2>& source_coords) const noexcept;
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 2>& source_coords) const noexcept;
 
   // clang-tidy: google runtime references
   void pup(PUP::er& p);  // NOLINT

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -219,8 +219,8 @@ void test_partial_derivatives_1d(const Index<1>& extents) {
   const auto map_1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
       CoordinateMaps::Affine{x_map});
   const auto x = map_1d(logical_coordinates(extents));
-  const InverseJacobian<1, Frame::Logical, Frame::Grid> inverse_jacobian(
-      extents.product(), 2.0);
+  const InverseJacobian<DataVector, 1, Frame::Logical, Frame::Grid>
+      inverse_jacobian(extents.product(), 2.0);
 
   Variables<VariableTags> u(number_of_grid_points);
   Variables<
@@ -256,7 +256,7 @@ void test_partial_derivatives_2d(const Index<2>& extents) {
       make_coordinate_map<Frame::Logical, Frame::Grid>(affine_map_2d{
           affine_map{-1.0, 1.0, -0.3, 0.7}, affine_map{-1.0, 1.0, 0.3, 0.55}});
   const auto x = prod_map2d(logical_coordinates(extents));
-  InverseJacobian<2, Frame::Logical, Frame::Grid> inverse_jacobian(
+  InverseJacobian<DataVector, 2, Frame::Logical, Frame::Grid> inverse_jacobian(
       number_of_grid_points, 0.0);
   inverse_jacobian.get(0, 0) = 2.0;
   inverse_jacobian.get(1, 1) = 8.0;
@@ -301,7 +301,7 @@ void test_partial_derivatives_3d(const Index<3>& extents) {
           affine_map{-1.0, 1.0, -0.3, 0.7}, affine_map{-1.0, 1.0, 0.3, 0.55},
           affine_map{-1.0, 1.0, 2.3, 2.8}});
   const auto x = prod_map3d(logical_coordinates(extents));
-  InverseJacobian<3, Frame::Logical, Frame::Grid> inverse_jacobian(
+  InverseJacobian<DataVector, 3, Frame::Logical, Frame::Grid> inverse_jacobian(
       extents.product(), 0.0);
   inverse_jacobian.get(0, 0) = 2.0;
   inverse_jacobian.get(1, 1) = 8.0;


### PR DESCRIPTION
## Proposed changes

Clean up more CoordinateMaps by using type aliases and GENERATE_INSTANTIATIONS
Closes #545 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
