### PR TITLE
Charm interface simplifications

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -320,7 +320,7 @@ Each %Parallel Component struct must have the following type aliases:
       equivalent. We ensure that all entry method calls done through the
       Algorithm's `simple_action` and `receive_data` functions are
       threadsafe. User controlled threading is possible by calling the non-entry
-      method member function `threaded_simple_action`.
+      method member function `threaded_action`.
 2. `using metavariables` is set to the Metavariables struct that stores the
    global metavariables. It is often easiest to have the %Parallel
    Component struct have a template parameter `Metavariables` that is the

--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -9,6 +9,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"
 #include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
 #include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -81,8 +82,7 @@ void DgElementArray<Metavariables, ActionList>::initialize(
   const Time time = time_reversed ? slab.end() : slab.start();
   const TimeDelta dt = time_reversed ? -slab.duration() : slab.duration();
 
-  dg_element_array
-      .template simple_action<dg::Actions::InitializeElement<volume_dim>>(
-          std::make_tuple(domain_creator->initial_extents(), std::move(domain),
-                          time, dt));
+  Parallel::simple_action<dg::Actions::InitializeElement<volume_dim>>(
+      dg_element_array, domain_creator->initial_extents(), std::move(domain),
+      time, dt);
 }

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -27,6 +27,8 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Time/Tags.hpp"
 #include "Time/TimeId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -329,12 +331,12 @@ struct SendDataForFluxes {
           packaged_data, boundary_extents, dimension, orientation);
 
       for (const auto& neighbor : neighbors_in_direction) {
-        receiver_proxy[neighbor]
-            .template receive_data<
-                typename ComputeBoundaryFlux<Metavariables>::FluxesTag>(
-                time_id, std::make_pair(std::make_pair(direction_from_neighbor,
-                                                       element.id()),
-                                        neighbor_packaged_data));
+        Parallel::receive_data<
+            typename ComputeBoundaryFlux<Metavariables>::FluxesTag>(
+            receiver_proxy[neighbor], time_id,
+            std::make_pair(
+                std::make_pair(direction_from_neighbor, element.id()),
+                neighbor_packaged_data));
 
         mortars_local_data.emplace(std::make_pair(direction, neighbor),
                                    local_data);

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -366,7 +366,7 @@ class AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
       Requires<(sizeof...(Args),
                 cpp17::is_same_v<Parallel::Algorithms::Nodegroup, ChareType>)> =
           nullptr>
-  void threaded_single_action(Args&&... args) noexcept;
+  void threaded_action(Args&&... args) noexcept;
 
   /// \brief Receive data and store it in the Inbox, and try to continue
   /// executing the algorithm
@@ -606,8 +606,8 @@ template <
     Requires<(sizeof...(Args),
               cpp17::is_same_v<Parallel::Algorithms::Nodegroup, ChareType>)>>
 void AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
-                   tmpl::list<ActionsPack...>, ArrayIndex, InitialDataBox>::
-    threaded_single_action(Args&&... args) noexcept {
+                   tmpl::list<ActionsPack...>, ArrayIndex,
+                   InitialDataBox>::threaded_action(Args&&... args) noexcept {
   const gsl::not_null<CmiNodeLock*> node_lock{&node_lock_};
   Algorithm_detail::apply_visitor<Action, InitialDataBox>(
       box_, inboxes_, *const_global_cache_,

--- a/src/Parallel/ConstGlobalCache.hpp
+++ b/src/Parallel/ConstGlobalCache.hpp
@@ -93,13 +93,15 @@ class ConstGlobalCache : public CBase_ConstGlobalCache<Metavariables> {
 
   // clang-tidy: false positive, redundant declaration
   template <typename ParallelComponentTag, typename MV>
-  friend Parallel::proxy_from_parallel_component<ParallelComponentTag>&
-  get_parallel_component(ConstGlobalCache<MV>& cache) noexcept;  // NOLINT
+  friend auto get_parallel_component(  // NOLINT
+      ConstGlobalCache<MV>& cache) noexcept
+      -> Parallel::proxy_from_parallel_component<ParallelComponentTag>&;
 
   // clang-tidy: false positive, redundant declaration
   template <typename ParallelComponentTag, typename MV>
-  friend const Parallel::proxy_from_parallel_component<ParallelComponentTag>&
-  get_parallel_component(const ConstGlobalCache<MV>& cache) noexcept;  // NOLINT
+  friend auto get_parallel_component(  // NOLINT
+      const ConstGlobalCache<MV>& cache) noexcept -> const
+      Parallel::proxy_from_parallel_component<ParallelComponentTag>&;  // NOLINT
 
   tuples::TaggedTupleTypelist<tag_list> const_global_cache_;
   tuples::TaggedTupleTypelist<parallel_component_tag_list> parallel_components_;
@@ -127,16 +129,17 @@ void ConstGlobalCache<Metavariables>::set_parallel_components(
 /// \returns a Charm++ proxy that can be used to call an entry method on the
 /// chare(s)
 template <typename ParallelComponentTag, typename Metavariables>
-Parallel::proxy_from_parallel_component<ParallelComponentTag>&
-get_parallel_component(ConstGlobalCache<Metavariables>& cache) noexcept {
+auto get_parallel_component(ConstGlobalCache<Metavariables>& cache) noexcept
+    -> Parallel::proxy_from_parallel_component<ParallelComponentTag>& {
   return tuples::get<tmpl::type_<
       Parallel::proxy_from_parallel_component<ParallelComponentTag>>>(
       cache.parallel_components_);
 }
 
 template <typename ParallelComponentTag, typename Metavariables>
-const Parallel::proxy_from_parallel_component<ParallelComponentTag>&
-get_parallel_component(const ConstGlobalCache<Metavariables>& cache) noexcept {
+auto get_parallel_component(
+    const ConstGlobalCache<Metavariables>& cache) noexcept
+    -> const Parallel::proxy_from_parallel_component<ParallelComponentTag>& {
   return tuples::get<tmpl::type_<
       Parallel::proxy_from_parallel_component<ParallelComponentTag>>>(
       cache.parallel_components_);

--- a/src/Parallel/Invoke.hpp
+++ b/src/Parallel/Invoke.hpp
@@ -48,7 +48,8 @@ void simple_action(Proxy&& proxy) noexcept {
 template <typename Action, typename Proxy, typename Arg0, typename... Args>
 void simple_action(Proxy&& proxy, Arg0&& arg0, Args&&... args) noexcept {
   proxy.template simple_action<Action>(
-      std::make_tuple(std::forward<Arg0>(arg0), std::forward<Args>(args)...));
+      std::tuple<std::decay_t<Arg0>, std::decay_t<Args>...>(
+          std::forward<Arg0>(arg0), std::forward<Args>(args)...));
 }
 // @}
 

--- a/src/Parallel/Invoke.hpp
+++ b/src/Parallel/Invoke.hpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <utility>
+
+namespace Parallel {
+// @{
+/*!
+ * \ingroup ParallelGroup
+ * \brief Send the data `args...` to the algorithm running on `proxy`, and tag
+ * the message with the identifier `temporal_id`.
+ *
+ * If the algorithm was previously disabled, set `enable_if_disabled` to true to
+ * enable the algorithm on the parallel component.
+ *
+ * \note The reason there are two separate functions is because Charm++ does not
+ * allow defaulted arguments for group and nodegroup chares.
+ */
+template <typename ReceiveTag, typename Proxy, typename ReceiveDataType>
+void receive_data(Proxy&& proxy, typename ReceiveTag::temporal_id temporal_id,
+                  ReceiveDataType&& receive_data,
+                  const bool enable_if_disabled) noexcept {
+  proxy.template receive_data<ReceiveTag>(
+      std::move(temporal_id), std::forward<ReceiveDataType>(receive_data),
+      enable_if_disabled);
+}
+
+template <typename ReceiveTag, typename Proxy, typename ReceiveDataType>
+void receive_data(Proxy&& proxy, typename ReceiveTag::temporal_id temporal_id,
+                  ReceiveDataType&& receive_data) noexcept {
+  proxy.template receive_data<ReceiveTag>(
+      std::move(temporal_id), std::forward<ReceiveDataType>(receive_data));
+}
+// @}
+
+// @{
+/*!
+ * \ingroup ParallelGroup
+ * \brief Invoke a simple action on `proxy`
+ */
+template <typename Action, typename Proxy>
+void simple_action(Proxy&& proxy) noexcept {
+  proxy.template simple_action<Action>();
+}
+
+template <typename Action, typename Proxy, typename Arg0, typename... Args>
+void simple_action(Proxy&& proxy, Arg0&& arg0, Args&&... args) noexcept {
+  proxy.template simple_action<Action>(
+      std::make_tuple(std::forward<Arg0>(arg0), std::forward<Args>(args)...));
+}
+// @}
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Invoke a threaded action on `proxy`, where the proxy must be a
+ * nodegroup.
+ */
+template <typename Action, typename Proxy, typename... Args>
+void threaded_action(Proxy&& proxy, Args&&... args) noexcept {
+  proxy.template threaded_action<Action>(std::forward<Args>(args)...);
+}
+}  // namespace Parallel

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -34,8 +34,11 @@ class MockArrayElementProxy {
       : local_algorithm_(local_algorithm), inbox_(inbox) {}
 
   template <typename InboxTag, typename Data>
-  void receive_data(const typename InboxTag::temporal_id& id,
-                    const Data& data) {
+  void receive_data(const typename InboxTag::temporal_id& id, const Data& data,
+                    const bool enable_if_disabled = false) {
+    // Might be useful in the future, not needed now but required by the
+    // interface to be compliant with the Algorithm invocations.
+    (void)enable_if_disabled;
     tuples::get<InboxTag>(inbox_)[id].emplace(data);
   }
 

--- a/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
@@ -9,6 +9,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -44,8 +45,8 @@ struct Component {
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
     auto& local_cache = *(global_cache.ckLocalBranch());
-    Parallel::get_parallel_component<Component>(local_cache)
-        .template simple_action<error_size_zero>();
+    Parallel::simple_action<error_size_zero>(
+        Parallel::get_parallel_component<Component>(local_cache));
   }
 
   static void execute_next_global_actions(

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -22,6 +22,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -187,8 +188,8 @@ struct NoOpsComponent {
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
     auto& local_cache = *(global_cache.ckLocalBranch());
-    Parallel::get_parallel_component<NoOpsComponent>(local_cache)
-        .template simple_action<no_op_test::initialize>();
+    Parallel::simple_action<no_op_test::initialize>(
+        Parallel::get_parallel_component<NoOpsComponent>(local_cache));
   }
 
   static void execute_next_global_actions(
@@ -201,8 +202,8 @@ struct NoOpsComponent {
           .perform_algorithm();
       /// [perform_algorithm]
     } else if (next_phase == Metavariables::Phase::NoOpsFinish) {
-      Parallel::get_parallel_component<NoOpsComponent>(local_cache)
-          .template simple_action<no_op_test::finalize>();
+      Parallel::simple_action<no_op_test::finalize>(
+          Parallel::get_parallel_component<NoOpsComponent>(local_cache));
     }
   }
 };
@@ -335,8 +336,8 @@ struct MutateComponent {
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
     auto& cache = *(global_cache.ckLocalBranch());
     /// [simple_action_call]
-    Parallel::get_parallel_component<MutateComponent>(cache)
-        .template simple_action<add_remove_test::initialize>();
+    Parallel::simple_action<add_remove_test::initialize>(
+        Parallel::get_parallel_component<MutateComponent>(cache));
     /// [simple_action_call]
   }
 
@@ -348,11 +349,11 @@ struct MutateComponent {
       Parallel::get_parallel_component<MutateComponent>(local_cache)
           .perform_algorithm();
     } else if (next_phase == Metavariables::Phase::MutateFinish) {
-      Parallel::get_parallel_component<MutateComponent>(local_cache)
-          .template simple_action<add_remove_test::test_args>(
-              std::make_tuple(4.82937, std::vector<double>{3.2, -8.4, 7.5}));
-      Parallel::get_parallel_component<MutateComponent>(local_cache)
-          .template simple_action<add_remove_test::finalize>();
+      Parallel::simple_action<add_remove_test::test_args>(
+          Parallel::get_parallel_component<MutateComponent>(local_cache),
+          4.82937, std::vector<double>{3.2, -8.4, 7.5});
+      Parallel::simple_action<add_remove_test::finalize>(
+          Parallel::get_parallel_component<MutateComponent>(local_cache));
     }
   }
 };
@@ -482,8 +483,8 @@ struct ReceiveComponent {
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
     auto& local_cache = *(global_cache.ckLocalBranch());
-    Parallel::get_parallel_component<ReceiveComponent>(local_cache)
-        .template simple_action<receive_data_test::initialize>();
+    Parallel::simple_action<receive_data_test::initialize>(
+        Parallel::get_parallel_component<ReceiveComponent>(local_cache));
   }
 
   static void execute_next_global_actions(
@@ -497,13 +498,13 @@ struct ReceiveComponent {
       for (TestAlgorithmArrayInstance instance{0};
            not(instance == TestAlgorithmArrayInstance{5}); ++instance) {
         int dummy_int = 10;
-        Parallel::get_parallel_component<ReceiveComponent>(local_cache)
-            .template receive_data<receive_data_test::IntReceiveTag>(instance,
-                                                                     dummy_int);
+        Parallel::receive_data<receive_data_test::IntReceiveTag>(
+            Parallel::get_parallel_component<ReceiveComponent>(local_cache),
+            instance, dummy_int);
       }
     } else if (next_phase == Metavariables::Phase::ReceiveFinish) {
-      Parallel::get_parallel_component<ReceiveComponent>(local_cache)
-          .template simple_action<receive_data_test::finalize>();
+      Parallel::simple_action<receive_data_test::finalize>(
+          Parallel::get_parallel_component<ReceiveComponent>(local_cache));
     }
   }
 };
@@ -594,8 +595,8 @@ struct AnyOrderComponent {
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
     auto& local_cache = *(global_cache.ckLocalBranch());
-    Parallel::get_parallel_component<AnyOrderComponent>(local_cache)
-        .template simple_action<add_remove_test::initialize>();
+    Parallel::simple_action<add_remove_test::initialize>(
+        Parallel::get_parallel_component<AnyOrderComponent>(local_cache));
   }
 
   static void execute_next_global_actions(
@@ -606,8 +607,8 @@ struct AnyOrderComponent {
       Parallel::get_parallel_component<AnyOrderComponent>(local_cache)
           .perform_algorithm();
     } else if (next_phase == Metavariables::Phase::AnyOrderFinish) {
-      Parallel::get_parallel_component<AnyOrderComponent>(local_cache)
-          .template simple_action<any_order::finalize>();
+      Parallel::simple_action<any_order::finalize>(
+          Parallel::get_parallel_component<AnyOrderComponent>(local_cache));
     }
   }
 };

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -9,6 +9,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -31,8 +32,8 @@ struct error_call_single_action_from_action {
     /// [bad_recursive_call]
     auto& local_parallel_component =
         *Parallel::get_parallel_component<ParallelComponent>(cache).ckLocal();
-    local_parallel_component
-        .template simple_action<error_call_single_action_from_action>();
+    Parallel::simple_action<error_call_single_action_from_action>(
+        local_parallel_component);
     /// [bad_recursive_call]
   }
 };
@@ -49,9 +50,8 @@ struct Component {
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
     auto& local_cache = *(global_cache.ckLocalBranch());
-    Parallel::get_parallel_component<Component>(local_cache)
-        .ckLocal()
-        ->template simple_action<error_call_single_action_from_action>();
+    Parallel::simple_action<error_call_single_action_from_action>(
+        *(Parallel::get_parallel_component<Component>(local_cache).ckLocal()));
   }
 
   static void execute_next_global_actions(

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
@@ -9,6 +9,7 @@
 #include "Options/Options.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -40,9 +41,8 @@ struct error_call_single_action_from_action {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) {
-    Parallel::get_parallel_component<ParallelComponent>(cache)
-        .ckLocal()
-        ->template simple_action<another_action>();
+    Parallel::simple_action<another_action>(*(
+        Parallel::get_parallel_component<ParallelComponent>(cache).ckLocal()));
   }
 };
 
@@ -58,9 +58,8 @@ struct Component {
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
     auto& local_cache = *(global_cache.ckLocalBranch());
-    Parallel::get_parallel_component<Component>(local_cache)
-        .ckLocal()
-        ->template simple_action<error_call_single_action_from_action>();
+    Parallel::simple_action<error_call_single_action_from_action>(
+        *(Parallel::get_parallel_component<Component>(local_cache).ckLocal()));
   }
 
   static void execute_next_global_actions(

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -231,7 +231,7 @@ struct reduce_threaded_method {
         *(Parallel::get_parallel_component<
               NodegroupParallelComponent<Metavariables>>(cache)
               .ckLocalBranch());
-    local_nodegroup.template threaded_single_action<nodegroup_threaded_receive>(
+    local_nodegroup.template threaded_action<nodegroup_threaded_receive>(
         array_index);
     return std::forward_as_tuple(std::move(box));
   }

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -201,29 +201,29 @@ struct ArrayReduce {
                                    ArrayParallelComponent<TestMetavariables>>,
                   "The ParallelComponent is not deduced to be the right type");
     int my_send_int = array_index;
+    const auto& my_proxy =
+        Parallel::get_parallel_component<ArrayParallelComponent<Metavariables>>(
+            cache)[array_index];
+    const auto& array_proxy =
+        Parallel::get_parallel_component<ArrayParallelComponent<Metavariables>>(
+            cache);
+    const auto& singleton_proxy = Parallel::get_parallel_component<
+        SingletonParallelComponent<Metavariables>>(cache);
     /// [contribute_to_reduction_example]
-    Parallel::contribute_to_reduction<ArrayParallelComponent<Metavariables>,
-                                      SingletonParallelComponent<Metavariables>,
-                                      ProcessReducedSumOfInts>(
-        cache, array_index, CkReduction::sum_int, my_send_int);
+    Parallel::contribute_to_reduction<ProcessReducedSumOfInts>(
+        my_send_int, my_proxy, singleton_proxy, CkReduction::sum_int);
     /// [contribute_to_reduction_example]
     /// [contribute_to_broadcast_reduction]
-    Parallel::contribute_to_reduction<ArrayParallelComponent<Metavariables>,
-                                      ArrayParallelComponent<Metavariables>,
-                                      ProcessReducedSumOfInts>(
-        cache, array_index, CkReduction::sum_int, my_send_int);
+    Parallel::contribute_to_reduction<ProcessReducedSumOfInts>(
+        my_send_int, my_proxy, array_proxy, CkReduction::sum_int);
     /// [contribute_to_broadcast_reduction]
 
     double my_send_double = 13.4;
-    Parallel::contribute_to_reduction<ArrayParallelComponent<Metavariables>,
-                                      SingletonParallelComponent<Metavariables>,
-                                      ProcessReducedSumOfDoubles>(
-        cache, array_index, CkReduction::sum_double, my_send_double);
+    Parallel::contribute_to_reduction<ProcessReducedSumOfDoubles>(
+        my_send_double, my_proxy, singleton_proxy, CkReduction::sum_double);
 
-    Parallel::contribute_to_reduction<ArrayParallelComponent<Metavariables>,
-                                      SingletonParallelComponent<Metavariables>,
-                                      ProcessReducedProductOfDoubles>(
-        cache, array_index, CkReduction::product_double, my_send_double);
+    Parallel::contribute_to_reduction<ProcessReducedProductOfDoubles>(
+        my_send_double, my_proxy, singleton_proxy, CkReduction::product_double);
 
     /// [custom_contribute_to_reduction_example]
     std::unordered_map<std::string, int> my_send_map;
@@ -231,22 +231,19 @@ struct ArrayReduce {
     my_send_map["double"] = 2 * array_index;
     my_send_map["negative"] = -array_index;
     Parallel::contribute_to_reduction<&reduce_reduction_data,
-                                      ArrayParallelComponent<Metavariables>,
-                                      SingletonParallelComponent<Metavariables>,
                                       ProcessCustomReductionAction>(
-        cache, array_index,
         Parallel::ReductionData<int, std::unordered_map<std::string, int>,
                                 std::vector<int>>{
-            10, my_send_map, std::vector<int>{array_index, 10, -8}});
+            10, my_send_map, std::vector<int>{array_index, 10, -8}},
+        my_proxy, singleton_proxy);
     /// [custom_contribute_to_reduction_example]
     /// [custom_contribute_to_broadcast_reduction]
-    Parallel::contribute_to_reduction<
-        &reduce_reduction_data, ArrayParallelComponent<Metavariables>,
-        ArrayParallelComponent<Metavariables>, ProcessCustomReductionAction>(
-        cache, array_index,
+    Parallel::contribute_to_reduction<&reduce_reduction_data,
+                                      ProcessCustomReductionAction>(
         Parallel::ReductionData<int, std::unordered_map<std::string, int>,
                                 std::vector<int>>{
-            10, my_send_map, std::vector<int>{array_index, 10, -8}});
+            10, my_send_map, std::vector<int>{array_index, 10, -8}},
+        my_proxy, array_proxy);
     /// [custom_contribute_to_broadcast_reduction]
 
     return std::forward_as_tuple(std::move(box));

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -20,6 +20,7 @@
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -282,8 +283,9 @@ struct ArrayParallelComponent {
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
     auto& local_cache = *(global_cache.ckLocalBranch());
     if (next_phase == Metavariables::Phase::CallArrayReduce) {
-      Parallel::get_parallel_component<ArrayParallelComponent>(local_cache)
-          .template simple_action<ArrayReduce>();
+      Parallel::simple_action<ArrayReduce>(
+          Parallel::get_parallel_component<ArrayParallelComponent>(
+              local_cache));
     }
   }
 };

--- a/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
@@ -16,8 +16,6 @@ void register_pupables();
 #include <memory>
 #include <string>
 
-#include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits.hpp"
 #include "AlgorithmArray.hpp"
 #include "AlgorithmGroup.hpp"
 #include "AlgorithmNodegroup.hpp"
@@ -30,7 +28,9 @@ void register_pupables();
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Exit.hpp"
 #include "Parallel/Printf.hpp"
+#include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 namespace Parallel {
 namespace charmxx {


### PR DESCRIPTION
## Proposed changes

- Use free functions `simple_action`, `receive_data`, and `threaded_action` to more closely align with the proposed interface changes to Charm++.
- Modify the `contribute_to_reduction` calls to exactly what is being proposed for inclusion in Charm++.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
