### PR TITLE
Corner numberings for layered domains

### DIFF
--- a/src/Domain/DomainCreators/Shell.cpp
+++ b/src/Domain/DomainCreators/Shell.cpp
@@ -42,18 +42,12 @@ Shell<TargetFrame>::Shell(
 
 template <typename TargetFrame>
 Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
-  std::vector<std::array<size_t, 8>> corners{
-      {{7, 5, 8, 6, 15, 13, 16, 14}},   // Upper z
-      {{4, 2, 3, 1, 12, 10, 11, 9}},    // Lower z
-      {{4, 8, 2, 6, 12, 16, 10, 14}},   // Upper y
-      {{7, 3, 5, 1, 15, 11, 13, 9}},    // Lower y
-      {{1, 2, 5, 6, 9, 10, 13, 14}},    // Upper x
-      {{4, 3, 8, 7, 12, 11, 16, 15}}};  // Lower x
   std::vector<
       std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
       coord_maps = wedge_coordinate_maps<TargetFrame>(
-          inner_radius_, outer_radius_, 1.0, use_equiangular_map_);
-  return Domain<3, TargetFrame>{std::move(coord_maps), corners};
+          inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_);
+  return Domain<3, TargetFrame>{std::move(coord_maps),
+                                corners_for_layered_domains(1)};
 }
 
 template <typename TargetFrame>

--- a/src/Domain/DomainCreators/Sphere.cpp
+++ b/src/Domain/DomainCreators/Sphere.cpp
@@ -50,15 +50,8 @@ Domain<3, TargetFrame> Sphere<TargetFrame>::create_domain() const noexcept {
   using Equiangular = CoordinateMaps::Equiangular;
   using Equiangular3D =
       CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
-
-  std::vector<std::array<size_t, 8>> corners{
-      {{7, 5, 8, 6, 15, 13, 16, 14}},  // Upper z
-      {{4, 2, 3, 1, 12, 10, 11, 9}},   // Lower z
-      {{4, 8, 2, 6, 12, 16, 10, 14}},  // Upper y
-      {{7, 3, 5, 1, 15, 11, 13, 9}},   // Lower y
-      {{1, 2, 5, 6, 9, 10, 13, 14}},   // Upper x
-      {{4, 3, 8, 7, 12, 11, 16, 15}},  // Lower x
-      {{3, 1, 4, 2, 7, 5, 8, 6}}};     // center cube
+  std::vector<std::array<size_t, 8>> corners = corners_for_layered_domains(1);
+  corners.push_back({{1, 2, 3, 4, 5, 6, 7, 8}});  // central Block
 
   std::vector<
       std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -71,3 +71,12 @@ template <typename TargetFrame>
 std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
 wedge_coordinate_maps(double inner_radius, double outer_radius,
                       double sphericity, bool use_equiangular_map) noexcept;
+
+/// \ingroup ComputationalDomainGroup
+/// Generates the corners for a Domain which is made of one or more layers
+/// of Blocks surrounding an interior volume, e.g. Shell or Sphere. The
+/// `number_of_partial_layers` parameter is used when constructing a BBH-like
+/// Domain where there are layers of blocks which surround the interior volume
+/// using only 5 blocks as opposed to 6.
+std::vector<std::array<size_t, 8>> corners_for_layered_domains(
+    size_t number_of_full_layers, size_t number_of_partial_layers = 0) noexcept;


### PR DESCRIPTION
## Proposed changes

Generates the correct corners for Sphere and Shell.
Will also be used for BBH domain creation.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
