### PR TITLE
Factor some of TestHelpers into TestingFramework

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -82,7 +82,8 @@ INPUT += @PROJECT_SOURCE_DIR@/docs
 INPUT += @PROJECT_SOURCE_DIR@/tests/Unit/ActionTesting.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/TestCreation.hpp \
-         @PROJECT_SOURCE_DIR@/tests/Unit/TestHelpers.hpp
+         @PROJECT_SOURCE_DIR@/tests/Unit/TestHelpers.hpp \
+         @PROJECT_SOURCE_DIR@/tests/Unit/TestingFramework.hpp
 
 
 

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
@@ -7,7 +7,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-#include "Utilities/StdHelpers.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
 
 template <typename FluxTags, size_t Dim, typename DerivativeFrame>
 Variables<db::wrap_tags_in<Tags::div, FluxTags, DerivativeFrame>> divergence(

--- a/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
+++ b/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
@@ -20,6 +20,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/ApparentHorizons/Test_SpherepackIterator.cpp
+++ b/tests/Unit/ApparentHorizons/Test_SpherepackIterator.cpp
@@ -5,6 +5,7 @@
 
 #include "ApparentHorizons/SpherepackIterator.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.SpherepackIterator",
                   "[ApparentHorizons][Unit]") {

--- a/tests/Unit/ApparentHorizons/Test_Strahlkorper.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Strahlkorper.cpp
@@ -11,6 +11,7 @@
 #include "ApparentHorizons/Strahlkorper.hpp"
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperDataBox.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperDataBox.cpp
@@ -11,7 +11,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "tests/Unit/ApparentHorizons/YlmTestFunctions.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -18,6 +18,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 namespace TestExpansion {

--- a/tests/Unit/ApparentHorizons/Test_YlmSpherepack.cpp
+++ b/tests/Unit/ApparentHorizons/Test_YlmSpherepack.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "tests/Unit/ApparentHorizons/YlmTestFunctions.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/ControlSystem/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/ControlSystem/Test_PiecewisePolynomial.cpp
@@ -5,7 +5,7 @@
 
 #include "ControlSystem/PiecewisePolynomial.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
                   "[ControlSystem][Unit]") {

--- a/tests/Unit/ControlSystem/Test_SettleToConstant.cpp
+++ b/tests/Unit/ControlSystem/Test_SettleToConstant.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "ControlSystem/SettleToConstant.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.SettleToConstant",
                   "[ControlSystem][Unit]") {

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Determinant.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Determinant.cpp
@@ -5,7 +5,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Determinant.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Determinant",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_DeterminantAndInverse.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_DeterminantAndInverse.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 // In the spirit of the Tensor type aliases, but for a rank-2 Tensor with each

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_DivideBy.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_DivideBy.cpp
@@ -5,6 +5,7 @@
 
 #include "DataStructures/Tensor/EagerMath/DivideBy.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.EuclideanMagnitude",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -13,7 +13,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Literals.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 double multiply_by_two(const double value) { return 2.0 * value; }

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -6,7 +6,9 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector", "[DataStructures][Unit]") {
   DataVector a{2};

--- a/tests/Unit/DataStructures/Test_GeneralIndexIterator.cpp
+++ b/tests/Unit/DataStructures/Test_GeneralIndexIterator.cpp
@@ -6,7 +6,7 @@
 
 #include "DataStructures/GeneralIndexIterator.hpp"
 #include "Utilities/Gsl.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.GeneralIndexIterator",
                   "[Unit][DataStructures]") {

--- a/tests/Unit/DataStructures/Test_Identity.cpp
+++ b/tests/Unit/DataStructures/Test_Identity.cpp
@@ -8,7 +8,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Identity.hpp"
 #include "Utilities/MakeWithValue.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <size_t Dim, typename DataType>

--- a/tests/Unit/DataStructures/Test_Index.cpp
+++ b/tests/Unit/DataStructures/Test_Index.cpp
@@ -7,6 +7,7 @@
 #include "DataStructures/Index.hpp"
 #include "Utilities/Literals.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Index", "[DataStructures][Unit]") {
   Index<0> index_0d;

--- a/tests/Unit/DataStructures/Test_IndexIterator.cpp
+++ b/tests/Unit/DataStructures/Test_IndexIterator.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "DataStructures/IndexIterator.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.IndexIterator",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_MakeWithValue.cpp
+++ b/tests/Unit/DataStructures/Test_MakeWithValue.cpp
@@ -9,7 +9,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TaggedTuple.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <size_t Dim>

--- a/tests/Unit/DataStructures/Test_Matrix.cpp
+++ b/tests/Unit/DataStructures/Test_Matrix.cpp
@@ -6,6 +6,7 @@
 
 #include "DataStructures/Matrix.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Matrix", "[DataStructures][Unit]") {
   Matrix matrix(3, 5, 1.0);

--- a/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
+++ b/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
@@ -17,7 +17,7 @@
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/SegmentId.hpp"
 #include "Utilities/MakeVector.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 using Affine = CoordinateMaps::Affine;
 using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;

--- a/tests/Unit/DataStructures/Test_SliceIterator.cpp
+++ b/tests/Unit/DataStructures/Test_SliceIterator.cpp
@@ -5,7 +5,7 @@
 
 #include "DataStructures/Index.hpp"
 #include "DataStructures/SliceIterator.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void check_slice_iterator_helper(SliceIterator si) {

--- a/tests/Unit/DataStructures/Test_StripeIterator.cpp
+++ b/tests/Unit/DataStructures/Test_StripeIterator.cpp
@@ -5,7 +5,7 @@
 
 #include "DataStructures/Index.hpp"
 #include "DataStructures/StripeIterator.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void check_stripe_iterator_helper(StripeIterator s) {

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -8,6 +8,7 @@
 #include "Utilities/Literals.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 /// [change_up_lo]
 using Index = SpatialIndex<3, UpLo::Lo, Frame::Grid>;

--- a/tests/Unit/DataStructures/Test_TensorExpressions.cpp
+++ b/tests/Unit/DataStructures/Test_TensorExpressions.cpp
@@ -9,7 +9,7 @@
 #include "DataStructures/Tensor/Expressions/Evaluate.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.Expression.AddSubtract",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -10,6 +10,7 @@
 #include "Parallel/PupStlCpp11.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace VariablesTestTags_detail {
 /// [simple_variables_tag]

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -14,6 +14,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 /*!
  * \ingroup TestingFrameworkGroup

--- a/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
@@ -7,6 +7,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Affine", "[Domain][Unit]") {
   const double xA = -1.0;

--- a/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
@@ -10,7 +10,7 @@
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Identity",
                   "[Domain][Unit]") {

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -12,6 +12,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <typename Map1, typename Map2, typename DataType, size_t Dim>

--- a/tests/Unit/Domain/CoordinateMaps/Test_Equiangular.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Equiangular.cpp
@@ -8,6 +8,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Equiangular", "[Domain][Unit]") {
   const double xA = -1.0;

--- a/tests/Unit/Domain/CoordinateMaps/Test_Identity.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Identity.cpp
@@ -7,6 +7,7 @@
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 template <size_t Dim>
 void test_identity() {

--- a/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
@@ -10,6 +10,7 @@
 #include "Domain/LogicalCoordinates.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf2Maps",
                   "[Domain][Unit]") {

--- a/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
@@ -7,6 +7,7 @@
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Rotation<2>", "[Domain][Unit]") {
   CoordinateMaps::Rotation<2> half_pi_rotation_map(M_PI_2);

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -9,6 +9,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equidistant",
                   "[Domain][Unit]") {

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -11,6 +11,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_wedge3d_all_directions(const bool with_equiangular_map) {

--- a/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
@@ -12,7 +12,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 using Affine = CoordinateMaps::Affine;

--- a/tests/Unit/Domain/DomainCreators/Test_Disk.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Disk.cpp
@@ -13,7 +13,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_disk_construction(

--- a/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
@@ -11,7 +11,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_interval_construction(

--- a/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
@@ -12,7 +12,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 using Affine = CoordinateMaps::Affine;

--- a/tests/Unit/Domain/DomainCreators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_RotatedIntervals.cpp
@@ -16,7 +16,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_rotated_intervals_construction(

--- a/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
@@ -12,7 +12,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_shell_construction(

--- a/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
@@ -20,7 +20,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_sphere_construction(

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -22,6 +22,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 namespace {
 template <size_t VolumeDim>

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -7,6 +7,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 template <size_t Dim>
 void test_block() {

--- a/tests/Unit/Domain/Test_BlockNeighbor.cpp
+++ b/tests/Unit/Domain/Test_BlockNeighbor.cpp
@@ -5,6 +5,7 @@
 
 #include "Domain/BlockNeighbor.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.BlockNeighbor", "[Domain][Unit]") {
   // Test default constructor, only used for Charm++ serialization so no CHECK

--- a/tests/Unit/Domain/Test_CoordinatesTag.cpp
+++ b/tests/Unit/Domain/Test_CoordinatesTag.cpp
@@ -11,7 +11,7 @@
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/Tags.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <size_t Dim, typename T>

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -16,7 +16,7 @@
 #include "Domain/Neighbors.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Utilities/MakeArray.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_create_initial_element(

--- a/tests/Unit/Domain/Test_Direction.cpp
+++ b/tests/Unit/Domain/Test_Direction.cpp
@@ -6,6 +6,7 @@
 #include "Domain/Direction.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction1D", "[Domain][Unit]") {
   auto upper_xi_1 = Direction<1>::upper_xi();

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -10,6 +10,7 @@
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_1d_domains() {

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -5,7 +5,7 @@
 
 #include "Domain/Direction.hpp"
 #include "Domain/DomainHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.SameBlock",
                   "[Domain][Unit]") {

--- a/tests/Unit/Domain/Test_Element.cpp
+++ b/tests/Unit/Domain/Test_Element.cpp
@@ -11,6 +11,7 @@
 #include "Domain/Neighbors.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <size_t VolumeDim>

--- a/tests/Unit/Domain/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Test_ElementId.cpp
@@ -7,6 +7,7 @@
 #include "Domain/ElementIndex.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.ElementId", "[Domain][Unit]") {
   // Test default constructor:

--- a/tests/Unit/Domain/Test_ElementIndex.cpp
+++ b/tests/Unit/Domain/Test_ElementIndex.cpp
@@ -8,6 +8,7 @@
 #include "Domain/ElementIndex.hpp"
 #include "Domain/SegmentId.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <size_t VolumeDim>

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -11,6 +11,7 @@
 #include "Domain/ElementMap.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 using DV = DataVector;

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -15,7 +15,7 @@
 #include "Domain/ElementMap.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Utilities/Gsl.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <typename Map>

--- a/tests/Unit/Domain/Test_InitialElementIds.cpp
+++ b/tests/Unit/Domain/Test_InitialElementIds.cpp
@@ -10,7 +10,7 @@
 #include "Domain/InitialElementIds.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <size_t VolumeDim>

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -16,7 +16,7 @@
 #include "Domain/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <size_t N>

--- a/tests/Unit/Domain/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_LogicalCoordinates.cpp
@@ -9,7 +9,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/LogicalCoordinates.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.LogicalCoordinates", "[Domain][Unit]") {
   using Affine2d = CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,

--- a/tests/Unit/Domain/Test_Neighbors.cpp
+++ b/tests/Unit/Domain/Test_Neighbors.cpp
@@ -5,6 +5,7 @@
 
 #include "Domain/Neighbors.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.Neighbors.1d", "[Domain][Unit]") {
   // Test default constructor, only used for Charm++ serialization so no CHECK

--- a/tests/Unit/Domain/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Test_OrientationMap.cpp
@@ -7,6 +7,7 @@
 #include "Domain/OrientationMap.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/Domain/Test_SegmentId.cpp
+++ b/tests/Unit/Domain/Test_SegmentId.cpp
@@ -6,6 +6,7 @@
 #include "Domain/SegmentId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.SegmentId", "[Domain][Unit]") {
   // Test default constructor:

--- a/tests/Unit/Domain/Test_Side.cpp
+++ b/tests/Unit/Domain/Test_Side.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "Domain/Side.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.Side", "[Domain][Unit]") {
   Side side_lower = Side::Lower;

--- a/tests/Unit/ErrorHandling/Test_AbortWithErrorMessage.cpp
+++ b/tests/Unit/ErrorHandling/Test_AbortWithErrorMessage.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "ErrorHandling/AbortWithErrorMessage.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 // [[OutputRegex, 'a == b' violated!]]
 [[noreturn]] SPECTRE_TEST_CASE(

--- a/tests/Unit/ErrorHandling/Test_AssertAndError.cpp
+++ b/tests/Unit/ErrorHandling/Test_AssertAndError.cpp
@@ -5,7 +5,7 @@
 
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/Error.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 // [[OutputRegex, Testing assert]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.ErrorHandling.Assert",

--- a/tests/Unit/ErrorHandling/Test_FloatingPointExceptions.cpp
+++ b/tests/Unit/ErrorHandling/Test_FloatingPointExceptions.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 
 #include "ErrorHandling/FloatingPointExceptions.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 // [[OutputRegex, Floating point exception!]]
 SPECTRE_TEST_CASE("Unit.ErrorHandling.FloatingPointExceptions.Invalid",

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
@@ -9,7 +9,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct var_tag : db::DataBoxTag {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -31,7 +31,7 @@
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct Var : db::DataBoxTag {

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -19,6 +19,7 @@
 #include "tests/Unit/ActionTesting.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct DefaultClasses {

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_DuDt.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Test_DuDt.cpp
@@ -7,7 +7,7 @@
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "tests/Unit/Evolution/Systems/CurvedScalarWave/TestHelpers.hpp"
 #include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <size_t Dim>

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
@@ -7,7 +7,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Equations.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <typename Tensor>

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -15,7 +15,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <size_t Dim>

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -14,6 +14,7 @@
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Literals.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
   const std::string h5_file_name("Unit.IO.H5.File.h5");

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -23,7 +23,7 @@
 #include "Time/TimeId.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct Var : db::DataBoxTag {

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
@@ -21,9 +21,10 @@
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 constexpr size_t volume_dim = 2;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -17,8 +17,9 @@
 #include "Domain/FaceNormal.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp"
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct Var : db::DataBoxTag {

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_LagrangePolynomial.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_LagrangePolynomial.cpp
@@ -5,7 +5,8 @@
 #include <catch.hpp>
 
 #include "NumericalAlgorithms/Interpolation/LagrangePolynomial.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.LagrangePolynomial",
                   "[Unit][NumericalAlgorithms]") {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
@@ -10,7 +10,7 @@
 #include "DataStructures/IndexIterator.hpp"
 #include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_definite_integral_1d(const Index<1>& extents) {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -22,7 +22,7 @@
 #include "PointwiseFunctions/MathFunctions/TensorProduct.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeWithValue.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 using Affine = CoordinateMaps::Affine;

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
@@ -11,7 +11,7 @@
 #include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
 #include "Utilities/Blas.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Linearize",
                   "[NumericalAlgorithms][LinearOperators][Unit]") {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
@@ -11,7 +11,7 @@
 #include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.MeanValue",
                   "[NumericalAlgorithms][LinearOperators][Unit]") {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -17,7 +17,7 @@
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/Tags.hpp"

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
@@ -6,7 +6,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "NumericalAlgorithms/LinearOperators/Transpose.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_OneDRootFinder.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_OneDRootFinder.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "NumericalAlgorithms/RootFinding/RootFinder.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 double f_free(double x) { return 2.0 - x * x; }

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 // [[OutputRegex, Assumes that there are two real roots]]
 [[noreturn]] SPECTRE_TEST_CASE(

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_LegendreGaussLobatto.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_LegendreGaussLobatto.cpp
@@ -9,7 +9,7 @@
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/Blas.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LegendreGaussLobatto.Points",

--- a/tests/Unit/Options/Test_CustomTypeConstruction.cpp
+++ b/tests/Unit/Options/Test_CustomTypeConstruction.cpp
@@ -8,7 +8,7 @@
 
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 /// [class_creation_example]

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -10,7 +10,7 @@
 
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -14,6 +14,7 @@
 #include "Options/ParseOptions.hpp"
 #include "Utilities/Literals.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Options.Empty.success", "[Unit][Options]") {
   Options<tmpl::list<>> opts("");

--- a/tests/Unit/Parallel/Test_Algorithm.cpp
+++ b/tests/Unit/Parallel/Test_Algorithm.cpp
@@ -8,7 +8,7 @@
 #include "Parallel/Info.hpp"
 #include "Parallel/Main.hpp"
 #include "Parallel/Printf.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct TestMetavariables {

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -14,7 +14,7 @@
 #include "Parallel/Main.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 static constexpr int number_of_1d_array_elements_per_core = 10;
 

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -14,7 +14,7 @@
 #include "Parallel/Main.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 static constexpr int number_of_1d_array_elements = 14;
 

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -17,7 +17,7 @@
 #include "Parallel/Printf.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 struct TestMetavariables;
 template <class Metavariables>

--- a/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
@@ -24,7 +24,7 @@ void register_pupables();
 #include "Parallel/Exit.hpp"
 #include "Parallel/Printf.hpp"
 #include "Utilities/TaggedTuple.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/Parallel/Test_Parallel.cpp
+++ b/tests/Unit/Parallel/Test_Parallel.cpp
@@ -5,7 +5,7 @@
 
 #include "Parallel/Info.hpp"
 #include "Parallel/Printf.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct TestStream {

--- a/tests/Unit/Parallel/Test_PupStlCpp11.cpp
+++ b/tests/Unit/Parallel/Test_PupStlCpp11.cpp
@@ -8,6 +8,7 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace Test_Classes {
 struct DerivedInPupStlCpp11;

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
@@ -13,6 +13,7 @@
 #include "tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp"
 #include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_Minkowski.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_Minkowski.cpp
@@ -4,6 +4,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <size_t Dim, typename T>

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
@@ -24,7 +24,7 @@
 #include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 /// \ingroup TestingFrameworkGroup
 /// Determines if the given `solution` is a time-independent solution

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -10,6 +10,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
@@ -10,7 +10,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 template <typename Symmetry, typename IndexList>
 void check_tensor_doubles_equals_tensor_datavectors(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -4,7 +4,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_1d_spatial_christoffel_first_kind(const DataVector &used_for_size) {

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -7,7 +7,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
 #include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_compute_1d_phi(const DataVector& used_for_size) {

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -7,7 +7,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_compute_1d_spacetime_metric(const DataVector& used_for_size) {

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
@@ -5,7 +5,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_1d_spatial_raise(const DataVector& used_for_size) {

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
@@ -6,7 +6,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <typename DataType>

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
@@ -7,6 +7,7 @@
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian",
                   "[PointwiseFunctions][Unit]") {

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
@@ -8,6 +8,7 @@
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
                   "[PointwiseFunctions][Unit]") {

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
@@ -8,6 +8,7 @@
 #include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid",
                   "[PointwiseFunctions][Unit]") {

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -24,6 +24,7 @@
 #include "PointwiseFunctions/MathFunctions/TensorProduct.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 using Affine = CoordinateMaps::Affine;

--- a/tests/Unit/TestFramework.cpp
+++ b/tests/Unit/TestFramework.cpp
@@ -2,9 +2,8 @@
 // See LICENSE.txt for details.
 
 #include <catch.hpp>
-#include <charm++.h>
 
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("TestFramework.Approx", "[Unit]") {
   /// [approx_test]
@@ -35,8 +34,8 @@ SPECTRE_TEST_CASE("TestFramework.Approx", "[Unit]") {
 
 /// [error_test]
 // [[OutputRegex, I failed]]
-SPECTRE_TEST_CASE("TestFramework.Abort", "[Unit]") {
+[[noreturn]] SPECTRE_TEST_CASE("TestFramework.Abort", "[Unit]") {
   ERROR_TEST();
   /// [error_test]
-  CkAbort("I failed");
+  Parallel::abort("I failed");
 }

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -8,223 +8,18 @@
 
 #include <array>
 #include <catch.hpp>
-#include <charm++.h>
-#include <csignal>
-#include <limits>
-#include <pup.h>
+#include <iterator>
+#include <memory>
 
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/Error.hpp"
-#include "Parallel/Exit.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Parallel/Serialize.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
-#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief A replacement for Catch's TEST_CASE that silences clang-tidy warnings
- */
-#define SPECTRE_TEST_CASE(m, n) TEST_CASE(m, n)  // NOLINT
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief A similar to Catch's REQUIRE statement, but can be used in tests that
- * spawn several chares with possibly complex interaction between the chares.
- */
-#define SPECTRE_PARALLEL_REQUIRE(expr)                                  \
-  do {                                                                  \
-    if (not(expr)) {                                                    \
-      ERROR("\nFailed comparison: " << #expr << "\nLine: " << __LINE__  \
-                                    << "\nFile: " << __FILE__ << "\n"); \
-    }                                                                   \
-  } while (false)
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief A similar to Catch's REQUIRE_FALSE statement, but can be used in tests
- * that spawn several chares with possibly complex interaction between the
- * chares.
- */
-#define SPECTRE_PARALLEL_REQUIRE_FALSE(expr)                            \
-  do {                                                                  \
-    if ((expr)) {                                                       \
-      ERROR("\nFailed comparison: " << #expr << "\nLine: " << __LINE__  \
-                                    << "\nFile: " << __FILE__ << "\n"); \
-    }                                                                   \
-  } while (false)
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief Set a default tolerance for floating-point number comparison
- *
- * \details
- * Catch's default (relative) tolerance for comparing floating-point numbers is
- * `std::numeric_limits<float>::%epsilon() * 100`, or roughly \f$10^{-5}\f$.
- * This tolerance is too loose for checking many scientific algorithms that
- * rely on double precision floating-point accuracy, so we provide a tighter
- * tighter tolerance through the `approx` static object.
- *
- * \example
- * \snippet TestFramework.cpp approx_test
- */
-// clang-tidy: static object creation may throw exception
-static Approx approx =                                          // NOLINT
-    Approx::custom()                                            // NOLINT
-        .epsilon(std::numeric_limits<double>::epsilon() * 100)  // NOLINT
-        .scale(1.0);                                            // NOLINT
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief A wrapper around Catch's CHECK macro that checks approximate
- * equality of entries in iterable containers.  For maplike
- * containers, keys are checked for strict equality and values are
- * checked for approximate equality.
- *
- * \note This compares elements in order, so it will not work reliably
- * on unordered containers.
- */
-#define CHECK_ITERABLE_APPROX(a, b)                                          \
-  do {                                                                       \
-    INFO(__FILE__ ":" + std::to_string(__LINE__) + ": " #a " == " #b);       \
-    check_iterable_approx<std::common_type_t<                                \
-        std::decay_t<decltype(a)>, std::decay_t<decltype(b)>>>::apply(a, b); \
-  } while (false)
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief Same as `CHECK_ITERABLE_APPROX` with user-defined Approx.
- *  The third argument should be of type `Approx`.
- */
-#define CHECK_ITERABLE_CUSTOM_APPROX(a, b, appx)                             \
-  do {                                                                       \
-    INFO(__FILE__ ":" + std::to_string(__LINE__) + ": " #a " == " #b);       \
-    check_iterable_approx<std::common_type_t<                                \
-        std::decay_t<decltype(a)>, std::decay_t<decltype(b)>>>::apply(a, b,  \
-                                                                      appx); \
-  } while (false)
-
-/// \cond HIDDEN_SYMBOLS
-template <typename T, typename = std::nullptr_t>
-struct check_iterable_approx {
-  // clang-tidy: non-const reference
-  static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
-    CHECK(a == appx(b));
-  }
-};
-
-template <typename T>
-struct check_iterable_approx<
-    T, Requires<not tt::is_maplike_v<T> and tt::is_iterable_v<T>>> {
-  // clang-tidy: non-const reference
-  static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
-    auto a_it = a.begin();
-    auto b_it = b.begin();
-    CHECK(a_it != a.end());
-    CHECK(b_it != b.end());
-    while (a_it != a.end() and b_it != b.end()) {
-      check_iterable_approx<std::decay_t<decltype(*a_it)>>::apply(*a_it, *b_it,
-                                                                  appx);
-      ++a_it;
-      ++b_it;
-    }
-    {
-      INFO("Iterable is longer in first argument than in second argument");
-      CHECK(a_it == a.end());
-    }
-    {
-      INFO("Iterable is shorter in first argument than in second argument");
-      CHECK(b_it == b.end());
-    }
-  }
-};
-
-template <typename T>
-struct check_iterable_approx<
-    T, Requires<tt::is_maplike_v<T> and tt::is_iterable_v<T>>> {
-  // clang-tidy: non-const reference
-  static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
-    auto a_it = a.begin();
-    auto b_it = b.begin();
-    CHECK(a_it != a.end());
-    CHECK(b_it != b.end());
-    while (a_it != a.end() and b_it != b.end()) {
-      CHECK(a_it->first == b_it->first);
-      check_iterable_approx<std::decay_t<decltype(a_it->second)>>::apply(
-          a_it->second, b_it->second, appx);
-      ++a_it;
-      ++b_it;
-    }
-    {
-      INFO("Iterable is longer in first argument than in second argument");
-      CHECK(a_it == a.end());
-    }
-    {
-      INFO("Iterable is shorter in first argument than in second argument");
-      CHECK(b_it == b.end());
-    }
-  }
-};
-/// \endcond
-
-/// \cond HIDDEN_SYMBOLS
-[[noreturn]] inline void spectre_testing_signal_handler(int /*signal*/) {
-  Parallel::exit();
-}
-/// \endcond
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief Mark a test as checking a call to ERROR
- *
- * \details
- * In order to properly handle aborting with Catch versions newer than 1.6.1
- * we must install a signal handler after Catch does, which means inside the
- * SPECTRE_TEST_CASE itself. The ERROR_TEST() macro should be the first line in
- * the SPECTRE_TEST_CASE.
- *
- * \example
- * \snippet TestFramework.cpp error_test
- */
-#define ERROR_TEST()                                      \
-  do {                                                    \
-    std::signal(SIGABRT, spectre_testing_signal_handler); \
-  } while (false)
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief Mark a test to be checking an ASSERT
- *
- * \details
- * Testing error handling is just as important as testing functionality. Tests
- * that are supposed to exit with an error must be annotated with the attribute
- * \code
- * // [[OutputRegex, The regex that should be found in the output]]
- * \endcode
- * Note that the regex only needs to be a sub-expression of the error message,
- * that is, there are implicit wildcards before and after the string.
- *
- * In order to test ASSERT's properly the test must also fail for release
- * builds. This is done by adding this macro at the beginning for the test.
- *
- * \example
- * \snippet Test_Time.cpp example_of_error_test
- */
-#ifdef SPECTRE_DEBUG
-#define ASSERTION_TEST() \
-  do {                   \
-    ERROR_TEST();        \
-  } while (false)
-#else
-#include "Parallel/Abort.hpp"
-#define ASSERTION_TEST()                                        \
-  do {                                                          \
-    ERROR_TEST();                                               \
-    Parallel::abort("### No ASSERT tests in release mode ###"); \
-  } while (false)
-#endif
 
 /*!
  * \ingroup TestingFrameworkGroup
@@ -432,23 +227,6 @@ std::string get_output(const Container& c) {
   os << c;
   return os.str();
 }
-
-namespace TestHelpers_detail {
-template <typename T>
-std::string format_capture_precise(const T& t) noexcept {
-  std::ostringstream os;
-  os << std::scientific << std::setprecision(18) << t;
-  return os.str();
-}
-}  // namespace TestHelpers_detail
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief Alternative to Catch's CAPTURE that prints more digits.
- */
-#define CAPTURE_PRECISE(variable)                                    \
-  INFO(#variable << ": "                                             \
-       << TestHelpers_detail::format_capture_precise(variable))
 
 /*!
  * \ingroup TestingFrameworkGroup

--- a/tests/Unit/Test_TestHelpers.cpp
+++ b/tests/Unit/Test_TestHelpers.cpp
@@ -4,7 +4,9 @@
 #include <catch.hpp>
 
 #include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Test.TestHelpers", "[Unit]") {
   std::vector<double> vector{0, 1, 2, 3};

--- a/tests/Unit/TestingFramework.hpp
+++ b/tests/Unit/TestingFramework.hpp
@@ -1,0 +1,242 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Code to wrap or improve the Catch testing framework used for unit tests.
+
+#pragma once
+
+#include <catch.hpp>
+#include <csignal>
+#include <cstddef>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <string>
+
+#include "ErrorHandling/Error.hpp"
+#include "Parallel/Abort.hpp"
+#include "Parallel/Exit.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief A replacement for Catch's TEST_CASE that silences clang-tidy warnings
+ */
+#define SPECTRE_TEST_CASE(m, n) TEST_CASE(m, n)  // NOLINT
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief A similar to Catch's REQUIRE statement, but can be used in tests that
+ * spawn several chares with possibly complex interaction between the chares.
+ */
+#define SPECTRE_PARALLEL_REQUIRE(expr)                                  \
+  do {                                                                  \
+    if (not(expr)) {                                                    \
+      ERROR("\nFailed comparison: " << #expr << "\nLine: " << __LINE__  \
+                                    << "\nFile: " << __FILE__ << "\n"); \
+    }                                                                   \
+  } while (false)
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief A similar to Catch's REQUIRE_FALSE statement, but can be used in tests
+ * that spawn several chares with possibly complex interaction between the
+ * chares.
+ */
+#define SPECTRE_PARALLEL_REQUIRE_FALSE(expr)                            \
+  do {                                                                  \
+    if ((expr)) {                                                       \
+      ERROR("\nFailed comparison: " << #expr << "\nLine: " << __LINE__  \
+                                    << "\nFile: " << __FILE__ << "\n"); \
+    }                                                                   \
+  } while (false)
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Set a default tolerance for floating-point number comparison
+ *
+ * \details
+ * Catch's default (relative) tolerance for comparing floating-point numbers is
+ * `std::numeric_limits<float>::%epsilon() * 100`, or roughly \f$10^{-5}\f$.
+ * This tolerance is too loose for checking many scientific algorithms that
+ * rely on double precision floating-point accuracy, so we provide a tighter
+ * tighter tolerance through the `approx` static object.
+ *
+ * \example
+ * \snippet TestFramework.cpp approx_test
+ */
+// clang-tidy: static object creation may throw exception
+static Approx approx =                                          // NOLINT
+    Approx::custom()                                            // NOLINT
+        .epsilon(std::numeric_limits<double>::epsilon() * 100)  // NOLINT
+        .scale(1.0);                                            // NOLINT
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief A wrapper around Catch's CHECK macro that checks approximate
+ * equality of entries in iterable containers.  For maplike
+ * containers, keys are checked for strict equality and values are
+ * checked for approximate equality.
+ *
+ * \note This compares elements in order, so it will not work reliably
+ * on unordered containers.
+ */
+#define CHECK_ITERABLE_APPROX(a, b)                                          \
+  do {                                                                       \
+    INFO(__FILE__ ":" + std::to_string(__LINE__) + ": " #a " == " #b);       \
+    check_iterable_approx<std::common_type_t<                                \
+        std::decay_t<decltype(a)>, std::decay_t<decltype(b)>>>::apply(a, b); \
+  } while (false)
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Same as `CHECK_ITERABLE_APPROX` with user-defined Approx.
+ *  The third argument should be of type `Approx`.
+ */
+#define CHECK_ITERABLE_CUSTOM_APPROX(a, b, appx)                             \
+  do {                                                                       \
+    INFO(__FILE__ ":" + std::to_string(__LINE__) + ": " #a " == " #b);       \
+    check_iterable_approx<std::common_type_t<                                \
+        std::decay_t<decltype(a)>, std::decay_t<decltype(b)>>>::apply(a, b,  \
+                                                                      appx); \
+  } while (false)
+
+/// \cond HIDDEN_SYMBOLS
+template <typename T, typename = std::nullptr_t>
+struct check_iterable_approx {
+  // clang-tidy: non-const reference
+  static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
+    CHECK(a == appx(b));
+  }
+};
+
+template <typename T>
+struct check_iterable_approx<
+    T, Requires<not tt::is_maplike_v<T> and tt::is_iterable_v<T>>> {
+  // clang-tidy: non-const reference
+  static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
+    auto a_it = a.begin();
+    auto b_it = b.begin();
+    CHECK(a_it != a.end());
+    CHECK(b_it != b.end());
+    while (a_it != a.end() and b_it != b.end()) {
+      check_iterable_approx<std::decay_t<decltype(*a_it)>>::apply(*a_it, *b_it,
+                                                                  appx);
+      ++a_it;
+      ++b_it;
+    }
+    {
+      INFO("Iterable is longer in first argument than in second argument");
+      CHECK(a_it == a.end());
+    }
+    {
+      INFO("Iterable is shorter in first argument than in second argument");
+      CHECK(b_it == b.end());
+    }
+  }
+};
+
+template <typename T>
+struct check_iterable_approx<
+    T, Requires<tt::is_maplike_v<T> and tt::is_iterable_v<T>>> {
+  // clang-tidy: non-const reference
+  static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
+    auto a_it = a.begin();
+    auto b_it = b.begin();
+    CHECK(a_it != a.end());
+    CHECK(b_it != b.end());
+    while (a_it != a.end() and b_it != b.end()) {
+      CHECK(a_it->first == b_it->first);
+      check_iterable_approx<std::decay_t<decltype(a_it->second)>>::apply(
+          a_it->second, b_it->second, appx);
+      ++a_it;
+      ++b_it;
+    }
+    {
+      INFO("Iterable is longer in first argument than in second argument");
+      CHECK(a_it == a.end());
+    }
+    {
+      INFO("Iterable is shorter in first argument than in second argument");
+      CHECK(b_it == b.end());
+    }
+  }
+};
+/// \endcond
+
+/// \cond HIDDEN_SYMBOLS
+[[noreturn]] inline void spectre_testing_signal_handler(int /*signal*/) {
+  Parallel::exit();
+}
+/// \endcond
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Mark a test as checking a call to ERROR
+ *
+ * \details
+ * In order to properly handle aborting with Catch versions newer than 1.6.1
+ * we must install a signal handler after Catch does, which means inside the
+ * SPECTRE_TEST_CASE itself. The ERROR_TEST() macro should be the first line in
+ * the SPECTRE_TEST_CASE.
+ *
+ * \example
+ * \snippet TestFramework.cpp error_test
+ */
+#define ERROR_TEST()                                      \
+  do {                                                    \
+    std::signal(SIGABRT, spectre_testing_signal_handler); \
+  } while (false)
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Mark a test to be checking an ASSERT
+ *
+ * \details
+ * Testing error handling is just as important as testing functionality. Tests
+ * that are supposed to exit with an error must be annotated with the attribute
+ * \code
+ * // [[OutputRegex, The regex that should be found in the output]]
+ * \endcode
+ * Note that the regex only needs to be a sub-expression of the error message,
+ * that is, there are implicit wildcards before and after the string.
+ *
+ * In order to test ASSERT's properly the test must also fail for release
+ * builds. This is done by adding this macro at the beginning for the test.
+ *
+ * \example
+ * \snippet Test_Time.cpp example_of_error_test
+ */
+#ifdef SPECTRE_DEBUG
+#define ASSERTION_TEST() \
+  do {                   \
+    ERROR_TEST();        \
+  } while (false)
+#else
+#include "Parallel/Abort.hpp"
+#define ASSERTION_TEST()                                        \
+  do {                                                          \
+    ERROR_TEST();                                               \
+    Parallel::abort("### No ASSERT tests in release mode ###"); \
+  } while (false)
+#endif
+
+namespace TestHelpers_detail {
+template <typename T>
+std::string format_capture_precise(const T& t) noexcept {
+  std::ostringstream os;
+  os << std::scientific << std::setprecision(18) << t;
+  return os.str();
+}
+}  // namespace TestHelpers_detail
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Alternative to Catch's CAPTURE that prints more digits.
+ */
+#define CAPTURE_PRECISE(variable)                                    \
+  INFO(#variable << ": "                                             \
+       << TestHelpers_detail::format_capture_precise(variable))
+

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -14,7 +14,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct Metavariables;

