### PR TITLE
Add RotatedRectangles

### DIFF
--- a/src/Domain/DomainCreators/CMakeLists.txt
+++ b/src/Domain/DomainCreators/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Rectangle.cpp
   RegisterDerivedWithCharm.cpp
   RotatedIntervals.cpp
+  RotatedRectangles.cpp
   Shell.cpp
   Sphere.cpp
   )

--- a/src/Domain/DomainCreators/DomainCreator.hpp
+++ b/src/Domain/DomainCreators/DomainCreator.hpp
@@ -36,6 +36,8 @@ class Rectangle;
 template <typename TargetFrame>
 class RotatedIntervals;
 template <typename TargetFrame>
+class RotatedRectangles;
+template <typename TargetFrame>
 class Shell;
 template <typename TargetFrame>
 class Sphere;
@@ -56,7 +58,8 @@ template <>
 struct domain_creators<2> {
   template <typename Frame>
   using creators =
-      tmpl::list<DomainCreators::Disk<Frame>, DomainCreators::Rectangle<Frame>>;
+      tmpl::list<DomainCreators::Disk<Frame>, DomainCreators::Rectangle<Frame>,
+                 DomainCreators::RotatedRectangles<Frame>>;
 };
 template <>
 struct domain_creators<3> {
@@ -99,5 +102,6 @@ class DomainCreator {
 #include "Domain/DomainCreators/Interval.hpp"
 #include "Domain/DomainCreators/Rectangle.hpp"
 #include "Domain/DomainCreators/RotatedIntervals.hpp"
+#include "Domain/DomainCreators/RotatedRectangles.hpp"
 #include "Domain/DomainCreators/Shell.hpp"
 #include "Domain/DomainCreators/Sphere.hpp"

--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
@@ -38,6 +39,9 @@ void register_with_charm<2>() {
       SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D>));
   PUPable_reg(SINGLE_ARG(
       ::CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular2D>));
+  PUPable_reg(
+      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D,
+                                 CoordinateMaps::DiscreteRotation<2>>));
   PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Wedge2D>));
 }

--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -15,42 +15,38 @@
 
 namespace DomainCreators {
 namespace DomainCreators_detail {
+using Affine = CoordinateMaps::Affine;
+using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+using Equiangular = CoordinateMaps::Equiangular;
+using Equiangular2D = CoordinateMaps::ProductOf2Maps<Equiangular, Equiangular>;
+using Equiangular3D =
+    CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
+
 template <size_t Dim>
 void register_with_charm();
 
 template <>
 void register_with_charm<1>() {
-  PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         CoordinateMaps::Affine>));
+  PUPable_reg(
+      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine>));
 }
 
 template <>
 void register_with_charm<2>() {
-  PUPable_reg(SINGLE_ARG(
-      ::CoordinateMap<Frame::Logical, Frame::Inertial,
-                      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                                     CoordinateMaps::Affine>>));
   PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<
-                 Frame::Logical, Frame::Inertial,
-                 CoordinateMaps::ProductOf2Maps<CoordinateMaps::Equiangular,
-                                                CoordinateMaps::Equiangular>>));
+      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D>));
+  PUPable_reg(SINGLE_ARG(
+      ::CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular2D>));
   PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Wedge2D>));
 }
 template <>
 void register_with_charm<3>() {
-  PUPable_reg(SINGLE_ARG(
-      ::CoordinateMap<Frame::Logical, Frame::Inertial,
-                      CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
-                                                     CoordinateMaps::Affine,
-                                                     CoordinateMaps::Affine>>));
   PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<
-                 Frame::Logical, Frame::Inertial,
-                 CoordinateMaps::ProductOf3Maps<CoordinateMaps::Equiangular,
-                                                CoordinateMaps::Equiangular,
-                                                CoordinateMaps::Equiangular>>));
+      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine3D>));
+  PUPable_reg(SINGLE_ARG(
+      ::CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular3D>));
 
   PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Wedge3D>));

