### PR TITLE
Add Tensor/EagerMath/DotProduct.hpp

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/DotProduct.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DotProduct.hpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines functions euclidean dot_product and dot_product with a metric
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/*!
+ * \ingroup TensorGroup
+ * \brief Compute the Euclidean dot product of two vectors or one forms
+ *
+ * \details
+ * Returns \f$A^a B^b \delta_{ab}\f$ for input vectors \f$A^a\f$ and \f$B^b\f$
+ * or \f$A_a B_b \delta^{ab}\f$ for input one forms \f$A_a\f$ and \f$B_b\f$.
+ */
+template <typename DataType, typename Index>
+Scalar<DataType> dot_product(
+    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector_a,
+    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector_b) noexcept {
+  auto dot_product = make_with_value<Scalar<DataType>>(vector_a, 0.);
+  for (size_t d = 0; d < Index::dim; ++d) {
+    get(dot_product) += vector_a.get(d) * vector_b.get(d);
+  }
+  return dot_product;
+}
+
+/*!
+ * \ingroup TensorGroup
+ * \brief Compute the dot product of a vector and a one form
+ *
+ * \details
+ * Returns \f$A^a B_b \delta_{a}^b\f$ for input vector \f$A^a\f$ and
+ * input one form \f$B_b\f$
+ * or \f$A_a B^b \delta^a_b\f$ for input one form \f$A_a\f$ and
+ * input vector \f$B^b\f$.
+ */
+template <typename DataType, typename Index>
+Scalar<DataType> dot_product(
+    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector_a,
+    const Tensor<DataType, Symmetry<1>, tmpl::list<change_index_up_lo<Index>>>&
+        vector_b) noexcept {
+  auto dot_product = make_with_value<Scalar<DataType>>(vector_a, 0.);
+  for (size_t d = 0; d < Index::dim; ++d) {
+    get(dot_product) += vector_a.get(d) * vector_b.get(d);
+  }
+  return dot_product;
+}
+
+/*!
+ * \ingroup TensorGroup
+ * \brief Compute the dot_product of two vectors or one forms
+ *
+ * \details
+ * Returns \f$g_{ab} A^a B^b\f$, where \f$g_{ab}\f$ is the metric,
+ * \f$A^a\f$ is vector_a, and \f$B^b\f$ is vector_b.
+ * Or, returns \f$g^{ab} A_a B_b\f$ when given one forms \f$A_a\f$
+ * and \f$B_b\f$ with an inverse metric \f$g^{ab}\f$.
+ */
+template <typename DataType, typename Index>
+Scalar<DataType> dot_product(
+    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector_a,
+    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector_b,
+    const Tensor<DataType, Symmetry<1, 1>,
+                 tmpl::list<change_index_up_lo<Index>,
+                            change_index_up_lo<Index>>>& metric) noexcept {
+  auto dot_product = make_with_value<Scalar<DataType>>(vector_a, 0.);
+  for (size_t a = 0; a < Index::dim; ++a) {
+    for (size_t b = 0; b < Index::dim; ++b) {
+      get(dot_product) += vector_a.get(a) * vector_b.get(b) * metric.get(a, b);
+    }
+  }
+  return dot_product;
+}

--- a/tests/Unit/DataStructures/TensorEagerMath/CMakeLists.txt
+++ b/tests/Unit/DataStructures/TensorEagerMath/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TENSOR_EAGER_MATH_TESTS
     DataStructures/TensorEagerMath/Test_Determinant.cpp
     DataStructures/TensorEagerMath/Test_DeterminantAndInverse.cpp
     DataStructures/TensorEagerMath/Test_DivideBy.cpp
