### PR TITLE
Optimize slice iterator

### DIFF
--- a/src/DataStructures/SliceIterator.cpp
+++ b/src/DataStructures/SliceIterator.cpp
@@ -15,6 +15,7 @@ SliceIterator::SliceIterator(const Index<Dim>& extents, const size_t fixed_dim,
     : size_(extents.product()),
       stride_(std::accumulate(extents.begin(), extents.begin() + fixed_dim,
                               1_st, std::multiplies<size_t>())),
+      stride_count_(0),
       jump_((extents[fixed_dim] - 1) * stride_),
       initial_offset_(fixed_index * stride_),
       volume_offset_(initial_offset_),
@@ -23,8 +24,10 @@ SliceIterator::SliceIterator(const Index<Dim>& extents, const size_t fixed_dim,
 SliceIterator& SliceIterator::operator++() {
   ++volume_offset_;
   ++slice_offset_;
-  if (0 == (volume_offset_ % stride_)) {
+  ++stride_count_;
+  if (stride_count_ == stride_) {
     volume_offset_ += jump_;
+    stride_count_ = 0;
   }
   return *this;
 }

--- a/src/DataStructures/SliceIterator.hpp
+++ b/src/DataStructures/SliceIterator.hpp
@@ -47,6 +47,7 @@ class SliceIterator {
  private:
   size_t size_ = std::numeric_limits<size_t>::max();
   size_t stride_ = std::numeric_limits<size_t>::max();
+  size_t stride_count_ = std::numeric_limits<size_t>::max();
   size_t jump_ = std::numeric_limits<size_t>::max();
   size_t initial_offset_ = std::numeric_limits<size_t>::max();
   size_t volume_offset_ = std::numeric_limits<size_t>::max();

--- a/src/DataStructures/StripeIterator.cpp
+++ b/src/DataStructures/StripeIterator.cpp
@@ -17,12 +17,15 @@ StripeIterator::StripeIterator(const Index<Dim>& extents,
       size_(extents.product()),
       stride_(std::accumulate(extents.begin(), extents.begin() + stripe_dim,
                               1_st, std::multiplies<size_t>())),
+      stride_count_(0),
       jump_((extents[stripe_dim] - 1) * stride_) {}
 
 StripeIterator& StripeIterator::operator++() {
   ++offset_;
-  if (UNLIKELY(0 == (offset_ % stride_))) {
+  ++stride_count_;
+  if (UNLIKELY(stride_count_ == stride_)) {
     offset_ += jump_;
+    stride_count_ = 0;
   }
   return *this;
 }

--- a/src/DataStructures/StripeIterator.hpp
+++ b/src/DataStructures/StripeIterator.hpp
@@ -37,5 +37,6 @@ class StripeIterator {
   size_t offset_ = std::numeric_limits<size_t>::max();
   size_t size_ = std::numeric_limits<size_t>::max();
   size_t stride_ = std::numeric_limits<size_t>::max();
+  size_t stride_count_ = std::numeric_limits<size_t>::max();
   size_t jump_ = std::numeric_limits<size_t>::max();
 };


### PR DESCRIPTION
## Proposed changes

- Avoid using the modulus operator in SliceIterator and StripeIterator because modulus is really slow.

### Types of changes:

- [x] Performance Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
