### PR TITLE
Change return type of magnitude to Scalar

### DIFF
--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -53,7 +53,7 @@ size_t FastFlow::current_l_mesh(const Strahlkorper<Frame>& strahlkorper) const
 namespace {
 template <typename Frame>
 DataVector fast_flow_weight(
-    const DataVector& one_form_magnitude,
+    const Scalar<DataVector>& one_form_magnitude,
     const db::item_type<StrahlkorperTags::Rhat<Frame>>& r_hat,
     const db::item_type<StrahlkorperTags::Radius<Frame>>& radius,
     const tnsr::II<DataVector, 3, Frame>& inverse_surface_metric) noexcept {
@@ -74,7 +74,7 @@ DataVector fast_flow_weight(
     }
   }
 
-  return 2.0 * one_form_magnitude * square(radius) / denominator;
+  return 2.0 * get(one_form_magnitude) * square(radius) / denominator;
 }
 }  // namespace
 
@@ -114,7 +114,7 @@ FastFlow::iterate_horizon_finder(
   const auto one_form_magnitude =
       magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame>>(box),
                 upper_spatial_metric);
-  const DataVector one_over_one_form_magnitude = 1.0 / one_form_magnitude;
+  const DataVector one_over_one_form_magnitude = 1.0 / get(one_form_magnitude);
   const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
       db::get<StrahlkorperTags::NormalOneForm<Frame>>(box),
       one_over_one_form_magnitude);
