### PR TITLE
Tweak Doxygen

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -49,13 +49,17 @@ SUBGROUPING            = YES
 # Build related configuration options
 #---------------------------------------------------------------------------
 
-EXTRACT_ALL            = YES
+EXTRACT_ALL            = NO
 
 EXTRACT_PRIVATE        = NO
 
-EXTRACT_STATIC         = YES
+EXTRACT_STATIC         = NO
 
-EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_CLASSES  = NO
+
+# We want to be able to have undocumented members, such as size() that show
+# up but what they do is rather obvious.
+WARN_IF_UNDOCUMENTED   = NO
 
 CASE_SENSE_NAMES       = YES
 
@@ -115,14 +119,6 @@ EXAMPLE_PATTERNS       =
 EXAMPLE_RECURSIVE      = NO
 
 #---------------------------------------------------------------------------
-# configuration options related to source browsing
-#---------------------------------------------------------------------------
-
-REFERENCED_BY_RELATION = YES
-
-REFERENCES_RELATION    = YES
-
-#---------------------------------------------------------------------------
 # configuration options related to the output
 #---------------------------------------------------------------------------
 
@@ -176,7 +172,7 @@ ALLEXTERNALS           = NO
 
 CLASS_DIAGRAMS         = NO
 
-HAVE_DOT               = YES
+HAVE_DOT               = NO
 
 CLASS_GRAPH            = NO
 
@@ -184,7 +180,7 @@ COLLABORATION_GRAPH    = NO
 
 GROUP_GRAPHS           = NO
 
-UML_LOOK               = YES
+UML_LOOK               = NO
 
 TEMPLATE_RELATIONS     = NO
 

--- a/docs/config/js/spectre.js
+++ b/docs/config/js/spectre.js
@@ -56,11 +56,6 @@ window.onload = function(){
             "$1implementation defined") );
     });
 
-    // Remove all return types
-    $("body").children().find("td.memItemLeft, td.memTemplItemLeft").each(function () {
-        $(this).html( $(this).html().replace(/(constexpr)?.*/g, "$1") );
-    });
-
     // Italicize "implementation defined"
     // Not applied to div.memitem because that causes problems with rendering
     // MathJAX

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -10,10 +10,12 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
 template <typename>
 class Variables;
 
 class DataVector;
+/// \endcond
 
 namespace Tags {
 template <typename, typename, typename>

--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -6,6 +6,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp"
 
+/// \cond
 namespace brigand {
 template <class...>
 struct list;
@@ -13,6 +14,7 @@ struct list;
 
 template <class>
 class Variables;
+/// \endcond
 
 /*!
  * \ingroup EvolutionSystemsGroup

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -10,6 +10,7 @@
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
 template <typename>
 class Variables;
 
@@ -39,6 +40,7 @@ struct Pi;
 template <size_t Dim>
 struct Phi;
 }  // namespace ScalarWave
+/// \endcond
 
 namespace ScalarWave {
 /*!

--- a/src/Utilities/Array.hpp
+++ b/src/Utilities/Array.hpp
@@ -186,10 +186,10 @@ inline std::ostream& operator<<(std::ostream& os, const array<T, N>& a) {
 namespace detail {
 template <typename List, size_t... indices,
           Requires<not tt::is_a_v<tmpl::list, tmpl::front<List>>> = nullptr>
-inline constexpr cpp17::array<std::decay_t<decltype(tmpl::front<List>::value)>,
-                              tmpl::size<List>::value>
-make_cpp17_array_from_list_helper(
-    std::integer_sequence<size_t, indices...> /*meta*/) {
+inline constexpr auto make_cpp17_array_from_list_helper(
+    std::integer_sequence<size_t, indices...> /*meta*/)
+    -> cpp17::array<std::decay_t<decltype(tmpl::front<List>::value)>,
+                    tmpl::size<List>::value> {
   return cpp17::array<std::decay_t<decltype(tmpl::front<List>::value)>,
                       tmpl::size<List>::value>{
       {tmpl::at<List, tmpl::size_t<indices>>::value...}};
@@ -204,9 +204,9 @@ make_cpp17_array_from_list_helper(
 /// \return array of integral values from the typelist
 template <typename List,
           Requires<not tt::is_a_v<tmpl::list, tmpl::front<List>>> = nullptr>
-inline constexpr cpp17::array<std::decay_t<decltype(tmpl::front<List>::value)>,
-                              tmpl::size<List>::value>
-make_cpp17_array_from_list() {
+inline constexpr auto make_cpp17_array_from_list()
+    -> cpp17::array<std::decay_t<decltype(tmpl::front<List>::value)>,
+                    tmpl::size<List>::value> {
   return detail::make_cpp17_array_from_list_helper<List>(
       std::make_integer_sequence<size_t, tmpl::size<List>::value>{});
 }

--- a/src/Utilities/ConstantExpressions.hpp
+++ b/src/Utilities/ConstantExpressions.hpp
@@ -246,9 +246,9 @@ make_array_from_list_helper(
 /// \return array of integral values from the typelist
 template <typename List,
           Requires<not tt::is_a_v<tmpl::list, tmpl::front<List>>> = nullptr>
-inline constexpr std::array<std::decay_t<decltype(tmpl::front<List>::value)>,
-                            tmpl::size<List>::value>
-make_array_from_list() {
+inline constexpr auto make_array_from_list()
+    -> std::array<std::decay_t<decltype(tmpl::front<List>::value)>,
+                  tmpl::size<List>::value> {
   return detail::make_array_from_list_helper<List>(
       std::make_integer_sequence<size_t, tmpl::size<List>::value>{});
 }

--- a/src/Utilities/GenerateInstantiations.hpp
+++ b/src/Utilities/GenerateInstantiations.hpp
@@ -136,7 +136,7 @@
  * One thing that can be difficult is debugging metaprograms (be they template
  * or macro-based). To this end we provide a make target `DebugPreprocessor`
  * which prints the output of running the preprocessor on the file
- * \ref src/Executables/DebugPreprocessor/DebugPreprocessor.cpp .
+ * `src/Executables/DebugPreprocessor/DebugPreprocessor.cpp`.
  * Note that the output of the `GENERATE_INSTANTIATIONS` macro will be on a
  * single line, so it often proves useful to copy-paste the output into an
  * editor and run clang-format over the code so it's easier to reason about.


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
