### PR TITLE
Extend Frustum to allow for Equiangular Frustums

### DIFF
--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -30,13 +30,16 @@ namespace CoordinateMaps {
 /// (2.0,5.0), and with the upper base extending from (0.0,1.0) to (1.0,3.0),
 /// the corresponding value for `face_vertices` is `{{{{-2.0,3.0}}, {{2.0,5.0}},
 /// {{0.0,1.0}}, {{1.0,3.0}}}}`. The user may reorient the frustum by passing
-/// an `OrientationMap` to the constructor.
+/// an `OrientationMap` to the constructor. If `with_equiangular_map` is true,
+/// then this coordinate map applies a tangent function mapping to the logical
+/// xi and eta coordinates.
 class Frustum {
  public:
   static constexpr size_t dim = 3;
   Frustum(const std::array<std::array<double, 2>, 4>& face_vertices,
           double lower_bound, double upper_bound,
-          OrientationMap<3> orientation_of_frustum) noexcept;
+          OrientationMap<3> orientation_of_frustum,
+          bool with_equiangular_map = false) noexcept;
   Frustum() = default;
   ~Frustum() = default;
   Frustum(Frustum&&) = default;
@@ -77,6 +80,7 @@ class Frustum {
   double dif_half_length_y_{std::numeric_limits<double>::signaling_NaN()};
   double midpoint_z_{std::numeric_limits<double>::signaling_NaN()};
   double half_length_z_{std::numeric_limits<double>::signaling_NaN()};
+  bool with_equiangular_map_{false};
 };
 
 bool operator!=(const Frustum& lhs, const Frustum& rhs) noexcept;

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -12,7 +12,8 @@
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
+namespace {
+void test_suite_for_frustum(const bool with_equiangular_map) {
   // Set up random number generator
   std::random_device rd;
   std::mt19937 gen(rd());
@@ -42,10 +43,21 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
          {{upper_x_lower_base, upper_y_lower_base}},
          {{lower_x_upper_base, lower_y_upper_base}},
          {{upper_x_upper_base, upper_y_upper_base}}}};
-    const CoordinateMaps::Frustum frustum_map(face_vertices, -1.0, 2.0,
-                                              map_i());
+    const CoordinateMaps::Frustum frustum_map(face_vertices, -1.0, 2.0, map_i(),
+                                              with_equiangular_map);
     test_suite_for_map(frustum_map);
   }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Equidistant",
+                  "[Domain][Unit]") {
+  test_suite_for_frustum(false);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Equiangular",
+                  "[Domain][Unit]") {
+  test_suite_for_frustum(true);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Alignment",


### PR DESCRIPTION
## Proposed changes

For a fully equiangular BBH domain, equiangular Frustums are needed.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
