### PR TITLE
Allow Pypp to work with arrays of DataVectors

### DIFF
--- a/src/Utilities/MakeWithValue.hpp
+++ b/src/Utilities/MakeWithValue.hpp
@@ -6,7 +6,10 @@
 
 #pragma once
 
+#include <array>
+
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 /// \ingroup DataStructuresGroup
@@ -40,6 +43,16 @@ SPECTRE_ALWAYS_INLINE double MakeWithValueImpl<double, double>::apply(
     const double& /* input */, const double value) {
   return value;
 }
+
+/// \brief Makes a `std::array`; each element of the `std::array`
+/// must be `make_with_value`-creatable from a `T`.
+template <size_t Size, typename T>
+struct MakeWithValueImpl<std::array<T, Size>, T> {
+  static SPECTRE_ALWAYS_INLINE std::array<T, Size> apply(const T& input,
+                                                         const double value) {
+    return make_array<Size>(make_with_value<T>(input, value));
+  }
+};
 
 /// \brief Makes a `TaggedTuple`; each element of the `TaggedTuple`
 /// must be `make_with_value`-creatable from a `T`.

--- a/tests/Unit/Pypp/PyppFundamentals.hpp
+++ b/tests/Unit/Pypp/PyppFundamentals.hpp
@@ -432,7 +432,8 @@ T* get_ptr_to_elem(PyObj* npy_array, const std::array<size_t, Size>& idx) {
 }
 
 template <typename T>
-struct FromPyObject<T, Requires<tt::is_a_v<Tensor, T> and T::rank() != 0>> {
+struct FromPyObject<T, Requires<tt::is_a_v<Tensor, T> and T::rank() != 0 and
+                                cpp17::is_same_v<typename T::type, double>>> {
   static T convert(PyObject* p) {
     if (p == nullptr) {
       throw std::runtime_error{"Received null PyObject."};
@@ -474,7 +475,8 @@ struct FromPyObject<T, Requires<tt::is_a_v<Tensor, T> and T::rank() != 0>> {
 };
 
 template <typename T>
-struct ToPyObject<T, Requires<tt::is_a_v<Tensor, T> and T::rank() != 0>> {
+struct ToPyObject<T, Requires<tt::is_a_v<Tensor, T> and T::rank() != 0 and
+                              cpp17::is_same_v<typename T::type, double>>> {
   static PyObject* convert(const T& t) {
     std::array<long, T::rank()> dims =
         convert_array_of_size_t_to_array_of_long(T::index_dims());

--- a/tests/Unit/Pypp/PyppPyTests.py
+++ b/tests/Unit/Pypp/PyppPyTests.py
@@ -207,3 +207,6 @@ def check2_by_value1_class1(t0, t1, a):
 
 def check2_by_value2_class1(t0, t1, a, b):
     return 2.0 * t0 + 5.0 * a + t1 * b
+
+def permute_array(a):
+    return [a[2], a[0], a[1]]

--- a/tests/Unit/Pypp/Test_Pypp.cpp
+++ b/tests/Unit/Pypp/Test_Pypp.cpp
@@ -106,6 +106,21 @@ SPECTRE_TEST_CASE("Unit.Pypp.std::array", "[Pypp][Unit]") {
   CHECK_THROWS(pypp::call<double>("PyppPyTests", "test_vector",
                                   std::array<double, 2>{{1.3, 4.9}},
                                   std::array<double, 2>{{4.2, 6.8}}));
+
+  std::array<DataVector, 3> expected_array{
+      {DataVector{2, 3.}, DataVector{2, 1.}, DataVector{2, 2.}}};
+
+  CHECK(expected_array ==
+        (pypp::call<std::array<DataVector, 3>>(
+            "PyppPyTests", "permute_array",
+            tnsr::i<DataVector, 3>{{{DataVector{2, 1.}, DataVector{2, 2.},
+                                   DataVector{2, 3.}}}})));
+
+  CHECK(expected_array ==
+        (pypp::call<std::array<DataVector, 3>>(
+            "PyppPyTests", "permute_array",
+            std::array<DataVector, 3>{
+                {DataVector{2, 1.}, DataVector{2, 2.}, DataVector{2, 3.}}})));
 }
 
 SPECTRE_TEST_CASE("Unit.Pypp.DataVector", "[Pypp][Unit]") {

--- a/tests/Unit/Utilities/Test_MakeWithValue.cpp
+++ b/tests/Unit/Utilities/Test_MakeWithValue.cpp
@@ -3,11 +3,13 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <array>
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -70,9 +72,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.MakeWithValue",
   check_make_with_value(8.3, tnsr::I<double, 3, Frame::Grid>(1.3), 8.3);
   check_make_with_value(tnsr::Ij<double, 3, Frame::Grid>(8.3),
                         tnsr::aB<double, 1, Frame::Inertial>(1.3), 8.3);
+  check_make_with_value(make_array<4>(8.3), 1.3, 8.3);
 
   for (size_t n_pts = 1; n_pts < 4; ++n_pts) {
     // create DataVector from DataVector
+    check_make_with_value(make_array<3>(DataVector(n_pts, 8.3)),
+                          DataVector(n_pts, 4.5), 8.3);
     check_make_with_value(DataVector(n_pts, -2.3), DataVector(n_pts, 4.5),
                           -2.3);
     check_make_with_value(Scalar<DataVector>(n_pts, -2.3),


### PR DESCRIPTION
## Proposed changes

The characteristic speeds in Cris' PR will be held as a `std::array` so we need to be able to test arrays with the python infrastructure. I also had to add a `make_with_value` implementation for arrays to get this to work.  

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
