### PR TITLE
Precompute Time::value()

### DIFF
--- a/src/Time/Time.cpp
+++ b/src/Time/Time.cpp
@@ -12,6 +12,7 @@
 void Time::pup(PUP::er& p) noexcept {
   p | slab_;
   p | fraction_;
+  p | value_;
 }
 
 Time Time::with_slab(const Slab& new_slab) const noexcept {
@@ -40,12 +41,12 @@ Time Time::with_slab(const Slab& new_slab) const noexcept {
   }
 }
 
-double Time::value() const noexcept {
+void Time::compute_value() noexcept {
   if (is_at_slab_end()) {
     // Protection against rounding error.
-    return slab_.end_;
+    value_ = slab_.end_;
   } else {
-    return slab_.start_ + (slab_.duration() * fraction_).value();
+    value_ = slab_.start_ + (slab_.duration() * fraction_).value();
   }
 }
 

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -317,25 +317,18 @@ AdamsBashforthN::compute_boundary_delta(
 
   const SimulationLess simulation_less(time_step.is_positive());
 
-  // Time::value is fairly slow, so cache values.
-  auto time_value =
-      make_cached_function<Time, std::map, Time::StructuralCompare>(
-          [](const Time& t) noexcept { return t.value(); });
-
   // Evaluate the cardinal function for a grid of points at a point on
   // the diagonal.
   const auto grid_cardinal_function =
-      [target_order_s, &time_value, &history](
-          const double evaluation_time,
-          const auto& local_index,
-          const auto& remote_index,
-          const auto& remote_times_start) noexcept {
+      [target_order_s, &history](const double evaluation_time,
+                                 const auto& local_index,
+                                 const auto& remote_index,
+                                 const auto& remote_times_start) noexcept {
     // Makes an iterator with a map to give time as a double.
-    const auto make_lagrange_iterator =
-        [&time_value](const auto& it) noexcept {
+    const auto make_lagrange_iterator = [](const auto& it) noexcept {
       return boost::make_transform_iterator(
-          it, [&time_value](const Time& t) noexcept {
-            return time_value(t);
+          it, [](const Time& t) noexcept {
+            return t.value();
           });
     };
 
@@ -465,7 +458,7 @@ AdamsBashforthN::compute_boundary_delta(
         double integrated_cardinal_function = 0.;
         for (; method_it != method_coefs.end(); ++method_it, ++recent_time) {
           integrated_cardinal_function +=
-              *method_it * grid_cardinal_function(time_value(*recent_time),
+              *method_it * grid_cardinal_function(recent_time->value(),
                                                   local_evaluation_step,
                                                   remote_evaluation_step,
                                                   remote_interpolation_start);

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -464,7 +464,7 @@ AdamsBashforthN::compute_boundary_delta(
                                                   remote_interpolation_start);
         }
         integrated_cardinal_function *=
-            (*union_time - *std::prev(union_time)).value();
+            union_time->value() - std::prev(union_time)->value();
 
         deriv_coef += integrated_cardinal_function;
       }  // for union_time


### PR DESCRIPTION
## Proposed changes

Computing the double value of a Time was somewhat slow due to the need to do rational arithmetic.  Since it is often needed several times for the same Time, we now precompute it.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
