### PR TITLE
Remove typelist type alias

### DIFF
--- a/docs/DevGuide/ProfilingWithProjections.md
+++ b/docs/DevGuide/ProfilingWithProjections.md
@@ -12,7 +12,7 @@ If you encounter issues it may
 be necessary to clone the git repository and build the correct version
 from scratch. Note that the version of Charm++ used to compile SpECTRE
 should match the version of Projections used to analyze the trace data.
-You can collect the trace data on a different machine than the one you 
+You can collect the trace data on a different machine than the one you
 will be analyzing the data on. For example, you can collect the data on
 a supercomputer and analyze it on your desktop or laptop.
 
@@ -36,7 +36,7 @@ in the main executable. This typically means right after the
 `the_ordered_actions_list` list is defined in the main executable. For example,
 
 ```cpp
-using the_ordered_actions_list = typelist<
+using the_ordered_actions_list = tmpl::list<
     Algorithms::CheckTriggers<the_system, the_volume_dim>,
     Algorithms::SendDataForFluxes<the_system, the_volume_dim>,
     Algorithms::ComputeVolumeDtU<the_system, the_volume_dim>,
@@ -46,7 +46,7 @@ using the_ordered_actions_list = typelist<
     Algorithms::AdvanceSlab<the_system, the_volume_dim>,
     Algorithms::UpdateInstance<the_system, the_volume_dim>>;
 
-using the_trace_actions_list = typelist<
+using the_trace_actions_list = tmpl::list<
     Algorithms::CheckTriggers<the_system, the_volume_dim>,
     Algorithms::ComputeVolumeDtU<the_system, the_volume_dim>,
     Algorithms::ComputeBoundaryFlux<the_system, the_volume_dim>,

--- a/src/ApparentHorizons/StrahlkorperDataBox.hpp
+++ b/src/ApparentHorizons/StrahlkorperDataBox.hpp
@@ -59,7 +59,7 @@ struct ThetaPhi : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "ThetaPhi";
   static StrahlkorperTags_detail::ThetaPhi<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper) noexcept;
-  using argument_tags = typelist<Strahlkorper<Frame>>;
+  using argument_tags = tmpl::list<Strahlkorper<Frame>>;
 };
 
 /// \f$x_i/\sqrt{x^2+y^2+z^2}\f$ on the grid.
@@ -69,7 +69,7 @@ struct Rhat : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "Rhat";
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
-  using argument_tags = typelist<ThetaPhi<Frame>>;
+  using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
 
 /// `Jacobian(i,0)` is \f$\frac{1}{r}\partial x^i/\partial\theta\f$,
@@ -82,7 +82,7 @@ struct Jacobian : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "Jacobian";
   static StrahlkorperTags_detail::Jacobian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
-  using argument_tags = typelist<ThetaPhi<Frame>>;
+  using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
 
 /// `InvJacobian(0,i)` is \f$r\partial\theta/\partial x^i\f$,
@@ -94,7 +94,7 @@ struct InvJacobian : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "InvJacobian";
   static StrahlkorperTags_detail::InvJacobian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
-  using argument_tags = typelist<ThetaPhi<Frame>>;
+  using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
 
 /// `InvHessian(k,i,j)` is \f$\partial (J^{-1}){}^k_j/\partial x^i\f$,
@@ -106,7 +106,7 @@ struct InvHessian : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "InvHessian";
   static StrahlkorperTags_detail::InvHessian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
-  using argument_tags = typelist<ThetaPhi<Frame>>;
+  using argument_tags = tmpl::list<ThetaPhi<Frame>>;
 };
 
 /// (Euclidean) distance \f$r(\theta,\phi)\f$ from the center to each
@@ -119,7 +119,7 @@ struct Radius : db::ComputeItemTag {
     return strahlkorper.ylm_spherepack().spec_to_phys(
         strahlkorper.coefficients());
   }
-  using argument_tags = typelist<Strahlkorper<Frame>>;
+  using argument_tags = tmpl::list<Strahlkorper<Frame>>;
 };
 
 /// \f$(x,y,z)\f$ of each point on the surface.
@@ -130,7 +130,7 @@ struct CartesianCoords : db::ComputeItemTag {
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<Rhat<Frame>>& r_hat) noexcept;
   using argument_tags =
-      typelist<Strahlkorper<Frame>, Radius<Frame>, Rhat<Frame>>;
+      tmpl::list<Strahlkorper<Frame>, Radius<Frame>, Rhat<Frame>>;
 };
 
 /// `DxRadius(i)` is \f$\partial r/\partial x^i\f$.
@@ -144,7 +144,7 @@ struct DxRadius : db::ComputeItemTag {
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<InvJacobian<Frame>>& inv_jac) noexcept;
   using argument_tags =
-      typelist<Strahlkorper<Frame>, Radius<Frame>, InvJacobian<Frame>>;
+      tmpl::list<Strahlkorper<Frame>, Radius<Frame>, InvJacobian<Frame>>;
 };
 
 /// `D2xRadius(i,j)` is \f$\partial^2 r/\partial x^i\partial x^j\f$.
@@ -158,8 +158,8 @@ struct D2xRadius : db::ComputeItemTag {
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<InvJacobian<Frame>>& inv_jac,
       const db::item_type<InvHessian<Frame>>& inv_hess) noexcept;
-  using argument_tags = typelist<Strahlkorper<Frame>, Radius<Frame>,
-                                 InvJacobian<Frame>, InvHessian<Frame>>;
+  using argument_tags = tmpl::list<Strahlkorper<Frame>, Radius<Frame>,
+                                   InvJacobian<Frame>, InvHessian<Frame>>;
 };
 
 /// \f$\nabla^2 r\f$, the flat Laplacian of the surface.
@@ -172,7 +172,7 @@ struct LaplacianRadius : db::ComputeItemTag {
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags =
-      typelist<Strahlkorper<Frame>, Radius<Frame>, ThetaPhi<Frame>>;
+      tmpl::list<Strahlkorper<Frame>, Radius<Frame>, ThetaPhi<Frame>>;
 };
 
 /// Cartesian components of (unnormalized) one-form defining the surface.
@@ -186,7 +186,7 @@ struct NormalOneForm : db::ComputeItemTag {
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const db::item_type<DxRadius<Frame>>& dx_radius,
       const db::item_type<Rhat<Frame>>& r_hat) noexcept;
-  using argument_tags = typelist<DxRadius<Frame>, Rhat<Frame>>;
+  using argument_tags = tmpl::list<DxRadius<Frame>, Rhat<Frame>>;
 };
 
 /// `Tangents(j,i)` is \f$\partial x_{\rm surf}^i/\partial q^j\f$,
@@ -203,18 +203,18 @@ struct Tangents : db::ComputeItemTag {
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<Rhat<Frame>>& r_hat,
       const db::item_type<Jacobian<Frame>>& jac) noexcept;
-  using argument_tags = typelist<Strahlkorper<Frame>, Radius<Frame>,
-                                 Rhat<Frame>, Jacobian<Frame>>;
+  using argument_tags = tmpl::list<Strahlkorper<Frame>, Radius<Frame>,
+                                   Rhat<Frame>, Jacobian<Frame>>;
 };
 
 template <typename Frame>
-using items_tags = typelist<Strahlkorper<Frame>>;
+using items_tags = tmpl::list<Strahlkorper<Frame>>;
 
 template <typename Frame>
 using compute_items_tags =
-    typelist<ThetaPhi<Frame>, Rhat<Frame>, Jacobian<Frame>, InvJacobian<Frame>,
-             InvHessian<Frame>, Radius<Frame>, CartesianCoords<Frame>,
-             DxRadius<Frame>, D2xRadius<Frame>, LaplacianRadius<Frame>,
-             NormalOneForm<Frame>, Tangents<Frame>>;
+    tmpl::list<ThetaPhi<Frame>, Rhat<Frame>, Jacobian<Frame>,
+               InvJacobian<Frame>, InvHessian<Frame>, Radius<Frame>,
+               CartesianCoords<Frame>, DxRadius<Frame>, D2xRadius<Frame>,
+               LaplacianRadius<Frame>, NormalOneForm<Frame>, Tangents<Frame>>;
 
 }  // namespace StrahlkorperTags

--- a/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp
@@ -19,7 +19,7 @@ namespace determinant_and_inverse_detail {
 // Helps to shorten some repeated code:
 template <typename Index0, typename Index1>
 using inverse_indices =
-    typelist<change_index_up_lo<Index1>, change_index_up_lo<Index0>>;
+    tmpl::list<change_index_up_lo<Index1>, change_index_up_lo<Index0>>;
 template <typename T, typename Symm, typename Index0, typename Index1>
 using determinant_inverse_pair =
     std::pair<Scalar<T>, Tensor<T, Symm, inverse_indices<Index0, Index1>>>;
@@ -32,7 +32,7 @@ template <typename Symm, typename Index0, typename Index1>
 struct DetAndInverseImpl<Symm, Index0, Index1, Requires<Index0::dim == 1>> {
   template <typename T>
   static determinant_inverse_pair<T, Symm, Index0, Index1> apply(
-      const Tensor<T, Symm, typelist<Index0, Index1>>& tensor) {
+      const Tensor<T, Symm, tmpl::list<Index0, Index1>>& tensor) {
     const T& t00 = get<0, 0>(tensor);
     // inv is non-const so that it can be moved into the std::pair:
     Tensor<T, Symm, inverse_indices<Index0, Index1>> inv{
@@ -47,7 +47,7 @@ struct DetAndInverseImpl<Symmetry<2, 1>, Index0, Index1,
                          Requires<Index0::dim == 2>> {
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<2, 1>, Index0, Index1> apply(
-      const Tensor<T, Symmetry<2, 1>, typelist<Index0, Index1>>& tensor) {
+      const Tensor<T, Symmetry<2, 1>, tmpl::list<Index0, Index1>>& tensor) {
     const T& t00 = get<0, 0>(tensor);
     const T& t01 = get<0, 1>(tensor);
     const T& t10 = get<1, 0>(tensor);
@@ -69,7 +69,7 @@ struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
                          Requires<Index0::dim == 2>> {
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<1, 1>, Index0, Index0> apply(
-      const Tensor<T, Symmetry<1, 1>, typelist<Index0, Index0>>& tensor) {
+      const Tensor<T, Symmetry<1, 1>, tmpl::list<Index0, Index0>>& tensor) {
     const T& t00 = get<0, 0>(tensor);
     const T& t01 = get<0, 1>(tensor);
     const T& t11 = get<1, 1>(tensor);
@@ -91,7 +91,7 @@ struct DetAndInverseImpl<Symmetry<2, 1>, Index0, Index1,
                          Requires<Index0::dim == 3>> {
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<2, 1>, Index0, Index1> apply(
-      const Tensor<T, Symmetry<2, 1>, typelist<Index0, Index1>>& tensor) {
+      const Tensor<T, Symmetry<2, 1>, tmpl::list<Index0, Index1>>& tensor) {
     const T& t00 = get<0, 0>(tensor);
     const T& t01 = get<0, 1>(tensor);
     const T& t02 = get<0, 2>(tensor);
@@ -126,7 +126,7 @@ struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
                          Requires<Index0::dim == 3>> {
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<1, 1>, Index0, Index0> apply(
-      const Tensor<T, Symmetry<1, 1>, typelist<Index0, Index0>>& tensor) {
+      const Tensor<T, Symmetry<1, 1>, tmpl::list<Index0, Index0>>& tensor) {
     const T& t00 = get<0, 0>(tensor);
     const T& t01 = get<0, 1>(tensor);
     const T& t02 = get<0, 2>(tensor);
@@ -171,7 +171,7 @@ struct DetAndInverseImpl<Symmetry<2, 1>, Index0, Index1,
                          Requires<Index0::dim == 4>> {
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<2, 1>, Index0, Index1> apply(
-      const Tensor<T, Symmetry<2, 1>, typelist<Index0, Index1>>& tensor) {
+      const Tensor<T, Symmetry<2, 1>, tmpl::list<Index0, Index1>>& tensor) {
     const T& p00 = get<0, 0>(tensor);
     const T& p01 = get<0, 1>(tensor);
     const T& p10 = get<1, 0>(tensor);
@@ -263,7 +263,7 @@ struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
                          Requires<Index0::dim == 4>> {
   template <typename T>
   static determinant_inverse_pair<T, Symmetry<1, 1>, Index0, Index0> apply(
-      const Tensor<T, Symmetry<1, 1>, typelist<Index0, Index0>>& tensor) {
+      const Tensor<T, Symmetry<1, 1>, tmpl::list<Index0, Index0>>& tensor) {
     const T& p00 = get<0, 0>(tensor);
     const T& p01 = get<0, 1>(tensor);
     const T& p11 = get<1, 1>(tensor);
@@ -349,10 +349,12 @@ struct DetAndInverseImpl<Symmetry<1, 1>, Index0, Index0,
  * 3-metric, in which only the spatial 3-metric needs to be inverted.
  */
 template <typename T, typename Symm, typename Index0, typename Index1>
-std::pair<Scalar<T>, Tensor<T, Symm, typelist<change_index_up_lo<Index1>,
-                                              change_index_up_lo<Index0>>>>
+std::pair<
+    Scalar<T>,
+    Tensor<T, Symm,
+           tmpl::list<change_index_up_lo<Index1>, change_index_up_lo<Index0>>>>
 determinant_and_inverse(
-    const Tensor<T, Symm, typelist<Index0, Index1>>& tensor) {
+    const Tensor<T, Symm, tmpl::list<Index0, Index1>>& tensor) {
   static_assert(Index0::dim == Index1::dim,
                 "Cannot take the inverse of a Tensor whose Indices are not "
                 "of the same dimensionality.");

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -23,7 +23,7 @@
  */
 template <typename DataType, typename Index>
 DataType magnitude(
-    const Tensor<DataType, Symmetry<1>, typelist<Index>>& tensor) {
+    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& tensor) {
   auto magnitude_squared = make_with_value<DataType>(tensor, 0.);
   for (size_t d = 0; d < Index::dim; ++d) {
     magnitude_squared += square(tensor.get(d));
@@ -43,8 +43,8 @@ DataType magnitude(
  */
 template <typename DataType, typename Index0, typename Index1>
 DataType magnitude(
-    const Tensor<DataType, Symmetry<1>, typelist<Index0>>& tensor,
-    const Tensor<DataType, Symmetry<1, 1>, typelist<Index1, Index1>>&
+    const Tensor<DataType, Symmetry<1>, tmpl::list<Index0>>& tensor,
+    const Tensor<DataType, Symmetry<1, 1>, tmpl::list<Index1, Index1>>&
         metric) {
   static_assert(std::is_same<Index0, change_index_up_lo<Index1>>::value,
                 "The indices of the tensor and metric must be the same, "

--- a/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
+++ b/src/DataStructures/Tensor/Expressions/TensorExpression.hpp
@@ -147,9 +147,9 @@ struct rhs_elements_in_lhs_helper {
 /// typelist
 ///
 /// \semantics
-/// If `Lhs = typelist<A, B, C, D>` and `Rhs = typelist<B, E, A>`, then
+/// If `Lhs = tmpl::list<A, B, C, D>` and `Rhs = tmpl::list<B, E, A>`, then
 /// \code{.cpp}
-/// result = typelist<B, A>;
+/// result = tmpl::list<B, A>;
 /// \endcode
 template <typename Lhs, typename Rhs>
 using rhs_elements_in_lhs =

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -112,7 +112,7 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   using symmetry = Symm;
   /// Typelist of the \ref SpacetimeIndex "TensorIndexType"'s that the
   /// Tensor has
-  using index_list = typelist<Indices...>;
+  using index_list = tmpl::list<Indices...>;
   /// The type of the TensorExpression that would represent this Tensor in a
   /// tensor expression.
   template <typename ArgsList>

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -374,10 +374,10 @@ using iJkk = Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
 template <size_t Dim, typename SourceFrame, typename TargetFrame>
 using InverseJacobian =
     Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-           typelist<SpatialIndex<Dim, UpLo::Up, SourceFrame>,
-                    SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>;
+           tmpl::list<SpatialIndex<Dim, UpLo::Up, SourceFrame>,
+                      SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>;
 
 template <size_t Dim, typename SourceFrame, typename TargetFrame>
 using Jacobian = Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                        typelist<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
-                                 SpatialIndex<Dim, UpLo::Lo, SourceFrame>>>;
+                        tmpl::list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
+                                   SpatialIndex<Dim, UpLo::Lo, SourceFrame>>>;

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -313,7 +313,7 @@ class Variables<tmpl::list<Tags...>> {
   //@}
 
   static SPECTRE_ALWAYS_INLINE void add_reference_variable_data(
-      typelist<> /*unused*/, const size_t /*variable_offset*/ = 0) {
+      tmpl::list<> /*unused*/, const size_t /*variable_offset*/ = 0) {
     ASSERT(sizeof...(Tags) > 0,
            "This ASSERT is triggered if you try to construct a Variables "
            "with no Tags. A Variables with no Tags is a valid type, but "
@@ -323,7 +323,7 @@ class Variables<tmpl::list<Tags...>> {
   template <
       typename TagToAdd, typename... Rest,
       Requires<tt::is_a<Tensor, typename TagToAdd::type>::value> = nullptr>
-  void add_reference_variable_data(typelist<TagToAdd, Rest...> /*unused*/,
+  void add_reference_variable_data(tmpl::list<TagToAdd, Rest...> /*unused*/,
                                    size_t variable_offset = 0);
 
   friend bool operator==(const Variables& lhs, const Variables& rhs) noexcept {
@@ -349,7 +349,7 @@ Variables<tmpl::list<Tags...>>::Variables(const size_t number_of_grid_points,
       variable_data_(variable_data_impl_.data(), variable_data_impl_.size()),
       size_(number_of_grid_points * number_of_independent_components),
       number_of_grid_points_(number_of_grid_points) {
-  add_reference_variable_data(typelist<Tags...>{});
+  add_reference_variable_data(tmpl::list<Tags...>{});
 }
 
 /// \cond HIDDEN_SYMBOLS
@@ -360,7 +360,7 @@ Variables<tmpl::list<Tags...>>::Variables(
       variable_data_(variable_data_impl_.data(), variable_data_impl_.size()),
       size_(rhs.size_),
       number_of_grid_points_(rhs.number_of_grid_points()) {
-  add_reference_variable_data(typelist<Tags...>{});
+  add_reference_variable_data(tmpl::list<Tags...>{});
 }
 
 template <typename... Tags>
@@ -373,7 +373,7 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
   size_ = rhs.size_;
   number_of_grid_points_ = rhs.number_of_grid_points();
-  add_reference_variable_data(typelist<Tags...>{});
+  add_reference_variable_data(tmpl::list<Tags...>{});
   return *this;
 }
 
@@ -387,7 +387,7 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
   size_ = rhs.size_;
   number_of_grid_points_ = std::move(rhs.number_of_grid_points_);
-  add_reference_variable_data(typelist<Tags...>{});
+  add_reference_variable_data(tmpl::list<Tags...>{});
   return *this;
 }
 
@@ -401,7 +401,7 @@ Variables<tmpl::list<Tags...>>::Variables(
       variable_data_(variable_data_impl_.data(), variable_data_impl_.size()),
       size_(rhs.size_),
       number_of_grid_points_(rhs.number_of_grid_points()) {
-  add_reference_variable_data(typelist<Tags...>{});
+  add_reference_variable_data(tmpl::list<Tags...>{});
 }
 
 template <typename... Tags>
@@ -414,7 +414,7 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
   size_ = rhs.size_;
   number_of_grid_points_ = rhs.number_of_grid_points();
-  add_reference_variable_data(typelist<Tags...>{});
+  add_reference_variable_data(tmpl::list<Tags...>{});
   return *this;
 }
 
@@ -440,7 +440,7 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
   size_ = rhs.size_;
   number_of_grid_points_ = std::move(rhs.number_of_grid_points_);
-  add_reference_variable_data(typelist<Tags...>{});
+  add_reference_variable_data(tmpl::list<Tags...>{});
   return *this;
 }
 
@@ -452,7 +452,7 @@ void Variables<tmpl::list<Tags...>>::pup(PUP::er& p) {
   if (p.isUnpacking()) {
     variable_data_.reset(variable_data_impl_.data(),
                          variable_data_impl_.size());
-    add_reference_variable_data(typelist<Tags...>{});
+    add_reference_variable_data(tmpl::list<Tags...>{});
   }
 }
 /// \endcond
@@ -483,7 +483,7 @@ Variables<tmpl::list<Tags...>>::Variables(
       size_((~expression).size()),
       number_of_grid_points_(size_ / number_of_independent_components) {
   variable_data_ = expression;
-  add_reference_variable_data(typelist<Tags...>{});
+  add_reference_variable_data(tmpl::list<Tags...>{});
 }
 
 /// \cond
@@ -496,7 +496,7 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   variable_data_impl_.resize(size_);
   variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
   variable_data_ = expression;
-  add_reference_variable_data(typelist<Tags...>{});
+  add_reference_variable_data(tmpl::list<Tags...>{});
   return *this;
 }
 /// \endcond
@@ -506,7 +506,7 @@ template <typename... Tags>
 template <typename TagToAdd, typename... Rest,
           Requires<tt::is_a<Tensor, typename TagToAdd::type>::value>>
 void Variables<tmpl::list<Tags...>>::add_reference_variable_data(
-    typelist<TagToAdd, Rest...> /*unused*/, const size_t variable_offset) {
+    tmpl::list<TagToAdd, Rest...> /*unused*/, const size_t variable_offset) {
   ASSERT(size_ > (variable_offset + TagToAdd::type::size() - 1) *
                      number_of_grid_points_,
          "This ASSERT is typically triggered because a Variables class was "
@@ -520,7 +520,7 @@ void Variables<tmpl::list<Tags...>>::add_reference_variable_data(
         &variable_data_[(variable_offset + i) * number_of_grid_points_],
         number_of_grid_points_);
   }
-  add_reference_variable_data(typelist<Rest...>{},
+  add_reference_variable_data(tmpl::list<Rest...>{},
                               variable_offset + TagToAdd::type::size());
 }
 /// \endcond
@@ -586,13 +586,13 @@ Variables<tmpl::list<Tags...>> operator/(
 namespace Variables_detail {
 template <typename TagsList>
 std::ostream& print_helper(std::ostream& os, const Variables<TagsList>& /*d*/,
-                           typelist<> /*meta*/) {
+                           tmpl::list<> /*meta*/) {
   return os << "Variables is empty!";
 }
 
 template <typename Tag, typename TagsList>
 std::ostream& print_helper(std::ostream& os, const Variables<TagsList>& d,
-                           typelist<Tag> /*meta*/) {
+                           tmpl::list<Tag> /*meta*/) {
   return os << pretty_type::short_name<Tag>() << ":\n" << get<Tag>(d);
 }
 
@@ -600,10 +600,10 @@ template <typename Tag, typename SecondTag, typename... RemainingTags,
           typename TagsList>
 std::ostream& print_helper(
     std::ostream& os, const Variables<TagsList>& d,
-    typelist<Tag, SecondTag, RemainingTags...> /*meta*/) {
+    tmpl::list<Tag, SecondTag, RemainingTags...> /*meta*/) {
   os << pretty_type::short_name<Tag>() << ":\n";
   os << get<Tag>(d) << "\n\n";
-  print_helper(os, d, typelist<SecondTag, RemainingTags...>{});
+  print_helper(os, d, tmpl::list<SecondTag, RemainingTags...>{});
   return os;
 }
 }  // namespace Variables_detail

--- a/src/Domain/DomainCreators/DomainCreator.hpp
+++ b/src/Domain/DomainCreators/DomainCreator.hpp
@@ -47,21 +47,21 @@ struct domain_creators;
 template <>
 struct domain_creators<1> {
   template <typename Frame>
-  using creators = typelist<DomainCreators::Interval<Frame>,
-                            DomainCreators::RotatedIntervals<Frame>>;
+  using creators = tmpl::list<DomainCreators::Interval<Frame>,
+                              DomainCreators::RotatedIntervals<Frame>>;
 };
 template <>
 struct domain_creators<2> {
   template <typename Frame>
   using creators =
-      typelist<DomainCreators::Disk<Frame>, DomainCreators::Rectangle<Frame>>;
+      tmpl::list<DomainCreators::Disk<Frame>, DomainCreators::Rectangle<Frame>>;
 };
 template <>
 struct domain_creators<3> {
   template <typename Frame>
   using creators =
-      typelist<DomainCreators::Brick<Frame>, DomainCreators::Shell<Frame>,
-               DomainCreators::Sphere<Frame>>;
+      tmpl::list<DomainCreators::Brick<Frame>, DomainCreators::Shell<Frame>,
+                 DomainCreators::Sphere<Frame>>;
 };
 }  // namespace DomainCreators_detail
 

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -100,7 +100,7 @@ struct Coordinates : db::ComputeItemTag, db::DataBoxPrefix {
       const db::item_type<SourceCoordsTag>& source_coords) noexcept {
     return element_map(source_coords);
   }
-  using argument_tags = typelist<MapTag, SourceCoordsTag>;
+  using argument_tags = tmpl::list<MapTag, SourceCoordsTag>;
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -117,7 +117,7 @@ struct InverseJacobian : db::ComputeItemTag, db::DataBoxPrefix {
       const db::item_type<SourceCoordsTag>& source_coords) noexcept {
     return element_map.inv_jacobian(source_coords);
   }
-  using argument_tags = typelist<MapTag, SourceCoordsTag>;
+  using argument_tags = tmpl::list<MapTag, SourceCoordsTag>;
 };
 
 namespace detail {

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -18,8 +18,8 @@ struct DgElementArray {
 
   using chare_type = Parallel::Algorithms::Array;
   using const_global_cache_tag_list = tmpl::flatten<
-      typelist<CacheTags::FinalTime, CacheTags::TimeStepper,
-               typename Metavariables::dg_element_array_add_to_cache>>;
+      tmpl::list<CacheTags::FinalTime, CacheTags::TimeStepper,
+                 typename Metavariables::dg_element_array_add_to_cache>>;
   using metavariables = Metavariables;
   using action_list = ActionList;
   using array_index = ElementIndex<volume_dim>;
@@ -31,8 +31,8 @@ struct DgElementArray {
       typename dg::Actions::InitializeElement<volume_dim>::
           template return_tag_list<typename Metavariables::system>>;
 
-  using options = typelist<typename Metavariables::domain_creator_tag,
-                           OptionTags::InitialTime, OptionTags::DeltaT>;
+  using options = tmpl::list<typename Metavariables::domain_creator_tag,
+                             OptionTags::InitialTime, OptionTags::DeltaT>;
 
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -69,8 +69,9 @@ namespace CurvedScalarWave {
  */
 template <size_t Dim>
 struct ComputeDuDt {
-  using return_tags = typelist<Tags::dt<Pi>, Tags::dt<Phi<Dim>>, Tags::dt<Psi>>;
-  using argument_tags = typelist<
+  using return_tags =
+      tmpl::list<Tags::dt<Pi>, Tags::dt<Phi<Dim>>, Tags::dt<Psi>>;
+  using argument_tags = tmpl::list<
       Pi, Phi<Dim>, Tags::deriv<Psi, tmpl::size_t<Dim>, Frame::Inertial>,
       Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,
       Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -37,23 +37,23 @@ namespace GeneralizedHarmonic {
 template <size_t Dim>
 struct ComputeDuDt {
  public:
-  using return_tags = typelist<Tags::dt<gr::Tags::SpacetimeMetric<Dim>>,
-                               Tags::dt<Pi<Dim>>, Tags::dt<Phi<Dim>>>;
+  using return_tags = tmpl::list<Tags::dt<gr::Tags::SpacetimeMetric<Dim>>,
+                                 Tags::dt<Pi<Dim>>, Tags::dt<Phi<Dim>>>;
   using argument_tags =
-      typelist<gr::Tags::SpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>,
-               Tags::deriv<gr::Tags::SpacetimeMetric<Dim>, tmpl::size_t<Dim>,
-                           Frame::Inertial>,
-               Tags::deriv<Pi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
-               Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
-               ConstraintGamma0, ConstraintGamma1, ConstraintGamma2,
-               GaugeH<Dim>, SpacetimeDerivGaugeH<Dim>, gr::Tags::Lapse<Dim>,
-               gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
-               gr::Tags::InverseSpacetimeMetric<Dim>,
-               gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim>,
-               gr::Tags::SpacetimeChristoffelFirstKind<Dim>,
-               gr::Tags::SpacetimeChristoffelSecondKind<Dim>,
-               gr::Tags::SpacetimeNormalVector<Dim>,
-               gr::Tags::SpacetimeNormalOneForm<Dim>>;
+      tmpl::list<gr::Tags::SpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>,
+                 Tags::deriv<gr::Tags::SpacetimeMetric<Dim>, tmpl::size_t<Dim>,
+                             Frame::Inertial>,
+                 Tags::deriv<Pi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+                 Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+                 ConstraintGamma0, ConstraintGamma1, ConstraintGamma2,
+                 GaugeH<Dim>, SpacetimeDerivGaugeH<Dim>, gr::Tags::Lapse<Dim>,
+                 gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
+                 gr::Tags::InverseSpacetimeMetric<Dim>,
+                 gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim>,
+                 gr::Tags::SpacetimeChristoffelFirstKind<Dim>,
+                 gr::Tags::SpacetimeChristoffelSecondKind<Dim>,
+                 gr::Tags::SpacetimeNormalVector<Dim>,
+                 gr::Tags::SpacetimeNormalOneForm<Dim>>;
 
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -58,7 +58,8 @@ namespace ScalarWave {
  */
 template <size_t Dim>
 struct ComputeDuDt {
-  using return_tags = typelist<Tags::dt<Pi>, Tags::dt<Phi<Dim>>, Tags::dt<Psi>>;
+  using return_tags =
+      tmpl::list<Tags::dt<Pi>, Tags::dt<Phi<Dim>>, Tags::dt<Psi>>;
 
   using argument_tags =
       tmpl::list<Pi, Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -88,7 +88,7 @@ void bench_all_gradient(benchmark::State& state) {  // NOLINT
   CoordinateMap<Frame::Logical, Frame::Grid, Map3d> map(
       Map3d{map1d, map1d, map1d});
 
-  using VarTags = typelist<Kappa<Dim>, Psi<Dim>>;
+  using VarTags = tmpl::list<Kappa<Dim>, Psi<Dim>>;
   const InverseJacobian<Dim, Frame::Logical, Frame::Grid> inv_jac =
       map.inv_jacobian(logical_coordinates(extents));
   const auto grid_coords = map(logical_coordinates(extents));

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -59,8 +59,8 @@ template <typename FluxTags, size_t Dim, typename DerivativeFrame>
 Variables<db::wrap_tags_in<Tags::div, FluxTags, DerivativeFrame>> divergence(
     const Variables<FluxTags>& F, const Index<Dim>& extents,
     const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                 typelist<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
-                          SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
+                 tmpl::list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
+                            SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
         inverse_jacobian) noexcept;
 
 namespace Tags {

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
@@ -13,7 +13,7 @@ template <typename FluxTags, size_t Dim, typename DerivativeFrame>
 Variables<db::wrap_tags_in<Tags::div, FluxTags, DerivativeFrame>> divergence(
     const Variables<FluxTags>& F, const Index<Dim>& extents,
     const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                 typelist<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
+                 tmpl::list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
                           SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
         inverse_jacobian) noexcept {
   const auto logical_partial_derivatives_of_F =

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -87,8 +87,8 @@ Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags, tmpl::size_t<Dim>,
 partial_derivatives(
     const Variables<VariableTags>& u, const Index<Dim>& extents,
     const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                 typelist<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
-                          SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
+                 tmpl::list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
+                            SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
         inverse_jacobian) noexcept;
 
 namespace Tags {
@@ -123,9 +123,9 @@ struct deriv_impl<
       partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
                           derivative_frame_index::dim,
                           typename derivative_frame_index::Frame>;
-  using argument_tags =
-      typelist<Tags::Variables<variables_tags>,
-               Tags::Extents<derivative_frame_index::dim>, InverseJacobianTag>;
+  using argument_tags = tmpl::list<Tags::Variables<variables_tags>,
+                                   Tags::Extents<derivative_frame_index::dim>,
+                                   InverseJacobianTag>;
 };
 
 // Logical partial derivatives
@@ -140,7 +140,7 @@ struct deriv_impl<tmpl::list<VariablesTags...>, tmpl::list<DerivativeTags...>,
       logical_partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
                                   Dim>;
   using argument_tags =
-      typelist<Tags::Variables<variables_tags>, Tags::Extents<Dim>>;
+      tmpl::list<Tags::Variables<variables_tags>, Tags::Extents<Dim>>;
 };
 }  // namespace Tags_detail
 }  // namespace Tags

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -32,7 +32,7 @@ Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags, tmpl::size_t<Dim>,
 partial_derivatives(
     const Variables<VariableTags>& u, const Index<Dim>& extents,
     const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                 typelist<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
+                 tmpl::list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
                           SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
         inverse_jacobian) noexcept {
   const auto logical_partial_derivatives_of_u =

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -317,7 +317,7 @@ class AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
   /// The metavariables class passed to the Algorithm
   using metavariables = Metavariables;
   /// List of Actions in the order they will be executed
-  using actions_list = typelist<ActionsPack...>;
+  using actions_list = tmpl::list<ActionsPack...>;
   /// List off all the Tags that can be received into the Inbox
   using inbox_tags_list = Parallel::get_inbox_tags<actions_list>;
   /// The type of the object used to identify the element of the array, group
@@ -601,7 +601,7 @@ void AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
       "single action, which is undefined behavior. See the first template "
       "parameter of 'Parallel::AlgorithmImpl' for which ParallelComponent is "
       "missing the explicit instantiation. An example of an "
-      "explicit_single_actions_list is: typelist<initialize>");
+      "explicit_single_actions_list is: tmpl::list<initialize>");
   if (performing_action_) {
     ERROR(
         "Already performing an Action and cannot execute additional Actions "
@@ -631,7 +631,7 @@ void AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
       "single action, which is undefined behavior. See the first template "
       "parameter of 'Parallel::AlgorithmImpl' for which ParallelComponent is "
       "missing the explicit instantiation. An example of an "
-      "explicit_single_actions_list is: typelist<initialize>");
+      "explicit_single_actions_list is: tmpl::list<initialize>");
   if (performing_action_) {
     ERROR(
         "Already performing an Action and cannot execute additional Actions "

--- a/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
+++ b/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
@@ -35,8 +35,8 @@ template <>
 class MathFunction<1> : public PUP::able {
  public:
   using creatable_classes =
-      typelist<MathFunctions::Gaussian, MathFunctions::PowX,
-               MathFunctions::Sinusoid>;
+      tmpl::list<MathFunctions::Gaussian, MathFunctions::PowX,
+                 MathFunctions::Sinusoid>;
 
   WRAPPED_PUPable_abstract(MathFunction);  // NOLINT
 

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -41,9 +41,8 @@ class TimeStepper : public PUP::able {
   using Inherit =
       TimeStepper_detail::FakeVirtualInherit_compute_boundary_delta<
           TimeStepper_detail::FakeVirtualInherit_update_u<TimeStepper>>;
-  using creatable_classes = typelist<
-      TimeSteppers::AdamsBashforthN,
-      TimeSteppers::RungeKutta3>;
+  using creatable_classes =
+      tmpl::list<TimeSteppers::AdamsBashforthN, TimeSteppers::RungeKutta3>;
 
   WRAPPED_PUPable_abstract(TimeStepper);  // NOLINT
 

--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -467,11 +467,6 @@ using branch_if_t = typename branch_if<B>::template type<T, F>;
 
 namespace tmpl = brigand;
 
-/// \ingroup UtilitiesGroup
-/// \brief Construct a typelist of types `Ts`.
-template <typename... Ts>
-using typelist = tmpl::list<Ts...>;
-
 /*!
  * \ingroup UtilitiesGroup
  * \brief Metaprogramming things that are not planned to be submitted to Brigand

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_DivideBy.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_DivideBy.cpp
@@ -18,7 +18,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
   const DataVector thirteen(npts, 13.0);
 
   const Tensor<DataVector, Symmetry<1>,
-               typelist<SpatialIndex<1, UpLo::Lo, Frame::Grid>>>
+               tmpl::list<SpatialIndex<1, UpLo::Lo, Frame::Grid>>>
       one_d_covector{{{two}}};
   const auto normalized_one_d_covector = divide_by(one_d_covector, two);
   for (size_t s = 0; s < npts; ++s) {
@@ -26,7 +26,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
   }
 
   const Tensor<DataVector, Symmetry<1>,
-               typelist<SpacetimeIndex<1, UpLo::Up, Frame::Grid>>>
+               tmpl::list<SpacetimeIndex<1, UpLo::Up, Frame::Grid>>>
       two_d_vector{{{three, four}}};
   const auto normalized_two_d_vector = divide_by(two_d_vector, five);
   for (size_t s = 0; s < npts; ++s) {
@@ -35,7 +35,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
   }
 
   const Tensor<DataVector, Symmetry<1>,
-               typelist<SpatialIndex<2, UpLo::Up, Frame::Grid>>>
+               tmpl::list<SpatialIndex<2, UpLo::Up, Frame::Grid>>>
       two_d_spatial_vector{{{five, twelve}}};
   const auto normalized_two_d_spatial_vector =
       divide_by(two_d_spatial_vector, thirteen);
@@ -45,7 +45,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
   }
 
   const Tensor<DataVector, Symmetry<1>,
-               typelist<SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
+               tmpl::list<SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
       three_d_covector{{{three, twelve, four}}};
   const auto normalized_three_d_covector =
       divide_by(three_d_covector, thirteen);
@@ -56,7 +56,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
   }
 
   const Tensor<DataVector, Symmetry<1>,
-               typelist<SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
+               tmpl::list<SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
       five_d_covector{{{two, twelve, four, one, two}}};
   const auto normalized_five_d_covector = divide_by(five_d_covector, thirteen);
   for (size_t s = 0; s < npts; ++s) {

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -50,26 +50,26 @@ struct Tag3 : db::DataBoxTag {
 struct ComputeTag0 : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "ComputeTag0";
   static constexpr auto function = multiply_by_two;
-  using argument_tags = typelist<Tag0>;
+  using argument_tags = tmpl::list<Tag0>;
 };
 /// [databox_compute_item_tag_example]
 struct ComputeTag1 : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "ComputeTag1";
   static constexpr auto function = append_word;
-  using argument_tags = typelist<Tag2, ComputeTag0>;
+  using argument_tags = tmpl::list<Tag2, ComputeTag0>;
 };
 
 struct TagTensor : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "TagTensor";
   static constexpr auto function = get_tensor;
-  using argument_tags = typelist<>;
+  using argument_tags = tmpl::list<>;
 };
 
 /// [compute_item_tag_function]
 struct ComputeLambda0 : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "ComputeLambda0";
   static constexpr double function(const double a) { return 3.0 * a; }
-  using argument_tags = typelist<Tag0>;
+  using argument_tags = tmpl::list<Tag0>;
 };
 /// [compute_item_tag_function]
 
@@ -77,7 +77,7 @@ struct ComputeLambda0 : db::ComputeItemTag {
 struct ComputeLambda1 : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "ComputeLambda1";
   static constexpr double function() { return 7.0; }
-  using argument_tags = typelist<>;
+  using argument_tags = tmpl::list<>;
 };
 /// [compute_item_tag_no_tags]
 
@@ -92,7 +92,7 @@ struct TagPrefix : db::DataBoxPrefix {
 }  // namespace test_databox_tags
 
 namespace {
-using Box_t = db::DataBox<db::get_databox_list<typelist<
+using Box_t = db::DataBox<db::get_databox_list<tmpl::list<
     test_databox_tags::Tag0, test_databox_tags::Tag1, test_databox_tags::Tag2,
     test_databox_tags::TagPrefix<test_databox_tags::Tag0>,
     test_databox_tags::ComputeTag0, test_databox_tags::ComputeTag1>>>;
@@ -101,7 +101,7 @@ static_assert(
     std::is_same<
         decltype(
             db::create_from<db::RemoveTags<test_databox_tags::Tag1>>(Box_t{})),
-        db::DataBox<db::get_databox_list<typelist<
+        db::DataBox<db::get_databox_list<tmpl::list<
             test_databox_tags::Tag0, test_databox_tags::Tag2,
             test_databox_tags::TagPrefix<test_databox_tags::Tag0>,
             test_databox_tags::ComputeTag0, test_databox_tags::ComputeTag1>>>>::
@@ -112,7 +112,7 @@ static_assert(
     std::is_same<
         decltype(db::create_from<
                  db::RemoveTags<test_databox_tags::ComputeTag1>>(Box_t{})),
-        db::DataBox<db::get_databox_list<typelist<
+        db::DataBox<db::get_databox_list<tmpl::list<
             test_databox_tags::Tag0, test_databox_tags::Tag1,
             test_databox_tags::TagPrefix<test_databox_tags::Tag0>,
             test_databox_tags::Tag2, test_databox_tags::ComputeTag0>>>>::value,
@@ -142,7 +142,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   static_assert(
       std::is_same<
           decltype(original_box),
-          db::DataBox<db::get_databox_list<typelist<
+          db::DataBox<db::get_databox_list<tmpl::list<
               test_databox_tags::Tag0, test_databox_tags::Tag1,
               test_databox_tags::Tag2, test_databox_tags::ComputeTag0,
               test_databox_tags::ComputeTag1, test_databox_tags::ComputeLambda0,
@@ -250,7 +250,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.get_databox",
     CHECK(db::get<test_databox_tags::ComputeTag1>(box) ==
           "My Sample String6.28"s);
   };
-  db::apply<typelist<Tags::DataBox>>(check_result_no_args, original_box);
+  db::apply<tmpl::list<Tags::DataBox>>(check_result_no_args, original_box);
   /// [databox_self_tag_example]
 }
 
@@ -428,7 +428,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.apply",
     CHECK(sample_string == "My Sample String"s);
     CHECK(computed_string == "My Sample String6.28"s);
   };
-  db::apply<typelist<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>>(
+  db::apply<
+      tmpl::list<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>>(
       check_result_no_args, original_box);
 
   /// [apply_example]
@@ -438,12 +439,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.apply",
     CHECK(computed_string == "My Sample String6.28"s);
     CHECK(vector == (std::vector<double>{8.7, 93.2, 84.7}));
   };
-  db::apply<typelist<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>>(
+  db::apply<
+      tmpl::list<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>>(
       check_result_args, original_box,
       db::get<test_databox_tags::Tag1>(original_box));
   /// [apply_example]
 
-  db::apply<typelist<>>(NonCopyableFunctor{}, original_box);
+  db::apply<tmpl::list<>>(NonCopyableFunctor{}, original_box);
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.apply_with_box",
@@ -463,7 +465,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.apply_with_box",
           (std::vector<double>{8.7, 93.2, 84.7}));
   };
   db::apply_with_box<
-      typelist<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>>(
+      tmpl::list<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>>(
       check_result_no_args, original_box);
 
   /// [apply_with_box_example]
@@ -477,11 +479,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.apply_with_box",
     CHECK((vector == std::vector<int>{1, 4, 8}));
   };
   db::apply_with_box<
-      typelist<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>>(
+      tmpl::list<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>>(
       check_result_args, original_box, std::vector<int>{1, 4, 8});
   /// [apply_with_box_example]
 
-  db::apply_with_box<typelist<>>(NonCopyableFunctor{}, original_box);
+  db::apply_with_box<tmpl::list<>>(NonCopyableFunctor{}, original_box);
 }
 
 // [[OutputRegex, Could not find the tag named "TagTensor__" in the DataBox]]
@@ -527,7 +529,7 @@ auto get_vector() { return tnsr::I<DataVector, 3, Frame::Grid>(5_st, 2.0); }
 struct Var1 : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "Var1";
   static constexpr auto function = get_vector;
-  using argument_tags = typelist<>;
+  using argument_tags = tmpl::list<>;
 };
 
 struct Var2 : db::DataBoxTag {
@@ -543,9 +545,9 @@ struct PrefixTag0 : db::DataBoxPrefix {
   static constexpr db::DataBoxString label = "PrefixTag0";
 };
 
-using two_vars = typelist<Var1, Var2>;
-using vector_only = typelist<Var1>;
-using scalar_only = typelist<Var2>;
+using two_vars = tmpl::list<Var1, Var2>;
+using vector_only = tmpl::list<Var1>;
+using scalar_only = tmpl::list<Var2>;
 
 static_assert(
     cpp17::is_same_v<
@@ -664,37 +666,37 @@ struct MultiplyScalarByTwo : db::ComputeItemTag {
       tmpl::list<test_databox_tags::ScalarTag2, test_databox_tags::VectorTag2>;
   static constexpr db::DataBoxString label = "MultiplyScalarByTwo";
   static constexpr auto function = multiply_scalar_by_two;
-  using argument_tags = typelist<test_databox_tags::ScalarTag>;
+  using argument_tags = tmpl::list<test_databox_tags::ScalarTag>;
 };
 
 struct MultiplyScalarByFour : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "MultiplyScalarByFour";
   static constexpr auto function = multiply_scalar_by_four;
-  using argument_tags = typelist<test_databox_tags::ScalarTag2>;
+  using argument_tags = tmpl::list<test_databox_tags::ScalarTag2>;
 };
 
 struct MultiplyScalarByThree : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "MultiplyScalarByThree";
   static constexpr auto function = multiply_scalar_by_three;
-  using argument_tags = typelist<test_databox_tags::MultiplyScalarByFour>;
+  using argument_tags = tmpl::list<test_databox_tags::MultiplyScalarByFour>;
 };
 
 struct DivideScalarByThree : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "DivideScalarByThree";
   static constexpr auto function = divide_scalar_by_three;
-  using argument_tags = typelist<test_databox_tags::MultiplyScalarByThree>;
+  using argument_tags = tmpl::list<test_databox_tags::MultiplyScalarByThree>;
 };
 
 struct DivideScalarByTwo : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "DivideScalarByTwo";
   static constexpr auto function = divide_scalar_by_two;
-  using argument_tags = typelist<test_databox_tags::DivideScalarByThree>;
+  using argument_tags = tmpl::list<test_databox_tags::DivideScalarByThree>;
 };
 
 struct MultiplyVariablesByTwo : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "MultiplyVariablesByTwo";
   static constexpr auto function = multiply_variables_by_two;
-  using argument_tags = typelist<Tags::Variables<
+  using argument_tags = tmpl::list<Tags::Variables<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>>;
 };
 }  // namespace test_databox_tags
@@ -1163,12 +1165,12 @@ struct MutateComputeTag0 : db::ComputeItemTag {
   using return_type = std::vector<double>;
   static constexpr db::DataBoxString label = "MutateComputeTag0";
   static constexpr auto function = multiply_by_two_mutate;
-  using argument_tags = typelist<Tag0>;
+  using argument_tags = tmpl::list<Tag0>;
 };
 struct NonMutateComputeTag0 : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "NonMutateComputeTag0";
   static constexpr auto function = multiply_by_two_non_mutate;
-  using argument_tags = typelist<Tag0>;
+  using argument_tags = tmpl::list<Tag0>;
 };
 /// [databox_mutating_compute_item_tag]
 struct MutateVariablesCompute : db::ComputeItemTag {
@@ -1176,7 +1178,7 @@ struct MutateVariablesCompute : db::ComputeItemTag {
   static constexpr auto function = mutate_variables;
   using return_type = Variables<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>;
-  using argument_tags = typelist<Tag0>;
+  using argument_tags = tmpl::list<Tag0>;
 };
 /// [databox_mutating_compute_item_tag]
 }  // namespace test_databox_tags
@@ -1310,7 +1312,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.data_on_slice.single",
                vec_size = DataBoxTest_detail::vector::type::size();
   Index<3> extents(x_extents, y_extents, z_extents);
   auto box = db::create<db::AddTags<DataBoxTest_detail::vector>>([]() {
-    Variables<typelist<DataBoxTest_detail::vector>> vars(24, 0.);
+    Variables<tmpl::list<DataBoxTest_detail::vector>> vars(24, 0.);
     for (size_t s = 0; s < vars.size(); ++s) {
       // clang-tidy: do not use pointer arithmetic
       vars.data()[s] = s;  // NOLINT
@@ -1318,7 +1320,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.data_on_slice.single",
     return get<DataBoxTest_detail::vector>(vars);
   }());
 
-  Variables<typelist<DataBoxTest_detail::vector>> expected_vars_sliced_in_x(
+  Variables<tmpl::list<DataBoxTest_detail::vector>> expected_vars_sliced_in_x(
       y_extents * z_extents, 0.),
       expected_vars_sliced_in_y(x_extents * z_extents, 0.),
       expected_vars_sliced_in_z(x_extents * y_extents, 0.);
@@ -1371,7 +1373,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.data_on_slice",
       db::AddTags<DataBoxTest_detail::vector, DataBoxTest_detail::scalar,
                   DataBoxTest_detail::vector2>>(
       []() {
-        Variables<typelist<DataBoxTest_detail::vector>> vars(24, 0.);
+        Variables<tmpl::list<DataBoxTest_detail::vector>> vars(24, 0.);
         for (size_t s = 0; s < vars.size(); ++s) {
           // clang-tidy: do not use pointer arithmetic
           vars.data()[s] = s;  // NOLINT
@@ -1380,7 +1382,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.data_on_slice",
       }(),
       Scalar<DataVector>(DataVector{8.9, 0.7, 6.7}),
       []() {
-        Variables<typelist<DataBoxTest_detail::vector>> vars(24, 0.);
+        Variables<tmpl::list<DataBoxTest_detail::vector>> vars(24, 0.);
         for (size_t s = 0; s < vars.size(); ++s) {
           // clang-tidy: do not use pointer arithmetic
           vars.data()[s] = s * 10.0;  // NOLINT
@@ -1388,7 +1390,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.data_on_slice",
         return get<DataBoxTest_detail::vector>(vars);
       }());
 
-  Variables<typelist<DataBoxTest_detail::vector>> expected_vars_sliced_in_x(
+  Variables<tmpl::list<DataBoxTest_detail::vector>> expected_vars_sliced_in_x(
       y_extents * z_extents, 0.),
       expected_vars_sliced_in_y(x_extents * z_extents, 0.),
       expected_vars_sliced_in_z(x_extents * y_extents, 0.);
@@ -1427,13 +1429,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.data_on_slice",
           get<DataBoxTest_detail::vector>(expected_vars_sliced_in_x));
     CHECK(get<DataBoxTest_detail::vector2>(sliced0) ==
           get<DataBoxTest_detail::vector>(
-              Variables<typelist<DataBoxTest_detail::vector>>(
+              Variables<tmpl::list<DataBoxTest_detail::vector>>(
                   expected_vars_sliced_in_x * 10.0)));
     const auto sliced1 = data_on_slice(
         box, extents, 0, x_offset, tmpl::list<DataBoxTest_detail::vector2>{});
     CHECK(get<DataBoxTest_detail::vector2>(sliced1) ==
           get<DataBoxTest_detail::vector>(
-              Variables<typelist<DataBoxTest_detail::vector>>(
+              Variables<tmpl::list<DataBoxTest_detail::vector>>(
                   expected_vars_sliced_in_x * 10.0)));
   }
   // y slice
@@ -1445,13 +1447,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.data_on_slice",
           get<DataBoxTest_detail::vector>(expected_vars_sliced_in_y));
     CHECK(get<DataBoxTest_detail::vector2>(sliced0) ==
           get<DataBoxTest_detail::vector>(
-              Variables<typelist<DataBoxTest_detail::vector>>(
+              Variables<tmpl::list<DataBoxTest_detail::vector>>(
                   expected_vars_sliced_in_y * 10.0)));
     const auto sliced1 = data_on_slice(
         box, extents, 1, y_offset, tmpl::list<DataBoxTest_detail::vector2>{});
     CHECK(get<DataBoxTest_detail::vector2>(sliced1) ==
           get<DataBoxTest_detail::vector>(
-              Variables<typelist<DataBoxTest_detail::vector>>(
+              Variables<tmpl::list<DataBoxTest_detail::vector>>(
                   expected_vars_sliced_in_y * 10.0)));
   }
   // z slice
@@ -1463,13 +1465,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.data_on_slice",
           get<DataBoxTest_detail::vector>(expected_vars_sliced_in_z));
     CHECK(get<DataBoxTest_detail::vector2>(sliced0) ==
           get<DataBoxTest_detail::vector>(
-              Variables<typelist<DataBoxTest_detail::vector>>(
+              Variables<tmpl::list<DataBoxTest_detail::vector>>(
                   expected_vars_sliced_in_z * 10.0)));
     const auto sliced1 = data_on_slice(
         box, extents, 2, z_offset, tmpl::list<DataBoxTest_detail::vector2>{});
     CHECK(get<DataBoxTest_detail::vector2>(sliced1) ==
           get<DataBoxTest_detail::vector>(
-              Variables<typelist<DataBoxTest_detail::vector>>(
+              Variables<tmpl::list<DataBoxTest_detail::vector>>(
                   expected_vars_sliced_in_z * 10.0)));
   }
 }

--- a/tests/Unit/DataStructures/Test_MakeWithValue.cpp
+++ b/tests/Unit/DataStructures/Test_MakeWithValue.cpp
@@ -22,10 +22,10 @@ struct Var2 {
 };
 
 template <size_t Dim>
-using two_vars = typelist<Var1<Dim>, Var2>;
+using two_vars = tmpl::list<Var1<Dim>, Var2>;
 
 template <size_t Dim>
-using one_var = typelist<Var1<Dim>>;
+using one_var = tmpl::list<Var1<Dim>>;
 
 template <typename R, typename T>
 void check_make_with_value(const R& expected, const T& input,

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -81,7 +81,7 @@ static_assert(cpp17::is_same_v<tnsr::aa<double, 3, Frame::Grid>,
               "Failed testing remove_first_index");
 
 // Test check_index_symmetry
-static_assert(TensorMetafunctions::check_index_symmetry_v<typelist<>>,
+static_assert(TensorMetafunctions::check_index_symmetry_v<tmpl::list<>>,
               "Failed testing check_index_symmetry");
 static_assert(TensorMetafunctions::check_index_symmetry_v<
                   Symmetry<1>, SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
@@ -174,10 +174,10 @@ static_assert(
     "Failed testing check_index_symmetry");
 
 static_assert(not cpp17::is_constructible_v<
-                  Tensor<double, Symmetry<>, typelist<>>, typelist<>>,
+                  Tensor<double, Symmetry<>, tmpl::list<>>, tmpl::list<>>,
               "Tensor construction failed to be SFINAE friendly");
 static_assert(
-    cpp17::is_constructible_v<Tensor<double, Symmetry<>, typelist<>>, double>,
+    cpp17::is_constructible_v<Tensor<double, Symmetry<>, tmpl::list<>>, double>,
     "Tensor construction failed to be SFINAE friendly");
 
 namespace {

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -439,7 +439,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.assign_subset",
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Variables.SliceVariables",
                   "[DataStructures][Unit]") {
-  Variables<typelist<VariablesTestTags_detail::vector>> vars(24, 0.);
+  Variables<tmpl::list<VariablesTestTags_detail::vector>> vars(24, 0.);
   const size_t x_extents = 2, y_extents = 3, z_extents = 4,
                vec_size = VariablesTestTags_detail::vector::type::size();
   Index<3> extents(x_extents, y_extents, z_extents);
@@ -447,7 +447,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.SliceVariables",
     // clang-tidy: do not use pointer arithmetic
     vars.data()[s] = s;  // NOLINT
   }
-  Variables<typelist<VariablesTestTags_detail::vector>>
+  Variables<tmpl::list<VariablesTestTags_detail::vector>>
       expected_vars_sliced_in_x(y_extents * z_extents, 0.),
       expected_vars_sliced_in_y(x_extents * z_extents, 0.),
       expected_vars_sliced_in_z(x_extents * y_extents, 0.);
@@ -499,7 +499,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.add_slice_to_data",
                   "[DataStructures][Unit]") {
   using Vector = VariablesTestTags_detail::vector::type;
   const Index<2> extents{{{4, 2}}};
-  Variables<typelist<VariablesTestTags_detail::vector>> vars(extents.product());
+  Variables<tmpl::list<VariablesTestTags_detail::vector>> vars(
+      extents.product());
   get<VariablesTestTags_detail::vector>(vars) =
       Vector{{{{1110000., 1120000., 1130000., 1140000., 1210000., 1220000.,
                 1230000., 1240000.},
@@ -510,7 +511,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.add_slice_to_data",
 
   {
     const auto slice_extents = extents.slice_away(0);
-    Variables<typelist<VariablesTestTags_detail::vector>> slice(
+    Variables<tmpl::list<VariablesTestTags_detail::vector>> slice(
         slice_extents.product(), 0.);
     get<VariablesTestTags_detail::vector>(slice) =
         Vector{{{{1100., 1200.}, {2100., 2200.}, {3100., 3200.}}}};
@@ -518,7 +519,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.add_slice_to_data",
   }
   {
     const auto slice_extents = extents.slice_away(1);
-    Variables<typelist<VariablesTestTags_detail::vector>> slice(
+    Variables<tmpl::list<VariablesTestTags_detail::vector>> slice(
         slice_extents.product(), 0.);
     get<VariablesTestTags_detail::vector>(slice) = Vector{
         {{{11., 12., 13., 14.}, {21., 22., 23., 24.}, {31., 32., 33., 34.}}}};

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -107,7 +107,7 @@ struct Flux2 : db::DataBoxTag {
 };
 
 template <size_t Dim, typename Frame>
-using two_fluxes = typelist<Flux1<Dim, Frame>, Flux2<Dim, Frame>>;
+using two_fluxes = tmpl::list<Flux1<Dim, Frame>, Flux2<Dim, Frame>>;
 
 template <size_t Dim, typename Frame = Frame::Inertial>
 void test_divergence(

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -99,10 +99,10 @@ struct Var2 : db::DataBoxTag {
 };
 
 template <size_t Dim>
-using two_vars = typelist<Var1<Dim>, Var2>;
+using two_vars = tmpl::list<Var1<Dim>, Var2>;
 
 template <size_t Dim>
-using one_var = typelist<Var1<Dim>>;
+using one_var = tmpl::list<Var1<Dim>>;
 
 template <typename VariableTags, typename GradientTags = VariableTags>
 void test_logical_partial_derivatives_1d(const Index<1>& extents) {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
@@ -20,10 +20,10 @@ struct Var2 {
 };
 
 template <size_t Dim>
-using two_vars = typelist<Var1<Dim>, Var2>;
+using two_vars = tmpl::list<Var1<Dim>, Var2>;
 
 template <size_t Dim>
-using one_var = typelist<Var1<Dim>>;
+using one_var = tmpl::list<Var1<Dim>>;
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Transpose",

--- a/tests/Unit/Parallel/ParallelTestTentacles.hpp
+++ b/tests/Unit/Parallel/ParallelTestTentacles.hpp
@@ -56,8 +56,8 @@ struct NonCopyable {
 template <typename Metavariables>
 struct Group {
   using type = CProxy_TestGroupChare<Metavariables>;
-  using const_global_cache_tag_list = typelist<Options::NonCopyable>;
-  using options = typelist<Options::Integer>;
+  using const_global_cache_tag_list = tmpl::list<Options::NonCopyable>;
+  using options = tmpl::list<Options::Integer>;
   static void initialize(
       const Parallel::CProxy_ConstGlobalCache<Metavariables>& /*unused*/,
       const int& /*unused*/) {}
@@ -69,8 +69,8 @@ struct Group {
 template <typename Metavariables>
 struct NodeGroup {
   using type = CProxy_TestNodeGroupChare<Metavariables>;
-  using const_global_cache_tag_list = typelist<>;
-  using options = typelist<Options::NonCopyable>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using options = tmpl::list<Options::NonCopyable>;
   static void initialize(
       const Parallel::CProxy_ConstGlobalCache<Metavariables>& /*unused*/,
       const MainTestObjects::CreatableNonCopyable& /*unused*/) {}
@@ -82,8 +82,8 @@ struct NodeGroup {
 template <typename Metavariables>
 struct Chare {
   using type = CProxy_TestChare<Metavariables>;
-  using const_global_cache_tag_list = typelist<>;
-  using options = typelist<Options::Integer>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using options = tmpl::list<Options::Integer>;
   static void initialize(
       const Parallel::CProxy_ConstGlobalCache<Metavariables>& cache_proxy,
       const int& integer) {
@@ -100,8 +100,8 @@ struct Chare {
 template <typename Metavariables>
 struct Array {
   using type = CProxy_TestArrayChare<Metavariables>;
-  using const_global_cache_tag_list = typelist<>;
-  using options = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using options = tmpl::list<>;
   static void initialize(
       const Parallel::CProxy_ConstGlobalCache<Metavariables>& cache_proxy);
   static void execute_next_global_actions(
@@ -113,8 +113,8 @@ template <typename Metavariables>
 struct BoundArray {
   using type = CProxy_TestBoundArrayChare<Metavariables>;
   using bind_to = Test_Tentacles::Array<Metavariables>;
-  using const_global_cache_tag_list = typelist<>;
-  using options = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using options = tmpl::list<>;
   static void initialize(
       const Parallel::CProxy_ConstGlobalCache<Metavariables>& /*unused*/) {}
   static void execute_next_global_actions(

--- a/tests/Unit/Parallel/Test_Algorithm.cpp
+++ b/tests/Unit/Parallel/Test_Algorithm.cpp
@@ -127,7 +127,7 @@ struct initialize {
                          SingletonParallelComponent<TestMetavariables>>,
         "The ParallelComponent is not deduced to be the right type");
     return std::make_tuple(
-        db::create<typelist<CountActionsCalled, Int0, Int1>>(0, 1, 100));
+        db::create<tmpl::list<CountActionsCalled, Int0, Int1>>(0, 1, 100));
   }
 };
 
@@ -162,10 +162,10 @@ SPECTRE_TEST_CASE("Unit.Parallel.Algorithm.local_no_ops", "[Unit][Parallel]") {
   Parallel::AlgorithmImpl<
       SingletonParallelComponent<TestMetavariables>,
       Parallel::Algorithms::Singleton, TestMetavariables,
-      typelist<no_op_test::increment_count_actions_called, no_op_test::no_op>,
+      tmpl::list<no_op_test::increment_count_actions_called, no_op_test::no_op>,
       ElementId,
       db::DataBox<
-          db::get_databox_list<typelist<CountActionsCalled, Int0, Int1>>>>
+          db::get_databox_list<tmpl::list<CountActionsCalled, Int0, Int1>>>>
       al_gore{};
   al_gore.template explicit_single_action<no_op_test::initialize>();
   al_gore.perform_algorithm();
@@ -192,7 +192,7 @@ struct add_int_value_10 {
         box, [](int& count_actions_called) { count_actions_called++; });
     static int a = 0;
     return std::make_tuple(
-        db::create_from<typelist<>, typelist<Int0>>(std::move(box), 10),
+        db::create_from<tmpl::list<>, tmpl::list<Int0>>(std::move(box), 10),
         ++a >= 5);
   }
 };
@@ -240,7 +240,7 @@ struct remove_int0 {
           count_actions_called++;
         },
         db::get<Int0>(box));
-    return std::make_tuple(db::create_from<typelist<Int0>>(std::move(box)));
+    return std::make_tuple(db::create_from<tmpl::list<Int0>>(std::move(box)));
   }
 };
 
@@ -280,8 +280,9 @@ struct initialize {
         cpp17::is_same_v<ParallelComponent,
                          SingletonParallelComponent<TestMetavariables>>,
         "The ParallelComponent is not deduced to be the right type");
-    return std::make_tuple(db::create<typelist<CountActionsCalled, TemporalId>>(
-        0, TestAlgorithmArrayInstance{0}));
+    return std::make_tuple(
+        db::create<tmpl::list<CountActionsCalled, TemporalId>>(
+            0, TestAlgorithmArrayInstance{0}));
   }
 };
 
@@ -314,11 +315,11 @@ SPECTRE_TEST_CASE("Unit.Parallel.Algorithm.local_mutate", "[Unit][Parallel]") {
   Parallel::AlgorithmImpl<
       SingletonParallelComponent<TestMetavariables>,
       Parallel::Algorithms::Singleton, TestMetavariables,
-      typelist<add_remove_test::add_int_value_10,
-               add_remove_test::increment_int0, add_remove_test::remove_int0>,
+      tmpl::list<add_remove_test::add_int_value_10,
+                 add_remove_test::increment_int0, add_remove_test::remove_int0>,
       ElementId,
       db::DataBox<
-          db::get_databox_list<typelist<CountActionsCalled, TemporalId>>>>
+          db::get_databox_list<tmpl::list<CountActionsCalled, TemporalId>>>>
       al_gore{};
   al_gore.template explicit_single_action<add_remove_test::initialize>();
   al_gore.perform_algorithm();
@@ -358,7 +359,7 @@ struct add_int0_from_receive {
             .begin());
     tuples::get<IntReceiveTag>(inboxes).erase(db::get<TemporalId>(box));
     return std::make_tuple(
-        db::create_from<typelist<>, typelist<Int0>>(box, int0), ++a >= 5);
+        db::create_from<tmpl::list<>, tmpl::list<Int0>>(box, int0), ++a >= 5);
   }
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
@@ -412,7 +413,7 @@ struct initialize {
                          SingletonParallelComponent<TestMetavariables>>,
         "The ParallelComponent is not deduced to be the right type");
     return std::make_tuple(
-        db::create<typelist<CountActionsCalled, Int1, TemporalId>>(
+        db::create<tmpl::list<CountActionsCalled, Int1, TemporalId>>(
             0, 0, TestAlgorithmArrayInstance{0}));
   }
 };
@@ -450,12 +451,12 @@ SPECTRE_TEST_CASE("Unit.Parallel.Algorithm.local_receive", "[Unit][Parallel]") {
   Parallel::AlgorithmImpl<
       SingletonParallelComponent<TestMetavariables>,
       Parallel::Algorithms::Singleton, TestMetavariables,
-      typelist<receive_data_test::add_int0_from_receive,
-               add_remove_test::increment_int0, add_remove_test::remove_int0,
-               receive_data_test::update_instance>,
+      tmpl::list<receive_data_test::add_int0_from_receive,
+                 add_remove_test::increment_int0, add_remove_test::remove_int0,
+                 receive_data_test::update_instance>,
       ElementId,
-      db::DataBox<
-          db::get_databox_list<typelist<CountActionsCalled, Int1, TemporalId>>>>
+      db::DataBox<db::get_databox_list<
+          tmpl::list<CountActionsCalled, Int1, TemporalId>>>>
       al_gore{};
   al_gore.template explicit_single_action<receive_data_test::initialize>();
   al_gore.perform_algorithm();
@@ -534,13 +535,13 @@ SPECTRE_TEST_CASE("Unit.Parallel.Algorithm.local_order", "[Unit][Parallel]") {
   Parallel::AlgorithmImpl<
       SingletonParallelComponent<TestMetavariables>,
       Parallel::Algorithms::Singleton, TestMetavariables,
-      typelist<add_remove_test::add_int_value_10,
-               add_remove_test::increment_int0,
-               any_order::iterate_increment_int0, add_remove_test::remove_int0,
-               receive_data_test::update_instance>,
+      tmpl::list<
+          add_remove_test::add_int_value_10, add_remove_test::increment_int0,
+          any_order::iterate_increment_int0, add_remove_test::remove_int0,
+          receive_data_test::update_instance>,
       ElementId,
       db::DataBox<
-          db::get_databox_list<typelist<CountActionsCalled, TemporalId>>>>
+          db::get_databox_list<tmpl::list<CountActionsCalled, TemporalId>>>>
       al_gore{};
   al_gore.template explicit_single_action<add_remove_test::initialize>();
   al_gore.perform_algorithm();
@@ -573,8 +574,8 @@ SPECTRE_TEST_CASE("Unit.Parallel.Algorithm.bad_box_apply", "[Unit][Parallel]") {
   ERROR_TEST();
   Parallel::AlgorithmImpl<SingletonParallelComponent<TestMetavariables>,
                           Parallel::Algorithms::Singleton, TestMetavariables,
-                          typelist<>, ElementId,
-                          db::DataBox<db::get_databox_list<typelist<>>>>
+                          tmpl::list<>, ElementId,
+                          db::DataBox<db::get_databox_list<tmpl::list<>>>>
       al_gore{};
   al_gore.template explicit_single_action<error_size_zero>();
 }
@@ -604,14 +605,14 @@ struct error_call_single_action_from_action {
     al_gore.template explicit_single_action<
         error_call_single_action_from_action<Parallel::AlgorithmImpl<
             SingletonParallelComponent<TestMetavariables>,
-            Parallel::Algorithms::Singleton, TestMetavariables, typelist<>,
-            ElementId, db::DataBox<db::get_databox_list<typelist<>>>>>>(
-        std::tuple<
-            Parallel::AlgorithmImpl<
-                SingletonParallelComponent<TestMetavariables>,
-                Parallel::Algorithms::Singleton, TestMetavariables, typelist<>,
-                ElementId, db::DataBox<db::get_databox_list<typelist<>>>>&,
-            int>(al_gore, 0));
+            Parallel::Algorithms::Singleton, TestMetavariables, tmpl::list<>,
+            ElementId, db::DataBox<db::get_databox_list<tmpl::list<>>>>>>(
+        std::tuple<Parallel::AlgorithmImpl<
+                       SingletonParallelComponent<TestMetavariables>,
+                       Parallel::Algorithms::Singleton, TestMetavariables,
+                       tmpl::list<>, ElementId,
+                       db::DataBox<db::get_databox_list<tmpl::list<>>>>&,
+                   int>(al_gore, 0));
   }
 };
 }  // namespace
@@ -625,19 +626,19 @@ SPECTRE_TEST_CASE("Unit.Parallel.Algorithm.action_from_action_1",
   ERROR_TEST();
   Parallel::AlgorithmImpl<SingletonParallelComponent<TestMetavariables>,
                           Parallel::Algorithms::Singleton, TestMetavariables,
-                          typelist<>, ElementId,
-                          db::DataBox<db::get_databox_list<typelist<>>>>
+                          tmpl::list<>, ElementId,
+                          db::DataBox<db::get_databox_list<tmpl::list<>>>>
       al_gore{};
   al_gore.template explicit_single_action<
       error_call_single_action_from_action<Parallel::AlgorithmImpl<
           SingletonParallelComponent<TestMetavariables>,
-          Parallel::Algorithms::Singleton, TestMetavariables, typelist<>,
-          ElementId, db::DataBox<db::get_databox_list<typelist<>>>>>>(
+          Parallel::Algorithms::Singleton, TestMetavariables, tmpl::list<>,
+          ElementId, db::DataBox<db::get_databox_list<tmpl::list<>>>>>>(
       std::tuple<
           Parallel::AlgorithmImpl<
               SingletonParallelComponent<TestMetavariables>,
-              Parallel::Algorithms::Singleton, TestMetavariables, typelist<>,
-              ElementId, db::DataBox<db::get_databox_list<typelist<>>>>&,
+              Parallel::Algorithms::Singleton, TestMetavariables, tmpl::list<>,
+              ElementId, db::DataBox<db::get_databox_list<tmpl::list<>>>>&,
           int>(al_gore, 0));
 }
 
@@ -650,19 +651,19 @@ SPECTRE_TEST_CASE("Unit.Parallel.Algorithm.action_from_action_2",
   ERROR_TEST();
   Parallel::AlgorithmImpl<SingletonParallelComponent<TestMetavariables>,
                           Parallel::Algorithms::Singleton, TestMetavariables,
-                          typelist<>, ElementId,
-                          db::DataBox<db::get_databox_list<typelist<>>>>
+                          tmpl::list<>, ElementId,
+                          db::DataBox<db::get_databox_list<tmpl::list<>>>>
       al_gore{};
   al_gore.template explicit_single_action<
       error_call_single_action_from_action<Parallel::AlgorithmImpl<
           SingletonParallelComponent<TestMetavariables>,
-          Parallel::Algorithms::Singleton, TestMetavariables, typelist<>,
-          ElementId, db::DataBox<db::get_databox_list<typelist<>>>>>>(
+          Parallel::Algorithms::Singleton, TestMetavariables, tmpl::list<>,
+          ElementId, db::DataBox<db::get_databox_list<tmpl::list<>>>>>>(
       std::tuple<
           Parallel::AlgorithmImpl<
               SingletonParallelComponent<TestMetavariables>,
-              Parallel::Algorithms::Singleton, TestMetavariables, typelist<>,
-              ElementId, db::DataBox<db::get_databox_list<typelist<>>>>&,
+              Parallel::Algorithms::Singleton, TestMetavariables, tmpl::list<>,
+              ElementId, db::DataBox<db::get_databox_list<tmpl::list<>>>>&,
           int>(al_gore, 1));
 }
 
@@ -672,9 +673,9 @@ struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
 
   using metavariables = Metavariables;
-  using action_list = typelist<>;
+  using action_list = tmpl::list<>;
   using array_index = int;
-  using initial_databox = db::DataBox<db::get_databox_list<typelist<>>>;
+  using initial_databox = db::DataBox<db::get_databox_list<tmpl::list<>>>;
   using explicit_single_actions_list = tmpl::list<
       no_op_test::initialize, no_op_test::finalize, add_remove_test::initialize,
       add_remove_test::finalize, add_remove_test::test_args,
@@ -682,8 +683,8 @@ struct SingletonParallelComponent {
       any_order::finalize, error_size_zero,
       error_call_single_action_from_action<Parallel::AlgorithmImpl<
           SingletonParallelComponent<TestMetavariables>,
-          Parallel::Algorithms::Singleton, TestMetavariables, typelist<>,
-          ElementId, db::DataBox<db::get_databox_list<typelist<>>>>>>;
+          Parallel::Algorithms::Singleton, TestMetavariables, tmpl::list<>,
+          ElementId, db::DataBox<db::get_databox_list<tmpl::list<>>>>>>;
 
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -53,8 +53,8 @@ struct nodegroup_initialize {
         cpp17::is_same_v<ParallelComponent,
                          NodegroupParallelComponent<TestMetavariables>>,
         "The ParallelComponent is not deduced to be the right type");
-    return std::make_tuple(db::create<typelist<Tags::vector_of_array_indexs,
-                                               Tags::total_receives_on_node>>(
+    return std::make_tuple(db::create<tmpl::list<Tags::vector_of_array_indexs,
+                                                 Tags::total_receives_on_node>>(
         std::vector<int>(
             static_cast<size_t>(number_of_1d_array_elements_per_core *
                                 Parallel::procs_on_node(Parallel::my_node()))),
@@ -241,12 +241,12 @@ struct reduce_threaded_method {
 template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
-  using const_global_cache_tag_list = typelist<>;
-  using options = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<>;
+  using action_list = tmpl::list<>;
   using array_index = int;
-  using initial_databox = db::DataBox<typelist<>>;
+  using initial_databox = db::DataBox<tmpl::list<>>;
 
   using explicit_single_actions_list =
       tmpl::list<reduce_to_nodegroup, reduce_threaded_method>;
@@ -286,12 +286,12 @@ struct ArrayParallelComponent {
 template <class Metavariables>
 struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
-  using const_global_cache_tag_list = typelist<>;
-  using options = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<>;
+  using action_list = tmpl::list<>;
   using initial_databox = db::DataBox<db::get_databox_list<
-      typelist<Tags::total_receives_on_node, Tags::vector_of_array_indexs>>>;
+      tmpl::list<Tags::total_receives_on_node, Tags::vector_of_array_indexs>>>;
 
   using explicit_single_actions_list =
       tmpl::list<nodegroup_initialize, nodegroup_receive,

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -131,7 +131,7 @@ struct Initialize {
     static_assert(cpp17::is_same_v<ParallelComponent,
                                    ArrayParallelComponent<TestMetavariables>>,
                   "The ParallelComponent is not deduced to be the right type");
-    return std::make_tuple(db::create<typelist<Tags::CountActionsCalled>>(0));
+    return std::make_tuple(db::create<tmpl::list<Tags::CountActionsCalled>>(0));
   }
 };
 
@@ -163,7 +163,8 @@ struct AddIntValue10 {
     const bool terminate_algorithm =
         db::get<Tags::CountActionsCalled>(box) >= 15;
     return std::make_tuple(
-        db::create_from<typelist<>, typelist<Tags::Int0>>(std::move(box), 10),
+        db::create_from<tmpl::list<>, tmpl::list<Tags::Int0>>(std::move(box),
+                                                              10),
         terminate_algorithm);
   }
 };
@@ -205,7 +206,7 @@ struct RemoveInt0 {
     db::mutate<Tags::CountActionsCalled>(
         box, [](int& count_actions_called) { count_actions_called++; });
     return std::make_tuple(
-        db::create_from<typelist<Tags::Int0>>(std::move(box)));
+        db::create_from<tmpl::list<Tags::Int0>>(std::move(box)));
   }
 };
 
@@ -249,7 +250,7 @@ struct Initialize {
     static_assert(cpp17::is_same_v<ParallelComponent,
                                    GroupParallelComponent<TestMetavariables>>,
                   "The ParallelComponent is not deduced to be the right type");
-    return std::make_tuple(db::create<typelist<Tags::CountActionsCalled>>(0));
+    return std::make_tuple(db::create<tmpl::list<Tags::CountActionsCalled>>(0));
   }
 };
 
@@ -312,7 +313,7 @@ struct Initialize {
         cpp17::is_same_v<ParallelComponent,
                          NodegroupParallelComponent<TestMetavariables>>,
         "The ParallelComponent is not deduced to be the right type");
-    return std::make_tuple(db::create<typelist<Tags::CountActionsCalled>>(0));
+    return std::make_tuple(db::create<tmpl::list<Tags::CountActionsCalled>>(0));
   }
 };
 
@@ -322,12 +323,12 @@ struct Initialize {
 template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<SingletonActions::CountReceives>;
-  using initial_databox = db::DataBox<db::get_databox_list<typelist<>>>;
+  using action_list = tmpl::list<SingletonActions::CountReceives>;
+  using initial_databox = db::DataBox<db::get_databox_list<tmpl::list<>>>;
   using explicit_single_actions_list = tmpl::list<SingletonActions::Initialize>;
-  using options = typelist<>;
+  using options = tmpl::list<>;
 
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
@@ -353,17 +354,17 @@ struct SingletonParallelComponent {
 template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
-  using const_global_cache_tag_list = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using action_list =
-      typelist<ArrayActions::AddIntValue10, ArrayActions::IncrementInt0,
-               ArrayActions::RemoveInt0, ArrayActions::SendToSingleton>;
+      tmpl::list<ArrayActions::AddIntValue10, ArrayActions::IncrementInt0,
+                 ArrayActions::RemoveInt0, ArrayActions::SendToSingleton>;
   using array_index = int;
   using initial_databox =
-      db::DataBox<db::get_databox_list<typelist<Tags::CountActionsCalled>>>;
+      db::DataBox<db::get_databox_list<tmpl::list<Tags::CountActionsCalled>>>;
 
   using explicit_single_actions_list = tmpl::list<ArrayActions::Initialize>;
-  using options = typelist<>;
+  using options = tmpl::list<>;
 
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
@@ -397,14 +398,14 @@ struct ArrayParallelComponent {
 template <class Metavariables>
 struct GroupParallelComponent {
   using chare_type = Parallel::Algorithms::Group;
-  using const_global_cache_tag_list = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<GroupActions::PrintSomething>;
+  using action_list = tmpl::list<GroupActions::PrintSomething>;
   using initial_databox =
-      db::DataBox<db::get_databox_list<typelist<Tags::CountActionsCalled>>>;
+      db::DataBox<db::get_databox_list<tmpl::list<Tags::CountActionsCalled>>>;
 
   using explicit_single_actions_list = tmpl::list<GroupActions::Initialize>;
-  using options = typelist<>;
+  using options = tmpl::list<>;
 
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
@@ -421,15 +422,15 @@ struct GroupParallelComponent {
 template <class Metavariables>
 struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
-  using const_global_cache_tag_list = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<GroupActions::PrintSomething>;
+  using action_list = tmpl::list<GroupActions::PrintSomething>;
   using initial_databox =
-      db::DataBox<db::get_databox_list<typelist<Tags::CountActionsCalled>>>;
+      db::DataBox<db::get_databox_list<tmpl::list<Tags::CountActionsCalled>>>;
 
   using explicit_single_actions_list =
       tmpl::list<NodegroupActions::Initialize>;
-  using options = typelist<>;
+  using options = tmpl::list<>;
 
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -173,11 +173,11 @@ struct singleton_reduce_custom_reduction {
 template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list = typelist<>;
-  using options = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<>;
-  using initial_databox = db::DataBox<db::get_databox_list<typelist<>>>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::DataBox<db::get_databox_list<tmpl::list<>>>;
   using reduction_actions_list =
       tmpl::list<singleton_reduce_sum_int, singleton_reduce_sum_double,
                  singleton_reduce_product_double,
@@ -255,12 +255,12 @@ struct array_reduce {
 template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
-  using const_global_cache_tag_list = typelist<>;
-  using options = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<>;
+  using action_list = tmpl::list<>;
   using array_index = int;
-  using initial_databox = db::DataBox<db::get_databox_list<typelist<>>>;
+  using initial_databox = db::DataBox<db::get_databox_list<tmpl::list<>>>;
 
   using explicit_single_actions_list = tmpl::list<array_reduce>;
 

--- a/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
@@ -82,10 +82,10 @@ struct shape_of_nametag : shape_of_nametag_base {
 template <class Metavariables>
 struct SingletonParallelComponent {
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list = typelist<name, age, height>;
-  using options = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<name, age, height>;
+  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<>;
+  using action_list = tmpl::list<>;
   using initial_databox = db::DataBox<tmpl::list<>>;
   using reduction_actions_list = tmpl::list<>;
 };
@@ -93,11 +93,11 @@ struct SingletonParallelComponent {
 template <class Metavariables>
 struct ArrayParallelComponent {
   using chare_type = Parallel::Algorithms::Array;
-  using const_global_cache_tag_list = typelist<height, shape_of_nametag>;
+  using const_global_cache_tag_list = tmpl::list<height, shape_of_nametag>;
   using array_index = int;
-  using options = typelist<>;
+  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<>;
+  using action_list = tmpl::list<>;
   using initial_databox = db::DataBox<tmpl::list<>>;
   using reduction_actions_list = tmpl::list<>;
 };
@@ -105,10 +105,10 @@ struct ArrayParallelComponent {
 template <class Metavariables>
 struct GroupParallelComponent {
   using chare_type = Parallel::Algorithms::Group;
-  using const_global_cache_tag_list = typelist<name>;
-  using options = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<name>;
+  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<>;
+  using action_list = tmpl::list<>;
   using initial_databox = db::DataBox<tmpl::list<>>;
   using reduction_actions_list = tmpl::list<>;
 };
@@ -116,20 +116,20 @@ struct GroupParallelComponent {
 template <class Metavariables>
 struct NodegroupParallelComponent {
   using chare_type = Parallel::Algorithms::Nodegroup;
-  using const_global_cache_tag_list = typelist<height>;
-  using options = typelist<>;
+  using const_global_cache_tag_list = tmpl::list<height>;
+  using options = tmpl::list<>;
   using metavariables = Metavariables;
-  using action_list = typelist<>;
+  using action_list = tmpl::list<>;
   using initial_databox = db::DataBox<tmpl::list<>>;
   using reduction_actions_list = tmpl::list<>;
 };
 
 struct TestMetavariables {
   using component_list =
-      typelist<SingletonParallelComponent<TestMetavariables>,
-               ArrayParallelComponent<TestMetavariables>,
-               GroupParallelComponent<TestMetavariables>,
-               NodegroupParallelComponent<TestMetavariables>>;
+      tmpl::list<SingletonParallelComponent<TestMetavariables>,
+                 ArrayParallelComponent<TestMetavariables>,
+                 GroupParallelComponent<TestMetavariables>,
+                 NodegroupParallelComponent<TestMetavariables>>;
 };
 
 }  // namespace

--- a/tests/Unit/Parallel/Test_Main.cpp
+++ b/tests/Unit/Parallel/Test_Main.cpp
@@ -50,11 +50,11 @@ struct TestMetavariables {
   // ctest passes options to control the tests
   static constexpr bool ignore_unrecognized_command_line_options = true;
   using component_list =
-      typelist<Test_Tentacles::Group<TestMetavariables>,
-               Test_Tentacles::NodeGroup<TestMetavariables>,
-               Test_Tentacles::Chare<TestMetavariables>,
-               Test_Tentacles::Array<TestMetavariables>,
-               Test_Tentacles::BoundArray<TestMetavariables>>;
+      tmpl::list<Test_Tentacles::Group<TestMetavariables>,
+                 Test_Tentacles::NodeGroup<TestMetavariables>,
+                 Test_Tentacles::Chare<TestMetavariables>,
+                 Test_Tentacles::Array<TestMetavariables>,
+                 Test_Tentacles::BoundArray<TestMetavariables>>;
   enum class phase { Initialization, Exit };
   static phase determine_next_phase(
       const Parallel::CProxy_ConstGlobalCache<TestMetavariables>& cache_proxy) {

--- a/tests/Unit/Parallel/Test_PupStlCpp11.cpp
+++ b/tests/Unit/Parallel/Test_PupStlCpp11.cpp
@@ -14,7 +14,7 @@ struct DerivedInPupStlCpp11;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 struct Base : public PUP::able {
-  using creatable_classes = typelist<Test_Classes::DerivedInPupStlCpp11>;
+  using creatable_classes = tmpl::list<Test_Classes::DerivedInPupStlCpp11>;
   // clang-tidy: internal charm++ warnings
   WRAPPED_PUPable_abstract(Base);  // NOLINT
 };

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.cpp
@@ -16,5 +16,5 @@ using Pi = ::GeneralizedHarmonic::Pi<3, Frame::Inertial>;
 using Phi = ::GeneralizedHarmonic::Phi<3, Frame::Inertial>;
 using GaugeH = ::GeneralizedHarmonic::GaugeH<3, Frame::Inertial>;
 
-using VariablesTags = typelist<SpacetimeMetric, Pi, Phi, GaugeH>;
+using VariablesTags = tmpl::list<SpacetimeMetric, Pi, Phi, GaugeH>;
 }  // namespace

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
@@ -44,7 +44,7 @@ void verify_time_independent_einstein_solution(
   using Pi = ::GeneralizedHarmonic::Pi<3, Frame::Inertial>;
   using Phi = ::GeneralizedHarmonic::Phi<3, Frame::Inertial>;
   using GaugeH = ::GeneralizedHarmonic::GaugeH<3, Frame::Inertial>;
-  using VariablesTags = typelist<SpacetimeMetric, Pi, Phi, GaugeH>;
+  using VariablesTags = tmpl::list<SpacetimeMetric, Pi, Phi, GaugeH>;
 
   // Set up grid
   const size_t data_size = pow<3>(grid_size_each_dimension);

--- a/tests/Unit/Utilities/Test_BoostHelpers.cpp
+++ b/tests/Unit/Utilities/Test_BoostHelpers.cpp
@@ -6,5 +6,5 @@
 
 static_assert(
     cpp17::is_same_v<boost::variant<double, int, char>,
-                     make_boost_variant_over<typelist<double, int, char>>>,
+                     make_boost_variant_over<tmpl::list<double, int, char>>>,
     "Failed testing make_variant_over");

--- a/tests/Unit/Utilities/Test_FakeVirtual.cpp
+++ b/tests/Unit/Utilities/Test_FakeVirtual.cpp
@@ -35,7 +35,7 @@ class Base {
 
   template <typename T>
   int fv(int x) {
-    return fake_virtual_fv<typelist<Derived>, T>(this, x);
+    return fake_virtual_fv<tmpl::list<Derived>, T>(this, x);
   }
 };
 
@@ -62,7 +62,7 @@ DEFINE_FAKE_VIRTUAL(deduced_and_nondeduced)
 
 class A;
 class B;
-using AB = typelist<A, B>;
+using AB = tmpl::list<A, B>;
 
 class MultipleBase {
  public:


### PR DESCRIPTION
## Proposed changes

We have a lot of inconsistencies when we use tmpl::list and typelist. Since they
both do the same thing we might as well stick to tmpl::list

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
