### PR TITLE
Fix NumPy API working for multiple cpp files, also refactor Christoffel to use Pypp. 

### DIFF
--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTests.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTests.py
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def christoffel_first_kind(d_metric):
+    dim = d_metric.shape[0]
+    return 0.5 * np.array([[[d_metric[b, c, a] + d_metric[a, c, b] - d_metric[
+        c, a, b] for b in range(dim)] for a in range(dim)] for c in range(dim)])

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Christoffel.cpp
@@ -3,175 +3,50 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "tests/Unit/DataStructures/TestHelpers.hpp"
 #include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
+#include "tests/Unit/Pypp/Pypp.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestingFramework.hpp"
 
 namespace {
-void test_1d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
-  const size_t spatial_dim = 1;
-  const auto christoffel = gr::christoffel_first_kind(
-      make_deriv_spatial_metric<spatial_dim>(0.));
-  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
 
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::christoffel_first_kind(
-          make_deriv_spatial_metric<spatial_dim>(used_for_size)),
-      christoffel);
-}
+template <size_t Dim, IndexType Index, typename DataType>
+void test_christoffel(const DataType& used_for_size) {
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed" << seed);
+  std::uniform_real_distribution<> dist(-10., 10.);
 
-void test_2d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
-  const size_t spatial_dim = 2;
-  const auto christoffel = gr::christoffel_first_kind(
-      make_deriv_spatial_metric<spatial_dim>(0.));
-  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
-  CHECK(christoffel.get(0, 0, 1) == approx(2.0));
-  CHECK(christoffel.get(0, 1, 1) == approx(1.0));
-  CHECK(christoffel.get(1, 0, 0) == approx(4.0));
-  CHECK(christoffel.get(1, 0, 1) == approx(6.0));
-  CHECK(christoffel.get(1, 1, 1) == approx(6.5));
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_dist = make_not_null(&dist);
 
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::christoffel_first_kind(
-          make_deriv_spatial_metric<spatial_dim>(used_for_size)),
-      christoffel);
-}
-
-void test_3d_spatial_christoffel_first_kind(const DataVector &used_for_size) {
-  const size_t spatial_dim = 3;
-  const auto christoffel = gr::christoffel_first_kind(
-      make_deriv_spatial_metric<spatial_dim>(0.));
-  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
-  CHECK(christoffel.get(0, 0, 1) == approx(2.0));
-  CHECK(christoffel.get(0, 0, 2) == approx(2.5));
-  CHECK(christoffel.get(0, 1, 1) == approx(1.0));
-  CHECK(christoffel.get(0, 1, 2) == approx(0.0));
-  CHECK(christoffel.get(0, 2, 2) == approx(-2.5));
-  CHECK(christoffel.get(1, 0, 0) == approx(4.0));
-  CHECK(christoffel.get(1, 0, 1) == approx(6.0));
-  CHECK(christoffel.get(1, 0, 2) == approx(8.0));
-  CHECK(christoffel.get(1, 1, 1) == approx(6.5));
-  CHECK(christoffel.get(1, 1, 2) == approx(7.0));
-  CHECK(christoffel.get(1, 2, 2) == approx(6.0));
-  CHECK(christoffel.get(2, 0, 0) == approx(6.5));
-  CHECK(christoffel.get(2, 0, 1) == approx(10.0));
-  CHECK(christoffel.get(2, 0, 2) == approx(13.5));
-  CHECK(christoffel.get(2, 1, 1) == approx(12.0));
-  CHECK(christoffel.get(2, 1, 2) == approx(14.0));
-  CHECK(christoffel.get(2, 2, 2) == approx(14.5));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::christoffel_first_kind(
-          make_deriv_spatial_metric<spatial_dim>(used_for_size)),
-      christoffel);
-}
-
-void test_1d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
-  const size_t spatial_dim = 1;
-  const auto christoffel = gr::christoffel_first_kind(
-      make_spacetime_deriv_spacetime_metric<spatial_dim>(0.));
-  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
-  CHECK(christoffel.get(0, 0, 1) == approx(2.0));
-  CHECK(christoffel.get(0, 1, 1) == approx(2.0));
-  CHECK(christoffel.get(1, 0, 0) == approx(4.0));
-  CHECK(christoffel.get(1, 0, 1) == approx(6.0));
-  CHECK(christoffel.get(1, 1, 1) == approx(8.0));
-
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::christoffel_first_kind(
-          make_spacetime_deriv_spacetime_metric<spatial_dim>(used_for_size)),
-      christoffel);
-}
-
-void test_2d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
-  const size_t spatial_dim = 2;
-  const auto christoffel = gr::christoffel_first_kind(
-      make_spacetime_deriv_spacetime_metric<spatial_dim>(0.));
-  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
-  CHECK(christoffel.get(0, 0, 1) == approx(2.0));
-  CHECK(christoffel.get(0, 0, 2) == approx(2.5));
-  CHECK(christoffel.get(0, 1, 1) == approx(2.0));
-  CHECK(christoffel.get(0, 1, 2) == approx(2.0));
-  CHECK(christoffel.get(0, 2, 2) == approx(1.5));
-  CHECK(christoffel.get(1, 0, 0) == approx(4.0));
-  CHECK(christoffel.get(1, 0, 1) == approx(6.0));
-  CHECK(christoffel.get(1, 0, 2) == approx(8.0));
-  CHECK(christoffel.get(1, 1, 1) == approx(8.0));
-  CHECK(christoffel.get(1, 1, 2) == approx(10.0));
-  CHECK(christoffel.get(1, 2, 2) == approx(12.0));
-  CHECK(christoffel.get(2, 0, 0) == approx(6.5));
-  CHECK(christoffel.get(2, 0, 1) == approx(10.0));
-  CHECK(christoffel.get(2, 0, 2) == approx(13.5));
-  CHECK(christoffel.get(2, 1, 1) == approx(14.0));
-  CHECK(christoffel.get(2, 1, 2) == approx(18.0));
-  CHECK(christoffel.get(2, 2, 2) == approx(22.5));
-
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::christoffel_first_kind(
-          make_spacetime_deriv_spacetime_metric<spatial_dim>(used_for_size)),
-      christoffel);
-}
-
-void test_3d_spacetime_christoffel_first_kind(const DataVector &used_for_size) {
-  const size_t spatial_dim = 3;
-  const auto christoffel = gr::christoffel_first_kind(
-      make_spacetime_deriv_spacetime_metric<spatial_dim>(0.));
-  CHECK(christoffel.get(0, 0, 0) == approx(1.5));
-  CHECK(christoffel.get(0, 0, 1) == approx(2.));
-  CHECK(christoffel.get(0, 0, 2) == approx(2.5));
-  CHECK(christoffel.get(0, 0, 3) == approx(3.));
-  CHECK(christoffel.get(0, 1, 1) == approx(2.));
-  CHECK(christoffel.get(0, 1, 2) == approx(2.));
-  CHECK(christoffel.get(0, 1, 3) == approx(2.));
-  CHECK(christoffel.get(0, 2, 2) == approx(1.5));
-  CHECK(christoffel.get(0, 2, 3) == approx(1.));
-  CHECK(christoffel.get(0, 3, 3) == approx(0.));
-  CHECK(christoffel.get(1, 0, 0) == approx(4.));
-  CHECK(christoffel.get(1, 0, 1) == approx(6.));
-  CHECK(christoffel.get(1, 0, 2) == approx(8.));
-  CHECK(christoffel.get(1, 0, 3) == approx(10.));
-  CHECK(christoffel.get(1, 1, 1) == approx(8.));
-  CHECK(christoffel.get(1, 1, 2) == approx(10.));
-  CHECK(christoffel.get(1, 1, 3) == approx(12.));
-  CHECK(christoffel.get(1, 2, 2) == approx(12.));
-  CHECK(christoffel.get(1, 2, 3) == approx(14.));
-  CHECK(christoffel.get(1, 3, 3) == approx(16.));
-  CHECK(christoffel.get(2, 0, 0) == approx(6.5));
-  CHECK(christoffel.get(2, 0, 1) == approx(10.));
-  CHECK(christoffel.get(2, 0, 2) == approx(13.5));
-  CHECK(christoffel.get(2, 0, 3) == approx(17.));
-  CHECK(christoffel.get(2, 1, 1) == approx(14.));
-  CHECK(christoffel.get(2, 1, 2) == approx(18.));
-  CHECK(christoffel.get(2, 1, 3) == approx(22.));
-  CHECK(christoffel.get(2, 2, 2) == approx(22.5));
-  CHECK(christoffel.get(2, 2, 3) == approx(27.));
-  CHECK(christoffel.get(2, 3, 3) == approx(32.));
-  CHECK(christoffel.get(3, 0, 0) == approx(9.));
-  CHECK(christoffel.get(3, 0, 1) == approx(14.));
-  CHECK(christoffel.get(3, 0, 2) == approx(19.));
-  CHECK(christoffel.get(3, 0, 3) == approx(24.));
-  CHECK(christoffel.get(3, 1, 1) == approx(20.));
-  CHECK(christoffel.get(3, 1, 2) == approx(26.));
-  CHECK(christoffel.get(3, 1, 3) == approx(32.));
-  CHECK(christoffel.get(3, 2, 2) == approx(33.));
-  CHECK(christoffel.get(3, 2, 3) == approx(40.));
-  CHECK(christoffel.get(3, 3, 3) == approx(48.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::christoffel_first_kind(
-          make_spacetime_deriv_spacetime_metric<spatial_dim>(used_for_size)),
-      christoffel);
+  const auto d_metric =
+      make_with_random_values<tnsr::abb<DataType, Dim, Frame::Inertial, Index>>(
+          nn_generator, nn_dist, used_for_size);
+  CHECK_ITERABLE_APPROX(
+      (gr::christoffel_first_kind(d_metric)),
+      (pypp::call<tnsr::abb<DataType, Dim, Frame::Inertial, Index>>(
+          "GrTests", "christoffel_first_kind", d_metric)));
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Christoffel.",
                   "[PointwiseFunctions][Unit]") {
-  const DataVector dv(2);
-  test_1d_spatial_christoffel_first_kind(dv);
-  test_2d_spatial_christoffel_first_kind(dv);
-  test_3d_spatial_christoffel_first_kind(dv);
-  test_1d_spacetime_christoffel_first_kind(dv);
-  test_2d_spacetime_christoffel_first_kind(dv);
-  test_3d_spacetime_christoffel_first_kind(dv);
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
+  const DataVector dv(5);
+  test_christoffel<1, IndexType::Spatial>(dv);
+  test_christoffel<2, IndexType::Spatial>(dv);
+  test_christoffel<3, IndexType::Spatial>(dv);
+  test_christoffel<1, IndexType::Spacetime>(dv);
+  test_christoffel<2, IndexType::Spacetime>(dv);
+  test_christoffel<3, IndexType::Spacetime>(dv);
+  test_christoffel<1, IndexType::Spatial>(0.);
+  test_christoffel<2, IndexType::Spatial>(0.);
+  test_christoffel<3, IndexType::Spatial>(0.);
+  test_christoffel<1, IndexType::Spacetime>(0.);
+  test_christoffel<2, IndexType::Spacetime>(0.);
+  test_christoffel<3, IndexType::Spacetime>(0.);
 }

--- a/tests/Unit/Pypp/CMakeLists.txt
+++ b/tests/Unit/Pypp/CMakeLists.txt
@@ -1,9 +1,14 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+SET(LIBRARY_SOURCES
+    SetupLocalPythonEnvironment.cpp
+    Test_Pypp.cpp
+    )
+
 add_test_library(
   "Test_Pypp"
   "Pypp"
-  "Test_Pypp.cpp"
+  "${LIBRARY_SOURCES}"
   ""
   )

--- a/tests/Unit/Pypp/PyppFundamentals.hpp
+++ b/tests/Unit/Pypp/PyppFundamentals.hpp
@@ -13,6 +13,13 @@
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
+
+// These macros are required so that the NumPy API will work when used in
+// multiple cpp files.
+#ifndef PY_ARRAY_UNIQUE_SYMBOL
+#define PY_ARRAY_UNIQUE_SYMBOL SPECTRE_PY_API
+#endif
+#define NO_IMPORT_ARRAY
 // Disable compiler warnings. NumPy ensures API compatibility among different
 // 1.x versions, as features become deprecated in Numpy 1.x will still function
 // but cause a compiler warning

--- a/tests/Unit/Pypp/SetupLocalPythonEnvironment.cpp
+++ b/tests/Unit/Pypp/SetupLocalPythonEnvironment.cpp
@@ -9,6 +9,7 @@
 #endif
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <Python.h>
 #include <numpy/arrayobject.h>
 
 #include "ErrorHandling/FloatingPointExceptions.hpp"

--- a/tests/Unit/Pypp/SetupLocalPythonEnvironment.cpp
+++ b/tests/Unit/Pypp/SetupLocalPythonEnvironment.cpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <codecvt>
+#include <string>
+
+#ifndef PY_ARRAY_UNIQUE_SYMBOL
+#define PY_ARRAY_UNIQUE_SYMBOL SPECTRE_PY_API
+#endif
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Informer/InfoFromBuild.hpp"
+#include "tests/Unit/Pypp/PyppFundamentals.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace pypp {
+SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
+    const std::string &cur_dir_relative_to_unit_test_path) {
+  Py_Initialize();
+  disable_floating_point_exceptions();
+  init_numpy();
+  enable_floating_point_exceptions();
+  // clang-tidy: Do not use const-cast
+  PyObject *pyob_old_paths =
+      PySys_GetObject(const_cast<char *>("path"));  // NOLINT
+  const auto old_paths =
+      pypp::from_py_object<std::vector<std::string>>(pyob_old_paths);
+  std::string new_path = unit_test_path() + cur_dir_relative_to_unit_test_path;
+  for (const auto &p : old_paths) {
+    new_path += ":";
+    new_path += p;
+  }
+
+
+#if PY_MAJOR_VERSION == 3
+  PySys_SetPath(std::wstring_convert<std::codecvt_utf8<wchar_t>>()
+                    .from_bytes(new_path)
+                    .c_str());
+#else
+  // clang-tidy: Do not use const-cast
+  PySys_SetPath(const_cast<char*>(new_path.c_str()));  // NOLINT
+#endif
+}
+
+SetupLocalPythonEnvironment::~SetupLocalPythonEnvironment() { Py_Finalize(); }
+
+#if PY_MAJOR_VERSION == 3
+std::nullptr_t SetupLocalPythonEnvironment::init_numpy() {
+  import_array();
+  return nullptr;
+}
+#else
+void SetupLocalPythonEnvironment::init_numpy() { import_array(); }
+#endif
+}  // namespace pypp

