### PR TITLE
Add test helper make_with_random_values

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -80,6 +80,7 @@ INPUT += @PROJECT_SOURCE_DIR@/docs
 
 # Add files to scan that explain testing framework
 INPUT += @PROJECT_SOURCE_DIR@/tests/Unit/ActionTesting.hpp \
+         @PROJECT_SOURCE_DIR@/tests/Unit/DataStructures/TestHelpers.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/TestCreation.hpp \
          @PROJECT_SOURCE_DIR@/tests/Unit/TestHelpers.hpp \

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -348,6 +348,10 @@ constexpr bool is_unsigned_v = std::is_unsigned<T>::value;
 template <class T>
 constexpr bool is_floating_point_v = std::is_floating_point<T>::value;
 
+/// \ingroup TypeTraitsGroup
+template <class T>
+constexpr bool is_fundamental_v = std::is_fundamental<T>::value;
+
 }  // namespace cpp17
 
 /// \ingroup TypeTraitsGroup

--- a/tests/Unit/DataStructures/TestHelpers.hpp
+++ b/tests/Unit/DataStructures/TestHelpers.hpp
@@ -1,0 +1,103 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Helper functions for data structures used in unit tests
+
+#pragma once
+
+#include <cstddef>  // for std::nullptr_t
+#include <limits>
+#include <random>
+
+#include "DataStructures/Variables.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace TestHelpers_detail {
+/// \cond HIDDEN_SYMBOLS
+template <typename T, typename = std::nullptr_t>
+struct FillWithRandomValuesImpl;
+
+template <typename T>
+struct FillWithRandomValuesImpl<T, Requires<cpp17::is_fundamental_v<T>>> {
+  template <typename UniformRandomBitGenerator,
+            typename RandomNumberDistribution>
+  static void apply(
+      const gsl::not_null<T*> data,
+      const gsl::not_null<UniformRandomBitGenerator*> generator,
+      const gsl::not_null<RandomNumberDistribution*> distribution) noexcept {
+    static_assert(
+        cpp17::is_same_v<T, typename RandomNumberDistribution::result_type>,
+        "Mismatch between data type and random number type.");
+    *data = (*distribution)(*generator);
+  }
+};
+
+template <typename T>
+struct FillWithRandomValuesImpl<
+    T, Requires<not tt::is_maplike_v<T> and tt::is_iterable_v<T>>> {
+  template <typename UniformRandomBitGenerator,
+            typename RandomNumberDistribution>
+  static void apply(
+      const gsl::not_null<T*> data,
+      const gsl::not_null<UniformRandomBitGenerator*> generator,
+      const gsl::not_null<RandomNumberDistribution*> distribution) noexcept {
+    for (auto& d : *data) {
+      FillWithRandomValuesImpl<std::decay_t<decltype(d)>>::apply(&d, generator,
+                                                                 distribution);
+    }
+  }
+};
+
+template <typename... Tags>
+struct FillWithRandomValuesImpl<Variables<tmpl::list<Tags...>>,
+                                std::nullptr_t> {
+  template <typename UniformRandomBitGenerator,
+            typename RandomNumberDistribution>
+  static void apply(
+      const gsl::not_null<Variables<tmpl::list<Tags...>>*> data,
+      const gsl::not_null<UniformRandomBitGenerator*> generator,
+      const gsl::not_null<RandomNumberDistribution*> distribution) noexcept {
+    swallow((FillWithRandomValuesImpl<std::decay_t<decltype(get<Tags>(
+                 *data))>>::apply(&get<Tags>(*data), generator, distribution),
+             cpp17::void_type{})...);
+  }
+};
+/// \endcond
+}  // namespace TestHelpers_detail
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Fill an existing data structure with random values
+template <typename T, typename UniformRandomBitGenerator,
+          typename RandomNumberDistribution>
+void fill_with_random_values(
+    const gsl::not_null<T*> data,
+    const gsl::not_null<UniformRandomBitGenerator*> generator,
+    const gsl::not_null<RandomNumberDistribution*> distribution) noexcept {
+  TestHelpers_detail::FillWithRandomValuesImpl<T>::apply(data, generator,
+                                                         distribution);
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Make a data structure and fill it with random values
+///
+/// \details Given an object of type `T`, create an object of type `ReturnType`
+/// whose elements are initialized to random values using the given random
+/// number generator and random number distribution.
+///
+/// \requires the type `ReturnType` to be creatable using
+/// `make_with_value<ReturnType>(T)`
+template <typename ReturnType, typename T, typename UniformRandomBitGenerator,
+          typename RandomNumberDistribution>
+ReturnType make_with_random_values(
+    const gsl::not_null<UniformRandomBitGenerator*> generator,
+    const gsl::not_null<RandomNumberDistribution*> distribution,
+    const T& used_for_size) noexcept {
+  auto result = make_with_value<ReturnType>(
+      used_for_size, std::numeric_limits<double>::signaling_NaN());
+  fill_with_random_values(make_not_null(&result), generator, distribution);
+  return result;
+}

--- a/tests/Unit/DataStructures/Test_MakeWithValue.cpp
+++ b/tests/Unit/DataStructures/Test_MakeWithValue.cpp
@@ -2,13 +2,19 @@
 // See LICENSE.txt for details.
 
 #include <catch.hpp>
+#include <cstddef>
+#include <random>
+#include <unordered_set>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/DataStructures/TestHelpers.hpp"
 #include "tests/Unit/TestingFramework.hpp"
 
 namespace {
@@ -104,4 +110,75 @@ SPECTRE_TEST_CASE("Unit.DataStructures.MakeWithValue",
                           Variables<one_var<3>>(n_pts, 4.5), -2.3);
   }
   test_make_tagged_tuple();
+}
+
+namespace {
+void check_random_values(
+    const gsl::not_null<std::unordered_set<double>*> values,
+    const gsl::not_null<size_t*> counter, const double v,
+    const double lower_bound, const double upper_bound) noexcept {
+  CHECK(v >= lower_bound);
+  CHECK(v <= upper_bound);
+  CHECK(values->insert(v).second);
+  ++(*counter);
+}
+
+// clang-tidy is wrong, this is a function definition
+template <typename T>
+void check_random_values(
+    const gsl::not_null<std::unordered_set<double>*> values,        // NOLINT
+    const gsl::not_null<size_t*> counter, const T& c,               // NOLINT
+    const double lower_bound, const double upper_bound) noexcept {  // NOLINT
+  for (const auto& v : c) {
+    check_random_values(values, counter, v, lower_bound, upper_bound);
+  }
+}
+
+template <typename... Tags>
+void check_random_values(
+    const gsl::not_null<std::unordered_set<double>*> values,
+    const gsl::not_null<size_t*> counter,
+    const Variables<tmpl::list<Tags...>>& v, const double lower_bound,
+    const double upper_bound) noexcept {
+  swallow((check_random_values<decltype(get<Tags>(v))>(
+               values, counter, get<Tags>(v), lower_bound, upper_bound),
+           cpp17::void_type{})...);
+}
+
+template <typename T, typename U>
+void test_make_with_random_values(const U& used_for_size) noexcept {
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed = " << seed);
+  std::uniform_real_distribution<> distribution(-10.0, 10.0);
+  // check that the data structure is filled with unique random values
+  // by adding them to a set and checking that the size of the set
+  // is equal to the number of doubles inserted
+  std::unordered_set<double> values;
+  size_t counter = 0;
+  const auto d = make_with_random_values<T>(
+      make_not_null(&generator), make_not_null(&distribution), used_for_size);
+  check_random_values(make_not_null(&values), make_not_null(&counter), d, -10.0,
+                      10.0);
+  CHECK(values.size() == counter);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Test.TestHelpers.MakeWithRandomValues", "[Unit]") {
+  const double d = std::numeric_limits<double>::signaling_NaN();
+  test_make_with_random_values<double>(d);
+  test_make_with_random_values<Scalar<double>>(d);
+  test_make_with_random_values<tnsr::A<double, 3>>(d);
+  test_make_with_random_values<tnsr::Abb<double, 3>>(d);
+  test_make_with_random_values<tnsr::aBcc<double, 3>>(d);
+
+  const DataVector dv(5);
+  test_make_with_random_values<DataVector>(dv);
+  test_make_with_random_values<Scalar<DataVector>>(dv);
+  test_make_with_random_values<tnsr::A<DataVector, 3>>(dv);
+  test_make_with_random_values<tnsr::Abb<DataVector, 3>>(dv);
+  test_make_with_random_values<tnsr::aBcc<DataVector, 3>>(dv);
+  test_make_with_random_values<Variables<one_var<3>>>(dv);
+  test_make_with_random_values<Variables<two_vars<3>>>(dv);
 }


### PR DESCRIPTION
## Proposed changes

Add a helper function for unit testing that fills a data structure with random values

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`
