### PR TITLE
Add characteristics for the Newtonian Euler system

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY NewtonianEuler)
 
 set(LIBRARY_SOURCES
+    Characteristics.cpp
     Fluxes.cpp
     PrimitiveFromConservative.cpp
     )

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeArray.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+namespace NewtonianEuler {
+
+template <size_t Dim>
+std::array<DataVector, Dim + 2> characteristic_speeds(
+    const tnsr::I<DataVector, Dim>& velocity,
+    const Scalar<DataVector>& sound_speed_squared,
+    const tnsr::I<DataVector, Dim>& normal) noexcept {
+  const DataVector sound_speed = sqrt(get(sound_speed_squared));
+
+  auto characteristic_speeds =
+      make_array<Dim + 2>(DataVector(get(dot_product(velocity, normal))));
+  characteristic_speeds[0] -= sound_speed;
+  characteristic_speeds[Dim + 1] += sound_speed;
+
+  return characteristic_speeds;
+}
+
+}  // namespace NewtonianEuler
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                          \
+  template std::array<DataVector, DIM(data) + 2>      \
+  NewtonianEuler::characteristic_speeds(              \
+      const tnsr::I<DataVector, DIM(data)>& velocity, \
+      const Scalar<DataVector>& sound_speed_squared,  \
+      const tnsr::I<DataVector, DIM(data)>& normal) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace NewtonianEuler {
+
+/*!
+ * \brief Compute the characteristic speeds of NewtonianEuler system
+ *
+ * The principal symbol of the system is diagonalized so that the elements of
+ * the diagonal matrix are the characteristic speeds
+ *
+ * \f{align*}
+ * \lambda_1 &= v_n - c_s,\\
+ * \lambda_{i + 1} &= v_n,\\
+ * \lambda_{\text{Dim} + 2} &= v_n + c_s,
+ * \f}
+ *
+ * where \f$i = 1,...,\text{Dim}\f$,
+ * \f$v_n = n_i v^i\f$ is the velocity projected onto the normal,
+ * and \f$c_s\f$ is the sound speed.
+ */
+template <size_t Dim>
+std::array<DataVector, Dim + 2> characteristic_speeds(
+    const tnsr::I<DataVector, Dim>& velocity,
+    const Scalar<DataVector>& sound_speed_squared,
+    const tnsr::I<DataVector, Dim>& normal) noexcept;
+
+}  // namespace NewtonianEuler

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -11,6 +11,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Side.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
@@ -23,16 +24,13 @@ template <size_t VolumeDim>
 class BlockNeighbor;
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
+class DataVector;
 template <size_t VolumeDim>
 class Direction;
 template <size_t VolumeDim, typename TargetFrame>
 class Domain;
 template <size_t VolumeDim>
 class ElementId;
-namespace Frame {
-struct Inertial;
-struct Logical;
-}  // namespace Frame
 /// \endcond
 
 // Iterates over the logical corners of a VolumeDim-dimensional cube.
@@ -99,3 +97,9 @@ template <size_t VolumeDim>
 void test_initial_domain(const Domain<VolumeDim, Frame::Inertial>& domain,
                          const std::vector<std::array<size_t, VolumeDim>>&
                              initial_refinement_levels) noexcept;
+
+// Euclidean basis vector along the given `Direction` and in the given `Frame`.
+template <size_t SpatialDim, typename SpatialFrame = Frame::Inertial>
+tnsr::I<DataVector, SpatialDim, SpatialFrame> euclidean_basis_vector(
+    const Direction<SpatialDim>& direction,
+    const DataVector& used_for_size) noexcept;

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_NewtonianEuler")
 
 set(LIBRARY_SOURCES
+  Test_Characteristics.cpp
   Test_Fluxes.cpp
   Test_PrimitiveFromConservative.cpp
   )

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
@@ -4,6 +4,21 @@
 import numpy as np
 
 
+# Functions for testing Characteristics.cpp
+def characteristic_speeds(velocity, sound_speed_squared, normal):
+    normal_velocity = np.dot(velocity, normal)
+    sound_speed = np.sqrt(sound_speed_squared)
+    result = [normal_velocity - sound_speed]
+    for i in range(0, velocity.size):
+        result.append(normal_velocity)
+    result.append(normal_velocity + sound_speed)
+    return result
+
+
+# End functions for testing Characteristics.cpp
+
+
+# Functions for testing Fluxes.cpp
 def mass_density_flux(momentum_density, energy_density, velocity, pressure):
     return momentum_density
 
@@ -16,3 +31,6 @@ def momentum_density_flux(momentum_density, energy_density, velocity, pressure):
 
 def energy_density_flux(momentum_density, energy_density, velocity, pressure):
     return (energy_density + pressure) * velocity
+
+
+# End functions for testing Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Direction.hpp"
+#include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/Domain/DomainTestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/Pypp.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+template <size_t Dim>
+void test_characteristic_speeds(const DataVector& used_for_size) noexcept {
+  pypp::check_with_random_values<3>(&NewtonianEuler::characteristic_speeds<Dim>,
+                                    "TestFunctions", "characteristic_speeds",
+                                    {{{-1.0, 1.0}, {0.0, 1.0}, {-1.0, 1.0}}},
+                                    used_for_size);
+}
+
+template <size_t Dim>
+void test_with_normal_along_coordinate_axes(
+    const DataVector& used_for_size) noexcept {
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed = " << seed);
+  std::uniform_real_distribution<> distribution(0.0, 1.0);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  const auto velocity = make_with_random_values<tnsr::I<DataVector, Dim>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto sound_speed_squared = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+
+  for (const auto& direction : Direction<Dim>::all_directions()) {
+    const auto normal = euclidean_basis_vector(direction, used_for_size);
+
+    CHECK_ITERABLE_APPROX(NewtonianEuler::characteristic_speeds(
+                              velocity, sound_speed_squared, normal),
+                          (pypp::call<std::array<DataVector, Dim + 2>>(
+                              "TestFunctions", "characteristic_speeds",
+                              velocity, sound_speed_squared, normal)));
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Characteristics",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/NewtonianEuler"};
+
+  const DataVector dv(5);
+
+  test_characteristic_speeds<1>(dv);
+  test_characteristic_speeds<2>(dv);
+  test_characteristic_speeds<3>(dv);
+
+  test_with_normal_along_coordinate_axes<1>(dv);
+  test_with_normal_along_coordinate_axes<2>(dv);
+  test_with_normal_along_coordinate_axes<3>(dv);
+}


### PR DESCRIPTION
## Proposed changes

Add the characteristic decomposition for the Newtonian Euler system.

- The characteristic decomposition is tested using normal vectors along randomized directions, as well as normal vectors along the coordinate axes.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
