### PR TITLE
Add DiscreteRotation CoordinateMap

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY CoordinateMaps)
 set(LIBRARY_SOURCES
     Affine.cpp
     BulgedCube.cpp
+    DiscreteRotation.cpp
     Equiangular.cpp
     Frustum.cpp
     Identity.cpp

--- a/src/Domain/CoordinateMaps/DiscreteRotation.cpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.cpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Domain/Direction.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Domain/Side.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace CoordinateMaps {
+
+template <size_t VolumeDim>
+DiscreteRotation<VolumeDim>::DiscreteRotation(
+    OrientationMap<VolumeDim> orientation) noexcept
+    : orientation_(std::move(orientation)) {}
+
+template <size_t VolumeDim>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, VolumeDim> DiscreteRotation<VolumeDim>::
+operator()(const std::array<T, VolumeDim>& source_coords) const noexcept {
+  return discrete_rotation(orientation_, source_coords);
+}
+
+template <size_t VolumeDim>
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, VolumeDim>
+DiscreteRotation<VolumeDim>::inverse(
+    const std::array<T, VolumeDim>& target_coords) const noexcept {
+  return discrete_rotation(orientation_.inverse_map(), target_coords);
+}
+
+template <size_t VolumeDim>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, VolumeDim, Frame::NoFrame>
+DiscreteRotation<VolumeDim>::jacobian(
+    const std::array<T, VolumeDim>& source_coords) const noexcept {
+  auto jacobian_matrix = make_with_value<
+      tnsr::Ij<tt::remove_cvref_wrap_t<T>, VolumeDim, Frame::NoFrame>>(
+      dereference_wrapper(source_coords[0]), 0.0);
+  for (size_t d = 0; d < VolumeDim; d++) {
+    const auto new_direction =
+        orientation_(Direction<VolumeDim>(d, Side::Upper));
+    jacobian_matrix.get(d, orientation_(d)) =
+        new_direction.side() == Side::Upper ? 1.0 : -1.0;
+  }
+  return jacobian_matrix;
+}
+
+template <size_t VolumeDim>
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, VolumeDim, Frame::NoFrame>
+DiscreteRotation<VolumeDim>::inv_jacobian(
+    const std::array<T, VolumeDim>& source_coords) const noexcept {
+  auto inv_jacobian_matrix = make_with_value<
+      tnsr::Ij<tt::remove_cvref_wrap_t<T>, VolumeDim, Frame::NoFrame>>(
+      dereference_wrapper(source_coords[0]), 0.0);
+  for (size_t d = 0; d < VolumeDim; d++) {
+    const auto new_direction =
+        orientation_(Direction<VolumeDim>(d, Side::Upper));
+    inv_jacobian_matrix.get(orientation_(d), d) =
+        new_direction.side() == Side::Upper ? 1.0 : -1.0;
+  }
+  return inv_jacobian_matrix;
+}
+
+template <size_t VolumeDim>
+void DiscreteRotation<VolumeDim>::pup(PUP::er& p) noexcept {
+  p | orientation_;
+}
+
+template class DiscreteRotation<1>;
+template class DiscreteRotation<2>;
+template class DiscreteRotation<3>;
+
+// Explicit instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
+  DiscreteRotation<DIM(data)>::operator()(                                     \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept; \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
+  DiscreteRotation<DIM(data)>::inverse(                                        \
+      const std::array<DTYPE(data), DIM(data)>& target_coords) const noexcept; \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
+                    Frame::NoFrame>                                            \
+  DiscreteRotation<DIM(data)>::jacobian(                                       \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept; \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
+                    Frame::NoFrame>                                            \
+  DiscreteRotation<DIM(data)>::inv_jacobian(                                   \
+      const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (double, DataVector,
+                         std::reference_wrapper<const double>,
+                         std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+}  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/DiscreteRotation.hpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.hpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ * \brief A CoordinateMap that swaps/negates the coordinate
+ * axes.
+ *
+ * Providing an OrientationMap to the constructor allows for
+ * the resulting map to have different orientations.
+ */
+template <size_t VolumeDim>
+class DiscreteRotation {
+ public:
+  static constexpr size_t dim = VolumeDim;
+
+  explicit DiscreteRotation(OrientationMap<VolumeDim> orientation =
+                                OrientationMap<VolumeDim>{}) noexcept;
+  ~DiscreteRotation() = default;
+  DiscreteRotation(const DiscreteRotation&) = default;
+  DiscreteRotation(DiscreteRotation&&) noexcept = default;  // NOLINT
+  DiscreteRotation& operator=(const DiscreteRotation&) = default;
+  DiscreteRotation& operator=(DiscreteRotation&&) = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, VolumeDim> operator()(
+      const std::array<T, VolumeDim>& source_coords) const noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, VolumeDim> inverse(
+      const std::array<T, VolumeDim>& target_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, VolumeDim, Frame::NoFrame> jacobian(
+      const std::array<T, VolumeDim>& source_coords) const noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, VolumeDim, Frame::NoFrame> inv_jacobian(
+      const std::array<T, VolumeDim>& source_coords) const noexcept;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  friend bool operator==(const DiscreteRotation& lhs,
+                         const DiscreteRotation& rhs) noexcept {
+    return lhs.orientation_ == rhs.orientation_;
+  }
+
+  OrientationMap<VolumeDim> orientation_{};
+};
+
+template <size_t VolumeDim>
+inline bool operator!=(
+    const CoordinateMaps::DiscreteRotation<VolumeDim>& lhs,
+    const CoordinateMaps::DiscreteRotation<VolumeDim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace CoordinateMaps

--- a/src/Domain/OrientationMap.hpp
+++ b/src/Domain/OrientationMap.hpp
@@ -9,6 +9,7 @@
 
 
 #include "Domain/Direction.hpp"
+#include "Domain/SegmentId.hpp"
 #include "Domain/Side.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TypeTraits.hpp"

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY_SOURCES
   CoordinateMaps/Test_Affine.cpp
   CoordinateMaps/Test_BulgedCube.cpp
   CoordinateMaps/Test_CoordinateMap.cpp
+  CoordinateMaps/Test_DiscreteRotation.cpp
   CoordinateMaps/Test_Equiangular.cpp
   CoordinateMaps/Test_Frustum.cpp
   CoordinateMaps/Test_Identity.cpp

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -55,16 +55,10 @@ void check_if_maps_are_equal(
     }
     CAPTURE_PRECISE(source_point);
     CHECK_ITERABLE_APPROX(map_one(source_point), map_two(source_point));
-    for (size_t i = 0; i < VolumeDim; ++i) {
-      for (size_t j = 0; j < VolumeDim; ++j) {
-        INFO("i: " << i << " j: " << j);
-        CHECK(map_one.jacobian(source_point).get(j, i) ==
-              map_two.jacobian(source_point).get(j, i));
-
-        CHECK(map_one.inv_jacobian(source_point).get(j, i) ==
-              map_two.inv_jacobian(source_point).get(j, i));
-      }
-    }
+    CHECK_ITERABLE_APPROX(map_one.jacobian(source_point),
+                          map_two.jacobian(source_point));
+    CHECK_ITERABLE_APPROX(map_one.inv_jacobian(source_point),
+                          map_two.inv_jacobian(source_point));
   }
 }
 

--- a/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/Rotation.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation.Specific1D",
+                  "[Domain][Unit]") {
+  const CoordinateMaps::DiscreteRotation<1> identity_map1d{};
+  const CoordinateMaps::DiscreteRotation<1> rotation_nx{OrientationMap<1>{
+      std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}}};
+
+  check_if_maps_are_equal(
+      make_coordinate_map<Frame::Logical, Frame::Grid>(
+          CoordinateMaps::Identity<1>{}),
+      make_coordinate_map<Frame::Logical, Frame::Grid>(identity_map1d));
+  check_if_maps_are_equal(
+      make_coordinate_map<Frame::Logical, Frame::Grid>(
+          CoordinateMaps::Affine{-1.0, 1.0, 1.0, -1.0}),
+      make_coordinate_map<Frame::Logical, Frame::Grid>(rotation_nx));
+
+  const std::array<double, 1> point_px{{0.5}};
+  const std::array<double, 1> point_nx{{-0.5}};
+  CHECK(rotation_nx(point_px) == point_nx);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation.Specific2D",
+                  "[Domain][Unit]") {
+  const CoordinateMaps::DiscreteRotation<2> identity_map2d{};
+  const CoordinateMaps::DiscreteRotation<2> rotation_ny_px{
+      OrientationMap<2>{std::array<Direction<2>, 2>{
+          {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}};
+
+  check_if_maps_are_equal(
+      make_coordinate_map<Frame::Logical, Frame::Grid>(
+          CoordinateMaps::Identity<2>{}),
+      make_coordinate_map<Frame::Logical, Frame::Grid>(identity_map2d));
+  check_if_maps_are_equal(
+      make_coordinate_map<Frame::Logical, Frame::Grid>(
+          CoordinateMaps::Rotation<2>{M_PI_2}),
+      make_coordinate_map<Frame::Logical, Frame::Grid>(rotation_ny_px));
+
+  const std::array<double, 2> point_px_py{{0.2, 0.5}};
+  const std::array<double, 2> point_ny_px{{-0.5, 0.2}};
+  CHECK(rotation_ny_px(point_px_py) == point_ny_px);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation.Specific3D",
+                  "[Domain][Unit]") {
+  const CoordinateMaps::DiscreteRotation<3> identity_map3d{};
+  const CoordinateMaps::DiscreteRotation<3> rotation_ny_nz_px{
+      OrientationMap<3>{std::array<Direction<3>, 3>{
+          {Direction<3>::lower_eta(), Direction<3>::lower_zeta(),
+           Direction<3>::upper_xi()}}}};
+
+  using Identity1D = CoordinateMaps::Identity<1>;
+  using Identity2D = CoordinateMaps::Identity<2>;
+  using Identity3D = CoordinateMaps::ProductOf2Maps<Identity1D, Identity2D>;
+  const Identity1D id1d{};
+  const Identity2D id2d{};
+  const Identity3D id3d{id1d, id2d};
+
+  check_if_maps_are_equal(
+      make_coordinate_map<Frame::Logical, Frame::Grid>(id3d),
+      make_coordinate_map<Frame::Logical, Frame::Grid>(identity_map3d));
+  check_if_maps_are_equal(
+      make_coordinate_map<Frame::Logical, Frame::Grid>(
+          CoordinateMaps::Rotation<3>{M_PI_2, -M_PI_2, 0.0}),
+      make_coordinate_map<Frame::Logical, Frame::Grid>(rotation_ny_nz_px));
+
+  const std::array<double, 3> point_px_py_pz{{0.2, 0.5, 0.3}};
+  const std::array<double, 3> point_ny_nz_px{{-0.5, -0.3, 0.2}};
+  CHECK(rotation_ny_nz_px(point_px_py_pz) == point_ny_nz_px);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation",
+                  "[Domain][Unit]") {
+  for (OrientationMapIterator<2> map_i{}; map_i; ++map_i) {
+    const CoordinateMaps::DiscreteRotation<2> coord_map{map_i()};
+    test_suite_for_map(coord_map);
+  }
+  for (OrientationMapIterator<3> map_i{}; map_i; ++map_i) {
+    const CoordinateMaps::DiscreteRotation<3> coord_map{map_i()};
+    test_suite_for_map(coord_map);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Allows for the factoring out of the discrete_rotation call that is done in each map like Wedge3D and Frustum - this will now be able to be done using map composition.

For testing purposes.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
