### PR TITLE
Add function to compute fluxes for the Valencia formulation of the relativistic Euler system

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,7 +2,7 @@
 SpECTRE Release License
 ==============================================================================
 
-Copyright 2017 Simulating eXtreme Spacetimes Collaboration
+Copyright 2017 - 2018 Simulating eXtreme Spacetimes Collaboration
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/config/footer.html
+++ b/docs/config/footer.html
@@ -12,7 +12,7 @@
 <!--END GENERATE_TREEVIEW-->
 <!--BEGIN !GENERATE_TREEVIEW-->
 <hr class="footer"/><address class="footer"><small>
-&copy; Copyright 2017
+&copy; Copyright 2017 - 2018
 <a href="https://black-holes.org">SXS Collaboration</a>,
 <a href="LICENSE.txt" target="_blank">
 <span class="hidden-xs">Distributed under the</span>

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Valencia)
 
 set(LIBRARY_SOURCES
   ConservativeFromPrimitive.cpp
+  Fluxes.cpp
   )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Fluxes.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Fluxes.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace RelativisticEuler {
+namespace Valencia {
+
+template <size_t Dim>
+void fluxes(const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+                tilde_d_flux,
+            const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+                tilde_tau_flux,
+            const gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*>
+                tilde_s_flux,
+            const Scalar<DataVector>& tilde_d,
+            const Scalar<DataVector>& tilde_tau,
+            const tnsr::i<DataVector, Dim, Frame::Inertial>& tilde_s,
+            const Scalar<DataVector>& lapse,
+            const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+            const Scalar<DataVector>& sqrt_det_spatial_metric,
+            const Scalar<DataVector>& pressure,
+            const tnsr::I<DataVector, Dim, Frame::Inertial>&
+                spatial_velocity) noexcept {
+  const DataVector p_alpha_sqrt_det_g =
+      get(sqrt_det_spatial_metric) * get(lapse) * get(pressure);
+  // Outside the loop to save allocations
+  DataVector transport_velocity_I(p_alpha_sqrt_det_g.size());
+  for (size_t i = 0; i < Dim; ++i) {
+    transport_velocity_I = get(lapse) * spatial_velocity.get(i) - shift.get(i);
+    tilde_d_flux->get(i) = get(tilde_d) * transport_velocity_I;
+    tilde_tau_flux->get(i) = get(tilde_tau) * transport_velocity_I +
+                             p_alpha_sqrt_det_g * spatial_velocity.get(i);
+    for (size_t j = 0; j < Dim; ++j) {
+      tilde_s_flux->get(i, j) = tilde_s.get(j) * transport_velocity_I;
+    }
+    tilde_s_flux->get(i, i) += p_alpha_sqrt_det_g;
+  }
+}
+}  // namespace Valencia
+}  // namespace RelativisticEuler
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                                                \
+  template void RelativisticEuler::Valencia::fluxes(                          \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>   \
+          tilde_d_flux,                                                       \
+      const gsl::not_null<tnsr::I<DataVector, DIM(data), Frame::Inertial>*>   \
+          tilde_tau_flux,                                                     \
+      const gsl::not_null<tnsr::Ij<DataVector, DIM(data), Frame::Inertial>*>  \
+          tilde_s_flux,                                                       \
+      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau, \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& tilde_s,         \
+      const Scalar<DataVector>& lapse,                                        \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& shift,           \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                      \
+      const Scalar<DataVector>& pressure,                                     \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>&                  \
+          spatial_velocity) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+class DataVector;
+/// \endcond
+
+namespace RelativisticEuler {
+namespace Valencia {
+
+/*!
+ * \brief The fluxes of the conservative variables
+ *
+ * \f{align*}
+ * F^i({\tilde D}) = &~ {\tilde D} v^i_{tr} \\
+ * F^i({\tilde S}_j) = &~  {\tilde S}_j v^i_{tr} + \sqrt{\gamma} \alpha p
+ * \delta^i_j \\
+ * F^i({\tilde \tau}) = &~  {\tilde \tau} v^i_{tr} + \sqrt{\gamma} \alpha p v^i
+ * \f}
+ * where the conservative variables \f${\tilde D}\f$, \f${\tilde S}_i\f$, and
+ * \f${\tilde \tau}\f$ are a generalized mass-energy density, momentum density,
+ * and specific internal energy density as measured by an Eulerian observer,
+ * \f$v^i_{tr} = \alpha v^i - \beta^i\f$ is the transport velocity, \f$\alpha\f$
+ * is the lapse, \f$\beta^i\f$ is the shift, \f$v^i\f$ is the spatial velocity,
+ * \f$\gamma\f$ is the determinant of the spatial metric, and \f$p\f$ is the
+ * pressure.
+ */
+template <size_t Dim>
+void fluxes(
+    gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> tilde_d_flux,
+    gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> tilde_tau_flux,
+    gsl::not_null<tnsr::Ij<DataVector, Dim, Frame::Inertial>*> tilde_s_flux,
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& tilde_s,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const Scalar<DataVector>& pressure,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& spatial_velocity) noexcept;
+}  // namespace Valencia
+}  // namespace RelativisticEuler

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -1,8 +1,11 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+set(VALENCIA_DIR Evolution/Systems/RelativisticEuler/Valencia)
+
 set(VALENCIA_TESTS
-  Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
+  ${VALENCIA_DIR}/Test_ConservativeFromPrimitive.cpp
+  ${VALENCIA_DIR}/Test_Fluxes.cpp
   )
 
 set(RELATIVISTIC_EULER_TESTS

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Fluxes.cpp
@@ -1,0 +1,134 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp"
+#include "tests/Unit/DataStructures/TestHelpers.hpp"
+#include "tests/Unit/TestingFramework.hpp"
+
+namespace {
+
+template <size_t Dim>
+tnsr::I<DataVector, Dim, Frame::Inertial> expected_tilde_d_flux(
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>&
+        spatial_velocity) noexcept {
+  auto result = make_with_value<tnsr::I<DataVector, Dim>>(lapse, 0.);
+  for (size_t i = 0; i < Dim; ++i) {
+    result.get(i) =
+        get(tilde_d) * (get(lapse) * spatial_velocity.get(i) - shift.get(i));
+  }
+  return result;
+}
+
+template <size_t Dim>
+tnsr::I<DataVector, Dim, Frame::Inertial> expected_tilde_tau_flux(
+    const Scalar<DataVector>& tilde_tau, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const Scalar<DataVector>& pressure,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>&
+        spatial_velocity) noexcept {
+  auto result = make_with_value<tnsr::I<DataVector, Dim>>(lapse, 0.);
+  for (size_t i = 0; i < Dim; ++i) {
+    result.get(i) =
+        get(sqrt_det_spatial_metric) * get(lapse) * get(pressure) *
+            spatial_velocity.get(i) +
+        get(tilde_tau) * (get(lapse) * spatial_velocity.get(i) - shift.get(i));
+  }
+  return result;
+}
+
+template <size_t Dim>
+tnsr::Ij<DataVector, Dim, Frame::Inertial> expected_tilde_s_flux(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& tilde_s,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const Scalar<DataVector>& pressure,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>&
+        spatial_velocity) noexcept {
+  auto result = make_with_value<tnsr::Ij<DataVector, Dim>>(lapse, 0.);
+  for (size_t i = 0; i < Dim; ++i) {
+    result.get(i, i) =
+        get(sqrt_det_spatial_metric) * get(lapse) * get(pressure);
+    for (size_t j = 0; j < Dim; ++j) {
+      result.get(i, j) += tilde_s.get(j) *
+                          (get(lapse) * spatial_velocity.get(i) - shift.get(i));
+    }
+  }
+  return result;
+}
+
+template <size_t Dim>
+void test_fluxes(
+    const gsl::not_null<std::mt19937*> generator,
+    const gsl::not_null<std::uniform_real_distribution<>*> distribution,
+    const DataVector& used_for_size) noexcept {
+  const auto tilde_d = make_with_random_values<Scalar<DataVector>>(
+      generator, distribution, used_for_size);
+  const auto tilde_tau = make_with_random_values<Scalar<DataVector>>(
+      generator, distribution, used_for_size);
+  const auto tilde_s = make_with_random_values<tnsr::i<DataVector, Dim>>(
+      generator, distribution, used_for_size);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      generator, distribution, used_for_size);
+  const auto pressure = make_with_random_values<Scalar<DataVector>>(
+      generator, distribution, used_for_size);
+  const auto sqrt_det_spatial_metric =
+      make_with_random_values<Scalar<DataVector>>(generator, distribution,
+                                                  used_for_size);
+  const auto shift = make_with_random_values<tnsr::I<DataVector, Dim>>(
+      generator, distribution, used_for_size);
+  const auto spatial_velocity =
+      make_with_random_values<tnsr::I<DataVector, Dim>>(generator, distribution,
+                                                        used_for_size);
+
+  auto tilde_d_flux =
+      make_with_value<tnsr::I<DataVector, Dim>>(used_for_size, 0.);
+  auto tilde_tau_flux =
+      make_with_value<tnsr::I<DataVector, Dim>>(used_for_size, 0.);
+  auto tilde_s_flux =
+      make_with_value<tnsr::Ij<DataVector, Dim>>(used_for_size, 0.);
+
+  RelativisticEuler::Valencia::fluxes(
+      make_not_null(&tilde_d_flux), make_not_null(&tilde_tau_flux),
+      make_not_null(&tilde_s_flux), tilde_d, tilde_tau, tilde_s, lapse, shift,
+      sqrt_det_spatial_metric, pressure, spatial_velocity);
+
+  CHECK_ITERABLE_APPROX(
+      expected_tilde_d_flux(tilde_d, lapse, shift, spatial_velocity),
+      tilde_d_flux);
+
+  CHECK_ITERABLE_APPROX(
+      expected_tilde_tau_flux(tilde_tau, lapse, shift, sqrt_det_spatial_metric,
+                              pressure, spatial_velocity),
+      tilde_tau_flux);
+
+  CHECK_ITERABLE_APPROX(
+      expected_tilde_s_flux(tilde_s, lapse, shift, sqrt_det_spatial_metric,
+                            pressure, spatial_velocity),
+      tilde_s_flux);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.Fluxes",
+                  "[Unit][RelativisticEuler]") {
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed = " << seed);
+  std::uniform_real_distribution<> distribution(0.0, 1.0);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  const DataVector dv(5);
+  test_fluxes<1>(nn_generator, nn_distribution, dv);
+  test_fluxes<2>(nn_generator, nn_distribution, dv);
+  test_fluxes<3>(nn_generator, nn_distribution, dv);
+}

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -209,6 +209,7 @@ license() {
               'cmake/FindPythonModule.cmake$' \
               'cmake/Findcppcheck.cmake$' \
               'cmake/Findcppcheck.cpp$' \
+              'docs/config/footer.html' \
               'LICENSE' \
               '.github/ISSUE_TEMPLATE.md' \
               '.github/PULL_REQUEST_TEMPLATE.md' \


### PR DESCRIPTION
## Proposed changes

Add fluxes for Valencia formulation
Update copyright date

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`


