### PR TITLE
Avoid setting up python for every test

### DIFF
--- a/tests/Unit/Pypp/SetupLocalPythonEnvironment.cpp
+++ b/tests/Unit/Pypp/SetupLocalPythonEnvironment.cpp
@@ -25,8 +25,7 @@ SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
   // In the case where we run all the non-failure tests at once we must ensure
   // that we only initialize and finalize the python env once. Initialization is
   // done in the constructor of SetupLocalPythonEnvironment, while finalization
-  // is done in the constructor of RunTests by constructing a
-  // SetupLocalPythonEnvironment object and calling finalize_env on it.
+  // is done in the constructor of RunTests.
   if (not initialized) {
     Py_Initialize();
     // On some python versions init_numpy() can throw an FPE, this occurred at

--- a/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp
+++ b/tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp
@@ -29,9 +29,8 @@ struct SetupLocalPythonEnvironment {
   // In the case where we run all the non-failure tests at once we must ensure
   // that we only initialize and finalize the python env once. Initialization is
   // done in the constructor of SetupLocalPythonEnvironment, while finalization
-  // is done in the constructor of RunTests by constructing a
-  // SetupLocalPythonEnvironment object and calling finalize_env on it.
-  void finalize_env();
+  // is done in the constructor of RunTests.
+  static void finalize_env();
   /// \endcond
 
  private:

--- a/tests/Unit/RunTests.cpp
+++ b/tests/Unit/RunTests.cpp
@@ -31,9 +31,8 @@ RunTests::RunTests(CkArgMsg* msg) {
   // In the case where we run all the non-failure tests at once we must ensure
   // that we only initialize and finalize the python env once. Initialization is
   // done in the constructor of SetupLocalPythonEnvironment, while finalization
-  // is done in the constructor of RunTests by constructing a
-  // SetupLocalPythonEnvironment object and calling finalize_env on it.
-  pypp::SetupLocalPythonEnvironment("").finalize_env();
+  // is done in the constructor of RunTests.
+  pypp::SetupLocalPythonEnvironment::finalize_env();
   if (0 == result) {
     Parallel::exit();
   }


### PR DESCRIPTION
The finalize_env function is a no-op if python is not initialized, so
we don't need to initialize python just to finalize it.  The extra
python initializations were about half of the total test runtime on my
machine.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
