### PR TITLE
Replace boost::rational in Time classes

### DIFF
--- a/src/Executables/Benchmark/CMakeLists.txt
+++ b/src/Executables/Benchmark/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Since benchmarking is only interesting in Release mode the executable isn't
-# added in any other build. Charm++'s main function is overridden with the main
+# Since benchmarking is only interesting in release mode the executable isn't
+# added for Debug builds. Charm++'s main function is overridden with the main
 # from the Google Benchmark library. The executable is not added to the `all` make
 # target since it is only interesting in specific circumstances.
-if("${GOOGLE_BENCHMARK_FOUND}" AND "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+if("${GOOGLE_BENCHMARK_FOUND}" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
   set(executable Benchmark)
 
   add_executable(

--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -16,4 +16,5 @@ add_library(${LIBRARY} ${LIBRARY_SOURCES})
 target_link_libraries(
   ${LIBRARY}
   INTERFACE ErrorHandling
+  INTERFACE Utilities
   )

--- a/src/Time/StepControllers/BinaryFraction.hpp
+++ b/src/Time/StepControllers/BinaryFraction.hpp
@@ -16,6 +16,7 @@
 #include "Time/StepControllers/StepController.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+// IWYU pragma: no_include "Utilities/Rational.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace StepControllers {
@@ -44,8 +45,9 @@ class BinaryFraction : public StepController {
 
     // Ensure we will hit the slab boundary if we continue taking
     // constant-sized steps.
-    const ssize_t step_count =
-        std::max(static_cast<ssize_t>(two_to_the(desired_step_power)),
+    const auto step_count =
+        std::max(static_cast<decltype(time.fraction().denominator())>(
+                     two_to_the(desired_step_power)),
                  time.fraction().denominator());
 
     return full_slab / step_count;

--- a/src/Time/StepControllers/BinaryFraction.hpp
+++ b/src/Time/StepControllers/BinaryFraction.hpp
@@ -6,13 +6,17 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
+#include <cstddef>
 
+#include "ErrorHandling/Assert.hpp"
 #include "Options/Options.hpp"
 #include "Time/Slab.hpp"
-#include "Time/StepControllers/StepController.hpp"
+#include "Time/StepControllers/StepController.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace StepControllers {
 

--- a/src/Time/StepControllers/FullSlab.hpp
+++ b/src/Time/StepControllers/FullSlab.hpp
@@ -6,10 +6,12 @@
 
 #pragma once
 
+#include "ErrorHandling/Assert.hpp"
 #include "Options/Options.hpp"
 #include "Time/Slab.hpp"
-#include "Time/StepControllers/StepController.hpp"
+#include "Time/StepControllers/StepController.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace StepControllers {
 

--- a/src/Time/StepControllers/SimpleTimes.hpp
+++ b/src/Time/StepControllers/SimpleTimes.hpp
@@ -47,8 +47,7 @@ class SimpleTimes : public StepController {
                          0.5 * desired_step);
 
     const double full_slab = time.slab().duration().value();
-    const auto current_position =
-        boost::rational_cast<double>(time.fraction());
+    const auto current_position = time.fraction().value();
     using Fraction = Time::rational_t;
     Fraction step_end = simplest_fraction_in_interval<Fraction>(
         current_position + min_step / full_slab,

--- a/src/Time/StepControllers/SimpleTimes.hpp
+++ b/src/Time/StepControllers/SimpleTimes.hpp
@@ -7,13 +7,15 @@
 #pragma once
 
 #include <cmath>
+#include <utility>
 
 #include "Options/Options.hpp"
 #include "Time/Slab.hpp"
-#include "Time/StepControllers/StepController.hpp"
+#include "Time/StepControllers/StepController.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/FractionUtilities.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace StepControllers {
 

--- a/src/Time/StepControllers/SplitRemaining.hpp
+++ b/src/Time/StepControllers/SplitRemaining.hpp
@@ -6,12 +6,15 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
+#include <cstddef>
 
 #include "Options/Options.hpp"
 #include "Time/Slab.hpp"
-#include "Time/StepControllers/StepController.hpp"
+#include "Time/StepControllers/StepController.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace StepControllers {
 

--- a/src/Time/StepControllers/StepController.hpp
+++ b/src/Time/StepControllers/StepController.hpp
@@ -13,10 +13,10 @@
 ///
 /// Holds all the StepControllers
 namespace StepControllers {
-class BinaryFraction;
-class FullSlab;
-class SimpleTimes;
-class SplitRemaining;
+class BinaryFraction;  // IWYU pragma: keep
+class FullSlab;  // IWYU pragma: keep
+class SimpleTimes;  // IWYU pragma: keep
+class SplitRemaining;  // IWYU pragma: keep
 }  // namespace StepControllers
 
 /// \ingroup TimeSteppersGroup
@@ -45,7 +45,7 @@ class StepController {
                                 double desired_step) const noexcept = 0;
 };
 
-#include "Time/StepControllers/BinaryFraction.hpp"
-#include "Time/StepControllers/FullSlab.hpp"
-#include "Time/StepControllers/SimpleTimes.hpp"
-#include "Time/StepControllers/SplitRemaining.hpp"
+#include "Time/StepControllers/BinaryFraction.hpp"  // IWYU pragma: keep
+#include "Time/StepControllers/FullSlab.hpp"  // IWYU pragma: keep
+#include "Time/StepControllers/SimpleTimes.hpp"  // IWYU pragma: keep
+#include "Time/StepControllers/SplitRemaining.hpp"  // IWYU pragma: keep

--- a/src/Time/Time.cpp
+++ b/src/Time/Time.cpp
@@ -11,17 +11,7 @@
 
 void Time::pup(PUP::er& p) noexcept {
   p | slab_;
-  if (p.isUnpacking()) {
-    rational_t::int_type n, d;
-    p | n;
-    p | d;
-    fraction_.assign(n, d);
-  } else {
-    rational_t::int_type n = fraction_.numerator();
-    rational_t::int_type d = fraction_.denominator();
-    p | n;
-    p | d;
-  }
+  p | fraction_;
 }
 
 Time Time::with_slab(const Slab& new_slab) const noexcept {
@@ -110,23 +100,13 @@ std::ostream& operator<<(std::ostream& os, const Time& t) noexcept {
 
 void TimeDelta::pup(PUP::er& p) noexcept {
   p | slab_;
-  if (p.isUnpacking()) {
-    rational_t::int_type n, d;
-    p | n;
-    p | d;
-    fraction_.assign(n, d);
-  } else {
-    rational_t::int_type n = fraction_.numerator();
-    rational_t::int_type d = fraction_.denominator();
-    p | n;
-    p | d;
-  }
+  p | fraction_;
 }
 
 double operator/(const TimeDelta& a, const TimeDelta& b) noexcept {
   // We need to use double/double here because this is the
   // implementation of TimeDelta/TimeDelta.
-  return boost::rational_cast<double>(a.fraction() / b.fraction()) *
+  return (a.fraction() / b.fraction()).value() *
          (a.slab().duration().value() / b.slab().duration().value());
 }
 
@@ -143,8 +123,7 @@ size_t hash_value(const Time& t) noexcept {
   } else {
     size_t h = 0;
     boost::hash_combine(h, t.slab());
-    boost::hash_combine(h, t.fraction().numerator());
-    boost::hash_combine(h, t.fraction().denominator());
+    boost::hash_combine(h, t.fraction());
     return h;
   }
 }

--- a/src/Time/Time.cpp
+++ b/src/Time/Time.cpp
@@ -70,24 +70,24 @@ bool operator==(const Time& a, const Time& b) noexcept {
 
 TimeDelta operator-(const Time& a, const Time& b) noexcept {
   if (a.slab() == b.slab()) {
-    return TimeDelta(a.slab(), a.fraction() - b.fraction());
+    return {a.slab(), a.fraction() - b.fraction()};
   } else if (a.slab().is_followed_by(b.slab())) {
     if (a.is_at_slab_end()) {
-      return TimeDelta(b.slab(), -b.fraction());
+      return {b.slab(), -b.fraction()};
     } else {
       ASSERT(b.is_at_slab_start(),
              "Can't subtract times from different slabs");
-      return TimeDelta(a.slab(), a.fraction() - 1);
+      return {a.slab(), a.fraction() - 1};
     }
   } else {
     ASSERT(a.slab().is_preceeded_by(b.slab()),
            "Can't subtract times from different slabs");
     if (a.is_at_slab_start()) {
-      return TimeDelta(b.slab(), 1 - b.fraction());
+      return {b.slab(), 1 - b.fraction()};
     } else {
       ASSERT(b.is_at_slab_end(),
              "Can't subtract times from different slabs");
-      return TimeDelta(a.slab(), a.fraction());
+      return {a.slab(), a.fraction()};
     }
   }
 }
@@ -128,7 +128,8 @@ size_t hash_value(const Time& t) noexcept {
   }
 }
 
-namespace std {
+// clang-tidy: do not modify std namespace (okay for hash)
+namespace std {  // NOLINT
 size_t hash<Time>::operator()(const Time& t) const noexcept {
   return boost::hash<Time>{}(t);
 }

--- a/src/Time/Time.hpp
+++ b/src/Time/Time.hpp
@@ -7,13 +7,13 @@
 #pragma once
 
 #include <algorithm>
-#include <boost/rational.hpp>
 #include <cstddef>
 #include <functional>
 #include <iosfwd>
 
 #include "ErrorHandling/Assert.hpp"
 #include "Time/Slab.hpp"
+#include "Utilities/Rational.hpp"
 
 /// \cond
 namespace PUP {
@@ -31,7 +31,7 @@ class TimeDelta;
 /// slabs.
 class Time {
  public:
-  using rational_t = boost::rational<ssize_t>;
+  using rational_t = Rational;
 
   /// Default constructor gives an invalid Time.
   Time() noexcept : fraction_(0) {}
@@ -123,8 +123,7 @@ class TimeDelta {
 
   /// Approximate numerical length of the interval.
   double value() const noexcept {
-    return (slab_.end_ - slab_.start_) *
-           boost::rational_cast<double>(fraction_);
+    return (slab_.end_ - slab_.start_) * fraction_.value();
   }
 
   /// Test if the interval is oriented towards larger time.
@@ -207,8 +206,7 @@ inline Time operator+(const TimeDelta& a, Time b) noexcept {
 }
 
 inline Time operator-(Time a, const TimeDelta& b) noexcept {
-  // clang-tidy misfeature: warns about boost internals here
-  a -= b;  // NOLINT
+  a -= b;
   return a;
 }
 
@@ -260,8 +258,7 @@ inline Time& Time::operator+=(const TimeDelta& delta) noexcept {
 
 inline Time& Time::operator-=(const TimeDelta& delta) noexcept {
   *this = this->with_slab(delta.slab_);
-  // clang-tidy misfeature: warns about boost internals here
-  fraction_ -= delta.fraction_;  // NOLINT
+  fraction_ -= delta.fraction_;
   range_check();
   return *this;
 }

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY Utilities)
 set(LIBRARY_SOURCES
     FileSystem.cpp
     PrettyType.cpp
+    Rational.cpp
     )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Utilities/Rational.cpp
+++ b/src/Utilities/Rational.cpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Utilities/Rational.hpp"
+
+// IWYU pragma: no_include <boost/cstdint.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/integer/common_factor_rt.hpp>
+#include <ostream>
+#include <pup.h>
+#include <tuple>
+
+#include "ErrorHandling/Assert.hpp"
+
+namespace {
+// This is needed a lot, so define a shorter name.
+std::int64_t to64(const std::int32_t n) noexcept {
+  return static_cast<std::int64_t>(n);
+}
+
+template <typename IntType>
+std::tuple<std::int32_t, std::int32_t> reduce(IntType numerator,
+                                              IntType denominator) noexcept {
+  const IntType common_factor = boost::integer::gcd(numerator, denominator);
+  numerator /= common_factor;
+  denominator /= common_factor;
+  if (denominator < 0) {
+    numerator = -numerator;
+    denominator = -denominator;
+  }
+  ASSERT(static_cast<std::int32_t>(numerator) == numerator and
+         static_cast<std::int32_t>(denominator) == denominator,
+         "Rational overflow: " << numerator << "/" << denominator);
+  return std::make_tuple(numerator, denominator);
+}
+}  // namespace
+
+Rational::Rational(const std::int32_t numerator,
+                   const std::int32_t denominator) noexcept {
+  ASSERT(denominator != 0, "Division by zero");
+  std::tie(numerator_, denominator_) = reduce(numerator, denominator);
+}
+
+double Rational::value() const noexcept {
+  return static_cast<double>(numerator_) / static_cast<double>(denominator_);
+}
+
+Rational Rational::inverse() const noexcept {
+  // Default construct to avoid the reduce() call.
+  ASSERT(*this != 0, "Division by zero");
+  Rational ret;
+  ret.numerator_ = denominator_;
+  ret.denominator_ = numerator_;
+  if (ret.denominator_ < 0) {
+    ret.numerator_ = -ret.numerator_;
+    ret.denominator_ = -ret.denominator_;
+  }
+  return ret;
+}
+
+Rational& Rational::operator+=(const Rational& other) noexcept {
+  std::tie(numerator_, denominator_) =
+      reduce(to64(numerator_) * to64(other.denominator_) +
+             to64(denominator_) * to64(other.numerator_),
+             to64(denominator_) * to64(other.denominator_));
+  return *this;
+}
+Rational& Rational::operator-=(const Rational& other) noexcept {
+  return *this += -other;
+}
+Rational& Rational::operator*=(const Rational& other) noexcept {
+  std::tie(numerator_, denominator_) =
+      reduce(to64(numerator_) * to64(other.numerator()),
+             to64(denominator_) * to64(other.denominator()));
+  return *this;
+}
+Rational& Rational::operator/=(const Rational& other) noexcept {
+  return *this *= other.inverse();
+}
+
+void Rational::pup(PUP::er& p) noexcept {
+  p | numerator_;
+  p | denominator_;
+}
+
+Rational operator-(Rational r) noexcept {
+  // No reduced-form check needed
+  r.numerator_ = -r.numerator_;
+  return r;
+}
+
+Rational operator+(const Rational& a, const Rational& b) noexcept {
+  Rational ret = a;
+  ret += b;
+  return ret;
+}
+Rational operator-(const Rational& a, const Rational& b) noexcept {
+  Rational ret = a;
+  ret -= b;
+  return ret;
+}
+Rational operator*(const Rational& a, const Rational& b) noexcept {
+  Rational ret = a;
+  ret *= b;
+  return ret;
+}
+Rational operator/(const Rational& a, const Rational& b) noexcept {
+  Rational ret = a;
+  ret /= b;
+  return ret;
+}
+
+bool operator==(const Rational& a, const Rational& b) noexcept {
+  return a.numerator() == b.numerator() and a.denominator() == b.denominator();
+}
+bool operator!=(const Rational& a, const Rational& b) noexcept {
+  return not (a == b);
+}
+bool operator<(const Rational& a, const Rational& b) noexcept {
+  return to64(a.numerator()) * to64(b.denominator()) <
+         to64(b.numerator()) * to64(a.denominator());
+}
+bool operator>(const Rational& a, const Rational& b) noexcept {
+  return b < a;
+}
+bool operator<=(const Rational& a, const Rational& b) noexcept {
+  return not (b < a);
+}
+bool operator>=(const Rational& a, const Rational& b) noexcept {
+  return not (a < b);
+}
+
+std::ostream& operator<<(std::ostream& os, const Rational& r) noexcept {
+  return os << r.numerator() << '/' << r.denominator();
+}
+
+size_t hash_value(const Rational& r) noexcept {
+  size_t h = 0;
+  boost::hash_combine(h, r.numerator());
+  boost::hash_combine(h, r.denominator());
+  return h;
+}
+
+// clang-tidy: do not modify std namespace (okay for hash)
+namespace std {  // NOLINT
+size_t hash<Rational>::operator()(const Rational& r) const noexcept {
+  return boost::hash<Rational>{}(r);
+}
+}  // namespace std

--- a/src/Utilities/Rational.hpp
+++ b/src/Utilities/Rational.hpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <iosfwd>
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/// \ingroup UtilitiesGroup
+/// A rational number
+///
+/// This serves as a faster replacement for
+/// `boost::rational<std::int32_t>`.  As of Boost 1.65.0, arithmetic
+/// operators average about twice as fast, and ordering operators are
+/// about eight times as fast.
+class Rational {
+ public:
+  // clang-tidy: google-explicit-constructor
+  // Treating integers as rationals is desired.
+  Rational(std::int32_t numerator = 0,  // NOLINT
+           std::int32_t denominator = 1) noexcept;
+
+  std::int32_t numerator() const noexcept { return numerator_; }
+  std::int32_t denominator() const noexcept { return denominator_; }
+
+  double value() const noexcept;
+
+  Rational inverse() const noexcept;
+
+  Rational& operator+=(const Rational& other) noexcept;
+  Rational& operator-=(const Rational& other) noexcept;
+  Rational& operator*=(const Rational& other) noexcept;
+  Rational& operator/=(const Rational& other) noexcept;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  friend Rational operator-(Rational r) noexcept;
+
+ private:
+  std::int32_t numerator_{0};
+  std::int32_t denominator_{1};
+};
+
+Rational operator+(const Rational& a, const Rational& b) noexcept;
+Rational operator-(const Rational& a, const Rational& b) noexcept;
+Rational operator*(const Rational& a, const Rational& b) noexcept;
+Rational operator/(const Rational& a, const Rational& b) noexcept;
+
+bool operator==(const Rational& a, const Rational& b) noexcept;
+bool operator!=(const Rational& a, const Rational& b) noexcept;
+bool operator<(const Rational& a, const Rational& b) noexcept;
+bool operator>(const Rational& a, const Rational& b) noexcept;
+bool operator<=(const Rational& a, const Rational& b) noexcept;
+bool operator>=(const Rational& a, const Rational& b) noexcept;
+
+std::ostream& operator<<(std::ostream& os, const Rational& r) noexcept;
+
+size_t hash_value(const Rational& r) noexcept;
+
+namespace std {
+template <>
+struct hash<Rational> {
+  size_t operator()(const Rational& r) const noexcept;
+};
+}  // namespace std

--- a/tests/Unit/Time/Test_StepControllers.cpp
+++ b/tests/Unit/Time/Test_StepControllers.cpp
@@ -3,7 +3,6 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <boost/rational.hpp>
 #include <limits>
 
 #include "ErrorHandling/Error.hpp"
@@ -13,6 +12,7 @@
 #include "Time/StepControllers/SimpleTimes.hpp"
 #include "Time/StepControllers/SplitRemaining.hpp"
 #include "Time/Time.hpp"
+// IWYU pragma: no_include "Utilities/Rational.hpp"
 #include "tests/Unit/TestCreation.hpp"
 
 class StepController;

--- a/tests/Unit/Time/Test_Time.cpp
+++ b/tests/Unit/Time/Test_Time.cpp
@@ -4,13 +4,13 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
-#include <boost/rational.hpp>
 #include <functional>
 #include <string>
 
 #include "ErrorHandling/Error.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
+// IWYU pragma: no_include "Utilities/Rational.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.Time", "[Unit][Time]") {

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LIBRARY_SOURCES
   Test_Math.cpp
   Test_Overloader.cpp
   Test_PrettyType.cpp
+  Test_Rational.cpp
   Test_Requires.cpp
   Test_StdArrayHelpers.cpp
   Test_StdHelpers.cpp

--- a/tests/Unit/Utilities/Test_Rational.cpp
+++ b/tests/Unit/Utilities/Test_Rational.cpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <functional>
+#include <string>
+
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/Rational.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.Rational", "[Unit][Utilities]") {
+  CHECK(Rational(6, 8).numerator() == 3);
+  CHECK(Rational(6, 8).denominator() == 4);
+  CHECK(Rational(-6, 8).numerator() == -3);
+  CHECK(Rational(-6, 8).denominator() == 4);
+  CHECK(Rational(6, -8).numerator() == -3);
+  CHECK(Rational(6, -8).denominator() == 4);
+  CHECK(Rational(-6, -8).numerator() == 3);
+  CHECK(Rational(-6, -8).denominator() == 4);
+
+  CHECK(Rational(0, 2).numerator() == 0);
+  CHECK(Rational(0, 2).denominator() == 1);
+  CHECK(Rational(0, -2).numerator() == 0);
+  CHECK(Rational(0, -2).denominator() == 1);
+
+  CHECK(Rational(3, 4).value() == 0.75);
+  CHECK(Rational(-3, 2).value() == -1.5);
+  CHECK(Rational(1, 3).value() == approx(1./3.));
+
+  check_cmp(Rational(3, 4), Rational(5, 4));
+  check_cmp(Rational(3, 5), Rational(3, 4));
+
+  CHECK(-Rational(3, 4) == Rational(-3, 4));
+  CHECK(-Rational(-3, 4) == Rational(3, 4));
+
+  CHECK(Rational(3, 4).inverse() == Rational(4, 3));
+  CHECK(Rational(-3, 4).inverse() == Rational(-4, 3));
+
+  CHECK_OP(Rational(3, 4), +, Rational(2, 5), Rational(23, 20));
+  CHECK_OP(Rational(3, 4), +, Rational(7, 4), Rational(5, 2));
+  CHECK_OP(Rational(3, 4), -, Rational(2, 5), Rational(7, 20));
+  CHECK_OP(Rational(3, 4), -, Rational(7, 4), Rational(-1));
+  CHECK_OP(Rational(3, 4), *, Rational(5, 2), Rational(15, 8));
+  CHECK_OP(Rational(3, 4), *, Rational(2, 3), Rational(1, 2));
+  CHECK_OP(Rational(3, 4), /, Rational(2, 5), Rational(15, 8));
+  CHECK_OP(Rational(3, 4), /, Rational(3, 2), Rational(1, 2));
+
+  const auto hash = std::hash<Rational>{};
+  CHECK(hash(Rational(1, 2)) != hash(Rational(1, 3)));
+  CHECK(hash(Rational(1, 2)) != hash(Rational(3, 2)));
+  CHECK(hash(Rational(1, 2)) != hash(Rational(-1, 2)));
+
+  CHECK(get_output(Rational(3, 4)) == "3/4");
+  CHECK(get_output(Rational(-3, 4)) == "-3/4");
+
+  test_serialization(Rational(3, 4));
+}
+
+SPECTRE_TEST_CASE("Unit.Utilities.Rational.internal_overflow",
+                  "[Unit][Utilities]") {
+  CHECK(Rational(6000000, 8000000) == Rational(3, 4));
+
+  check_cmp(Rational(5, 1 << 16), Rational(1 << 16));
+
+  CHECK_OP(Rational((1 << 21) + 1, 1 << 17), +,
+           Rational((1 << 22) - 1, 1 << 18), Rational((1 << 23) + 1, 1 << 18));
+  CHECK_OP(Rational((1 << 21) + 1, 1 << 17), -,
+           Rational((1 << 22) - 1, 1 << 18), Rational(3, 1 << 18));
+  CHECK_OP(Rational((1 << 20) - 1, 1 << 20), *,
+           Rational(1 << 17, (1 << 10) + 1), Rational((1 << 10) - 1, 1 << 3));
+  CHECK_OP(Rational((1 << 20) - 1, 1 << 20), /,
+           Rational((1 << 10) + 1, 1 << 17), Rational((1 << 10) - 1, 1 << 3));
+}
+
+// [[OutputRegex, Division by zero]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.denominator_zero",
+                               "[Unit][Utilities]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Rational(1, 0);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Division by zero]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.invert_zero",
+                               "[Unit][Utilities]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Rational(0).inverse();
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Division by zero]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.divide_zero",
+                               "[Unit][Utilities]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Rational(1) / 0;
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Division by zero]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.divide_equal_zero",
+                               "[Unit][Utilities]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Rational r(1);
+  r /= 0;
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Rational overflow: 1000000000000/1]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.overflow_numerator",
+                               "[Unit][Utilities]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Rational(1000000) * Rational(1000000);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Rational overflow: 1/1000000000000]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Rational.overflow_denominator",
+                               "[Unit][Utilities]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Rational(1, 1000000) * Rational(1, 1000000);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}

--- a/tools/Iwyu/stl.imp
+++ b/tools/Iwyu/stl.imp
@@ -3,6 +3,7 @@
 
 [
   { symbol: ["size_t", private, "<cstddef>", public]},
+  { symbol: ["ssize_t", private, "<cstddef>", public]},
   { symbol: ["std::abs", private, "<cmath>", public]},
   { symbol: ["abs", private, "<cmath>", public]},
   { symbol: ["std::hash", private, "<functional>", public]},


### PR DESCRIPTION
## Proposed changes

This class is much faster than boost::rational, probably because the
latter is templated on the integer type and therefore can't make many
assumptions or optimizations (and optimized specializations are not
implemented).  Mathematical operators average about twice as fast,
albeit with wide variation.  Ordering operators are roughly eight
times as fast.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