--- a/src/Domain/DomainCreators/RotatedRectangles.cpp
+++ b/src/Domain/DomainCreators/RotatedRectangles.cpp
@@ -1,0 +1,88 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/DomainCreators/RotatedRectangles.hpp"
+
+#include <algorithm>
+
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/OrientationMap.hpp"
+
+namespace DomainCreators {
+
+template <typename TargetFrame>
+RotatedRectangles<TargetFrame>::RotatedRectangles(
+    const typename LowerBound::type lower_xy,
+    const typename Midpoint::type midpoint_xy,
+    const typename UpperBound::type upper_xy,
+    const typename InitialRefinement::type initial_refinement_level_xy,
+    const typename InitialGridPoints::type
+        initial_number_of_grid_points_in_xy) noexcept
+    // clang-tidy: trivially copyable
+    : lower_xy_(std::move(lower_xy)),                         // NOLINT
+      midpoint_xy_(std::move(midpoint_xy)),                   // NOLINT
+      upper_xy_(std::move(upper_xy)),                         // NOLINT
+      initial_refinement_level_xy_(                           // NOLINT
+          std::move(initial_refinement_level_xy)),            // NOLINT
+      initial_number_of_grid_points_in_xy_(                   // NOLINT
+          std::move(initial_number_of_grid_points_in_xy)) {}  // NOLINT
+
+template <typename TargetFrame>
+Domain<2, TargetFrame> RotatedRectangles<TargetFrame>::create_domain() const
+    noexcept {
+  using Affine = CoordinateMaps::Affine;
+  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  using DiscreteRotation2D = CoordinateMaps::DiscreteRotation<2>;
+
+  const Affine lower_x_map(-1.0, 1.0, lower_xy_[0], midpoint_xy_[0]);
+  const Affine upper_x_map(-1.0, 1.0, midpoint_xy_[0], upper_xy_[0]);
+  const Affine lower_y_map(-1.0, 1.0, lower_xy_[1], midpoint_xy_[1]);
+  const Affine upper_y_map(-1.0, 1.0, midpoint_xy_[1], upper_xy_[1]);
+  std::vector<
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 2>>>
+      coord_maps;
+  coord_maps.emplace_back(make_coordinate_map_base<Frame::Logical, TargetFrame>(
+      Affine2D(lower_x_map, lower_y_map)));
+  coord_maps.emplace_back(make_coordinate_map_base<Frame::Logical, TargetFrame>(
+      Affine2D(lower_x_map, upper_y_map),
+      DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
+          {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}}}));
+  coord_maps.emplace_back(make_coordinate_map_base<Frame::Logical, TargetFrame>(
+      Affine2D(upper_x_map, lower_y_map),
+      DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
+          {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}}));
+  coord_maps.emplace_back(make_coordinate_map_base<Frame::Logical, TargetFrame>(
+      Affine2D(upper_x_map, upper_y_map),
+      DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
+          {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}}));
+  std::vector<std::array<size_t, 4>> corners{
+      {{0, 1, 3, 4}}, {{7, 6, 4, 3}}, {{2, 5, 1, 4}}, {{7, 4, 8, 5}}};
+  return Domain<2, TargetFrame>(std::move(coord_maps), std::move(corners));
+}
+
+template <typename TargetFrame>
+std::vector<std::array<size_t, 2>>
+RotatedRectangles<TargetFrame>::initial_extents() const noexcept {
+  const size_t& x_0 = initial_number_of_grid_points_in_xy_[0][0];
+  const size_t& x_1 = initial_number_of_grid_points_in_xy_[0][1];
+  const size_t& y_0 = initial_number_of_grid_points_in_xy_[1][0];
+  const size_t& y_1 = initial_number_of_grid_points_in_xy_[1][1];
+  return {{{x_0, y_0}}, {{x_0, y_1}}, {{y_0, x_1}}, {{y_1, x_1}}};
+}
+
+template <typename TargetFrame>
+std::vector<std::array<size_t, 2>>
+RotatedRectangles<TargetFrame>::initial_refinement_levels() const noexcept {
+  const size_t& x_0 = initial_refinement_level_xy_[0];
+  const size_t& y_0 = initial_refinement_level_xy_[1];
+  return {{{x_0, y_0}}, {{x_0, y_0}}, {{y_0, x_0}}, {{y_0, x_0}}};
+}
+}  // namespace DomainCreators
+
+template class DomainCreators::RotatedRectangles<Frame::Inertial>;
+template class DomainCreators::RotatedRectangles<Frame::Grid>;

