### PR TITLE
Add Mesh type

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
     Index.cpp
     IndexIterator.cpp
     Matrix.cpp
+    Mesh.cpp
     SliceIterator.cpp
     StripeIterator.cpp
     VariablesHelpers.cpp

--- a/src/DataStructures/Index.hpp
+++ b/src/DataStructures/Index.hpp
@@ -27,7 +27,7 @@ template <size_t Dim>
 class Index {
  public:
   /// Construct with each element set to the same value.
-  explicit Index(const size_t i0 = std::numeric_limits<size_t>::max())
+  explicit Index(const size_t i0 = std::numeric_limits<size_t>::max()) noexcept
       : indices_(make_array<Dim>(i0)) {}
 
   /// Construct specifying value in each dimension
@@ -76,7 +76,7 @@ class Index {
   }
   /// \endcond
 
-  /// Return a smaller Index with the d-th elmenent removed.
+  /// Return a smaller Index with the d-th element removed.
   ///
   /// \param d the element to remove.
   template <size_t N = Dim, Requires<(N > 0)> = nullptr>

--- a/src/DataStructures/Mesh.cpp
+++ b/src/DataStructures/Mesh.cpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/Mesh.hpp"
+
+#include <pup.h>  // IWYU pragma: keep
+
+#include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
+
+template <size_t Dim>
+// clang-tidy: incorrectly reported redundancy in template expression
+template <size_t N, Requires<(N > 0 and N == Dim)>>  // NOLINT
+Mesh<Dim - 1> Mesh<Dim>::slice_away(const size_t d) const noexcept {
+  std::array<size_t, Dim - 1> slice_extents{};
+  std::array<Spectral::Basis, Dim - 1> slice_bases{};
+  std::array<Spectral::Quadrature, Dim - 1> slice_quadratures{};
+  for (size_t i = 0; i < Dim; ++i) {
+    if (i < d) {
+      gsl::at(slice_extents, i) = gsl::at(extents_.indices(), i);
+      gsl::at(slice_bases, i) = gsl::at(bases_, i);
+      gsl::at(slice_quadratures, i) = gsl::at(quadratures_, i);
+    } else if (i > d) {
+      gsl::at(slice_extents, i - 1) = gsl::at(extents_.indices(), i);
+      gsl::at(slice_bases, i - 1) = gsl::at(bases_, i);
+      gsl::at(slice_quadratures, i - 1) = gsl::at(quadratures_, i);
+    }
+  }
+  return Mesh<Dim - 1>(slice_extents, slice_bases, slice_quadratures);
+}
+
+/// \cond HIDDEN_SYMBOLS
+template <size_t Dim>
+void Mesh<Dim>::pup(PUP::er& p) noexcept {
+  p | extents_;
+  p | bases_;
+  p | quadratures_;
+}
+
+template <size_t Dim>
+bool operator==(const Mesh<Dim>& lhs, const Mesh<Dim>& rhs) noexcept {
+  return lhs.extents() == rhs.extents() and lhs.basis() == rhs.basis() and
+         lhs.quadrature() == rhs.quadrature();
+}
+
+template <size_t Dim>
+bool operator!=(const Mesh<Dim>& lhs, const Mesh<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define GEN_OP(op, dim)                           \
+  template bool operator op(const Mesh<dim>& lhs, \
+                            const Mesh<dim>& rhs) noexcept;
+#define INSTANTIATE_MESH(_, data) \
+  template class Mesh<DIM(data)>; \
+  GEN_OP(==, DIM(data))           \
+  GEN_OP(!=, DIM(data))
+#define INSTANTIATE_SLICE_AWAY(_, data)                                  \
+  template Mesh<DIM(data) - 1> Mesh<DIM(data)>::slice_away(const size_t) \
+      const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_MESH, (0, 1, 2, 3))
+GENERATE_INSTANTIATIONS(INSTANTIATE_SLICE_AWAY, (1, 2, 3))
+
+#undef DIM
+#undef GEN_OP
+#undef INSTANTIATE_MESH
+#undef INSTANTIATE_SLICE_AWAY
+/// \endcond

--- a/src/DataStructures/Mesh.hpp
+++ b/src/DataStructures/Mesh.hpp
@@ -1,0 +1,177 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines the class template Mesh.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace Spectral {
+enum class Basis;
+enum class Quadrature;
+}  // namespace Spectral
+/// \endcond
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief Holds the number of grid points, basis, and quadrature in each
+ * direction of the computational grid.
+ *
+ * \details A mesh encapsulates all information necessary to construct the
+ * placement of grid points in the computational domain. It does so through a
+ * choice of basis functions, quadrature and number of points \f$N\f$ in each
+ * dimension. The grid points are the associated collocation points and can be
+ * computed by `Spectral::collocation_points`. This means that a simulated
+ * physical field can be represented by its value on each grid point and then
+ * approximated by a polynomial of degree \f$p=N-1\f$ through a linear
+ * combination of Lagrange polynomials.
+ *
+ * \note A field represented by a `DataVector` has no meaning without an
+ * accompanying `Mesh` to provide context. Only w.r.t a `Mesh` can a
+ * `DataVector` of length `mesh.number_of_grid_points()` be interpreted as the
+ * field values at the collocation points. These field values are identical to
+ * the nodal expansion coefficients in Lagrange polynomials.
+ *
+ * \tparam Dim the number of dimensions of the computational grid.
+ */
+template <size_t Dim>
+class Mesh {
+ public:
+  Mesh() noexcept = default;
+
+  /*!
+   * \brief Construct a computational grid with the same number of collocation
+   * points in each dimension.
+   *
+   * \param isotropic_extents The number of collocation points in each
+   * dimension.
+   * \param basis The choice of spectral basis to compute the
+   * collocation points
+   * \param quadrature The choice of quadrature to compute
+   * the collocation points
+   */
+  Mesh(const size_t isotropic_extents, const Spectral::Basis basis,
+       const Spectral::Quadrature quadrature) noexcept
+      : extents_(isotropic_extents) {
+    bases_.fill(basis);
+    quadratures_.fill(quadrature);
+  }
+
+  /*!
+   * \brief Construct a computational grid where each dimension can have a
+   * different number of collocation points.
+   *
+   * \param extents The number of collocation points per dimension
+   * \param basis The choice of spectral basis to compute the
+   * collocation points
+   * \param quadrature The choice of quadrature to compute
+   * the collocation points
+   */
+  Mesh(std::array<size_t, Dim> extents, const Spectral::Basis basis,
+       const Spectral::Quadrature quadrature) noexcept
+      : extents_(std::move(extents)) {
+    bases_.fill(basis);
+    quadratures_.fill(quadrature);
+  }
+
+  /*!
+   * \brief Construct a computational grid where each dimension can have both a
+   * different number and placement of collocation points.
+   *
+   * \param extents The number of collocation points per dimension
+   * \param bases The choice of spectral bases to compute the
+   * collocation points per dimension
+   * \param quadratures The choice of quadratures to compute
+   * the collocation points per dimension
+   */
+  Mesh(std::array<size_t, Dim> extents, std::array<Spectral::Basis, Dim> bases,
+       std::array<Spectral::Quadrature, Dim> quadratures) noexcept
+      : extents_(std::move(extents)),
+        bases_(std::move(bases)),
+        quadratures_(std::move(quadratures)) {}
+
+  /*!
+   * \brief The number of grid points in each dimension of the grid.
+   */
+  const Index<Dim>& extents() const noexcept { return extents_; }
+
+  /*!
+   * \brief The number of grid points in dimension `d` of the grid.
+   */
+  size_t extents(const size_t d) const noexcept { return extents_[d]; }
+
+  /*!
+   * \brief The total number of grid points in all dimensions.
+   *
+   * \details `DataVector`s that represent field values on the grid have this
+   * many entries.
+   *
+   * \note A zero-dimensional mesh has one grid point, since it is the slice
+   * through a one-dimensional mesh (a line).
+   */
+  size_t number_of_grid_points() const noexcept { return extents_.product(); }
+
+  /*!
+   * \brief The basis chosen in each dimension of the grid.
+   */
+  const std::array<Spectral::Basis, Dim>& basis() const noexcept {
+    return bases_;
+  }
+
+  /*!
+   * \brief The basis chosen in dimension `d` of the grid.
+   */
+  Spectral::Basis basis(const size_t d) const noexcept {
+    return gsl::at(bases_, d);
+  }
+
+  /*!
+   * \brief The quadrature chosen in each dimension of the grid.
+   */
+  const std::array<Spectral::Quadrature, Dim>& quadrature() const noexcept {
+    return quadratures_;
+  }
+
+  /*!
+   * \brief The quadrature chosen in dimension `d` of the grid.
+   */
+  Spectral::Quadrature quadrature(const size_t d) const noexcept {
+    return gsl::at(quadratures_, d);
+  }
+
+  /*!
+   * \brief Returns a mesh with dimension `d` removed.
+   *
+   * \param d The dimension to remove (zero-indexed).
+   */
+  // clang-tidy: incorrectly reported redundancy in template expression
+  template <size_t N = Dim, Requires<(N > 0 and N == Dim)> = nullptr>  // NOLINT
+  Mesh<Dim - 1> slice_away(size_t d) const noexcept;
+
+  // clang-tidy: runtime-references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  Index<Dim> extents_{};
+  std::array<Spectral::Basis, Dim> bases_{};
+  std::array<Spectral::Quadrature, Dim> quadratures_{};
+};
+
+/// \cond HIDDEN_SYMBOLS
+template <size_t Dim>
+bool operator==(const Mesh<Dim>& lhs, const Mesh<Dim>& rhs) noexcept;
+
+template <size_t Dim>
+bool operator!=(const Mesh<Dim>& lhs, const Mesh<Dim>& rhs) noexcept;
+/// \endcond

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/*!
+ * \file
+ * Declares functionality to retrieve spectral quantities associated with
+ * a particular choice of basis functions and quadrature.
+ */
+
+#pragma once
+
+/*!
+ * \ingroup SpectralGroup
+ * \brief Functionality associated with a particular choice of basis functions
+ * and quadrature for spectral operations
+ */
+namespace Spectral {
+
+/*!
+ * \ingroup SpectralGroup
+ * \brief The choice of basis functions for computing collocation points and
+ * weights.
+ */
+enum class Basis { Legendre };
+
+/*!
+ * \ingroup SpectralGroup
+ * \brief The choice of quadrature method to compute integration weights.
+ */
+enum class Quadrature { Gauss, GaussLobatto };
+
+}  // namespace Spectral

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_Index.cpp
   Test_IndexIterator.cpp
   Test_Matrix.cpp
+  Test_Mesh.cpp
   Test_OrientVariablesOnSlice.cpp
   Test_SliceIterator.cpp
   Test_StripeIterator.cpp

--- a/tests/Unit/DataStructures/Test_Mesh.cpp
+++ b/tests/Unit/DataStructures/Test_Mesh.cpp
@@ -1,0 +1,197 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <numeric>
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+template <size_t Dim>
+void test_extents_basis_and_quadrature(
+    const Mesh<Dim>& mesh, const std::array<size_t, Dim>& extents,
+    const std::array<Spectral::Basis, Dim>& basis,
+    const std::array<Spectral::Quadrature, Dim>& quadrature) {
+  CHECK(mesh.number_of_grid_points() ==
+        std::accumulate(extents.begin(), extents.end(), size_t{1},
+                        std::multiplies<size_t>()));
+  CHECK(mesh.extents() == Index<Dim>{extents});
+  CHECK(mesh.basis() == basis);
+  CHECK(mesh.quadrature() == quadrature);
+  for (size_t d = 0; d < Dim; d++) {
+    CHECK(mesh.extents(d) == gsl::at(extents, d));
+    CHECK(mesh.basis(d) == gsl::at(basis, d));
+    CHECK(mesh.quadrature(d) == gsl::at(quadrature, d));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Mesh", "[DataStructures][Unit]") {
+  SECTION("Uniform LGL mesh") {
+    const Mesh<1> mesh1d_lgl{3, Spectral::Basis::Legendre,
+                             Spectral::Quadrature::GaussLobatto};
+    test_extents_basis_and_quadrature(mesh1d_lgl, {{3}},
+                                      {{Spectral::Basis::Legendre}},
+                                      {{Spectral::Quadrature::GaussLobatto}});
+    const Mesh<2> mesh2d_lgl{3, Spectral::Basis::Legendre,
+                             Spectral::Quadrature::GaussLobatto};
+    test_extents_basis_and_quadrature(
+        mesh2d_lgl, {{3, 3}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::GaussLobatto,
+          Spectral::Quadrature::GaussLobatto}});
+    const Mesh<3> mesh3d_lgl{3, Spectral::Basis::Legendre,
+                             Spectral::Quadrature::GaussLobatto};
+    test_extents_basis_and_quadrature(
+        mesh3d_lgl, {{3, 3, 3}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+          Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::GaussLobatto,
+          Spectral::Quadrature::GaussLobatto,
+          Spectral::Quadrature::GaussLobatto}});
+  }
+
+  SECTION("Explicit choices per dimension") {
+    const Mesh<1> mesh1d{{{2}},
+                         {{Spectral::Basis::Legendre}},
+                         {{Spectral::Quadrature::GaussLobatto}}};
+    test_extents_basis_and_quadrature(mesh1d, {{2}},
+                                      {{Spectral::Basis::Legendre}},
+                                      {{Spectral::Quadrature::GaussLobatto}});
+    const auto mesh1d_sliced = mesh1d.slice_away(0);
+    test_extents_basis_and_quadrature(mesh1d_sliced, {}, {}, {});
+    const Mesh<2> mesh2d{
+        {{2, 3}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}}};
+    test_extents_basis_and_quadrature(
+        mesh2d, {{2, 3}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}});
+    const auto mesh2d_sliced_0 = mesh2d.slice_away(0);
+    test_extents_basis_and_quadrature(mesh2d_sliced_0, {{3}},
+                                      {{Spectral::Basis::Legendre}},
+                                      {{Spectral::Quadrature::GaussLobatto}});
+    const auto mesh2d_sliced_1 = mesh2d.slice_away(1);
+    test_extents_basis_and_quadrature(mesh2d_sliced_1, {{2}},
+                                      {{Spectral::Basis::Legendre}},
+                                      {{Spectral::Quadrature::Gauss}});
+    const Mesh<3> mesh3d{
+        {{2, 3, 4}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+          Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+          Spectral::Quadrature::GaussLobatto}}};
+    test_extents_basis_and_quadrature(
+        mesh3d, {{2, 3, 4}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+          Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+          Spectral::Quadrature::GaussLobatto}});
+    const auto mesh3d_sliced_0 = mesh3d.slice_away(0);
+    test_extents_basis_and_quadrature(
+        mesh3d_sliced_0, {{3, 4}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}});
+    const auto mesh3d_sliced_1 = mesh3d.slice_away(1);
+    test_extents_basis_and_quadrature(
+        mesh3d_sliced_1, {{2, 4}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::GaussLobatto,
+          Spectral::Quadrature::GaussLobatto}});
+    const auto mesh3d_sliced_2 = mesh3d.slice_away(2);
+    test_extents_basis_and_quadrature(
+        mesh3d_sliced_2, {{2, 3}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}});
+  }
+
+  SECTION("Equality") {
+    CHECK(Mesh<1>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} ==
+          Mesh<1>{{{3}},
+                  {{Spectral::Basis::Legendre}},
+                  {{Spectral::Quadrature::GaussLobatto}}});
+    CHECK(Mesh<1>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} !=
+          Mesh<1>{{{2}},
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto});
+    CHECK(Mesh<1>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} !=
+          Mesh<1>{{{3}},
+                  {{Spectral::Basis::Legendre}},
+                  {{Spectral::Quadrature::Gauss}}});
+    CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} ==
+          Mesh<2>{{{3, 3}},
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto});
+    CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} ==
+          Mesh<2>{{{3, 3}},
+                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+                  {{Spectral::Quadrature::GaussLobatto,
+                    Spectral::Quadrature::GaussLobatto}}});
+    CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} !=
+          Mesh<2>{{{3, 2}},
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto});
+    CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} !=
+          Mesh<2>{{{3, 3}},
+                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+                  {{Spectral::Quadrature::Gauss,
+                    Spectral::Quadrature::GaussLobatto}}});
+    CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} ==
+          Mesh<3>{{{3, 3, 3}},
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto});
+    CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} ==
+          Mesh<3>{{{3, 3, 3}},
+                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                    Spectral::Basis::Legendre}},
+                  {{Spectral::Quadrature::GaussLobatto,
+                    Spectral::Quadrature::GaussLobatto,
+                    Spectral::Quadrature::GaussLobatto}}});
+    CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} !=
+          Mesh<3>{{{3, 2, 3}},
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto});
+    CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto} !=
+          Mesh<3>{
+              {{3, 3, 3}},
+              {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                Spectral::Basis::Legendre}},
+              {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+                Spectral::Quadrature::GaussLobatto}}});
+  }
+}
+SPECTRE_TEST_CASE("Unit.Serialization.Mesh",
+                  "[DataStructures][Unit][Serialization]") {
+  test_serialization(Mesh<1>{3, Spectral::Basis::Legendre,
+                             Spectral::Quadrature::GaussLobatto});
+  test_serialization(Mesh<2>{
+      {{3, 2}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}}});
+  test_serialization(
+      Mesh<3>{{{3, 2, 4}},
+              {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                Spectral::Basis::Legendre}},
+              {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+                Spectral::Quadrature::GaussLobatto}}});
+}


### PR DESCRIPTION
## Proposed changes

In preparation for #633, this PR adds the `Mesh` type and tests. These are non-breaking changes. The stripped-down `Spectral.hpp` is only needed for the tests.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
