### PR TITLE
Error and documentation improvements

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -367,7 +367,7 @@ into two classes:
  * To compare two floating-point numbers that may differ by round-off, use the
  * helper object `approx`. This is an instance of Catch's comparison class
  * `Approx` in which the relative tolerance for comparisons is set to roughly
- * \f$10^{-14}\f$ (i.e. `std\:\:numeric_limits<double>\:\:epsilon()*100`).
+ * \f$10^{-14}\f$ (i.e. `std::numeric_limits<double>::%epsilon()*100`).
  * When possible, we recommend using `approx` for fuzzy comparisons as follows:
  * \example
  * \snippet TestFramework.cpp approx_default
@@ -385,7 +385,7 @@ into two classes:
  * \snippet TestFramework.cpp approx_new_custom
  *
  * Note: We provide the `approx` object because Catch's `Approx` defaults to a
- * very loose tolerance (`std\:\:numeric_limits<float>\:\:epsilon()*100`, or
+ * very loose tolerance (`std::numeric_limits<float>::%epsilon()*100`, or
  * roughly \f$10^{-5}\f$ relative error), and so is poorly-suited to checking
  * many numerical algorithms that rely on double-precision accuracy. By
  * providing a tighter tolerance with `approx`, we avoid having to redefine the
@@ -416,12 +416,12 @@ into two classes:
  * </td>
  * </tr>
  * <tr>
- * <td>ErrorRegex </td>
+ * <td>OutputRegex </td>
  * <td>
  * When testing failure modes the exact error message must be tested, not
  * just that the test failed. Since the string passed is a regular
  * expression you must escape any regex tokens. For example, to match
- * "some (word) and" you must specify the string "some \(word\) and".
+ * `some (word) and` you must specify the string `some \(word\) and`.
  * </td>
  * </tr>
  * </table>

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -381,9 +381,8 @@ struct compute_item_result_impl<
   using type = typename Tag::type;
 };
 
-template <typename Tag>
-struct compute_item_result_impl<
-    Tag, Requires<not std::is_base_of<db::DataBoxTag, Tag>::value>> {
+template <>
+struct compute_item_result_impl<Tags::DataBox> {
   using type = NoSuchType;
 };
 }  // namespace detail

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -466,10 +466,20 @@ void Variables<tmpl::list<Tags...>>::pup(PUP::er& p) {
  */
 template <typename Tag, typename TagList>
 constexpr typename Tag::type& get(Variables<TagList>& v) noexcept {
+  static_assert(tmpl::list_contains_v<TagList, Tag>,
+                "Could not retrieve Tag from Variables. See the first "
+                "template parameter of the instantiation for what Tag is "
+                "being retrieved and the second template parameter for "
+                "what Tags are available.");
   return tuples::get<Tag>(v.reference_variable_data_);
 }
 template <typename Tag, typename TagList>
 constexpr const typename Tag::type& get(const Variables<TagList>& v) noexcept {
+  static_assert(tmpl::list_contains_v<TagList, Tag>,
+                "Could not retrieve Tag from Variables. See the first "
+                "template parameter of the instantiation for what Tag is "
+                "being retrieved and the second template parameter for "
+                "what Tags are available.");
   return tuples::get<Tag>(v.reference_variable_data_);
 }
 // @}

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -14,12 +14,14 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
 template <size_t Dim>
 class Index;
 template <typename DataType, typename Symm, typename IndexList>
 class Tensor;
 template <typename TagsList>
 class Variables;
+/// \endcond
 
 namespace Tags {
 template <size_t Dim>

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -61,7 +61,7 @@
  *
  * \details
  * Catch's default (relative) tolerance for comparing floating-point numbers is
- * `std\:\:numeric_limits<float>\:\:epsilon() * 100`, or roughly \f$10^{-5}\f$.
+ * `std::numeric_limits<float>::%epsilon() * 100`, or roughly \f$10^{-5}\f$.
  * This tolerance is too loose for checking many scientific algorithms that
  * rely on double precision floating-point accuracy, so we provide a tighter
  * tighter tolerance through the `approx` static object.


### PR DESCRIPTION
### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
