### PR TITLE
Euclidean tensors

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1085,6 +1085,21 @@ inline const DataBox<TagsList<Tags...>>& DataBox<TagsList<Tags...>>::get_impl()
   return *this;
 }
 
+namespace DataBox_detail {
+// This function (and its unused template argument) exist so that
+// users can see what tag has the wrong type when the static_assert
+// fails.
+template <typename Tag, typename TagType, typename SuppliedType>
+int check_argument_type() {
+  static_assert(cpp17::is_same_v<TagType, SuppliedType>,
+                "The type of each Tag must be the same as the type being "
+                "passed into the function creating the new DataBox.  See the "
+                "function template parameters for the tag, expected type, and "
+                "supplied type.");
+  return 0;
+}
+}  // namespace DataBox_detail
+
 template <template <typename...> class TagsList, typename... Tags>
 template <
     typename... TagsInArgsOrder, typename... FullItems,
@@ -1100,11 +1115,9 @@ constexpr DataBox<TagsList<Tags...>>::DataBox(
       "Must pass in as many (compute) items as there are Tags.");
   static_assert(sizeof...(TagsInArgsOrder) == sizeof...(Args),
                 "Must pass in as many arguments as AddTags");
-  static_assert(
-      tmpl2::flat_all_v<cpp17::is_same_v<typename TagsInArgsOrder::type,
-                                         std::decay_t<Args>>...>,
-      "The type of each Tag must be the same as the type being passed into "
-      "the function creating the new DataBox.");
+  swallow(DataBox_detail::check_argument_type<TagsInArgsOrder,
+                                              typename TagsInArgsOrder::type,
+                                              std::decay_t<Args>>()...);
 
   std::tuple<Args...> args_tuple(std::forward<Args>(args)...);
   databox_detail::add_items_to_box<
