### PR TITLE
Add outer_sphericity to Wedge3D

### DIFF
--- a/src/Domain/CoordinateMaps/Wedge2D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <array>
-#include <stddef.h>
+#include <cstddef>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Direction.hpp"

--- a/src/Domain/CoordinateMaps/Wedge3D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.cpp
@@ -20,18 +20,22 @@ namespace CoordinateMaps {
 
 Wedge3D::Wedge3D(const double radius_inner, const double radius_outer,
                  const OrientationMap<3> orientation_of_wedge,
-                 const double sphericity_inner, const bool with_equiangular_map,
+                 const double sphericity_inner, const double sphericity_outer,
+                 const bool with_equiangular_map,
                  const WedgeHalves halves_to_use) noexcept
     : radius_inner_(radius_inner),
       radius_outer_(radius_outer),
       orientation_of_wedge_(orientation_of_wedge),
       sphericity_inner_(sphericity_inner),
+      sphericity_outer_(sphericity_outer),
       with_equiangular_map_(with_equiangular_map),
       halves_to_use_(halves_to_use) {
   ASSERT(radius_inner > 0.0,
          "The radius of the inner surface must be greater than zero.");
   ASSERT(sphericity_inner >= 0.0 and sphericity_inner <= 1.0,
          "Sphericity of the inner surface must be between 0 and 1");
+  ASSERT(sphericity_outer >= 0.0 and sphericity_outer <= 1.0,
+         "Sphericity of the outer surface must be between 0 and 1");
   ASSERT(radius_outer > radius_inner,
          "The radius of the outer surface must be greater than the radius of "
          "the inner surface.");

--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -25,17 +25,15 @@ namespace CoordinateMaps {
  *
  * \details The mapping that goes from a reference cube to a three-dimensional
  *  wedge centered on a coordinate axis covering a volume between an inner
- *  surface and outer surface. The inner surface can be given a curvature
+ *  surface and outer surface. Each surface can be given a curvature
  *  between flat (a sphericity of 0) or spherical (a sphericity of 1).
- *  The sphericity of the outer surface is currently constrained to have a
- *  value of 1.
  *
  *  The first two logical coordinates correspond to the two angular coordinates,
  *  and the third to the radial coordinate.
  *
  *  The Wedge3D map is constructed by linearly interpolating between a bulged
- *  face of radius `radius_of_inner_surface` to a spherical face of
- *  radius `radius_of_outer_surface`, where the radius of the bulged face
+ *  face of radius `radius_of_inner_surface` to a bulged face of
+ *  radius `radius_of_outer_surface`, where the radius of each bulged face
  *  is defined to be the radius of the sphere circumscribing the bulge.
  *
  *  We make a choice here as to whether we wish to use the logical coordinates
@@ -201,16 +199,19 @@ class Wedge3D {
 
   /*!
    * Constructs a 3D wedge.
-   * \param radius_outer Radius of the spherical surface
    * \param radius_inner Distance from the origin to one of the
-   * corners which lie on the inner surface, which may be anything between flat
-   * and spherical.
+   * corners which lie on the inner surface.
+   * \param radius_outer Distance from the origin to one of the
+   * corners which lie on the outer surface.
    * \param orientation_of_wedge The orientation of the desired wedge relative
    * to the orientation of the default wedge which is a wedge that has its
    * curved surfaces pierced by the upper-z axis. The logical xi and eta
    * coordinates point in the cartesian x and y directions, respectively.
    * \param sphericity_inner Value between 0 and 1 which determines
    * whether the inner surface is flat (value of 0), spherical (value of 1) or
+   * somewhere in between
+   * \param sphericity_outer Value between 0 and 1 which determines
+   * whether the outer surface is flat (value of 0), spherical (value of 1) or
    * somewhere in between
    * \param with_equiangular_map Determines whether to apply a tangent function
    * mapping to the logical coordinates (for `true`) or not (for `false`).
@@ -222,7 +223,7 @@ class Wedge3D {
    */
   Wedge3D(double radius_inner, double radius_outer,
           OrientationMap<3> orientation_of_wedge, double sphericity_inner,
-          bool with_equiangular_map,
+          double sphericity_outer, bool with_equiangular_map,
           WedgeHalves halves_to_use = WedgeHalves::Both) noexcept;
 
   Wedge3D() = default;
@@ -263,7 +264,7 @@ class Wedge3D {
   double radius_outer_{std::numeric_limits<double>::signaling_NaN()};
   OrientationMap<3> orientation_of_wedge_{};
   double sphericity_inner_{std::numeric_limits<double>::signaling_NaN()};
-  double sphericity_outer_{1.0};
+  double sphericity_outer_{std::numeric_limits<double>::signaling_NaN()};
   bool with_equiangular_map_ = false;
   WedgeHalves halves_to_use_ = WedgeHalves::Both;
   double scaled_frustum_zero_{std::numeric_limits<double>::signaling_NaN()};

--- a/src/Domain/DomainCreators/Shell.cpp
+++ b/src/Domain/DomainCreators/Shell.cpp
@@ -52,7 +52,7 @@ Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
   std::vector<
       std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
       coord_maps = wedge_coordinate_maps<TargetFrame>(
-          inner_radius_, outer_radius_, 1.0, use_equiangular_map_);
+          inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_);
   return Domain<3, TargetFrame>{std::move(coord_maps), corners};
 }
 

--- a/src/Domain/DomainCreators/Sphere.cpp
+++ b/src/Domain/DomainCreators/Sphere.cpp
@@ -63,7 +63,7 @@ Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
   std::vector<
       std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
       coord_maps = wedge_coordinate_maps<TargetFrame>(
-          inner_radius_, outer_radius_, 0.0, use_equiangular_map_);
+          inner_radius_, outer_radius_, 0.0, 1.0, use_equiangular_map_);
   if (use_equiangular_map_) {
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::Logical, TargetFrame>(Equiangular3D{

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -326,37 +326,38 @@ void set_periodic_boundaries(
 template <typename TargetFrame>
 std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
 wedge_coordinate_maps(const double inner_radius, const double outer_radius,
-                      const double sphericity,
+                      const double inner_sphericity,
+                      const double outer_sphericity,
                       const bool use_equiangular_map) noexcept {
   using Wedge3DMap = CoordinateMaps::Wedge3D;
   return make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
-      Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{}, sphericity,
-                 use_equiangular_map},
+      Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
+                 inner_sphericity, outer_sphericity, use_equiangular_map},
       Wedge3DMap{inner_radius, outer_radius,
                  OrientationMap<3>(std::array<Direction<3>, 3>{
                      {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                       Direction<3>::lower_zeta()}}),
-                 sphericity, use_equiangular_map},
+                 inner_sphericity, outer_sphericity, use_equiangular_map},
       Wedge3DMap{inner_radius, outer_radius,
                  OrientationMap<3>(std::array<Direction<3>, 3>{
                      {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
                       Direction<3>::upper_xi()}}),
-                 sphericity, use_equiangular_map},
+                 inner_sphericity, outer_sphericity, use_equiangular_map},
       Wedge3DMap{inner_radius, outer_radius,
                  OrientationMap<3>(std::array<Direction<3>, 3>{
                      {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
                       Direction<3>::lower_xi()}}),
-                 sphericity, use_equiangular_map},
+                 inner_sphericity, outer_sphericity, use_equiangular_map},
       Wedge3DMap{inner_radius, outer_radius,
                  OrientationMap<3>(std::array<Direction<3>, 3>{
                      {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                       Direction<3>::upper_eta()}}),
-                 sphericity, use_equiangular_map},
+                 inner_sphericity, outer_sphericity, use_equiangular_map},
       Wedge3DMap{inner_radius, outer_radius,
                  OrientationMap<3>(std::array<Direction<3>, 3>{
                      {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                       Direction<3>::upper_eta()}}),
-                 sphericity, use_equiangular_map});
+                 inner_sphericity, outer_sphericity, use_equiangular_map});
 }
 
 template void set_internal_boundaries(
@@ -396,10 +397,12 @@ template void set_periodic_boundaries(
 template std::vector<
     std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
 wedge_coordinate_maps(const double inner_radius, const double outer_radius,
-                      const double sphericity,
+                      const double inner_sphericity,
+                      const double outer_sphericity,
                       const bool use_equiangular_map) noexcept;
 template std::vector<
     std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
 wedge_coordinate_maps(const double inner_radius, const double outer_radius,
-                      const double sphericity,
+                      const double inner_sphericity,
+                      const double outer_sphericity,
                       const bool use_equiangular_map) noexcept;

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -70,4 +70,5 @@ void set_periodic_boundaries(
 template <typename TargetFrame>
 std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
 wedge_coordinate_maps(double inner_radius, double outer_radius,
-                      double sphericity, bool use_equiangular_map) noexcept;
+                      double inner_sphericity, double outer_sphericity,
+                      bool use_equiangular_map) noexcept;

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -8,6 +8,8 @@
 #include <random>
 
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "ErrorHandling/Error.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
@@ -15,26 +17,29 @@
 namespace {
 void test_wedge3d_all_directions(const bool with_equiangular_map) {
   // Set up random number generator
-  std::random_device rd;
-  std::mt19937 gen(rd());
+  const auto seed = std::random_device{}();
+  std::mt19937 gen(seed);
+  INFO("seed = " << seed);
   std::uniform_real_distribution<> unit_dis(0, 1);
   std::uniform_real_distribution<> inner_dis(1, 3);
-  std::uniform_real_distribution<> outer_dis(4, 7);
+  std::uniform_real_distribution<> outer_dis(5.2, 7);
   const double inner_radius = inner_dis(gen);
   CAPTURE_PRECISE(inner_radius);
   const double outer_radius = outer_dis(gen);
   CAPTURE_PRECISE(outer_radius);
-  const double sphericity = unit_dis(gen);
-  CAPTURE_PRECISE(sphericity);
+  const double inner_sphericity = unit_dis(gen);
+  CAPTURE_PRECISE(inner_sphericity);
+  const double outer_sphericity = unit_dis(gen);
+  CAPTURE_PRECISE(outer_sphericity);
 
   using WedgeHalves = CoordinateMaps::Wedge3D::WedgeHalves;
   const std::array<WedgeHalves, 3> halves_array = {
       {WedgeHalves::UpperOnly, WedgeHalves::LowerOnly, WedgeHalves::Both}};
   for (const auto& halves : halves_array) {
     for (const auto& direction : all_wedge_directions()) {
-      const CoordinateMaps::Wedge3D wedge_map(inner_radius, outer_radius,
-                                              direction, sphericity,
-                                              with_equiangular_map, halves);
+      const CoordinateMaps::Wedge3D wedge_map(
+          inner_radius, outer_radius, direction, inner_sphericity,
+          outer_sphericity, with_equiangular_map, halves);
       test_suite_for_map(wedge_map);
     }
   }
@@ -49,22 +54,22 @@ void test_wedge3d_alignment(const bool with_equiangular_map) {
 
   const auto wedge_directions = all_wedge_directions();
   const CoordinateMaps::Wedge3D map_upper_zeta(
-      inner_r, outer_r, wedge_directions[0], 0,
+      inner_r, outer_r, wedge_directions[0], 0.0, 1.0,
       with_equiangular_map);  // Upper Z wedge
   const CoordinateMaps::Wedge3D map_upper_eta(
-      inner_r, outer_r, wedge_directions[2], 0,
+      inner_r, outer_r, wedge_directions[2], 0.0, 1.0,
       with_equiangular_map);  // Upper Y wedge
   const CoordinateMaps::Wedge3D map_upper_xi(
-      inner_r, outer_r, wedge_directions[4], 0,
+      inner_r, outer_r, wedge_directions[4], 0.0, 1.0,
       with_equiangular_map);  // Upper X Wedge
   const CoordinateMaps::Wedge3D map_lower_zeta(
-      inner_r, outer_r, wedge_directions[1], 0,
+      inner_r, outer_r, wedge_directions[1], 0.0, 1.0,
       with_equiangular_map);  // Lower Z wedge
   const CoordinateMaps::Wedge3D map_lower_eta(
-      inner_r, outer_r, wedge_directions[3], 0,
+      inner_r, outer_r, wedge_directions[3], 0.0, 1.0,
       with_equiangular_map);  // Lower Y wedge
   const CoordinateMaps::Wedge3D map_lower_xi(
-      inner_r, outer_r, wedge_directions[5], 0,
+      inner_r, outer_r, wedge_directions[5], 0.0, 1.0,
       with_equiangular_map);  // Lower X wedge
   const std::array<double, 3> lowest_corner{{-1.0, -1.0, -1.0}};
   const std::array<double, 3> along_xi{{1.0, -1.0, -1.0}};
@@ -129,8 +134,9 @@ void test_wedge3d_alignment(const bool with_equiangular_map) {
 
 void test_wedge3d_random_radii(const bool with_equiangular_map) {
   // Set up random number generator:
-  std::random_device rd;
-  std::mt19937 gen(rd());
+  const auto seed = std::random_device{}();
+  std::mt19937 gen(seed);
+  INFO("seed = " << seed);
   std::uniform_real_distribution<> real_dis(-1, 1);
   std::uniform_real_distribution<> inner_dis(1, 3);
   std::uniform_real_distribution<> outer_dis(4, 7);
@@ -168,22 +174,22 @@ void test_wedge3d_random_radii(const bool with_equiangular_map) {
   const auto wedge_directions = all_wedge_directions();
   const CoordinateMaps::Wedge3D map_lower_xi(
       random_inner_radius_lower_xi, random_outer_radius_lower_xi,
-      wedge_directions[5], 0, with_equiangular_map);
+      wedge_directions[5], 0.0, 1.0, with_equiangular_map);
   const CoordinateMaps::Wedge3D map_lower_eta(
       random_inner_radius_lower_eta, random_outer_radius_lower_eta,
-      wedge_directions[3], 0, with_equiangular_map);
+      wedge_directions[3], 0.0, 1.0, with_equiangular_map);
   const CoordinateMaps::Wedge3D map_lower_zeta(
       random_inner_radius_lower_zeta, random_outer_radius_lower_zeta,
-      wedge_directions[1], 0, with_equiangular_map);
+      wedge_directions[1], 0.0, 1.0, with_equiangular_map);
   const CoordinateMaps::Wedge3D map_upper_xi(
       random_inner_radius_upper_xi, random_outer_radius_upper_xi,
-      wedge_directions[4], 0, with_equiangular_map);
+      wedge_directions[4], 0.0, 1.0, with_equiangular_map);
   const CoordinateMaps::Wedge3D map_upper_eta(
       random_inner_radius_upper_eta, random_outer_radius_upper_eta,
-      wedge_directions[2], 0, with_equiangular_map);
+      wedge_directions[2], 0.0, 1.0, with_equiangular_map);
   const CoordinateMaps::Wedge3D map_upper_zeta(
       random_inner_radius_upper_zeta, random_outer_radius_upper_zeta,
-      wedge_directions[0], 0, with_equiangular_map);
+      wedge_directions[0], 0.0, 1.0, with_equiangular_map);
   CHECK(map_lower_xi(outer_corner)[0] ==
         approx(-random_outer_radius_lower_xi / sqrt(3.0)));
   CHECK(map_lower_eta(outer_corner)[1] ==
@@ -255,4 +261,66 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.RandomRadii.Equiangular",
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.RandomRadii.Equidistant",
                   "[Domain][Unit]") {
   test_wedge3d_random_radii(false);
+}
+
+// [[OutputRegex, The radius of the inner surface must be greater than zero.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.RadiusInner",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_wedge3d =
+      CoordinateMaps::Wedge3D(-0.2, 4.0, OrientationMap<3>{}, 0.0, 1.0, true);
+  static_cast<void>(failed_wedge3d);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Sphericity of the inner surface must be between 0 and 1]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SphericityInner",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_wedge3d =
+      CoordinateMaps::Wedge3D(0.2, 4.0, OrientationMap<3>{}, -0.2, 1.0, true);
+  static_cast<void>(failed_wedge3d);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Sphericity of the outer surface must be between 0 and 1]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SphericityOuter",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_wedge3d =
+      CoordinateMaps::Wedge3D(0.2, 4.0, OrientationMap<3>{}, 0.0, -0.2, true);
+  static_cast<void>(failed_wedge3d);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The radius of the outer surface must be greater than the
+// radius of the inner surface.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.RadiusOuter",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_wedge3d =
+      CoordinateMaps::Wedge3D(4.2, 4.0, OrientationMap<3>{}, 0.0, 1.0, true);
+  static_cast<void>(failed_wedge3d);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The arguments passed into the constructor for Wedge3D result
+// in an object where the outer surface is pierced by the inner surface.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.PiercedSurface",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_wedge3d =
+      CoordinateMaps::Wedge3D(3.0, 4.0, OrientationMap<3>{}, 1.0, 0.0, true);
+  static_cast<void>(failed_wedge3d);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
 }

