### PR TITLE
Unify analytic solutions interface more

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -173,7 +173,9 @@ class Variables<tmpl::list<Tags...>> {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p);  // NOLINT
 
-  /// \brief Assign a subset of the `Tensor`s from another Variables
+  // @{
+  /// \brief Assign a subset of the `Tensor`s from another Variables or a
+  /// tuples::TaggedTuple
   ///
   /// \note There is no need for an rvalue overload because we need to copy into
   /// the contiguous array anyway
@@ -185,6 +187,16 @@ class Variables<tmpl::list<Tags...>> {
     (void)std::initializer_list<char>{
         (get<SubsetOfTags>(*this) = get<SubsetOfTags>(vars), '0')...};
   }
+
+  template <typename... SubsetOfTags,
+            Requires<tmpl2::flat_all_v<tmpl::list_contains_v<
+                tmpl::list<Tags...>, SubsetOfTags>...>> = nullptr>
+  void assign_subset(
+      const tuples::TaggedTuple<SubsetOfTags...>& vars) noexcept {
+    (void)std::initializer_list<char>{
+        (get<SubsetOfTags>(*this) = get<SubsetOfTags>(vars), '0')...};
+  }
+  // @}
 
   /// Converting constructor for an expression to a Variables class
   // clang-tidy: mark as explicit (we want conversion to Variables)

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -467,8 +467,11 @@ struct Interface<
                   detail::ShouldBeSlicedToBoundary<tmpl::_1>>::value and
         not tmpl::all<typename db::item_type<VariablesTag>::tags_list,
                       detail::ShouldBeSlicedToBoundary<tmpl::_1>>::value>> {
-  static_assert(cpp17::is_same_v<VariablesTag, void> && false,
-                "Cannot compute a partially-sliced Variables");
+  // This static_assert should always trigger. We compare the VariablesTag to a
+  // very unusual type that in general will not appear as a tag.
+  static_assert(
+      cpp17::is_same_v<VariablesTag, void* volatile const* volatile const*>,
+      "Cannot compute a partially-sliced Variables");
 };
 /// \endcond
 }  // namespace Tags

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
@@ -175,12 +175,12 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::variables(
 
   auto result = make_with_value<tuples::TaggedTuple<
       gr::Tags::Lapse<3, Frame::Inertial, DataType>,
-      gr::Tags::DtLapse<3, Frame::Inertial, DataType>, deriv_lapse<DataType>,
+      gr::Tags::DtLapse<3, Frame::Inertial, DataType>, DerivLapse<DataType>,
       gr::Tags::Shift<3, Frame::Inertial, DataType>,
-      gr::Tags::DtShift<3, Frame::Inertial, DataType>, deriv_shift<DataType>,
+      gr::Tags::DtShift<3, Frame::Inertial, DataType>, DerivShift<DataType>,
       gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
       gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataType>,
-      deriv_spatial_metric<DataType>>>(x, 0.0);
+      DerivSpatialMetric<DataType>>>(x, 0.0);
 
   get(get<gr::Tags::Lapse<3, Frame::Inertial, DataType>>(result)) =
       sqrt(lapse_squared);
@@ -191,7 +191,7 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::variables(
         get(get<gr::Tags::Lapse<3, Frame::Inertial, DataType>>(result)) *
         lapse_squared;
     for (size_t i = 0; i < 3; ++i) {
-      get<deriv_lapse<DataType>>(result).get(i) = temp * deriv_H.get(i);
+      get<DerivLapse<DataType>>(result).get(i) = temp * deriv_H.get(i);
     }
   }
 
@@ -205,7 +205,7 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::variables(
 
   for (size_t m = 0; m < 3; ++m) {
     for (size_t i = 0; i < 3; ++i) {
-      get<deriv_shift<DataType>>(result).get(m, i) =
+      get<DerivShift<DataType>>(result).get(m, i) =
           4.0 * H * null_form.get(i) * square(lapse_squared) *
               cube(null_vector_0) * deriv_H.get(m) -
           2.0 * lapse_squared * null_vector_0 *
@@ -226,10 +226,11 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::variables(
   for (size_t i = 0; i < 3; ++i) {
     for (size_t j = i; j < 3; ++j) {  // Symmetry
       for (size_t m = 0; m < 3; ++m) {
-        get<deriv_spatial_metric<DataType>>(result).get(m, i, j) =
+        get<DerivSpatialMetric<DataType>>(result).get(m, i, j) =
             2.0 * null_form.get(i) * null_form.get(j) * deriv_H.get(m) +
-            2.0 * H * (null_form.get(i) * deriv_null_form.get(m, j) +
-                       null_form.get(j) * deriv_null_form.get(m, i));
+            2.0 * H *
+                (null_form.get(i) * deriv_null_form.get(m, j) +
+                 null_form.get(j) * deriv_null_form.get(m, i));
       }
     }
   }

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
@@ -46,8 +46,9 @@ void KerrSchild::pup(PUP::er& p) noexcept {
 }
 
 template <typename DataType>
-tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::solution(
-    const tnsr::I<DataType, 3>& x, const double /*t*/) const noexcept {
+tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::variables(
+    const tnsr::I<DataType, 3>& x, const double /*t*/,
+    tags<DataType> /*meta*/) const noexcept {
   // Input spin is dimensionless spin.  But below we use `spin` = the
   // Kerr spin parameter `a`, which is `J/M` where `J` is the angular
   // momentum.  So compute `spin=a` here.
@@ -239,9 +240,11 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::solution(
 
 template tuples::TaggedTupleTypelist<
     EinsteinSolutions::KerrSchild::tags<DataVector>>
-EinsteinSolutions::KerrSchild::solution(const tnsr::I<DataVector, 3>& x,
-                                        const double /*t*/) const noexcept;
+EinsteinSolutions::KerrSchild::variables(
+    const tnsr::I<DataVector, 3>& x, const double /*t*/,
+    KerrSchild::tags<DataVector> /*meta*/) const noexcept;
 template tuples::TaggedTupleTypelist<
     EinsteinSolutions::KerrSchild::tags<double>>
-EinsteinSolutions::KerrSchild::solution(const tnsr::I<double, 3>& x,
-                                        const double /*t*/) const noexcept;
+EinsteinSolutions::KerrSchild::variables(
+    const tnsr::I<double, 3>& x, const double /*t*/,
+    KerrSchild::tags<double> /*meta*/) const noexcept;

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
@@ -175,11 +175,12 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::variables(
 
   auto result = make_with_value<tuples::TaggedTuple<
       gr::Tags::Lapse<3, Frame::Inertial, DataType>,
-      gr::Tags::DtLapse<3, Frame::Inertial, DataType>, DerivLapse<DataType>,
-      gr::Tags::Shift<3, Frame::Inertial, DataType>,
-      gr::Tags::DtShift<3, Frame::Inertial, DataType>, DerivShift<DataType>,
+      Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, DataType>>,
+      DerivLapse<DataType>, gr::Tags::Shift<3, Frame::Inertial, DataType>,
+      Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataType>>,
+      DerivShift<DataType>,
       gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
-      gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataType>,
+      Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>,
       DerivSpatialMetric<DataType>>>(x, 0.0);
 
   get(get<gr::Tags::Lapse<3, Frame::Inertial, DataType>>(result)) =

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
@@ -234,24 +234,24 @@ class KerrSchild {
   ~KerrSchild() = default;
 
   template <typename DataType>
-  using deriv_lapse = Tags::deriv<gr::Tags::Lapse<3, Frame::Inertial, DataType>,
-                                  tmpl::size_t<3>, Frame::Inertial>;
+  using DerivLapse = Tags::deriv<gr::Tags::Lapse<3, Frame::Inertial, DataType>,
+                                 tmpl::size_t<3>, Frame::Inertial>;
   template <typename DataType>
-  using deriv_shift = Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataType>,
-                                  tmpl::size_t<3>, Frame::Inertial>;
+  using DerivShift = Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataType>,
+                                 tmpl::size_t<3>, Frame::Inertial>;
   template <typename DataType>
-  using deriv_spatial_metric =
+  using DerivSpatialMetric =
       Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
                   tmpl::size_t<3>, Frame::Inertial>;
   template <typename DataType>
   using tags = tmpl::list<
       gr::Tags::Lapse<3, Frame::Inertial, DataType>,
-      gr::Tags::DtLapse<3, Frame::Inertial, DataType>, deriv_lapse<DataType>,
+      gr::Tags::DtLapse<3, Frame::Inertial, DataType>, DerivLapse<DataType>,
       gr::Tags::Shift<3, Frame::Inertial, DataType>,
-      gr::Tags::DtShift<3, Frame::Inertial, DataType>, deriv_shift<DataType>,
+      gr::Tags::DtShift<3, Frame::Inertial, DataType>, DerivShift<DataType>,
       gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
       gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataType>,
-      deriv_spatial_metric<DataType>>;
+      DerivSpatialMetric<DataType>>;
 
   template <typename DataType>
   tuples::TaggedTupleTypelist<tags<DataType>> variables(

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Options.hpp"
@@ -246,11 +247,12 @@ class KerrSchild {
   template <typename DataType>
   using tags = tmpl::list<
       gr::Tags::Lapse<3, Frame::Inertial, DataType>,
-      gr::Tags::DtLapse<3, Frame::Inertial, DataType>, DerivLapse<DataType>,
-      gr::Tags::Shift<3, Frame::Inertial, DataType>,
-      gr::Tags::DtShift<3, Frame::Inertial, DataType>, DerivShift<DataType>,
+      Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, DataType>>,
+      DerivLapse<DataType>, gr::Tags::Shift<3, Frame::Inertial, DataType>,
+      Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataType>>,
+      DerivShift<DataType>,
       gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
-      gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataType>,
+      Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>,
       DerivSpatialMetric<DataType>>;
 
   template <typename DataType>

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
@@ -254,8 +254,9 @@ class KerrSchild {
       deriv_spatial_metric<DataType>>;
 
   template <typename DataType>
-  tuples::TaggedTupleTypelist<tags<DataType>> solution(
-      const tnsr::I<DataType, 3>& x, double t) const noexcept;
+  tuples::TaggedTupleTypelist<tags<DataType>> variables(
+      const tnsr::I<DataType, 3>& x, double t, tags<DataType> /*meta*/) const
+      noexcept;
 
   // clang-tidy: no runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.cpp
@@ -3,6 +3,7 @@
 
 #include "PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp"
 
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -11,119 +12,156 @@ namespace EinsteinSolutions {
 
 template <size_t Dim>
 template <typename DataType>
-tuples::TaggedTupleTypelist<typename Minkowski<Dim>::template tags<DataType>>
-Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double t,
-                          tags<DataType> /*meta*/) const noexcept {
-  return tuples::TaggedTupleTypelist<
-      typename Minkowski<Dim>::template tags<DataType>>(
-      lapse(x, t), dt_lapse(x, t), deriv_lapse(x, t), shift(x, t),
-      dt_shift(x, t), deriv_shift(x, t), spatial_metric(x, t),
-      dt_spatial_metric(x, t), deriv_spatial_metric(x, t));
-}
-
-template<size_t Dim>
-template<typename T>
-Scalar<T> Minkowski<Dim>::lapse(const tnsr::I<T, Dim> &x,
-                                const double /*t*/) const noexcept {
-  return Scalar<T>(make_with_value<T>(x, 1.));
-}
-
-template<size_t Dim>
-template<typename T>
-Scalar<T> Minkowski<Dim>::dt_lapse(const tnsr::I<T, Dim> &x,
-                                   const double /*t*/) const noexcept {
-  return Scalar<T>(make_with_value<T>(x, 0.));
-}
-
-template<size_t Dim>
-template<typename T>
-tnsr::i<T, Dim> Minkowski<Dim>::deriv_lapse(const tnsr::I<T, Dim> &x,
-                                            const double /*t*/) const noexcept {
-  return tnsr::i<T, Dim>(make_with_value<T>(x, 0.));
-}
-
-template<size_t Dim>
-template<typename T>
-Scalar<T> Minkowski<Dim>::sqrt_determinant_of_spatial_metric(
-    const tnsr::I<T, Dim> &x, const double /*t*/) const noexcept {
-  return Scalar<T>(make_with_value<T>(x, 1.));
-}
-
-template<size_t Dim>
-template<typename T>
-Scalar<T> Minkowski<Dim>::dt_sqrt_determinant_of_spatial_metric(
-    const tnsr::I<T, Dim> &x, const double /*t*/) const noexcept {
-  return Scalar<T>(make_with_value<T>(x, 0.));
-}
-
-template<size_t Dim>
-template<typename T>
-tnsr::I<T, Dim> Minkowski<Dim>::shift(const tnsr::I<T, Dim> &x,
-                                      const double /*t*/) const noexcept {
-  return tnsr::I<T, Dim>(make_with_value<T>(x, 0.));
+tuples::TaggedTuple<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>> /*meta*/) const
+    noexcept {
+  return {Scalar<DataType>(make_with_value<DataType>(x, 1.))};
 }
 
 template <size_t Dim>
-template <typename T>
-tnsr::I<T, Dim> Minkowski<Dim>::dt_shift(const tnsr::I<T, Dim>& x,
-                                         const double /*t*/) const noexcept {
-  return tnsr::I<T, Dim>(make_with_value<T>(x, 0.));
+template <typename DataType>
+tuples::TaggedTuple<Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<
+        Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>> /*meta*/)
+    const noexcept {
+  return {Scalar<DataType>(make_with_value<DataType>(x, 0.))};
 }
 
-template<size_t Dim>
-template<typename T>
-tnsr::iJ<T, Dim> Minkowski<Dim>::deriv_shift(const tnsr::I<T, Dim> &x,
-                                             const double /*t*/) const
-noexcept {
-  return tnsr::iJ<T, Dim>(make_with_value<T>(x, 0.));
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
+                                tmpl::size_t<Dim>, Frame::Inertial>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
+                           tmpl::size_t<Dim>, Frame::Inertial>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::i<DataType, Dim>>(x, 0.)};
 }
 
-template<size_t Dim>
-template<typename T>
-tnsr::ii<T, Dim> Minkowski<Dim>::spatial_metric(const tnsr::I<T, Dim> &x,
-                                                const double /*t*/) const
-noexcept {
-  tnsr::ii<T, Dim> lower_metric(make_with_value<T>(x, 0.));
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<gr::Tags::Shift<Dim, Frame::Inertial, DataType>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::I<DataType, Dim>>(x, 0.)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<
+        Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>> /*meta*/)
+    const noexcept {
+  return {make_with_value<tnsr::I<DataType, Dim>>(x, 0.)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
+                                tmpl::size_t<Dim>, Frame::Inertial>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
+                           tmpl::size_t<Dim>, Frame::Inertial>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::iJ<DataType, Dim>>(x, 0.)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<
+        gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>> /*meta*/) const
+    noexcept {
+  tnsr::ii<DataType, Dim> lower_metric(make_with_value<DataType>(x, 0.));
   for (size_t i = 0; i < Dim; ++i) {
     lower_metric.get(i, i) = 1.;
   }
-  return lower_metric;
+  return {std::move(lower_metric)};
 }
 
-template<size_t Dim>
-template<typename T>
-tnsr::ii<T, Dim> Minkowski<Dim>::dt_spatial_metric(const tnsr::I<T, Dim> &x,
-                                                   const double /*t*/) const
-noexcept {
-  return tnsr::ii<T, Dim>(make_with_value<T>(x, 0.));
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>>
+Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                          tmpl::list<Tags::dt<gr::Tags::SpatialMetric<
+                              Dim, Frame::Inertial, DataType>>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::ii<DataType, Dim>>(x, 0.)};
 }
 
-template<size_t Dim>
-template<typename T>
-tnsr::ijj<T, Dim> Minkowski<Dim>::deriv_spatial_metric(const tnsr::I<T, Dim> &x,
-                                                       const double /*t*/) const
-noexcept {
-  return tnsr::ijj<T, Dim>(make_with_value<T>(x, 0.));
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                tmpl::size_t<Dim>, Frame::Inertial>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<
+        Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                    tmpl::size_t<Dim>, Frame::Inertial>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::ijj<DataType, Dim>>(x, 0.)};
 }
 
-template<size_t Dim>
-template<typename T>
-tnsr::II<T, Dim> Minkowski<Dim>::inverse_spatial_metric(
-    const tnsr::I<T, Dim> &x, const double /*t*/
-) const noexcept {
-  tnsr::II<T, Dim> upper_metric(make_with_value<T>(x, 0.));
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>>
+Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                          tmpl::list<gr::Tags::InverseSpatialMetric<
+                              Dim, Frame::Inertial, DataType>> /*meta*/) const
+    noexcept {
+  tnsr::II<DataType, Dim> upper_metric(make_with_value<DataType>(x, 0.));
   for (size_t i = 0; i < Dim; ++i) {
     upper_metric.get(i, i) = 1.;
   }
-  return upper_metric;
+  return {std::move(upper_metric)};
 }
 
-template<size_t Dim>
-template<typename T>
-tnsr::ii<T, Dim> Minkowski<Dim>::extrinsic_curvature(const tnsr::I<T, Dim> &x,
-                                                     const double /*t*/) const
-noexcept {
-  return tnsr::ii<T, Dim>(make_with_value<T>(x, 0.));
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>>
+Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                          tmpl::list<gr::Tags::ExtrinsicCurvature<
+                              Dim, Frame::Inertial, DataType>> /*meta*/) const
+    noexcept {
+  return {make_with_value<tnsr::ii<DataType, Dim>>(x, 0.)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, DataType>>
+Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                          tmpl::list<gr::Tags::SqrtDetSpatialMetric<
+                              Dim, Frame::Inertial, DataType>> /*meta*/) const
+    noexcept {
+  return {make_with_value<Scalar<DataType>>(x, 1.)};
+}
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<
+    Tags::dt<gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, DataType>>>
+Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+                          tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<
+                              Dim, Frame::Inertial, DataType>>> /*meta*/) const
+    noexcept {
+  return {make_with_value<Scalar<DataType>>(x, 0.)};
 }
 } // namespace EinsteinSolutions
 
@@ -132,52 +170,99 @@ noexcept {
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                                   \
-  template tuples::TaggedTupleTypelist<typename EinsteinSolutions::Minkowski<  \
-      DIM(data)>::template tags<DTYPE(data)>>                                  \
+  template tuples::TaggedTuple<                                                \
+      gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>>                \
   EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
       const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
-      typename EinsteinSolutions::Minkowski<DIM(data)>::template tags<DTYPE(   \
-          data)> /*meta*/) const noexcept;                                     \
-  template Scalar<DTYPE(data)> EinsteinSolutions::Minkowski<DIM(data)>::lapse( \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
-  template Scalar<DTYPE(data)>                                                 \
-  EinsteinSolutions::Minkowski<DIM(data)>::dt_lapse(                           \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
-  template tnsr::i<DTYPE(data), DIM(data)>                                     \
-  EinsteinSolutions::Minkowski<DIM(data)>::deriv_lapse(                        \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
-  template Scalar<DTYPE(data)>                                                 \
-  EinsteinSolutions::Minkowski<DIM(data)>::sqrt_determinant_of_spatial_metric( \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
-  template Scalar<DTYPE(data)> EinsteinSolutions::Minkowski<DIM(data)>::       \
-      dt_sqrt_determinant_of_spatial_metric(                                   \
-          const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/)              \
-          const noexcept;                                                      \
-  template tnsr::I<DTYPE(data), DIM(data)>                                     \
-  EinsteinSolutions::Minkowski<DIM(data)>::shift(                              \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
-  template tnsr::I<DTYPE(data), DIM(data)>                                     \
-  EinsteinSolutions::Minkowski<DIM(data)>::dt_shift(                           \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
-  template tnsr::iJ<DTYPE(data), DIM(data)>                                    \
-  EinsteinSolutions::Minkowski<DIM(data)>::deriv_shift(                        \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
-  template tnsr::ii<DTYPE(data), DIM(data)>                                    \
-  EinsteinSolutions::Minkowski<DIM(data)>::spatial_metric(                     \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
-  template tnsr::ii<DTYPE(data), DIM(data)>                                    \
-  EinsteinSolutions::Minkowski<DIM(data)>::dt_spatial_metric(                  \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
-  template tnsr::ijj<DTYPE(data), DIM(data)>                                   \
-  EinsteinSolutions::Minkowski<DIM(data)>::deriv_spatial_metric(               \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
-  template tnsr::II<DTYPE(data), DIM(data)>                                    \
-  EinsteinSolutions::Minkowski<DIM(data)>::inverse_spatial_metric(             \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/                   \
-      ) const noexcept;                                                        \
-  template tnsr::ii<DTYPE(data), DIM(data)>                                    \
-  EinsteinSolutions::Minkowski<DIM(data)>::extrinsic_curvature(                \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;
+      tmpl::list<                                                              \
+          gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>> /*meta*/)  \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      Tags::dt<gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>>>      \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<Tags::dt<                                                     \
+          gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>>> /*meta*/) \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      Tags::deriv<gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>,    \
+                  tmpl::size_t<DIM(data)>, Frame::Inertial>>                   \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<Tags::deriv<                                                  \
+          gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>,            \
+          tmpl::size_t<DIM(data)>, Frame::Inertial>> /*meta*/) const noexcept; \
+  template tuples::TaggedTuple<                                                \
+      gr::Tags::Shift<DIM(data), Frame::Inertial, DTYPE(data)>>                \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<                                                              \
+          gr::Tags::Shift<DIM(data), Frame::Inertial, DTYPE(data)>> /*meta*/)  \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      Tags::dt<gr::Tags::Shift<DIM(data), Frame::Inertial, DTYPE(data)>>>      \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<Tags::dt<                                                     \
+          gr::Tags::Shift<DIM(data), Frame::Inertial, DTYPE(data)>>> /*meta*/) \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      Tags::deriv<gr::Tags::Shift<DIM(data), Frame::Inertial, DTYPE(data)>,    \
+                  tmpl::size_t<DIM(data)>, Frame::Inertial>>                   \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<Tags::deriv<                                                  \
+          gr::Tags::Shift<DIM(data), Frame::Inertial, DTYPE(data)>,            \
+          tmpl::size_t<DIM(data)>, Frame::Inertial>> /*meta*/) const noexcept; \
+  template tuples::TaggedTuple<                                                \
+      gr::Tags::SpatialMetric<DIM(data), Frame::Inertial, DTYPE(data)>>        \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<gr::Tags::SpatialMetric<DIM(data), Frame::Inertial,           \
+                                         DTYPE(data)>> /*meta*/)               \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<Tags::dt<                                       \
+      gr::Tags::SpatialMetric<DIM(data), Frame::Inertial, DTYPE(data)>>>       \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<Tags::dt<gr::Tags::SpatialMetric<DIM(data), Frame::Inertial,  \
+                                                  DTYPE(data)>>> /*meta*/)     \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<Tags::deriv<                                    \
+      gr::Tags::SpatialMetric<DIM(data), Frame::Inertial, DTYPE(data)>,        \
+      tmpl::size_t<DIM(data)>, Frame::Inertial>>                               \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<Tags::deriv<                                                  \
+          gr::Tags::SpatialMetric<DIM(data), Frame::Inertial, DTYPE(data)>,    \
+          tmpl::size_t<DIM(data)>, Frame::Inertial>> /*meta*/) const noexcept; \
+  template tuples::TaggedTuple<                                                \
+      gr::Tags::InverseSpatialMetric<DIM(data), Frame::Inertial, DTYPE(data)>> \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<gr::Tags::InverseSpatialMetric<DIM(data), Frame::Inertial,    \
+                                                DTYPE(data)>> /*meta*/)        \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      gr::Tags::ExtrinsicCurvature<DIM(data), Frame::Inertial, DTYPE(data)>>   \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<gr::Tags::ExtrinsicCurvature<DIM(data), Frame::Inertial,      \
+                                              DTYPE(data)>> /*meta*/)          \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<                                                \
+      gr::Tags::SqrtDetSpatialMetric<DIM(data), Frame::Inertial, DTYPE(data)>> \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<gr::Tags::SqrtDetSpatialMetric<DIM(data), Frame::Inertial,    \
+                                                DTYPE(data)>> /*meta*/)        \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<Tags::dt<gr::Tags::SqrtDetSpatialMetric<        \
+      DIM(data), Frame::Inertial, DTYPE(data)>>>                               \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<                      \
+          DIM(data), Frame::Inertial, DTYPE(data)>>> /*meta*/) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))
 

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.cpp
@@ -3,9 +3,24 @@
 
 #include "PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp"
 
+#include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/TaggedTuple.hpp"
 
 namespace EinsteinSolutions {
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTupleTypelist<typename Minkowski<Dim>::template tags<DataType>>
+Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double t,
+                          tags<DataType> /*meta*/) const noexcept {
+  return tuples::TaggedTupleTypelist<
+      typename Minkowski<Dim>::template tags<DataType>>(
+      lapse(x, t), dt_lapse(x, t), deriv_lapse(x, t), shift(x, t),
+      dt_shift(x, t), deriv_shift(x, t), spatial_metric(x, t),
+      dt_spatial_metric(x, t), deriv_spatial_metric(x, t));
+}
+
 template<size_t Dim>
 template<typename T>
 Scalar<T> Minkowski<Dim>::lapse(const tnsr::I<T, Dim> &x,
@@ -45,6 +60,13 @@ template<size_t Dim>
 template<typename T>
 tnsr::I<T, Dim> Minkowski<Dim>::shift(const tnsr::I<T, Dim> &x,
                                       const double /*t*/) const noexcept {
+  return tnsr::I<T, Dim>(make_with_value<T>(x, 0.));
+}
+
+template <size_t Dim>
+template <typename T>
+tnsr::I<T, Dim> Minkowski<Dim>::dt_shift(const tnsr::I<T, Dim>& x,
+                                         const double /*t*/) const noexcept {
   return tnsr::I<T, Dim>(make_with_value<T>(x, 0.));
 }
 
@@ -110,6 +132,12 @@ noexcept {
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                                   \
+  template tuples::TaggedTupleTypelist<typename EinsteinSolutions::Minkowski<  \
+      DIM(data)>::template tags<DTYPE(data)>>                                  \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      typename EinsteinSolutions::Minkowski<DIM(data)>::template tags<DTYPE(   \
+          data)> /*meta*/) const noexcept;                                     \
   template Scalar<DTYPE(data)> EinsteinSolutions::Minkowski<DIM(data)>::lapse( \
       const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
   template Scalar<DTYPE(data)>                                                 \
@@ -127,6 +155,9 @@ noexcept {
           const noexcept;                                                      \
   template tnsr::I<DTYPE(data), DIM(data)>                                     \
   EinsteinSolutions::Minkowski<DIM(data)>::shift(                              \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
+  template tnsr::I<DTYPE(data), DIM(data)>                                     \
+  EinsteinSolutions::Minkowski<DIM(data)>::dt_shift(                           \
       const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/) const noexcept;  \
   template tnsr::iJ<DTYPE(data), DIM(data)>                                    \
   EinsteinSolutions::Minkowski<DIM(data)>::deriv_shift(                        \

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp
@@ -4,7 +4,9 @@
 #pragma once
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // for tags
 #include "Options/Options.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 namespace EinsteinSolutions {
@@ -30,6 +32,33 @@ class Minkowski {
   Minkowski& operator=(Minkowski&& /*rhs*/) noexcept = default;
   ~Minkowski() = default;
 
+  template <typename DataType>
+  using DerivLapse =
+      Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
+                  tmpl::size_t<Dim>, Frame::Inertial>;
+  template <typename DataType>
+  using DerivShift =
+      Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
+                  tmpl::size_t<Dim>, Frame::Inertial>;
+  template <typename DataType>
+  using DerivSpatialMetric =
+      Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                  tmpl::size_t<Dim>, Frame::Inertial>;
+  template <typename DataType>
+  using tags = tmpl::list<
+      gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
+      gr::Tags::DtLapse<Dim, Frame::Inertial, DataType>, DerivLapse<DataType>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
+      gr::Tags::DtShift<Dim, Frame::Inertial, DataType>, DerivShift<DataType>,
+      gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+      gr::Tags::DtSpatialMetric<Dim, Frame::Inertial, DataType>,
+      DerivSpatialMetric<DataType>>;
+
+  template <typename DataType>
+  tuples::TaggedTupleTypelist<tags<DataType>> variables(
+      const tnsr::I<DataType, Dim>& x, double t, tags<DataType> /*meta*/) const
+      noexcept;
+
   template <typename T>
   Scalar<T> lapse(const tnsr::I<T, Dim>& x, double t) const noexcept;
 
@@ -50,6 +79,9 @@ class Minkowski {
 
   template <typename T>
   tnsr::I<T, Dim> shift(const tnsr::I<T, Dim>& x, double t) const noexcept;
+
+  template <typename T>
+  tnsr::I<T, Dim> dt_shift(const tnsr::I<T, Dim>& x, double t) const noexcept;
 
   template <typename T>
   tnsr::iJ<T, Dim> deriv_shift(const tnsr::I<T, Dim>& x, double t) const

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp
@@ -3,11 +3,14 @@
 
 #pragma once
 
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // for tags
 #include "Options/Options.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp"
 #include "Utilities/MakeWithValue.hpp"
+
+#include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
 
 namespace EinsteinSolutions {
 
@@ -47,65 +50,127 @@ class Minkowski {
   template <typename DataType>
   using tags = tmpl::list<
       gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
-      gr::Tags::DtLapse<Dim, Frame::Inertial, DataType>, DerivLapse<DataType>,
-      gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
-      gr::Tags::DtShift<Dim, Frame::Inertial, DataType>, DerivShift<DataType>,
+      Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>,
+      DerivLapse<DataType>, gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
+      Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>,
+      DerivShift<DataType>,
       gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
-      gr::Tags::DtSpatialMetric<Dim, Frame::Inertial, DataType>,
+      Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>,
       DerivSpatialMetric<DataType>>;
 
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, Dim>& x,
+                                         double t,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
+    return {get<Tags>(variables(x, t, tmpl::list<Tags>{}))...};
+  }
+
   template <typename DataType>
-  tuples::TaggedTupleTypelist<tags<DataType>> variables(
-      const tnsr::I<DataType, Dim>& x, double t, tags<DataType> /*meta*/) const
+  tuples::TaggedTuple<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>
+  variables(
+      const tnsr::I<DataType, Dim>& x, double t,
+      tmpl::list<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>> /*meta*/)
+      const noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>>
+  variables(
+      const tnsr::I<DataType, Dim>& x, double t,
+      tmpl::list<
+          Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>> /*meta*/)
+      const noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<
+      Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
+                  tmpl::size_t<Dim>, Frame::Inertial>>
+  variables(
+      const tnsr::I<DataType, Dim>& x, double t,
+      tmpl::list<Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
+                             tmpl::size_t<Dim>, Frame::Inertial>> /*meta*/)
+      const noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>
+  variables(
+      const tnsr::I<DataType, Dim>& x, double /*t*/,
+      tmpl::list<gr::Tags::Shift<Dim, Frame::Inertial, DataType>> /*meta*/)
+      const noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>>
+  variables(
+      const tnsr::I<DataType, Dim>& x, double /*t*/,
+      tmpl::list<
+          Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>> /*meta*/)
+      const noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<
+      Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
+                  tmpl::size_t<Dim>, Frame::Inertial>>
+  variables(
+      const tnsr::I<DataType, Dim>& x, double /*t*/,
+      tmpl::list<Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
+                             tmpl::size_t<Dim>, Frame::Inertial>> /*meta*/)
+      const noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTuple<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>
+  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+            tmpl::list<gr::Tags::SpatialMetric<Dim, Frame::Inertial,
+                                               DataType>> /*meta*/) const
       noexcept;
 
-  template <typename T>
-  Scalar<T> lapse(const tnsr::I<T, Dim>& x, double t) const noexcept;
+  template <typename DataType>
+  tuples::TaggedTuple<
+      Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>>>
+  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+            tmpl::list<Tags::dt<gr::Tags::SpatialMetric<
+                Dim, Frame::Inertial, DataType>>> /*meta*/) const noexcept;
 
-  template <typename T>
-  Scalar<T> dt_lapse(const tnsr::I<T, Dim>& x, double t) const noexcept;
-
-  template <typename T>
-  tnsr::i<T, Dim> deriv_lapse(const tnsr::I<T, Dim>& x, double t) const
+  template <typename DataType>
+  tuples::TaggedTuple<
+      Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                  tmpl::size_t<Dim>, Frame::Inertial>>
+  variables(
+      const tnsr::I<DataType, Dim>& x, double /*t*/,
+      tmpl::list<
+          Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, DataType>,
+                      tmpl::size_t<Dim>, Frame::Inertial>> /*meta*/) const
       noexcept;
 
-  template <typename T>
-  Scalar<T> sqrt_determinant_of_spatial_metric(const tnsr::I<T, Dim>& x,
-                                               double t) const noexcept;
-
-  template <typename T>
-  Scalar<T> dt_sqrt_determinant_of_spatial_metric(const tnsr::I<T, Dim>& x,
-                                                  double t) const noexcept;
-
-  template <typename T>
-  tnsr::I<T, Dim> shift(const tnsr::I<T, Dim>& x, double t) const noexcept;
-
-  template <typename T>
-  tnsr::I<T, Dim> dt_shift(const tnsr::I<T, Dim>& x, double t) const noexcept;
-
-  template <typename T>
-  tnsr::iJ<T, Dim> deriv_shift(const tnsr::I<T, Dim>& x, double t) const
+  template <typename DataType>
+  tuples::TaggedTuple<
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataType>>
+  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+            tmpl::list<gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial,
+                                                      DataType>> /*meta*/) const
       noexcept;
 
-  template <typename T>
-  tnsr::ii<T, Dim> spatial_metric(const tnsr::I<T, Dim>& x, double t) const
+  template <typename DataType>
+  tuples::TaggedTuple<
+      gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, DataType>>
+  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+            tmpl::list<gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial,
+                                                    DataType>> /*meta*/) const
       noexcept;
 
-  template <typename T>
-  tnsr::ii<T, Dim> dt_spatial_metric(const tnsr::I<T, Dim>& x, double t) const
+  template <typename DataType>
+  tuples::TaggedTuple<
+      gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, DataType>>
+  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+            tmpl::list<gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial,
+                                                      DataType>> /*meta*/) const
       noexcept;
 
-  template <typename T>
-  tnsr::ijj<T, Dim> deriv_spatial_metric(const tnsr::I<T, Dim>& x,
-                                         double t) const noexcept;
-
-  template <typename T>
-  tnsr::II<T, Dim> inverse_spatial_metric(const tnsr::I<T, Dim>& x,
-                                          double t) const noexcept;
-
-  template <typename T>
-  tnsr::ii<T, Dim> extrinsic_curvature(const tnsr::I<T, Dim>& x, double t) const
-      noexcept;
+  template <typename DataType>
+  tuples::TaggedTuple<
+      Tags::dt<gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, DataType>>>
+  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
+            tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<
+                Dim, Frame::Inertial, DataType>>> /*meta*/) const noexcept;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -80,30 +80,28 @@ tnsr::ii<T, Dim> PlaneWave<Dim>::d2psi_dxdx(const tnsr::I<T, Dim>& x,
 }
 
 template <size_t Dim>
-Variables<tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>>
-PlaneWave<Dim>::evolution_variables(const tnsr::I<DataVector, Dim>& x,
-                                    double t) const noexcept {
-  Variables<tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>>
-      variables{x.begin()->size()};
-  get<ScalarWave::Psi>(variables) = psi(x, t);
-  get<ScalarWave::Pi>(variables) = dpsi_dt(x, t);
+tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>
+PlaneWave<Dim>::variables(const tnsr::I<DataVector, Dim>& x, double t,
+                          const tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>,
+                                           ScalarWave::Psi> /*meta*/) const
+    noexcept {
+  tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>
+      variables{dpsi_dt(x, t), dpsi_dx(x, t), psi(x, t)};
   get<ScalarWave::Pi>(variables).get() *= -1.0;
-  get<ScalarWave::Phi<Dim>>(variables) = dpsi_dx(x, t);
   return variables;
 }
 
 template <size_t Dim>
-Variables<tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                     Tags::dt<ScalarWave::Psi>>>
-PlaneWave<Dim>::dt_evolution_variables(const tnsr::I<DataVector, Dim>& x,
-                                       double t) const noexcept {
-  Variables<tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                       Tags::dt<ScalarWave::Psi>>>
-      dt_variables{x.begin()->size()};
-  get<Tags::dt<ScalarWave::Psi>>(dt_variables) = dpsi_dt(x, t);
-  get<Tags::dt<ScalarWave::Pi>>(dt_variables) = d2psi_dt2(x, t);
+tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                    Tags::dt<ScalarWave::Psi>>
+PlaneWave<Dim>::variables(
+    const tnsr::I<DataVector, Dim>& x, double t,
+    const tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                     Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept {
+  tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                      Tags::dt<ScalarWave::Psi>>
+      dt_variables{d2psi_dt2(x, t), d2psi_dtdx(x, t), dpsi_dt(x, t)};
   get<Tags::dt<ScalarWave::Pi>>(dt_variables).get() *= -1.0;
-  get<Tags::dt<ScalarWave::Phi<Dim>>>(dt_variables) = d2psi_dtdx(x, t);
   return dt_variables;
 }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -96,19 +96,21 @@ class PlaneWave {
       noexcept;
 
   /// Retrieve the evolution variables at time `t` and spatial coordinates `x`
-  Variables<tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>>
-  evolution_variables(const tnsr::I<DataVector, Dim>& x, double t) const
-      noexcept;
+  tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>
+  variables(const tnsr::I<DataVector, Dim>& x, double t,
+            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>,
+                       ScalarWave::Psi> /*meta*/) const noexcept;
 
   /// Retrieve the time derivative of the evolution variables at time `t` and
   /// spatial coordinates `x`
   ///
   /// \note This function's expected use case is setting the past time
   /// derivative values for Adams-Bashforth-like steppers.
-  Variables<tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                       Tags::dt<ScalarWave::Psi>>>
-  dt_evolution_variables(const tnsr::I<DataVector, Dim>& x, double t) const
-      noexcept;
+  tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                      Tags::dt<ScalarWave::Psi>>
+  variables(const tnsr::I<DataVector, Dim>& x, double t,
+            tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                       Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept;
 
   // clang-tidy: no pass by reference
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
@@ -31,6 +31,11 @@ struct InverseSpatialMetric : db::DataBoxTag {
   static constexpr db::DataBoxString label = "InverseSpatialMetric";
 };
 template <size_t Dim, typename Frame, typename DataType>
+struct SqrtDetSpatialMetric : db::DataBoxTag {
+  using type = Scalar<DataType>;
+  static constexpr db::DataBoxString label = "SqrtDetSpatialMetric";
+};
+template <size_t Dim, typename Frame, typename DataType>
 struct Shift : db::DataBoxTag {
   using type = tnsr::I<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "Shift";
@@ -88,6 +93,11 @@ struct TraceSpatialChristoffelSecondKind : db::DataBoxTag {
   using type = tnsr::I<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label =
       "TraceSpatialChristoffelSecondKind";
+};
+template <size_t Dim, typename Frame, typename DataType>
+struct ExtrinsicCurvature : db::DataBoxTag {
+  using type = tnsr::ii<DataType, Dim, Frame>;
+  static constexpr db::DataBoxString label = "ExtrinsicCurvature";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceExtrinsicCurvature : db::DataBoxTag {

--- a/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
@@ -47,22 +47,6 @@ struct Lapse : db::DataBoxTag {
 };
 
 template <size_t Dim, typename Frame, typename DataType>
-struct DtShift : db::DataBoxTag {
-  using type = tnsr::I<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "DtShift";
-};
-template <size_t Dim, typename Frame, typename DataType>
-struct DtLapse : db::DataBoxTag {
-  using type = Scalar<DataType>;
-  static constexpr db::DataBoxString label = "DtLapse";
-};
-template <size_t Dim, typename Frame, typename DataType>
-struct DtSpatialMetric : db::DataBoxTag {
-  using type = tnsr::ii<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "DtSpatialMetric";
-};
-
-template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelFirstKind : db::DataBoxTag {
   using type = tnsr::abb<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "SpacetimeChristoffelFirstKind";

--- a/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
@@ -35,16 +35,6 @@ struct Lapse;
 
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
-struct DtShift;
-template <size_t Dim, typename Frame = Frame::Inertial,
-          typename DataType = DataVector>
-struct DtLapse;
-template <size_t Dim, typename Frame = Frame::Inertial,
-          typename DataType = DataVector>
-struct DtSpatialMetric;
-
-template <size_t Dim, typename Frame = Frame::Inertial,
-          typename DataType = DataVector>
 struct SpacetimeChristoffelFirstKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>

--- a/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
@@ -24,6 +24,8 @@ struct SpatialMetric;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct InverseSpatialMetric;
+template <size_t Dim, typename Frame, typename DataType>
+struct SqrtDetSpatialMetric;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct Shift;
@@ -58,6 +60,8 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct TraceSpacetimeChristoffelFirstKind;
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceSpatialChristoffelSecondKind;
+template <size_t Dim, typename Frame, typename DataType>
+struct ExtrinsicCurvature;
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceExtrinsicCurvature;
 }  // namespace Tags

--- a/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
+++ b/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
@@ -62,8 +62,8 @@ FastFlow::Status do_iteration(
             get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
             get<EinsteinSolutions::KerrSchild::DerivShift<DataVector>>(vars),
             spatial_metric,
-            get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataVector>>(
-                vars),
+            get<Tags::dt<
+                gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(vars),
             deriv_spatial_metric),
         raise_or_lower_first_index(
             gr::christoffel_first_kind(deriv_spatial_metric),

--- a/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
+++ b/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
@@ -44,7 +44,8 @@ FastFlow::Status do_iteration(
     const double t = 0.0;
     const auto& cart_coords =
         db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
-    const auto vars = solution.solution(cart_coords, t);
+    const auto vars = solution.variables(
+        cart_coords, t, EinsteinSolutions::KerrSchild::tags<DataVector>{});
 
     const auto& spatial_metric =
         get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);

--- a/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
+++ b/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
@@ -50,7 +50,7 @@ FastFlow::Status do_iteration(
     const auto& spatial_metric =
         get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);
     const auto& deriv_spatial_metric =
-        get<EinsteinSolutions::KerrSchild::deriv_spatial_metric<DataVector>>(
+        get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<DataVector>>(
             vars);
     const auto inverse_spatial_metric =
         determinant_and_inverse(spatial_metric).second;
@@ -60,7 +60,7 @@ FastFlow::Status do_iteration(
         gr::extrinsic_curvature(
             get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
             get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
-            get<EinsteinSolutions::KerrSchild::deriv_shift<DataVector>>(vars),
+            get<EinsteinSolutions::KerrSchild::DerivShift<DataVector>>(vars),
             spatial_metric,
             get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataVector>>(
                 vars),

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -75,7 +75,8 @@ void test_expansion(const Solution& solution,
           get<Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
                           tmpl::size_t<3>, Frame::Inertial>>(vars),
           spatial_metric,
-          get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataVector>>(vars),
+          get<Tags::dt<
+              gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(vars),
           deriv_spatial_metric));
 
   Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
@@ -99,9 +100,19 @@ void test_minkowski() {
   EinsteinSolutions::Minkowski<3> solution{};
 
   const auto deriv_spatial_metric =
-      solution.deriv_spatial_metric(cart_coords, t);
+      get<Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                      tmpl::size_t<3>, Frame::Inertial>>(
+          solution.variables(
+              cart_coords, t,
+              tmpl::list<Tags::deriv<
+                  gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                  tmpl::size_t<3>, Frame::Inertial>>{}));
   const auto inverse_spatial_metric =
-      solution.inverse_spatial_metric(cart_coords, t);
+      get<gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>(
+          solution.variables(
+              cart_coords, t,
+              tmpl::list<gr::Tags::InverseSpatialMetric<3, Frame::Inertial,
+                                                        DataVector>>{}));
 
   const DataVector one_over_one_form_magnitude =
       1.0 / get(magnitude(

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -21,8 +21,9 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 namespace {
-namespace TestExpansion {
-void test_schwarzschild() {
+template <typename Solution, typename ExpectedLambda>
+void test_expansion(const Solution& solution,
+                    const ExpectedLambda& expected) noexcept {
   // Make surface of radius 2.
   const auto box =
       db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
@@ -34,19 +35,14 @@ void test_schwarzschild() {
   const auto& cart_coords =
       db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
 
-  // Schwarzschild solution
-  const double mass = 1.0;
-  const std::array<double, 3> spin{{0.0, 0.0, 0.0}};
-  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
-  EinsteinSolutions::KerrSchild solution(mass, spin, center);
   const auto vars = solution.variables(
-      cart_coords, t, EinsteinSolutions::KerrSchild::tags<DataVector>{});
+      cart_coords, t, typename Solution::template tags<DataVector>{});
 
   const auto& spatial_metric =
       get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);
   const auto& deriv_spatial_metric =
-      get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<DataVector>>(
-          vars);
+      get<Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                      tmpl::size_t<3>, Frame::Inertial>>(vars);
   const auto inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
 
@@ -76,65 +72,16 @@ void test_schwarzschild() {
       gr::extrinsic_curvature(
           get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
           get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
-          get<EinsteinSolutions::KerrSchild::DerivShift<DataVector>>(vars),
+          get<Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                          tmpl::size_t<3>, Frame::Inertial>>(vars),
           spatial_metric,
           get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataVector>>(vars),
           deriv_spatial_metric));
 
   Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
-  CHECK_ITERABLE_CUSTOM_APPROX(
-      get(residual), DataVector(get(residual).size(), 0.0), custom_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(get(residual), expected(get(residual).size()),
+                               custom_approx);
 }
-
-void test_minkowski() {
-  // Make surface of radius 2.
-  const auto box =
-      db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
-                 db::AddComputeItemsTags<
-                     StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
-          Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
-
-  const double t = 0.0;
-  const auto& cart_coords =
-      db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
-
-  EinsteinSolutions::Minkowski<3> solution{};
-
-  const auto deriv_spatial_metric =
-      solution.deriv_spatial_metric(cart_coords, t);
-  const auto inverse_spatial_metric =
-      solution.inverse_spatial_metric(cart_coords, t);
-
-  const DataVector one_over_one_form_magnitude =
-      1.0 / get(magnitude(
-                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-                inverse_spatial_metric));
-  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
-      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-      one_over_one_form_magnitude);
-  const auto grad_unit_normal_one_form =
-      StrahlkorperGr::grad_unit_normal_one_form(
-          db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
-          db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box),
-          unit_normal_one_form,
-          db::get<StrahlkorperTags::D2xRadius<Frame::Inertial>>(box),
-          one_over_one_form_magnitude,
-          raise_or_lower_first_index(
-              gr::christoffel_first_kind(deriv_spatial_metric),
-              inverse_spatial_metric));
-  const auto inverse_surface_metric = StrahlkorperGr::inverse_surface_metric(
-      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric),
-      inverse_spatial_metric);
-
-  const auto residual = StrahlkorperGr::expansion(
-      grad_unit_normal_one_form, inverse_surface_metric,
-      solution.extrinsic_curvature(cart_coords, t));
-
-  Approx custom_approx = Approx::custom().epsilon(1.e-12);
-  CHECK_ITERABLE_CUSTOM_APPROX(
-      get(residual), DataVector(get(residual).size(), 1.0), custom_approx);
-}
-}  // namespace TestExpansion
 
 namespace TestExtrinsicCurvature {
 void test_minkowski() {
@@ -185,8 +132,11 @@ void test_minkowski() {
 }
 }  // namespace TestExtrinsicCurvature
 
-namespace TestRicciScalar {
-void test_schwarzschild() {
+template <typename Solution, typename SpatialRicciScalar,
+          typename ExpectedLambda>
+void test_ricci_scalar(const Solution& solution,
+                       const SpatialRicciScalar& spatial_ricci_scalar,
+                       const ExpectedLambda& expected) noexcept {
   // Make surface of radius 2.
   const auto box =
       db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
@@ -198,19 +148,14 @@ void test_schwarzschild() {
   const auto& cart_coords =
       db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
 
-  // Schwarzschild solution
-  const double mass = 1.0;
-  const std::array<double, 3> spin{{0.0, 0.0, 0.0}};
-  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
-  EinsteinSolutions::KerrSchild solution(mass, spin, center);
   const auto vars = solution.variables(
-      cart_coords, t, EinsteinSolutions::KerrSchild::tags<DataVector>{});
+      cart_coords, t, typename Solution::template tags<DataVector>{});
 
   const auto& spatial_metric =
       get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);
   const auto& deriv_spatial_metric =
-      get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<DataVector>>(
-          vars);
+      get<Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                      tmpl::size_t<3>, Frame::Inertial>>(vars);
   const auto inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
 
@@ -235,73 +180,24 @@ void test_schwarzschild() {
   const auto unit_normal_vector =
       raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
   const auto ricci_scalar = StrahlkorperGr::ricci_scalar(
-      TestHelpers::Schwarzschild::spatial_ricci(cart_coords, mass),
-      unit_normal_vector,
+      spatial_ricci_scalar(cart_coords), unit_normal_vector,
       StrahlkorperGr::extrinsic_curvature(
           grad_unit_normal_one_form, unit_normal_one_form, unit_normal_vector),
       inverse_spatial_metric);
 
-  CHECK_ITERABLE_APPROX(get(ricci_scalar), DataVector(get(ricci_scalar).size(),
-                                                      0.5 / square(mass)));
+  CHECK_ITERABLE_APPROX(get(ricci_scalar), expected(get(ricci_scalar).size()));
 }
-
-void test_minkowski() {
-  // Make surface of radius 2.
-  const auto box =
-      db::create<db::AddTags<StrahlkorperTags::items_tags<Frame::Inertial>>,
-                 db::AddComputeItemsTags<
-                     StrahlkorperTags::compute_items_tags<Frame::Inertial>>>(
-          Strahlkorper<Frame::Inertial>(8, 8, 2.0, {{0.0, 0.0, 0.0}}));
-
-  const double t = 0.0;
-  const auto& cart_coords =
-      db::get<StrahlkorperTags::CartesianCoords<Frame::Inertial>>(box);
-
-  EinsteinSolutions::Minkowski<3> solution{};
-
-  const auto deriv_spatial_metric =
-      solution.deriv_spatial_metric(cart_coords, t);
-  const auto inverse_spatial_metric =
-      solution.inverse_spatial_metric(cart_coords, t);
-
-  const DataVector one_over_one_form_magnitude =
-      1.0 / get(magnitude(
-                db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-                inverse_spatial_metric));
-  const auto unit_normal_one_form = StrahlkorperGr::unit_normal_one_form(
-      db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
-      one_over_one_form_magnitude);
-  const auto grad_unit_normal_one_form =
-      StrahlkorperGr::grad_unit_normal_one_form(
-          db::get<StrahlkorperTags::Rhat<Frame::Inertial>>(box),
-          db::get<StrahlkorperTags::Radius<Frame::Inertial>>(box),
-          unit_normal_one_form,
-          db::get<StrahlkorperTags::D2xRadius<Frame::Inertial>>(box),
-          one_over_one_form_magnitude,
-          raise_or_lower_first_index(
-              gr::christoffel_first_kind(deriv_spatial_metric),
-              inverse_spatial_metric));
-
-  const auto unit_normal_vector =
-      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
-  const auto extrinsic_curvature = StrahlkorperGr::extrinsic_curvature(
-      grad_unit_normal_one_form, unit_normal_one_form, unit_normal_vector);
-
-  const auto ricci_scalar = StrahlkorperGr::ricci_scalar(
-      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(
-          inverse_spatial_metric, 0.0),
-      unit_normal_vector, extrinsic_curvature, inverse_spatial_metric);
-
-  CHECK_ITERABLE_APPROX(get(ricci_scalar),
-                        DataVector(get(ricci_scalar).size(), 0.5));
-}
-}  // namespace TestRicciScalar
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.Expansion",
                   "[ApparentHorizons][Unit]") {
-  TestExpansion::test_schwarzschild();
-  TestExpansion::test_minkowski();
+  test_expansion(
+      EinsteinSolutions::KerrSchild{1.0, {{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}},
+      [](const size_t size) noexcept { return DataVector(size, 0.0); });
+  test_expansion(
+      EinsteinSolutions::Minkowski<3>{}, [](const size_t size) noexcept {
+        return DataVector(size, 1.0);
+      });
 }
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.ExtrinsicCurvature",
@@ -315,6 +211,21 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.ExtrinsicCurvature",
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.RicciScalar",
                   "[ApparentHorizons][Unit]") {
-  TestRicciScalar::test_schwarzschild();
-  TestRicciScalar::test_minkowski();
+  const double mass = 1.0;
+  test_ricci_scalar(
+      EinsteinSolutions::KerrSchild(mass, {{0.0, 0.0, 0.0}}, {{0.0, 0.0, 0.0}}),
+      [&mass](const auto& cartesian_coords) noexcept {
+        return TestHelpers::Schwarzschild::spatial_ricci(cartesian_coords,
+                                                         mass);
+      },
+      [&mass](const size_t size) noexcept {
+        return DataVector(size, 0.5 / square(mass));
+      });
+  test_ricci_scalar(
+      EinsteinSolutions::Minkowski<3>{},
+      [](const auto& cartesian_coords) noexcept {
+        return make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(
+            cartesian_coords, 0.0);
+      },
+      [](const size_t size) noexcept { return DataVector(size, 0.5); });
 }

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -45,7 +45,7 @@ void test_schwarzschild() {
   const auto& spatial_metric =
       get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);
   const auto& deriv_spatial_metric =
-      get<EinsteinSolutions::KerrSchild::deriv_spatial_metric<DataVector>>(
+      get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<DataVector>>(
           vars);
   const auto inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
@@ -76,7 +76,7 @@ void test_schwarzschild() {
       gr::extrinsic_curvature(
           get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
           get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
-          get<EinsteinSolutions::KerrSchild::deriv_shift<DataVector>>(vars),
+          get<EinsteinSolutions::KerrSchild::DerivShift<DataVector>>(vars),
           spatial_metric,
           get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataVector>>(vars),
           deriv_spatial_metric));
@@ -209,7 +209,7 @@ void test_schwarzschild() {
   const auto& spatial_metric =
       get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);
   const auto& deriv_spatial_metric =
-      get<EinsteinSolutions::KerrSchild::deriv_spatial_metric<DataVector>>(
+      get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<DataVector>>(
           vars);
   const auto inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -39,7 +39,8 @@ void test_schwarzschild() {
   const std::array<double, 3> spin{{0.0, 0.0, 0.0}};
   const std::array<double, 3> center{{0.0, 0.0, 0.0}};
   EinsteinSolutions::KerrSchild solution(mass, spin, center);
-  const auto vars = solution.solution(cart_coords, t);
+  const auto vars = solution.variables(
+      cart_coords, t, EinsteinSolutions::KerrSchild::tags<DataVector>{});
 
   const auto& spatial_metric =
       get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);
@@ -202,7 +203,8 @@ void test_schwarzschild() {
   const std::array<double, 3> spin{{0.0, 0.0, 0.0}};
   const std::array<double, 3> center{{0.0, 0.0, 0.0}};
   EinsteinSolutions::KerrSchild solution(mass, spin, center);
-  const auto vars = solution.solution(cart_coords, t);
+  const auto vars = solution.variables(
+      cart_coords, t, EinsteinSolutions::KerrSchild::tags<DataVector>{});
 
   const auto& spatial_metric =
       get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars);

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -382,60 +382,85 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.Serialization",
 SPECTRE_TEST_CASE("Unit.DataStructures.Variables.assign_subset",
                   "[DataStructures][Unit]") {
   constexpr size_t size = 3;
-  Variables<tmpl::list<VariablesTestTags_detail::vector>> vars_subset0(size,
-                                                                       8.0);
-  Variables<tmpl::list<VariablesTestTags_detail::scalar>> vars_subset1(size,
-                                                                       4.0);
+  const auto first_test = [&size](const auto& vars_subset0,
+                                  const auto& vars_subset1) noexcept {
+    Variables<tmpl::list<VariablesTestTags_detail::vector,
+                         VariablesTestTags_detail::scalar>>
+        vars_set0{size, 3.0};
+    CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
+          db::item_type<VariablesTestTags_detail::vector>(size, 3.0));
+    CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
+          db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
+    vars_set0.assign_subset(vars_subset0);
+    CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
+          db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+    CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
+          db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
+    vars_set0.assign_subset(vars_subset1);
+    CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
+          db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+    CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
+          db::item_type<VariablesTestTags_detail::scalar>(size, 4.0));
+  };
 
-  Variables<tmpl::list<VariablesTestTags_detail::vector,
-                       VariablesTestTags_detail::scalar>>
-      vars_set0(size, 3.0);
-  CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
-        db::item_type<VariablesTestTags_detail::vector>(size, 3.0));
-  CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
-        db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
-  vars_set0.assign_subset(vars_subset0);
-  CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
-        db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
-  CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
-        db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
-  vars_set0.assign_subset(vars_subset1);
-  CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
-        db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
-  CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
-        db::item_type<VariablesTestTags_detail::scalar>(size, 4.0));
+  first_test(
+      Variables<tmpl::list<VariablesTestTags_detail::vector>>(size, 8.0),
+      Variables<tmpl::list<VariablesTestTags_detail::scalar>>(size, 4.0));
+  first_test(tuples::TaggedTuple<VariablesTestTags_detail::vector>(
+                 VariablesTestTags_detail::vector::type{size, 8.0}),
+             tuples::TaggedTuple<VariablesTestTags_detail::scalar>(
+                 VariablesTestTags_detail::scalar::type{size, 4.0}));
 
-  Variables<tmpl::list<VariablesTestTags_detail::vector,
-                       VariablesTestTags_detail::scalar,
-                       VariablesTestTags_detail::scalar2>>
-      vars_set1(size, 3.0);
-  CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
-        db::item_type<VariablesTestTags_detail::vector>(size, 3.0));
-  CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
-        db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
-  CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
-        db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
-  vars_set1.assign_subset(vars_subset0);
-  CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
-        db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
-  CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
-        db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
-  CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
-        db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
-  vars_set1.assign_subset(vars_subset1);
-  CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
-        db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
-  CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
-        db::item_type<VariablesTestTags_detail::scalar>(size, 4.0));
-  CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
-        db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
+  const auto second_test = [&size](const auto& vars_subset0,
+                                   const auto& vars_subset1) noexcept {
+    Variables<tmpl::list<VariablesTestTags_detail::vector,
+                         VariablesTestTags_detail::scalar,
+                         VariablesTestTags_detail::scalar2>>
+        vars_set1(size, 3.0);
+    CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
+          db::item_type<VariablesTestTags_detail::vector>(size, 3.0));
+    CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
+          db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
+    CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
+          db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
+    vars_set1.assign_subset(vars_subset0);
+    CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
+          db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+    CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
+          db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
+    CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
+          db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
+    vars_set1.assign_subset(vars_subset1);
+    CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
+          db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+    CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
+          db::item_type<VariablesTestTags_detail::scalar>(size, 4.0));
+    CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
+          db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
+  };
 
-  Variables<tmpl::list<VariablesTestTags_detail::vector>> vars_set2(size, -7.0);
-  CHECK(get<VariablesTestTags_detail::vector>(vars_set2) ==
-        db::item_type<VariablesTestTags_detail::vector>(size, -7.0));
-  vars_set2.assign_subset(vars_subset0);
-  CHECK(get<VariablesTestTags_detail::vector>(vars_set2) ==
-        db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+  second_test(
+      Variables<tmpl::list<VariablesTestTags_detail::vector>>(size, 8.0),
+      Variables<tmpl::list<VariablesTestTags_detail::scalar>>(size, 4.0));
+  second_test(tuples::TaggedTuple<VariablesTestTags_detail::vector>(
+                  VariablesTestTags_detail::vector::type{size, 8.0}),
+              tuples::TaggedTuple<VariablesTestTags_detail::scalar>(
+                  VariablesTestTags_detail::scalar::type{size, 4.0}));
+
+  const auto third_test = [&size](const auto& vars_subset0) noexcept {
+    Variables<tmpl::list<VariablesTestTags_detail::vector>> vars_set2(size,
+                                                                      -7.0);
+    CHECK(get<VariablesTestTags_detail::vector>(vars_set2) ==
+          db::item_type<VariablesTestTags_detail::vector>(size, -7.0));
+    vars_set2.assign_subset(vars_subset0);
+    CHECK(get<VariablesTestTags_detail::vector>(vars_set2) ==
+          db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+  };
+
+  third_test(
+      Variables<tmpl::list<VariablesTestTags_detail::vector>>(size, 8.0));
+  third_test(tuples::TaggedTuple<VariablesTestTags_detail::vector>(
+      VariablesTestTags_detail::vector::type{size, 8.0}));
 }
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Variables.SliceVariables",

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
@@ -63,10 +63,10 @@ void test_schwarzschild(const DataType& used_for_size) noexcept {
   const auto& dt_lapse =
       get<gr::Tags::DtLapse<3, Frame::Inertial, DataType>>(vars);
   const auto& d_lapse =
-      get<EinsteinSolutions::KerrSchild::deriv_lapse<DataType>>(vars);
+      get<EinsteinSolutions::KerrSchild::DerivLapse<DataType>>(vars);
   const auto& shift = get<gr::Tags::Shift<3, Frame::Inertial, DataType>>(vars);
   const auto& d_shift =
-      get<EinsteinSolutions::KerrSchild::deriv_shift<DataType>>(vars);
+      get<EinsteinSolutions::KerrSchild::DerivShift<DataType>>(vars);
   const auto& dt_shift =
       get<gr::Tags::DtShift<3, Frame::Inertial, DataType>>(vars);
   const auto& g =
@@ -74,7 +74,7 @@ void test_schwarzschild(const DataType& used_for_size) noexcept {
   const auto& dt_g =
       get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataType>>(vars);
   const auto& d_g =
-      get<EinsteinSolutions::KerrSchild::deriv_spatial_metric<DataType>>(vars);
+      get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<DataType>>(vars);
 
   // Check those quantities that should be zero.
   const auto zero = make_with_value<DataType>(x, 0.);
@@ -174,10 +174,10 @@ void test_double_vs_datavector() noexcept {
   const auto& dt_lapse1 =
       get<gr::Tags::DtLapse<3, Frame::Inertial, double>>(vars1);
   const auto& d_lapse1 =
-      get<EinsteinSolutions::KerrSchild::deriv_lapse<double>>(vars1);
+      get<EinsteinSolutions::KerrSchild::DerivLapse<double>>(vars1);
   const auto& shift1 = get<gr::Tags::Shift<3, Frame::Inertial, double>>(vars1);
   const auto& d_shift1 =
-      get<EinsteinSolutions::KerrSchild::deriv_shift<double>>(vars1);
+      get<EinsteinSolutions::KerrSchild::DerivShift<double>>(vars1);
   const auto& dt_shift1 =
       get<gr::Tags::DtShift<3, Frame::Inertial, double>>(vars1);
   const auto& g1 =
@@ -185,7 +185,7 @@ void test_double_vs_datavector() noexcept {
   const auto& dt_g1 =
       get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, double>>(vars1);
   const auto& d_g1 =
-      get<EinsteinSolutions::KerrSchild::deriv_spatial_metric<double>>(vars1);
+      get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<double>>(vars1);
 
   const auto vars2 = solution.variables(
       x2, t, EinsteinSolutions::KerrSchild::tags<DataVector>{});
@@ -194,11 +194,11 @@ void test_double_vs_datavector() noexcept {
   const auto& dt_lapse2 =
       get<gr::Tags::DtLapse<3, Frame::Inertial, DataVector>>(vars2);
   const auto& d_lapse2 =
-      get<EinsteinSolutions::KerrSchild::deriv_lapse<DataVector>>(vars2);
+      get<EinsteinSolutions::KerrSchild::DerivLapse<DataVector>>(vars2);
   const auto& shift2 =
       get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars2);
   const auto& d_shift2 =
-      get<EinsteinSolutions::KerrSchild::deriv_shift<DataVector>>(vars2);
+      get<EinsteinSolutions::KerrSchild::DerivShift<DataVector>>(vars2);
   const auto& dt_shift2 =
       get<gr::Tags::DtShift<3, Frame::Inertial, DataVector>>(vars2);
   const auto& g2 =
@@ -206,8 +206,7 @@ void test_double_vs_datavector() noexcept {
   const auto& dt_g2 =
       get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataVector>>(vars2);
   const auto& d_g2 =
-      get<EinsteinSolutions::KerrSchild::deriv_spatial_metric<DataVector>>(
-          vars2);
+      get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<DataVector>>(vars2);
 
   check_tensor_doubles_approx_equals_tensor_datavectors(lapse2, lapse1);
   check_tensor_doubles_approx_equals_tensor_datavectors(shift2, shift1);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
@@ -61,18 +61,19 @@ void test_schwarzschild(const DataType& used_for_size) noexcept {
       solution.variables(x, t, EinsteinSolutions::KerrSchild::tags<DataType>{});
   const auto& lapse = get<gr::Tags::Lapse<3, Frame::Inertial, DataType>>(vars);
   const auto& dt_lapse =
-      get<gr::Tags::DtLapse<3, Frame::Inertial, DataType>>(vars);
+      get<Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, DataType>>>(vars);
   const auto& d_lapse =
       get<EinsteinSolutions::KerrSchild::DerivLapse<DataType>>(vars);
   const auto& shift = get<gr::Tags::Shift<3, Frame::Inertial, DataType>>(vars);
   const auto& d_shift =
       get<EinsteinSolutions::KerrSchild::DerivShift<DataType>>(vars);
   const auto& dt_shift =
-      get<gr::Tags::DtShift<3, Frame::Inertial, DataType>>(vars);
+      get<Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataType>>>(vars);
   const auto& g =
       get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>(vars);
   const auto& dt_g =
-      get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataType>>(vars);
+      get<Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>>(
+          vars);
   const auto& d_g =
       get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<DataType>>(vars);
 
@@ -172,18 +173,18 @@ void test_double_vs_datavector() noexcept {
       solution.variables(x1, t, EinsteinSolutions::KerrSchild::tags<double>{});
   const auto& lapse1 = get<gr::Tags::Lapse<3, Frame::Inertial, double>>(vars1);
   const auto& dt_lapse1 =
-      get<gr::Tags::DtLapse<3, Frame::Inertial, double>>(vars1);
+      get<Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, double>>>(vars1);
   const auto& d_lapse1 =
       get<EinsteinSolutions::KerrSchild::DerivLapse<double>>(vars1);
   const auto& shift1 = get<gr::Tags::Shift<3, Frame::Inertial, double>>(vars1);
   const auto& d_shift1 =
       get<EinsteinSolutions::KerrSchild::DerivShift<double>>(vars1);
   const auto& dt_shift1 =
-      get<gr::Tags::DtShift<3, Frame::Inertial, double>>(vars1);
+      get<Tags::dt<gr::Tags::Shift<3, Frame::Inertial, double>>>(vars1);
   const auto& g1 =
       get<gr::Tags::SpatialMetric<3, Frame::Inertial, double>>(vars1);
   const auto& dt_g1 =
-      get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, double>>(vars1);
+      get<Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, double>>>(vars1);
   const auto& d_g1 =
       get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<double>>(vars1);
 
@@ -192,7 +193,7 @@ void test_double_vs_datavector() noexcept {
   const auto& lapse2 =
       get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars2);
   const auto& dt_lapse2 =
-      get<gr::Tags::DtLapse<3, Frame::Inertial, DataVector>>(vars2);
+      get<Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>>(vars2);
   const auto& d_lapse2 =
       get<EinsteinSolutions::KerrSchild::DerivLapse<DataVector>>(vars2);
   const auto& shift2 =
@@ -200,11 +201,12 @@ void test_double_vs_datavector() noexcept {
   const auto& d_shift2 =
       get<EinsteinSolutions::KerrSchild::DerivShift<DataVector>>(vars2);
   const auto& dt_shift2 =
-      get<gr::Tags::DtShift<3, Frame::Inertial, DataVector>>(vars2);
+      get<Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>(vars2);
   const auto& g2 =
       get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(vars2);
   const auto& dt_g2 =
-      get<gr::Tags::DtSpatialMetric<3, Frame::Inertial, DataVector>>(vars2);
+      get<Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
+          vars2);
   const auto& d_g2 =
       get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<DataVector>>(vars2);
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
@@ -57,7 +57,8 @@ void test_schwarzschild(const DataType& used_for_size) noexcept {
   // Evaluate solution
   EinsteinSolutions::KerrSchild solution(mass, spin, center);
 
-  const auto vars = solution.solution(x, t);
+  const auto vars =
+      solution.variables(x, t, EinsteinSolutions::KerrSchild::tags<DataType>{});
   const auto& lapse = get<gr::Tags::Lapse<3, Frame::Inertial, DataType>>(vars);
   const auto& dt_lapse =
       get<gr::Tags::DtLapse<3, Frame::Inertial, DataType>>(vars);
@@ -167,7 +168,8 @@ void test_double_vs_datavector() noexcept {
   const auto x1 = spatial_coords(0.0);
   const auto x2 = spatial_coords(DataVector{0.0, 0.0, 0.0});
 
-  const auto vars1 = solution.solution(x1, t);
+  const auto vars1 =
+      solution.variables(x1, t, EinsteinSolutions::KerrSchild::tags<double>{});
   const auto& lapse1 = get<gr::Tags::Lapse<3, Frame::Inertial, double>>(vars1);
   const auto& dt_lapse1 =
       get<gr::Tags::DtLapse<3, Frame::Inertial, double>>(vars1);
@@ -185,7 +187,8 @@ void test_double_vs_datavector() noexcept {
   const auto& d_g1 =
       get<EinsteinSolutions::KerrSchild::deriv_spatial_metric<double>>(vars1);
 
-  const auto vars2 = solution.solution(x2, t);
+  const auto vars2 = solution.variables(
+      x2, t, EinsteinSolutions::KerrSchild::tags<DataVector>{});
   const auto& lapse2 =
       get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars2);
   const auto& dt_lapse2 =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_Minkowski.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_Minkowski.cpp
@@ -17,24 +17,80 @@ void test_minkowski(const T& value) {
   const auto one = make_with_value<T>(value, 1.);
   const auto zero = make_with_value<T>(value, 0.);
 
-  const auto lapse = minkowski.lapse(x, t);
-  const auto dt_lapse = minkowski.dt_lapse(x, t);
-  const auto d_lapse = minkowski.deriv_lapse(x, t);
-  const auto shift = minkowski.shift(x, t);
-  const auto deriv_shift = minkowski.deriv_shift(x, t);
-  const auto g = minkowski.spatial_metric(x, t);
-  const auto dt_g = minkowski.dt_spatial_metric(x, t);
-  const auto d_g = minkowski.deriv_spatial_metric(x, t);
-  const auto det_g = minkowski.sqrt_determinant_of_spatial_metric(x, t);
-  const auto dt_det_g = minkowski.dt_sqrt_determinant_of_spatial_metric(x, t);
-  const auto inv_g = minkowski.inverse_spatial_metric(x, t);
-  const auto extrinsic_curvature = minkowski.extrinsic_curvature(x, t);
+  const auto lapse =
+      get<gr::Tags::Lapse<Dim, Frame::Inertial, T>>(minkowski.variables(
+          x, t, tmpl::list<gr::Tags::Lapse<Dim, Frame::Inertial, T>>{}));
+  const auto dt_lapse = get<Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, T>>>(
+      minkowski.variables(
+          x, t,
+          tmpl::list<Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, T>>>{}));
+  const auto d_lapse = get<Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, T>,
+                                       tmpl::size_t<Dim>, Frame::Inertial>>(
+      minkowski.variables(
+          x, t,
+          tmpl::list<Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, T>,
+                                 tmpl::size_t<Dim>, Frame::Inertial>>{}));
+  const auto shift =
+      get<gr::Tags::Shift<Dim, Frame::Inertial, T>>(minkowski.variables(
+          x, t, tmpl::list<gr::Tags::Shift<Dim, Frame::Inertial, T>>{}));
+  const auto dt_shift = get<Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, T>>>(
+      minkowski.variables(
+          x, t,
+          tmpl::list<Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, T>>>{}));
+  const auto d_shift = get<Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, T>,
+                                       tmpl::size_t<Dim>, Frame::Inertial>>(
+      minkowski.variables(
+          x, t,
+          tmpl::list<Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, T>,
+                                 tmpl::size_t<Dim>, Frame::Inertial>>{}));
+  const auto g =
+      get<gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>>(minkowski.variables(
+          x, t,
+          tmpl::list<gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>>{}));
+  const auto dt_g =
+      get<Tags::dt<gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>>>(
+          minkowski.variables(
+              x, t,
+              tmpl::list<Tags::dt<
+                  gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>>>{}));
+  const auto d_g =
+      get<Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>,
+                      tmpl::size_t<Dim>, Frame::Inertial>>(
+          minkowski.variables(
+              x, t,
+              tmpl::list<
+                  Tags::deriv<gr::Tags::SpatialMetric<Dim, Frame::Inertial, T>,
+                              tmpl::size_t<Dim>, Frame::Inertial>>{}));
+  const auto inv_g =
+      get<gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, T>>(
+          minkowski.variables(
+              x, t,
+              tmpl::list<
+                  gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, T>>{}));
+  const auto extrinsic_curvature = get<
+      gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, T>>(
+      minkowski.variables(
+          x, t,
+          tmpl::list<gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, T>>{}));
+  const auto det_g =
+      get<gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, T>>(
+          minkowski.variables(
+              x, t,
+              tmpl::list<
+                  gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, T>>{}));
+  const auto dt_det_g =
+      get<Tags::dt<gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, T>>>(
+          minkowski.variables(
+              x, t,
+              tmpl::list<Tags::dt<
+                  gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, T>>>{}));
 
   CHECK(lapse.get() == one);
   CHECK(dt_lapse.get() == zero);
   CHECK(det_g.get() == one);
   for (size_t i = 0; i < Dim; ++i) {
     CHECK(shift.get(i) == zero);
+    CHECK(dt_shift.get(i) == zero);
     CHECK(d_lapse.get(i) == zero);
     CHECK(g.get(i, i) == one);
     CHECK(inv_g.get(i, i) == one);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
@@ -65,7 +65,8 @@ void verify_time_independent_einstein_solution(
   const double t = 1.3;  // Arbitrary time for time-independent solution.
 
   // Evaluate analytic solution
-  const auto vars = solution.solution(x, t);
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
   const auto& lapse = get<gr::Tags::Lapse<3>>(vars);
   const auto& dt_lapse = get<gr::Tags::DtLapse<3>>(vars);
   const auto& d_lapse =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
@@ -68,15 +68,15 @@ void verify_time_independent_einstein_solution(
   const auto vars =
       solution.variables(x, t, typename Solution::template tags<DataVector>{});
   const auto& lapse = get<gr::Tags::Lapse<3>>(vars);
-  const auto& dt_lapse = get<gr::Tags::DtLapse<3>>(vars);
+  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<3>>>(vars);
   const auto& d_lapse =
       get<typename Solution::template DerivLapse<DataVector>>(vars);
   const auto& shift = get<gr::Tags::Shift<3>>(vars);
   const auto& d_shift =
       get<typename Solution::template DerivShift<DataVector>>(vars);
-  const auto& dt_shift = get<gr::Tags::DtShift<3>>(vars);
+  const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<3>>>(vars);
   const auto& g = get<gr::Tags::SpatialMetric<3>>(vars);
-  const auto& dt_g = get<gr::Tags::DtSpatialMetric<3>>(vars);
+  const auto& dt_g = get<Tags::dt<gr::Tags::SpatialMetric<3>>>(vars);
   const auto& d_g =
       get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
@@ -70,15 +70,15 @@ void verify_time_independent_einstein_solution(
   const auto& lapse = get<gr::Tags::Lapse<3>>(vars);
   const auto& dt_lapse = get<gr::Tags::DtLapse<3>>(vars);
   const auto& d_lapse =
-      get<typename Solution::template deriv_lapse<DataVector>>(vars);
+      get<typename Solution::template DerivLapse<DataVector>>(vars);
   const auto& shift = get<gr::Tags::Shift<3>>(vars);
   const auto& d_shift =
-      get<typename Solution::template deriv_shift<DataVector>>(vars);
+      get<typename Solution::template DerivShift<DataVector>>(vars);
   const auto& dt_shift = get<gr::Tags::DtShift<3>>(vars);
   const auto& g = get<gr::Tags::SpatialMetric<3>>(vars);
   const auto& dt_g = get<gr::Tags::DtSpatialMetric<3>>(vars);
   const auto& d_g =
-      get<typename Solution::template deriv_spatial_metric<DataVector>>(vars);
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
 
   // Check those quantities that should vanish identically.
   CHECK(get(dt_lapse) == make_with_value<DataVector>(x, 0.));

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -32,207 +32,115 @@ inline tnsr::I<double, 3, Frame::Inertial> extract_point_from_coords(
       {x.get(0)[offset], x.get(1)[offset], x.get(2)[offset]}}};
 }
 
-template <size_t Dim>
-void check_solution_x(const double kx, const double omega, const DataVector& u,
-                      const ScalarWave::Solutions::PlaneWave<Dim>& pw,
-                      const tnsr::I<DataVector, Dim>& x, const double t) {
-  const DataVector psi = cube(u);
-  const DataVector dpsi_dt = -3.0 * omega * square(u);
-  const DataVector dpsi_dx = 3.0 * kx * square(u);
-  const DataVector d2psi_dt2 = 6.0 * square(omega) * u;
-  const DataVector d2psi_dtdx = -6.0 * omega * kx * u;
-  const DataVector d2psi_dxdx = 6.0 * square(kx) * u;
-  CHECK_ITERABLE_APPROX(psi, pw.psi(x, t).get());
-  CHECK_ITERABLE_APPROX(dpsi_dt, pw.dpsi_dt(x, t).get());
-  CHECK_ITERABLE_APPROX(d2psi_dt2, pw.d2psi_dt2(x, t).get());
-  CHECK_ITERABLE_APPROX(dpsi_dx, pw.dpsi_dx(x, t).get(0));
-  CHECK_ITERABLE_APPROX(d2psi_dtdx, pw.d2psi_dtdx(x, t).get(0));
-  CHECK_ITERABLE_APPROX(d2psi_dxdx, pw.d2psi_dxdx(x, t).get(0, 0));
-  for (size_t s = 0; s < u.size(); ++s) {
+template <size_t Dim, size_t DimSolution>
+void check_solution(
+    const DataVector& expected_psi, const DataVector& expected_dpsi_dt,
+    const DataVector& expected_d2psi_dt2, const DataVector& expected_dpsi_dlast,
+    const std::array<DataVector, Dim + 1>& expected_second_derivs,
+    const ScalarWave::Solutions::PlaneWave<DimSolution>& pw,
+    const tnsr::I<DataVector, DimSolution>& x, const double t) noexcept {
+  // expected_second_derivs is:
+  // 0 -> d^2 psi / dt dx^(Dim-1)
+  // 1-3 -> d^2 psi / dx^(Dim - 1) dx^i where i is in [0, 2]
+  CHECK_ITERABLE_APPROX(expected_psi, pw.psi(x, t).get());
+  CHECK_ITERABLE_APPROX(expected_dpsi_dt, pw.dpsi_dt(x, t).get());
+  CHECK_ITERABLE_APPROX(expected_d2psi_dt2, pw.d2psi_dt2(x, t).get());
+  CHECK_ITERABLE_APPROX(expected_dpsi_dlast, pw.dpsi_dx(x, t).get(Dim - 1));
+  CHECK_ITERABLE_APPROX(expected_second_derivs[0],
+                        pw.d2psi_dtdx(x, t).get(Dim - 1));
+  for (size_t i = 0; i < Dim; ++i) {
+    CHECK_ITERABLE_APPROX(gsl::at(expected_second_derivs, i + 1),
+                          pw.d2psi_dxdx(x, t).get(i, Dim - 1));
+    if (i < Dim - 1) {
+      CHECK_ITERABLE_APPROX(gsl::at(expected_second_derivs, i + 1),
+                            pw.d2psi_dxdx(x, t).get(Dim - 1, i));
+    }
+  }
+
+  for (size_t s = 0; s < x.get(0).size(); ++s) {
     const auto p = extract_point_from_coords(s, x);
-    CHECK(approx(psi[s]) == pw.psi(p, t).get());
-    CHECK(approx(dpsi_dt[s]) == pw.dpsi_dt(p, t).get());
-    CHECK(approx(d2psi_dt2[s]) == pw.d2psi_dt2(p, t).get());
-    CHECK(approx(dpsi_dx[s]) == pw.dpsi_dx(p, t).get(0));
-    CHECK(approx(d2psi_dtdx[s]) == pw.d2psi_dtdx(p, t).get(0));
-    CHECK(approx(d2psi_dxdx[s]) == pw.d2psi_dxdx(p, t).get(0, 0));
+    CHECK_ITERABLE_APPROX(expected_psi[s], pw.psi(p, t).get());
+    CHECK_ITERABLE_APPROX(expected_dpsi_dt[s], pw.dpsi_dt(p, t).get());
+    CHECK_ITERABLE_APPROX(expected_d2psi_dt2[s], pw.d2psi_dt2(p, t).get());
+    CHECK_ITERABLE_APPROX(expected_dpsi_dlast[s],
+                          pw.dpsi_dx(p, t).get(Dim - 1));
+    CHECK_ITERABLE_APPROX(expected_second_derivs[0][s],
+                          pw.d2psi_dtdx(p, t).get(Dim - 1));
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(gsl::at(expected_second_derivs, i + 1)[s],
+                            pw.d2psi_dxdx(p, t).get(i, Dim - 1));
+      if (i < Dim - 1) {
+        CHECK_ITERABLE_APPROX(gsl::at(expected_second_derivs, i + 1)[s],
+                              pw.d2psi_dxdx(p, t).get(Dim - 1, i));
+      }
+    }
   }
 
   CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Psi>(pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
+      get<ScalarWave::Psi>(
+          pw.variables(x, t,
+                       tmpl::list<ScalarWave::Pi, ScalarWave::Phi<DimSolution>,
+                                  ScalarWave::Psi>{})),
       pw.psi(x, t));
   CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Phi<Dim>>(pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
+      get<ScalarWave::Phi<DimSolution>>(
+          pw.variables(x, t,
+                       tmpl::list<ScalarWave::Pi, ScalarWave::Phi<DimSolution>,
+                                  ScalarWave::Psi>{})),
       pw.dpsi_dx(x, t));
   CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Pi>(pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
+      get<ScalarWave::Pi>(
+          pw.variables(x, t,
+                       tmpl::list<ScalarWave::Pi, ScalarWave::Phi<DimSolution>,
+                                  ScalarWave::Psi>{})),
       Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
 
+  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Psi>>(pw.variables(
+                            x, t,
+                            tmpl::list<Tags::dt<ScalarWave::Pi>,
+                                       Tags::dt<ScalarWave::Phi<DimSolution>>,
+                                       Tags::dt<ScalarWave::Psi>>{})),
+                        pw.dpsi_dt(x, t));
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Psi>>(pw.variables(
-          x, t,
-          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                     Tags::dt<ScalarWave::Psi>>{})),
-      pw.dpsi_dt(x, t));
-  CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Phi<Dim>>>(pw.variables(
-          x, t,
-          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                     Tags::dt<ScalarWave::Psi>>{})),
+      get<Tags::dt<ScalarWave::Phi<DimSolution>>>(
+          pw.variables(x, t,
+                       tmpl::list<Tags::dt<ScalarWave::Pi>,
+                                  Tags::dt<ScalarWave::Phi<DimSolution>>,
+                                  Tags::dt<ScalarWave::Psi>>{})),
       pw.d2psi_dtdx(x, t));
-  CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Pi>>(pw.variables(
-          x, t,
-          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                     Tags::dt<ScalarWave::Psi>>{})),
-      Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
-}
-
-template <size_t Dim>
-void check_solution_y(const double kx, const double ky, const double omega,
-                      const DataVector& u,
-                      const ScalarWave::Solutions::PlaneWave<Dim>& pw,
-                      const tnsr::I<DataVector, Dim>& x, const double t) {
-  const DataVector dpsi_dy = 3.0 * ky * square(u);
-  const DataVector d2psi_dtdy = -6.0 * omega * ky * u;
-  const DataVector d2psi_dxdy = 6.0 * kx * ky * u;
-  const DataVector d2psi_dydy = 6.0 * square(ky) * u;
-  CHECK_ITERABLE_APPROX(dpsi_dy, pw.dpsi_dx(x, t).get(1));
-  CHECK_ITERABLE_APPROX(d2psi_dtdy, pw.d2psi_dtdx(x, t).get(1));
-  CHECK_ITERABLE_APPROX(d2psi_dxdy, pw.d2psi_dxdx(x, t).get(0, 1));
-  CHECK_ITERABLE_APPROX(d2psi_dxdy, pw.d2psi_dxdx(x, t).get(1, 0));
-  CHECK_ITERABLE_APPROX(d2psi_dydy, pw.d2psi_dxdx(x, t).get(1, 1));
-  for (size_t s = 0; s < u.size(); ++s) {
-    const auto p = extract_point_from_coords(s, x);
-    CHECK(approx(dpsi_dy[s]) == pw.dpsi_dx(p, t).get(1));
-    CHECK(approx(d2psi_dtdy[s]) == pw.d2psi_dtdx(p, t).get(1));
-    CHECK(approx(d2psi_dxdy[s]) == pw.d2psi_dxdx(p, t).get(0, 1));
-    CHECK(approx(d2psi_dxdy[s]) == pw.d2psi_dxdx(p, t).get(1, 0));
-    CHECK(approx(d2psi_dydy[s]) == pw.d2psi_dxdx(p, t).get(1, 1));
-  }
-
-  CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Psi>(pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
-      pw.psi(x, t));
-  CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Phi<Dim>>(pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
-      pw.dpsi_dx(x, t));
-  CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Pi>(pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
-      Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
-
-  CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Psi>>(pw.variables(
-          x, t,
-          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                     Tags::dt<ScalarWave::Psi>>{})),
-      pw.dpsi_dt(x, t));
-  CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Phi<Dim>>>(pw.variables(
-          x, t,
-          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                     Tags::dt<ScalarWave::Psi>>{})),
-      pw.d2psi_dtdx(x, t));
-  CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Pi>>(pw.variables(
-          x, t,
-          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
-                     Tags::dt<ScalarWave::Psi>>{})),
-      Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
-}
-
-void check_solution_z(const double kx, const double ky, const double kz,
-                      const double omega, const DataVector& u,
-                      const ScalarWave::Solutions::PlaneWave<3>& pw,
-                      const tnsr::I<DataVector, 3>& x, const double t) {
-  const DataVector dpsi_dz = 3.0 * kz * square(u);
-  const DataVector d2psi_dtdz = -6.0 * omega * kz * u;
-  const DataVector d2psi_dxdz = 6.0 * kx * kz * u;
-  const DataVector d2psi_dydz = 6.0 * ky * kz * u;
-  const DataVector d2psi_dzdz = 6.0 * square(kz) * u;
-  CHECK_ITERABLE_APPROX(dpsi_dz, pw.dpsi_dx(x, t).get(2));
-  CHECK_ITERABLE_APPROX(d2psi_dtdz, pw.d2psi_dtdx(x, t).get(2));
-  CHECK_ITERABLE_APPROX(d2psi_dxdz, pw.d2psi_dxdx(x, t).get(0, 2));
-  CHECK_ITERABLE_APPROX(d2psi_dxdz, pw.d2psi_dxdx(x, t).get(2, 0));
-  CHECK_ITERABLE_APPROX(d2psi_dydz, pw.d2psi_dxdx(x, t).get(2, 1));
-  CHECK_ITERABLE_APPROX(d2psi_dydz, pw.d2psi_dxdx(x, t).get(1, 2));
-  CHECK_ITERABLE_APPROX(d2psi_dzdz, pw.d2psi_dxdx(x, t).get(2, 2));
-  for (size_t s = 0; s < u.size(); ++s) {
-    const auto p = extract_point_from_coords(s, x);
-    CHECK(approx(dpsi_dz[s]) == pw.dpsi_dx(p, t).get(2));
-    CHECK(approx(d2psi_dtdz[s]) == pw.d2psi_dtdx(p, t).get(2));
-    CHECK(approx(d2psi_dxdz[s]) == pw.d2psi_dxdx(p, t).get(0, 2));
-    CHECK(approx(d2psi_dxdz[s]) == pw.d2psi_dxdx(p, t).get(2, 0));
-    CHECK(approx(d2psi_dydz[s]) == pw.d2psi_dxdx(p, t).get(2, 1));
-    CHECK(approx(d2psi_dydz[s]) == pw.d2psi_dxdx(p, t).get(1, 2));
-    CHECK(approx(d2psi_dzdz[s]) == pw.d2psi_dxdx(p, t).get(2, 2));
-  }
-
-  CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Psi>(pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{})),
-      pw.psi(x, t));
-  CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Phi<3>>(pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{})),
-      pw.dpsi_dx(x, t));
-  CHECK_ITERABLE_APPROX(
-      get<ScalarWave::Pi>(pw.variables(
-          x, t,
-          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{})),
-      Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
-
-  CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Psi>>(pw.variables(
-          x, t,
-          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
-                     Tags::dt<ScalarWave::Psi>>{})),
-      pw.dpsi_dt(x, t));
-  CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Phi<3>>>(pw.variables(
-          x, t,
-          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
-                     Tags::dt<ScalarWave::Psi>>{})),
-      pw.d2psi_dtdx(x, t));
-  CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Pi>>(pw.variables(
-          x, t,
-          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
-                     Tags::dt<ScalarWave::Psi>>{})),
-      Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
+  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Pi>>(pw.variables(
+                            x, t,
+                            tmpl::list<Tags::dt<ScalarWave::Pi>,
+                                       Tags::dt<ScalarWave::Phi<DimSolution>>,
+                                       Tags::dt<ScalarWave::Psi>>{})),
+                        Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
 }
 
 void test_1d() {
-  const double k = -1.5;
+  const double kx = -1.5;
   const double center_x = 2.4;
-  const double omega = std::abs(k);
+  const double omega = std::abs(kx);
   const double t = 3.1;
   const double x1 = -0.2;
   const double x2 = 8.7;
   const tnsr::I<DataVector, 1> x(DataVector({x1, x2}));
   const DataVector u(
-      {k * (x1 - center_x) - omega * t, k * (x2 - center_x) - omega * t});
+      {kx * (x1 - center_x) - omega * t, kx * (x2 - center_x) - omega * t});
   const ScalarWave::Solutions::PlaneWave<1> pw(
-      {{k}}, {{center_x}}, std::make_unique<MathFunctions::PowX>(3));
-  check_solution_x(k, omega, u, pw, x, t);
+      {{kx}}, {{center_x}}, std::make_unique<MathFunctions::PowX>(3));
+  check_solution<1>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * kx * square(u),
+      std::array<DataVector, 2>{{-6.0 * omega * kx * u, 6.0 * square(kx) * u}},
+      pw, x, t);
 
   Parallel::register_derived_classes_with_charm<MathFunction<1>>();
   const auto deserialized_pw = serialize_and_deserialize(pw);
-  check_solution_x(k, omega, u, deserialized_pw, x, t);
+  check_solution<1>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * kx * square(u),
+      std::array<DataVector, 2>{{-6.0 * omega * kx * u, 6.0 * square(kx) * u}},
+      deserialized_pw, x, t);
 
   test_creation<ScalarWave::Solutions::PlaneWave<1>>(
       "  WaveVector: [3.5]\n"
@@ -260,13 +168,31 @@ void test_2d() {
   const ScalarWave::Solutions::PlaneWave<2> pw(
       {{kx, ky}}, {{center_x, center_y}},
       std::make_unique<MathFunctions::PowX>(3));
-  check_solution_x(kx, omega, u, pw, x, t);
-  check_solution_y(kx, ky, omega, u, pw, x, t);
+  check_solution<1>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * kx * square(u),
+      std::array<DataVector, 2>{{-6.0 * omega * kx * u, 6.0 * square(kx) * u}},
+      pw, x, t);
+  check_solution<2>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * ky * square(u),
+      std::array<DataVector, 3>{
+          {-6.0 * omega * ky * u, 6.0 * kx * ky * u, 6.0 * square(ky) * u}},
+      pw, x, t);
 
   Parallel::register_derived_classes_with_charm<MathFunction<1>>();
   const auto deserialized_pw = serialize_and_deserialize(pw);
-  check_solution_x(kx, omega, u, deserialized_pw, x, t);
-  check_solution_y(kx, ky, omega, u, deserialized_pw, x, t);
+  check_solution<1>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * kx * square(u),
+      std::array<DataVector, 2>{{-6.0 * omega * kx * u, 6.0 * square(kx) * u}},
+      deserialized_pw, x, t);
+  check_solution<2>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * ky * square(u),
+      std::array<DataVector, 3>{
+          {-6.0 * omega * ky * u, 6.0 * kx * ky * u, 6.0 * square(ky) * u}},
+      deserialized_pw, x, t);
 
   test_creation<ScalarWave::Solutions::PlaneWave<2>>(
       "  WaveVector: [-2, 3.5]\n"
@@ -300,15 +226,43 @@ void test_3d() {
   const ScalarWave::Solutions::PlaneWave<3> pw(
       {{kx, ky, kz}}, {{center_x, center_y, center_z}},
       std::make_unique<MathFunctions::PowX>(3));
-  check_solution_x(kx, omega, u, pw, x, t);
-  check_solution_y(kx, ky, omega, u, pw, x, t);
-  check_solution_z(kx, ky, kz, omega, u, pw, x, t);
+  check_solution<1>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * kx * square(u),
+      std::array<DataVector, 2>{{-6.0 * omega * kx * u, 6.0 * square(kx) * u}},
+      pw, x, t);
+  check_solution<2>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * ky * square(u),
+      std::array<DataVector, 3>{
+          {-6.0 * omega * ky * u, 6.0 * kx * ky * u, 6.0 * square(ky) * u}},
+      pw, x, t);
+  check_solution<3>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * kz * square(u),
+      std::array<DataVector, 4>{{-6.0 * omega * kz * u, 6.0 * kx * kz * u,
+                                 6.0 * ky * kz * u, 6.0 * square(kz) * u}},
+      pw, x, t);
 
   Parallel::register_derived_classes_with_charm<MathFunction<1>>();
   const auto deserialized_pw = serialize_and_deserialize(pw);
-  check_solution_x(kx, omega, u, deserialized_pw, x, t);
-  check_solution_y(kx, ky, omega, u, deserialized_pw, x, t);
-  check_solution_z(kx, ky, kz, omega, u, deserialized_pw, x, t);
+  check_solution<1>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * kx * square(u),
+      std::array<DataVector, 2>{{-6.0 * omega * kx * u, 6.0 * square(kx) * u}},
+      deserialized_pw, x, t);
+  check_solution<2>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * ky * square(u),
+      std::array<DataVector, 3>{
+          {-6.0 * omega * ky * u, 6.0 * kx * ky * u, 6.0 * square(ky) * u}},
+      deserialized_pw, x, t);
+  check_solution<3>(
+      cube(u), -3.0 * omega * square(u), 6.0 * square(omega) * u,
+      3.0 * kz * square(u),
+      std::array<DataVector, 4>{{-6.0 * omega * kz * u, 6.0 * kx * kz * u,
+                                 6.0 * ky * kz * u, 6.0 * square(kz) * u}},
+      deserialized_pw, x, t);
 
   test_creation<ScalarWave::Solutions::PlaneWave<3>>(
       "  WaveVector: [-1, -2, 3.5]\n"

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -58,21 +58,39 @@ void check_solution_x(const double kx, const double omega, const DataVector& u,
     CHECK(approx(d2psi_dxdx[s]) == pw.d2psi_dxdx(p, t).get(0, 0));
   }
 
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Psi>(pw.evolution_variables(x, t)),
-                        pw.psi(x, t));
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Phi<Dim>>(pw.evolution_variables(x, t)),
-                        pw.dpsi_dx(x, t));
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Pi>(pw.evolution_variables(x, t)),
-                        Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Psi>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
+      pw.psi(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Phi<Dim>>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
+      pw.dpsi_dx(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Pi>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
+      Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
 
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Psi>>(pw.dt_evolution_variables(x, t)),
+      get<Tags::dt<ScalarWave::Psi>>(pw.variables(
+          x, t,
+          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                     Tags::dt<ScalarWave::Psi>>{})),
       pw.dpsi_dt(x, t));
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Phi<Dim>>>(pw.dt_evolution_variables(x, t)),
+      get<Tags::dt<ScalarWave::Phi<Dim>>>(pw.variables(
+          x, t,
+          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                     Tags::dt<ScalarWave::Psi>>{})),
       pw.d2psi_dtdx(x, t));
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Pi>>(pw.dt_evolution_variables(x, t)),
+      get<Tags::dt<ScalarWave::Pi>>(pw.variables(
+          x, t,
+          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                     Tags::dt<ScalarWave::Psi>>{})),
       Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
 }
 
@@ -99,21 +117,39 @@ void check_solution_y(const double kx, const double ky, const double omega,
     CHECK(approx(d2psi_dydy[s]) == pw.d2psi_dxdx(p, t).get(1, 1));
   }
 
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Psi>(pw.evolution_variables(x, t)),
-                        pw.psi(x, t));
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Phi<Dim>>(pw.evolution_variables(x, t)),
-                        pw.dpsi_dx(x, t));
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Pi>(pw.evolution_variables(x, t)),
-                        Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Psi>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
+      pw.psi(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Phi<Dim>>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
+      pw.dpsi_dx(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Pi>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<Dim>, ScalarWave::Psi>{})),
+      Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
 
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Psi>>(pw.dt_evolution_variables(x, t)),
+      get<Tags::dt<ScalarWave::Psi>>(pw.variables(
+          x, t,
+          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                     Tags::dt<ScalarWave::Psi>>{})),
       pw.dpsi_dt(x, t));
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Phi<Dim>>>(pw.dt_evolution_variables(x, t)),
+      get<Tags::dt<ScalarWave::Phi<Dim>>>(pw.variables(
+          x, t,
+          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                     Tags::dt<ScalarWave::Psi>>{})),
       pw.d2psi_dtdx(x, t));
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Pi>>(pw.dt_evolution_variables(x, t)),
+      get<Tags::dt<ScalarWave::Pi>>(pw.variables(
+          x, t,
+          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<Dim>>,
+                     Tags::dt<ScalarWave::Psi>>{})),
       Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
 }
 
@@ -144,21 +180,39 @@ void check_solution_z(const double kx, const double ky, const double kz,
     CHECK(approx(d2psi_dzdz[s]) == pw.d2psi_dxdx(p, t).get(2, 2));
   }
 
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Psi>(pw.evolution_variables(x, t)),
-                        pw.psi(x, t));
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Phi<3>>(pw.evolution_variables(x, t)),
-                        pw.dpsi_dx(x, t));
-  CHECK_ITERABLE_APPROX(get<ScalarWave::Pi>(pw.evolution_variables(x, t)),
-                        Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Psi>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{})),
+      pw.psi(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Phi<3>>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{})),
+      pw.dpsi_dx(x, t));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Pi>(pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{})),
+      Scalar<DataVector>(-1.0 * pw.dpsi_dt(x, t).get()));
 
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Psi>>(pw.dt_evolution_variables(x, t)),
+      get<Tags::dt<ScalarWave::Psi>>(pw.variables(
+          x, t,
+          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
+                     Tags::dt<ScalarWave::Psi>>{})),
       pw.dpsi_dt(x, t));
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Phi<3>>>(pw.dt_evolution_variables(x, t)),
+      get<Tags::dt<ScalarWave::Phi<3>>>(pw.variables(
+          x, t,
+          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
+                     Tags::dt<ScalarWave::Psi>>{})),
       pw.d2psi_dtdx(x, t));
   CHECK_ITERABLE_APPROX(
-      get<Tags::dt<ScalarWave::Pi>>(pw.dt_evolution_variables(x, t)),
+      get<Tags::dt<ScalarWave::Pi>>(pw.variables(
+          x, t,
+          tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
+                     Tags::dt<ScalarWave::Psi>>{})),
       Scalar<DataVector>(-1.0 * pw.d2psi_dt2(x, t).get()));
 }
 