@@ -1125,11 +1138,8 @@ constexpr DataBox<TagsList<Tags...>>::DataBox(
     Args&&... args) {
   static_assert(sizeof...(NewTags) == sizeof...(Args),
                 "Must pass in as many arguments as AddTags");
-  static_assert(
-      tmpl2::flat_all_v<
-          cpp17::is_same_v<typename NewTags::type, std::decay_t<Args>>...>,
-      "The type of each Tag must be the same as the type being passed into "
-      "the function creating the new DataBox.");
+  swallow(DataBox_detail::check_argument_type<NewTags, typename NewTags::type,
+                                              std::decay_t<Args>>()...);
 
   check_tags();
   // Merge old tags, including all ComputeItems even though they might be

--- a/src/DataStructures/Tensor/EagerMath/DotProduct.hpp
+++ b/src/DataStructures/Tensor/EagerMath/DotProduct.hpp
@@ -13,40 +13,17 @@
 
 /*!
  * \ingroup TensorGroup
- * \brief Compute the Euclidean dot product of two vectors or one forms
- *
- * \details
- * Returns \f$A^a B^b \delta_{ab}\f$ for input vectors \f$A^a\f$ and \f$B^b\f$
- * or \f$A_a B_b \delta^{ab}\f$ for input one forms \f$A_a\f$ and \f$B_b\f$.
+ * \brief Contract the indices of a pair of rank-1 tensors
  */
-template <typename DataType, typename Index>
+template <typename DataType, typename IndexA, typename IndexB>
 Scalar<DataType> dot_product(
-    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector_a,
-    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector_b) noexcept {
-  auto dot_product = make_with_value<Scalar<DataType>>(vector_a, 0.);
-  for (size_t d = 0; d < Index::dim; ++d) {
-    get(dot_product) += vector_a.get(d) * vector_b.get(d);
-  }
-  return dot_product;
-}
-
-/*!
- * \ingroup TensorGroup
- * \brief Compute the dot product of a vector and a one form
- *
- * \details
- * Returns \f$A^a B_b \delta_{a}^b\f$ for input vector \f$A^a\f$ and
- * input one form \f$B_b\f$
- * or \f$A_a B^b \delta^a_b\f$ for input one form \f$A_a\f$ and
- * input vector \f$B^b\f$.
- */
-template <typename DataType, typename Index>
-Scalar<DataType> dot_product(
-    const Tensor<DataType, Symmetry<1>, tmpl::list<Index>>& vector_a,
-    const Tensor<DataType, Symmetry<1>, tmpl::list<change_index_up_lo<Index>>>&
+    const Tensor<DataType, Symmetry<1>, tmpl::list<IndexA>>& vector_a,
+    const Tensor<DataType, Symmetry<1>, tmpl::list<IndexB>>&
         vector_b) noexcept {
+  static_assert(can_contract_v<IndexA, IndexB>,
+                "Noncontractible tensors passed to dot_product");
   auto dot_product = make_with_value<Scalar<DataType>>(vector_a, 0.);
-  for (size_t d = 0; d < Index::dim; ++d) {
+  for (size_t d = 0; d < IndexA::dim; ++d) {
     get(dot_product) += vector_a.get(d) * vector_b.get(d);
   }
   return dot_product;

--- a/src/DataStructures/Tensor/IndexType.hpp
+++ b/src/DataStructures/Tensor/IndexType.hpp
@@ -11,6 +11,7 @@
 
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/Literals.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 namespace brigand {
@@ -240,6 +241,28 @@ constexpr bool can_contract_v =
     IndexA::dim == IndexB::dim and
     cpp17::is_same_v<typename IndexA::Frame, typename IndexB::Frame> and
     (IndexA::ul != IndexB::ul or IndexA::ul == UpLo::Euclidean);
+
+/// \ingroup TensorGroup
+/// Whether an index can be converted to another.  They can be if they
+/// are the same or the first is Euclidean.
+//@{
+template <typename From, typename To, typename = std::nullptr_t>
+struct can_convert_index : std::false_type {};
+/// \cond HIDDEN_SYMBOLS
+template <typename From, typename To>
+struct can_convert_index<
+    From, To,
+    Requires<From::index_type == To::index_type and From::dim == To::dim and
+             cpp17::is_same_v<typename From::Frame, typename To::Frame> and
+             (From::ul == To::ul or From::ul == UpLo::Euclidean)>>
+    : std::true_type {};
+/// \endcond
+template <typename From, typename To>
+using can_convert_index_t = typename can_convert_index<From, To>::type;
+
+template <typename From, typename To>
+constexpr bool can_convert_index_v = can_convert_index<From, To>::value;
+//@}
 
 template <typename... Ts>
 using index_list = brigand::list<Ts...>;

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -339,14 +339,8 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   // @{
   /// Get dimensionality of i'th tensor index
   ///
-  /// \details
-  /// Consider the tensor \f$T_{abc}\f$ where the dimensionality of each index
-  /// is \f$(3, 2, 4)\f$, respectively. Then
-  /// \code
-  /// dimensionality(0) = 3;
-  /// dimensionality(1) = 2;
-  /// dimensionality(2) = 4;
-  /// \endcode
+  /// \snippet Test_Tensor.cpp index_dim
+  /// \see ::index_dim
   SPECTRE_ALWAYS_INLINE static constexpr size_t index_dim(
       const size_t i) noexcept {
     static_assert(sizeof...(Indices),
@@ -375,6 +369,9 @@ class Tensor<X, Symm, IndexList<Indices...>> {
 
   //@{
   /// Return array of dimensionality of each index
+  ///
+  /// \snippet Test_Tensor.cpp index_dim
+  /// \see index_dim ::index_dim
   SPECTRE_ALWAYS_INLINE static constexpr std::array<size_t, sizeof...(Indices)>
   index_dims() noexcept {
     return structure::dims();
@@ -423,9 +420,11 @@ class Tensor<X, Symm, IndexList<Indices...>> {
 
  private:
   // clang-tidy: redundant declaration
+  /// \cond
   template <int I, class... Ts>
   friend SPECTRE_ALWAYS_INLINE constexpr size_t index_dim(  // NOLINT
       const Tensor<Ts...>& /*t*/) noexcept;
+  /// \endcond
 
   storage_type data_;
 };
@@ -501,6 +500,8 @@ bool operator!=(const Tensor<X, Symm, IndexList<Indices...>>& lhs,
 
 /// \ingroup TensorGroup
 /// Get dimensionality of i'th tensor index
+///
+/// \snippet Test_Tensor.cpp index_dim
 template <int I, class... Ts>
 SPECTRE_ALWAYS_INLINE constexpr size_t index_dim(
     const Tensor<Ts...>& /*t*/) noexcept {

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -411,6 +411,24 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   std::pair<std::vector<std::string>, std::vector<X>> get_vector_of_data()
       const;
 
+  /// Convert from Euclidean indices to up/down indices.
+  //@{
+  template <typename... OtherIndices,
+            Requires<tmpl::all<tmpl::list<
+                can_convert_index<OtherIndices, Indices>...>>::value> = nullptr>
+  Tensor(Tensor<X, Symm, IndexList<OtherIndices...>>&& other) noexcept
+      : data_(std::move(other.data_)) {}
+
+  template <typename... OtherIndices,
+            Requires<tmpl::all<tmpl::list<
+                can_convert_index<OtherIndices, Indices>...>>::value> = nullptr>
+  Tensor& operator=(
+      Tensor<X, Symm, IndexList<OtherIndices...>>&& other) noexcept {
+    data_ = std::move(other.data_);
+    return *this;
+  }
+  //@}
+
   /// \cond HIDDEN_SYMBOLS
   /// Serialization function used by Charm++
   void pup(PUP::er& p) {  // NOLINT
@@ -419,6 +437,12 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   /// \endcond
 
  private:
+  /// \cond
+  // For the converting constructor
+  template <typename, typename, typename>
+  friend class Tensor;
+  /// \endcond
+
   // clang-tidy: redundant declaration
   /// \cond
   template <int I, class... Ts>

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -97,6 +97,10 @@ using IJ = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
                   index_list<SpatialIndex<SpatialDim, UpLo::Up, Fr>,
                              SpatialIndex<SpatialDim, UpLo::Up, Fr>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using wx = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+index_list<SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>,
+           SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using ia = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
 index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
            SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
@@ -104,6 +108,34 @@ template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using iw = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
 index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
            SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using Iw = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+index_list<SpatialIndex<SpatialDim, UpLo::Up, Fr>,
+           SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using wi = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+index_list<SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>,
+           SpatialIndex<SpatialDim, UpLo::Lo, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using wI = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+index_list<SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>,
+           SpatialIndex<SpatialDim, UpLo::Up, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using aw = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+index_list<SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>,
+           SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using Aw = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+index_list<SpacetimeIndex<SpatialDim, UpLo::Up, Fr>,
+           SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using wa = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+index_list<SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>,
+           SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using wA = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+index_list<SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>,
+           SpacetimeIndex<SpatialDim, UpLo::Up, Fr>>>;
 
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
@@ -127,6 +159,10 @@ template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using II = Tensor<DataType, tmpl::integral_list<std::int32_t, 1, 1>,
                   index_list<SpatialIndex<SpatialDim, UpLo::Up, Fr>,
                              SpatialIndex<SpatialDim, UpLo::Up, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using ww = Tensor<DataType, tmpl::integral_list<std::int32_t, 1, 1>,
+                  index_list<SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>,
+                             SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>>>;
 
 // Rank 3 - spacetime
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -26,7 +26,8 @@ using Scalar = Tensor<T, Symmetry<>, index_list<>>;
  *
  * Lower case letters represent covariant indices and upper case letters
  * represent contravariant indices. Letters a, b, c, d represent spacetime
- * indices and i, j, k, l represent spatial indices.
+ * indices and i, j, k, l represent spatial indices.  Letters near the end
+ * of the alphabet (w, x, y, z) represent Euclidean indices.
  */
 namespace tnsr {
 // Rank 1
@@ -46,6 +47,9 @@ using i = Tensor<DataType, tmpl::integral_list<std::int32_t, 1>,
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using I = Tensor<DataType, tmpl::integral_list<std::int32_t, 1>,
                  index_list<SpatialIndex<SpatialDim, UpLo::Up, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using w = Tensor<DataType, tmpl::integral_list<std::int32_t, 1>,
+                 index_list<SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>>>;
 
 // Rank 2
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
@@ -96,6 +100,10 @@ template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using ia = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
 index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
            SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
+template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
+using iw = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+           SpatialIndex<SpatialDim, UpLo::Euclidean, Fr>>>;
 
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>

--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -16,11 +16,11 @@ namespace ScalarWave {
 template <size_t Dim>
 void ComputeDuDt<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> dt_pi,
-    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
+    const gsl::not_null<tnsr::w<DataVector, Dim, Frame::Inertial>*> dt_phi,
     const gsl::not_null<Scalar<DataVector>*> dt_psi,
     const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
-    const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi) noexcept {
+    const tnsr::iw<DataVector, Dim, Frame::Inertial>& d_phi) noexcept {
   get(*dt_psi) = -get(pi);
   get(*dt_pi) = -get<0, 0>(d_phi);
   for (size_t d = 1; d < Dim; ++d) {
@@ -35,11 +35,11 @@ void ComputeDuDt<Dim>::apply(
 template <size_t Dim>
 void ComputeNormalDotFluxes<Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
-    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+    const gsl::not_null<tnsr::w<DataVector, Dim, Frame::Inertial>*>
         phi_normal_dot_flux,
     const gsl::not_null<Scalar<DataVector>*> psi_normal_dot_flux,
     const Scalar<DataVector>& pi,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const tnsr::w<DataVector, Dim, Frame::Inertial>& phi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>&
         interface_unit_normal) noexcept {
   // We assume that all values of psi_normal_dot_flux are the same. The reason
@@ -63,7 +63,7 @@ template <size_t Dim>
 void UpwindFlux<Dim>::package_data(
     const gsl::not_null<Variables<package_tags>*> packaged_data,
     const Scalar<DataVector>& normal_dot_flux_pi,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_dot_flux_phi,
+    const tnsr::w<DataVector, Dim, Frame::Inertial>& normal_dot_flux_phi,
     const Scalar<DataVector>& /*normal_dot_flux_psi*/,
     const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
@@ -94,17 +94,17 @@ void UpwindFlux<Dim>::package_data(
 template <size_t Dim>
 void UpwindFlux<Dim>::operator()(
     const gsl::not_null<Scalar<DataVector>*> pi_normal_dot_numerical_flux,
-    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+    const gsl::not_null<tnsr::w<DataVector, Dim, Frame::Inertial>*>
         phi_normal_dot_numerical_flux,
     const gsl::not_null<Scalar<DataVector>*> psi_normal_dot_numerical_flux,
     const Scalar<DataVector>& normal_dot_flux_pi_interior,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+    const tnsr::w<DataVector, Dim, Frame::Inertial>&
         normal_dot_flux_phi_interior,
     const Scalar<DataVector>& pi_interior,
     const tnsr::i<DataVector, Dim, Frame::Inertial>&
         normal_times_flux_pi_interior,
     const Scalar<DataVector>& minus_normal_dot_flux_pi_exterior,
-    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+    const tnsr::w<DataVector, Dim, Frame::Inertial>&
         minus_normal_dot_flux_phi_exterior,
     const Scalar<DataVector>& pi_exterior,
     const tnsr::i<DataVector, Dim, Frame::Inertial>&

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -66,10 +66,10 @@ struct ComputeDuDt {
                  Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>;
   static void apply(
       gsl::not_null<Scalar<DataVector>*> dt_pi,
-      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> dt_phi,
+      gsl::not_null<tnsr::w<DataVector, Dim, Frame::Inertial>*> dt_phi,
       gsl::not_null<Scalar<DataVector>*> dt_psi, const Scalar<DataVector>& pi,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& d_pi,
-      const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi) noexcept;
+      const tnsr::iw<DataVector, Dim, Frame::Inertial>& d_phi) noexcept;
 };
 
 /*!
@@ -88,11 +88,11 @@ struct ComputeNormalDotFluxes {
                  Tags::NormalDotFlux<Psi>>;
   using argument_tags = tmpl::list<Pi, Phi<Dim>>;
   static void apply(gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
-                    gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+                    gsl::not_null<tnsr::w<DataVector, Dim, Frame::Inertial>*>
                         phi_normal_dot_flux,
                     gsl::not_null<Scalar<DataVector>*> psi_normal_dot_flux,
                     const Scalar<DataVector>& pi,
-                    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+                    const tnsr::w<DataVector, Dim, Frame::Inertial>& phi,
                     const tnsr::i<DataVector, Dim, Frame::Inertial>&
                         interface_unit_normal) noexcept;
 };
@@ -146,7 +146,7 @@ struct UpwindFlux {
   void package_data(
       gsl::not_null<Variables<package_tags>*> packaged_data,
       const Scalar<DataVector>& normal_dot_flux_pi,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_dot_flux_phi,
+      const tnsr::w<DataVector, Dim, Frame::Inertial>& normal_dot_flux_phi,
       const Scalar<DataVector>& /*normal_dot_flux_psi*/,
       const Scalar<DataVector>& pi,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
@@ -156,17 +156,17 @@ struct UpwindFlux {
   // user-level code
   void operator()(
       gsl::not_null<Scalar<DataVector>*> pi_normal_dot_numerical_flux,
-      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+      gsl::not_null<tnsr::w<DataVector, Dim, Frame::Inertial>*>
           phi_normal_dot_numerical_flux,
       gsl::not_null<Scalar<DataVector>*> psi_normal_dot_numerical_flux,
       const Scalar<DataVector>& normal_dot_flux_pi_interior,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+      const tnsr::w<DataVector, Dim, Frame::Inertial>&
           normal_dot_flux_phi_interior,
       const Scalar<DataVector>& pi_interior,
       const tnsr::i<DataVector, Dim, Frame::Inertial>&
           normal_times_flux_pi_interior,
       const Scalar<DataVector>& minus_normal_dot_flux_pi_exterior,
-      const tnsr::i<DataVector, Dim, Frame::Inertial>&
+      const tnsr::w<DataVector, Dim, Frame::Inertial>&
           minus_normal_dot_flux_phi_exterior,
       const Scalar<DataVector>& pi_exterior,
       const tnsr::i<DataVector, Dim, Frame::Inertial>&

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -26,7 +26,7 @@ struct Pi : db::DataBoxTag {
 
 template <size_t Dim>
 struct Phi : db::DataBoxTag {
-  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+  using type = tnsr::w<DataVector, Dim, Frame::Inertial>;
   static constexpr db::DataBoxString label = "Phi";
 };
 }  // namespace ScalarWave

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.cpp
@@ -35,9 +35,9 @@ Scalar<T> PlaneWave<Dim>::dpsi_dt(const tnsr::I<T, Dim>& x,
 
 template <size_t Dim>
 template <typename T>
-tnsr::i<T, Dim> PlaneWave<Dim>::dpsi_dx(const tnsr::I<T, Dim>& x,
+tnsr::w<T, Dim> PlaneWave<Dim>::dpsi_dx(const tnsr::I<T, Dim>& x,
                                         const double t) const noexcept {
-  auto result = make_with_value<tnsr::i<T, Dim>>(x, 0.0);
+  auto result = make_with_value<tnsr::w<T, Dim>>(x, 0.0);
   const auto du = profile_->first_deriv(u(x, t));
   for (size_t i = 0; i < Dim; ++i) {
     result.get(i) = gsl::at(wave_vector_, i) * du;
@@ -54,9 +54,9 @@ Scalar<T> PlaneWave<Dim>::d2psi_dt2(const tnsr::I<T, Dim>& x,
 
 template <size_t Dim>
 template <typename T>
-tnsr::i<T, Dim> PlaneWave<Dim>::d2psi_dtdx(const tnsr::I<T, Dim>& x,
+tnsr::w<T, Dim> PlaneWave<Dim>::d2psi_dtdx(const tnsr::I<T, Dim>& x,
                                            const double t) const noexcept {
-  auto result = make_with_value<tnsr::i<T, Dim>>(x, 0.0);
+  auto result = make_with_value<tnsr::w<T, Dim>>(x, 0.0);
   const auto d2u = profile_->second_deriv(u(x, t));
   for (size_t i = 0; i < Dim; ++i) {
     result.get(i) = -omega_ * gsl::at(wave_vector_, i) * d2u;
@@ -66,9 +66,9 @@ tnsr::i<T, Dim> PlaneWave<Dim>::d2psi_dtdx(const tnsr::I<T, Dim>& x,
 
 template <size_t Dim>
 template <typename T>
-tnsr::ii<T, Dim> PlaneWave<Dim>::d2psi_dxdx(const tnsr::I<T, Dim>& x,
+tnsr::ww<T, Dim> PlaneWave<Dim>::d2psi_dxdx(const tnsr::I<T, Dim>& x,
                                             const double t) const noexcept {
-  auto result = make_with_value<tnsr::ii<T, Dim>>(x, 0.0);
+  auto result = make_with_value<tnsr::ww<T, Dim>>(x, 0.0);
   const auto d2u = profile_->second_deriv(u(x, t));
   for (size_t i = 0; i < Dim; ++i) {
     for (size_t j = i; j < Dim; ++j) {
@@ -139,7 +139,7 @@ T PlaneWave<Dim>::u(const tnsr::I<T, Dim>& x, const double t) const noexcept {
   template Scalar<DTYPE(data)>                                            \
   ScalarWave::Solutions::PlaneWave<DIM(data)>::dpsi_dt(                   \
       const tnsr::I<DTYPE(data), DIM(data)>& x, double t) const noexcept; \
-  template tnsr::i<DTYPE(data), DIM(data)>                                \
+  template tnsr::w<DTYPE(data), DIM(data)>                                \
   ScalarWave::Solutions::PlaneWave<DIM(data)>::dpsi_dx(                   \
       const tnsr::I<DTYPE(data), DIM(data)>& x, const double t)           \
       const noexcept;                                                     \
@@ -147,11 +147,11 @@ T PlaneWave<Dim>::u(const tnsr::I<T, Dim>& x, const double t) const noexcept {
   ScalarWave::Solutions::PlaneWave<DIM(data)>::d2psi_dt2(                 \
       const tnsr::I<DTYPE(data), DIM(data)>& x, const double t)           \
       const noexcept;                                                     \
-  template tnsr::i<DTYPE(data), DIM(data)>                                \
+  template tnsr::w<DTYPE(data), DIM(data)>                                \
   ScalarWave::Solutions::PlaneWave<DIM(data)>::d2psi_dtdx(                \
       const tnsr::I<DTYPE(data), DIM(data)>& x, const double t)           \
       const noexcept;                                                     \
-  template tnsr::ii<DTYPE(data), DIM(data)>                               \
+  template tnsr::ww<DTYPE(data), DIM(data)>                               \
   ScalarWave::Solutions::PlaneWave<DIM(data)>::d2psi_dxdx(                \
       const tnsr::I<DTYPE(data), DIM(data)>& x, const double t)           \
       const noexcept;                                                     \

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -80,7 +80,7 @@ class PlaneWave {
 
   /// The spatial derivatives of the scalar field
   template <typename T>
-  tnsr::i<T, Dim> dpsi_dx(const tnsr::I<T, Dim>& x, double t) const noexcept;
+  tnsr::w<T, Dim> dpsi_dx(const tnsr::I<T, Dim>& x, double t) const noexcept;
 
   /// The second time derivative of the scalar field
   template <typename T>
@@ -88,11 +88,11 @@ class PlaneWave {
 
   /// The second mixed derivatives of the scalar field
   template <typename T>
-  tnsr::i<T, Dim> d2psi_dtdx(const tnsr::I<T, Dim>& x, double t) const noexcept;
+  tnsr::w<T, Dim> d2psi_dtdx(const tnsr::I<T, Dim>& x, double t) const noexcept;
 
   /// The second spatial derivatives of the scalar field
   template <typename T>
-  tnsr::ii<T, Dim> d2psi_dxdx(const tnsr::I<T, Dim>& x, double t) const
+  tnsr::ww<T, Dim> d2psi_dxdx(const tnsr::I<T, Dim>& x, double t) const
       noexcept;
 
   /// Retrieve the evolution variables at time `t` and spatial coordinates `x`

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_DotProduct.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_DotProduct.cpp
@@ -23,9 +23,22 @@ void check_dot_product(const T& used_for_size) noexcept {
   {
     const tnsr::i<T, 1, Frame::Grid> one_d_covector{{{two}}};
     const tnsr::I<T, 1, Frame::Grid> one_d_vector{{{four}}};
+    const tnsr::w<T, 1, Frame::Grid> one_d_euclidean_a{{{two}}};
+    const tnsr::w<T, 1, Frame::Grid> one_d_euclidean_b{{{four}}};
     CHECK_ITERABLE_APPROX(get(dot_product(one_d_covector, one_d_vector)),
                           eight);
     CHECK_ITERABLE_APPROX(get(dot_product(one_d_vector, one_d_covector)),
+                          eight);
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_covector, one_d_euclidean_a)),
+                          four);
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_euclidean_a, one_d_covector)),
+                          four);
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_vector, one_d_euclidean_a)),
+                          eight);
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_euclidean_a, one_d_vector)),
+                          eight);
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_euclidean_a,
+                                          one_d_euclidean_b)),
                           eight);
 
     const tnsr::i<T, 1, Frame::Grid> negative_one_d_covector{{{minus_three}}};

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_DotProduct.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_DotProduct.cpp
@@ -4,139 +4,88 @@
 #include <catch.hpp>
 
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/TestingFramework.hpp"
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.EuclideanDotProduct",
-                  "[DataStructures][Unit]") {
-  // Check for DataVectors
+namespace {
+template <typename T>
+void check_dot_product(const T& used_for_size) noexcept {
+  const auto one = make_with_value<T>(used_for_size, 1.0);
+  const auto two = make_with_value<T>(used_for_size, 2.0);
+  const auto minus_three = make_with_value<T>(used_for_size, -3.0);
+  const auto four = make_with_value<T>(used_for_size, 4.0);
+  const auto minus_five = make_with_value<T>(used_for_size, -5.0);
+  const auto eight = make_with_value<T>(used_for_size, 8.0);
+  const auto twelve = make_with_value<T>(used_for_size, 12.0);
+  const auto thirteen = make_with_value<T>(used_for_size, 13.0);
+
+  // Check non-metric version
   {
-    const size_t npts = 5;
-    const DataVector one(npts, 1.0);
-    const DataVector two(npts, 2.0);
-    const DataVector minus_three(npts, -3.0);
-    const DataVector four(npts, 4.0);
-    const DataVector minus_five(npts, -5.0);
-    const DataVector twelve(npts, 12.0);
+    const tnsr::i<T, 1, Frame::Grid> one_d_covector{{{two}}};
+    const tnsr::I<T, 1, Frame::Grid> one_d_vector{{{four}}};
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_covector, one_d_vector)),
+                          eight);
+    CHECK_ITERABLE_APPROX(get(dot_product(one_d_vector, one_d_covector)),
+                          eight);
 
-    const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector_a{{{two}}};
-    const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector_b{{{four}}};
-    const tnsr::I<DataVector, 1, Frame::Grid> one_d_vector_c{{{four}}};
-    CHECK_ITERABLE_APPROX(get(dot_product(one_d_covector_a, one_d_covector_b)),
-                          DataVector(npts, 8.0));
-    CHECK_ITERABLE_APPROX(get(dot_product(one_d_covector_a, one_d_vector_c)),
-                          DataVector(npts, 8.0));
-
-    const tnsr::i<DataVector, 1, Frame::Grid> negative_one_d_covector{
-        {{minus_three}}};
-    const tnsr::I<DataVector, 1, Frame::Grid> negative_one_d_vector{
-        {{minus_three}}};
+    const tnsr::i<T, 1, Frame::Grid> negative_one_d_covector{{{minus_three}}};
+    const tnsr::I<T, 1, Frame::Grid> negative_one_d_vector{{{minus_three}}};
     CHECK_ITERABLE_APPROX(
-        get(dot_product(negative_one_d_covector, one_d_covector_b)),
-        DataVector(npts, -12.0));
-    CHECK_ITERABLE_APPROX(
-        get(dot_product(negative_one_d_covector, one_d_vector_c)),
-        DataVector(npts, -12.0));
+        get(dot_product(negative_one_d_covector, negative_one_d_vector)),
+        make_with_value<T>(used_for_size, 9.0));
+    CHECK_ITERABLE_APPROX(get(dot_product(negative_one_d_covector,
+                                          one_d_vector)),
+                          make_with_value<T>(used_for_size, -12.0));
 
-    const tnsr::A<DataVector, 1, Frame::Grid> one_d_vector_a{
+    const tnsr::A<T, 1, Frame::Grid> one_plus_one_d_vector{
         {{minus_three, four}}};
-    const tnsr::A<DataVector, 1, Frame::Grid> one_d_vector_b{{{two, twelve}}};
-    const tnsr::a<DataVector, 1, Frame::Grid> one_d_covector_c{{{two, twelve}}};
-    CHECK_ITERABLE_APPROX(get(dot_product(one_d_vector_a, one_d_vector_b)),
-                          DataVector(npts, 42.0));
-    CHECK_ITERABLE_APPROX(get(dot_product(one_d_vector_a, one_d_covector_c)),
-                          DataVector(npts, 42.0));
+    const tnsr::a<T, 1, Frame::Grid> one_plus_one_d_covector{{{two, twelve}}};
+    CHECK_ITERABLE_APPROX(get(dot_product(one_plus_one_d_vector,
+                                          one_plus_one_d_covector)),
+                          make_with_value<T>(used_for_size, 42.0));
 
-    const tnsr::I<DataVector, 2, Frame::Grid> two_d_vector_a{
+    const tnsr::I<T, 2, Frame::Grid> two_d_vector{
         {{minus_five, twelve}}};
-    const tnsr::I<DataVector, 2, Frame::Grid> two_d_vector_b{{{two, four}}};
-    const tnsr::i<DataVector, 2, Frame::Grid> two_d_covector_b{{{two, four}}};
-    CHECK_ITERABLE_APPROX(get(dot_product(two_d_vector_a, two_d_vector_b)),
-                          DataVector(npts, 38.0));
-    CHECK_ITERABLE_APPROX(get(dot_product(two_d_vector_a, two_d_covector_b)),
-                          DataVector(npts, 38.0));
+    const tnsr::i<T, 2, Frame::Grid> two_d_covector{{{two, four}}};
+    CHECK_ITERABLE_APPROX(get(dot_product(two_d_vector, two_d_covector)),
+                          make_with_value<T>(used_for_size, 38.0));
 
-    const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector_a{
+    const tnsr::i<T, 3, Frame::Grid> three_d_covector{
         {{minus_three, twelve, four}}};
-    const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector_b{
+    const tnsr::I<T, 3, Frame::Grid> three_d_vector{
         {{four, minus_five, two}}};
-    const tnsr::I<DataVector, 3, Frame::Grid> three_d_vector_b{
-        {{four, minus_five, two}}};
-    CHECK_ITERABLE_APPROX(
-        get(dot_product(three_d_covector_a, three_d_covector_b)),
-        DataVector(npts, -64.0));
-    CHECK_ITERABLE_APPROX(
-        get(dot_product(three_d_covector_a, three_d_vector_b)),
-        DataVector(npts, -64.0));
+    CHECK_ITERABLE_APPROX(get(dot_product(three_d_covector, three_d_vector)),
+                          make_with_value<T>(used_for_size, -64.0));
 
     // 5D example
-    const tnsr::a<DataVector, 4, Frame::Grid> five_d_covector_a{
+    const tnsr::a<T, 4, Frame::Grid> five_d_covector{
         {{two, twelve, four, one, two}}};
-    const tnsr::a<DataVector, 4, Frame::Grid> five_d_covector_b{
+    const tnsr::A<T, 4, Frame::Grid> five_d_vector{
         {{minus_five, minus_three, two, four, one}}};
-    const tnsr::A<DataVector, 4, Frame::Grid> five_d_vector_b{
-        {{minus_five, minus_three, two, four, one}}};
-    CHECK_ITERABLE_APPROX(
-        get(dot_product(five_d_covector_a, five_d_covector_b)),
-        DataVector(npts, -32.0));
-    CHECK_ITERABLE_APPROX(
-        get(dot_product(five_d_covector_a, five_d_vector_b)),
-        DataVector(npts, -32.0));
+    CHECK_ITERABLE_APPROX(get(dot_product(five_d_covector, five_d_vector)),
+                          make_with_value<T>(used_for_size, -32.0));
   }
-  // Check case for doubles
+
+  // Check metric versions
   {
-    const tnsr::i<double, 1, Frame::Grid> one_d_covector_double_a{{{2.}}};
-    const tnsr::i<double, 1, Frame::Grid> one_d_covector_double_b{{{4.}}};
-    const tnsr::I<double, 1, Frame::Grid> one_d_vector_double_b{{{4.}}};
-    CHECK(get(dot_product(one_d_covector_double_a, one_d_covector_double_b)) ==
-          8.0);
-    CHECK(get(dot_product(one_d_covector_double_a, one_d_vector_double_b)) ==
-          8.0);
-
-    const tnsr::a<double, 4, Frame::Grid> five_d_covector_double_a{
-        {{2.0, 12.0, 4.0, 1.0, 2.0}}};
-    const tnsr::a<double, 4, Frame::Grid> five_d_covector_double_b{
-        {{4.0, 2.0, -4.0, 3.0, 5.0}}};
-    const tnsr::A<double, 4, Frame::Grid> five_d_vector_double_b{
-        {{4.0, 2.0, -4.0, 3.0, 5.0}}};
-    CHECK(get(dot_product(five_d_covector_double_a,
-                          five_d_covector_double_b)) == 29.0);
-    CHECK(get(dot_product(five_d_covector_double_a,
-                          five_d_vector_double_b)) == 29.0);
-  }
-}
-
-SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DotProduct",
-                  "[DataStructures][Unit]") {
-  // Check for DataVectors
-  {
-    const size_t npts = 5;
-    const DataVector one(npts, 1.0);
-    const DataVector two(npts, 2.0);
-    const DataVector minus_three(npts, -3.0);
-    const DataVector four(npts, 4.0);
-    const DataVector minus_five(npts, -5.0);
-    const DataVector twelve(npts, 12.0);
-    const DataVector thirteen(npts, 13.0);
-
-    const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector_a{{{two}}};
-    const tnsr::i<DataVector, 1, Frame::Grid> one_d_covector_b{{{four}}};
-    const tnsr::II<DataVector, 1, Frame::Grid> inv_h = [&four]() {
-      tnsr::II<DataVector, 1, Frame::Grid> tensor;
+    const tnsr::i<T, 1, Frame::Grid> one_d_covector_a{{{two}}};
+    const tnsr::i<T, 1, Frame::Grid> one_d_covector_b{{{four}}};
+    const tnsr::II<T, 1, Frame::Grid> inv_h = [&four]() {
+      tnsr::II<T, 1, Frame::Grid> tensor;
       get<0, 0>(tensor) = four;
       return tensor;
     }();
     CHECK_ITERABLE_APPROX(
         get(dot_product(one_d_covector_a, one_d_covector_b, inv_h)),
-        DataVector(npts, 32.0));
+        make_with_value<T>(used_for_size, 32.0));
 
-    const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector_a{
+    const tnsr::i<T, 3, Frame::Grid> three_d_covector_a{
         {{minus_three, twelve, four}}};
-    const tnsr::i<DataVector, 3, Frame::Grid> three_d_covector_b{
+    const tnsr::i<T, 3, Frame::Grid> three_d_covector_b{
         {{minus_five, four, two}}};
-    const tnsr::II<DataVector, 3, Frame::Grid> inv_g =
+    const tnsr::II<T, 3, Frame::Grid> inv_g =
         [&two, &minus_three, &four, &minus_five, &twelve, &thirteen]() {
-          tnsr::II<DataVector, 3, Frame::Grid> tensor;
+          tnsr::II<T, 3, Frame::Grid> tensor;
           get<0, 0>(tensor) = two;
           get<0, 1>(tensor) = minus_three;
           get<0, 2>(tensor) = four;
@@ -147,36 +96,13 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DotProduct",
         }();
     CHECK_ITERABLE_APPROX(
         get(dot_product(three_d_covector_a, three_d_covector_b, inv_g)),
-        DataVector(npts, 486.0));
+        make_with_value<T>(used_for_size, 486.0));
   }
+}
+}  // namespace
 
-  {
-    // Check for doubles
-    const tnsr::i<double, 1, Frame::Grid> one_d_covector_a{2.0};
-    const tnsr::i<double, 1, Frame::Grid> one_d_covector_b{4.0};
-    const tnsr::II<double, 1, Frame::Grid> inv_h = []() {
-      tnsr::II<double, 1, Frame::Grid> tensor{};
-      get<0, 0>(tensor) = 4.0;
-      return tensor;
-    }();
-
-    CHECK(get(dot_product(one_d_covector_a, one_d_covector_b, inv_h)) == 32.0);
-
-    const tnsr::i<double, 3, Frame::Grid> three_d_covector_a{
-        {{-3.0, 12.0, 4.0}}};
-    const tnsr::i<double, 3, Frame::Grid> three_d_covector_b{
-        {{-5.0, 4.0, 2.0}}};
-    const tnsr::II<double, 3, Frame::Grid> inv_g = []() {
-      tnsr::II<double, 3, Frame::Grid> tensor{};
-      get<0, 0>(tensor) = 2.0;
-      get<0, 1>(tensor) = -3.0;
-      get<0, 2>(tensor) = 4.0;
-      get<1, 1>(tensor) = -5.0;
-      get<1, 2>(tensor) = 12.0;
-      get<2, 2>(tensor) = 13.0;
-      return tensor;
-    }();
-    CHECK(get(dot_product(three_d_covector_a, three_d_covector_b, inv_g)) ==
-          486.0);
-  }
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.DotProduct",
+                  "[DataStructures][Unit]") {
+  check_dot_product(double{});
+  check_dot_product(DataVector(5));
 }

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -16,6 +16,59 @@ using UpIndex = change_index_up_lo<Index>;
 static_assert(cpp17::is_same_v<UpIndex, SpatialIndex<3, UpLo::Up, Frame::Grid>>,
               "Failed testing change_index_up_lo");
 /// [change_up_lo]
+static_assert(
+    cpp17::is_same_v<change_index_up_lo<SpatialIndex<3, UpLo::Up, Frame::Grid>>,
+                     SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+    "Failed testing change_index_up_lo");
+static_assert(
+    cpp17::is_same_v<
+        change_index_up_lo<SpatialIndex<3, UpLo::Euclidean, Frame::Grid>>,
+        SpatialIndex<3, UpLo::Euclidean, Frame::Grid>>,
+    "Failed testing change_index_up_lo");
+static_assert(cpp17::is_same_v<
+                  change_index_up_lo<SpacetimeIndex<3, UpLo::Up, Frame::Grid>>,
+                  SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>,
+              "Failed testing change_index_up_lo");
+
+static_assert(not can_contract_v<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                                 SpatialIndex<3, UpLo::Up, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(can_contract_v<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                             SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(can_contract_v<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                             SpatialIndex<3, UpLo::Euclidean, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(can_contract_v<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                             SpatialIndex<3, UpLo::Up, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(not can_contract_v<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                                 SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(can_contract_v<SpatialIndex<3, UpLo::Lo, Frame::Grid>,
+                             SpatialIndex<3, UpLo::Euclidean, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(can_contract_v<SpatialIndex<3, UpLo::Euclidean, Frame::Grid>,
+                             SpatialIndex<3, UpLo::Up, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(can_contract_v<SpatialIndex<3, UpLo::Euclidean, Frame::Grid>,
+                             SpatialIndex<3, UpLo::Lo, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(can_contract_v<SpatialIndex<3, UpLo::Euclidean, Frame::Grid>,
+                             SpatialIndex<3, UpLo::Euclidean, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(not can_contract_v<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                                 SpatialIndex<3, UpLo::Lo, Frame::Logical>>,
+              "Failed testing can_contract_v");
+static_assert(not can_contract_v<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                                 SpatialIndex<4, UpLo::Lo, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(not can_contract_v<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                                 SpacetimeIndex<3, UpLo::Lo, Frame::Grid>>,
+              "Failed testing can_contract_v");
+static_assert(not can_contract_v<SpatialIndex<3, UpLo::Up, Frame::Grid>,
+                                 SpacetimeIndex<2, UpLo::Lo, Frame::Grid>>,
+              "Failed testing can_contract_v");
 
 /// [is_frame_physical]
 static_assert(not Frame::is_frame_physical_v<Frame::Logical>,

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -532,6 +532,23 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.RankAndSize",
     CHECK(get<2>(spatial_vector3) == 3);
   }
 
+  {
+    /// [index_dim]
+    using T = Tensor<double, Symmetry<1, 2, 3>,
+                     index_list<SpacetimeIndex<2, UpLo::Up, Frame::Inertial>,
+                                SpatialIndex<1, UpLo::Up, Frame::Inertial>,
+                                SpatialIndex<2, UpLo::Up, Frame::Inertial>>>;
+    T t;
+    CHECK(index_dim<0>(t) == 3);
+    CHECK(index_dim<1>(t) == 1);
+    CHECK(index_dim<2>(t) == 2);
+    CHECK(T::index_dim(0) == 3);
+    CHECK(T::index_dim(1) == 1);
+    CHECK(T::index_dim(2) == 2);
+    CHECK(T::index_dims() == std::array<size_t, 3>{{3, 1, 2}});
+    /// [index_dim]
+  }
+
   Tensor<double, Symmetry<3>,
          index_list<SpatialIndex<4, UpLo::Lo, Frame::Grid>>>
       spatial_vector4{};

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -39,20 +39,21 @@ void check_du_dt(const size_t npts, const double time) {
       Tags::deriv<ScalarWave::Pi, tmpl::size_t<Dim>, Frame::Inertial>,
       Tags::deriv<ScalarWave::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>>>(
       Scalar<DataVector>(pow<Dim>(npts), 0.0),
-      tnsr::i<DataVector, Dim, Frame::Inertial>(pow<Dim>(npts), 0.0),
+      tnsr::w<DataVector, Dim, Frame::Inertial>(pow<Dim>(npts), 0.0),
       Scalar<DataVector>(pow<Dim>(npts), 0.0),
       Scalar<DataVector>(-1.0 * solution.dpsi_dt(x, time).get()),
       [&x, &time, &solution ]() noexcept {
-        auto dpi_dx = solution.d2psi_dtdx(x, time);
+        tnsr::i<DataVector, Dim, Frame::Inertial> dpi_dx =
+          solution.d2psi_dtdx(x, time);
         for (size_t i = 0; i < Dim; ++i) {
           dpi_dx.get(i) *= -1.0;
         }
         return dpi_dx;
       }(),
       [&npts, &x, &time, &solution ]() noexcept {
-        tnsr::ij<DataVector, Dim, Frame::Inertial> d2psi_dxdx{pow<Dim>(npts),
+        tnsr::iw<DataVector, Dim, Frame::Inertial> d2psi_dxdx{pow<Dim>(npts),
                                                               0.0};
-        const tnsr::ii<DataVector, Dim, Frame::Inertial> ddpsi_soln =
+        const tnsr::ww<DataVector, Dim, Frame::Inertial> ddpsi_soln =
             solution.d2psi_dxdx(x, time);
         for (size_t i = 0; i < Dim; ++i) {
           for (size_t j = 0; j < Dim; ++j) {
@@ -114,7 +115,7 @@ void check_normal_dot_fluxes(const size_t npts, const double t) {
   auto normal_dot_flux_pi = make_with_value<Scalar<DataVector>>(pi, 0.0);
   auto normal_dot_flux_psi = make_with_value<Scalar<DataVector>>(pi, 0.0);
   auto normal_dot_flux_phi =
-      make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(pi, 0.0);
+      make_with_value<tnsr::w<DataVector, Dim, Frame::Inertial>>(pi, 0.0);
 
   ScalarWave::ComputeNormalDotFluxes<Dim>::apply(
       make_not_null(&normal_dot_flux_pi), make_not_null(&normal_dot_flux_phi),
@@ -129,7 +130,7 @@ void check_normal_dot_fluxes(const size_t npts, const double t) {
   CHECK(get(normal_dot_flux_pi) == normal_dot_flux_pi_expected);
 
   auto normal_dot_flux_phi_expected =
-      make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(pi, 0.0);
+      make_with_value<tnsr::w<DataVector, Dim, Frame::Inertial>>(pi, 0.0);
   for (size_t d = 0; d < Dim; ++d) {
     normal_dot_flux_phi_expected.get(d) = unit_normal.get(d) * get(pi);
   }
@@ -194,7 +195,7 @@ void check_upwind_flux(const size_t npts, const double t) {
 
   Scalar<DataVector> normal_dot_numerical_flux_pi(pow<Dim>(npts), 0.0);
   Scalar<DataVector> normal_dot_numerical_flux_psi(pow<Dim>(npts), 0.0);
-  tnsr::i<DataVector, Dim, Frame::Inertial> normal_dot_numerical_flux_phi(
+  tnsr::w<DataVector, Dim, Frame::Inertial> normal_dot_numerical_flux_phi(
       pow<Dim>(npts), 0.0);
   apply_numerical_flux(flux_computer, packaged_data_int, packaged_data_ext,
                        make_not_null(&normal_dot_numerical_flux_pi),
@@ -209,7 +210,7 @@ void check_upwind_flux(const size_t npts, const double t) {
                                   get(solution.dpsi_dt(x, t + 1.0)) -
                                   get(solution.dpsi_dt(x, 2.0 * t + 10.0)))));
 
-  tnsr::i<DataVector, Dim> normal_dot_numerical_flux_phi_expected(
+  tnsr::w<DataVector, Dim> normal_dot_numerical_flux_phi_expected(
       pow<Dim>(npts), 0.0);
   for (size_t d = 0; d < Dim; ++d) {
     normal_dot_numerical_flux_phi_expected.get(d) =


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
