### PR TITLE
Start to add Valencia formulation of the relativistic Euler system

### DIFF
--- a/cmake/SpectreParseTests.py
+++ b/cmake/SpectreParseTests.py
@@ -23,6 +23,7 @@ allowed_tags = [
                 "Options",
                 "Parallel",
                 "PointwiseFunctions",
+                "RelativisticEuler",
                 "RootFinding",
                 "Serialization",
                 "Spectral",

--- a/src/Evolution/Systems/CMakeLists.txt
+++ b/src/Evolution/Systems/CMakeLists.txt
@@ -3,4 +3,5 @@
 
 add_subdirectory(CurvedScalarWave)
 add_subdirectory(GeneralizedHarmonic)
+add_subdirectory(RelativisticEuler)
 add_subdirectory(ScalarWave)

--- a/src/Evolution/Systems/RelativisticEuler/CMakeLists.txt
+++ b/src/Evolution/Systems/RelativisticEuler/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+add_subdirectory(Valencia)

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY Valencia)
+
+set(LIBRARY_SOURCES
+  ConservativeFromPrimitive.cpp
+  )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  )

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.cpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace RelativisticEuler {
+namespace Valencia {
+
+template <typename DataType, size_t Dim>
+void conservative_from_primitive(
+    const gsl::not_null<Scalar<DataType>*> tilde_d,
+    const gsl::not_null<Scalar<DataType>*> tilde_tau,
+    const gsl::not_null<tnsr::i<DataType, Dim, Frame::Inertial>*> tilde_s,
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const tnsr::i<DataType, Dim, Frame::Inertial>& spatial_velocity_oneform,
+    const Scalar<DataType>& spatial_velocity_squared,
+    const Scalar<DataType>& lorentz_factor,
+    const Scalar<DataType>& specific_enthalpy, const Scalar<DataType>& pressure,
+    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept {
+  get(*tilde_d) = get(sqrt_det_spatial_metric) * get(rest_mass_density) *
+                  get(lorentz_factor);
+
+  get(*tilde_tau) = get(sqrt_det_spatial_metric) * square(get(lorentz_factor)) *
+                    (get(rest_mass_density) *
+                         (get(specific_internal_energy) +
+                          get(spatial_velocity_squared) * get(lorentz_factor) /
+                              (get(lorentz_factor) + 1.)) +
+                     get(pressure) * get(spatial_velocity_squared));
+
+  for (size_t i = 0; i < Dim; ++i) {
+    tilde_s->get(i) = get(*tilde_d) * get(lorentz_factor) *
+                      get(specific_enthalpy) * spatial_velocity_oneform.get(i);
+  }
+}
+
+}  // namespace Valencia
+}  // namespace RelativisticEuler
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(_, data)                                               \
+  template void RelativisticEuler::Valencia::conservative_from_primitive(    \
+      const gsl::not_null<Scalar<DTYPE(data)>*> tilde_d,                     \
+      const gsl::not_null<Scalar<DTYPE(data)>*> tilde_tau,                   \
+      const gsl::not_null<tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>*> \
+          tilde_s,                                                           \
+      const Scalar<DTYPE(data)>& rest_mass_density,                          \
+      const Scalar<DTYPE(data)>& specific_internal_energy,                   \
+      const tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>&                \
+          spatial_velocity_oneform,                                          \
+      const Scalar<DTYPE(data)>& spatial_velocity_squared,                   \
+      const Scalar<DTYPE(data)>& lorentz_factor,                             \
+      const Scalar<DTYPE(data)>& specific_enthalpy,                          \
+      const Scalar<DTYPE(data)>& pressure,                                   \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (double, DataVector), (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+#undef DTYPE
+/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+namespace RelativisticEuler {
+namespace Valencia {
+
+/*!
+ * \brief Compute the conservative variables from primitive variables
+ *
+ * \f{align*}
+ * {\tilde D} = & \sqrt{\gamma} \rho W \\
+ * {\tilde S}_i = & \sqrt{\gamma} \rho h W^2 v_i \\
+ * {\tilde \tau} = & \sqrt{\gamma} \left( \rho h W^2 - p - \rho W \right)
+ * \f}
+ * where \f${\tilde D}\f$, \f${\tilde S}_i\f$, and \f${\tilde \tau}\f$ are a
+ * generalized mass-energy density, momentum density, and specific internal
+ * energy density as measured by an Eulerian observer, \f$\gamma\f$ is the
+ * determinant of the spatial metric, \f$\rho\f$ is the rest mass density,
+ * \f$W = 1/\sqrt{1-v_i v^i}\f$ is the Lorentz factor, \f$h = 1 + \epsilon +
+ * \frac{p}{\rho}\f$ is the specific enthalpy, \f$v_i\f$ is the spatial
+ * velocity, \f$\epsilon\f$ is the specific internal energy, and \f$p\f$ is the
+ * pressure.
+ *
+ * Using the definitions of the Lorentz factor and the specific enthalpy, the
+ * last equation can be rewritten in a form that has a well-behaved Newtonian
+ * limit: \f[
+ * {\tilde \tau} = \sqrt{\gamma} W^2 \left[ \rho \left( \epsilon + v^2
+ * \frac{W}{W + 1} \right) + p v^2 \right] .\f]
+ */
+template <typename DataType, size_t Dim>
+void conservative_from_primitive(
+    gsl::not_null<Scalar<DataType>*> tilde_d,
+    gsl::not_null<Scalar<DataType>*> tilde_tau,
+    gsl::not_null<tnsr::i<DataType, Dim, Frame::Inertial>*> tilde_s,
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const tnsr::i<DataType, Dim, Frame::Inertial>& spatial_velocity_oneform,
+    const Scalar<DataType>& spatial_velocity_squared,
+    const Scalar<DataType>& lorentz_factor,
+    const Scalar<DataType>& specific_enthalpy, const Scalar<DataType>& pressure,
+    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept;
+}  // namespace Valencia
+}  // namespace RelativisticEuler

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/System.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/System.hpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Tags {
+template <class>
+class Variables;
+}  // namespace Tags
+
+/// \ingroup EvolutionSystemsGroup
+/// \brief Items related to evolving the relativistic Euler system
+namespace RelativisticEuler {
+/// \brief The Valencia formulation of the relativistic Euler System
+/// See Chapter 7 of Relativistic Hydrodynamics by Luciano Rezzolla and Olindo
+/// Zanotti or http://iopscience.iop.org/article/10.1086/303604
+namespace Valencia {
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+
+  using variables_tag =
+      Tags::Variables<tmpl::list<TildeD, TildeTau, TildeS<Dim>>>;
+};
+
+}  // namespace Valencia
+}  // namespace RelativisticEuler

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+class DataVector;
+
+namespace RelativisticEuler {
+namespace Valencia {
+struct TildeD : db::DataBoxTag {
+  using type = Scalar<DataVector>;
+  static constexpr db::DataBoxString_t label = "TildeD";
+};
+
+struct TildeTau : db::DataBoxTag {
+  using type = Scalar<DataVector>;
+  static constexpr db::DataBoxString_t label = "TildeTau";
+};
+
+template <size_t Dim>
+struct TildeS : db::DataBoxTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+  static constexpr db::DataBoxString_t label = "TildeS";
+};
+}  // namespace Valencia
+}  // namespace RelativisticEuler

--- a/tests/Unit/Evolution/Systems/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(CurvedScalarWave)
 add_subdirectory(GeneralizedHarmonic)
+add_subdirectory(RelativisticEuler)
 add_subdirectory(ScalarWave)
 
 set(EVOLUTION_TESTS "${EVOLUTION_TESTS};${SYSTEM_TESTS}" PARENT_SCOPE)

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+add_subdirectory(Valencia)
+
+set(SYSTEM_TESTS "${SYSTEM_TESTS};${RELATIVISTIC_EULER_TESTS}" PARENT_SCOPE)
+set(LIBRARIES_TO_LINK "${LIBRARIES_TO_LINK}" PARENT_SCOPE)

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(VALENCIA_TESTS
+  Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
+  )
+
+set(RELATIVISTIC_EULER_TESTS
+  "${RELATIVISTIC_EULER_TESTS};${VALENCIA_TESTS}" PARENT_SCOPE
+  )
+set(LIBRARIES_TO_LINK "${LIBRARIES_TO_LINK};Valencia" PARENT_SCOPE)

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
@@ -1,0 +1,129 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "tests/Unit/DataStructures/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
+
+namespace {
+template <typename DataType>
+Scalar<DataType> expected_tilde_d(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& lorentz_factor,
+    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept {
+  auto result = make_with_value<Scalar<DataType>>(rest_mass_density, 0.);
+  get(result) = get(lorentz_factor) * get(rest_mass_density) *
+                get(sqrt_det_spatial_metric);
+  return result;
+}
+
+template <typename DataType>
+Scalar<DataType> expected_tilde_tau(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const Scalar<DataType>& spatial_velocity_squared,
+    const Scalar<DataType>& lorentz_factor, const Scalar<DataType>& pressure,
+    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept {
+  auto result = make_with_value<Scalar<DataType>>(rest_mass_density, 0.);
+  get(result) = (get(pressure) * get(spatial_velocity_squared) +
+                 (get(lorentz_factor) / (1.0 + get(lorentz_factor)) *
+                      get(spatial_velocity_squared) +
+                  get(specific_internal_energy)) *
+                     get(rest_mass_density)) *
+                square(get(lorentz_factor)) * get(sqrt_det_spatial_metric);
+  return result;
+}
+
+template <typename DataType, size_t Dim>
+tnsr::i<DataType, Dim> expected_tilde_s(
+    const Scalar<DataType>& rest_mass_density,
+    const tnsr::i<DataType, Dim, Frame::Inertial>& spatial_velocity_oneform,
+    const Scalar<DataType>& lorentz_factor,
+    const Scalar<DataType>& specific_enthalpy,
+    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept {
+  auto result = make_with_value<tnsr::i<DataType, Dim>>(rest_mass_density, 0.);
+  for (size_t i = 0; i < Dim; ++i) {
+    result.get(i) = spatial_velocity_oneform.get(i) *
+                    square(get(lorentz_factor)) * get(specific_enthalpy) *
+                    get(rest_mass_density) * get(sqrt_det_spatial_metric);
+  }
+  return result;
+}
+
+template <size_t Dim, typename DataType>
+void test_conservative_from_primitive(
+    const gsl::not_null<std::mt19937*> generator,
+    const gsl::not_null<std::uniform_real_distribution<>*> distribution,
+    const DataType& used_for_size) noexcept {
+  const auto rest_mass_density = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto specific_internal_energy =
+      make_with_random_values<Scalar<DataType>>(generator, distribution,
+                                                used_for_size);
+  const auto spatial_velocity_squared =
+      make_with_random_values<Scalar<DataType>>(generator, distribution,
+                                                used_for_size);
+  const auto lorentz_factor = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto specific_enthalpy = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto pressure = make_with_random_values<Scalar<DataType>>(
+      generator, distribution, used_for_size);
+  const auto sqrt_det_spatial_metric =
+      make_with_random_values<Scalar<DataType>>(generator, distribution,
+                                                used_for_size);
+  const auto spatial_velocity_oneform =
+      make_with_random_values<tnsr::i<DataType, Dim>>(generator, distribution,
+                                                      used_for_size);
+
+  auto tilde_d = make_with_value<Scalar<DataType>>(used_for_size, 0.);
+  auto tilde_tau = make_with_value<Scalar<DataType>>(used_for_size, 0.);
+  auto tilde_s = make_with_value<tnsr::i<DataType, Dim>>(used_for_size, 0.);
+
+  RelativisticEuler::Valencia::conservative_from_primitive(
+      make_not_null(&tilde_d), make_not_null(&tilde_tau),
+      make_not_null(&tilde_s), rest_mass_density, specific_internal_energy,
+      spatial_velocity_oneform, spatial_velocity_squared, lorentz_factor,
+      specific_enthalpy, pressure, sqrt_det_spatial_metric);
+  CHECK_ITERABLE_APPROX(expected_tilde_d(rest_mass_density, lorentz_factor,
+                                         sqrt_det_spatial_metric),
+                        tilde_d);
+  CHECK_ITERABLE_APPROX(
+      expected_tilde_tau(rest_mass_density, specific_internal_energy,
+                         spatial_velocity_squared, lorentz_factor, pressure,
+                         sqrt_det_spatial_metric),
+      tilde_tau);
+  CHECK_ITERABLE_APPROX(
+      expected_tilde_s(rest_mass_density, spatial_velocity_oneform,
+                       lorentz_factor, specific_enthalpy,
+                       sqrt_det_spatial_metric),
+      tilde_s);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.ConservativeFromPrimitive",
+                  "[Unit][RelativisticEuler]") {
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed = " << seed);
+  std::uniform_real_distribution<> distribution(0.0, 1.0);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  const double d = std::numeric_limits<double>::signaling_NaN();
+  test_conservative_from_primitive<1>(nn_generator, nn_distribution, d);
+  test_conservative_from_primitive<2>(nn_generator, nn_distribution, d);
+  test_conservative_from_primitive<3>(nn_generator, nn_distribution, d);
+
+  const DataVector dv(5);
+  test_conservative_from_primitive<1>(nn_generator, nn_distribution, dv);
+  test_conservative_from_primitive<2>(nn_generator, nn_distribution, dv);
+  test_conservative_from_primitive<3>(nn_generator, nn_distribution, dv);
+}


### PR DESCRIPTION
Add a function to compute the conservative variables.
Make tags for the conservative variables.

## Proposed changes

Add directory structure for Valencia formulation of relativistic Euler equations.  


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`