--- a/src/Domain/DomainCreators/RotatedRectangles.hpp
+++ b/src/Domain/DomainCreators/RotatedRectangles.hpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+#include <vector>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace DomainCreators {
+
+/// \ingroup DomainCreatorsGroup
+/// Create a 2D Domain consisting of four rotated Blocks.
+/// - The lower left block has its logical \f$\xi\f$-axis aligned with
+/// the grid x-axis.
+/// - The upper left block has its logical \f$\xi\f$-axis opposite to
+/// the grid x-axis.
+/// - The lower right block has its logical \f$\xi\f$-axis aligned with
+/// the grid y-axis.
+/// - The upper right block has its logical \f$\xi\f$-axis opposite to
+/// the grid y-axis.
+///
+/// This DomainCreator is useful for testing code that deals with
+/// unaligned blocks.
+template <typename TargetFrame>
+class RotatedRectangles : public DomainCreator<2, TargetFrame> {
+ public:
+  struct LowerBound {
+    using type = std::array<double, 2>;
+    static constexpr OptionString help = {
+        "Sequence of [x,y] for lower bounds in the target frame."};
+  };
+
+  struct Midpoint {
+    using type = std::array<double, 2>;
+    static constexpr OptionString help = {
+        "Sequence of [x,y] for midpoints in the target frame."};
+  };
+
+  struct UpperBound {
+    using type = std::array<double, 2>;
+    static constexpr OptionString help = {
+        "Sequence of [x,y] for upper bounds in the target frame."};
+  };
+
+  struct InitialRefinement {
+    using type = std::array<size_t, 2>;
+    static constexpr OptionString help = {
+        "Initial refinement level in [x, y]."};
+  };
+
+  struct InitialGridPoints {
+    using type = std::array<std::array<size_t, 2>, 2>;
+    static constexpr OptionString help = {
+        "Initial number of grid points in [[x], [y]]."};
+  };
+
+  using options = tmpl::list<LowerBound, Midpoint, UpperBound,
+                             InitialRefinement, InitialGridPoints>;
+
+  static constexpr OptionString help = {
+      "A DomainCreator useful for testing purposes.\n"
+      "RotatedRectangles uses four rotated Blocks to create the rectangle\n"
+      "[LowerX,UpperX] x [LowerY,UpperY]. The outermost index to\n"
+      "InitialGridPoints is the dimension index, and the innermost index is\n"
+      "the block index along that dimension."};
+
+  RotatedRectangles(
+      typename LowerBound::type lower_xy, typename Midpoint::type midpoint_xy,
+      typename UpperBound::type upper_xy,
+      typename InitialRefinement::type initial_refinement_level_xy,
+      typename InitialGridPoints::type
+          initial_number_of_grid_points_in_xy) noexcept;
+
+  RotatedRectangles() = default;
+  RotatedRectangles(const RotatedRectangles&) = delete;
+  RotatedRectangles(RotatedRectangles&&) noexcept = default;
+  RotatedRectangles& operator=(const RotatedRectangles&) = delete;
+  RotatedRectangles& operator=(RotatedRectangles&&) noexcept = default;
+  ~RotatedRectangles() override = default;
+
+  Domain<2, TargetFrame> create_domain() const noexcept override;
+
+  std::vector<std::array<size_t, 2>> initial_extents() const noexcept override;
+
+  std::vector<std::array<size_t, 2>> initial_refinement_levels() const
+      noexcept override;
+
+ private:
+  typename LowerBound::type lower_xy_{
+      {std::numeric_limits<double>::signaling_NaN()}};
+  typename Midpoint::type midpoint_xy_{
+      {std::numeric_limits<double>::signaling_NaN()}};
+  typename UpperBound::type upper_xy_{
+      {std::numeric_limits<double>::signaling_NaN()}};
+  typename InitialRefinement::type initial_refinement_level_xy_{
+      {std::numeric_limits<size_t>::max()}};
+  typename InitialGridPoints::type initial_number_of_grid_points_in_xy_{
+      {{{std::numeric_limits<size_t>::max()}}}};
+};
+}  // namespace DomainCreators

