### PR TITLE
Add function to compute source terms of volume RHS for Valencia formulation

### DIFF
--- a/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Valencia)
 
 set(LIBRARY_SOURCES
   ConservativeFromPrimitive.cpp
+  Equations.cpp
   Fluxes.cpp
   )
 

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Equations.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Equations.cpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/RelativisticEuler/Valencia/Equations.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_include <array>
+
+/// \cond
+namespace {
+template <size_t Dim>
+tnsr::II<DataVector, Dim, Frame::Inertial> densitized_stress(
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& tilde_s_vector,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& spatial_velocity,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const Scalar<DataVector>& pressure) noexcept {
+  auto result = inv_spatial_metric;
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = i; j < Dim; ++j) {
+      result.get(i, j) *= get(sqrt_det_spatial_metric) * get(pressure);
+      result.get(i, j) +=
+          0.5 * (tilde_s_vector.get(i) * spatial_velocity.get(j) +
+                 tilde_s_vector.get(j) * spatial_velocity.get(i));
+    }
+  }
+  return result;
+}
+}  // namespace
+
+namespace RelativisticEuler {
+namespace Valencia {
+
+template <size_t Dim>
+void compute_source_terms_of_u(
+    const gsl::not_null<Scalar<DataVector>*> source_tilde_d,
+    const gsl::not_null<Scalar<DataVector>*> source_tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        source_tilde_s,
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& pressure, const Scalar<DataVector>& lapse,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& d_lapse,
+    const tnsr::iJ<DataVector, Dim, Frame::Inertial>& d_shift,
+    const tnsr::ijj<DataVector, Dim, Frame::Inertial>& d_spatial_metric,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, Dim, Frame::Inertial>&
+        extrinsic_curvature) noexcept {
+  get(*source_tilde_d) = 0.0;
+
+  const auto tilde_s_M = raise_or_lower_index(tilde_s, inv_spatial_metric);
+  const auto tilde_s_MN =
+      densitized_stress(tilde_s_M, spatial_velocity, inv_spatial_metric,
+                        sqrt_det_spatial_metric, pressure);
+
+  // unroll contributions from m=0 and n=0 to avoid initializing
+  // source_tilde_tau to zero
+  get(*source_tilde_tau) =
+      get(lapse) * get<0, 0>(extrinsic_curvature) * get<0, 0>(tilde_s_MN) -
+      get<0>(tilde_s_M) * get<0>(d_lapse);
+  for (size_t m = 1; m < Dim; ++m) {
+    get(*source_tilde_tau) +=
+        get(lapse) * (extrinsic_curvature.get(m, 0) * tilde_s_MN.get(m, 0) +
+                      extrinsic_curvature.get(0, m) * tilde_s_MN.get(0, m)) -
+        tilde_s_M.get(m) * d_lapse.get(m);
+    for (size_t n = 1; n < Dim; ++n) {
+      get(*source_tilde_tau) +=
+          get(lapse) * extrinsic_curvature.get(m, n) * tilde_s_MN.get(m, n);
+    }
+  }
+
+  for (size_t i = 0; i < Dim; ++i) {
+    source_tilde_s->get(i) = -(get(tilde_d) + get(tilde_tau)) * d_lapse.get(i);
+    for (size_t m = 0; m < Dim; ++m) {
+      source_tilde_s->get(i) += tilde_s.get(m) * d_shift.get(i, m);
+      for (size_t n = 0; n < Dim; ++n) {
+        source_tilde_s->get(i) += 0.5 * get(lapse) *
+                                  d_spatial_metric.get(i, m, n) *
+                                  tilde_s_MN.get(m, n);
+      }
+    }
+  }
+}
+}  // namespace Valencia
+}  // namespace RelativisticEuler
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                                                 \
+  template void RelativisticEuler::Valencia::compute_source_terms_of_u(        \
+      const gsl::not_null<Scalar<DataVector>*> source_tilde_d,                 \
+      const gsl::not_null<Scalar<DataVector>*> source_tilde_tau,               \
+      const gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::Inertial>*>    \
+          source_tilde_s,                                                      \
+      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,  \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& tilde_s,          \
+      const tnsr::I<DataVector, DIM(data), Frame::Inertial>& spatial_velocity, \
+      const Scalar<DataVector>& pressure, const Scalar<DataVector>& lapse,     \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& d_lapse,          \
+      const tnsr::iJ<DataVector, DIM(data), Frame::Inertial>& d_shift,         \
+      const tnsr::ijj<DataVector, DIM(data), Frame::Inertial>&                 \
+          d_spatial_metric,                                                    \
+      const tnsr::II<DataVector, DIM(data), Frame::Inertial>&                  \
+          inv_spatial_metric,                                                  \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                       \
+      const tnsr::ii<DataVector, DIM(data), Frame::Inertial>&                  \
+          extrinsic_curvature) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Equations.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Equations.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+class DataVector;
+/// \endcond
+
+namespace RelativisticEuler {
+namespace Valencia {
+
+/*!
+ * \brief Compute the source terms for the flux-conservative Valencia
+ * formulation of the relativistic Euler system.
+ *
+ *
+ * A flux-conservative system has the generic form:
+ * \f[
+ * \partial_t U_i + \partial_m F^m(U_i) = S(U_i)
+ * \f]
+ *
+ * where \f$F^a()\f$ denotes the flux of a conserved variable \f$U_i\f$ and
+ * \f$S()\f$ denotes the source term for the conserved variable.
+ *
+ * For the Valencia formulation:
+ * \f{align*}
+ * S({\tilde D}) = & 0\\
+ * S({\tilde S}_i) = & \frac{1}{2} \alpha {\tilde S}^{mn} \partial_i \gamma_{mn}
+ * + {\tilde S}_m \partial_i \beta^m - ({\tilde D} + {\tilde \tau}) \partial_i
+ * \alpha \\ S({\tilde \tau}) = & \alpha {\tilde S}^{mn} K_{mn}
+ * - {\tilde S}^m \partial_m \alpha
+ * \f}
+ *
+ * where
+ * \f{align*}
+ * {\tilde S}^i = & {\tilde S}_m \gamma^{im} \\
+ * {\tilde S}^{ij} = & {\tilde S}^i v^j + \sqrt{\gamma} p \gamma^{ij}
+ * \f}
+ * where \f${\tilde D}\f$, \f${\tilde S}_i\f$, and \f${\tilde \tau}\f$ are a
+ * generalized mass-energy density, momentum density, and specific internal
+ * energy density as measured by an Eulerian observer, \f$\gamma\f$ is the
+ * determinant of the spatial metric \f$\gamma_{ij}\f$, \f$\rho\f$ is the rest
+ * mass density, \f$W\f$ is the Lorentz factor, \f$h\f$ is the specific
+ * enthalpy, \f$v^i\f$ is the spatial velocity, \f$p\f$ is the pressure,
+ * \f$\alpha\f$ is the lapse, \f$\beta^i\f$ is the shift, and \f$K_{ij}\f$ is
+ * the extrinsic curvature.
+ */
+template <size_t Dim>
+void compute_source_terms_of_u(
+    gsl::not_null<Scalar<DataVector>*> source_tilde_d,
+    gsl::not_null<Scalar<DataVector>*> source_tilde_tau,
+    gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> source_tilde_s,
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& pressure, const Scalar<DataVector>& lapse,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& d_lapse,
+    const tnsr::iJ<DataVector, Dim, Frame::Inertial>& d_shift,
+    const tnsr::ijj<DataVector, Dim, Frame::Inertial>& d_spatial_metric,
+    const tnsr::II<DataVector, Dim, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, Dim, Frame::Inertial>&
+        extrinsic_curvature) noexcept;
+}  // namespace Valencia
+}  // namespace RelativisticEuler

