### PR TITLE
Additions for BBH Domain creation

### DIFF
--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -39,11 +39,11 @@ template <>
 void register_with_charm<2>() {
   PUPable_reg(
       SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D>));
-  PUPable_reg(SINGLE_ARG(
-      ::CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular2D>));
   PUPable_reg(
       SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D,
                                  CoordinateMaps::DiscreteRotation<2>>));
+  PUPable_reg(SINGLE_ARG(
+      ::CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular2D>));
   PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Identity<2>>));
   PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,

--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -10,6 +10,8 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
+#include "Domain/CoordinateMaps/Frustum.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
@@ -43,6 +45,8 @@ void register_with_charm<2>() {
       SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D,
                                  CoordinateMaps::DiscreteRotation<2>>));
   PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                         CoordinateMaps::Identity<2>>));
+  PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Wedge2D>));
 }
 template <>
@@ -51,7 +55,8 @@ void register_with_charm<3>() {
       SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine3D>));
   PUPable_reg(SINGLE_ARG(
       ::CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular3D>));
-
+  PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                         CoordinateMaps::Frustum>));
   PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Wedge3D>));
 }

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -66,9 +66,19 @@ void set_periodic_boundaries(
         neighbors_of_all_blocks);
 
 /// \ingroup ComputationalDomainGroup
-/// These are the six Wedge3Ds used in the DomainCreators for Sphere and Shell.
+/// These are the CoordinateMaps of the Wedge3Ds used in the Sphere, Shell, and
+/// binary compact object DomainCreators. This function can also be used to
+/// wrap the Sphere or Shell in a cube made of six Wedge3Ds.
+/// The argument `x_coord_of_shell_center` specifies a translation of the Shell
+/// in the x-direction in the TargetFrame. For example, the BBH DomainCreator
+/// uses this to set the position of each BH.
+/// When the argument `use_half_wedges` is set to `true`, the wedges in the
+/// +z,-z,+y,-y directions are cut in half along their xi-axes. The resulting
+/// ten CoordinateMaps are used for the outermost Blocks of the BBH Domain.
 template <typename TargetFrame>
 std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
 wedge_coordinate_maps(double inner_radius, double outer_radius,
                       double inner_sphericity, double outer_sphericity,
-                      bool use_equiangular_map) noexcept;
+                      bool use_equiangular_map,
+                      double x_coord_of_shell_center = 0.0,
+                      bool use_half_wedges = false) noexcept;

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -82,3 +82,13 @@ wedge_coordinate_maps(double inner_radius, double outer_radius,
                       bool use_equiangular_map,
                       double x_coord_of_shell_center = 0.0,
                       bool use_half_wedges = false) noexcept;
+
+/// \ingroup ComputationalDomainGroup
+/// These are the ten Frustums used in the DomainCreators for binary compact
+/// objects. The cubes enveloping the two Shells each have a side length of
+/// `length_inner_cube`. The ten frustums also make up a cube of their own,
+/// of side length `length_outer_cube`.
+template <typename TargetFrame>
+std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+frustum_coordinate_maps(double length_inner_cube, double length_outer_cube,
+                        bool use_equiangular_map) noexcept;

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -9,12 +9,16 @@
 #include <vector>
 
 #include "Domain/BlockNeighbor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeVector.hpp"
 #include "Utilities/StdHelpers.hpp"
 
 namespace Frame {
@@ -79,51 +83,241 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.DifferentBlocks",
   CHECK(neighbors_of_all_blocks == expected_block_neighbors);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.AllWedgeDirections",
-                  "[Domain][Unit]") {
+namespace {
+std::vector<
+    std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+test_wedge_map_generation(double inner_radius, double outer_radius,
+                          double inner_sphericity, double outer_sphericity,
+                          bool use_equiangular_map,
+                          double x_coord_of_shell_center = 0.0,
+                          bool use_half_wedges = false) {
   using Wedge3DMap = CoordinateMaps::Wedge3D;
-  const double inner_radius = 1.0;
-  const double outer_radius = 2.0;
-  const double inner_sphericity = 1.0;
-  const double outer_sphericity = 1.0;
-  const bool use_equiangular_map = true;
+  if (use_half_wedges) {
+    using Halves = Wedge3DMap::WedgeHalves;
+    return make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
+                   inner_sphericity, outer_sphericity, use_equiangular_map,
+                   Halves::LowerOnly},
+        Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
+                   inner_sphericity, outer_sphericity, use_equiangular_map,
+                   Halves::UpperOnly},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                        Direction<3>::lower_zeta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map,
+                   Halves::LowerOnly},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                        Direction<3>::lower_zeta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map,
+                   Halves::UpperOnly},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                        Direction<3>::lower_eta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map,
+                   Halves::LowerOnly},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                        Direction<3>::lower_eta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map,
+                   Halves::UpperOnly},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                        Direction<3>::upper_eta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map,
+                   Halves::LowerOnly},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                        Direction<3>::upper_eta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map,
+                   Halves::UpperOnly},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                        Direction<3>::upper_eta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                        Direction<3>::upper_eta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map});
+  }
+  if (x_coord_of_shell_center == 0.0) {
+    return make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+        Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
+                   inner_sphericity, outer_sphericity, use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                        Direction<3>::lower_zeta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                        Direction<3>::lower_eta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                        Direction<3>::upper_eta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                        Direction<3>::upper_eta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map},
+        Wedge3DMap{inner_radius, outer_radius,
+                   OrientationMap<3>{std::array<Direction<3>, 3>{
+                       {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                        Direction<3>::upper_eta()}}},
+                   inner_sphericity, outer_sphericity, use_equiangular_map});
+  }
+  using Identity2D = CoordinateMaps::Identity<2>;
+  using Affine = CoordinateMaps::Affine;
+  const auto translation = CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(
+      Affine{-1.0, 1.0, -1.0 + x_coord_of_shell_center,
+             1.0 + x_coord_of_shell_center},
+      Identity2D{});
 