--- a/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp
+++ b/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+
 /// Contains all functions for pypp
 namespace pypp {
 /// Enable calling of python in the local scope, and add directory(ies) to the

--- a/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp
+++ b/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp
@@ -3,51 +3,17 @@
 
 #pragma once
 
-#include <codecvt>
 #include <string>
-
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
-
-#include "ErrorHandling/FloatingPointExceptions.hpp"
-#include "Informer/InfoFromBuild.hpp"
-#include "tests/Unit/Pypp/PyppFundamentals.hpp"
-
 /// Contains all functions for pypp
 namespace pypp {
-
 /// Enable calling of python in the local scope, and add directory(ies) to the
 /// front of the search path for modules. The directory which is appended to the
 /// path is relative to the `tests/Unit` directory.
 struct SetupLocalPythonEnvironment {
   explicit SetupLocalPythonEnvironment(
-      const std::string& cur_dir_relative_to_unit_test_path) {
-    Py_Initialize();
-    disable_floating_point_exceptions();
-    init_numpy();
-    enable_floating_point_exceptions();
-    // clang-tidy: Do not use const-cast
-    PyObject* pyob_old_paths =
-        PySys_GetObject(const_cast<char*>("path"));  // NOLINT
-    const auto old_paths =
-        pypp::from_py_object<std::vector<std::string>>(pyob_old_paths);
-    std::string new_path =
-        unit_test_path() + cur_dir_relative_to_unit_test_path;
-    for (const auto& p : old_paths) {
-      new_path += ":";
-      new_path += p;
-    }
+      const std::string& cur_dir_relative_to_unit_test_path);
 
-#if PY_MAJOR_VERSION == 3
-    PySys_SetPath(std::wstring_convert<std::codecvt_utf8<wchar_t>>()
-                      .from_bytes(new_path)
-                      .c_str());
-#else
-    // clang-tidy: Do not use const-cast
-    PySys_SetPath(const_cast<char*>(new_path.c_str()));  // NOLINT
-#endif
-  }
-  ~SetupLocalPythonEnvironment() { Py_Finalize(); }
+  ~SetupLocalPythonEnvironment();
 
   SetupLocalPythonEnvironment(const SetupLocalPythonEnvironment&) = delete;
   SetupLocalPythonEnvironment& operator=(const SetupLocalPythonEnvironment&) =
@@ -62,12 +28,9 @@ struct SetupLocalPythonEnvironment {
 // in python 2. As such it needs to be factored into its own function which
 // returns either nullptr or void depending on the version.
 #if PY_MAJOR_VERSION == 3
-  std::nullptr_t init_numpy() {
-    import_array();
-    return nullptr;
-  }
+  std::nullptr_t init_numpy();
 #else
-  void init_numpy() { import_array(); }
+  void init_numpy();
 #endif
 };
 }  // namespace pypp

--- a/tests/Unit/Pypp/Test_Pypp.cpp
+++ b/tests/Unit/Pypp/Test_Pypp.cpp
@@ -166,8 +166,6 @@ SPECTRE_TEST_CASE("Unit.Pypp.Tensor.Double", "[Pypp][Unit]") {
     return tnsr;
   }();
 
-
-
   // Check converting from Tensor to ndarray
   CHECK(pypp::call<bool>("PyppPyTests", "convert_scalar_successful", scalar));
   CHECK(pypp::call<bool>("PyppPyTests", "convert_vector_successful", vector));
@@ -283,8 +281,8 @@ SPECTRE_TEST_CASE("Unit.Pypp.Tensor.DataVector", "[Pypp][Unit]") {
 }
 
 namespace {
-template<typename T>
-void test_einsum(const T &used_for_size) {
+template <typename T>
+void test_einsum(const T& used_for_size) {
   std::random_device r;
   const auto seed = r();
   std::mt19937 generator(seed);
@@ -295,25 +293,19 @@ void test_einsum(const T &used_for_size) {
   const auto nn_dist = make_not_null(&dist);
 
   const auto scalar =
-      make_with_random_values < Scalar
-          < T >> (nn_generator, nn_dist, used_for_size);
-  const auto vector = make_with_random_values < tnsr::A < T,
-  3 >> (
+      make_with_random_values<Scalar<T>>(nn_generator, nn_dist, used_for_size);
+  const auto vector = make_with_random_values<tnsr::A<T, 3>>(
       nn_generator, nn_dist, used_for_size);
-  const auto tnsr_ia = make_with_random_values < tnsr::ia < T,
-  3 >> (
+  const auto tnsr_ia = make_with_random_values<tnsr::ia<T, 3>>(
       nn_generator, nn_dist, used_for_size);
-  const auto tnsr_AA = make_with_random_values < tnsr::AA < T,
-  3 >> (
+  const auto tnsr_AA = make_with_random_values<tnsr::AA<T, 3>>(
       nn_generator, nn_dist, used_for_size);
-  const auto tnsr_iaa = make_with_random_values < tnsr::iaa < T,
-  3 >> (
+  const auto tnsr_iaa = make_with_random_values<tnsr::iaa<T, 3>>(
       nn_generator, nn_dist, used_for_size);
 
   const auto expected = [&scalar, &vector, &tnsr_ia, &tnsr_AA, &tnsr_iaa,
-      &used_for_size]() {
-    auto tnsr = make_with_value < tnsr::i < T,
-    3 >> (used_for_size, 0.);
+                         &used_for_size]() {
+    auto tnsr = make_with_value<tnsr::i<T, 3>>(used_for_size, 0.);
     for (size_t i = 0; i < 3; ++i) {
       for (size_t a = 0; a < 4; ++a) {
         tnsr.get(i) += scalar.get() * vector.get(a) * tnsr_ia.get(i, a);
@@ -325,13 +317,12 @@ void test_einsum(const T &used_for_size) {
     return tnsr;
   }();
   /// [einsum_example]
-  const auto tensor_from_python = pypp::call < tnsr::i < T,
-  3 >> (
+  const auto tensor_from_python = pypp::call<tnsr::i<T, 3>>(
       "PyppPyTests", "test_einsum", scalar, vector, tnsr_ia, tnsr_AA, tnsr_iaa);
   /// [einsum_example]
   CHECK_ITERABLE_APPROX(expected, tensor_from_python);
 }
-} // namespace
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Pypp.EinSum", "[Pypp][Unit]") {
   pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};

--- a/tests/Unit/TestingFramework.hpp
+++ b/tests/Unit/TestingFramework.hpp
@@ -25,7 +25,7 @@
 // add_test_library CMake function. It is used to make a call into a translation
 // unit so that static variables for Catch are properly initialized.
 #ifdef SPECTRE_TEST_REGISTER_FUNCTION
-void SPECTRE_TEST_REGISTER_FUNCTION() noexcept {}
+void SPECTRE_TEST_REGISTER_FUNCTION() noexcept {} // NOLINT
 #endif // SPECTRE_TEST_REGISTER_FUNCTION
 /// \endcond
 


### PR DESCRIPTION
## Proposed changes

The NumPy API didn't work when used in several cpp files. The solution was to refactor where the `import_numpy` call was happening into a cpp file and add some macros which are used by the python internals. To make sure it now works with multiple cpp files I refactored the Christoffel tests. 

Fixes #606 

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`
