### PR TITLE
Use tensor aliases/improve DataBox error

### DIFF
--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -339,14 +339,8 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   // @{
   /// Get dimensionality of i'th tensor index
   ///
-  /// \details
-  /// Consider the tensor \f$T_{abc}\f$ where the dimensionality of each index
-  /// is \f$(3, 2, 4)\f$, respectively. Then
-  /// \code
-  /// dimensionality(0) = 3;
-  /// dimensionality(1) = 2;
-  /// dimensionality(2) = 4;
-  /// \endcode
+  /// \snippet Test_Tensor.cpp index_dim
+  /// \see ::index_dim
   SPECTRE_ALWAYS_INLINE static constexpr size_t index_dim(
       const size_t i) noexcept {
     static_assert(sizeof...(Indices),
@@ -375,6 +369,9 @@ class Tensor<X, Symm, IndexList<Indices...>> {
 
   //@{
   /// Return array of dimensionality of each index
+  ///
+  /// \snippet Test_Tensor.cpp index_dim
+  /// \see index_dim ::index_dim
   SPECTRE_ALWAYS_INLINE static constexpr std::array<size_t, sizeof...(Indices)>
   index_dims() noexcept {
     return structure::dims();
@@ -423,9 +420,11 @@ class Tensor<X, Symm, IndexList<Indices...>> {
 
  private:
   // clang-tidy: redundant declaration
+  /// \cond
   template <int I, class... Ts>
   friend SPECTRE_ALWAYS_INLINE constexpr size_t index_dim(  // NOLINT
       const Tensor<Ts...>& /*t*/) noexcept;
+  /// \endcond
 
   storage_type data_;
 };
@@ -501,6 +500,8 @@ bool operator!=(const Tensor<X, Symm, IndexList<Indices...>>& lhs,
 
 /// \ingroup TensorGroup
 /// Get dimensionality of i'th tensor index
+///
+/// \snippet Test_Tensor.cpp index_dim
 template <int I, class... Ts>
 SPECTRE_ALWAYS_INLINE constexpr size_t index_dim(
     const Tensor<Ts...>& /*t*/) noexcept {

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -62,26 +62,18 @@ class CoordinateMapBase : public PUP::able {
   // @{
   /// Compute the inverse Jacobian of the `Maps` at the point(s)
   /// `source_point`
-  virtual Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                 index_list<SpatialIndex<Dim, UpLo::Up, SourceFrame>,
-                            SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>
-  inv_jacobian(tnsr::I<double, Dim, SourceFrame> source_point) const = 0;
-  virtual Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                 index_list<SpatialIndex<Dim, UpLo::Up, SourceFrame>,
-                            SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>
+  virtual InverseJacobian<double, Dim, SourceFrame, TargetFrame> inv_jacobian(
+      tnsr::I<double, Dim, SourceFrame> source_point) const = 0;
+  virtual InverseJacobian<DataVector, Dim, SourceFrame, TargetFrame>
   inv_jacobian(tnsr::I<DataVector, Dim, SourceFrame> source_point) const = 0;
   // @}
 
   // @{
   /// Compute the Jacobian of the `Maps` at the point(s) `source_point`
-  virtual Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                 index_list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
-                            SpatialIndex<Dim, UpLo::Lo, SourceFrame>>>
-  jacobian(tnsr::I<double, Dim, SourceFrame> source_point) const = 0;
-  virtual Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                 index_list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
-                            SpatialIndex<Dim, UpLo::Lo, SourceFrame>>>
-  jacobian(tnsr::I<DataVector, Dim, SourceFrame> source_point) const = 0;
+  virtual Jacobian<double, Dim, SourceFrame, TargetFrame> jacobian(
+      tnsr::I<double, Dim, SourceFrame> source_point) const = 0;
+  virtual Jacobian<DataVector, Dim, SourceFrame, TargetFrame> jacobian(
+      tnsr::I<DataVector, Dim, SourceFrame> source_point) const = 0;
   // @}
  private:
   virtual bool is_equal_to(const CoordinateMapBase& other) const = 0;
@@ -173,33 +165,25 @@ class CoordinateMap
   // @{
   /// Compute the inverse Jacobian of the `Maps...` at the point(s)
   /// `source_point`
-  constexpr Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                   index_list<SpatialIndex<dim, UpLo::Up, SourceFrame>,
-                              SpatialIndex<dim, UpLo::Lo, TargetFrame>>>
-  inv_jacobian(tnsr::I<double, dim, SourceFrame> source_point) const override {
+  constexpr InverseJacobian<double, dim, SourceFrame, TargetFrame> inv_jacobian(
+      tnsr::I<double, dim, SourceFrame> source_point) const override {
     return inv_jacobian_impl(std::move(source_point));
   }
-  constexpr Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                   index_list<SpatialIndex<dim, UpLo::Up, SourceFrame>,
-                              SpatialIndex<dim, UpLo::Lo, TargetFrame>>>
-  inv_jacobian(tnsr::I<DataVector, dim, SourceFrame> source_point)
-      const override {
+  constexpr InverseJacobian<DataVector, dim, SourceFrame, TargetFrame>
+  inv_jacobian(
+      tnsr::I<DataVector, dim, SourceFrame> source_point) const override {
     return inv_jacobian_impl(std::move(source_point));
   }
   // @}
 
   // @{
   /// Compute the Jacobian of the `Maps...` at the point(s) `source_point`
-  constexpr Tensor<double, tmpl::integral_list<std::int32_t, 2, 1>,
-                   index_list<SpatialIndex<dim, UpLo::Up, TargetFrame>,
-                              SpatialIndex<dim, UpLo::Lo, SourceFrame>>>
-  jacobian(tnsr::I<double, dim, SourceFrame> source_point) const override {
+  constexpr Jacobian<double, dim, SourceFrame, TargetFrame> jacobian(
+      tnsr::I<double, dim, SourceFrame> source_point) const override {
     return jacobian_impl(std::move(source_point));
   }
-  constexpr Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                   index_list<SpatialIndex<dim, UpLo::Up, TargetFrame>,
-                              SpatialIndex<dim, UpLo::Lo, SourceFrame>>>
-  jacobian(tnsr::I<DataVector, dim, SourceFrame> source_point) const override {
+  constexpr Jacobian<DataVector, dim, SourceFrame, TargetFrame> jacobian(
+      tnsr::I<DataVector, dim, SourceFrame> source_point) const override {
     return jacobian_impl(std::move(source_point));
   }
   // @}
@@ -238,17 +222,12 @@ class CoordinateMap
 
   template <typename T>
   constexpr SPECTRE_ALWAYS_INLINE
-      Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
-             index_list<SpatialIndex<dim, UpLo::Up, SourceFrame>,
-                        SpatialIndex<dim, UpLo::Lo, TargetFrame>>>
+      InverseJacobian<T, dim, SourceFrame, TargetFrame>
       inv_jacobian_impl(tnsr::I<T, dim, SourceFrame>&& source_point) const;
 
   template <typename T>
-  constexpr SPECTRE_ALWAYS_INLINE
-      Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
-             index_list<SpatialIndex<dim, UpLo::Up, TargetFrame>,
-                        SpatialIndex<dim, UpLo::Lo, SourceFrame>>>
-      jacobian_impl(tnsr::I<T, dim, SourceFrame>&& source_point) const;
+  constexpr SPECTRE_ALWAYS_INLINE Jacobian<T, dim, SourceFrame, TargetFrame>
+  jacobian_impl(tnsr::I<T, dim, SourceFrame>&& source_point) const;
 
   std::tuple<Maps...> maps_;
 };
@@ -295,15 +274,10 @@ template <typename T>
 constexpr SPECTRE_ALWAYS_INLINE auto
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::inv_jacobian_impl(
     tnsr::I<T, dim, SourceFrame>&& source_point) const
-    -> Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
-              index_list<SpatialIndex<dim, UpLo::Up, SourceFrame>,
-                         SpatialIndex<dim, UpLo::Lo, TargetFrame>>> {
+    -> InverseJacobian<T, dim, SourceFrame, TargetFrame> {
   std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
 
-  Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<dim, UpLo::Up, SourceFrame>,
-                    SpatialIndex<dim, UpLo::Lo, TargetFrame>>>
-      inv_jac{};
+  InverseJacobian<T, dim, SourceFrame, TargetFrame> inv_jac{};
 
   tuple_transform(
       maps_,
@@ -348,14 +322,9 @@ template <typename T>
 constexpr SPECTRE_ALWAYS_INLINE auto
 CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
     tnsr::I<T, dim, SourceFrame>&& source_point) const
-    -> Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
-              index_list<SpatialIndex<dim, UpLo::Up, TargetFrame>,
-                         SpatialIndex<dim, UpLo::Lo, SourceFrame>>> {
+    -> Jacobian<T, dim, SourceFrame, TargetFrame> {
   std::array<T, dim> mapped_point = make_array<T, dim>(std::move(source_point));
-  Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<dim, UpLo::Up, TargetFrame>,
-                    SpatialIndex<dim, UpLo::Lo, SourceFrame>>>
-      jac{};
+  Jacobian<T, dim, SourceFrame, TargetFrame> jac{};
   tuple_transform(
       maps_,
       [&jac, &mapped_point](const auto& map, auto index,

--- a/src/Domain/CoordinateMaps/Wedge2D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.cpp
@@ -116,10 +116,7 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> Wedge2D::jacobian(
                                       const auto& cap_eta_deriv) noexcept {
     const ReturnType one_over_rho = 1.0 / sqrt(1.0 + square(cap_eta));
 
-    Tensor<tt::remove_cvref_wrap_t<T>, tmpl::integral_list<std::int32_t, 2, 1>,
-           index_list<SpatialIndex<2, UpLo::Up, Frame::NoFrame>,
-                      SpatialIndex<2, UpLo::Lo, Frame::NoFrame>>>
-        jacobian_matrix{};
+    tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> jacobian_matrix{};
 
     auto &dxdxi = get<0, 0>(jacobian_matrix),
          &dydeta = get<1, 1>(jacobian_matrix),

--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -67,10 +67,8 @@ class ElementMap {
   }
 
   template <typename T>
-  Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
-                    SpatialIndex<Dim, UpLo::Lo, TargetFrame>>>
-  inv_jacobian(tnsr::I<T, Dim, Frame::Logical> source_point) const noexcept {
+  InverseJacobian<T, Dim, Frame::Logical, TargetFrame> inv_jacobian(
+      tnsr::I<T, Dim, Frame::Logical> source_point) const noexcept {
     apply_affine_transformation_to_point(source_point);
     auto inv_jac = block_map_->inv_jacobian(std::move(source_point));
     for (size_t d = 0; d < Dim; ++d) {
@@ -82,10 +80,8 @@ class ElementMap {
   }
 
   template <typename T>
-  Tensor<T, tmpl::integral_list<std::int32_t, 2, 1>,
-         index_list<SpatialIndex<Dim, UpLo::Up, TargetFrame>,
-                    SpatialIndex<Dim, UpLo::Lo, Frame::Logical>>>
-  jacobian(tnsr::I<T, Dim, Frame::Logical> source_point) const noexcept {
+  Jacobian<T, Dim, Frame::Logical, TargetFrame> jacobian(
+      tnsr::I<T, Dim, Frame::Logical> source_point) const noexcept {
     apply_affine_transformation_to_point(source_point);
     auto jac = block_map_->jacobian(std::move(source_point));
     for (size_t d = 0; d < Dim; ++d) {

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.cpp
@@ -88,11 +88,8 @@ using derivative_frame = Frame::Inertial;
                       DIM(data), derivative_frame>(                          \
       const Variables<variables_tags<DIM(data)>>& u,                         \
       const Index<DIM(data)>& extents,                                       \
-      const Tensor<                                                          \
-          DataVector, tmpl::integral_list<std::int32_t, 2, 1>,               \
-          tmpl::list<SpatialIndex<DIM(data), UpLo::Up, Frame::Logical>,      \
-                     SpatialIndex<DIM(data), UpLo::Lo, derivative_frame>>>&  \
-          inverse_jacobian) noexcept;
+      const InverseJacobian<DataVector, DIM(data), Frame::Logical,           \
+                            derivative_frame>& inverse_jacobian) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -152,11 +152,8 @@ using derivative_frame = Frame::Inertial;
                       DIM(data), derivative_frame>(                          \
       const Variables<variables_tags<DIM(data)>>& u,                         \
       const Index<DIM(data)>& extents,                                       \
-      const Tensor<                                                          \
-          DataVector, tmpl::integral_list<std::int32_t, 2, 1>,               \
-          tmpl::list<SpatialIndex<DIM(data), UpLo::Up, Frame::Logical>,      \
-                     SpatialIndex<DIM(data), UpLo::Lo, derivative_frame>>>&  \
-          inverse_jacobian) noexcept;
+      const InverseJacobian<DataVector, DIM(data), Frame::Logical,           \
+                            derivative_frame>& inverse_jacobian) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -60,9 +60,7 @@ struct div : Tags_detail::div_impl<T, S> {};
 template <typename FluxTags, size_t Dim, typename DerivativeFrame>
 Variables<db::wrap_tags_in<Tags::div, FluxTags, DerivativeFrame>> divergence(
     const Variables<FluxTags>& F, const Index<Dim>& extents,
-    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                 tmpl::list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
-                            SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept;
 
 namespace Tags {

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.tpp
@@ -12,9 +12,7 @@
 template <typename FluxTags, size_t Dim, typename DerivativeFrame>
 Variables<db::wrap_tags_in<Tags::div, FluxTags, DerivativeFrame>> divergence(
     const Variables<FluxTags>& F, const Index<Dim>& extents,
-    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                 tmpl::list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
-                          SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept {
   const auto logical_partial_derivatives_of_F =
       logical_partial_derivatives<FluxTags>(F, extents);

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -86,9 +86,7 @@ Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags, tmpl::size_t<Dim>,
                            DerivativeFrame>>
 partial_derivatives(
     const Variables<VariableTags>& u, const Index<Dim>& extents,
-    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                 tmpl::list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
-                            SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept;
 
 namespace Tags {

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -32,9 +32,7 @@ Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags, tmpl::size_t<Dim>,
                            DerivativeFrame>>
 partial_derivatives(
     const Variables<VariableTags>& u, const Index<Dim>& extents,
-    const Tensor<DataVector, tmpl::integral_list<std::int32_t, 2, 1>,
-                 tmpl::list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
-                          SpatialIndex<Dim, UpLo::Lo, DerivativeFrame>>>&
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept {
   const auto logical_partial_derivatives_of_u =
       logical_partial_derivatives<DerivativeTags>(u, extents);

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_DivideBy.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_DivideBy.cpp
@@ -18,26 +18,21 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
   const DataVector twelve(npts, 12.0);
   const DataVector thirteen(npts, 13.0);
 
-  const Tensor<DataVector, Symmetry<1>,
-               tmpl::list<SpatialIndex<1, UpLo::Lo, Frame::Grid>>>
-      one_d_covector{{{two}}};
+  const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector{{{two}}};
   const auto normalized_one_d_covector = divide_by(one_d_covector, two);
   for (size_t s = 0; s < npts; ++s) {
     CHECK(get<0>(normalized_one_d_covector)[s] == 1.0);
   }
 
-  const Tensor<DataVector, Symmetry<1>,
-               tmpl::list<SpacetimeIndex<1, UpLo::Up, Frame::Grid>>>
-      two_d_vector{{{three, four}}};
+  const tnsr::A<DataVector, 1, Frame::Grid> two_d_vector{{{three, four}}};
   const auto normalized_two_d_vector = divide_by(two_d_vector, five);
   for (size_t s = 0; s < npts; ++s) {
     CHECK(get<0>(normalized_two_d_vector)[s] == 0.6);
     CHECK(get<1>(normalized_two_d_vector)[s] == 0.8);
   }
 
-  const Tensor<DataVector, Symmetry<1>,
-               tmpl::list<SpatialIndex<2, UpLo::Up, Frame::Grid>>>
-      two_d_spatial_vector{{{five, twelve}}};
+  const tnsr::I<DataVector, 2, Frame::Grid> two_d_spatial_vector{
+      {{five, twelve}}};
   const auto normalized_two_d_spatial_vector =
       divide_by(two_d_spatial_vector, thirteen);
   for (size_t s = 0; s < npts; ++s) {
@@ -45,9 +40,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
     CHECK(get<1>(normalized_two_d_spatial_vector)[s] == 12.0 / 13.0);
   }
 
-  const Tensor<DataVector, Symmetry<1>,
-               tmpl::list<SpatialIndex<3, UpLo::Lo, Frame::Grid>>>
-      three_d_covector{{{three, twelve, four}}};
+  const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector{
+      {{three, twelve, four}}};
   const auto normalized_three_d_covector =
       divide_by(three_d_covector, thirteen);
   for (size_t s = 0; s < npts; ++s) {
@@ -56,9 +50,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DivideBy",
     CHECK(get<2>(normalized_three_d_covector)[s] == 4.0 / 13.0);
   }
 
-  const Tensor<DataVector, Symmetry<1>,
-               tmpl::list<SpacetimeIndex<4, UpLo::Lo, Frame::Grid>>>
-      five_d_covector{{{two, twelve, four, one, two}}};
+  const tnsr::a<DataVector, 4, Frame::Grid> five_d_covector{
+      {{two, twelve, four, one, two}}};
   const auto normalized_five_d_covector = divide_by(five_d_covector, thirteen);
   for (size_t s = 0; s < npts; ++s) {
     CHECK(get<0>(normalized_five_d_covector)[s] == 2.0 / 13.0);

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -479,6 +479,23 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.RankAndSize",
     CHECK(get<2>(spatial_vector3) == 3);
   }
 
+  {
+    /// [index_dim]
+    using T = Tensor<double, Symmetry<1, 2, 3>,
+                     index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                                SpatialIndex<1, UpLo::Up, Frame::Inertial>,
+                                SpatialIndex<2, UpLo::Up, Frame::Inertial>>>;
+    const T t{};
+    CHECK(index_dim<0>(t) == 3);
+    CHECK(index_dim<1>(t) == 1);
+    CHECK(index_dim<2>(t) == 2);
+    CHECK(T::index_dim(0) == 3);
+    CHECK(T::index_dim(1) == 1);
+    CHECK(T::index_dim(2) == 2);
+    CHECK(T::index_dims() == std::array<size_t, 3>{{3, 1, 2}});
+    /// [index_dim]
+  }
+
   Tensor<double, Symmetry<3>,
          index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
       spatial_vector4{};

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -21,11 +21,9 @@ auto compose_jacobians(const Map1& map1, const Map2& map2,
   const auto jac1 = map1.jacobian(point);
   const auto jac2 = map2.jacobian(map1(point));
 
-  auto result = make_with_value<
-      Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
-             index_list<SpatialIndex<Dim, UpLo::Up, Frame::Grid>,
-                        SpatialIndex<Dim, UpLo::Lo, Frame::Logical>>>>(
-      point[0], 0.);
+  auto result =
+      make_with_value<Jacobian<DataType, Dim, Frame::Logical, Frame::Grid>>(
+          point[0], 0.);
   for (size_t target = 0; target < Dim; ++target) {
     for (size_t source = 0; source < Dim; ++source) {
       for (size_t dummy = 0; dummy < Dim; ++dummy) {
@@ -44,10 +42,8 @@ auto compose_inv_jacobians(const Map1& map1, const Map2& map2,
   const auto inv_jac2 = map2.inv_jacobian(map1(point));
 
   auto result = make_with_value<
-      Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
-             index_list<SpatialIndex<Dim, UpLo::Up, Frame::Logical>,
-                        SpatialIndex<Dim, UpLo::Lo, Frame::Grid>>>>(
-      point[0], 0.);
+      InverseJacobian<DataType, Dim, Frame::Logical, Frame::Grid>>(point[0],
+                                                                   0.);
   for (size_t target = 0; target < Dim; ++target) {
     for (size_t source = 0; source < Dim; ++source) {
       for (size_t dummy = 0; dummy < Dim; ++dummy) {


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
