### PR TITLE
Stop db::create moving out of lvalue references

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -797,19 +797,20 @@ SPECTRE_ALWAYS_INLINE constexpr cpp17::void_type add_item_to_box(
     std::tuple<Ts...>& tupull,
     databox_detail::TaggedDeferredTuple<Tags...>&
         data) noexcept(noexcept(::db::databox_detail::get<Tag>(data) =
-                                    Deferred<item_type<Tag>>(std::move(
-                                        std::get<ArgsIndex>(tupull)))) and
+                                    Deferred<item_type<Tag>>(
+                                        std::forward<std::tuple_element_t<
+                                            ArgsIndex, std::tuple<Ts...>>>(
+                                            std::get<ArgsIndex>(tupull)))) and
                        noexcept(add_subitem_tags_to_box<Tag>(
                            data, typename Subitems<Tag>::type{}))) {
-  static_assert(
-      not tt::is_a<Deferred,
-                   std::decay_t<decltype(std::get<ArgsIndex>(tupull))>>::value,
-      "Cannot pass a Deferred into the DataBox as an Item. This "
-      "functionally can trivially be added, however it is "
-      "intentionally omitted because users of DataBox are not "
-      "supposed to deal with Deferred.");
-  ::db::databox_detail::get<Tag>(data) =
-      Deferred<item_type<Tag>>(std::move(std::get<ArgsIndex>(tupull)));
+  using ArgType = std::tuple_element_t<ArgsIndex, std::tuple<Ts...>>;
+  static_assert(not tt::is_a<Deferred, std::decay_t<ArgType>>::value,
+                "Cannot pass a Deferred into the DataBox as an Item. This "
+                "functionally can trivially be added, however it is "
+                "intentionally omitted because users of DataBox are not "
+                "supposed to deal with Deferred.");
+  ::db::databox_detail::get<Tag>(data) = Deferred<item_type<Tag>>(
+      std::forward<ArgType>(std::get<ArgsIndex>(tupull)));
   add_subitem_tags_to_box<Tag>(data, typename Subitems<Tag>::type{});
   return cpp17::void_type{};  // must return in constexpr function
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
