### PR TITLE
Remove unnecessary variable

### DIFF
--- a/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
@@ -40,26 +40,25 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.Translation",
   const auto trans_map_deserialized = serialize_and_deserialize(trans_map);
 
   const std::array<double, 1> point_xi{{3.2}};
-  const std::array<double, 1> point_x{{3.2}};
 
   while (t < final_time) {
     const std::array<double, 1> trans_x{{square(t)}};
     const std::array<double, 1> frame_vel{{f_of_t.func_and_deriv(t)[1][0]}};
 
     CHECK_ITERABLE_APPROX(trans_map(point_xi, t, f_of_t_list),
-                          point_x + trans_x);
-    CHECK_ITERABLE_APPROX(trans_map.inverse(point_x + trans_x, t, f_of_t_list),
+                          point_xi + trans_x);
+    CHECK_ITERABLE_APPROX(trans_map.inverse(point_xi + trans_x, t, f_of_t_list),
                           point_xi);
-    CHECK_ITERABLE_APPROX(
-        trans_map.frame_velocity(point_x + trans_x, t, f_of_t_list), frame_vel);
+    CHECK_ITERABLE_APPROX(trans_map.frame_velocity(point_xi, t, f_of_t_list),
+                          frame_vel);
 
     CHECK_ITERABLE_APPROX(trans_map_deserialized(point_xi, t, f_of_t_list),
-                          point_x + trans_x);
+                          point_xi + trans_x);
     CHECK_ITERABLE_APPROX(
-        trans_map_deserialized.inverse(point_x + trans_x, t, f_of_t_list),
+        trans_map_deserialized.inverse(point_xi + trans_x, t, f_of_t_list),
         point_xi);
     CHECK_ITERABLE_APPROX(trans_map_deserialized.frame_velocity(
-                              point_x + trans_x, t, f_of_t_list),
+                              point_xi + trans_x, t, f_of_t_list),
                           frame_vel);
 
     t += dt;


### PR DESCRIPTION
## Proposed changes
Remove the use of an unnecessary variable.

### Types of changes:

- [X] Bugfix
- [ ] New feature

### Component:

- [X] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
