### PR TITLE
Add support for running on Bluewaters

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -13,3 +13,7 @@ set(CMAKE_CXX_FLAGS "-g ${CMAKE_CXX_FLAGS}")
 # Always compile only for the current architecture. This can be overridden
 # by passing `-D CMAKE_CXX_FLAGS="-march=THE_ARCHITECTURE"` to CMake
 set(CMAKE_CXX_FLAGS "-march=native ${CMAKE_CXX_FLAGS}")
+
+# We always want a detailed backtrace of template errors to make debugging them
+# easier
+set(CMAKE_CXX_FLAGS "-ftemplate-backtrace-limit=0 ${CMAKE_CXX_FLAGS}")

--- a/cmake/SetupNumPy.cmake
+++ b/cmake/SetupNumPy.cmake
@@ -3,8 +3,6 @@
 
 find_package(NumPy REQUIRED)
 
-include_directories(SYSTEM ${NUMPY_INCLUDE_DIRS})
-
 message(STATUS "NumPy incl: " ${NUMPY_INCLUDE_DIRS})
 message(STATUS "NumPy vers: " ${NUMPY_VERSION})
 

--- a/cmake/SetupPythonLibs.cmake
+++ b/cmake/SetupPythonLibs.cmake
@@ -2,8 +2,6 @@
 # See LICENSE.txt for details.
 
 find_package(PythonLibs REQUIRED)
-include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
-list(APPEND SPECTRE_LIBRARIES ${PYTHON_LIBRARIES})
 
 message(STATUS "Python libs: " ${PYTHON_LIBRARIES})
 message(STATUS "Python incl: " ${PYTHON_INCLUDE_DIRS})

--- a/cmake/SpectreAddCatchTests.cmake
+++ b/cmake/SpectreAddCatchTests.cmake
@@ -41,160 +41,160 @@ find_package(PythonInterp REQUIRED)
 
 # Main function - the only one designed to be called from outside this module.
 function(spectre_add_catch_tests TEST_TARGET TEST_LIBS)
-    get_target_property(SOURCE_FILES ${TEST_TARGET} SOURCES)
-    # For each of the source files, we use spectre_parse_file to find all the
-    # Catch tests inside the source file and add them to CTest.
-    # We ignore the Charm++ generated header files.
+  get_target_property(SOURCE_FILES ${TEST_TARGET} SOURCES)
+  # For each of the source files, we use spectre_parse_file to find all the
+  # Catch tests inside the source file and add them to CTest.
+  # We ignore the Charm++ generated header files.
 
-    # For each one of the test libraries, retrieve the source files, and
-    # the path of the library relative to ${CMAKE_SOURCE_DIR}/tests/Unit
-    # (or whatever the testing root directory is). The results are stored
-    # in "CORRECTED_LIB_SOURCES" before being added to the "SOURCE_FILES"
-    foreach (TEST_LIB ${TEST_LIBS})
-      set(CORRECTED_LIB_SOURCES "")
-      get_target_property(LIB_SOURCES ${TEST_LIB} SOURCES)
-      get_target_property(LIB_FOLDER ${TEST_LIB} FOLDER)
-      foreach (SOURCE ${LIB_SOURCES})
-        set(CORRECTED_LIB_SOURCES "${CORRECTED_LIB_SOURCES};${LIB_FOLDER}${SOURCE}")
-      endforeach()
-      set(SOURCE_FILES "${SOURCE_FILES};${CORRECTED_LIB_SOURCES}")
+  # For each one of the test libraries, retrieve the source files, and
+  # the path of the library relative to ${CMAKE_SOURCE_DIR}/tests/Unit
+  # (or whatever the testing root directory is). The results are stored
+  # in "CORRECTED_LIB_SOURCES" before being added to the "SOURCE_FILES"
+  foreach (TEST_LIB ${TEST_LIBS})
+    set(CORRECTED_LIB_SOURCES "")
+    get_target_property(LIB_SOURCES ${TEST_LIB} SOURCES)
+    get_target_property(LIB_FOLDER ${TEST_LIB} FOLDER)
+    foreach (SOURCE ${LIB_SOURCES})
+      set(CORRECTED_LIB_SOURCES "${CORRECTED_LIB_SOURCES};${LIB_FOLDER}${SOURCE}")
     endforeach()
+    set(SOURCE_FILES "${SOURCE_FILES};${CORRECTED_LIB_SOURCES}")
+  endforeach()
 
-    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/tmp")
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/tmp")
 