@@ -136,7 +136,7 @@ FastFlow::iterate_horizon_finder(
       // Do nothing
       break;
     case FlowType::Curvature: {
-      weighted_residual *= one_form_magnitude;
+      weighted_residual *= get(one_form_magnitude);
     } break;
     case FlowType::Fast: {
       weighted_residual *= fast_flow_weight<Frame>(

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -15,34 +15,30 @@
  * \ingroup TensorGroup
  * \brief compute the Euclidean magnitude of a rank-1 tensor
  *
- * \returns the Euclidean magnitude of the rank-1 tensor
- *
  * \details
  * Computes the square root of the sum of the squares of the components of
  * the rank-1 tensor.
  */
 template <typename DataType, typename Index>
-DataType magnitude(
+Scalar<DataType> magnitude(
     const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& tensor) {
   auto magnitude_squared = make_with_value<DataType>(tensor, 0.);
   for (size_t d = 0; d < Index::dim; ++d) {
     magnitude_squared += square(tensor.get(d));
   }
-  return sqrt(magnitude_squared);
+  return Scalar<DataType>{sqrt(magnitude_squared)};
 }
 
 /*!
  * \ingroup TensorGroup
  * \brief compute the magnitude of a rank-1 tensor
  *
- * \returns the magnitude of the rank-1 tensor
- *
  * \details
  * Returns the square root of the input tensor contracted twice with the given
  * metric.
  */
 template <typename DataType, typename Index0, typename Index1>
-DataType magnitude(
+Scalar<DataType> magnitude(
     const Tensor<DataType, Symmetry<1>, tmpl::list<Index0>>& tensor,
     const Tensor<DataType, Symmetry<1, 1>, tmpl::list<Index1, Index1>>&
         metric) {
@@ -55,5 +51,5 @@ DataType magnitude(
       magnitude_squared += tensor.get(a) * tensor.get(b) * metric.get(a, b);
     }
   }
-  return sqrt(magnitude_squared);
+  return Scalar<DataType>{sqrt(magnitude_squared)};
 }

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -6,14 +6,14 @@
 
 #pragma once
 
-#include "DataStructures/DataVector.hpp"
+#include <cstddef>
+
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "ErrorHandling/Assert.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 /*!
  * \ingroup TensorGroup
- * \brief compute the Euclidean magnitude of a rank-1 tensor
+ * \brief Compute the Euclidean magnitude of a rank-1 tensor
  *
  * \details
  * Computes the square root of the sum of the squares of the components of
@@ -21,34 +21,33 @@
  */
 template <typename DataType, typename Index>
 Scalar<DataType> magnitude(
-    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& tensor) {
-  auto magnitude_squared = make_with_value<DataType>(tensor, 0.);
+    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector) noexcept {
+  auto magnitude_squared = make_with_value<DataType>(vector, 0.);
   for (size_t d = 0; d < Index::dim; ++d) {
-    magnitude_squared += square(tensor.get(d));
+    magnitude_squared += square(vector.get(d));
   }
   return Scalar<DataType>{sqrt(magnitude_squared)};
 }
 
 /*!
  * \ingroup TensorGroup
- * \brief compute the magnitude of a rank-1 tensor
+ * \brief Compute the magnitude of a rank-1 tensor
  *
  * \details
  * Returns the square root of the input tensor contracted twice with the given
  * metric.
  */
-template <typename DataType, typename Index0, typename Index1>
+template <typename DataType, typename Index>
 Scalar<DataType> magnitude(
-    const Tensor<DataType, Symmetry<1>, tmpl::list<Index0>>& tensor,
-    const Tensor<DataType, Symmetry<1, 1>, tmpl::list<Index1, Index1>>&
-        metric) {
-  static_assert(std::is_same<Index0, change_index_up_lo<Index1>>::value,
-                "The indices of the tensor and metric must be the same, "
-                "except for their valence which must be opposite");
-  auto magnitude_squared = make_with_value<DataType>(tensor, 0.);
-  for (size_t a = 0; a < Index0::dim; ++a) {
-    for (size_t b = 0; b < Index0::dim; ++b) {
-      magnitude_squared += tensor.get(a) * tensor.get(b) * metric.get(a, b);
+    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector,
+    const Tensor<DataType, Symmetry<1, 1>,
+                 tmpl::list<change_index_up_lo<Index>,
+                            change_index_up_lo<Index>>>&
+        metric) noexcept {
+  auto magnitude_squared = make_with_value<DataType>(vector, 0.);
+  for (size_t a = 0; a < Index::dim; ++a) {
+    for (size_t b = 0; b < Index::dim; ++b) {
+      magnitude_squared += vector.get(a) * vector.get(b) * metric.get(a, b);
     }
   }
   return Scalar<DataType>{sqrt(magnitude_squared)};

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -134,7 +134,7 @@ struct ComputeBoundaryFlux {
       const auto& face_normal =
           db::get<Tags::UnnormalizedFaceNormal<volume_dim>>(box).at(direction);
 
-      DataVector magnitude_of_face_normal = magnitude(face_normal);
+      DataVector magnitude_of_face_normal = get(magnitude(face_normal));
 
       std::decay_t<decltype(face_normal)> unit_face_normal(
           magnitude_of_face_normal.size(), 0.0);

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication2.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication2.hpp
@@ -151,7 +151,7 @@ struct ComputeBoundaryFlux {
       db::item_type<dt_variables_tag> lifted_data(dg::lift_flux(
           local_normal_dot_flux.at(std::make_pair(direction, neighbor)),
           std::move(normal_dot_numerical_fluxes), extents[dimension],
-          magnitude(face_normal)));
+          get(magnitude(face_normal))));
 
       db::mutate<dt_variables_tag>(box, [
         &lifted_data, &extents, &dimension, &direction
@@ -280,7 +280,7 @@ struct SendDataForFluxes {
         const auto& face_normal =
             db::get<Tags::UnnormalizedFaceNormal<volume_dim>>(box).at(
                 direction);
-        DataVector magnitude_of_face_normal = magnitude(face_normal);
+        DataVector magnitude_of_face_normal = get(magnitude(face_normal));
         std::decay_t<decltype(face_normal)> unit_face_normal(
             magnitude_of_face_normal.size(), 0.0);
         for (size_t d = 0; d < volume_dim; ++d) {

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -20,7 +20,7 @@ tnsr::ii<DataType, SpatialDim, Frame> spatial_ricci(
 
   constexpr auto dimensionality = index_dim<0>(ricci);
 
-  const DataType r = magnitude(x);
+  const DataType r = get(magnitude(x));
 
   for (size_t i = 0; i < dimensionality; ++i) {
     for (size_t j = i; j < dimensionality; ++j) {
@@ -46,7 +46,7 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature_sphere(
 
   constexpr auto dimensionality = index_dim<0>(extrinsic_curvature);
 
-  const DataType one_over_r = 1.0 / magnitude(x);
+  const DataType one_over_r = 1.0 / get(magnitude(x));
 
   for (size_t i = 0; i < dimensionality; ++i) {
     extrinsic_curvature.get(i, i) += 1.0;

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperDataBox.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperDataBox.cpp
@@ -273,7 +273,7 @@ void test_normals() {
     return sqrt(normsquared);
   }();
   const auto& normal_mag = magnitude(normal_one_form, invg);
-  CHECK_ITERABLE_APPROX(expected_normal_mag, normal_mag);
+  CHECK_ITERABLE_APPROX(expected_normal_mag, get(normal_mag));
 }
 }  // namespace
 

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -50,9 +50,9 @@ void test_schwarzschild() {
       determinant_and_inverse(spatial_metric).second;
 
   const DataVector one_over_one_form_magnitude =
-      1.0 /
-      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-                inverse_spatial_metric);
+      1.0 / get(magnitude(
+                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric));
   const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
       one_over_one_form_magnitude);
@@ -105,9 +105,9 @@ void test_minkowski() {
       solution.inverse_spatial_metric(cart_coords, t);
 
   const DataVector one_over_one_form_magnitude =
-      1.0 /
-      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-                inverse_spatial_metric);
+      1.0 / get(magnitude(
+                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric));
   const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
       one_over_one_form_magnitude);
@@ -156,9 +156,9 @@ void test_minkowski() {
       solution.inverse_spatial_metric(cart_coords, t);
 
   const DataVector one_over_one_form_magnitude =
-      1.0 /
-      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-                inverse_spatial_metric);
+      1.0 / get(magnitude(
+                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric));
   const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
       one_over_one_form_magnitude);
@@ -213,9 +213,9 @@ void test_schwarzschild() {
       determinant_and_inverse(spatial_metric).second;
 
   const DataVector one_over_one_form_magnitude =
-      1.0 /
-      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-                inverse_spatial_metric);
+      1.0 / get(magnitude(
+                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric));
   const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
       one_over_one_form_magnitude);
@@ -263,9 +263,9 @@ void test_minkowski() {
       solution.inverse_spatial_metric(cart_coords, t);
 
   const DataVector one_over_one_form_magnitude =
-      1.0 /
-      magnitude(db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-                inverse_spatial_metric);
+      1.0 / get(magnitude(
+                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
+                inverse_spatial_metric));
   const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
       one_over_one_form_magnitude);

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
@@ -10,7 +10,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.EuclideanMagnitude",
                   "[DataStructures][Unit]") {
   // Check for DataVectors
   {
-    const size_t npts = 2;
+    const size_t npts = 5;
     const DataVector one(npts, 1.0);
     const DataVector two(npts, 2.0);
     const DataVector minus_three(npts, -3.0);
@@ -19,55 +19,36 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.EuclideanMagnitude",
     const DataVector twelve(npts, 12.0);
 
     const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector{{{two}}};
-    const DataVector magnitude_one_d_covector = magnitude(one_d_covector);
-    for (size_t s = 0; s < npts; ++s) {
-      CHECK(magnitude_one_d_covector[s] == 2.0);
-    }
+    CHECK(get(magnitude(one_d_covector)) == two);
 
     const tnsr::i<DataVector, 1, Frame::Grid> negative_one_d_covector{
         {{minus_three}}};
-    const DataVector magnitude_negative_one_d_covector =
-        magnitude(negative_one_d_covector);
-    for (size_t s = 0; s < npts; ++s) {
-      CHECK(magnitude_negative_one_d_covector[s] == 3.0);
-    }
+    CHECK(get(magnitude(negative_one_d_covector)) == (DataVector{npts, 3.0}));
+
     const tnsr::A<DataVector, 1, Frame::Grid> one_d_vector{
         {{minus_three, four}}};
-    const DataVector magnitude_one_d_vector = magnitude(one_d_vector);
-    for (size_t s = 0; s < npts; ++s) {
-      CHECK(magnitude_one_d_vector[s] == 5.0);
-    }
+    CHECK(get(magnitude(one_d_vector)) == (DataVector{npts, 5.0}));
 
     const tnsr::I<DataVector, 2, Frame::Grid> two_d_vector{
         {{minus_five, twelve}}};
-    const DataVector magnitude_two_d_vector = magnitude(two_d_vector);
-    for (size_t s = 0; s < npts; ++s) {
-      CHECK(magnitude_two_d_vector[s] == 13.0);
-    }
+    CHECK(get(magnitude(two_d_vector)) == (DataVector{npts, 13.0}));
 
     const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector{
         {{minus_three, twelve, four}}};
-    const DataVector magnitude_three_d_covector = magnitude(three_d_covector);
-    for (size_t s = 0; s < npts; ++s) {
-      CHECK(magnitude_three_d_covector[s] == 13.0);
-    }
+    CHECK(get(magnitude(three_d_covector)) == (DataVector{npts, 13.0}));
 
-    // 5D example
     const tnsr::a<DataVector, 4, Frame::Grid> five_d_covector{
         {{two, twelve, four, one, two}}};
-    const DataVector magnitude_five_d_covector = magnitude(five_d_covector);
-    for (size_t s = 0; s < npts; ++s) {
-      CHECK(magnitude_five_d_covector[s] == 13.0);
-    }
+    CHECK(get(magnitude(five_d_covector)) == (DataVector{npts, 13.0}));
   }
   // Check case for doubles
   {
     const tnsr::i<double, 1, Frame::Grid> one_d_covector_double{{{2.}}};
-    CHECK(magnitude(one_d_covector_double) == 2.);
+    CHECK(get(magnitude(one_d_covector_double)) == 2.);
 
     const tnsr::a<double, 4, Frame::Grid> five_d_covector_double{
         {{2, 12, 4, 1, 2}}};
-    CHECK(magnitude(five_d_covector_double) == 13.);
+    CHECK(get(magnitude(five_d_covector_double)) == 13.);
   }
 }
 
@@ -75,7 +56,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
                   "[DataStructures][Unit]") {
   // Check for DataVectors
   {
-    const size_t npts = 2;
+    const size_t npts = 5;
     const DataVector one(npts, 1.0);
     const DataVector two(npts, 2.0);
     const DataVector minus_three(npts, -3.0);
@@ -91,10 +72,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
       return tensor;
     }();
 
-    const DataVector magnitude_a = magnitude(one_d_covector, inv_h);
-    for (size_t s = 0; s < npts; ++s) {
-      CHECK(magnitude_a[s] == 4.0);
-    }
+    CHECK(get(magnitude(one_d_covector, inv_h)) == (DataVector{npts, 4.0}));
     const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector{
         {{minus_three, twelve, four}}};
     const tnsr::II<DataVector, 3, Frame::Grid> inv_g =
@@ -108,11 +86,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
           get<2, 2>(tensor) = thirteen;
           return tensor;
         }();
-    const DataVector magnitude_three_d_covector =
-        magnitude(three_d_covector, inv_g);
-    for (size_t s = 0; s < npts; ++s) {
-      CHECK(magnitude_three_d_covector[s] == sqrt(778.0));
-    }
+    CHECK(get(magnitude(three_d_covector, inv_g)) ==
+          (DataVector{npts, sqrt(778.0)}));
   }
 
   {
@@ -124,7 +99,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
       return tensor;
     }();
 
-    CHECK(magnitude(one_d_covector, inv_h) == 4.0);
+    CHECK(get(magnitude(one_d_covector, inv_h)) == 4.0);
 
     const tnsr::i<double, 3, Frame::Grid> three_d_covector{{{-3.0, 12.0, 4.0}}};
     const tnsr::II<double, 3, Frame::Grid> inv_g = []() {
@@ -137,6 +112,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
       get<2, 2>(tensor) = 13;
       return tensor;
     }();
-    CHECK(magnitude(three_d_covector, inv_g) == sqrt(778.0));
+    CHECK(get(magnitude(three_d_covector, inv_g)) == sqrt(778.0));
   }
 }

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
@@ -19,27 +19,32 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.EuclideanMagnitude",
     const DataVector twelve(npts, 12.0);
 
     const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector{{{two}}};
-    CHECK(get(magnitude(one_d_covector)) == two);
+    CHECK_ITERABLE_APPROX(get(magnitude(one_d_covector)), two);
 
     const tnsr::i<DataVector, 1, Frame::Grid> negative_one_d_covector{
         {{minus_three}}};
-    CHECK(get(magnitude(negative_one_d_covector)) == (DataVector{npts, 3.0}));
+    CHECK_ITERABLE_APPROX(get(magnitude(negative_one_d_covector)),
+                          (DataVector{npts, 3.0}));
 
     const tnsr::A<DataVector, 1, Frame::Grid> one_d_vector{
         {{minus_three, four}}};
-    CHECK(get(magnitude(one_d_vector)) == (DataVector{npts, 5.0}));
+    CHECK_ITERABLE_APPROX(get(magnitude(one_d_vector)),
+                          (DataVector{npts, 5.0}));
 
     const tnsr::I<DataVector, 2, Frame::Grid> two_d_vector{
         {{minus_five, twelve}}};
-    CHECK(get(magnitude(two_d_vector)) == (DataVector{npts, 13.0}));
+    CHECK_ITERABLE_APPROX(get(magnitude(two_d_vector)),
+                          (DataVector{npts, 13.0}));
 
     const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector{
         {{minus_three, twelve, four}}};
-    CHECK(get(magnitude(three_d_covector)) == (DataVector{npts, 13.0}));
+    CHECK_ITERABLE_APPROX(get(magnitude(three_d_covector)),
+                          (DataVector{npts, 13.0}));
 
     const tnsr::a<DataVector, 4, Frame::Grid> five_d_covector{
         {{two, twelve, four, one, two}}};
-    CHECK(get(magnitude(five_d_covector)) == (DataVector{npts, 13.0}));
+    CHECK_ITERABLE_APPROX(get(magnitude(five_d_covector)),
+                          (DataVector{npts, 13.0}));
   }
   // Check case for doubles
   {
@@ -72,7 +77,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
       return tensor;
     }();
 
-    CHECK(get(magnitude(one_d_covector, inv_h)) == (DataVector{npts, 4.0}));
+    CHECK_ITERABLE_APPROX(get(magnitude(one_d_covector, inv_h)),
+                          (DataVector{npts, 4.0}));
     const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector{
         {{minus_three, twelve, four}}};
     const tnsr::II<DataVector, 3, Frame::Grid> inv_g =
@@ -86,8 +92,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
           get<2, 2>(tensor) = thirteen;
           return tensor;
         }();
-    CHECK(get(magnitude(three_d_covector, inv_g)) ==
-          (DataVector{npts, sqrt(778.0)}));
+    CHECK_ITERABLE_APPROX(get(magnitude(three_d_covector, inv_g)),
+                          (DataVector{npts, sqrt(778.0)}));
   }
 
   {
@@ -95,7 +101,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
     const tnsr::i<double, 1, Frame::Grid> one_d_covector{2.0};
     const tnsr::II<double, 1, Frame::Grid> inv_h = []() {
       tnsr::II<double, 1, Frame::Grid> tensor{};
-      get<0, 0>(tensor) = 4.;
+      get<0, 0>(tensor) = 4.0;
       return tensor;
     }();
 
@@ -104,12 +110,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
     const tnsr::i<double, 3, Frame::Grid> three_d_covector{{{-3.0, 12.0, 4.0}}};
     const tnsr::II<double, 3, Frame::Grid> inv_g = []() {
       tnsr::II<double, 3, Frame::Grid> tensor{};
-      get<0, 0>(tensor) = 2;
-      get<0, 1>(tensor) = -3;
-      get<0, 2>(tensor) = 4;
-      get<1, 1>(tensor) = -5;
-      get<1, 2>(tensor) = 12;
-      get<2, 2>(tensor) = 13;
+      get<0, 0>(tensor) = 2.0;
+      get<0, 1>(tensor) = -3.0;
+      get<0, 2>(tensor) = 4.0;
+      get<1, 1>(tensor) = -5.0;
+      get<1, 2>(tensor) = 12.0;
+      get<2, 2>(tensor) = 13.0;
       return tensor;
     }();
     CHECK(get(magnitude(three_d_covector, inv_g)) == sqrt(778.0));

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication2.cpp
@@ -297,16 +297,19 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication2",
   const DataVector xi_boundaries{
       0.,
       0.,
-      15774. / magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
-                   Direction<2>::lower_xi()))[0],
+      15774. /
+          get(magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::lower_xi())))[0],
       0.,
       0.,
