### PR TITLE
Add Newton-Raphson root finder

### DIFF
--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -14,7 +14,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/Error.hpp"
-#include "NumericalAlgorithms/RootFinding/RootFinder.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
@@ -79,10 +79,10 @@ DType scaling_factor(RootFunction<DType>&& rootfunction) noexcept {
   const DType& physical_r_squared = rootfunction.get_r_sq();
   try {
     DType rho =
-        find_root_of_function(rootfunction, make_with_value<DType>(x_sq, 0.0),
-                              make_with_value<DType>(x_sq, sqrt(3.0)),
-                              10.0 * std::numeric_limits<double>::epsilon(),
-                              10.0 * std::numeric_limits<double>::epsilon());
+        RootFinder::toms748(rootfunction, make_with_value<DType>(x_sq, 0.0),
+                            make_with_value<DType>(x_sq, sqrt(3.0)),
+                            10.0 * std::numeric_limits<double>::epsilon(),
+                            10.0 * std::numeric_limits<double>::epsilon());
     for (size_t i = 0; i < get_size(rho); i++) {
       if (not(equal_within_roundoff(get_element(physical_r_squared, i), 0.0))) {
         get_element(rho, i) /= sqrt(get_element(physical_r_squared, i));

--- a/src/NumericalAlgorithms/RootFinding/NewtonRaphson.hpp
+++ b/src/NumericalAlgorithms/RootFinding/NewtonRaphson.hpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Declares function RootFinder::newton_raphson
+
+#pragma once
+
+#include <boost/math/tools/roots.hpp>
+#include <functional>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+
+namespace RootFinder {
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Finds the root of the function `f` with the Newton-Raphson method.
+ *
+ * `f` is a unary invokable that takes a `double` which is the current value at
+ * which to evaluate `f`. An example is below.
+ *
+ * \snippet Test_NewtonRaphson.cpp double_newton_raphson_root_find
+ *
+ * See the [Boost](http://www.boost.org/) documentation for more details.
+ *
+ * \requires Function `f` is invokable with a `double`
+ * \note The parameter `digits` specifies the precision of the result in its
+ * desired number of base-10 digits
+ */
+template <typename Function>
+double newton_raphson(const Function& f, const double initial_guess,
+                      const double lower_bound, const double upper_bound,
+                      const size_t digits, const size_t max_iterations = 50) {
+  ASSERT(digits < std::numeric_limits<double>::digits10,
+         "The desired accuracy of " << digits
+                                    << " base-10 digits must be smaller than "
+                                       "the machine numeric limit of "
+                                    << std::numeric_limits<double>::digits10
+                                    << " base-10 digits.");
+
+  boost::uintmax_t max_iters = max_iterations;
+  // clang-tidy: internal boost warning, can't fix it.
+  return boost::math::tools::newton_raphson_iterate(  // NOLINT
+      f, initial_guess, lower_bound, upper_bound,
+      std::round(std::log2(std::pow(10, digits))), max_iters);
+}
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Finds the root of the function `f` with the Newton-Raphson method on
+ * each element in a `DataVector`.
+ *
+ * `f` is a binary invokable that takes a `double` as its first argument and a
+ * `size_t` as its second. The `double` is the current value at which to
+ * evaluate `f`, and the `size_t` is the current index into the `DataVector`s.
+ * Below is an example of how to root find different functions by indexing into
+ * a lambda-captured `DataVector` using the `size_t` passed to `f`.
+ *
+ * \snippet Test_NewtonRaphson.cpp datavector_newton_raphson_root_find
+ *
+ * See the [Boost](http://www.boost.org/) documentation for more details.
+ *
+ * \requires Function `f` be callable with a `double` and a `size_t`
+ * \note The parameter `digits` specifies the precision of the result in its
+ * desired number of base-10 digits
+ */
+template <typename Function>
+DataVector newton_raphson(const Function& f, const DataVector& initial_guess,
+                          const DataVector& lower_bound,
+                          const DataVector& upper_bound, const size_t digits,
+                          const size_t max_iterations = 50) {
+  ASSERT(digits < std::numeric_limits<double>::digits10,
+         "The desired accuracy of " << digits
+                                    << " base-10 digits must be smaller than "
+                                       "the machine numeric limit of "
+                                    << std::numeric_limits<double>::digits10
+                                    << " base-10 digits.");
+  const auto digits_binary = std::round(std::log2(std::pow(10, digits)));
+
+  DataVector result_vector{lower_bound.size()};
+  for (size_t i = 0; i < result_vector.size(); ++i) {
+    boost::uintmax_t max_iters = max_iterations;
+    // clang-tidy: internal boost warning, can't fix it.
+    result_vector[i] = boost::math::tools::newton_raphson_iterate(  // NOLINT
+        [&f, i ](double x) noexcept { return f(x, i); }, initial_guess[i],
+        lower_bound[i], upper_bound[i], digits_binary, max_iters);
+  }
+  return result_vector;
+}
+
+}  // namespace RootFinder

--- a/src/NumericalAlgorithms/RootFinding/TOMS748.hpp
+++ b/src/NumericalAlgorithms/RootFinding/TOMS748.hpp
@@ -2,15 +2,17 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Declares function find_root_of_function
+/// Declares function RootFinder::toms748
 
 #pragma once
 
-#include <boost/math/tools/toms748_solve.hpp>
+#include <boost/math/tools/roots.hpp>
 #include <functional>
 #include <limits>
 
 #include "DataStructures/DataVector.hpp"
+
+namespace RootFinder {
 
 /*!
  * \ingroup NumericalAlgorithmsGroup
@@ -19,22 +21,21 @@
  * `f` is a unary invokable that takes a `double` which is the current value at
  * which to evaluate `f`. An example is below.
  *
- * \snippet Test_OneDRootFinder.cpp double_root_find
+ * \snippet Test_TOMS748.cpp double_root_find
  *
  * See the [Boost](http://www.boost.org/) documentation for more details.
  *
- * \requires Function f is invokable with a `double`
+ * \requires Function `f` is invokable with a `double`
  */
 template <typename Function>
-double find_root_of_function(const Function& f, const double lower_bound,
-                             const double upper_bound,
-                             const double absolute_tolerance,
-                             const double relative_tolerance,
-                             const size_t max_iterations = 100) {
+double toms748(const Function& f, const double lower_bound,
+               const double upper_bound, const double absolute_tolerance,
+               const double relative_tolerance,
+               const size_t max_iterations = 100) {
   ASSERT(relative_tolerance > std::numeric_limits<double>::epsilon(),
          "The relative tolerance is too small.");
 
-  boost::uintmax_t max_iter = max_iterations;
+  boost::uintmax_t max_iters = max_iterations;
 
   // This solver requires tol to be passed as a termination condition. This
   // termination condition is equivalent to the convergence criteria used by the
@@ -50,7 +51,7 @@ double find_root_of_function(const Function& f, const double lower_bound,
   // clang-tidy: internal boost warning, can't fix it.
   auto result = boost::math::tools::toms748_solve(  // NOLINT
       f, lower_bound - absolute_tolerance, upper_bound + absolute_tolerance,
-      tol, max_iter);
+      tol, max_iters);
   return result.first + 0.5 * (result.second - result.first);
 }
 
@@ -65,19 +66,18 @@ double find_root_of_function(const Function& f, const double lower_bound,
  * Below is an example of how to root find different functions by indexing into
  * a lambda-captured `DataVector` using the `size_t` passed to `f`.
  *
- * \snippet Test_OneDRootFinder.cpp datavector_root_find
+ * \snippet Test_TOMS748.cpp datavector_root_find
  *
  * See the [Boost](http://www.boost.org/) documentation for more details.
  *
- * \requires Function f be callable with a `double` and a `size_t`
+ * \requires Function `f` be callable with a `double` and a `size_t`
  */
 template <typename Function>
-DataVector find_root_of_function(const Function& f,
-                                 const DataVector& lower_bound,
-                                 const DataVector& upper_bound,
-                                 const double absolute_tolerance,
-                                 const double relative_tolerance,
-                                 const size_t max_iterations = 100) {
+DataVector toms748(const Function& f, const DataVector& lower_bound,
+                   const DataVector& upper_bound,
+                   const double absolute_tolerance,
+                   const double relative_tolerance,
+                   const size_t max_iterations = 100) {
   ASSERT(relative_tolerance > std::numeric_limits<double>::epsilon(),
          "The relative tolerance is too small.");
   // This solver requires tol to be passed as a termination condition. This
@@ -94,15 +94,18 @@ DataVector find_root_of_function(const Function& f,
   // tolerance
   DataVector result_vector{lower_bound.size()};
   for (size_t i = 0; i < result_vector.size(); ++i) {
-    // toms748_solver modifies the max_iter after the root is found to the
+    // toms748_solver modifies the max_iters after the root is found to the
     // number of iterations that it took to find the root, so we reset it to
     // max_iterations after each root find.
-    boost::uintmax_t max_iter = max_iterations;
-    auto result = boost::math::tools::toms748_solve(
+    boost::uintmax_t max_iters = max_iterations;
+    // clang-tidy: internal boost warning, can't fix it.
+    auto result = boost::math::tools::toms748_solve(  // NOLINT
         [&f, i](double x) { return f(x, i); },
         lower_bound[i] - absolute_tolerance,
-        upper_bound[i] + absolute_tolerance, tol, max_iter);
+        upper_bound[i] + absolute_tolerance, tol, max_iters);
     result_vector[i] = result.first + 0.5 * (result.second - result.first);
   }
   return result_vector;
 }
+
+}  // namespace RootFinder

--- a/tests/Unit/NumericalAlgorithms/RootFinding/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/CMakeLists.txt
@@ -4,8 +4,9 @@
 set(LIBRARY "Test_RootFinding")
 
 set(LIBRARY_SOURCES
-  Test_OneDRootFinder.cpp
+  Test_NewtonRaphson.cpp
   Test_QuadraticEquation.cpp
+  Test_TOMS748.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_NewtonRaphson.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_NewtonRaphson.cpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/RootFinding/NewtonRaphson.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace {
+std::pair<double, double> func_and_deriv_free(double x) noexcept {
+  return std::make_pair(2. - square(x), -2. * x);
+}
+struct FuncAndDeriv {
+  std::pair<double, double> operator()(double x) noexcept {
+    return std::make_pair(2. - square(x), -2. * x);
+  }
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson",
+                  "[NumericalAlgorithms][RootFinding][Unit]") {
+  /// [double_newton_raphson_root_find]
+  const size_t digits = 8;
+  const double correct = sqrt(2.);
+  const double guess = 1.5;
+  const double lower = 1.;
+  const double upper = 2.;
+  const auto func_and_deriv_lambda = [](double x) noexcept {
+    return std::make_pair(2. - square(x), -2. * x);
+  };
+  const auto root_from_lambda = RootFinder::newton_raphson(
+      func_and_deriv_lambda, guess, lower, upper, digits);
+  /// [double_newton_raphson_root_find]
+  const auto root_from_free = RootFinder::newton_raphson(
+      func_and_deriv_free, guess, lower, upper, digits);
+  const FuncAndDeriv func_and_deriv_functor{};
+  const auto root_from_functor = RootFinder::newton_raphson(
+      func_and_deriv_functor, guess, lower, upper, digits);
+  CHECK(std::abs(root_from_lambda - correct) < 1.0 / std::pow(10, digits));
+  CHECK(root_from_free == root_from_lambda);
+  CHECK(root_from_free == root_from_functor);
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson.Bounds",
+                  "[NumericalAlgorithms][RootFinding][Unit]") {
+  const size_t digits = 8;
+  const double guess = 1.5;
+  double upper = 2.;
+  double lower = sqrt(2.);
+  const auto func_and_deriv_lambda = [](double x) noexcept {
+    return std::make_pair(2. - square(x), -2. * x);
+  };
+
+  auto root = RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower,
+                                         upper, digits);
+  const double correct = sqrt(2.);
+
+  CHECK(std::abs(root - correct) < 1.0 / std::pow(10, digits));
+
+  lower = 0.;
+  upper = sqrt(2.);
+
+  root = RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower, upper,
+                                    digits);
+  CHECK(std::abs(root - correct) < 1.0 / std::pow(10, digits));
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson.DataVector",
+                  "[NumericalAlgorithms][RootFinding][Unit]") {
+  /// [datavector_newton_raphson_root_find]
+  const size_t digits = 8;
+  const DataVector guess{1.6, 1.9, -1.6, -1.9};
+  const DataVector lower{sqrt(2.), sqrt(2.), -2., -3.};
+  const DataVector upper{2., 3., -sqrt(2.), -sqrt(2.)};
+  const DataVector constant{2., 4., 2., 4.};
+
+  const auto func_and_deriv_lambda = [&constant](const double x,
+                                                 const size_t i) noexcept {
+    return std::make_pair(constant[i] - square(x), -2. * x);
+  };
+
+  const auto root = RootFinder::newton_raphson(func_and_deriv_lambda, guess,
+                                               lower, upper, digits);
+  /// [datavector_newton_raphson_root_find]
+
+  const DataVector correct{sqrt(2.), 2., -sqrt(2.), -2.};
+
+  for (size_t i = 0; i < guess.size(); i++) {
+    CHECK(std::abs(root[i] - correct[i]) < 1.0 / std::pow(10, digits));
+  }
+}
+
+// [[OutputRegex, The desired accuracy of 100 base-10 digits must be smaller]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.RootFinding.NewtonRaphson.Digits.Double",
+    "[NumericalAlgorithms][RootFinding][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const size_t digits = 100;
+  const double guess = 1.5;
+  double lower = 1.;
+  double upper = 2.;
+  const auto func_and_deriv_lambda = [](double x) {
+    return std::make_pair(2. - square(x), -2. * x);
+  };
+
+  auto root = RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower,
+                                         upper, digits);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The desired accuracy of 100 base-10 digits must be smaller]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.RootFinding.NewtonRaphson.Digits.DataVector",
+    "[NumericalAlgorithms][RootFinding][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const size_t digits = 100;
+  const DataVector guess{1.6, 1.9, -1.6, -1.9};
+  const DataVector lower{sqrt(2.), sqrt(2.), -2., -3.};
+  const DataVector upper{2., 3., -sqrt(2.), -sqrt(2.)};
+  const DataVector constant{2., 4., 2., 4.};
+
+  const auto func_and_deriv_lambda = [&constant](const double x,
+                                                 const size_t i) noexcept {
+    return std::make_pair(constant[i] - square(x), -2. * x);
+  };
+
+  const auto root = RootFinder::newton_raphson(func_and_deriv_lambda, guess,
+                                               lower, upper, digits);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_TOMS748.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_TOMS748.cpp
@@ -9,45 +9,46 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "ErrorHandling/Error.hpp"
-#include "NumericalAlgorithms/RootFinding/RootFinder.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 
 namespace {
-double f_free(double x) { return 2.0 - x * x; }
+double f_free(double x) { return 2.0 - square(x); }
 struct F {
-  double operator()(double x) { return 2.0 - x * x; }
+  double operator()(double x) { return 2.0 - square(x); }
 };
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver",
+SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748",
                   "[NumericalAlgorithms][RootFinding][Unit]") {
   const double abs_tol = 1e-15;
   const double rel_tol = 1e-15;
   const double upper = 2.0;
   const double lower = 0.0;
-  const auto f_lambda = [](double x) { return 2.0 - x * x; };
+  const auto f_lambda = [](double x) { return 2.0 - square(x); };
   const F f_functor{};
   const auto root_from_lambda =
-      find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);
+      RootFinder::toms748(f_lambda, lower, upper, abs_tol, rel_tol);
   const auto root_from_free =
-      find_root_of_function(f_free, lower, upper, abs_tol, rel_tol);
+      RootFinder::toms748(f_free, lower, upper, abs_tol, rel_tol);
   const auto root_from_functor =
-      find_root_of_function(f_functor, lower, upper, abs_tol, rel_tol);
+      RootFinder::toms748(f_functor, lower, upper, abs_tol, rel_tol);
   CHECK(std::abs(root_from_lambda - sqrt(2)) < abs_tol);
   CHECK(std::abs(root_from_lambda - sqrt(2)) / sqrt(2) < rel_tol);
   CHECK(root_from_free == root_from_lambda);
   CHECK(root_from_free == root_from_functor);
 }
 
-SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.Bounds",
+SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748.Bounds",
                   "[NumericalAlgorithms][RootFinding][Unit]") {
   /// [double_root_find]
   const double abs_tol = 1e-15;
   const double rel_tol = 1e-15;
   double upper = 2.0;
-  double lower = sqrt(2.);
-  const auto f_lambda = [](double x) { return 2.0 - x * x; };
+  double lower = sqrt(2.0);
+  const auto f_lambda = [](double x) { return 2.0 - square(x); };
 
-  auto root = find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);
+  auto root = RootFinder::toms748(f_lambda, lower, upper, abs_tol, rel_tol);
   /// [double_root_find]
 
   CHECK(std::abs(root - sqrt(2)) < abs_tol);
@@ -56,12 +57,12 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.Bounds",
   lower = 0.;
   upper = sqrt(2.);
 
-  root = find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);
+  root = RootFinder::toms748(f_lambda, lower, upper, abs_tol, rel_tol);
   CHECK(std::abs(root - sqrt(2)) < abs_tol);
   CHECK(std::abs(root - sqrt(2)) / sqrt(2) < rel_tol);
 }
 
-SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.DataVector",
+SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748.DataVector",
                   "[NumericalAlgorithms][RootFinding][Unit]") {
   /// [datavector_root_find]
   const double abs_tol = 1e-15;
@@ -71,11 +72,11 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.DataVector",
 
   const DataVector constant{2.0, 4.0, 2.0, 4.0};
   const auto f_lambda = [&constant](const double x, const size_t i) noexcept {
-    return constant[i] - x * x;
+    return constant[i] - square(x);
   };
 
   const auto root =
-      find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);
+      RootFinder::toms748(f_lambda, lower, upper, abs_tol, rel_tol);
   /// [datavector_root_find]
 
   CHECK(std::abs(root[0] - sqrt(2.0)) < abs_tol);
@@ -90,39 +91,38 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748RootSolver.DataVector",
 
 // [[OutputRegex, The relative tolerance is too small.]]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Numerical.RootFinding.TOMS748RootSolver.RelativeTol.DataVector",
+    "Unit.Numerical.RootFinding.TOMS748.RelativeTol.DataVector",
     "[NumericalAlgorithms][RootFinding][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   const double abs_tol = 1e-15;
   const double rel_tol = 0.5 * std::numeric_limits<double>::epsilon();
   const DataVector upper{2.0, 3.0, -sqrt(2.0), -sqrt(2.0)};
-  const DataVector lower{sqrt(2.), sqrt(2.0), -2.0, -3.0};
+  const DataVector lower{sqrt(2.0), sqrt(2.0), -2.0, -3.0};
 
   const DataVector constant{2.0, 4.0, 2.0, 4.0};
   const auto f_lambda = [&constant](const double x, const size_t i) noexcept {
-    return constant[i] - x * x;
+    return constant[i] - square(x);
   };
 
-  find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);
+  RootFinder::toms748(f_lambda, lower, upper, abs_tol, rel_tol);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
 // [[OutputRegex, The relative tolerance is too small.]]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Numerical.RootFinding.TOMS748RootSolver.RelativeTol.Double",
+    "Unit.Numerical.RootFinding.TOMS748.RelativeTol.Double",
     "[NumericalAlgorithms][RootFinding][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   const double abs_tol = 1e-15;
   const double rel_tol = 0.5 * std::numeric_limits<double>::epsilon();
   double upper = 2.0;
-  double lower = sqrt(2.);
-  const auto f_lambda = [](double x) { return 2.0 - x * x; };
+  double lower = sqrt(2.0);
+  const auto f_lambda = [](double x) { return 2.0 - square(x); };
 
-  // clang-tidy: internal boost warning, can't fix it.
-  find_root_of_function(f_lambda, lower, upper, abs_tol, rel_tol);  // NOLINT
+  RootFinder::toms748(f_lambda, lower, upper, abs_tol, rel_tol);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }


### PR DESCRIPTION
## Proposed changes

Adds `RootFinder::newton_raphson` and renames the existing TOMS748 root finder from `find_root_of_function` to `RootFinder::toms748`.

**What breaks:**
- Code that calls `find_root_of_function` must be refactored to `RootFinder::newton_raphson` if derivatives are available, or `RootFinder::toms748` if they are not.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`