### PR TITLE
Add Inverse Jacobian to Wedge3D

### DIFF
--- a/src/Domain/CoordinateMaps/Wedge3D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.cpp
@@ -5,7 +5,6 @@
 
 #include <pup.h>
 
-#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "ErrorHandling/Assert.hpp"
@@ -17,30 +16,50 @@
 
 namespace CoordinateMaps {
 
-Wedge3D::Wedge3D(const double radius_of_other_surface,
-                 const double radius_of_spherical_surface,
+Wedge3D::Wedge3D(const double radius_inner, const double radius_outer,
                  const OrientationMap<3> orientation_of_wedge,
-                 const double sphericity_of_other_surface,
-                 const bool with_equiangular_map,
+                 const double sphericity_inner, const bool with_equiangular_map,
                  const WedgeHalves halves_to_use) noexcept
-    : radius_of_other_surface_(radius_of_other_surface),
-      radius_of_spherical_surface_(radius_of_spherical_surface),
+    : radius_inner_(radius_inner),
+      radius_outer_(radius_outer),
       orientation_of_wedge_(orientation_of_wedge),
-      sphericity_of_other_surface_(sphericity_of_other_surface),
+      sphericity_inner_(sphericity_inner),
       with_equiangular_map_(with_equiangular_map),
       halves_to_use_(halves_to_use) {
-  ASSERT(radius_of_other_surface > 0,
-         "The radius of the other surface must be greater than zero.");
-  ASSERT(radius_of_spherical_surface > 0,
-         "The radius of the spherical surface must be greater than zero.");
-  ASSERT(sphericity_of_other_surface >= 0 and sphericity_of_other_surface <= 1,
-         "Sphericity of other surface must be between 0 and 1");
-  ASSERT(radius_of_other_surface < radius_of_spherical_surface or
-             (1. + sphericity_of_other_surface * (sqrt(3.) - 1.)) *
-                     radius_of_other_surface >
-                 sqrt(3.) * radius_of_spherical_surface,
-         "For the value of the given radii and sphericity, the spherical "
-         "surface intersects with the other surface");
+  ASSERT(radius_inner > 0.0,
+         "The radius of the inner surface must be greater than zero.");
+  ASSERT(sphericity_inner >= 0.0 and sphericity_inner <= 1.0,
+         "Sphericity of the inner surface must be between 0 and 1");
+  ASSERT(radius_outer > radius_inner,
+         "The radius of the outer surface must be greater than the radius of "
+         "the inner surface.");
+  ASSERT(radius_outer *
+                 ((1.0 - sphericity_outer_) / sqrt(3.0) + sphericity_outer_) >
+             radius_inner *
+                 ((1.0 - sphericity_inner) / sqrt(3.0) + sphericity_inner),
+         "The arguments passed into the constructor for Wedge3D result in an "
+         "object where the "
+         "outer surface is pierced by the inner surface.");
+  scaled_frustum_zero_ = 0.5 / sqrt(3.0) *
+                         ((1.0 - sphericity_outer_) * radius_outer +
+                          (1.0 - sphericity_inner) * radius_inner);
+  sphere_zero_ = 0.5 * (sphericity_outer_ * radius_outer +
+                        sphericity_inner * radius_inner);
+  scaled_frustum_rate_ = 0.5 / sqrt(3.0) *
+                         ((1.0 - sphericity_outer_) * radius_outer -
+                          (1.0 - sphericity_inner) * radius_inner);
+  sphere_rate_ = 0.5 * (sphericity_outer_ * radius_outer -
+                        sphericity_inner * radius_inner);
+}
+
+template <typename T>
+tt::remove_cvref_wrap_t<T> Wedge3D::default_physical_z(
+    const T& zeta, const T& one_over_rho) const noexcept {
+  // Using auto keeps this as a blaze expression.
+  const auto zeta_coefficient =
+      (scaled_frustum_rate_ + sphere_rate_ * one_over_rho);
+  const auto z_zero = (scaled_frustum_zero_ + sphere_zero_ * one_over_rho);
+  return z_zero + zeta_coefficient * zeta;
 }
 
 template <typename T>
@@ -52,28 +71,19 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Wedge3D::operator()(
   if (halves_to_use_ == WedgeHalves::UpperOnly) {
     xi += 1.0;
     xi *= 0.5;
-  }
-  if (halves_to_use_ == WedgeHalves::LowerOnly) {
+  } else if (halves_to_use_ == WedgeHalves::LowerOnly) {
     xi -= 1.0;
     xi *= 0.5;
   }
   const ReturnType& eta = source_coords[1];
+
+  const ReturnType cap_xi = with_equiangular_map_ ? tan(M_PI_4 * xi) : xi;
+  const ReturnType cap_eta = with_equiangular_map_ ? tan(M_PI_4 * eta) : eta;
   const ReturnType& zeta = source_coords[2];
+  const ReturnType one_over_rho =
+      1.0 / sqrt(1.0 + square(cap_xi) + square(cap_eta));
 
-  const ReturnType& cap_xi = with_equiangular_map_ ? tan(M_PI_4 * xi) : xi;
-  const ReturnType& cap_eta = with_equiangular_map_ ? tan(M_PI_4 * eta) : eta;
-
-  const ReturnType first_blending_factor =
-      0.5 * (1.0 - sphericity_of_other_surface_) * radius_of_other_surface_ /
-      sqrt(3.0) * (1.0 - zeta);
-  const ReturnType second_blending_factor_over_rho =
-      (0.5 * sphericity_of_other_surface_ * radius_of_other_surface_ *
-           (1.0 - zeta) +
-       0.5 * radius_of_spherical_surface_ * (1.0 + zeta)) /
-      sqrt(1.0 + square(cap_xi) + square(cap_eta));
-
-  ReturnType physical_z =
-      first_blending_factor + second_blending_factor_over_rho;
+  ReturnType physical_z = default_physical_z(zeta, one_over_rho);
   ReturnType physical_x = physical_z * cap_xi;
   ReturnType physical_y = physical_z * cap_eta;
 
@@ -97,14 +107,12 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Wedge3D::inverse(
   const ReturnType cap_eta = physical_y / physical_z;
   const ReturnType one_over_rho =
       1.0 / sqrt(1.0 + square(cap_xi) + square(cap_eta));
-  const ReturnType common_factor_one =
-      0.5 * radius_of_other_surface_ *
-      ((1.0 - sphericity_of_other_surface_) / sqrt(3.0) +
-       sphericity_of_other_surface_ * one_over_rho);
-  const ReturnType common_factor_two =
-      0.5 * radius_of_spherical_surface_ * one_over_rho;
-  ReturnType zeta = (physical_z - (common_factor_two + common_factor_one)) /
-                    (common_factor_two - common_factor_one);
+
+  // Using auto keeps this as a blaze expression.
+  const auto zeta_coefficient =
+      (scaled_frustum_rate_ + sphere_rate_ * one_over_rho);
+  const auto z_zero = (scaled_frustum_zero_ + sphere_zero_ * one_over_rho);
+  ReturnType zeta = (physical_z - z_zero) / zeta_coefficient;
   ReturnType xi =
       with_equiangular_map_ ? atan(cap_xi) / M_PI_4 : std::move(cap_xi);
   ReturnType eta =
@@ -112,8 +120,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Wedge3D::inverse(
   if (halves_to_use_ == WedgeHalves::UpperOnly) {
     xi *= 2.0;
     xi -= 1.0;
-  }
-  if (halves_to_use_ == WedgeHalves::LowerOnly) {
+  } else if (halves_to_use_ == WedgeHalves::LowerOnly) {
     xi *= 2.0;
     xi += 1.0;
   }
@@ -125,22 +132,18 @@ template <typename T>
 tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Wedge3D::jacobian(
     const std::array<T, 3>& source_coords) const noexcept {
   using ReturnType = tt::remove_cvref_wrap_t<T>;
-
   ReturnType xi = source_coords[0];
   if (halves_to_use_ == WedgeHalves::UpperOnly) {
     xi += 1.0;
     xi *= 0.5;
-  }
-  if (halves_to_use_ == WedgeHalves::LowerOnly) {
+  } else if (halves_to_use_ == WedgeHalves::LowerOnly) {
     xi -= 1.0;
     xi *= 0.5;
   }
   const ReturnType& eta = source_coords[1];
   const ReturnType& zeta = source_coords[2];
-
   const ReturnType& cap_xi = with_equiangular_map_ ? tan(M_PI_4 * xi) : xi;
   const ReturnType& cap_eta = with_equiangular_map_ ? tan(M_PI_4 * eta) : eta;
-
   const ReturnType cap_xi_deriv = with_equiangular_map_
                                       ? M_PI_4 * (1.0 + square(cap_xi))
                                       : make_with_value<ReturnType>(xi, 1.0);
@@ -150,76 +153,51 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Wedge3D::jacobian(
 
   const ReturnType one_over_rho =
       1.0 / sqrt(1.0 + square(cap_xi) + square(cap_eta));
-  const ReturnType first_blending_factor =
-      0.5 * (1.0 - sphericity_of_other_surface_) * radius_of_other_surface_ /
-      sqrt(3.0) * (1.0 - zeta);
-  const double first_blending_rate = -0.5 *
-                                     (1.0 - sphericity_of_other_surface_) *
-                                     radius_of_other_surface_ / sqrt(3.0);
-  const ReturnType second_blending_factor_over_rho_cubed =
-      (0.5 * sphericity_of_other_surface_ * radius_of_other_surface_ *
-           (1.0 - zeta) +
-       0.5 * radius_of_spherical_surface_ * (1.0 + zeta)) *
-      pow<3>(one_over_rho);
-  const ReturnType second_blending_rate_over_rho =
-      0.5 *
-      (-sphericity_of_other_surface_ * radius_of_other_surface_ +
-       radius_of_spherical_surface_) *
-      one_over_rho;
+  const ReturnType one_over_rho_cubed = pow<3>(one_over_rho);
+  const ReturnType physical_z = default_physical_z(zeta, one_over_rho);
+  const ReturnType s_factor = sphere_zero_ + sphere_rate_ * zeta;
 
   auto jacobian_matrix =
       make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
           dereference_wrapper(source_coords[0]), 0.0);
 
-  ReturnType dz_dxi =
-      -second_blending_factor_over_rho_cubed * cap_xi * cap_xi_deriv;
-  ReturnType dx_dxi =
-      (first_blending_factor +
-       second_blending_factor_over_rho_cubed * (1.0 + square(cap_eta))) *
-      cap_xi_deriv;
-  ReturnType dy_dxi = dz_dxi * cap_eta;
-
+  ReturnType dz_dxi = -s_factor * cap_xi * cap_xi_deriv * one_over_rho_cubed;
+  ReturnType dx_dxi = cap_xi * dz_dxi + cap_xi_deriv * physical_z;
+  ReturnType dy_dxi = cap_eta * dz_dxi;
   // Implement Scalings:
   if (halves_to_use_ != WedgeHalves::Both) {
     dz_dxi *= 0.5;
     dy_dxi *= 0.5;
     dx_dxi *= 0.5;
   }
-
   std::array<ReturnType, 3> dX_dlogical = discrete_rotation(
       orientation_of_wedge_,
       std::array<ReturnType, 3>{
           {std::move(dx_dxi), std::move(dy_dxi), std::move(dz_dxi)}});
-
   get<0, 0>(jacobian_matrix) = dX_dlogical[0];
   get<1, 0>(jacobian_matrix) = dX_dlogical[1];
   get<2, 0>(jacobian_matrix) = dX_dlogical[2];
 
-  // reuse allocation, compute next subset of Jacobian
-  dX_dlogical[2] =  // dz_deta
-      -second_blending_factor_over_rho_cubed * cap_eta * cap_eta_deriv;
-  dX_dlogical[0] =  // dx_deta
-      dX_dlogical[2] * cap_xi;
-  dX_dlogical[1] =  // dy_deta
-      (first_blending_factor +
-       second_blending_factor_over_rho_cubed * (1.0 + square(cap_xi))) *
-      cap_eta_deriv;
-
+  // dz_deta
+  dX_dlogical[2] = -s_factor * cap_eta * cap_eta_deriv * one_over_rho_cubed;
+  // dy_deta
+  dX_dlogical[1] = cap_eta * dX_dlogical[2] + cap_eta_deriv * physical_z;
+  // dx_deta
+  dX_dlogical[0] = cap_xi * dX_dlogical[2];
   dX_dlogical =
       discrete_rotation(orientation_of_wedge_, std::move(dX_dlogical));
-
   get<0, 1>(jacobian_matrix) = dX_dlogical[0];
   get<1, 1>(jacobian_matrix) = dX_dlogical[1];
   get<2, 1>(jacobian_matrix) = dX_dlogical[2];
 
-  dX_dlogical[2] =  // dz_dzeta
-      first_blending_rate + second_blending_rate_over_rho;
-  dX_dlogical[0] = dX_dlogical[2] * cap_xi;   // dx_dzeta
-  dX_dlogical[1] = dX_dlogical[2] * cap_eta;  // dy_dzeta
-
+  // dz_dzeta
+  dX_dlogical[2] = scaled_frustum_rate_ + sphere_rate_ * one_over_rho;
+  // dx_dzeta
+  dX_dlogical[0] = cap_xi * dX_dlogical[2];
+  // dy_dzeta
+  dX_dlogical[1] = cap_eta * dX_dlogical[2];
   dX_dlogical =
       discrete_rotation(orientation_of_wedge_, std::move(dX_dlogical));
-
   get<0, 2>(jacobian_matrix) = dX_dlogical[0];
   get<1, 2>(jacobian_matrix) = dX_dlogical[1];
   get<2, 2>(jacobian_matrix) = dX_dlogical[2];
@@ -229,27 +207,113 @@ tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Wedge3D::jacobian(
 template <typename T>
 tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> Wedge3D::inv_jacobian(
     const std::array<T, 3>& source_coords) const noexcept {
-  return determinant_and_inverse(jacobian(source_coords)).second;
+  using ReturnType = tt::remove_cvref_wrap_t<T>;
+
+  ReturnType xi = source_coords[0];
+  if (halves_to_use_ == WedgeHalves::UpperOnly) {
+    xi += make_with_value<ReturnType>(xi, 1.0);
+    xi *= 0.5;
+  } else if (halves_to_use_ == WedgeHalves::LowerOnly) {
+    xi += make_with_value<ReturnType>(xi, -1.0);
+    xi *= 0.5;
+  }
+
+  const ReturnType& eta = source_coords[1];
+  const ReturnType& zeta = source_coords[2];
+  const ReturnType cap_xi = with_equiangular_map_ ? tan(M_PI_4 * xi) : xi;
+  const ReturnType cap_eta = with_equiangular_map_ ? tan(M_PI_4 * eta) : eta;
+  const ReturnType cap_xi_deriv = with_equiangular_map_
+                                      ? M_PI_4 * (1.0 + square(cap_xi))
+                                      : make_with_value<ReturnType>(xi, 1.0);
+  const ReturnType cap_eta_deriv = with_equiangular_map_
+                                       ? M_PI_4 * (1.0 + square(cap_eta))
+                                       : make_with_value<ReturnType>(eta, 1.0);
+
+  const ReturnType one_over_rho =
+      1.0 / sqrt(1.0 + square(cap_xi) + square(cap_eta));
+  const ReturnType one_over_rho_cubed = pow<3>(one_over_rho);
+  const ReturnType one_over_physical_z =
+      1.0 / default_physical_z(zeta, one_over_rho);
+  const ReturnType scaled_z_frustum =
+      scaled_frustum_zero_ + scaled_frustum_rate_ * zeta;
+  const ReturnType s_factor_over_rho_cubed =
+      (sphere_zero_ + sphere_rate_ * zeta) * one_over_rho_cubed;
+  const ReturnType one_over_dz_dzeta =
+      1.0 / (scaled_frustum_rate_ + sphere_rate_ * one_over_rho);
+  const ReturnType dzeta_factor = one_over_physical_z * one_over_dz_dzeta;
+
+  auto inv_jacobian_matrix =
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0);
+
+  ReturnType dxi_dx = one_over_physical_z / cap_xi_deriv;
+  // Implement Scalings:
+  if (halves_to_use_ != WedgeHalves::Both) {
+    dxi_dx *= 2.0;
+  }
+  auto dxi_dy = make_with_value<ReturnType>(xi, 0.0);
+  ReturnType dxi_dz = -cap_xi * dxi_dx;
+
+  std::array<ReturnType, 3> dlogical_dX = discrete_rotation(
+      orientation_of_wedge_,
+      std::array<ReturnType, 3>{
+          {std::move(dxi_dx), std::move(dxi_dy), std::move(dxi_dz)}});
+  get<0, 0>(inv_jacobian_matrix) = dlogical_dX[0];
+  get<0, 1>(inv_jacobian_matrix) = dlogical_dX[1];
+  get<0, 2>(inv_jacobian_matrix) = dlogical_dX[2];
+
+  // deta_dx
+  dlogical_dX[0] = 0.0;
+  // deta_dy
+  dlogical_dX[1] = one_over_physical_z / cap_eta_deriv;
+  // deta_dz
+  dlogical_dX[2] = -cap_eta * dlogical_dX[1];
+  dlogical_dX =
+      discrete_rotation(orientation_of_wedge_, std::move(dlogical_dX));
+  get<1, 0>(inv_jacobian_matrix) = dlogical_dX[0];
+  get<1, 1>(inv_jacobian_matrix) = dlogical_dX[1];
+  get<1, 2>(inv_jacobian_matrix) = dlogical_dX[2];
+
+  // dzeta_dx
+  dlogical_dX[0] = dzeta_factor * cap_xi * s_factor_over_rho_cubed;
+  // dzeta_dy
+  dlogical_dX[1] = dzeta_factor * cap_eta * s_factor_over_rho_cubed;
+  // dzeta_dz
+  dlogical_dX[2] = dzeta_factor * (scaled_z_frustum + s_factor_over_rho_cubed);
+  dlogical_dX =
+      discrete_rotation(orientation_of_wedge_, std::move(dlogical_dX));
+  get<2, 0>(inv_jacobian_matrix) = dlogical_dX[0];
+  get<2, 1>(inv_jacobian_matrix) = dlogical_dX[1];
+  get<2, 2>(inv_jacobian_matrix) = dlogical_dX[2];
+  return inv_jacobian_matrix;
 }
 
 void Wedge3D::pup(PUP::er& p) noexcept {
-  p | radius_of_other_surface_;
-  p | radius_of_spherical_surface_;
+  p | radius_inner_;
+  p | radius_outer_;
   p | orientation_of_wedge_;
-  p | sphericity_of_other_surface_;
+  p | sphericity_inner_;
+  p | sphericity_outer_;
   p | with_equiangular_map_;
   p | halves_to_use_;
+  p | scaled_frustum_zero_;
+  p | sphere_zero_;
+  p | scaled_frustum_rate_;
+  p | sphere_rate_;
 }
 
 bool operator==(const Wedge3D& lhs, const Wedge3D& rhs) noexcept {
-  return lhs.radius_of_other_surface_ == rhs.radius_of_other_surface_ and
-         lhs.radius_of_spherical_surface_ ==
-             rhs.radius_of_spherical_surface_ and
+  return lhs.radius_inner_ == rhs.radius_inner_ and
+         lhs.radius_outer_ == rhs.radius_outer_ and
          lhs.orientation_of_wedge_ == rhs.orientation_of_wedge_ and
-         lhs.sphericity_of_other_surface_ ==
-             rhs.sphericity_of_other_surface_ and
          lhs.with_equiangular_map_ == rhs.with_equiangular_map_ and
-         lhs.halves_to_use_ == rhs.halves_to_use_;
+         lhs.halves_to_use_ == rhs.halves_to_use_ and
+         lhs.sphericity_inner_ == rhs.sphericity_inner_ and
+         lhs.sphericity_outer_ == rhs.sphericity_outer_ and
+         lhs.scaled_frustum_zero_ == rhs.scaled_frustum_zero_ and
+         lhs.sphere_zero_ == rhs.sphere_zero_ and
+         lhs.scaled_frustum_rate_ == rhs.scaled_frustum_rate_ and
+         lhs.sphere_rate_ == rhs.sphere_rate_;
 }
 
 bool operator!=(const Wedge3D& lhs, const Wedge3D& rhs) noexcept {


### PR DESCRIPTION
## Proposed changes

Also refactoring changes to Wedge3D

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