-    foreach (SOURCE_FILE ${SOURCE_FILES})
-        string(REGEX MATCH ".*(decl.h|def.h)" CHARM_INTERFACE_FILE
-               "${SOURCE_FILE}")
-        if (NOT CHARM_INTERFACE_FILE)
-            if (NOT IS_ABSOLUTE ${SOURCE_FILE})
-                set(SOURCE_FILE ${CMAKE_CURRENT_LIST_DIR}/${SOURCE_FILE})
-            endif()
-            set(ABSOLUTE_SOURCE_FILES "${ABSOLUTE_SOURCE_FILES};${SOURCE_FILE}")
-        endif()
-    endforeach()
-
-    execute_process(
-        COMMAND
-        ${PYTHON_EXECUTABLE}
-        ${CMAKE_SOURCE_DIR}/cmake/SpectreParseTests.py
-        ${ABSOLUTE_SOURCE_FILES}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tmp
-        RESULT_VARIABLE PARSED_TESTS_SUCCESSFULLY)
-    if (${PARSED_TESTS_SUCCESSFULLY} GREATER 0)
-      message(FATAL_ERROR "Failed to parse test files")
+  foreach (SOURCE_FILE ${SOURCE_FILES})
+    string(REGEX MATCH ".*(decl.h|def.h)" CHARM_INTERFACE_FILE
+      "${SOURCE_FILE}")
+    if (NOT CHARM_INTERFACE_FILE)
+      if (NOT IS_ABSOLUTE ${SOURCE_FILE})
+        set(SOURCE_FILE ${CMAKE_CURRENT_LIST_DIR}/${SOURCE_FILE})
+      endif()
+      set(ABSOLUTE_SOURCE_FILES "${ABSOLUTE_SOURCE_FILES};${SOURCE_FILE}")
     endif()
+  endforeach()
 
-    foreach (SOURCE_FILE ${ABSOLUTE_SOURCE_FILES})
-        spectre_parse_file(${SOURCE_FILE} ${TEST_TARGET})
-    endforeach ()
+  execute_process(
+    COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${CMAKE_SOURCE_DIR}/cmake/SpectreParseTests.py
+    ${ABSOLUTE_SOURCE_FILES}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tmp
+    RESULT_VARIABLE PARSED_TESTS_SUCCESSFULLY)
+  if (${PARSED_TESTS_SUCCESSFULLY} GREATER 0)
+    message(FATAL_ERROR "Failed to parse test files")
+  endif()
+
+  foreach (SOURCE_FILE ${ABSOLUTE_SOURCE_FILES})
+    spectre_parse_file(${SOURCE_FILE} ${TEST_TARGET})
+  endforeach ()
 endfunction()
 
 # Parses the cpp file and extracts the tests specified in it. Each test is then
 # added to CTest, and the run command is adjusted according to timeout,
 # willfail, and serialization needs.
 function(spectre_parse_file SOURCE_FILE TEST_TARGET)
