### PR TITLE
Add KerrHorizon to expansion test

### DIFF
--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -22,7 +23,7 @@ namespace Schwarzschild {
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> spatial_ricci(
     const tnsr::I<DataType, SpatialDim, Frame>& x, const double& mass) noexcept;
-} //namespace Schwarzschild
+}  // namespace Schwarzschild
 
 namespace Minkowski {
 /*!
@@ -38,5 +39,25 @@ namespace Minkowski {
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature_sphere(
     const tnsr::I<DataType, SpatialDim, Frame>& x) noexcept;
-} //namespace Minkowski
-} //namespace TestHelpers
+}  // namespace Minkowski
+
+namespace Kerr {
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Radius of Kerr horizon in Kerr-Schild coordinates
+ *
+ * \details
+ * Computes the radius of a Kerr black hole with mass `mass`
+ * and dimensionless spin `spin`. The input
+ * argument `theta_phi` is the output of the
+ * `theta_phi_points()` method of a `YlmSpherepack` object;
+ * i.e., it is typically a std::array of two DataVectors containing
+ * the values of theta and phi at each point on a Strahlkorper.
+ */
+template <typename DataType>
+Scalar<DataType> horizon_radius(const std::array<DataType, 2>& theta_phi,
+                                const double& mass,
+                                const std::array<double, 3>& spin) noexcept;
+
+}  // namespace Kerr
+}  // namespace TestHelpers


### PR DESCRIPTION
## Proposed changes

Add code to compute the radius of a Kerr horizon to StrahlkorperGrTestHelpers.?pp, and use it to add a kerr expansion test in Test_StrahlkorperGr.cpp.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