--- a/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
@@ -97,33 +97,33 @@ void test_shell_construction(
   test_domain_construction(
       domain, expected_block_neighbors, expected_external_boundaries,
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{}, 1.0,
+          Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{}, 1.0, 1.0,
                      use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                           Direction<3>::lower_zeta()}}},
-                     1.0, use_equiangular_map},
+                     1.0, 1.0, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
                           Direction<3>::upper_xi()}}},
-                     1.0, use_equiangular_map},
+                     1.0, 1.0, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
                           Direction<3>::lower_xi()}}},
-                     1.0, use_equiangular_map},
+                     1.0, 1.0, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                           Direction<3>::upper_eta()}}},
-                     1.0, use_equiangular_map},
+                     1.0, 1.0, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                           Direction<3>::upper_eta()}}},
-                     1.0, use_equiangular_map}
+                     1.0, 1.0, use_equiangular_map}
 
           ));
 

--- a/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
@@ -140,33 +140,33 @@ void test_sphere_construction(
 
   auto coord_maps =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{}, 0.0,
+          Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{}, 0.0, 1.0,
                      use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                           Direction<3>::lower_zeta()}}},
-                     0.0, use_equiangular_map},
+                     0.0, 1.0, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
                           Direction<3>::upper_xi()}}},
-                     0.0, use_equiangular_map},
+                     0.0, 1.0, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
                           Direction<3>::lower_xi()}}},