-  const auto expected_coord_maps =
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+  return make_vector(
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
                      inner_sphericity, outer_sphericity, use_equiangular_map},
+          translation),
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                           Direction<3>::lower_zeta()}}},
                      inner_sphericity, outer_sphericity, use_equiangular_map},
+          translation),
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                           Direction<3>::lower_eta()}}},
                      inner_sphericity, outer_sphericity, use_equiangular_map},
+          translation),
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                           Direction<3>::upper_eta()}}},
                      inner_sphericity, outer_sphericity, use_equiangular_map},
+          translation),
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                           Direction<3>::upper_eta()}}},
                      inner_sphericity, outer_sphericity, use_equiangular_map},
+          translation),
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Wedge3DMap{inner_radius, outer_radius,
                      OrientationMap<3>{std::array<Direction<3>, 3>{
                          {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                           Direction<3>::upper_eta()}}},
-                     inner_sphericity, outer_sphericity, use_equiangular_map});
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
+          translation));
+}
+void test_wedge_map_generation_against_domain_helpers(
+    double inner_radius, double outer_radius, double inner_sphericity,
+    double outer_sphericity, bool use_equiangular_map,
+    double x_coord_of_shell_center = 0.0, bool use_half_wedges = false) {
+  const auto expected_coord_maps = test_wedge_map_generation(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center, use_half_wedges);
   const auto maps = wedge_coordinate_maps<Frame::Inertial>(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center, use_half_wedges);
+  for (size_t i = 0; i < maps.size(); i++) {
+    CHECK(*expected_coord_maps[i] == *maps[i]);
+  }
+}
+
+}  // namespace
+SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.DefaultSixWedgeDirections.Equiangular",
+    "[Domain][Unit]") {
+  const double inner_radius = 1.2;
+  const double outer_radius = 2.7;
+  const double inner_sphericity = 0.8;
+  const double outer_sphericity = 0.6;
+  const bool use_equiangular_map = true;
+  test_wedge_map_generation_against_domain_helpers(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map);
-  CHECK(*expected_coord_maps[0] == *maps[0]);
-  CHECK(*expected_coord_maps[1] == *maps[1]);
-  CHECK(*expected_coord_maps[2] == *maps[2]);
-  CHECK(*expected_coord_maps[3] == *maps[3]);
-  CHECK(*expected_coord_maps[4] == *maps[4]);
-  CHECK(*expected_coord_maps[5] == *maps[5]);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.DefaultSixWedgeDirections.Equidistant",
+    "[Domain][Unit]") {
+  const double inner_radius = 0.8;
+  const double outer_radius = 7.1;
+  const double inner_sphericity = 0.2;
+  const double outer_sphericity = 0.4;
+  const bool use_equiangular_map = false;
+  test_wedge_map_generation_against_domain_helpers(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.TranslatedSixWedgeDirections.Equiangular",
+    "[Domain][Unit]") {
+  const double inner_radius = 1.2;
+  const double outer_radius = 3.1;
+  const double inner_sphericity = 0.3;
+  const double outer_sphericity = 0.6;
+  const bool use_equiangular_map = true;
+  const double x_coord_of_shell_center = 0.6;
+  test_wedge_map_generation_against_domain_helpers(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.TranslatedSixWedgeDirections.Equidistant",
+    "[Domain][Unit]") {
+  const double inner_radius = 12.2;
+  const double outer_radius = 31.1;
+  const double inner_sphericity = 0.9;
+  const double outer_sphericity = 0.1;
+  const bool use_equiangular_map = false;
+  const double x_coord_of_shell_center = -2.7;
+  test_wedge_map_generation_against_domain_helpers(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.TenWedgeDirections.Equiangular",
+                  "[Domain][Unit]") {
+  const double inner_radius = 0.2;
+  const double outer_radius = 2.2;
+  const double inner_sphericity = 0.0;
+  const double outer_sphericity = 1.0;
+  const bool use_equiangular_map = true;
+  const bool use_half_wedges = true;
+  test_wedge_map_generation_against_domain_helpers(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, 0.0, use_half_wedges);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.TenWedgeDirections.Equidistant",
+                  "[Domain][Unit]") {
+  const double inner_radius = 0.2;
+  const double outer_radius = 29.2;
+  const double inner_sphericity = 0.01;
+  const double outer_sphericity = 0.99;
+  const bool use_equiangular_map = false;
+  const bool use_half_wedges = true;
+  test_wedge_map_generation_against_domain_helpers(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, 0.0, use_half_wedges);
 }


### PR DESCRIPTION
## Proposed changes

Addition of tools necessary for BBH Domain creation.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