--- a/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
+++ b/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
@@ -266,10 +266,15 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.FastFlowSchwarzschild",
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.FastFlowKerr", "[Utilities][Unit]") {
   test_kerr(FastFlow::FlowType::Fast, 2.0, 100);
-  // Changing the mass to 2.0 for Jacobi and Curvature slows down
-  // those methods, so we keep mass=1.0 for those tests so that they
-  // don't take too much time.
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.JacobiKerr", "[Utilities][Unit]") {
+  // Keep mass at 1.0 so test doesn't timeout.
   test_kerr(FastFlow::FlowType::Jacobi, 1.0, 200);
+}
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.CurvatureKerr", "[Utilities][Unit]") {
+  // Keep mass at 1.0 so test doesn't timeout.
   test_kerr(FastFlow::FlowType::Curvature, 1.0, 200);
 }
 

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Valencia")
 
 set(LIBRARY_SOURCES
   Test_ConservativeFromPrimitive.cpp
+  Test_Equations.cpp
   Test_Fluxes.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/TestFunctions.py
@@ -31,6 +31,45 @@ def tilde_s(rest_mass_density, specific_internal_energy,
 # End functions for testing ConservativeFromPrimitive.cpp
 
 
+# Functions for testing Equations.cpp
+def source_tilde_d(tilde_d, tilde_tau, tilde_s, spatial_velocity, pressure,
+                   lapse, d_lapse, d_shift, d_spatial_metric,
+                   inv_spatial_metric, sqrt_det_spatial_metric,
+                   extrinsic_curvature):
+    return 0.0
+
+
+def source_tilde_tau(tilde_d, tilde_tau, tilde_s, spatial_velocity, pressure,
+                     lapse, d_lapse, d_shift, d_spatial_metric,
+                     inv_spatial_metric, sqrt_det_spatial_metric,
+                     extrinsic_curvature):
+    upper_tilde_s = np.einsum("a, ia", tilde_s, inv_spatial_metric)
+    densitized_stress = (0.5 * np.outer(upper_tilde_s, spatial_velocity)
+                         + 0.5 * np.outer(spatial_velocity, upper_tilde_s)
+                         + sqrt_det_spatial_metric * pressure
+                         * inv_spatial_metric)
+    return (lapse * np.einsum("ab, ab", densitized_stress, extrinsic_curvature)
+            - np.einsum("ab, ab", inv_spatial_metric,
+                        np.outer(tilde_s, d_lapse)))
+
+
+def source_tilde_s(tilde_d, tilde_tau, tilde_s, spatial_velocity, pressure,
+                   lapse, d_lapse, d_shift, d_spatial_metric,
+                   inv_spatial_metric, sqrt_det_spatial_metric,
+                   extrinsic_curvature):
+    upper_tilde_s = np.einsum("a, ia", tilde_s, inv_spatial_metric)
+    densitized_stress = (np.outer(upper_tilde_s, spatial_velocity)
+                         + sqrt_det_spatial_metric * pressure
+                         * inv_spatial_metric)
+    return (np.einsum("a, ia", tilde_s, d_shift)
+            - d_lapse * (tilde_tau + tilde_d)
+            + 0.5 * lapse * np.einsum("ab, iab", densitized_stress,
+                                      d_spatial_metric))
+
+
+# End functions for testing Equations.cpp
+
+
 # Functions for testing Fluxes.cpp
 def tilde_d_flux(tilde_d, tilde_tau, tilde_s, lapse, shift,
                  sqrt_det_spatial_metric, pressure, spatial_velocity):

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Equations.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/Equations.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace {
+
+template <size_t Dim>
+void test_source_terms(const DataVector& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &RelativisticEuler::Valencia::compute_source_terms_of_u<Dim>,
+      "TestFunctions", {"source_tilde_d", "source_tilde_tau", "source_tilde_s"},
+      {{{0.0, 1.0}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.Equations",
+                  "[Unit][RelativisticEuler]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/RelativisticEuler/Valencia"};
+
+  const DataVector dv(5);
+  test_source_terms<1>(dv);
+  test_source_terms<2>(dv);
+  test_source_terms<3>(dv);
+}

--- a/tests/Unit/Pypp/CheckWithRandomValues.hpp
+++ b/tests/Unit/Pypp/CheckWithRandomValues.hpp
@@ -129,6 +129,7 @@ void check_with_random_values_impl(
     using Tag = tmpl::type_from<decltype(tag)>;
     const auto result =
         tuples::get<Tag>((klass.*f)(std::get<ArgumentIs>(args)...));
+    INFO("function: " << function_names[count]);
     CHECK_ITERABLE_APPROX(
         result,
         (pypp::call<std::decay_t<decltype(result)>>(
@@ -174,6 +175,7 @@ void check_with_random_values_impl(
       std::integral_constant<
           bool, not cpp17::is_same_v<NoSuchType, std::decay_t<Klass>>>{},
       std::forward<F>(f));
+  INFO("function: " << function_name);
   CHECK_ITERABLE_APPROX(
       result, pypp::call<ResultType>(
                   module_name, function_name, std::get<ArgumentIs>(args)...,
@@ -234,6 +236,7 @@ void check_with_random_values_impl(
     (void)member_args;  // avoid compiler warning
     (void)used_for_size;  // avoid compiler warning
     constexpr size_t iter = decltype(result_i)::value;
+    INFO("function: " << function_names[iter]);
     CHECK_ITERABLE_APPROX(
         std::get<iter>(results),
         (pypp::call<std::tuple_element_t<iter, std::tuple<ReturnTypes...>>>(


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
