### PR TITLE
Magnitude.hpp calls DotProduct.hpp

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -1,15 +1,10 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-/// \file
-/// Defines functions euclidean_magnitude and magnitude
-
 #pragma once
 
-#include <cstddef>
-
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/MakeWithValue.hpp"
 
 /*!
  * \ingroup TensorGroup
@@ -22,11 +17,7 @@
 template <typename DataType, typename Index>
 Scalar<DataType> magnitude(
     const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector) noexcept {
-  auto magnitude_squared = make_with_value<DataType>(vector, 0.);
-  for (size_t d = 0; d < Index::dim; ++d) {
-    magnitude_squared += square(vector.get(d));
-  }
-  return Scalar<DataType>{sqrt(magnitude_squared)};
+  return Scalar<DataType>{sqrt(get(dot_product(vector, vector)))};
 }
 
 /*!
@@ -44,11 +35,5 @@ Scalar<DataType> magnitude(
                  tmpl::list<change_index_up_lo<Index>,
                             change_index_up_lo<Index>>>&
         metric) noexcept {
-  auto magnitude_squared = make_with_value<DataType>(vector, 0.);
-  for (size_t a = 0; a < Index::dim; ++a) {
-    for (size_t b = 0; b < Index::dim; ++b) {
-      magnitude_squared += vector.get(a) * vector.get(b) * metric.get(a, b);
-    }
-  }
-  return Scalar<DataType>{sqrt(magnitude_squared)};
+  return Scalar<DataType>{sqrt(get(dot_product(vector, vector, metric)))};
 }


### PR DESCRIPTION
## Proposed changes

Make magnitude() call dot_product() instead of using its own implementation of the dot product.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
