### PR TITLE
Ninja compilation tests

### DIFF
--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -108,7 +108,7 @@ function(SETUP_TARGET_FOR_COVERAGE
       COMMAND ${LCOV} --gcov-tool ${GCOV} --rc lcov_branch_coverage=0
       --remove ${OUTPUT}.total.info '*/c++/*' '*/include/*'
       '*/boost/*' '*/charm/*' '*.decl.h' '*.def.h'
-      '*/STDIN' '*/tut/*' '*/moduleinit*'
+      '*/STDIN' '*/tut/*' '*/moduleinit*' '*InfoFromBuild.cpp'
       '${CMAKE_SOURCE_DIR}/src/Executables/*'
       ${ARG_IGNORE_COV}
       --output-file ${OUTPUT}.filtered.info

--- a/cmake/SetupCompilationFailureTests.cmake
+++ b/cmake/SetupCompilationFailureTests.cmake
@@ -130,16 +130,18 @@ function(compilation_tests_parse_file SOURCE_FILE TEST_TARGET)
     endif()
     string(REGEX REPLACE " " ";" TEST_TAGS "${TEST_TAGS}")
 
-    add_test(
+    if ("${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")
+      add_test(
         NAME "${TEST_NAME}"
         COMMAND make WHICH_TEST="-D${TEST_NAME}" ${TEST_TARGET}
         )
-    set_tests_properties(
-      "${TEST_NAME}"
-      PROPERTIES
-      TIMEOUT 10
-      LABELS "${TEST_TAGS}"
-      PASS_REGULAR_EXPRESSION ${OUTPUT_REGEX}
-      )
+      set_tests_properties(
+        "${TEST_NAME}"
+        PROPERTIES
+        TIMEOUT 10
+        LABELS "${TEST_TAGS}"
+        PASS_REGULAR_EXPRESSION ${OUTPUT_REGEX}
+        )
+    endif()
   endforeach()
 endfunction()


### PR DESCRIPTION
## Proposed changes

- Disable compilation tests when using Ninja (since TravisCI and most people will use make this won't be an issue, though I'm filing a feature request)
- Ignore InfoFromBuild in our code cov because we have one for each executable and so we can't possibly cover them all.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