-                     0.0, use_equiangular_map},
+                     0.0, 1.0, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                           Direction<3>::upper_eta()}}},
-                     0.0, use_equiangular_map},
+                     0.0, 1.0, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                           Direction<3>::upper_eta()}}},
-                     0.0, use_equiangular_map});
+                     0.0, 1.0, use_equiangular_map});
   if (use_equiangular_map) {
     coord_maps.emplace_back(
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(Equiangular3D{

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -3,8 +3,8 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <cstddef>
 #include <array>
+#include <cstddef>
 #include <unordered_map>
 #include <vector>
 
@@ -84,40 +84,42 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.AllWedgeDirections",
   using Wedge3DMap = CoordinateMaps::Wedge3D;
   const double inner_radius = 1.0;
   const double outer_radius = 2.0;
-  const double sphericity = 1.0;
+  const double inner_sphericity = 1.0;
+  const double outer_sphericity = 1.0;
   const bool use_equiangular_map = true;
 
   const auto expected_coord_maps =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
-                     sphericity, use_equiangular_map},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                           Direction<3>::lower_zeta()}}},
-                     sphericity, use_equiangular_map},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_eta(), Direction<3>::upper_zeta(),
                           Direction<3>::upper_xi()}}},
-                     sphericity, use_equiangular_map},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
                           Direction<3>::lower_xi()}}},
-                     sphericity, use_equiangular_map},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                           Direction<3>::upper_eta()}}},
-                     sphericity, use_equiangular_map},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                           Direction<3>::upper_eta()}}},
-                     sphericity, use_equiangular_map});
+                     inner_sphericity, outer_sphericity, use_equiangular_map});
   const auto maps = wedge_coordinate_maps<Frame::Inertial>(
-      inner_radius, outer_radius, sphericity, use_equiangular_map);
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map);
   CHECK(*expected_coord_maps[0] == *maps[0]);
   CHECK(*expected_coord_maps[1] == *maps[1]);
   CHECK(*expected_coord_maps[2] == *maps[2]);

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -176,7 +176,7 @@ void test_element_map<3>() {
   // test with rotation and wedge
   test_element_impl(
       true, element_id, affine_map, first_map,
-      CoordinateMaps::Wedge3D{3.0, 7.0, OrientationMap<3>{}, 0.8, true},
+      CoordinateMaps::Wedge3D{3.0, 7.0, OrientationMap<3>{}, 0.8, 0.9, true},
       logical_point_double, logical_point_dv);
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Also adds ASSERT tests

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
