### PR TITLE
Require CATCH 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,7 +171,7 @@ before_install:
 
       git clone https://github.com/philsquared/Catch.git;
       cd Catch;
-      git checkout v1.9.4;
+      git checkout v2.1.2;
       cd $HOME;
 
       git clone https://github.com/edouarda/brigand.git;

--- a/cmake/SetupCatch.cmake
+++ b/cmake/SetupCatch.cmake
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(Catch 1.8 REQUIRED)
+find_package(Catch 2.1.0 REQUIRED)
 
 include_directories(SYSTEM "${CATCH_INCLUDE_DIR}")
 message(STATUS "Catch include: ${CATCH_INCLUDE_DIR}")

--- a/docs/MainSite/Installation.md
+++ b/docs/MainSite/Installation.md
@@ -17,7 +17,7 @@ See LICENSE.txt for details.
 * [Blaze](https://bitbucket.org/blaze-lib/blaze/overview) v3.2
 * [Boost](http://www.boost.org/)
 * [Brigand](https://github.com/edouarda/brigand)
-* [Catch](https://github.com/philsquared/Catch)
+* [Catch](https://github.com/philsquared/Catch) 2.1.0 or later
 * [GSL](https://www.gnu.org/software/gsl/)
 * [HDF5](https://support.hdfgroup.org/HDF5/) (non-mpi version on macOS)
 * [jemalloc](https://github.com/jemalloc/jemalloc)

--- a/tests/Unit/Parallel/Test_Algorithm.cpp
+++ b/tests/Unit/Parallel/Test_Algorithm.cpp
@@ -1,6 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <catch.hpp>
 #include <unordered_map>
 
 #include "AlgorithmSingleton.hpp"

--- a/tests/Unit/Parallel/Test_Parallel.cpp
+++ b/tests/Unit/Parallel/Test_Parallel.cpp
@@ -37,6 +37,9 @@ SPECTRE_TEST_CASE("Unit.Parallel.printf", "[Unit][Parallel]") {
   Parallel::printf("%d %lld %s %s %s %s\n", -100, 3000000000, TestStream{},
                    c_string0, c_string1, c_string2);
   delete[] c_string1;
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.Parallel.printf does not need to check anything
+  CHECK(true);
 }
 
 SPECTRE_TEST_CASE("Unit.Parallel.NodeAndPes", "[Unit][Parallel]") {

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -1,6 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <catch.hpp>
 #include <string>
 #include <vector>
 

--- a/tests/Unit/Utilities/Test_TaggedTuple.cpp
+++ b/tests/Unit/Utilities/Test_TaggedTuple.cpp
@@ -1,6 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include <catch.hpp>
 #include <memory>
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
## Proposed changes

With the current CATCH 1, inlined std arrays are interpreted as extra arguments if extra parentheses are not added around them. Closes #563 
~~note: there are unresolved issues (#566) with Catch 2.1.2 so we are using 2.1.1 or 2.1.0.~~
note: these issues are resolved in #577.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