--- a/tests/Unit/Time/Actions/Test_FinalTime.cpp
+++ b/tests/Unit/Time/Actions/Test_FinalTime.cpp
@@ -13,7 +13,7 @@
 #include "Time/TimeId.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct Metavariables;

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -16,7 +16,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct Var : db::DataBoxTag {

--- a/tests/Unit/Time/Test_EveryNSlabs.cpp
+++ b/tests/Unit/Time/Test_EveryNSlabs.cpp
@@ -12,6 +12,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct TimeTriggers {

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -10,6 +10,7 @@
 #include "Time/Time.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 Time make_time(const double t) noexcept {

--- a/tests/Unit/Time/Test_PastTime.cpp
+++ b/tests/Unit/Time/Test_PastTime.cpp
@@ -12,6 +12,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct TimeTriggers {

--- a/tests/Unit/Time/Test_Slab.cpp
+++ b/tests/Unit/Time/Test_Slab.cpp
@@ -7,6 +7,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.Slab", "[Unit][Time]") {
   const double tstart_d = 0.68138945475734402635;

--- a/tests/Unit/Time/Test_SpecifiedSlabs.cpp
+++ b/tests/Unit/Time/Test_SpecifiedSlabs.cpp
@@ -12,6 +12,7 @@
 #include "Time/Triggers/TimeTriggers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct TimeTriggers {

--- a/tests/Unit/Time/Test_StepControllers.cpp
+++ b/tests/Unit/Time/Test_StepControllers.cpp
@@ -12,6 +12,7 @@
 #include "Time/Time.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.BinaryFraction", "[Unit][Time]") {
   const StepControllers::BinaryFraction bf{};

--- a/tests/Unit/Time/Test_Time.cpp
+++ b/tests/Unit/Time/Test_Time.cpp
@@ -7,6 +7,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.Time", "[Unit][Time]") {
   using rational_t = Time::rational_t;

--- a/tests/Unit/Time/Test_TimeId.cpp
+++ b/tests/Unit/Time/Test_TimeId.cpp
@@ -7,6 +7,7 @@
 #include "Time/TimeId.hpp"
 
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.TimeId", "[Unit][Time]") {
   using Hash = std::hash<TimeId>;

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -16,6 +16,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 #include "tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -6,6 +6,7 @@
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 #include "tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3", "[Unit][Time]") {

--- a/tests/Unit/Utilities/Test_Array.cpp
+++ b/tests/Unit/Utilities/Test_Array.cpp
@@ -8,6 +8,7 @@
 #include "Utilities/Array.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 // AppleClang does not correctly compute noexcept
 #ifndef __APPLE__

--- a/tests/Unit/Utilities/Test_Blas.cpp
+++ b/tests/Unit/Utilities/Test_Blas.cpp
@@ -3,7 +3,7 @@
 
 #include <catch.hpp>
 
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 #include "tests/Unit/Utilities/Test_Blas.hpp"
 
 // [[OutputRegex, TRANSA must be upper or lower case N, T, or C. See the BLAS

--- a/tests/Unit/Utilities/Test_CachedFunction.cpp
+++ b/tests/Unit/Utilities/Test_CachedFunction.cpp
@@ -7,7 +7,7 @@
 
 #include "Utilities/CachedFunction.hpp"
 #include "Utilities/TypeTraits.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.CachedFunction", "[Unit][Utilities]") {
   size_t call_count = 0;

--- a/tests/Unit/Utilities/Test_ConstantExpressions.cpp
+++ b/tests/Unit/Utilities/Test_ConstantExpressions.cpp
@@ -5,7 +5,7 @@
 
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/TypeTraits.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <typename T>

--- a/tests/Unit/Utilities/Test_ContainerHelpers.cpp
+++ b/tests/Unit/Utilities/Test_ContainerHelpers.cpp
@@ -5,7 +5,7 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "Utilities/ContainerHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.ContainerHelpers", "[Unit][Utilities]") {
   const std::vector<double> a{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};

--- a/tests/Unit/Utilities/Test_Deferred.cpp
+++ b/tests/Unit/Utilities/Test_Deferred.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "Utilities/Deferred.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 /// [functions_used]

--- a/tests/Unit/Utilities/Test_DereferenceWrapper.cpp
+++ b/tests/Unit/Utilities/Test_DereferenceWrapper.cpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 #include "Utilities/DereferenceWrapper.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 static_assert(
     std::is_same<decltype(dereference_wrapper(std::declval<double>())),

--- a/tests/Unit/Utilities/Test_EqualWithinRoundoff.cpp
+++ b/tests/Unit/Utilities/Test_EqualWithinRoundoff.cpp
@@ -1,10 +1,7 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include <catch.hpp>
-
 #include "Utilities/EqualWithinRoundoff.hpp"
-#include "tests/Unit/TestHelpers.hpp"
 
 static_assert(equal_within_roundoff(1.0, 1.0 - 4.0e-16, 1.0e-15),
               "Failed testing EqualWithinRoundoff");

--- a/tests/Unit/Utilities/Test_FakeVirtual.cpp
+++ b/tests/Unit/Utilities/Test_FakeVirtual.cpp
@@ -10,7 +10,7 @@
 #include "Utilities/FakeVirtual.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/Utilities/Test_FileSystem.cpp
+++ b/tests/Unit/Utilities/Test_FileSystem.cpp
@@ -7,7 +7,7 @@
 
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Literals.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.FileSystem.get_parent_path",
                   "[Unit][Utilities]") {

--- a/tests/Unit/Utilities/Test_FractionUtilities.cpp
+++ b/tests/Unit/Utilities/Test_FractionUtilities.cpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "Utilities/FractionUtilities.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <typename Source>

--- a/tests/Unit/Utilities/Test_Gsl.cpp
+++ b/tests/Unit/Utilities/Test_Gsl.cpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 #include "Utilities/Gsl.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <typename T>

--- a/tests/Unit/Utilities/Test_MakeArray.cpp
+++ b/tests/Unit/Utilities/Test_MakeArray.cpp
@@ -5,9 +5,11 @@
 #include <memory>
 #include <vector>
 
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 template <typename T>

--- a/tests/Unit/Utilities/Test_MakeVector.cpp
+++ b/tests/Unit/Utilities/Test_MakeVector.cpp
@@ -5,6 +5,7 @@
 
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.MakeVector", "[Unit][Utilities]") {
   static_assert(

--- a/tests/Unit/Utilities/Test_Math.cpp
+++ b/tests/Unit/Utilities/Test_Math.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "Utilities/Math.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.Math", "[Unit][Utilities]") {
   // Test number_of_digits

--- a/tests/Unit/Utilities/Test_Overloader.cpp
+++ b/tests/Unit/Utilities/Test_Overloader.cpp
@@ -5,7 +5,7 @@
 
 #include "Utilities/Overloader.hpp"
 #include "Utilities/TypeTraits.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 /// [overloader_example]

--- a/tests/Unit/Utilities/Test_PrettyType.cpp
+++ b/tests/Unit/Utilities/Test_PrettyType.cpp
@@ -4,7 +4,7 @@
 #include <catch.hpp>
 
 #include "Utilities/PrettyType.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.PrettyType.Fundamental",
                   "[Utilities][Unit]") {

--- a/tests/Unit/Utilities/Test_Requires.cpp
+++ b/tests/Unit/Utilities/Test_Requires.cpp
@@ -7,7 +7,7 @@
 
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 /// [function_definitions]

--- a/tests/Unit/Utilities/Test_StdArrayHelpers.cpp
+++ b/tests/Unit/Utilities/Test_StdArrayHelpers.cpp
@@ -11,7 +11,7 @@
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #include "Utilities/StdArrayHelpers.hpp"
 #pragma GCC diagnostic pop
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.StdArrayHelpers.Arithmetic",
                   "[DataStructures][Unit]") {

--- a/tests/Unit/Utilities/Test_StdHelpers.cpp
+++ b/tests/Unit/Utilities/Test_StdHelpers.cpp
@@ -15,6 +15,7 @@
 #include "Utilities/Literals.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.StdHelpers.Output", "[Utilities][Unit]") {
   std::list<int> my_list;

--- a/tests/Unit/Utilities/Test_TMPL.cpp
+++ b/tests/Unit/Utilities/Test_TMPL.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 /// [swallow_example]
 namespace {

--- a/tests/Unit/Utilities/Test_TaggedTuple.cpp
+++ b/tests/Unit/Utilities/Test_TaggedTuple.cpp
@@ -8,6 +8,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 struct name {

--- a/tests/Unit/Utilities/Test_Tuple.cpp
+++ b/tests/Unit/Utilities/Test_Tuple.cpp
@@ -5,7 +5,7 @@
 
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Tuple.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 /// [tuple_fold_struct_defn]


### PR DESCRIPTION
Moved functions that just wrap Catch stuff into TestingFramework.hpp

## Proposed changes

Split macros, functions, etc. that only depend upon catch into tests/Unit/TestingFramework.hpp

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
