### PR TITLE
Add volume fluxes for the Newtonian Euler system

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY NewtonianEuler)
 
 set(LIBRARY_SOURCES
+    Fluxes.cpp
     PrimitiveFromConservative.cpp
     )
 

--- a/src/Evolution/Systems/NewtonianEuler/Fluxes.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Fluxes.cpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Fluxes.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/// \cond
+namespace NewtonianEuler {
+
+template <size_t Dim>
+void ComputeFluxes<Dim>::apply(
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> mass_density_flux,
+    const gsl::not_null<tnsr::IJ<DataVector, Dim>*> momentum_density_flux,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> energy_density_flux,
+    const tnsr::I<DataVector, Dim>& momentum_density,
+    const Scalar<DataVector>& energy_density,
+    const tnsr::I<DataVector, Dim>& velocity,
+    const Scalar<DataVector>& pressure) noexcept {
+  const DataVector enthalpy_density = get(energy_density) + get(pressure);
+
+  for (size_t i = 0; i < Dim; ++i) {
+    mass_density_flux->get(i) = momentum_density.get(i);
+    for (size_t j = 0; j < Dim; ++j) {
+      momentum_density_flux->get(i, j) =
+          momentum_density.get(i) * velocity.get(j);
+    }
+    momentum_density_flux->get(i, i) += get(pressure);
+    energy_density_flux->get(i) = enthalpy_density * velocity.get(i);
+  }
+}
+
+}  // namespace NewtonianEuler
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) \
+  template class NewtonianEuler::ComputeFluxes<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/Fluxes.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Fluxes.hpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+class DataVector;
+
+namespace Tags {
+template <typename>
+struct Fluxes;
+}  // namespace Tags
+
+namespace NewtonianEuler {
+struct MassDensity;
+template <size_t Dim>
+struct MomentumDensity;
+struct EnergyDensity;
+template <size_t Dim>
+struct Velocity;
+struct Pressure;
+}  // namespace NewtonianEuler
+/// \endcond
+
+namespace NewtonianEuler {
+
+/*!
+ * \brief Compute the fluxes of the conservative variables of the
+ * Newtonian Euler system
+ *
+ * The fluxes are \f$(\text{Dim} + 2)\f$ vectors of
+ * dimension \f$\text{Dim}\f$. Denoting the flux of the conservative
+ * variable \f$u\f$ as \f$F(u)\f$, one has
+ *
+ * \f{align*}
+ * F^i(\rho) &= S^i\\
+ * F^i(S^j) &= S^i v^j + \delta^{ij}p\\
+ * F^i(e) &= (e + p)v^i
+ * \f}
+ *
+ * where \f$S^i\f$ is the momentum density, \f$e\f$ is the energy density,
+ * \f$v^i\f$ is the velocity, \f$p\f$ is the pressure, and \f$\delta^{ij}\f$
+ * is the Kronecker delta. This form of the fluxes combines conservative and
+ * primitive variables (while the velocity appears explicitly, the pressure
+ * implicitly depends, for instance, on the mass density and the specific
+ * internal energy), so the conversion from one variable set to the other
+ * must be known prior to calling this function.
+ */
+template <size_t Dim>
+struct ComputeFluxes {
+  using return_tags =
+      tmpl::list<Tags::Fluxes<MassDensity>, Tags::Fluxes<MomentumDensity<Dim>>,
+                 Tags::Fluxes<EnergyDensity>>;
+
+  using argument_tags =
+      tmpl::list<MomentumDensity<Dim>, EnergyDensity, Velocity<Dim>, Pressure>;
+
+  static void apply(
+      gsl::not_null<tnsr::I<DataVector, Dim>*> mass_density_flux,
+      gsl::not_null<tnsr::IJ<DataVector, Dim>*> momentum_density_flux,
+      gsl::not_null<tnsr::I<DataVector, Dim>*> energy_density_flux,
+      const tnsr::I<DataVector, Dim>& momentum_density,
+      const Scalar<DataVector>& energy_density,
+      const tnsr::I<DataVector, Dim>& velocity,
+      const Scalar<DataVector>& pressure) noexcept;
+};
+
+}  // namespace NewtonianEuler

--- a/src/Evolution/Systems/NewtonianEuler/System.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/System.hpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \ingroup EvolutionSystemsGroup
+/// \brief Items related to evolving the Newtonian Euler system
+namespace NewtonianEuler {
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+};
+
+}  // namespace NewtonianEuler

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_NewtonianEuler")
 
 set(LIBRARY_SOURCES
+  Test_Fluxes.cpp
   Test_PrimitiveFromConservative.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
@@ -1,0 +1,18 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def mass_density_flux(momentum_density, energy_density, velocity, pressure):
+    return momentum_density
+
+
+def momentum_density_flux(momentum_density, energy_density, velocity, pressure):
+    result = np.outer(momentum_density, velocity)
+    result += pressure * np.identity(velocity.size)
+    return result
+
+
+def energy_density_flux(momentum_density, energy_density, velocity, pressure):
+    return (energy_density + pressure) * velocity

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Fluxes.cpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/NewtonianEuler/Fluxes.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestingFramework.hpp"
+
+namespace {
+
+template <size_t Dim>
+void test_fluxes(const DataVector& used_for_size) {
+  pypp::check_with_random_values<4>(
+      &NewtonianEuler::ComputeFluxes<Dim>::apply, "TestFunctions",
+      {"mass_density_flux", "momentum_density_flux", "energy_density_flux"},
+      {{{-1.0, 1.0}, {-1.0, 1.0}, {-1.0, 1.0}, {-1.0, 1.0}}}, used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Fluxes",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/NewtonianEuler"};
+
+  const DataVector dv(5);
+  test_fluxes<1>(dv);
+  test_fluxes<2>(dv);
+  test_fluxes<3>(dv);
+}


### PR DESCRIPTION
## Proposed changes

Add the volume fluxes for the Newtonian Euler system.

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
