### PR TITLE
Cubic scale

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY CoordinateMaps)
 set(LIBRARY_SOURCES
     Affine.cpp
     BulgedCube.cpp
+    CubicScale.cpp
     DiscreteRotation.cpp
     Equiangular.cpp
     Frustum.cpp

--- a/src/Domain/CoordinateMaps/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/CubicScale.cpp
@@ -1,0 +1,264 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/CubicScale.hpp"
+
+#include <array>
+#include <functional>
+#include <ostream>
+#include <pup.h>
+#include <pup_stl.h>
+#include <utility>
+
+#include "ControlSystem/FunctionOfTime.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/RootFinding/NewtonRaphson.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace CoordMapsTimeDependent {
+
+CubicScale::CubicScale(const double outer_boundary) noexcept
+    : outer_boundary_(outer_boundary) {}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 1> CubicScale::operator()(
+    const std::array<T, 1>& source_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  const auto a_of_t = map_list.at(f_of_t_a_).func(time)[0][0];
+  const auto b_of_t = map_list.at(f_of_t_b_).func(time)[0][0];
+  return {{source_coords[0] *
+           (a_of_t +
+            (b_of_t - a_of_t) * square(source_coords[0] / outer_boundary_))}};
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 1> CubicScale::inverse(
+    const std::array<T, 1>& target_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  // the original coordinates are found by solving for the roots
+  // of (b-a)/X^2*\xi^3 + a*\xi - x = 0, where a and b are the FunctionsOfTime,
+  // X is the outer_boundary, and x represents the mapped coordinates
+  const auto a_of_t = map_list.at(f_of_t_a_).func(time)[0][0];
+  const auto b_of_t = map_list.at(f_of_t_b_).func(time)[0][0];
+
+  // these checks ensure that the function is monotonically increasing
+  // and that there is one real root in the domain of \xi, [0,X]
+  if (a_of_t <= 0.0) {
+    ERROR("We require expansion_a > 0 for invertibility, however expansion_a = "
+          << a_of_t << ".");
+  }
+  if (b_of_t < 2.0 / 3.0 * a_of_t) {
+    ERROR("The map is only invertible if expansion_b < expansion_a*2/3, however"
+          << " expansion_b = " << b_of_t << " and expansion_a = " << a_of_t
+          << " does not satisfy this criterion.");
+  }
+
+  // Make the coordinates dimensionless
+  const tt::remove_cvref_wrap_t<T> x_bar = target_coords[0] / outer_boundary_;
+  // with the assumptions above:
+  // x_bar lies within the range [0,b]
+  // and \xi_bar = \xi/X is restricted to the domain [0,1]
+  // For an initial guess, we provide a linearly approximated solution for
+  // \xi_bar, which is just x_bar/b.
+  const tt::remove_cvref_wrap_t<T> initial_guess = x_bar / b_of_t;
+  const double cubic_coef_a = (b_of_t - a_of_t);
+
+  const auto cubic_and_deriv =
+      [&cubic_coef_a, &a_of_t, &x_bar ](double x) noexcept {
+    return std::make_pair(x * (cubic_coef_a * square(x) + a_of_t) - x_bar,
+                          3.0 * cubic_coef_a * square(x) + a_of_t);
+  };
+
+  // The original implementation of this inverse function used a cubic
+  // equation solver. However, given that the problem of finding the inverse
+  // in this case is well constrained -- using a Newton-Raphson root find with
+  // a linearly approximated guess is almost twice as fast.
+  // Using google benchmark,
+  // the CubicEquation solver: ~ 480 ns
+  // boost implemented Newton-Raphson: ~ 280 ns
+  // minimal Newton-Raphson from Numerical Recipes: ~ 255 ns
+  // Despite the minimal Newton-Raphson being more efficient than the boost
+  // version, here we utilize the boost implementation, as it includes
+  // additional checks for zero derivative, checks on bounds, and can implement
+  // bisection if necessary.
+  return {
+      {outer_boundary_ * RootFinder::newton_raphson(
+                             cubic_and_deriv, initial_guess, 0.0, 1.0, 14)}};
+}
+
+template <>
+std::array<tt::remove_cvref_wrap_t<DataVector>, 1> CubicScale::inverse(
+    const std::array<DataVector, 1>& target_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  DataVector solutions{target_coords[0]};
+  for (auto& solution : solutions) {
+    solution = inverse<double>({{solution}}, time, map_list)[0];
+  }
+  return {{solutions}};
+}
+
+template <>
+std::array<tt::remove_cvref_wrap_t<std::reference_wrapper<const DataVector>>, 1>
+CubicScale::inverse(
+    const std::array<std::reference_wrapper<const DataVector>, 1>&
+        target_coords,
+    const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  DataVector solutions{target_coords[0]};
+  for (auto& solution : solutions) {
+    solution = inverse<double>({{solution}}, time, map_list)[0];
+  }
+  return {{solutions}};
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 1> CubicScale::frame_velocity(
+    const std::array<T, 1>& source_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  const auto dt_a_of_t = map_list.at(f_of_t_a_).func_and_deriv(time)[1][0];
+  const auto dt_b_of_t = map_list.at(f_of_t_b_).func_and_deriv(time)[1][0];
+  const auto frame_vel =
+      source_coords[0] *
+      (dt_a_of_t +
+       (dt_b_of_t - dt_a_of_t) * square(source_coords[0] / outer_boundary_));
+
+  return {{frame_vel}};
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> CubicScale::jacobian(
+    const std::array<T, 1>& source_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  const auto a_of_t = map_list.at(f_of_t_a_).func(time)[0][0];
+  const auto b_of_t = map_list.at(f_of_t_b_).func(time)[0][0];
+  auto jac{
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0)};
+
+  get<0, 0>(jac) =
+      a_of_t +
+      3.0 * (b_of_t - a_of_t) * square(source_coords[0] / outer_boundary_);
+
+  return jac;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>
+CubicScale::inv_jacobian(
+    const std::array<T, 1>& source_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  const auto a_of_t = map_list.at(f_of_t_a_).func(time)[0][0];
+  const auto b_of_t = map_list.at(f_of_t_b_).func(time)[0][0];
+  auto inv_jac{
+      make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0)};
+
+  get<0, 0>(inv_jac) = 1.0 / (a_of_t +
+                              3.0 * (b_of_t - a_of_t) *
+                                  square(source_coords[0] / outer_boundary_));
+
+  return inv_jac;
+}
+
+template <typename T>
+tnsr::Iaa<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> CubicScale::hessian(
+    const std::array<T, 1>& source_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept {
+  const auto a_of_t_and_derivs = map_list.at(f_of_t_a_).func_and_2_derivs(time);
+  const auto b_of_t_and_derivs = map_list.at(f_of_t_b_).func_and_2_derivs(time);
+
+  auto result{
+      make_with_value<tnsr::Iaa<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame>>(
+          dereference_wrapper(source_coords[0]), 0.0)};
+  // time-time
+  get<0, 0, 0>(result) = a_of_t_and_derivs[2][0] * source_coords[0] +
+                         (b_of_t_and_derivs[2][0] - a_of_t_and_derivs[2][0]) *
+                             cube(source_coords[0]) / square(outer_boundary_);
+  // time-space
+  get<0, 0, 1>(result) =
+      a_of_t_and_derivs[1][0] +
+      3.0 * (b_of_t_and_derivs[1][0] - a_of_t_and_derivs[1][0]) *
+          square(source_coords[0] / outer_boundary_);
+  // space-space
+  get<0, 1, 1>(result) = 6.0 *
+                         (b_of_t_and_derivs[0][0] - a_of_t_and_derivs[0][0]) *
+                         source_coords[0] / square(outer_boundary_);
+
+  return result;
+}
+
+void CubicScale::pup(PUP::er& p) noexcept {
+  p | f_of_t_a_;
+  p | f_of_t_b_;
+  p | outer_boundary_;
+}
+
+bool operator==(const CoordMapsTimeDependent::CubicScale& lhs,
+                const CoordMapsTimeDependent::CubicScale& rhs) noexcept {
+  return lhs.f_of_t_a_ == rhs.f_of_t_a_ and lhs.f_of_t_b_ == rhs.f_of_t_b_ and
+         lhs.outer_boundary_ == rhs.outer_boundary_;
+}
+
+// Explicit instantiations
+/// \cond
+template std::array<tt::remove_cvref_wrap_t<double>, 1> CubicScale::inverse(
+    const std::array<double, 1>& target_coords, const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept;
+template std::array<
+    tt::remove_cvref_wrap_t<std::reference_wrapper<const double>>, 1>
+CubicScale::inverse(
+    const std::array<std::reference_wrapper<const double>, 1>& target_coords,
+    const double time,
+    const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+    noexcept;
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1> CubicScale::    \
+  operator()(const std::array<DTYPE(data), 1>& source_coords,                  \
+             const double time,                                                \
+             const std::unordered_map<std::string, FunctionOfTime&>& map_list) \
+      const noexcept;                                                          \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
+  CubicScale::frame_velocity(                                                  \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
+  CubicScale::jacobian(                                                        \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
+      const noexcept;                                                          \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>   \
+  CubicScale::inv_jacobian(                                                    \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
+      const noexcept;                                                          \
+  template tnsr::Iaa<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>  \
+  CubicScale::hessian(                                                         \
+      const std::array<DTYPE(data), 1>& source_coords, const double time,      \
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
+      const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond
+}  // namespace CoordMapsTimeDependent

--- a/src/Domain/CoordinateMaps/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/CubicScale.hpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TypeTraits.hpp"
+/// \cond
+class FunctionOfTime;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace CoordMapsTimeDependent {
+/*!
+ * \ingroup CoordMapsTimeDependentGroup
+ * \brief CubicScale map defined by \f$x = a(t)*\xi+(b(t)-a(t))\xi^3/X^2\f$,
+ *  where \f$X\f$ is the outer boundary.
+ *
+ * The map scales the coordinates \f$\xi\f$ near the center by a factor
+ * \f$a(t)\f$, while the coordinates near the outer boundary \f$X\f$, are scaled
+ * by a factor \f$b(t)\f$. Here \f$a(t)\f$ and \f$b(t)\f$ are FunctionsOfTime.
+ *
+ * Currently, only a 1-D implementation.
+ */
+class CubicScale {
+ public:
+  static constexpr size_t dim = 1;
+
+  explicit CubicScale(double outer_boundary) noexcept;
+  CubicScale() = default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
+      const std::array<T, 1>& source_coords, double time,
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+      noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 1> inverse(
+      const std::array<T, 1>& target_coords, double time,
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+      noexcept;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 1> frame_velocity(
+      const std::array<T, 1>& source_coords, double time,
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+      noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 1>& source_coords, double time,
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+      noexcept;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
+      const std::array<T, 1>& source_coords, double time,
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+      noexcept;
+
+  template <typename T>
+  tnsr::Iaa<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> hessian(
+      const std::array<T, 1>& source_coords, double time,
+      const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
+      noexcept;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  friend bool operator==(const CubicScale& lhs, const CubicScale& rhs) noexcept;
+
+  std::string f_of_t_a_ = "expansion_a";
+  std::string f_of_t_b_ = "expansion_b";
+  double outer_boundary_{std::numeric_limits<double>::signaling_NaN()};
+};
+
+inline bool operator!=(const CoordMapsTimeDependent::CubicScale& lhs,
+                       const CoordMapsTimeDependent::CubicScale& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace CoordMapsTimeDependent

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY_SOURCES
   CoordinateMaps/Test_Affine.cpp
   CoordinateMaps/Test_BulgedCube.cpp
   CoordinateMaps/Test_CoordinateMap.cpp
+  CoordinateMaps/Test_CubicScale.cpp
   CoordinateMaps/Test_DiscreteRotation.cpp
   CoordinateMaps/Test_Equiangular.cpp
   CoordinateMaps/Test_Frustum.cpp

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -177,30 +177,22 @@ void test_coordinate_map_argument_types(
                    });
     return result;
   };
-  const auto make_tensor_data_vector = [](const auto& double_tensor) noexcept {
-    using Arg = std::decay_t<decltype(double_tensor)>;
-    Tensor<DataVector, typename Arg::symmetry, typename Arg::index_list> result;
-    std::transform(double_tensor.begin(), double_tensor.end(), result.begin(),
-                   [](const double x) noexcept {
-                     return DataVector{x, x};
-                   });
-    return result;
-  };
   const auto add_reference_wrapper = [](const auto& unwrapped_array) noexcept {
     using Arg = std::decay_t<decltype(unwrapped_array)>;
     return make_array<std::reference_wrapper<const typename Arg::value_type>,
                       Map::dim>(unwrapped_array);
   };
 
-  const auto mapped_point = map(test_point, args...);
-  CHECK_ITERABLE_APPROX(map(add_reference_wrapper(test_point), args...),
-                        mapped_point);
-  CHECK_ITERABLE_APPROX(map(make_array_data_vector(test_point), args...),
-                        make_array_data_vector(mapped_point));
-  CHECK_ITERABLE_APPROX(
-      map(add_reference_wrapper(make_array_data_vector(test_point)), args...),
-      make_array_data_vector(mapped_point));
   {
+    const auto mapped_point = map(test_point, args...);
+    CHECK_ITERABLE_APPROX(map(add_reference_wrapper(test_point), args...),
+                          mapped_point);
+    CHECK_ITERABLE_APPROX(map(make_array_data_vector(test_point), args...),
+                          make_array_data_vector(mapped_point));
+    CHECK_ITERABLE_APPROX(
+        map(add_reference_wrapper(make_array_data_vector(test_point)), args...),
+        make_array_data_vector(mapped_point));
+
     const auto expected = map.inverse(mapped_point, args...);
     CHECK_ITERABLE_APPROX(
         map.inverse(add_reference_wrapper(mapped_point), args...), expected);
@@ -213,27 +205,78 @@ void test_coordinate_map_argument_types(
         make_array_data_vector(expected));
   }
 
-  {
-    const auto expected = map.jacobian(test_point);
-    CHECK_ITERABLE_APPROX(map.jacobian(add_reference_wrapper(test_point)),
-                          expected);
-    CHECK_ITERABLE_APPROX(map.jacobian(make_array_data_vector(test_point)),
-                          make_tensor_data_vector(expected));
-    CHECK_ITERABLE_APPROX(
-        map.jacobian(add_reference_wrapper(make_array_data_vector(test_point))),
-        make_tensor_data_vector(expected));
-  }
+  // Here, time_args is a const auto& not const Args& because time_args
+  // is allowed to be different than Args (which was the reason for the
+  // overloader below that calls this function).
+  const auto check_jac = [](const auto& make_arr_data_vec,
+                            const auto& add_ref_wrap, const Map& the_map,
+                            const std::array<double, Map::dim>& point,
+                            const auto&... time_args) noexcept {
+    const auto make_tensor_data_vector = [](const auto& double_tensor) {
+      using Arg = std::decay_t<decltype(double_tensor)>;
+      Tensor<DataVector, typename Arg::symmetry, typename Arg::index_list>
+          result;
+      std::transform(double_tensor.begin(), double_tensor.end(), result.begin(),
+                     [](const double x) {
+                       return DataVector{x, x};
+                     });
+      return result;
+    };
 
-  {
-    const auto expected = map.inv_jacobian(test_point);
-    CHECK_ITERABLE_APPROX(map.inv_jacobian(add_reference_wrapper(test_point)),
-                          expected);
-    CHECK_ITERABLE_APPROX(map.inv_jacobian(make_array_data_vector(test_point)),
-                          make_tensor_data_vector(expected));
-    CHECK_ITERABLE_APPROX(map.inv_jacobian(add_reference_wrapper(
-                              make_array_data_vector(test_point))),
-                          make_tensor_data_vector(expected));
-  }
+    {
+      const auto expected = the_map.jacobian(point, time_args...);
+      CHECK_ITERABLE_APPROX(the_map.jacobian(add_ref_wrap(point), time_args...),
+                            expected);
+      CHECK_ITERABLE_APPROX(
+          the_map.jacobian(make_arr_data_vec(point), time_args...),
+          make_tensor_data_vector(expected));
+      CHECK_ITERABLE_APPROX(
+          the_map.jacobian(add_ref_wrap(make_arr_data_vec(point)),
+                           time_args...),
+          make_tensor_data_vector(expected));
+    }
+    {
+      const auto expected = the_map.inv_jacobian(point, time_args...);
+      CHECK_ITERABLE_APPROX(
+          the_map.inv_jacobian(add_ref_wrap(point), time_args...), expected);
+      CHECK_ITERABLE_APPROX(
+          the_map.inv_jacobian(make_arr_data_vec(point), time_args...),
+          make_tensor_data_vector(expected));
+      CHECK_ITERABLE_APPROX(
+          the_map.inv_jacobian(add_ref_wrap(make_arr_data_vec(point)),
+                               time_args...),
+          make_tensor_data_vector(expected));
+    }
+
+    return nullptr;
+  };
+
+  const auto jac_overloader = make_overloader(
+      // The first two functions are passed through the jacobian
+      // overloader and the check_jac function due to gcc failing to deduce auto
+      [&check_jac](const auto& make_array_data_vec, const auto& add_ref_wrapper,
+                   const Map& this_map,
+                   const std::array<double, Map::dim>& this_point,
+                   const std::false_type /*is_time_independent*/,
+                   const Args&... /*the_args*/) noexcept {
+        check_jac(make_array_data_vec, add_ref_wrapper, this_map, this_point);
+        return nullptr;
+      },
+      [&check_jac](const auto& make_array_data_vec, const auto& add_ref_wrapper,
+                   const Map& this_map,
+                   const std::array<double, Map::dim>& this_point,
+                   const std::true_type /*is_time_dependent*/,
+                   const Args&... the_args) noexcept {
+        check_jac(make_array_data_vec, add_ref_wrapper, this_map, this_point,
+                  the_args...);
+        return nullptr;
+      });
+
+  jac_overloader(
+      make_array_data_vector, add_reference_wrapper, map, test_point,
+      CoordinateMap_detail::is_jacobian_time_dependent_t<decltype(map),
+                                                         double>{},
+      args...);
 }
 
 /*!

--- a/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
@@ -1,0 +1,265 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+
+#include "ControlSystem/FunctionOfTime.hpp"
+#include "ControlSystem/PiecewisePolynomial.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CubicScale.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.CubicScale",
+                  "[Domain][Unit]") {
+  static constexpr size_t deriv_order = 2;
+
+  const auto run_tests = [](
+      const std::array<DataVector, deriv_order + 1>& init_func_a,
+      const std::array<DataVector, deriv_order + 1>& init_func_b,
+      const double outer_b, const double x0, const double final_time) {
+    double t = -0.5;
+    const double dt = 0.6;
+
+    FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_a(t,
+                                                                  init_func_a);
+    FunctionOfTime& expansion_a_base = expansion_a;
+
+    FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_b(t,
+                                                                  init_func_b);
+    FunctionOfTime& expansions_b_base = expansion_b;
+
+    const std::unordered_map<std::string, FunctionOfTime&> f_of_t_list = {
+        {"expansion_a", expansion_a_base}, {"expansion_b", expansions_b_base}};
+
+    const double outer_boundary = outer_b;
+    const CoordMapsTimeDependent::CubicScale scale_map(outer_boundary);
+    const std::array<double, 1> point_xi{{x0}};
+
+    // test serialized/deserialized map
+    const auto scale_map_deserialized = serialize_and_deserialize(scale_map);
+
+    while (t < final_time) {
+      const double a = expansion_a_base.func_and_deriv(t)[0][0];
+      const double b = expansions_b_base.func_and_deriv(t)[0][0];
+
+      const std::array<double, 1> mapped_point{
+          {point_xi[0] * (a + (b - a) * square(point_xi[0] / outer_boundary))}};
+
+      CHECK_ITERABLE_APPROX(scale_map(point_xi, t, f_of_t_list), mapped_point);
+      CHECK_ITERABLE_APPROX(scale_map.inverse(mapped_point, t, f_of_t_list),
+                            point_xi);
+      CHECK_ITERABLE_APPROX(scale_map_deserialized(point_xi, t, f_of_t_list),
+                            mapped_point);
+      CHECK_ITERABLE_APPROX(
+          scale_map_deserialized.inverse(mapped_point, t, f_of_t_list),
+          point_xi);
+
+      const double jacobian =
+          a + 3.0 * (b - a) * square(point_xi[0] / outer_boundary);
+      const double inv_jacobian =
+          1.0 / (a + 3.0 * (b - a) * square(point_xi[0] / outer_boundary));
+
+      CHECK(scale_map.jacobian(point_xi, t, f_of_t_list).get(0, 0) == jacobian);
+      CHECK(scale_map.inv_jacobian(point_xi, t, f_of_t_list).get(0, 0) ==
+            inv_jacobian);
+      CHECK(
+          scale_map_deserialized.jacobian(point_xi, t, f_of_t_list).get(0, 0) ==
+          jacobian);
+      CHECK(scale_map_deserialized.inv_jacobian(point_xi, t, f_of_t_list)
+                .get(0, 0) == inv_jacobian);
+
+      const double a_dot = expansion_a_base.func_and_deriv(t)[1][0];
+      const double b_dot = expansions_b_base.func_and_deriv(t)[1][0];
+      const std::array<double, 1> frame_vel =
+          point_xi *
+          (a_dot + (b_dot - a_dot) * square(point_xi[0] / outer_boundary));
+
+      CHECK_ITERABLE_APPROX(scale_map.frame_velocity(point_xi, t, f_of_t_list),
+                            frame_vel);
+      CHECK_ITERABLE_APPROX(
+          scale_map_deserialized.frame_velocity(point_xi, t, f_of_t_list),
+          frame_vel);
+
+      const double a_ddot = expansion_a_base.func_and_2_derivs(t)[2][0];
+      const double b_ddot = expansions_b_base.func_and_2_derivs(t)[2][0];
+      const double time_time =
+          a_ddot * point_xi[0] +
+          (b_ddot - a_ddot) * cube(point_xi[0]) / square(outer_boundary);
+      const double time_space =
+          a_dot + 3.0 * (b_dot - a_dot) * square(point_xi[0] / outer_boundary);
+      const double space_space =
+          6.0 * (b - a) * point_xi[0] / square(outer_boundary);
+
+      CHECK(scale_map.hessian(point_xi, t, f_of_t_list).get(0, 0, 0) ==
+            time_time);
+      CHECK(scale_map.hessian(point_xi, t, f_of_t_list).get(0, 1, 0) ==
+            time_space);
+      CHECK(scale_map.hessian(point_xi, t, f_of_t_list).get(0, 0, 1) ==
+            time_space);
+      CHECK(scale_map.hessian(point_xi, t, f_of_t_list).get(0, 1, 1) ==
+            space_space);
+
+      CHECK(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
+                .get(0, 0, 0) == time_time);
+      CHECK(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
+                .get(0, 1, 0) == time_space);
+      CHECK(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
+                .get(0, 0, 1) == time_space);
+      CHECK(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
+                .get(0, 1, 1) == space_space);
+
+      // Check inequivalence operator
+      CHECK_FALSE(scale_map != scale_map);
+      CHECK_FALSE(scale_map_deserialized != scale_map_deserialized);
+
+      // Check serialization
+      CHECK(scale_map == scale_map_deserialized);
+      CHECK_FALSE(scale_map != scale_map_deserialized);
+
+      test_coordinate_map_argument_types(scale_map, point_xi, t, f_of_t_list);
+
+      t += dt;
+    }
+  };
+
+  std::array<DataVector, deriv_order + 1> init_func_a1{
+      {{1.0}, {0.0007}, {-0.004}}};
+  std::array<DataVector, deriv_order + 1> init_func_b1{
+      {{1.0}, {-0.001}, {0.003}}};
+  run_tests(init_func_a1, init_func_b1, 20.0, 19.2, 4.0);
+  // test again with inputs that explicitly result in multiple roots
+  std::array<DataVector, deriv_order + 1> init_func_a2{{{1.0}, {0.0}, {0.0}}};
+  std::array<DataVector, deriv_order + 1> init_func_b2{{{0.99}, {0.0}, {0.0}}};
+  run_tests(init_func_a2, init_func_b2, 6.0, 5.0, 0.0);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.CoordMapsTimeDependent.CubicScale.TestBoundaries",
+    "[Domain][Unit]") {
+  static constexpr size_t deriv_order = 2;
+
+  const auto run_tests = [](const double x0) {
+    double t = -0.5;
+    const double dt = 0.6;
+    const double final_time = 4.0;
+
+    const std::array<DataVector, deriv_order + 1> init_func_a{
+        {{1.0}, {0.0}, {0.0}}};
+    const std::array<DataVector, deriv_order + 1> init_func_b{
+        {{0.99}, {0.0}, {0.0}}};
+
+    FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_a(t,
+                                                                  init_func_a);
+    FunctionOfTime& expansion_a_base = expansion_a;
+
+    FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_b(t,
+                                                                  init_func_b);
+    FunctionOfTime& expansions_b_base = expansion_b;
+
+    const std::unordered_map<std::string, FunctionOfTime&> f_of_t_list = {
+        {"expansion_a", expansion_a_base}, {"expansion_b", expansions_b_base}};
+
+    const double outer_boundary = 20.0;
+    const CoordMapsTimeDependent::CubicScale scale_map(outer_boundary);
+    const std::array<double, 1> point_xi{{x0}};
+
+    while (t < final_time) {
+      const double a = expansion_a_base.func_and_deriv(t)[0][0];
+      const double b = expansions_b_base.func_and_deriv(t)[0][0];
+
+      const std::array<double, 1> mapped_point{
+          {point_xi[0] * (a + (b - a) * square(point_xi[0] / outer_boundary))}};
+
+      CHECK_ITERABLE_APPROX(scale_map(point_xi, t, f_of_t_list), mapped_point);
+      CHECK_ITERABLE_APPROX(scale_map.inverse(mapped_point, t, f_of_t_list),
+                            point_xi);
+      t += dt;
+    }
+  };
+
+  // test inverse at inner and outer boundary values
+  run_tests(0.0);
+  run_tests(20.0);
+}
+
+// [[OutputRegex, The map is only invertible if expansion_b < expansion_a\*2/3]]
+SPECTRE_TEST_CASE(
+    "Unit.Domain.CoordMapsTimeDependent.CubicScale.NonInvertible1",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+  // the two expansion factors are chosen such that the map is non-invertible
+  double t = 4.0;
+  constexpr size_t deriv_order = 2;
+
+  const std::array<DataVector, deriv_order + 1> init_func_a{
+      {{0.96}, {0.0}, {0.0}}};
+  FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_a(t, init_func_a);
+  FunctionOfTime& expansion_a_base = expansion_a;
+
+  const std::array<DataVector, deriv_order + 1> init_func_b{
+      {{0.58}, {0.0}, {0.0}}};
+  FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_b(t, init_func_b);
+  FunctionOfTime& expansions_b_base = expansion_b;
+
+  const std::unordered_map<std::string, FunctionOfTime&> f_of_t_list = {
+      {"expansion_a", expansion_a_base}, {"expansion_b", expansions_b_base}};
+
+  const double outer_boundary = 20.0;
+  const CoordMapsTimeDependent::CubicScale scale_map(outer_boundary);
+  const std::array<double, 1> point_xi{{19.2}};
+
+  const std::array<double, 1> mapped_point{
+      {point_xi[0] *
+       (expansion_a_base.func(t)[0][0] +
+        (expansions_b_base.func(t)[0][0] - expansion_a_base.func(t)[0][0]) *
+            square(point_xi[0] / outer_boundary))}};
+
+  // this call should fail since this specific choice of expansion factors makes
+  // the map non-invertible
+  scale_map.inverse(mapped_point, t, f_of_t_list);
+}
+
+// [[OutputRegex, We require expansion_a > 0 for invertibility]]
+SPECTRE_TEST_CASE(
+    "Unit.Domain.CoordMapsTimeDependent.CubicScale.NonInvertible2",
+    "[Domain][Unit]") {
+  ERROR_TEST();
+  double t = 4.0;
+  constexpr size_t deriv_order = 2;
+
+  const std::array<DataVector, deriv_order + 1> init_func_a{
+      {{-0.0001}, {0.0}, {0.0}}};
+  FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_a(t, init_func_a);
+  FunctionOfTime& expansion_a_base = expansion_a;
+
+  const std::array<DataVector, deriv_order + 1> init_func_b{
+      {{1.0}, {0.0}, {0.0}}};
+  FunctionsOfTime::PiecewisePolynomial<deriv_order> expansion_b(t, init_func_b);
+  FunctionOfTime& expansions_b_base = expansion_b;
+
+  const std::unordered_map<std::string, FunctionOfTime&> f_of_t_list = {
+      {"expansion_a", expansion_a_base}, {"expansion_b", expansions_b_base}};
+
+  const double outer_boundary = 20.0;
+  const CoordMapsTimeDependent::CubicScale scale_map(outer_boundary);
+  const std::array<double, 1> point_xi{{19.2}};
+
+  const std::array<double, 1> mapped_point{
+      {point_xi[0] *
+       (expansion_a_base.func(t)[0][0] +
+        (expansions_b_base.func(t)[0][0] - expansion_a_base.func(t)[0][0]) *
+            square(point_xi[0] / outer_boundary))}};
+
+  // fails due to a_of_t <= 0.0
+  scale_map.inverse(mapped_point, t, f_of_t_list);
+}


### PR DESCRIPTION
## Proposed changes
Add CubicScale map and tests.

+Added time-dependent checks to TestMapHelpers and CoordinateMaps, since this map has a time dependent jacobian
+Added hessian and tests (do we need to add anything related to the hessian to CoordinateMaps or TestMapHelpers ?)

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
