### PR TITLE
Add TimescaleTuner

### DIFF
--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY ControlSystem)
 set(LIBRARY_SOURCES
     PiecewisePolynomial.cpp
     SettleToConstant.cpp
+    TimescaleTuner.cpp
    )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/ControlSystem/TimescaleTuner.cpp
+++ b/src/ControlSystem/TimescaleTuner.cpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/TimescaleTuner.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <ostream>
+
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+TimescaleTuner::TimescaleTuner(DataVector initial_timescale,
+                               const double max_timescale,
+                               const double min_timescale,
+                               const double decrease_timescale_threshold,
+                               const double increase_timescale_threshold,
+                               const double increase_factor,
+                               const double decrease_factor) noexcept
+    : timescale_{std::move(initial_timescale)},
+      max_timescale_{max_timescale},
+      min_timescale_{min_timescale},
+      decrease_timescale_threshold_{decrease_timescale_threshold},
+      increase_timescale_threshold_{increase_timescale_threshold},
+      increase_factor_{increase_factor},
+      decrease_factor_{decrease_factor} {
+  for (const auto& t_scale : timescale_) {
+    if (t_scale <= 0.0) {
+      ERROR("Initial timescale must be > 0");
+    }
+  }
+
+  if (decrease_factor_ > 1.0 or decrease_factor <= 0.0) {
+    ERROR("The specified decrease_factor "
+          << decrease_factor_ << " must satisfy 0 < decrease_factor <= 1");
+  }
+  if (increase_factor_ < 1.0) {
+    ERROR("The specified increase factor " << increase_factor_
+                                           << " must be >= 1.0");
+  }
+  if (min_timescale_ <= 0.0) {
+    ERROR("The specified minimum timescale " << min_timescale_
+                                             << " must be > 0");
+  }
+  if (max_timescale_ <= min_timescale_) {
+    ERROR("The maximum timescale "
+          << max_timescale_
+          << " must be > than the specified minimum timescale "
+          << min_timescale_);
+  }
+  if (increase_timescale_threshold_ <= 0.0) {
+    ERROR("The specified increase-timescale threshold "
+          << increase_timescale_threshold_ << " must be > 0");
+  }
+  if (decrease_timescale_threshold_ <= increase_timescale_threshold_) {
+    ERROR("The decrease-timescale threshold "
+          << decrease_timescale_threshold_
+          << " must be > than the specified increase-timescale threshold "
+          << increase_timescale_threshold_);
+  }
+}
+
+void TimescaleTuner::set_timescale_if_in_allowable_range(
+    const double suggested_timescale) noexcept {
+  for (auto& t_scale : timescale_) {
+    t_scale = cpp17::clamp(suggested_timescale, min_timescale_, max_timescale_);
+  }
+}
+
+void TimescaleTuner::update_timescale(
+    const std::array<DataVector, 2>& q_and_dtq) noexcept {
+  ASSERT(q_and_dtq[0].size() == timescale_.size() and
+             q_and_dtq[1].size() == timescale_.size(),
+         "One or both of the number of components in q_and_dtq("
+             << q_and_dtq[0].size() << "," << q_and_dtq[1].size()
+             << ") is inconsistent with the number of timescales("
+             << timescale_.size() << ")");
+
+  const DataVector& q = gsl::at(q_and_dtq, 0);
+  const DataVector& dtq = gsl::at(q_and_dtq, 1);
+
+  for (size_t i = 0; i < q.size(); i++) {
+    // check whether we need to decrease the timescale:
+    if ((fabs(q[i]) > decrease_timescale_threshold_ or
+         fabs(dtq[i] * timescale_[i]) > decrease_timescale_threshold_) and
+        (dtq[i] * q[i] > 0.0 or
+         fabs(dtq[i]) * timescale_[i] < 0.5 * fabs(q[i]))) {
+      // the first check is if Q `or` dtQ are above the maximum tolerance.
+      // the second condition of the `and` is
+      // that Q and dtQ are the same sign (the error is growing)
+      // `or` that Q is not expected to drop to half of its current value in
+      // one timescale (not decreasing fast enough)
+      timescale_[i] *= decrease_factor_;
+    }
+    // check whether we need to increase the timescale:
+    else if (fabs(q[i]) < increase_timescale_threshold_ and
+             fabs(dtq[i] * timescale_[i]) <
+                 (increase_timescale_threshold_ - fabs(q[i]))) {
+      // if Q `and` dtQ are below the minimum required threshold
+      timescale_[i] *= increase_factor_;
+    }
+
+    // make sure the timescale has not increased(decreased) above(below) the
+    // maximum(minimum) value.
+    timescale_[i] = cpp17::clamp(timescale_[i], min_timescale_, max_timescale_);
+  }
+}

