### PR TITLE
Small optimizations

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -17,3 +17,9 @@ set(CMAKE_CXX_FLAGS "-march=native ${CMAKE_CXX_FLAGS}")
 # We always want a detailed backtrace of template errors to make debugging them
 # easier
 set(CMAKE_CXX_FLAGS "-ftemplate-backtrace-limit=0 ${CMAKE_CXX_FLAGS}")
+
+# We disable thread safety of Boost::shared_ptr since it makes them faster
+# to use and we do not share them between threads. If a thread-safe
+# shared_ptr is desired it must be implemented to work with Charm++'s threads
+# anyway.
+add_definitions(-DBOOST_SP_DISABLE_THREADS)

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -682,10 +682,10 @@ AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
     using this_databox =
         tmpl::at_c<databox_types,
                    iter == 0 ? tmpl::size<databox_types>::value - 1 : iter>;
-    this_databox box{};
+    this_databox* box{};
 
     try {
-      box = boost::get<this_databox>(box_);
+      box = &boost::get<this_databox>(box_);
     } catch (std::exception& e) {
       ERROR(
           "\nFailed to retrieve Databox in take_next_action:\nCaught "
@@ -698,7 +698,7 @@ AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
     const auto check_if_ready = make_overloader(
         [this, &box](std::true_type /*has_is_ready*/, auto t) {
           return decltype(t)::is_ready(
-              static_cast<const this_databox&>(box),
+              static_cast<const this_databox&>(*box),
               static_cast<const tuples::TaggedTupleTypelist<inbox_tags_list>&>(
                   inboxes_),
               *const_global_cache_,
@@ -745,10 +745,10 @@ AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
                   static_cast<const array_index&>(array_index_), actions_list{},
                   std::add_pointer_t<ParallelComponent>{});
             })(
-        box, typename std::tuple_size<decltype(this_action::apply(
-                 box, inboxes_, *const_global_cache_,
-                 static_cast<const array_index&>(array_index_), actions_list{},
-                 std::add_pointer_t<ParallelComponent>{}))>::type{});
+        *box, typename std::tuple_size<decltype(this_action::apply(
+                  *box, inboxes_, *const_global_cache_,
+                  static_cast<const array_index&>(array_index_), actions_list{},
+                  std::add_pointer_t<ParallelComponent>{}))>::type{});
 
     performing_action_ = false;
 #ifdef SPECTRE_CHARM_PROJECTIONS

--- a/src/Utilities/Deferred.hpp
+++ b/src/Utilities/Deferred.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 #include <memory>
 #include <tuple>
 #include <type_traits>
@@ -149,7 +151,7 @@ class Deferred {
  public:
   Deferred() = default;
   explicit Deferred(Rt t)
-      : state_(std::make_shared<Deferred_detail::simple_assoc_state<Rt>>(
+      : state_(boost::make_shared<Deferred_detail::simple_assoc_state<Rt>>(
             std::move(t))) {}
 
   constexpr const Rt& get() const { return state_->get(); }
@@ -157,9 +159,9 @@ class Deferred {
   constexpr Rt& mutate() { return state_->mutate(); }
 
  private:
-  std::shared_ptr<Deferred_detail::assoc_state<Rt>> state_;
+  boost::shared_ptr<Deferred_detail::assoc_state<Rt>> state_;
 
-  explicit Deferred(std::shared_ptr<Deferred_detail::assoc_state<Rt>>&& state)
+  explicit Deferred(boost::shared_ptr<Deferred_detail::assoc_state<Rt>>&& state)
       : state_(std::move(state)) {}
 
   // clang-tidy: redundant declaration
@@ -212,7 +214,7 @@ class Deferred {
  */
 template <typename Rt, typename Fp, typename... Args>
 Deferred<Rt> make_deferred(Fp f, Args&&... args) {
-  return Deferred<Rt>(std::make_shared<Deferred_detail::deferred_assoc_state<
+  return Deferred<Rt>(boost::make_shared<Deferred_detail::deferred_assoc_state<
                           Rt, std::decay_t<Fp>, std::decay_t<Args>...>>(
       f, std::forward<Args>(args)...));
 }


### PR DESCRIPTION
## Proposed changes

Several small optimizations to improve runtime. Total 3D scalar wave evolution runtime is reduced by ~15%.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