-      18048. / magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
-                   Direction<2>::lower_xi()))[1],
+      18048. /
+          get(magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::lower_xi())))[1],
       0.,
       0.,
-      20322. / magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
-                   Direction<2>::lower_xi()))[2]};
+      20322. /
+          get(magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::lower_xi())))[2]};
   const DataVector eta_boundaries{
       0.,
       0.,
@@ -315,14 +318,14 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication2",
       0.,
       0.,
       16612. / 3. /
-          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
-              Direction<2>::upper_eta()))[0],
+          get(magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::upper_eta())))[0],
       18128. / 3. /
-          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
-              Direction<2>::upper_eta()))[1],
+          get(magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::upper_eta())))[1],
       19644. / 3. /
-          magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
-              Direction<2>::upper_eta()))[2]};
+          get(magnitude(db::get<Tags::UnnormalizedFaceNormal<2>>(start_box).at(
+              Direction<2>::upper_eta())))[2]};
 
   CHECK_ITERABLE_APPROX(
       get<Tags::dt<Var>>(db::get<dt_variables_tag>(received_box)).get(),
@@ -376,6 +379,6 @@ SPECTRE_TEST_CASE(
       runner.apply<component, dg::Actions::ComputeBoundaryFlux<Metavariables>>(
           sent_box, CharmIndexType(self_id)));
 
-  CHECK(get<Tags::dt<Var>>(db::get<dt_variables_tag>(received_box))
-            .get() == (DataVector{0., 0., 0., 0., 0., 0., 0., 0., 0.}));
+  CHECK(get<Tags::dt<Var>>(db::get<dt_variables_tag>(received_box)).get() ==
+        (DataVector{0., 0., 0., 0., 0., 0., 0., 0., 0.}));
 }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -42,9 +42,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.LiftFlux",
   const double weight = Basis::lgl::quadrature_weights(perpendicular_extent)[0];
 
   const Index<1> boundary_extents{{{3}}};
