### PR TITLE
Add support for catch v2.1.2

### DIFF
--- a/support/Environments/wheeler_gcc.env
+++ b/support/Environments/wheeler_gcc.env
@@ -4,11 +4,11 @@
 # See LICENSE.txt for details.
 
 module purge
-module load gcc/6.4.0
+module load gcc/7.3.0
 module load blaze/3.2
 module load boost/1.65.0-gcc-6.4.0
 module load brigand/master
-module load catch/1.10.0
+module load catch/2.1.2
 module load gsl/2.1
 module load hdf5/1.8.17
 module load jemalloc/5.0.1

--- a/support/Environments/wheeler_llvm.env
+++ b/support/Environments/wheeler_llvm.env
@@ -4,11 +4,11 @@
 # See LICENSE.txt for details.
 
 module purge
-module load gcc/6.4.0
+module load gcc/7.3.0
 module load blaze/3.2
 module load boost/1.65.0-gcc-6.4.0
 module load brigand/master
-module load catch/1.10.0
+module load catch/2.1.2
 module load gsl/2.1
 module load hdf5/1.8.17
 module load jemalloc/5.0.1

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -62,6 +62,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileMove", "[Unit][IO][H5]") {
   auto my_file2 = std::make_unique<h5::H5File<h5::AccessType::ReadWrite>>(
       std::move(*my_file));
   my_file.reset();
+  CHECK(my_file == nullptr);
 
   h5::H5File<h5::AccessType::ReadWrite> my_file3(h5_file_name2);
   my_file3 = std::move(*my_file2);
@@ -501,6 +502,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.OpenGroupMove", "[Unit][IO][H5]") {
         file_id, "/group/group2/group3", h5::AccessType::ReadWrite);
     h5::detail::OpenGroup group2(std::move(*group));
     group.reset();
+    CHECK(group == nullptr);
     CHECK_H5(H5Fclose(file_id), "Failed to close file: '" << file_name << "'");
   }
 

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -19,6 +19,9 @@
 SPECTRE_TEST_CASE("Unit.Options.Empty.success", "[Unit][Options]") {
   Options<tmpl::list<>> opts("");
   opts.parse("");
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.Options.Empty.success does not need to check anything
+  CHECK(true);
 }
 
 // [[OutputRegex, In string:.*At line 1 column 1:.Option 'Option' is not a valid
@@ -286,6 +289,9 @@ SPECTRE_TEST_CASE("Unit.Options.ZeroArray.missing", "[Unit][Options]") {
   Options<tmpl::list<ZeroArray>> opts("");
   opts.parse("ZeroArray:");
   opts.get<ZeroArray>();
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.Options.ZeroArray.missing does not need to check anything
+  CHECK(true);
 }
 
 namespace {

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
@@ -63,4 +63,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian.Factory",
       "    Amplitude: 3\n"
       "    Width: 2\n"
       "    Center: -9");
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.PointwiseFunctions.MathFunctions.Gaussian.Factory does not need to
+  // check anything
+  CHECK(true);
 }

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
@@ -75,4 +75,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX.Factory",
                   "[PointwiseFunctions][Unit]") {
   test_factory_creation<MathFunction<1>>("  PowX:\n    Power: 3");
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.PointwiseFunctions.MathFunctions.PowX.Factory does not need to
+  // check anything
+  CHECK(true);
 }

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
@@ -58,4 +58,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid.Factory",
       "    Amplitude: 3\n"
       "    Wavenumber: 2\n"
       "    Phase: -9");
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.PointwiseFunctions.MathFunctions.Sinusoid.Factory does not need to
+  // check anything
+  CHECK(true);
 }

--- a/tests/Unit/Time/Test_StepControllers.cpp
+++ b/tests/Unit/Time/Test_StepControllers.cpp
@@ -33,6 +33,10 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.BinaryFraction", "[Unit][Time]") {
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.BinaryFraction.Factory",
                   "[Unit][Time]") {
   test_factory_creation<StepController>("  BinaryFraction");
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.Time.StepControllers.BinaryFraction.Factory does not need to
+  // check anything
+  CHECK(true);
 }
 
 // [[OutputRegex, Not at a binary-fraction time within slab]]