--- a/tests/Unit/TestingFramework.hpp
+++ b/tests/Unit/TestingFramework.hpp
@@ -29,6 +29,23 @@ void SPECTRE_TEST_REGISTER_FUNCTION() noexcept {} // NOLINT
 #endif // SPECTRE_TEST_REGISTER_FUNCTION
 /// \endcond
 
+namespace TestHelpers_detail {
+template <typename T>
+std::string format_capture_precise(const T& t) noexcept {
+  std::ostringstream os;
+  os << std::scientific << std::setprecision(18) << t;
+  return os.str();
+}
+}  // namespace TestHelpers_detail
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Alternative to Catch's CAPTURE that prints more digits.
+ */
+#define CAPTURE_PRECISE(variable)                                    \
+  INFO(#variable << ": "                                             \
+       << TestHelpers_detail::format_capture_precise(variable))
+
 /*!
  * \ingroup TestingFrameworkGroup
  * \brief A replacement for Catch's TEST_CASE that silences clang-tidy warnings
@@ -117,6 +134,8 @@ template <typename T, typename = std::nullptr_t>
 struct check_iterable_approx {
   // clang-tidy: non-const reference
   static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
+    CAPTURE_PRECISE(a);
+    CAPTURE_PRECISE(b);
     CHECK(a == appx(b));
   }
 };
@@ -231,20 +250,3 @@ struct check_iterable_approx<
     Parallel::abort("### No ASSERT tests in release mode ###"); \
   } while (false)
 #endif
-
-namespace TestHelpers_detail {
-template <typename T>
-std::string format_capture_precise(const T& t) noexcept {
-  std::ostringstream os;
-  os << std::scientific << std::setprecision(18) << t;
-  return os.str();
-}
-}  // namespace TestHelpers_detail
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief Alternative to Catch's CAPTURE that prints more digits.
- */
-#define CAPTURE_PRECISE(variable)                                    \
-  INFO(#variable << ": "                                             \
-       << TestHelpers_detail::format_capture_precise(variable))


### PR DESCRIPTION
## Proposed changes

- Add `assign_subset(TaggedTuple)` 
- Use a `TaggedTuple<Tags...> variables(x, t, tmpl::list<Tags...>)` method to replace `evolution_variables` and `dt_evolution_variables` in `ScalarWave::PlaneWave` analytic solution. This interface will allow us to overload the `variables` function for retrieving different variables. For example, in EinsteinSolutions we can overload it for the 3+1 variables and the GH variables.
- Adds the `variables` function to Minkowski and KerrSchild einstein solutions
- Use unified interface to reduce the size of `Test_Strahlkorper.cpp` 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
