### PR TITLE
Add area element for Strahlkorpers

### DIFF
--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "ApparentHorizons/StrahlkorperDataBox.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
@@ -128,4 +129,33 @@ Scalar<DataVector> ricci_scalar(
     const tnsr::I<DataVector, 3, Frame>& unit_normal_vector,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature,
     const tnsr::II<DataVector, 3, Frame>& upper_spatial_metric) noexcept;
+
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Area element of a 2D `Strahlkorper`.
+ *
+ * \details Implements Eq. (D.13), using Eqs. (D.4) and (D.5),
+ * of https://arxiv.org/abs/gr-qc/9606010.
+ * Specifically, computes
+ * \f$\sqrt{(\Theta^i\Theta_i)(\Phi^j\Phi_j)-(\Theta^i\Phi_i)^2}\f$,
+ * \f$\Theta^i=\left(n^i(n_j-s_j) r J^j_\theta + r J^i_\theta\right)\f$,
+ * \f$\Phi^i=\left(n^i(n_j-s_j)r J^j_\phi + r J^i_\phi\right)\f$,
+ * and \f$\Theta^i\f$ and \f$\Phi^i\f$ are lowered by the
+ * 3D spatial metric \f$g_{ij}\f$. Here \f$J^i_\alpha\f$, \f$s_j\f$,
+ * \f$r\f$, and \f$n^i=n_i\f$ correspond to the input arguments
+ * `jacobian`, `normal_one_form`, `radius`, and `r_hat`, respectively;
+ * these input arguments depend only on the Strahlkorper, not on the
+ * metric, and can be computed from a Strahlkorper using ComputeItems
+ * in `StrahlkorperTags`. Note that this does not include the factor
+ * of \f$\sin\theta\f$, i.e., this returns \f$r^2\f$ for flat space.
+ * This choice makes the area element returned here compatible with
+ * `definite_integral` defined in `YlmSpherePack.hpp`.
+ */
+template <typename Frame>
+Scalar<DataVector> area_element(
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const StrahlkorperTags::StrahlkorperTags_detail::Jacobian<Frame>& jacobian,
+    const tnsr::i<DataVector, 3, Frame>& normal_one_form,
+    const DataVector& radius,
+    const tnsr::i<DataVector, 3, Frame>& r_hat) noexcept;
 }  // namespace StrahlkorperGr


### PR DESCRIPTION
## Proposed changes

Compute area element of a Strahlkorper. Test on Schwarzschild and on a sphere in Minkowski space.

This pull request depends on #572 (add dot_product to Tensor/EagerMath), because the area element depends on a complicated combination of dot products.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