-    if (NOT EXISTS ${SOURCE_FILE})
-        message(WARNING "Could not find source file:\n\"${SOURCE_FILE}\"\nfor \
+  if (NOT EXISTS ${SOURCE_FILE})
+    message(WARNING "Could not find source file:\n\"${SOURCE_FILE}\"\nfor \
         tests\n.")
-        return()
+    return()
+  endif ()
+
+  file(STRINGS ${SOURCE_FILE} CONTENTS NEWLINE_CONSUME)
+
+  # Remove commented out tests so they are not added to ctest
+  string(REGEX REPLACE "\n[ \t]*//+[^\n]+" "\n" CONTENTS "${CONTENTS}")
+
+  # The regex searches for SPECTRE_TEST_CASE_METHOD, SCENARIO and SPECTRE_TEST_CASE
+  # to find tests that need to be added.  TESTS will be a list of all tests
+  # found in the SOURCE_FILE.
+  string(REGEX MATCHALL
+    "(CATCH_)?(SPECTRE_TEST_CASE_METHOD|SCENARIO|SPECTRE_TEST_CASE)[ \t]*\\([^\)]+\\)[ \t]*{"
+    TESTS
+    "${CONTENTS}")
+
+  foreach (TEST_NAME ${TESTS})
+    # Get test type and fixture if applicable
+    string(REGEX MATCH "(CATCH_)?(SPECTRE_TEST_CASE_METHOD|SCENARIO|SPECTRE_TEST_CASE)"
+      TEST_TYPE "${TEST_NAME}")
+
+    string(REPLACE "${TEST_TYPE}(" ""
+      TEST_FIXTURE "${TEST_TYPE_AND_FIXTURE}")
+
+    # Get string parts of test definition
+    string(REGEX MATCHALL "\"[^\"]+\"" TEST_STRINGS "${TEST_NAME}")
+
+    # Strip wrapping quotation marks of each element of the list
+    # TEST_STRINGS
+    string(REGEX REPLACE "^\"(.*)\"$" "\\1" TEST_STRINGS "${TEST_STRINGS}")
+    string(REPLACE "\";\"" ";" TEST_STRINGS "${TEST_STRINGS}")
+
+    # Validate that a test name and tags have been provided
+    list(LENGTH TEST_STRINGS TEST_STRINGS_LENGTH)
+    if (NOT TEST_STRINGS_LENGTH EQUAL 2)
+      message(FATAL_ERROR
+        "You must provide a valid test name and tags "
+        "for all tests in ${SOURCE_FILE}. Cannot use the test:\n"
+        "\"${TEST_STRINGS}\"\n")
     endif ()
 
-    file(STRINGS ${SOURCE_FILE} CONTENTS NEWLINE_CONSUME)
+    # Assign name and tags
+    list(GET TEST_STRINGS 0 NAME)
+    if ("${TEST_TYPE}" STREQUAL "SCENARIO")
+      set(NAME "Scenario: ${NAME}")
+    endif ()
+    set(CTEST_NAME "${NAME}")
 
-    # Remove commented out tests so they are not added to ctest
-    string(REGEX REPLACE "\n[ \t]*//+[^\n]+" "\n" CONTENTS "${CONTENTS}")
+    # Gets the TAGS of the test which is element 1 of TEST_STRINGS,
+    # strips the enclosing brackets, and makes a list
+    list(GET TEST_STRINGS 1 TAGS)
+    string(TOLOWER "${TAGS}" TAGS)
+    string(REPLACE "]" ";" TAGS "${TAGS}")
+    string(REPLACE "[" "" TAGS "${TAGS}")
 
-    # The regex searches for SPECTRE_TEST_CASE_METHOD, SCENARIO and SPECTRE_TEST_CASE
-    # to find tests that need to be added.  TESTS will be a list of all tests
-    # found in the SOURCE_FILE.
-    string(REGEX MATCHALL
-           "(CATCH_)?(SPECTRE_TEST_CASE_METHOD|SCENARIO|SPECTRE_TEST_CASE)[ \t]*\\([^\)]+\\)[ \t]*{"
-           TESTS
-           "${CONTENTS}")
+    # These files are generated by the SpectreParseTests.py
+    file(READ "${CMAKE_BINARY_DIR}/tmp/${CTEST_NAME}.output_regex" OUTPUT_REGEX)
+    file(REMOVE "${CMAKE_BINARY_DIR}/tmp/${CTEST_NAME}.output_regex")
+    file(READ "${CMAKE_BINARY_DIR}/tmp/${CTEST_NAME}.timeout" TIMEOUT)
+    file(REMOVE "${CMAKE_BINARY_DIR}/tmp/${CTEST_NAME}.timeout")
 
-    foreach (TEST_NAME ${TESTS})
-        # Get test type and fixture if applicable
-        string(REGEX MATCH "(CATCH_)?(SPECTRE_TEST_CASE_METHOD|SCENARIO|SPECTRE_TEST_CASE)"
-               TEST_TYPE "${TEST_NAME}")
+    # The default TIMEOUT is set to -1, but overwritten by each type
+    # of test or a specified TIMEOUT attribute for a given test.
+    # Thus we can use it to check if each test has been tagged by an
+    # appropriate type.
+    if (TIMEOUT EQUAL -1)
+      message(FATAL_ERROR
+        "You must set at least one tag of value [unit] "
+        "for \"${NAME}\" in ${SOURCE_FILE}\n")
+    endif ()
 
-        string(REPLACE "${TEST_TYPE}(" ""
-               TEST_FIXTURE "${TEST_TYPE_AND_FIXTURE}")
+    # Add the test and set its properties
+    add_test(NAME "\"${CTEST_NAME}\""
+      COMMAND $<TARGET_FILE:${TEST_TARGET}>
+      \"${NAME}\" --durations yes
+      --warn NoAssertions
+      --name "\"$<CONFIGURATION>.${CTEST_NAME}\"")
 
-        # Get string parts of test definition
-        string(REGEX MATCHALL "\"[^\"]+\"" TEST_STRINGS "${TEST_NAME}")
-
-        # Strip wrapping quotation marks of each element of the list
-        # TEST_STRINGS
-        string(REGEX REPLACE "^\"(.*)\"$" "\\1" TEST_STRINGS "${TEST_STRINGS}")
-        string(REPLACE "\";\"" ";" TEST_STRINGS "${TEST_STRINGS}")
-
-        # Validate that a test name and tags have been provided
-        list(LENGTH TEST_STRINGS TEST_STRINGS_LENGTH)
-        if (NOT TEST_STRINGS_LENGTH EQUAL 2)
-            message(FATAL_ERROR
-                    "You must provide a valid test name and tags "
-                    "for all tests in ${SOURCE_FILE}. Cannot use the test:\n"
-                    "\"${TEST_STRINGS}\"\n")
-        endif ()
-
-        # Assign name and tags
-        list(GET TEST_STRINGS 0 NAME)
-        if ("${TEST_TYPE}" STREQUAL "SCENARIO")
-            set(NAME "Scenario: ${NAME}")
-        endif ()
-        set(CTEST_NAME "${NAME}")
-
-        # Gets the TAGS of the test which is element 1 of TEST_STRINGS,
-        # strips the enclosing brackets, and makes a list
-        list(GET TEST_STRINGS 1 TAGS)
-        string(TOLOWER "${TAGS}" TAGS)
-        string(REPLACE "]" ";" TAGS "${TAGS}")
-        string(REPLACE "[" "" TAGS "${TAGS}")
-
-        # These files are generated by the SpectreParseTests.py
-        file(READ "${CMAKE_BINARY_DIR}/tmp/${CTEST_NAME}.output_regex" OUTPUT_REGEX)
-        file(REMOVE "${CMAKE_BINARY_DIR}/tmp/${CTEST_NAME}.output_regex")
-        file(READ "${CMAKE_BINARY_DIR}/tmp/${CTEST_NAME}.timeout" TIMEOUT)
-        file(REMOVE "${CMAKE_BINARY_DIR}/tmp/${CTEST_NAME}.timeout")
-
-        # The default TIMEOUT is set to -1, but overwritten by each type
-        # of test or a specified TIMEOUT attribute for a given test.
-        # Thus we can use it to check if each test has been tagged by an
-        # appropriate type.
-        if (TIMEOUT EQUAL -1)
-            message(FATAL_ERROR
-                    "You must set at least one tag of value [unit] "
-                    "for \"${NAME}\" in ${SOURCE_FILE}\n")
-        endif ()
-
-        # Add the test and set its properties
-        add_test(NAME "\"${CTEST_NAME}\""
-                 COMMAND $<TARGET_FILE:${TEST_TARGET}>
-                 \"${NAME}\" --durations yes
-                 --warn NoAssertions
-                 --name "\"$<CONFIGURATION>.${CTEST_NAME}\"")
-
-        # Check if the test is supposed to fail. If so then let ctest know
-        # that a failed test is actually a pass.
-        if (NOT "${OUTPUT_REGEX}" STREQUAL "None")
-            if (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-                set(OUTPUT_REGEX
-                    "${OUTPUT_REGEX}|### No ASSERT tests in release mode ###")
-            endif()
-            set_tests_properties(
-                "\"${CTEST_NAME}\"" PROPERTIES
-                FAIL_REGULAR_EXPRESSION "No tests ran"
-                TIMEOUT ${TIMEOUT}
-                PASS_REGULAR_EXPRESSION "${OUTPUT_REGEX}"
-                LABELS "${TAGS}"
-                ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-        else ()
-            set_tests_properties(
-                "\"${CTEST_NAME}\"" PROPERTIES
-                FAIL_REGULAR_EXPRESSION "No tests ran"
-                TIMEOUT ${TIMEOUT}
-                LABELS "${TAGS}"
-                ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
-        endif ()
-    endforeach ()
+    # Check if the test is supposed to fail. If so then let ctest know
+    # that a failed test is actually a pass.
+    if (NOT "${OUTPUT_REGEX}" STREQUAL "None")
+      if (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+        set(OUTPUT_REGEX
+          "${OUTPUT_REGEX}|### No ASSERT tests in release mode ###")
+      endif()
+      set_tests_properties(
+        "\"${CTEST_NAME}\"" PROPERTIES
+        FAIL_REGULAR_EXPRESSION "No tests ran"
+        TIMEOUT ${TIMEOUT}
+        PASS_REGULAR_EXPRESSION "${OUTPUT_REGEX}"
+        LABELS "${TAGS}"
+        ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+    else ()
+      set_tests_properties(
+        "\"${CTEST_NAME}\"" PROPERTIES
+        FAIL_REGULAR_EXPRESSION "No tests ran"
+        TIMEOUT ${TIMEOUT}
+        LABELS "${TAGS}"
+        ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+    endif ()
+  endforeach ()
 endfunction()

--- a/cmake/SpectreAddTestLibs.cmake
+++ b/cmake/SpectreAddTestLibs.cmake
@@ -93,12 +93,21 @@ function(add_test_library LIBRARY FOLDER LIBRARY_SOURCES LINK_LIBS)
     ${LIBRARY}
     INTERFACE
     ${LINK_LIBS}
+    INTERFACE
+    ${PYTHON_LIBRARIES}
     )
 
   set_target_properties(
     ${LIBRARY}
     PROPERTIES
     FOLDER "${FOLDER}/"
+    )
+
+  target_include_directories(
+    ${LIBRARY}
+    SYSTEM
+    PUBLIC ${NUMPY_INCLUDE_DIRS}
+    PUBLIC ${PYTHON_INCLUDE_DIRS}
     )
 
   # We use a global variable to also make a list of all the

--- a/docs/MainSite/InstallationOnClusters.md
+++ b/docs/MainSite/InstallationOnClusters.md
@@ -4,6 +4,54 @@ See LICENSE.txt for details.
 \endcond
 # Installation on Clusters {#installation_on_clusters}
 
+## BlueWaters at the National Centre for Supercomputing Applications
+
+1. Run `export SPECTRE_HOME=/path/to/where/you/want/to/clone`
+2. Clone SpECTRE using `git clone SPECTRE_URL $SPECTRE_HOME`
+3. Run `cd $SPECTRE_HOME && mkdir build && cd build`
+4. Run `module load bwpy && bwpy-environ` followed by `module unload bwpy` (you
+   cannot join the unload with the first two)
+5. Run `. $SPECTRE_HOME/support/Environments/bluewaters_gcc.sh`
+6. If you haven't already, choose where you want to install the dependencies,
+   e.g. into `SPECTRE_DEPS` and run `spectre_setup_modules SPECTRE_DEPS`. This
+   will take a while to finish. Near the end the command will tell you how to
+   load make the modules available by providing a `module use` command.
+7. Run `module use SPECTRE_DEPS/modules`
+8. Run `spectre_run_cmake`, if you get module loading errors run
+   `spectre_unload_modules` and try again. CMake should set up successfully.
+9. Build the targets you are interested in by running, e.g.
+   `make -j4 EvolveScalarWave3D`
+
+#### Running tests on BlueWaters
+
+You cannot just run `make test` or `ctest` on BlueWaters. The python and Boost
+modules on BlueWaters do not work together at all (you get segmentation faults).
+You must build a separate version of SpECTRE that links in the python module.
+If you haven't set up the dependencies, do so now. After which you can:
+1. Run `cd $SPECTRE_HOME && mkdir build && cd build`
+2. Run `module load bwpy && bwpy-environ` followed by `module unload bwpy` (you
+   cannot join the unload with the first two)
+3. Uncomment the lines `module load bwpy` and `module unload bwpy` in
+   `$SPECTRE_HOME/support/Environments/bluewaters_gcc.sh` and run
+   `. $SPECTRE_HOME/support/Environments/bluewaters_gcc.sh`
+4. Run `spectre_run_cmake`, if you get module loading errors run
+   `spectre_unload_modules` and try again. CMake should set up successfully.
+5. Run `make -j4`
+
+To run the tests:
+1. Get an interactive node using, e.g. `qsub -q debug -I -l nodes=1:ppn=16:xe -l
+   walltime=00:30:00` or see the [BlueWaters documentation]
+   (https://bluewaters.ncsa.illinois.edu/interactive-jobs)
+2. Setup the bwpy environment `module load bwpy && bwpy-environ` followed by
+   `module unload bwpy` (you cannot join the unload with the first two)
+3. Run the `module use` command you did earlier
+4. Load the module using the `spectre_load_modules` command
+5. Run
+   ```
+   aprun -n1 -d1 -- bwpy-environ -- \
+     $SPECTRE_HOME/build/bin/NonFailureTestsRunTests.sh
+   ```
+
 ## Wheeler at Caltech
 
 1. Clone SpECTRE into `$SPECTRE_HOME`

--- a/support/Environments/bluewaters_gcc.sh
+++ b/support/Environments/bluewaters_gcc.sh
@@ -1,0 +1,293 @@
+#!/bin/bash -e
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Swap to GCC to 6.3.0 env
+load_gcc() {
+    module swap PrgEnv-cray PrgEnv-gnu
+    module unload gcc
+    module load gcc/6.3.0
+}
+
+# Swap to Cray compiler env
+load_cray_cc() {
+    module unload gcc/6.3.0
+    module swap PrgEnv-gnu PrgEnv-cray
+}
+
+# Since curl on BlueWaters breaks randomly we can't use spack reliably.
+spectre_setup_modules() {
+    if [ -z ${SPECTRE_HOME} ]; then
+        echo "You must set SPECTRE_HOME to the cloned SpECTRE directory"
+        return 1
+    fi
+
+    local start_dir=`pwd`
+    dep_dir=$1
+    if [ $# != 1 ]; then
+        echo "You must pass one argument to spectre_setup_modules, which"
+        echo "is the directory where you want the dependencies to be built."
+        return 1
+    fi
+    mkdir -p $dep_dir
+    cd $dep_dir
+    mkdir -p $dep_dir/modules
+
+    load_gcc
+
+    if [ -f catch/include/catch.hpp ]; then
+        echo "Catch is already installed"
+    else
+        echo "Installing catch..."
+        mkdir -p $dep_dir/catch/include
+        cd $dep_dir/catch/include
+        wget https://github.com/catchorg/Catch2/releases/download/v2.2.1/catch.hpp -O catch.hpp
+        echo "Installed Catch into $dep_dir/catch"
+        echo "#%Module1.0" > $dep_dir/modules/catch
+        echo "prepend-path CPATH \"$dep_dir/catch/include\"" >> $dep_dir/modules/catch
+        echo "prepend-path CMAKE_PREFIX_PATH \"$dep_dir/catch/\"" >> $dep_dir/modules/catch
+    fi
+    cd $dep_dir
+
+    if [ -f blaze/include/blaze/Blaze.h ]; then
+        echo "Blaze is already installed"
+    else
+        echo "Installing Blaze..."
+        mkdir -p $dep_dir/blaze/
+        cd $dep_dir/blaze/
+        wget https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.2.tar.gz -O blaze.tar.gz
+        tar -xzf blaze.tar.gz
+        mv blaze-* include
+        echo "Installed Blaze into $dep_dir/blaze"
+        echo "#%Module1.0" > $dep_dir/modules/blaze
+        echo "prepend-path CPATH \"$dep_dir/blaze/include\"" >> $dep_dir/modules/blaze
+        echo "prepend-path CMAKE_PREFIX_PATH \"$dep_dir/blaze/\"" >> $dep_dir/modules/blaze
+    fi
+    cd $dep_dir
+
+
+    if [ -f brigand/include/brigand/brigand.hpp ]; then
+        echo "Brigand is already installed"
+    else
+        echo "Installing Brigand..."
+        rm -rf $dep_dir/brigand
+        git clone https://github.com/edouarda/brigand.git
+        echo "Installed Brigand into $dep_dir/brigand"
+        echo "#%Module1.0" > $dep_dir/modules/brigand
+        echo "prepend-path CPATH \"$dep_dir/brigand/include\"" >> $dep_dir/modules/brigand
+        echo "prepend-path CMAKE_PREFIX_PATH \"$dep_dir/brigand/\"" >> $dep_dir/modules/brigand
+    fi
+    cd $dep_dir
+
+    if [ -f libxsmm/lib/libxsmm.a ]; then
+        echo "LIBXSMM is already installed"
+    else
+        load_cray_cc
+        echo "Installing LIBXSMM..."
+        rm -rf $dep_dir/libxsmm
+        wget https://github.com/hfp/libxsmm/archive/1.9.tar.gz -O libxsmm.tar.gz
+        tar -xzf libxsmm.tar.gz
+        mv libxsmm-* libxsmm
+        cd libxsmm
+        load_cray_cc
+        make CXX=CC CC=cc FC=ftn -j4
+        cd $dep_dir
+        rm libxsmm.tar.gz
+        echo "Installed LIBXSMM into $dep_dir/libxsmm"
+        load_gcc
+        echo "#%Module1.0" > $dep_dir/modules/libxsmm
+        echo "prepend-path LIBRARY_PATH \"$dep_dir/libxsmm/lib\"" >> $dep_dir/modules/libxsmm
+        echo "prepend-path LD_LIBRARY_PATH \"$dep_dir/libxsmm/lib\"" >> $dep_dir/modules/libxsmm
+        echo "prepend-path CPATH \"$dep_dir/libxsmm/include\"" >> $dep_dir/modules/libxsmm
+        echo "prepend-path CMAKE_PREFIX_PATH \"$dep_dir/libxsmm/\"" >> $dep_dir/modules/libxsmm
+    fi
+    cd $dep_dir
+
+    if [ -f jemalloc/include/jemalloc/jemalloc.h ]; then
+        echo "jemalloc is already installed"
+    else
+        echo "Installing jemalloc..."
+        rm -r $dep_dir/jemalloc
+        wget https://github.com/jemalloc/jemalloc/archive/5.0.1.tar.gz -O jemalloc.tar.gz
+        tar -xzf jemalloc.tar.gz
+        mv jemalloc-* jemalloc-build
+        cd $dep_dir/jemalloc-build
+        module load autoconf/2.69
+        ./autogen.sh --prefix=$dep_dir/jemalloc
+        make -j4
+        make install_bin && make install_include && make install_lib
+        cd $dep_dir
+        rm -r $dep_dir/jemalloc-build
+        rm $dep_dir/jemalloc.tar.gz
+        module unload autoconf/2.69
+        echo "Installed jemalloc into $dep_dir/jemalloc"
+        echo "#%Module1.0" > $dep_dir/modules/jemalloc
+        echo "prepend-path LIBRARY_PATH \"$dep_dir/jemalloc/lib\"" >> $dep_dir/modules/jemalloc
+        echo "prepend-path LD_LIBRARY_PATH \"$dep_dir/jemalloc/lib\"" >> $dep_dir/modules/jemalloc
+        echo "prepend-path CPATH \"$dep_dir/jemalloc/include\"" >> $dep_dir/modules/jemalloc
+        echo "prepend-path CMAKE_PREFIX_PATH \"$dep_dir/jemalloc/\"" >> $dep_dir/modules/jemalloc
+    fi
+    cd $dep_dir
+
+    if [ -f $dep_dir/yaml-cpp/lib/libyaml-cpp.a ]; then
+        echo "yaml-cpp is already installed"
+    else
+        echo "Installing yaml-cpp..."
+        wget https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.2.tar.gz -O yaml-cpp.tar.gz
+        tar -xzf yaml-cpp.tar.gz
+        mv yaml-cpp-* yaml-cpp-build
+        cd $dep_dir/yaml-cpp-build
+        mkdir build
+        cd build
+        module load cmake/3.9.4
+        cmake -D CMAKE_BUILD_TYPE=Release -D YAML_CPP_BUILD_TESTS=OFF \
+              -D YAML_CPP_BUILD_CONTRIB=OFF \
+              -D YAML_CPP_BUILD_TOOLS=ON \
+              -D CMAKE_INSTALL_PREFIX=$dep_dir/yaml-cpp ..
+        make -j4
+        make install
+        module unload cmake/3.9.4
+        cd $dep_dir
+        rm -r yaml-cpp-build
+        rm -r yaml-cpp.tar.gz
+        echo "Installed yaml-cpp into $dep_dir/yaml-cpp"
+        echo "#%Module1.0" > $dep_dir/modules/yaml-cpp
+        echo "prepend-path LIBRARY_PATH \"$dep_dir/yaml-cpp/lib\"" >> $dep_dir/modules/yaml-cpp
+        echo "prepend-path LD_LIBRARY_PATH \"$dep_dir/yaml-cpp/lib\"" >> $dep_dir/modules/yaml-cpp
+        echo "prepend-path CPATH \"$dep_dir/yaml-cpp/include\"" >> $dep_dir/modules/yaml-cpp
+        echo "prepend-path CMAKE_PREFIX_PATH \"$dep_dir/yaml-cpp/\"" >> $dep_dir/modules/yaml-cpp
+    fi
+    cd $dep_dir
+
+    # Set up Charm++ because that can be difficult
+    if [ -f $dep_dir/charm/gni-crayxe-smp/lib/libck.a ]; then
+        echo "Charm++ is already installed"
+    else
+        echo "Installing Charm++..."
+        load_gcc
+        module load craype-hugepages8M
+        git clone https://charm.cs.illinois.edu/gerrit/charm
+        cd $dep_dir/charm
+        git checkout v6.8.2
+        ./build charm++ gni-crayxe smp -j4 --with-production
+        git apply $SPECTRE_HOME/support/Charm/v6.8.patch
+        module unload craype-hugepages8M
+        cd $dep_dir
+        rm charm.tar.gz
+        echo "Installed Charm++ into $dep_dir/charm"
+        echo "#%Module1.0" > $dep_dir/modules/charm
+        echo "prepend-path LIBRARY_PATH \"$dep_dir/charm/lib\"" >> $dep_dir/modules/charm
+        echo "prepend-path LD_LIBRARY_PATH \"$dep_dir/charm/lib\"" >> $dep_dir/modules/charm
+        echo "prepend-path CPATH \"$dep_dir/charm/include\"" >> $dep_dir/modules/charm
+        echo "prepend-path CMAKE_PREFIX_PATH \"$dep_dir/charm/\"" >> $dep_dir/modules/charm
+        echo "setenv CHARM_VERSION 6.8.2" >> $dep_dir/modules/charm
+        echo "setenv CHARM_HOME $dep_dir/charm/gni-crayxe-smp" >> $dep_dir/modules/charm
+        echo "setenv CHARM_ROOT $dep_dir/charm/gni-crayxe-smp" >> $dep_dir/modules/charm
+    fi
+    cd $dep_dir
+
+    # We need to be able to link in the MKL, which BlueWaters doesn't allow
+    echo "#%Module1.0" > $dep_dir/modules/mkl
+    echo "prepend-path LIBRARY_PATH \"/opt/intel/compilers_and_libraries_2017.4.196/linux/mkl/lib/intel64_lin\"" >> $dep_dir/modules/mkl
+    echo "prepend-path LD_LIBRARY_PATH \"/opt/intel/compilers_and_libraries_2017.4.196/linux/mkl/lib/intel64_lin\"" >> $dep_dir/modules/mkl
+    echo "prepend-path CPATH \"/opt/intel/compilers_and_libraries_2017.4.196/linux/mkl/include\"" >> $dep_dir/modules/mkl
+    echo "prepend-path CMAKE_PREFIX_PATH \"/opt/intel/compilers_and_libraries_2017.4.196/linux/mkl/\"" >> $dep_dir/modules/mkl
+
+    # Set up env variables needed to get traces and linking working
+    echo "#%Module1.0" > $dep_dir/modules/env_vars
+    echo "setenv XTPE_LINK_TYPE dynamic" >> $dep_dir/modules/env_vars
+    echo "setenv CRAYPE_LINK_TYPE dynamic" >> $dep_dir/modules/env_vars
+    echo "setenv CRAY_ADD_RPATH yes" >> $dep_dir/modules/env_vars
+    echo "setenv XTPE_LINK_TYPE dynamic" >> $dep_dir/modules/env_vars
+    echo "prepend-path PE_PKGCONFIG_LIBS \"cray-pmi\"" >> $dep_dir/modules/env_vars
+    echo "prepend-path PE_PKGCONFIG_LIBS \"cray-ugni\"" >> $dep_dir/modules/env_vars
+    echo "setenv ATP_ENABLED 1" >> $dep_dir/modules/env_vars
+
+    cd $start_dir
+
+    printf "\n\nIMPORTANT!!!\nIn order to be able to use these modules you\n"
+    echo "must run:"
+    echo "  module use $dep_dir/modules"
+    echo "You will need to do this every time you compile SpECTRE, so you may"
+    echo "want to add it to your ~/.bashrc."
+}
+
+spectre_unload_modules() {
+    load_cray_cc
+    # Unload system modules
+    module unload craype-hugepages8M
+    module unload gsl
+    module unload cray-hdf5/1.8.16
+    # uncomment the bwpy load line to run tests
+    module unload bwpy
+    module unload cmake/3.9.4
+    export -n SPECTRE_BOOST_ROOT
+    export -n BOOST_ROOT
+
+    # Unload user modules
+    module unload blaze
+    module unload brigand
+    module unload catch
+    module unload charm
+    module unload jemalloc
+    module unload libxsmm
+    module unload yaml-cpp
+
+    module unload mkl
+    module unload env_vars
+    ulimit -c unlimited
+}
+
+spectre_load_modules() {
+    echo "If you receive module not found errors make sure to run"
+    echo "  module use /PATH/TO/DEPS/modules"
+    echo "and then load the modules"
+    echo "Unloading any existing SpECTRE-related modules"
+    spectre_unload_modules
+    echo "Loading SpECTRE-related modules"
+    load_gcc
+    # Load system modules, the order matters
+    # The boost installation is not quite right, so we need to work around it
+    module load boost/1.63.0
+    export SPECTRE_BOOST_ROOT=$BOOST_ROOT
+    module unload boost/1.63.0
+    export BOOST_ROOT=$SPECTRE_BOOST_ROOT
+    module load craype-hugepages8M
+    module load gsl
+    module load cray-hdf5/1.8.16
+    # uncomment the bwpy load line to run tests
+    # module load bwpy
+    module load cmake/3.9.4
+
+    # Load user modules
+    module load blaze
+    module load brigand
+    module load catch
+    module load charm
+    module load jemalloc
+    module load libxsmm
+    module load yaml-cpp
+
+    module load mkl
+    module load env_vars
+    ulimit -c unlimited
+}
+
+spectre_run_cmake() {
+    if [ -z ${SPECTRE_HOME} ]; then
+        echo "You must set SPECTRE_HOME to the cloned SpECTRE directory"
+        return 1
+    fi
+    spectre_load_modules
+    cmake -D CHARM_ROOT=$CHARM_ROOT \
+          -D CMAKE_BUILD_TYPE=Release \
+          -D CMAKE_CXX_COMPILER=CC \
+          -D CMAKE_C_COMPILER=cc \
+          -D CMAKE_Fortran_COMPILER=ftn \
+          -D Boost_USE_STATIC_LIBS=ON \
+          -D Boost_USE_STATIC_RUNTIME=ON \
+          -D CMAKE_EXE_LINKER_FLAGS="-isystem$BOOST_ROOT/include" \
+          -D USE_PCH=OFF \
+          $SPECTRE_HOME
+}

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -62,6 +62,13 @@ add_dependencies(
   module_Main
   )
 
+target_include_directories(
+  ${executable}
+  SYSTEM
+  PUBLIC ${NUMPY_INCLUDE_DIRS}
+  PUBLIC ${PYTHON_INCLUDE_DIRS}
+  )
+
 add_dependencies(test-executables ${executable})
 
 spectre_add_catch_tests(${executable} "${SPECTRE_TESTS_LIBRARIES}")

--- a/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp
+++ b/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <cstddef>
 #include <patchlevel.h>  // for PY_MAJOR_VERSION
 #include <string>
 
@@ -16,7 +15,7 @@ struct SetupLocalPythonEnvironment {
   explicit SetupLocalPythonEnvironment(
       const std::string& cur_dir_relative_to_unit_test_path);
 
-  ~SetupLocalPythonEnvironment();
+  ~SetupLocalPythonEnvironment() = default;
 
   SetupLocalPythonEnvironment(const SetupLocalPythonEnvironment&) = delete;
   SetupLocalPythonEnvironment& operator=(const SetupLocalPythonEnvironment&) =
@@ -24,6 +23,15 @@ struct SetupLocalPythonEnvironment {
   SetupLocalPythonEnvironment(const SetupLocalPythonEnvironment&&) = delete;
   SetupLocalPythonEnvironment& operator=(const SetupLocalPythonEnvironment&&) =
       delete;
+
+  /// \cond
+  // In the case where we run all the non-failure tests at once we must ensure
+  // that we only initialize and finalize the python env once. Initialization is
+  // done in the constructor of SetupLocalPythonEnvironment, while finalization
+  // is done in the constructor of RunTests by constructing a
+  // SetupLocalPythonEnvironment object and calling finalize_env on it.
+  void finalize_env();
+  /// \endcond
 
  private:
 // In order to use NumPy's API, import_array() must be called. However it is a
@@ -35,5 +43,7 @@ struct SetupLocalPythonEnvironment {
 #else
   void init_numpy();
 #endif
+  static bool initialized;
+  static bool finalized;
 };
 }  // namespace pypp

--- a/tests/Unit/RunTests.cpp
+++ b/tests/Unit/RunTests.cpp
@@ -18,6 +18,7 @@
 #include "Parallel/Abort.hpp"
 #include "Parallel/Exit.hpp"
 #include "Parallel/Printf.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/RunTestsRegister.hpp"
 
 RunTests::RunTests(CkArgMsg* msg) {
@@ -26,7 +27,13 @@ RunTests::RunTests(CkArgMsg* msg) {
   register_run_tests_libs();
   Parallel::printf("%s", info_from_build().c_str());
   enable_floating_point_exceptions();
-  int result = Catch::Session().run(msg->argc, msg->argv);
+  const int result = Catch::Session().run(msg->argc, msg->argv);
+  // In the case where we run all the non-failure tests at once we must ensure
+  // that we only initialize and finalize the python env once. Initialization is
+  // done in the constructor of SetupLocalPythonEnvironment, while finalization
+  // is done in the constructor of RunTests by constructing a
+  // SetupLocalPythonEnvironment object and calling finalize_env on it.
+  pypp::SetupLocalPythonEnvironment("").finalize_env();
   if (0 == result) {
     Parallel::exit();
   }

--- a/tools/Iwyu/iwyu.imp
+++ b/tools/Iwyu/iwyu.imp
@@ -38,6 +38,8 @@
               "<Python.h>", public]},
   { include: ["<sysmodule.h>", private,
               "<Python.h>", public]},
+  { include: ["<pythonrun.h>", private,
+              "<Python.h>", public]},
 
   { symbol: ["db::DataBox", private,
              "\"DataStructures/DataBox/DataBox.hpp\"", public]},


### PR DESCRIPTION
## Proposed changes

- Work around BWs fragile python env
- Work around one PMI single init restriction by having a shell script that runs all non-failure tests in RunTests in one shot
- Enable template backtraces by default to make life easier
- Only link Python into the testing framework, not into the executables
- Add "env" file and documentation for running on BWs

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [x] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
