### PR TITLE
Use OrientationMapIterator in test for DiscreteRotation

### DIFF
--- a/tests/Unit/Domain/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Test_OrientationMap.cpp
@@ -9,6 +9,7 @@
 #include "Domain/Direction.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Utilities/StdHelpers.hpp"
+#include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Unit/TestingFramework.hpp"
@@ -313,56 +314,30 @@ SPECTRE_TEST_CASE("Unit.Domain.OrientationMap", "[Domain][Unit]") {
 #endif
 }
 
-namespace {
-template <size_t VolumeDim>
-OrientationMap<VolumeDim> generate_orientation_map(
-    const VolumeCornerIterator<VolumeDim>& vci,
-    const std::array<size_t, VolumeDim>& dimensions) {
-  std::array<Direction<VolumeDim>, VolumeDim> array_of_directions{};
-  for (size_t i = 0; i < VolumeDim; i++) {
-    gsl::at(array_of_directions, i) =
-        Direction<VolumeDim>{gsl::at(dimensions, i), gsl::at(vci(), i)};
-  }
-  return OrientationMap<VolumeDim>{array_of_directions};
-}
-}  // namespace
-
 SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.AllOrientations",
                   "[Domain][Unit]") {
-  std::array<size_t, 2> dimensions_2d{};
-  std::iota(dimensions_2d.begin(), dimensions_2d.end(), 0);
-  do {
-    for (VolumeCornerIterator<2> vci{}; vci; ++vci) {
-      const OrientationMap<2> map_2d =
-          generate_orientation_map<2>(vci, dimensions_2d);
-      const std::array<double, 2> original_point{{0.5, -2.0}};
-      const std::array<double, 2> new_point =
-          discrete_rotation(map_2d, original_point);
-      for (size_t d = 0; d < 2; d++) {
-        CHECK(gsl::at(new_point, d) ==
-              (map_2d(Direction<2>{d, Side::Upper}).side() == Side::Upper
-                   ? gsl::at(original_point, map_2d(d))
-                   : -1.0 * gsl::at(original_point, map_2d(d))));
-      }
+  for (OrientationMapIterator<2> map_i{}; map_i; ++map_i) {
+    const std::array<double, 2> original_point{{0.5, -2.0}};
+    const std::array<double, 2> new_point =
+        discrete_rotation(map_i(), original_point);
+    for (size_t d = 0; d < 2; d++) {
+      CHECK(gsl::at(new_point, d) ==
+            (map_i()(Direction<2>{d, Side::Upper}).side() == Side::Upper
+                 ? gsl::at(original_point, map_i()(d))
+                 : -1.0 * gsl::at(original_point, map_i()(d))));
     }
-  } while (std::next_permutation(dimensions_2d.begin(), dimensions_2d.end()));
-  std::array<size_t, 3> dimensions_3d{};
-  std::iota(dimensions_3d.begin(), dimensions_3d.end(), 0);
-  do {
-    for (VolumeCornerIterator<3> vci{}; vci; ++vci) {
-      const OrientationMap<3> map_3d =
-          generate_orientation_map<3>(vci, dimensions_3d);
+    }
+    for (OrientationMapIterator<3> map_i{}; map_i; ++map_i) {
       const std::array<double, 3> original_point{{0.5, -2.0, 1.5}};
       const std::array<double, 3> new_point =
-          discrete_rotation(map_3d, original_point);
+          discrete_rotation(map_i(), original_point);
       for (size_t d = 0; d < 3; d++) {
         CHECK(gsl::at(new_point, d) ==
-              (map_3d(Direction<3>{d, Side::Upper}).side() == Side::Upper
-                   ? gsl::at(original_point, map_3d(d))
-                   : -1.0 * gsl::at(original_point, map_3d(d))));
+              (map_i()(Direction<3>{d, Side::Upper}).side() == Side::Upper
+                   ? gsl::at(original_point, map_i()(d))
+                   : -1.0 * gsl::at(original_point, map_i()(d))));
       }
     }
-  } while (std::next_permutation(dimensions_3d.begin(), dimensions_3d.end()));
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.Rotation", "[Domain][Unit]") {


### PR DESCRIPTION
## Proposed changes
closes #600 
### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