+    DataStructures/TensorEagerMath/Test_DotProduct.cpp
     DataStructures/TensorEagerMath/Test_Magnitude.cpp
     )
 

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_DotProduct.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_DotProduct.cpp
@@ -1,0 +1,182 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <catch.hpp>
+
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.EuclideanDotProduct",
+                  "[DataStructures][Unit]") {
+  // Check for DataVectors
+  {
+    const size_t npts = 5;
+    const DataVector one(npts, 1.0);
+    const DataVector two(npts, 2.0);
+    const DataVector minus_three(npts, -3.0);
+    const DataVector four(npts, 4.0);
+    const DataVector minus_five(npts, -5.0);
+    const DataVector twelve(npts, 12.0);
+
+    const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector_a{{{two}}};
+    const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector_b{{{four}}};
+    const tnsr::I<DataVector, 1, Frame::Grid> one_d_vector_c{{{four}}};
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_covector_a, one_d_covector_b)),
+                          DataVector(npts, 8.0));
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_covector_a, one_d_vector_c)),
+                          DataVector(npts, 8.0));
+
+    const tnsr::i<DataVector, 1, Frame::Grid> negative_one_d_covector{
+        {{minus_three}}};
+    const tnsr::I<DataVector, 1, Frame::Grid> negative_one_d_vector{
+        {{minus_three}}};
+    CHECK_ITERABLE_APPROX(
+        get(dot_product(negative_one_d_covector, one_d_covector_b)),
+        DataVector(npts, -12.0));
+    CHECK_ITERABLE_APPROX(
+        get(dot_product(negative_one_d_covector, one_d_vector_c)),
+        DataVector(npts, -12.0));
+
+    const tnsr::A<DataVector, 1, Frame::Grid> one_d_vector_a{
+        {{minus_three, four}}};
+    const tnsr::A<DataVector, 1, Frame::Grid> one_d_vector_b{{{two, twelve}}};
+    const tnsr::a<DataVector, 1, Frame::Grid> one_d_covector_c{{{two, twelve}}};
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_vector_a, one_d_vector_b)),
+                          DataVector(npts, 42.0));
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_vector_a, one_d_covector_c)),
+                          DataVector(npts, 42.0));
+
+    const tnsr::I<DataVector, 2, Frame::Grid> two_d_vector_a{
+        {{minus_five, twelve}}};
+    const tnsr::I<DataVector, 2, Frame::Grid> two_d_vector_b{{{two, four}}};
+    const tnsr::i<DataVector, 2, Frame::Grid> two_d_covector_b{{{two, four}}};
+    CHECK_ITERABLE_APPROX(get(dot_product(two_d_vector_a, two_d_vector_b)),
+                          DataVector(npts, 38.0));
+    CHECK_ITERABLE_APPROX(get(dot_product(two_d_vector_a, two_d_covector_b)),
+                          DataVector(npts, 38.0));
+
+    const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector_a{
+        {{minus_three, twelve, four}}};
+    const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector_b{
+        {{four, minus_five, two}}};
+    const tnsr::I<DataVector, 3, Frame::Grid> three_d_vector_b{
+        {{four, minus_five, two}}};
+    CHECK_ITERABLE_APPROX(
+        get(dot_product(three_d_covector_a, three_d_covector_b)),
+        DataVector(npts, -64.0));
+    CHECK_ITERABLE_APPROX(
+        get(dot_product(three_d_covector_a, three_d_vector_b)),
+        DataVector(npts, -64.0));
+
+    // 5D example
+    const tnsr::a<DataVector, 4, Frame::Grid> five_d_covector_a{
+        {{two, twelve, four, one, two}}};
+    const tnsr::a<DataVector, 4, Frame::Grid> five_d_covector_b{
+        {{minus_five, minus_three, two, four, one}}};
+    const tnsr::A<DataVector, 4, Frame::Grid> five_d_vector_b{
+        {{minus_five, minus_three, two, four, one}}};
+    CHECK_ITERABLE_APPROX(
+        get(dot_product(five_d_covector_a, five_d_covector_b)),
+        DataVector(npts, -32.0));
+    CHECK_ITERABLE_APPROX(
+        get(dot_product(five_d_covector_a, five_d_vector_b)),
+        DataVector(npts, -32.0));
+  }
+  // Check case for doubles
+  {
+    const tnsr::i<double, 1, Frame::Grid> one_d_covector_double_a{{{2.}}};
+    const tnsr::i<double, 1, Frame::Grid> one_d_covector_double_b{{{4.}}};
+    const tnsr::I<double, 1, Frame::Grid> one_d_vector_double_b{{{4.}}};
+    CHECK(get(dot_product(one_d_covector_double_a, one_d_covector_double_b)) ==
+          8.0);
+    CHECK(get(dot_product(one_d_covector_double_a, one_d_vector_double_b)) ==
+          8.0);
+
+    const tnsr::a<double, 4, Frame::Grid> five_d_covector_double_a{
+        {{2.0, 12.0, 4.0, 1.0, 2.0}}};
+    const tnsr::a<double, 4, Frame::Grid> five_d_covector_double_b{
+        {{4.0, 2.0, -4.0, 3.0, 5.0}}};
+    const tnsr::A<double, 4, Frame::Grid> five_d_vector_double_b{
+        {{4.0, 2.0, -4.0, 3.0, 5.0}}};
+    CHECK(get(dot_product(five_d_covector_double_a,
+                          five_d_covector_double_b)) == 29.0);
+    CHECK(get(dot_product(five_d_covector_double_a,
+                          five_d_vector_double_b)) == 29.0);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DotProduct",
+                  "[DataStructures][Unit]") {
+  // Check for DataVectors
+  {
+    const size_t npts = 5;
+    const DataVector one(npts, 1.0);
+    const DataVector two(npts, 2.0);
+    const DataVector minus_three(npts, -3.0);
+    const DataVector four(npts, 4.0);
+    const DataVector minus_five(npts, -5.0);
+    const DataVector twelve(npts, 12.0);
+    const DataVector thirteen(npts, 13.0);
+
+    const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector_a{{{two}}};
+    const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector_b{{{four}}};
+    const tnsr::II<DataVector, 1, Frame::Grid> inv_h = [&four]() {
+      tnsr::II<DataVector, 1, Frame::Grid> tensor;
+      get<0, 0>(tensor) = four;
+      return tensor;
+    }();
+    CHECK_ITERABLE_APPROX(
+        get(dot_product(one_d_covector_a, one_d_covector_b, inv_h)),
+        DataVector(npts, 32.0));
+
+    const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector_a{
+        {{minus_three, twelve, four}}};
+    const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector_b{
+        {{minus_five, four, two}}};
+    const tnsr::II<DataVector, 3, Frame::Grid> inv_g =
+        [&two, &minus_three, &four, &minus_five, &twelve, &thirteen]() {
+          tnsr::II<DataVector, 3, Frame::Grid> tensor;
+          get<0, 0>(tensor) = two;
+          get<0, 1>(tensor) = minus_three;
+          get<0, 2>(tensor) = four;
+          get<1, 1>(tensor) = minus_five;
+          get<1, 2>(tensor) = twelve;
+          get<2, 2>(tensor) = thirteen;
+          return tensor;
+        }();
+    CHECK_ITERABLE_APPROX(
+        get(dot_product(three_d_covector_a, three_d_covector_b, inv_g)),
+        DataVector(npts, 486.0));
+  }
+
+  {
+    // Check for doubles
+    const tnsr::i<double, 1, Frame::Grid> one_d_covector_a{2.0};
+    const tnsr::i<double, 1, Frame::Grid> one_d_covector_b{4.0};
+    const tnsr::II<double, 1, Frame::Grid> inv_h = []() {
+      tnsr::II<double, 1, Frame::Grid> tensor{};
+      get<0, 0>(tensor) = 4.0;
+      return tensor;
+    }();
+
+    CHECK(get(dot_product(one_d_covector_a, one_d_covector_b, inv_h)) == 32.0);
+
+    const tnsr::i<double, 3, Frame::Grid> three_d_covector_a{
+        {{-3.0, 12.0, 4.0}}};
+    const tnsr::i<double, 3, Frame::Grid> three_d_covector_b{
+        {{-5.0, 4.0, 2.0}}};
+    const tnsr::II<double, 3, Frame::Grid> inv_g = []() {
+      tnsr::II<double, 3, Frame::Grid> tensor{};
+      get<0, 0>(tensor) = 2.0;
+      get<0, 1>(tensor) = -3.0;
+      get<0, 2>(tensor) = 4.0;
+      get<1, 1>(tensor) = -5.0;
+      get<1, 2>(tensor) = 12.0;
+      get<2, 2>(tensor) = 13.0;
+      return tensor;
+    }();
+    CHECK(get(dot_product(three_d_covector_a, three_d_covector_b, inv_g)) ==
+          486.0);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add EagerMath/DotProduct.hpp, which is similar to EagerMath/Magnitude.hpp except computes the dot product of two tensors instead of the magnitude of one tensor. dot_product() accepts either two arguments (for the Euclidean dot product) or three arguments (for the dot product with respect to a metric), following magnitude().

The test parallels the test for magnitude(), but instead of taking the magnitude of tensor, it dot products tensor_a and tensor_b.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
