### PR TITLE
Extend test_map3d to other dimensions

### DIFF
--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_Direction.cpp
   Test_Domain.cpp
   Test_DomainHelpers.cpp
+  Test_DomainTestHelpers.cpp
   Test_Element.cpp
   Test_ElementId.cpp
   Test_ElementIndex.cpp

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -55,6 +55,16 @@ void check_if_maps_are_equal(
     }
     CAPTURE_PRECISE(source_point);
     CHECK_ITERABLE_APPROX(map_one(source_point), map_two(source_point));
+    for (size_t i = 0; i < VolumeDim; ++i) {
+      for (size_t j = 0; j < VolumeDim; ++j) {
+        INFO("i: " << i << " j: " << j);
+        CHECK(map_one.jacobian(source_point).get(j, i) ==
+              map_two.jacobian(source_point).get(j, i));
+
+        CHECK(map_one.inv_jacobian(source_point).get(j, i) ==
+              map_two.inv_jacobian(source_point).get(j, i));
+      }
+    }
   }
 }
 

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -255,50 +255,50 @@ void test_inverse_map(const Map& map,
 
 /*!
  * \ingroup TestingFrameworkGroup
- * \brief Given a 3D Map `map`, tests the map functions, including map inverse,
+ * \brief Given a Map `map`, tests the map functions, including map inverse,
  * jacobian, and inverse jacobian, for a series of points.
  */
 template <typename Map>
-void test_map3d(const Map& map) {
+void test_suite_for_map(const Map& map) {
   // Set up random number generator
-  std::random_device rd;
-  std::mt19937 gen(rd());
+  const auto seed = std::random_device{}();
+  std::mt19937 gen(seed);
+  INFO("seed = " << seed);
   std::uniform_real_distribution<> real_dis(-1.0, 1.0);
-  const double xi = real_dis(gen);
-  CAPTURE_PRECISE(xi);
-  const double eta = real_dis(gen);
-  CAPTURE_PRECISE(eta);
-  const double zeta = real_dis(gen);
-  CAPTURE_PRECISE(zeta);
 
-  const std::array<std::array<double, 3>, 13> test_points{{{{0.0, 0.0, 0.0}},
-                                                          {{-1.0, -1.0, -1.0}},
-                                                          {{1.0, -1.0, -1.0}},
-                                                          {{-1.0, 1.0, -1.0}},
-                                                          {{1.0, 1.0, -1.0}},
-                                                          {{-1.0, -1.0, 1.0}},
-                                                          {{1.0, -1.0, 1.0}},
-                                                          {{-1.0, 1.0, 1.0}},
-                                                          {{1.0, 1.0, 1.0}},
-                                                          {{-0.1, 0.3, 0.1}},
-                                                          {{0.5, 0.7, -0.5}},
-                                                          {{0.9, -1.0, 0.4}},
-                                                          {{xi, eta, zeta}}}};
-  test_serialization(map);
-  CHECK_FALSE(map != map);
-  test_coordinate_map_argument_types(map, test_points[0]);
-  for (const auto& point : test_points) {
-    test_jacobian(map, point);
-    test_inv_jacobian(map, point);
-    test_inverse_map(map, point);
+  std::array<double, Map::dim> origin{};
+  std::array<double, Map::dim> random_point{};
+  for (size_t i = 0; i < Map::dim; i++) {
+    gsl::at(origin, i) = 0.0;
+    gsl::at(random_point, i) = real_dis(gen);
   }
+
+  const auto test_helper =
+      [&origin, &random_point ](const auto& map_to_test) noexcept {
+    test_serialization(map_to_test);
+    CHECK_FALSE(map_to_test != map_to_test);
+    test_coordinate_map_argument_types(map_to_test, origin);
+
+    test_jacobian(map_to_test, origin);
+    test_inv_jacobian(map_to_test, origin);
+    test_inverse_map(map_to_test, origin);
+
+    for (VolumeCornerIterator<Map::dim> vci{}; vci; ++vci) {
+      test_jacobian(map_to_test, vci.coords_of_corner());
+      test_inv_jacobian(map_to_test, vci.coords_of_corner());
+      test_inverse_map(map_to_test, vci.coords_of_corner());
+    }
+
+    test_jacobian(map_to_test, random_point);
+    test_inv_jacobian(map_to_test, random_point);
+    test_inverse_map(map_to_test, random_point);
+  };
+  test_helper(map);
   const auto map2 = serialize_and_deserialize(map);
-  CHECK(map2 == map);
-  for (const auto& point : test_points) {
-    test_jacobian(map2, point);
-    test_inv_jacobian(map2, point);
-    test_inverse_map(map2, point);
-  }
+  check_if_maps_are_equal(
+      make_coordinate_map<Frame::Logical, Frame::Grid>(map),
+      make_coordinate_map<Frame::Logical, Frame::Grid>(map2));
+  test_helper(map2);
 }
 
 /*!

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -44,7 +44,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
          {{upper_x_upper_base, upper_y_upper_base}}}};
     const CoordinateMaps::Frustum frustum_map(face_vertices, -1.0, 2.0,
                                               map_i());
-    test_map3d(frustum_map);
+    test_suite_for_map(frustum_map);
   }
 }
 

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -35,7 +35,7 @@ void test_wedge3d_all_directions(const bool with_equiangular_map) {
       const CoordinateMaps::Wedge3D wedge_map(inner_radius, outer_radius,
                                               direction, sphericity,
                                               with_equiangular_map, halves);
-      test_map3d(wedge_map);
+      test_suite_for_map(wedge_map);
     }
   }
 }

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -44,6 +44,7 @@ class VolumeCornerIterator {
   void operator++() noexcept {
     ++index_;
     for (size_t i = 0; i < VolumeDim; i++) {
+      gsl::at(coords_of_corner_, i) = 2.0 * get_nth_bit(index_, i) - 1.0;
       gsl::at(array_sides_, i) =
           2 * get_nth_bit(index_, i) - 1 == 1 ? Side::Upper : Side::Lower;
     }
@@ -57,10 +58,14 @@ class VolumeCornerIterator {
   const std::array<Side, VolumeDim>& operator*() const noexcept {
     return array_sides_;
   }
+  const std::array<double, VolumeDim>& coords_of_corner() const noexcept {
+    return coords_of_corner_;
+  }
 
  private:
   size_t index_ = 0;
   std::array<Side, VolumeDim> array_sides_ = make_array<VolumeDim>(Side::Lower);
+  std::array<double, VolumeDim> coords_of_corner_ = make_array<VolumeDim>(-1.0);
 };
 
 // Test that the Blocks in the Domain are constructed correctly.

--- a/tests/Unit/Domain/Test_DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainTestHelpers.cpp
@@ -1,0 +1,79 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+
+#include "Domain/Side.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "tests/Unit/Domain/DomainTestHelpers.hpp"
+
+namespace {
+void test_vci_1d() {
+  VolumeCornerIterator<1> vci{};
+  CHECK(vci);
+  CHECK(vci() == std::array<Side, 1>{{Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 1>{{-1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 1>{{Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 1>{{1.0}});
+  ++vci;
+  CHECK(not vci);
+}
+
+void test_vci_2d() {
+  VolumeCornerIterator<2> vci{};
+  CHECK(vci);
+  CHECK(vci() == std::array<Side, 2>{{Side::Lower, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 2>{{-1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 2>{{Side::Upper, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 2>{{1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 2>{{Side::Lower, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 2>{{-1.0, 1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 2>{{Side::Upper, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 2>{{1.0, 1.0}});
+  ++vci;
+  CHECK(not vci);
+}
+
+void test_vci_3d() {
+  VolumeCornerIterator<3> vci{};
+  CHECK(vci);
+  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Lower, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, -1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Lower, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, -1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Upper, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, 1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Upper, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, 1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Lower, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, -1.0, 1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Lower, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, -1.0, 1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Upper, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, 1.0, 1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Upper, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, 1.0, 1.0}});
+  ++vci;
+  CHECK(not vci);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.TestHelpers.VolumeCornerIterator",
+                  "[Domain][Unit]") {
+  test_vci_1d();
+  test_vci_2d();
+  test_vci_3d();
+}


### PR DESCRIPTION
## Proposed changes

In preparation for the future Affine2D map, I extended test_map3d to be able to work with 1 and 2 dimensional maps as well.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