--- a/src/ControlSystem/TimescaleTuner.hpp
+++ b/src/ControlSystem/TimescaleTuner.hpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+
+#include "DataStructures/DataVector.hpp"
+
+/*!
+ * \ingroup ControlSystemGroup
+ * \brief Manages control system timescales
+ *
+ * The TimescaleTuner adjusts the damping timescale, \f$\tau\f$, of the control
+ * system.\n The damping timescale is restricted to
+ * `min_timescale`\f$\le\tau\le\f$`max_timescale`
+ *
+ * The damping time is adjusted according to the following criteria:
+ *
+ * **Decrease** the timescale by a factor of `decrease_factor` if either \n
+ * - the error is too large: \f$|Q| >\f$ `decrease_timescale_threshold`
+ * OR
+ * the error is changing quickly: \f$|\dot{Q}|\tau >\f$
+ * `decrease_timescale_threshold`,\n
+ * AND \n
+ * - the error is growing: \f$\dot{Q}Q > 0\f$
+ * OR
+ * the expected change in \f$Q\f$ is less than half its current value:
+ * \f$|\dot{Q}|\tau < |Q|/2\f$
+ *
+ * **Increase** the timescale by a factor of `increase_factor` if \n
+ * - the error is sufficiently small: \f$|Q|<\f$ `increase_timescale_threshold`
+ * \n
+ * AND \n
+ * - the expected change in \f$Q\f$ is less than the difference between the
+ * current error and the threshold:
+ * \f$|\dot{Q}|\tau < \f$ (`increase_timescale_threshold` \f$-|Q|\f$)
+ */
+
+class TimescaleTuner {
+ public:
+  TimescaleTuner(DataVector initial_timescale, double max_timescale,
+                 double min_timescale, double decrease_timescale_threshold,
+                 double increase_timescale_threshold, double increase_factor,
+                 double decrease_factor) noexcept;
+
+  TimescaleTuner(TimescaleTuner&&) noexcept = default;
+  TimescaleTuner& operator=(TimescaleTuner&&) noexcept = default;
+  TimescaleTuner(const TimescaleTuner&) = delete;
+  TimescaleTuner& operator=(const TimescaleTuner&) = delete;
+  ~TimescaleTuner() = default;
+
+  /// returns the current timescale for each component of a FunctionOfTime
+  const DataVector& current_timescale() noexcept { return timescale_; }
+  /// manually sets all timescales to a specified value, unless the value is
+  /// outside of the specified minimum and maximum timescale bounds, in which
+  /// case it is set to the nearest bounded value
+  void set_timescale_if_in_allowable_range(double suggested_timescale) noexcept;
+  /// the update function responsible for modifying the timescale based on
+  /// the control system errors
+  void update_timescale(const std::array<DataVector, 2>& q_and_dtq) noexcept;
+
+ private:
+  DataVector timescale_;
+  double max_timescale_;
+  double min_timescale_;
+  double decrease_timescale_threshold_;
+  double increase_timescale_threshold_;
+  double increase_factor_;
+  double decrease_factor_;
+};

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ControlSystem")
 set(LIBRARY_SOURCES
   Test_PiecewisePolynomial.cpp
   Test_SettleToConstant.cpp
+  Test_TimescaleTuner.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
+++ b/tests/Unit/ControlSystem/Test_TimescaleTuner.cpp
@@ -1,0 +1,440 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+
+#include "ControlSystem/TimescaleTuner.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.IncreaseOrDecrease",
+                  "[ControlSystem][Unit]") {
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+
+  const DataVector timescale{1.0};
+  CHECK(tst.current_timescale() == timescale);
+
+  // Check the suggested timescale function
+  // (1) timescale < min_timescale
+  double suggested_tscale = min_timescale * 0.5;
+  tst.set_timescale_if_in_allowable_range(suggested_tscale);
+  CHECK(tst.current_timescale() ==
+        make_with_value<DataVector>(timescale, min_timescale));
+  // (2) min_timescale < timescale < max_timescale
+  suggested_tscale = 0.5 * (min_timescale + max_timescale);
+  tst.set_timescale_if_in_allowable_range(suggested_tscale);
+  CHECK(tst.current_timescale() ==
+        make_with_value<DataVector>(timescale, suggested_tscale));
+  // (3) max_timescale < timescale
+  suggested_tscale = max_timescale * 2.0;
+  tst.set_timescale_if_in_allowable_range(suggested_tscale);
+  CHECK(tst.current_timescale() ==
+        make_with_value<DataVector>(timescale, max_timescale));
+
+  // set timescale for remaining tests
+  double tscale = 10.0;
+  tst.set_timescale_if_in_allowable_range(tscale);
+  CHECK(tst.current_timescale() ==
+        make_with_value<DataVector>(timescale, tscale));
+
+  // helper vars for greater than and less than one, used to choose
+  // the correct Q for each CHECK
+  const double greater_than_one = 1.1;
+  const double less_than_one = 0.9;
+
+  auto run_tests = [&](double sign_of_q) {
+    // Here, situations that trigger the outer conditional related to a decrease
+    // in timescale are numbered, while the nested conditional choices for each
+    // associated outer case are suffixed with letters
+
+    // (1) |Q| > decrease_timescale_threshold
+    //     |\dot{Q}| <= decrease_timescale_threshold/timescale
+    DataVector q{sign_of_q * greater_than_one * decrease_timescale_threshold};
+    DataVector qdot{sign_of_q * less_than_one * decrease_timescale_threshold /
+                    tscale};
+
+    // (1a) Q\dot{Q} > 0
+    //      |\dot{Q}| >= 0.5*|Q|/timescale
+    // the error is large and growing: decrease timescale
+    tscale *= decrease_factor;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (1b) Q\dot{Q} <= 0
+    //      |\dot{Q}| < 0.5*|Q|/timescale
+    // the error is not decreasing quickly enough: decrease timescale
+    qdot = -less_than_one * 0.5 * q / tscale;
+    tscale *= decrease_factor;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (1c) Q\dot{Q} > 0
+    //      |\dot{Q}| < 0.5*|Q|/timescale
+    // the error is large and growing quickly: decrease timescale
+    qdot *= -1.0;
+    tscale *= decrease_factor;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (2) |Q| <= decrease_timescale_threshold
+    //     |\dot{Q}| > decrease_timescale_threshold/timescale
+    q = sign_of_q * less_than_one * decrease_timescale_threshold;
+    qdot = sign_of_q * greater_than_one * decrease_timescale_threshold / tscale;
+
+    // (2a) Q\dot{Q} > 0
+    //      |\dot{Q}| >= 0.5*|Q|/timescale
+    // the error is growing quickly: decrease timescale
+    tscale *= decrease_factor;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (2b) Q\dot{Q} <= 0
+    //      |\dot{Q}| < 0.5*|Q|/timescale
+    // NOTE: the second piece is unachievable, given the conditions of (2).
+    // This check is included in the do nothing test.
+
+    // (2c) Q\dot{Q} > 0
+    //      |\dot{Q}| < 0.5*|Q|/timescale
+    // NOTE: the second piece is unachievable, given the conditions of (2),
+    // however, Q\dot{Q} > 0 is sufficient to trigger a decrease.
+    // the error is growing quickly: decrease timescale
+    tscale *= decrease_factor;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (3) |Q| > decrease_timescale_threshold
+    //     |\dot{Q}| > decrease_timescale_threshold/timescale
+    q = sign_of_q * greater_than_one * decrease_timescale_threshold;
+    qdot = sign_of_q * greater_than_one * decrease_timescale_threshold / tscale;
+
+    // (3a) Q\dot{Q} > 0
+    //      |\dot{Q}| >= 0.5*|Q|/timescale
+    // the error is large and growing quickly: decrease timescale
+    tscale *= decrease_factor;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (3b) Q\dot{Q} <= 0
+    //      |\dot{Q}| < 0.5*|Q|/timescale
+    // the error is large and not decreasing quickly enough: decrease timescale
+    qdot *= -1.0;
+    q = sign_of_q * greater_than_one * 2.0 * greater_than_one *
+        decrease_timescale_threshold;
+    tscale *= decrease_factor;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (3c) Q\dot{Q} > 0
+    //      |\dot{Q}| < 0.5*|Q|/timescale
+    // the error is large and growing quickly: decrease timescale
+    qdot *= -1.0;
+    tscale *= decrease_factor;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // There is only one case which triggers an increase in the timescale
+    // (4) |Q| < increase_timescale_threshold
+    //     |\dot{Q}| < (increase_timescale_threshold-|Q|)/timescale
+    // the error and time derivative are sufficiently small: increase timescale
+    q = sign_of_q * less_than_one * increase_timescale_threshold;
+    qdot = sign_of_q * less_than_one *
+           (increase_timescale_threshold - fabs(q)) / tscale;
+    tscale *= increase_factor;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+  };
+  // testing for Q>0 and Q<0
+  run_tests(1.0);
+  run_tests(-1.0);
+}
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.NoChangeToTimescale",
+                  "[ControlSystem][Unit]") {
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+
+  const DataVector timescale{1.0};
+  CHECK(tst.current_timescale() == timescale);
+
+  double tscale = 10.0;
+  tst.set_timescale_if_in_allowable_range(tscale);
+  CHECK(tst.current_timescale() ==
+        make_with_value<DataVector>(timescale, tscale));
+
+  // helper vars for greater than and less than one, used to choose
+  // the correct Q for each CHECK
+  const double greater_than_one = 1.1;
+  const double less_than_one = 0.9;
+
+  auto run_tests = [&](double sign_of_q) {
+
+    // (1) |Q| > decrease_timescale_threshold
+    //     |\dot{Q}| <= decrease_timescale_threshold/timescale
+    DataVector q{sign_of_q * greater_than_one * decrease_timescale_threshold};
+    DataVector qdot{-1.0 * sign_of_q * less_than_one *
+                    decrease_timescale_threshold / tscale};
+
+    // (1d) Q\dot{Q} <= 0
+    //      |\dot{Q}| >= 0.5*|Q|/timescale
+    // the error is large, but decreasing quickly enough: do nothing
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (2) |Q| <= decrease_timescale_threshold
+    //     |\dot{Q}| > decrease_timescale_threshold/timescale
+    q = sign_of_q * less_than_one * decrease_timescale_threshold;
+    qdot = -1.0 * sign_of_q * greater_than_one * decrease_timescale_threshold /
+           tscale;
+
+    // (2b) Q\dot{Q} <= 0
+    //      |\dot{Q}| < 0.5*|Q|/timescale
+    // NOTE: the second piece is unachievable, given the conditions of (2).
+    // the error is small and decreasing: do nothing
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (2d) Q\dot{Q} <= 0
+    //      |\dot{Q}| >= 0.5*|Q|/timescale
+    // the error is small and decreasing quickly: do nothing
+    q = less_than_one * 2.0 * qdot * tscale;
+    qdot *= -1.0;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (3) |Q| > decrease_timescale_threshold
+    //     |\dot{Q}| > decrease_timescale_threshold/timescale
+    q = sign_of_q * greater_than_one * decrease_timescale_threshold;
+    qdot = -1.0 * sign_of_q * greater_than_one * decrease_timescale_threshold /
+           tscale;
+
+    // (3d) Q\dot{Q} <= 0
+    //      |\dot{Q}| >= 0.5*|Q|/timescale
+    // the error is large, but decreasing quickly: do nothing
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (4) |Q| < increase_timescale_threshold
+    //     |\dot{Q}| >= (increase_timescale_threshold-|Q|)/timescale
+    // the error and time derivative are sufficiently small: increase timescale
+    q = sign_of_q * less_than_one * increase_timescale_threshold;
+    qdot = sign_of_q * greater_than_one *
+           (increase_timescale_threshold - fabs(q)) / tscale;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (5) |Q| >= increase_timescale_threshold
+    //     |\dot{Q}| < (increase_timescale_threshold-|Q|)/timescale
+    // the error and time derivative are sufficiently small: increase timescale
+    q = sign_of_q * greater_than_one * increase_timescale_threshold;
+    qdot = sign_of_q * less_than_one *
+           (increase_timescale_threshold - fabs(q)) / tscale;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+
+    // (6) |Q| >= increase_timescale_threshold
+    //     |\dot{Q}| >= (increase_timescale_threshold-|Q|)/timescale
+    // the error and time derivative are sufficiently small: increase timescale
+    q = sign_of_q * greater_than_one * increase_timescale_threshold;
+    qdot = sign_of_q * greater_than_one *
+           (increase_timescale_threshold - fabs(q)) / tscale;
+    tst.update_timescale({{q, qdot}});
+    CHECK(tst.current_timescale() ==
+          make_with_value<DataVector>(timescale, tscale));
+  };
+  run_tests(1.0);   // test positive Q
+  run_tests(-1.0);  // test negative Q
+}
+
+// [[OutputRegex, Initial timescale must be > 0]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadInitTimescale",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  const DataVector init_timescale{0.0};
+  TimescaleTuner tst(init_timescale, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+}
+
+// [[OutputRegex, must satisfy 0 < decrease_factor <= 1]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadDecFactor0",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  const double increase_factor = 1.1;
+  const double decrease_factor = -0.99;
+
+  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+}
+
+// [[OutputRegex, must satisfy 0 < decrease_factor <= 1]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadDecFactor1",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  const double increase_factor = 1.1;
+  const double decrease_factor = 1.01;
+
+  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+}
+
+// [[OutputRegex, must be >= 1]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadIncFactor",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  const double increase_factor = 0.99;
+  const double decrease_factor = 0.8;
+
+  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+}
+
+// [[OutputRegex, must be > 0]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadMinTimescale",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+
+  const double max_timescale = 10.0;
+  const double min_timescale = 0.0;
+
+  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+}
+
+// [[OutputRegex, must be > than the specified minimum timescale]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadMaxTimescale",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+
+  const double max_timescale = 1.0e-4;
+  const double min_timescale = 1.0e-3;
+
+  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+}
+
+// [[OutputRegex, The specified increase-timescale threshold]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadIncreaseThreshold",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 0.0;
+
+  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+}
+
+// [[OutputRegex, must be > than the specified increase-timescale threshold]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.BadDecreaseThreshold",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  const double decrease_timescale_threshold = 1.0e-4;
+  const double increase_timescale_threshold = 1.0e-3;
+
+  TimescaleTuner tst({1.0}, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+}
+
+// [[OutputRegex, One or both of the number of components in q_and_dtq]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.ControlSystem.TimescaleTuner.SizeMismatch",
+                               "[ControlSystem][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+
+  const DataVector init_timescale{{1.0, 2.0}};
+  TimescaleTuner tst(init_timescale, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+
+  const std::array<DataVector, 2> qs{{{2.0}, {3.0}}};
+  tst.update_timescale(qs);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}