--- a/tests/Unit/Domain/DomainCreators/CMakeLists.txt
+++ b/tests/Unit/Domain/DomainCreators/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   DomainCreators/Test_Interval.cpp
   DomainCreators/Test_Rectangle.cpp
   DomainCreators/Test_RotatedIntervals.cpp
+  DomainCreators/Test_RotatedRectangles.cpp
   DomainCreators/Test_Shell.cpp
   DomainCreators/Test_Sphere.cpp
   PARENT_SCOPE

--- a/tests/Unit/Domain/DomainCreators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_RotatedRectangles.cpp
@@ -1,0 +1,163 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/DomainCreator.hpp"
+#include "Domain/DomainCreators/RotatedRectangles.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "tests/Unit/Domain/DomainTestHelpers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+
+namespace {
+void test_rotated_rectangles_construction(
+    const DomainCreators::RotatedRectangles<Frame::Inertial>&
+        rotated_rectangles,
+    const std::array<double, 2>& lower_bound,
+    const std::array<double, 2>& midpoint,
+    const std::array<double, 2>& upper_bound,
+    const std::vector<std::array<size_t, 2>>& expected_extents,
+    const std::vector<std::array<size_t, 2>>& expected_refinement_level,
+    const std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>&
+        expected_block_neighbors,
+    const std::vector<std::unordered_set<Direction<2>>>&
+        expected_external_boundaries) noexcept {
+  const auto domain = rotated_rectangles.create_domain();
+
+  CHECK(domain.blocks().size() == expected_extents.size());
+  CHECK(domain.blocks().size() == expected_refinement_level.size());
+  CHECK(rotated_rectangles.initial_extents() == expected_extents);
+  CHECK(rotated_rectangles.initial_refinement_levels() ==
+        expected_refinement_level);
+
+  using Affine = CoordinateMaps::Affine;
+  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  using DiscreteRotation2D = CoordinateMaps::DiscreteRotation<2>;
+
+  const Affine lower_x_map(-1.0, 1.0, lower_bound[0], midpoint[0]);
+  const Affine upper_x_map(-1.0, 1.0, midpoint[0], upper_bound[0]);
+  const Affine lower_y_map(-1.0, 1.0, lower_bound[1], midpoint[1]);
+  const Affine upper_y_map(-1.0, 1.0, midpoint[1], upper_bound[1]);
+  std::vector<
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 2>>>
+      coord_maps;
+  coord_maps.emplace_back(
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Affine2D(lower_x_map, lower_y_map)));
+  coord_maps.emplace_back(
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Affine2D(lower_x_map, upper_y_map),
+          DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}}}));
+  coord_maps.emplace_back(
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Affine2D(upper_x_map, lower_y_map),
+          DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}}));
+  coord_maps.emplace_back(
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Affine2D(upper_x_map, upper_y_map),
+          DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}}));
+
+  test_domain_construction(domain, expected_block_neighbors,
+                           expected_external_boundaries, coord_maps);
+  test_initial_domain(domain, rotated_rectangles.initial_refinement_levels());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles",
+                  "[Domain][Unit]") {
+  const std::vector<std::array<size_t, 2>> grid_points{
+      {{4, 2}}, {{4, 3}}, {{2, 1}}, {{3, 1}}},
+      refinement_level{{{0, 1}}, {{0, 1}}, {{1, 0}}, {{1, 0}}};
+  const std::array<double, 2> lower_bound{{-1.2, -2.0}}, midpoint{{-0.6, 0.2}},
+      upper_bound{{0.8, 3.0}};
+  const OrientationMap<2> flipped{std::array<Direction<2>, 2>{
+      {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}};
+  const OrientationMap<2> quarter_turn_cw{std::array<Direction<2>, 2>{
+      {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}};
+  const OrientationMap<2> quarter_turn_ccw{std::array<Direction<2>, 2>{
+      {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}};
+
+  const DomainCreators::RotatedRectangles<Frame::Inertial> rotated_rectangles{
+      lower_bound,
+      midpoint,
+      upper_bound,
+      {{refinement_level[0][0], refinement_level[0][1]}},
+      {{{{grid_points[0][0], grid_points[2][1]}},
+        {{grid_points[0][1], grid_points[1][1]}}}}};
+  test_rotated_rectangles_construction(
+      rotated_rectangles, lower_bound, midpoint, upper_bound, grid_points,
+      refinement_level,
+      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+          {{Direction<2>::upper_xi(), {2, quarter_turn_ccw}},
+           {Direction<2>::upper_eta(), {1, flipped}}},
+          {{Direction<2>::lower_xi(), {3, quarter_turn_ccw}},
+           {Direction<2>::upper_eta(), {0, flipped}}},
+          {{Direction<2>::upper_xi(), {3, flipped}},
+           {Direction<2>::upper_eta(), {0, quarter_turn_cw}}},
+          {{Direction<2>::upper_xi(), {2, flipped}},
+           {Direction<2>::lower_eta(), {1, quarter_turn_cw}}}},
+      std::vector<std::unordered_set<Direction<2>>>{
+          {Direction<2>::lower_xi(), Direction<2>::lower_eta()},
+          {Direction<2>::upper_xi(), Direction<2>::lower_eta()},
+          {Direction<2>::lower_xi(), Direction<2>::lower_eta()},
+          {Direction<2>::lower_xi(), Direction<2>::upper_eta()}});
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles.Factory",
+                  "[Domain][Unit]") {
+  const OrientationMap<2> flipped{std::array<Direction<2>, 2>{
+      {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}};
+  const OrientationMap<2> quarter_turn_cw{std::array<Direction<2>, 2>{
+      {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}};
+  const OrientationMap<2> quarter_turn_ccw{std::array<Direction<2>, 2>{
+      {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}};
+
+  const auto domain_creator =
+      test_factory_creation<DomainCreator<2, Frame::Inertial>>(
+          "  RotatedRectangles:\n"
+          "    LowerBound: [0.1, -0.4]\n"
+          "    Midpoint:   [2.6, 3.2]\n"
+          "    UpperBound: [5.1, 6.2]\n"
+          "    InitialGridPoints: [[3,2],[1,4]]\n"
+          "    InitialRefinement: [2,1]\n");
+  const auto* rotated_rectangles_creator =
+      dynamic_cast<const DomainCreators::RotatedRectangles<Frame::Inertial>*>(
+          domain_creator.get());
+  test_rotated_rectangles_construction(
+      *rotated_rectangles_creator, {{0.1, -0.4}}, {{2.6, 3.2}}, {{5.1, 6.2}},
+      {{{3, 1}}, {{3, 4}}, {{1, 2}}, {{4, 2}}},
+      {{{2, 1}}, {{2, 1}}, {{1, 2}}, {{1, 2}}},
+      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+          {{Direction<2>::upper_xi(), {2, quarter_turn_ccw}},
+           {Direction<2>::upper_eta(), {1, flipped}}},
+          {{Direction<2>::lower_xi(), {3, quarter_turn_ccw}},
+           {Direction<2>::upper_eta(), {0, flipped}}},
+          {{Direction<2>::upper_xi(), {3, flipped}},
+           {Direction<2>::upper_eta(), {0, quarter_turn_cw}}},
+          {{Direction<2>::upper_xi(), {2, flipped}},
+           {Direction<2>::lower_eta(), {1, quarter_turn_cw}}}},
+      std::vector<std::unordered_set<Direction<2>>>{
+          {Direction<2>::lower_xi(), Direction<2>::lower_eta()},
+          {Direction<2>::upper_xi(), Direction<2>::lower_eta()},
+          {Direction<2>::lower_xi(), Direction<2>::lower_eta()},
+          {Direction<2>::lower_xi(), Direction<2>::upper_eta()}});
+}


### PR DESCRIPTION
## Proposed changes

The extension of RotatedIntervals to 2D. Useful for testing.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
