### PR TITLE
Fix compilation failure in Benchmark.cpp

### DIFF
--- a/containers/Dockerfile.travis
+++ b/containers/Dockerfile.travis
@@ -125,11 +125,9 @@ RUN if [ -z "${RUN_CPPCHECK}" ] \
                spack load catch; \
                spack load libxsmm; \
                spack load yaml-cpp; \
-               make test-executables -j2; \
-               if [ $BUILD_TYPE = Release ]; then \
-                   make Benchmark -j2; \
-               fi; \
-               ccache -s; \
+               make test-executables \
+                    $([ $BUILD_TYPE = Release ] && echo Benchmark) -j2 && \
+               ccache -s && \
                ctest --output-on-failure"; \
     fi
 

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -89,7 +89,7 @@ void bench_all_gradient(benchmark::State& state) {  // NOLINT
       Map3d{map1d, map1d, map1d});
 
   using VarTags = tmpl::list<Kappa<Dim>, Psi<Dim>>;
-  const InverseJacobian<Dim, Frame::Logical, Frame::Grid> inv_jac =
+  const InverseJacobian<DataVector, Dim, Frame::Logical, Frame::Grid> inv_jac =
       map.inv_jacobian(logical_coordinates(extents));
   const auto grid_coords = map(logical_coordinates(extents));
   Variables<VarTags> vars(extents.product(), 0.0);


### PR DESCRIPTION
It would be good if this were checked by Travis, but I don't know how to do that.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
