### PR TITLE
KerrSchild: Fix dimensionless vs dimensionful spin bug.

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
@@ -17,20 +17,22 @@
 
 namespace EinsteinSolutions {
 
-KerrSchild::KerrSchild(const double mass, KerrSchild::Spin::type spin,
+KerrSchild::KerrSchild(const double mass,
+                       KerrSchild::Spin::type dimensionless_spin,
                        KerrSchild::Center::type center,
                        const OptionContext& context)
     : mass_(mass),
       // clang-tidy: do not std::move trivial types.
-      spin_(std::move(spin)),  // NOLINT
+      dimensionless_spin_(std::move(dimensionless_spin)),  // NOLINT
       // clang-tidy: do not std::move trivial types.
       center_(std::move(center))  // NOLINT
 {
-  const double spin_magnitude = magnitude(spin_);
+  const double spin_magnitude = magnitude(dimensionless_spin_);
   if (spin_magnitude > 1.0) {
     PARSE_ERROR(context,
                 "Spin magnitude must be < 1. Given spin: "
-                    << spin_ << " with magnitude " << spin_magnitude);
+                    << dimensionless_spin_ << " with magnitude "
+                    << spin_magnitude);
   }
   if (mass_ < 0.0) {
     PARSE_ERROR(context, "Mass must be non-negative. Given mass: " << mass_);
@@ -39,15 +41,23 @@ KerrSchild::KerrSchild(const double mass, KerrSchild::Spin::type spin,
 
 void KerrSchild::pup(PUP::er& p) noexcept {
   p | mass_;
-  p | spin_;
+  p | dimensionless_spin_;
   p | center_;
 }
 
 template <typename DataType>
 tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::solution(
     const tnsr::I<DataType, 3>& x, const double /*t*/) const noexcept {
+  // Input spin is dimensionless spin.  But below we use `spin` = the
+  // Kerr spin parameter `a`, which is `J/M` where `J` is the angular
+  // momentum.  So compute `spin=a` here.
+  auto spin = dimensionless_spin_;
+  for (auto& s : spin) {
+    s *= mass_;
+  }
+
   const auto a_squared =
-      std::inner_product(spin_.begin(), spin_.end(), spin_.begin(), 0.);
+      std::inner_product(spin.begin(), spin.end(), spin.begin(), 0.);
 
   const auto x_minus_center = [&x, this ]() noexcept {
     auto l_x_minus_center = x;
@@ -58,9 +68,9 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::solution(
   }
   ();
 
-  const DataType a_dot_x = spin_[0] * get<0>(x_minus_center) +
-                           spin_[1] * get<1>(x_minus_center) +
-                           spin_[2] * get<2>(x_minus_center);
+  const DataType a_dot_x = spin[0] * get<0>(x_minus_center) +
+                           spin[1] * get<1>(x_minus_center) +
+                           spin[2] * get<2>(x_minus_center);
   const DataType a_dot_x_squared = square(a_dot_x);
   const DataType half_xsq_minus_asq =
       0.5 * (square(get<0>(x_minus_center)) + square(get<1>(x_minus_center)) +
@@ -72,14 +82,14 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::solution(
   const DataType deriv_log_r_denom = 0.5 / (r_squared - half_xsq_minus_asq);
 
   const auto deriv_log_r = [
-    &deriv_log_r_denom, &x_minus_center, &a_dot_x_over_rsquared, this
+    &deriv_log_r_denom, &x_minus_center, &a_dot_x_over_rsquared, &spin
   ]() noexcept {
     auto l_deriv_log_r =
         make_with_value<tnsr::i<DataType, 3>>(x_minus_center, 0.0);
     for (size_t i = 0; i < 3; ++i) {
       l_deriv_log_r.get(i) =
           deriv_log_r_denom *
-          (x_minus_center.get(i) + gsl::at(spin_, i) * a_dot_x_over_rsquared);
+          (x_minus_center.get(i) + gsl::at(spin, i) * a_dot_x_over_rsquared);
     }
     return l_deriv_log_r;
   }
@@ -89,12 +99,12 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::solution(
   const DataType H = mass_ * sqrt(r_squared) * r_squared * H_denom;
 
   const auto deriv_H =
-      [&H, &r_squared, &H_denom, &a_dot_x, &deriv_log_r, this ]() noexcept {
+      [&H, &r_squared, &H_denom, &a_dot_x, &deriv_log_r, &spin ]() noexcept {
     auto l_deriv_H = make_with_value<tnsr::i<DataType, 3>>(H_denom, 0.0);
     const DataType temp1 = H * (3.0 - 4.0 * square(r_squared) * H_denom);
     const DataType temp2 = H * (2.0 * H_denom * a_dot_x);
     for (size_t i = 0; i < 3; ++i) {
-      l_deriv_H.get(i) = temp1 * deriv_log_r.get(i) - temp2 * gsl::at(spin_, i);
+      l_deriv_H.get(i) = temp1 * deriv_log_r.get(i) - temp2 * gsl::at(spin, i);
     }
     return l_deriv_H;
   }
@@ -108,20 +118,19 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::solution(
     get<2>(l_a_cross_x) = a[0] * get<1>(coord) - a[1] * get<0>(coord);
     return l_a_cross_x;
   }
-  (spin_, x_minus_center);
+  (spin, x_minus_center);
 
   const DataType denom = 1.0 / (r_squared + a_squared);
   const DataType r = sqrt(r_squared);
 
   const auto null_form = [
-    &x, &a_dot_x, &r, &denom, &x_minus_center, &a_cross_x, this
+    &x, &a_dot_x, &r, &denom, &x_minus_center, &a_cross_x, &spin
   ]() noexcept {
     auto l_null_form = make_with_value<tnsr::i<DataType, 3>>(x, 0.0);
     const DataType temp = a_dot_x / r;
     for (size_t i = 0; i < 3; ++i) {
-      l_null_form.get(i) =
-          denom * (r * x_minus_center.get(i) - a_cross_x.get(i) +
-                   temp * gsl::at(spin_, i));
+      l_null_form.get(i) = denom * (r * x_minus_center.get(i) -
+                                    a_cross_x.get(i) + temp * gsl::at(spin, i));
     }
     return l_null_form;
   }
@@ -129,15 +138,15 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::solution(
 
   const auto deriv_null_form = [
     &denom, &x_minus_center, &r, &null_form, &a_dot_x_over_rsquared,
-    &deriv_log_r, this
+    &deriv_log_r, &spin
   ]() noexcept {
     auto l_deriv_null_form = make_with_value<tnsr::ij<DataType, 3>>(r, 0.0);
     for (size_t i = 0; i < 3; i++) {
       for (size_t j = 0; j < 3; j++) {
         l_deriv_null_form.get(j, i) =
-            denom * (gsl::at(spin_, i) * gsl::at(spin_, j) / r +
+            denom * (gsl::at(spin, i) * gsl::at(spin, j) / r +
                      (x_minus_center.get(i) - 2.0 * r * null_form.get(i) -
-                      a_dot_x_over_rsquared * gsl::at(spin_, i)) *
+                      a_dot_x_over_rsquared * gsl::at(spin, i)) *
                          deriv_log_r.get(j) * r);
         if (i == j) {
           l_deriv_null_form.get(j, i) += denom * r;
@@ -146,9 +155,9 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::solution(
           if (k == i) {  // j+1 = i (cyclic), so choose minus sign
             k++;
             k = k % 3;  // and set k to be neither i nor j
-            l_deriv_null_form.get(j, i) -= denom * gsl::at(spin_, k);
+            l_deriv_null_form.get(j, i) -= denom * gsl::at(spin, k);
           } else {  // i+1 = j (cyclic), so choose plus sign
-            l_deriv_null_form.get(j, i) += denom * gsl::at(spin_, k);
+            l_deriv_null_form.get(j, i) += denom * gsl::at(spin, k);
           }
         }
       }

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
@@ -221,7 +221,7 @@ class KerrSchild {
   using options = tmpl::list<Mass, Spin, Center>;
   static constexpr OptionString help{"Black hole in Kerr-Schild coordinates"};
 
-  KerrSchild(double mass, Spin::type spin, Center::type center,
+  KerrSchild(double mass, Spin::type dimensionless_spin, Center::type center,
              const OptionContext& context = {});
 
   explicit KerrSchild(CkMigrateMessage* /*unused*/) noexcept {}
@@ -264,18 +264,21 @@ class KerrSchild {
   SPECTRE_ALWAYS_INLINE const std::array<double, 3>& center() const noexcept {
     return center_;
   }
-  SPECTRE_ALWAYS_INLINE const std::array<double, 3>& spin() const noexcept {
-    return spin_;
+  SPECTRE_ALWAYS_INLINE const std::array<double, 3>& dimensionless_spin() const
+      noexcept {
+    return dimensionless_spin_;
   }
 
  private:
   double mass_{1.0};
-  std::array<double, 3> spin_{{0.0, 0.0, 0.0}}, center_{{0.0, 0.0, 0.0}};
+  std::array<double, 3> dimensionless_spin_{{0.0, 0.0, 0.0}},
+      center_{{0.0, 0.0, 0.0}};
 };
 
 SPECTRE_ALWAYS_INLINE bool operator==(const KerrSchild& lhs,
                                       const KerrSchild& rhs) noexcept {
-  return lhs.mass() == rhs.mass() and lhs.spin() == rhs.spin() and
+  return lhs.mass() == rhs.mass() and
+         lhs.dimensionless_spin() == rhs.dimensionless_spin() and
          lhs.center() == rhs.center();
 }
 


### PR DESCRIPTION
## Proposed changes

Fixes bug where dimensionless spin was used where Kerr parameter `a` should have been used.
The bug is not apparent when mass=1 because dimensionless spin and `a` are the same in that case.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