@@ -64,6 +68,10 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.FullSlab", "[Unit][Time]") {
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.FullSlab.Factory",
                   "[Unit][Time]") {
   test_factory_creation<StepController>("  FullSlab");
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.Time.StepControllers.FullSlab.Factory does not need to
+  // check anything
+  CHECK(true);
 }
 
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.SimpleTimes", "[Unit][Time]") {
@@ -91,6 +99,10 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.SimpleTimes", "[Unit][Time]") {
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.SimpleTimes.Factory",
                   "[Unit][Time]") {
   test_factory_creation<StepController>("  SimpleTimes");
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.Time.StepControllers.SimpleTimes.Factory does not need to
+  // check anything
+  CHECK(true);
 }
 
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.SplitRemaining", "[Unit][Time]") {
@@ -114,4 +126,8 @@ SPECTRE_TEST_CASE("Unit.Time.StepControllers.SplitRemaining", "[Unit][Time]") {
 SPECTRE_TEST_CASE("Unit.Time.StepControllers.SplitRemaining.Factory",
                   "[Unit][Time]") {
   test_factory_creation<StepController>("  SplitRemaining");
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.Time.StepControllers.SplitRemaining.Factory does not need to
+  // check anything
+  CHECK(true);
 }

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -84,6 +84,10 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Factory",
                   "[Unit][Time]") {
   test_factory_creation<TimeStepper>("  AdamsBashforthN:\n"
                                      "    TargetOrder: 3");
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.Time.TimeSteppers.AdamsBashforthN.Factory does not need to
+  // check anything
+  CHECK(true);
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.Equal",

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -35,6 +35,10 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Stability",
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Factory",
                   "[Unit][Time]") {
   test_factory_creation<TimeStepper>("  RungeKutta3");
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.Time.TimeSteppers.RungeKutta3.Factory does not need to
+  // check anything
+  CHECK(true);
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Boundary.Equal",

--- a/tests/Unit/Utilities/Test_TaggedTuple.cpp
+++ b/tests/Unit/Utilities/Test_TaggedTuple.cpp
@@ -5,7 +5,6 @@
 #include <sstream>
 #include <vector>
 
-#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Unit/TestingFramework.hpp"
@@ -150,6 +149,9 @@ SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple.NoTag", "[Unit][Utilities]") {
   tuples::TaggedTuple<> dummy;
   tuples::TaggedTuple<> dummy1;
   dummy.swap(dummy1);
+  // Catch requires us to have at least one CHECK in each test
+  // The Unit.Utilities.TaggedTuple.NoTag does not need to check anything
+  CHECK(true);
 }
 
 SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple.SingleTag", "[Unit][Utilities]") {
@@ -681,32 +683,31 @@ SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple.relational",
 #endif
 }
 
-SPECTRE_TEST_CASE("Unit.Utilities.TaggedTuple.helper_classes",
-                  "[Unit][Utilities]") {
-  static_assert(
-      tuples::tuple_size<
-          tuples::TaggedTuple<tags::no_default, tags::empty_base>>::value == 2,
-      "Failed check tuple_size");
-  static_assert(tuples::tuple_size<const tuples::TaggedTuple<
-                        tags::no_default, tags::empty_base>>::value == 2,
-                "Failed check tuple_size");
-  static_assert(tuples::tuple_size<volatile tuples::TaggedTuple<
-                        tags::no_default, tags::empty_base>>::value == 2,
-                "Failed check tuple_size");
-  static_assert(tuples::tuple_size<const volatile tuples::TaggedTuple<
-                        tags::no_default, tags::empty_base>>::value == 2,
-                "Failed check tuple_size");
+static_assert(
+    tuples::tuple_size<
+        tuples::TaggedTuple<tags::no_default, tags::empty_base>>::value == 2,
+    "Failed check tuple_size");
+static_assert(
+    tuples::tuple_size<
+        const tuples::TaggedTuple<tags::no_default, tags::empty_base>>::value ==
+        2,
+    "Failed check tuple_size");
+static_assert(tuples::tuple_size<volatile tuples::TaggedTuple<
+                      tags::no_default, tags::empty_base>>::value == 2,
+              "Failed check tuple_size");
+static_assert(tuples::tuple_size<const volatile tuples::TaggedTuple<
+                      tags::no_default, tags::empty_base>>::value == 2,
+              "Failed check tuple_size");
 
-  static_assert(tuples::tuple_size<tuples::TaggedTuple<>>::value == 0,
-                "Failed check tuple_size");
-  static_assert(tuples::tuple_size<const tuples::TaggedTuple<>>::value == 0,
-                "Failed check tuple_size");
-  static_assert(tuples::tuple_size<volatile tuples::TaggedTuple<>>::value == 0,
-                "Failed check tuple_size");
-  static_assert(
-      tuples::tuple_size<const volatile tuples::TaggedTuple<>>::value == 0,
-      "Failed check tuple_size");
-}
+static_assert(tuples::tuple_size<tuples::TaggedTuple<>>::value == 0,
+              "Failed check tuple_size");
+static_assert(tuples::tuple_size<const tuples::TaggedTuple<>>::value == 0,
+              "Failed check tuple_size");
+static_assert(tuples::tuple_size<volatile tuples::TaggedTuple<>>::value == 0,
+              "Failed check tuple_size");
+static_assert(tuples::tuple_size<const volatile tuples::TaggedTuple<>>::value ==
+                  0,
+              "Failed check tuple_size");
 
 // C++17 Draft 23.5.3.3 swap
 struct not_swappable {


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