--- a/tests/Unit/Utilities/Test_ConstantExpressions.cpp
+++ b/tests/Unit/Utilities/Test_ConstantExpressions.cpp
@@ -4,8 +4,9 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
-#include <cstddef>
 #include <cmath>  // IWYU pragma: keep
+#include <cstddef>
+#include <functional>
 
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/TMPL.hpp"
@@ -101,10 +102,8 @@ static_assert(max_by_magnitude(-2, -1) == -2,
               "Failed testing max_by_magnitude");
 static_assert(max_by_magnitude({-2, -1, -3}) == -3,
               "Failed testing max_by_magnitude");
-static_assert(max_by_magnitude(1, -1) == 1,
-              "Failed testing max_by_magnitude");
-static_assert(max_by_magnitude(-1, 1) == -1,
-              "Failed testing max_by_magnitude");
+static_assert(max_by_magnitude(1, -1) == 1, "Failed testing max_by_magnitude");
+static_assert(max_by_magnitude(-1, 1) == -1, "Failed testing max_by_magnitude");
 static_assert(max_by_magnitude({1, -1}) == 1,
               "Failed testing max_by_magnitude");
 static_assert(max_by_magnitude({-1, 1}) == -1,
@@ -123,25 +122,37 @@ static_assert(min_by_magnitude(-2, -1) == -1,
               "Failed testing min_by_magnitude");
 static_assert(min_by_magnitude({-2, -1, -3}) == -1,
               "Failed testing min_by_magnitude");
-static_assert(min_by_magnitude(1, -1) == 1,
-              "Failed testing min_by_magnitude");
-static_assert(min_by_magnitude(-1, 1) == -1,
-              "Failed testing min_by_magnitude");
+static_assert(min_by_magnitude(1, -1) == 1, "Failed testing min_by_magnitude");
+static_assert(min_by_magnitude(-1, 1) == -1, "Failed testing min_by_magnitude");
 static_assert(min_by_magnitude({1, -1}) == 1,
               "Failed testing min_by_magnitude");
 static_assert(min_by_magnitude({-1, 1}) == -1,
               "Failed testing min_by_magnitude");
 
+// Test clamp
+static_assert(cpp17::clamp(10, 0, 9) == 9, "Failed testing clamp");
+static_assert(cpp17::clamp(-1, 0, 9) == 0, "Failed testing clamp");
+static_assert(cpp17::clamp(5, 0, 9) == 5, "Failed testing clamp");
+static_assert(cpp17::clamp(9, 0, 9) == 9, "Failed testing clamp");
+static_assert(cpp17::clamp(0, 0, 9) == 0, "Failed testing clamp");
+static_assert(cpp17::clamp(10.0, 0.0, 9.0) == 9.0, "Failed testing clamp");
+static_assert(cpp17::clamp(-1.0, 0.0, 9.0) == 0.0, "Failed testing clamp");
+static_assert(cpp17::clamp(5.0, 0.0, 9.0) == 5.0, "Failed testing clamp");
+static_assert(cpp17::clamp(9.0, 0.0, 9.0) == 9.0, "Failed testing clamp");
+static_assert(cpp17::clamp(0.0, 0.0, 9.0) == 0.0, "Failed testing clamp");
+
 struct TwoN {
   template <typename T>
-  constexpr size_t operator()(T n) noexcept { return 2 * n; }
+  constexpr size_t operator()(T n) noexcept {
+    return 2 * n;
+  }
 };
 static_assert(constexpr_sum<5>(TwoN{}) == 20, "Failed testing constexpr_sum");
 
 // Test string manipulation
-constexpr const char *const dummy_string1 = "test 1";
-constexpr const char *const dummy_string2 = "test 1";
-constexpr const char *const dummy_string3 = "test blah";
+constexpr const char* const dummy_string1 = "test 1";
+constexpr const char* const dummy_string2 = "test 1";
+constexpr const char* const dummy_string3 = "test blah";
 static_assert(6 == cstring_length(dummy_string1),
               "Failed testing cstring_length");
 static_assert(cstring_hash(dummy_string1) == cstring_hash(dummy_string2),


### PR DESCRIPTION
## Proposed changes

Add the control system timescale tuner

### Types of changes:

- [ ] Bugfix
- [X] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