-  const DataVector magnitude_of_face_normal =
-      magnitude(unnormalized_face_normal(boundary_extents, coordinate_map,
-                                         Direction<2>::lower_eta()));
+  const auto magnitude_of_face_normal = magnitude(unnormalized_face_normal(
+      boundary_extents, coordinate_map, Direction<2>::lower_eta()));
 
   Variables<tmpl::list<Tags::NormalDotFlux<Var>>> local_flux(
       boundary_extents.product());
@@ -57,6 +56,6 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.LiftFlux",
       -2. / (element_length * weight) * (numerical_flux - local_flux);
 
   CHECK(dg::lift_flux(local_flux, numerical_flux, perpendicular_extent,
-                      magnitude_of_face_normal) ==
+                      get(magnitude_of_face_normal)) ==
         expected);
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
@@ -85,7 +85,7 @@ void test_schwarzschild(const DataType& used_for_size) noexcept {
     }
   }
 
-  const DataType r = magnitude(x);
+  const DataType r = get(magnitude(x));
   const DataType one_over_r_squared = 1.0 / square(r);
   const DataType one_over_r_cubed = 1.0 / cube(r);
   const DataType one_over_r_fifth = one_over_r_squared * one_over_r_cubed;


### PR DESCRIPTION
## Proposed changes

Changes return type of magnitude from DataVector to Scalar. 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`



