### PR TITLE
Wrap BLAS matrix algebra

### DIFF
--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -15,6 +15,8 @@
 #include <type_traits>
 #include <vector>
 
+// TODO: Should we do this, or what would be an alternative?
+#include "DataStructures/Matrix.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ForceInline.hpp"
@@ -533,6 +535,18 @@ class DataVector {
   SPECTRE_ALWAYS_INLINE friend decltype(auto) step_function(
       const DataVector& t) noexcept {
     return step_function(t.data_);
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) apply_matrix(
+      const Matrix& A, const DataVector& x) {
+    // FIXME: Without the `evaluate` the result of this function can't be
+    // assigned to a `DataVector` variable.
+    return evaluate(A * x.data_);
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) apply_matrix(const DataVector& x,
+                                                           const Matrix& A) {
+    return trans(trans(x.data_) * A);
   }
 
  private:

--- a/src/DataStructures/Matrix.cpp
+++ b/src/DataStructures/Matrix.cpp
@@ -1,41 +1,10 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Matrix.hpp"
+#include "DataStructures/Matrix.hpp"
 
-#include <algorithm>
-#include <ostream>
-#include <pup.h>
-#include <pup_stl.h>
+#include <pup.h>  // IWYU pragma: keep
 
-Matrix::Matrix(const size_t number_of_rows, const size_t number_of_colums,
-               const double value)
-    : number_of_rows_(number_of_rows),
-      number_of_columns_(number_of_colums),
-      data_(number_of_rows_ * number_of_columns_, value) {}
+#include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
 
-void Matrix::pup(PUP::er& p) {  // NOLINT
-  p | number_of_rows_;
-  p | number_of_columns_;
-  p | data_;
-}
-
-std::ostream& operator<<(std::ostream& os, const Matrix& m) {
-  for (size_t i = 0; i < m.rows(); ++i) {
-    os << "{ ";
-    for (size_t j = 0; j < m.columns(); ++j) {
-      os << m(i, j) << " ";
-    }
-    os << "}\n";
-  }
-  return os;
-}
-
-bool operator==(const Matrix& lhs, const Matrix& rhs) {
-  return lhs.columns() == rhs.columns() and lhs.rows() == rhs.rows() and
-         std::equal(lhs.begin(), lhs.end(), rhs.begin());
-}
-
-bool operator!=(const Matrix& lhs, const Matrix& rhs) {
-  return not(lhs == rhs);
-}
+void operator|(PUP::er& p, Matrix& matrix) { p | *matrix.data(); }

--- a/src/DataStructures/Matrix.hpp
+++ b/src/DataStructures/Matrix.hpp
@@ -6,63 +6,19 @@
 
 #pragma once
 
-#include <cstddef>
-#include <iosfwd>
-#include <limits>
-#include <vector>
+#include <blaze/math/DynamicMatrix.h>
+
+#include "Utilities/Blaze.hpp"
 
 namespace PUP {
 class er;
 }  // namespace PUP
 
-/*!
- * \ingroup DataStructuresGroup
- * \brief A dynamically sized matrix.
- *
- * \note The data layout is column-major (0-based)
- */
-class Matrix {
- public:
-  /// Create and set each element to value
-  Matrix(size_t number_of_rows, size_t number_of_colums,
-         double value = std::numeric_limits<double>::signaling_NaN());
+// We are choosing row-major storage for the following reasons:
+// - `Matrix` is nothrow move assignable and constructible.
+// - It is the Blaze default.
+// - The constructor takes arrays as rows x columns.
+using Matrix = blaze::DynamicMatrix<double, blaze::rowMajor>;
 
-  /// Default constructor needed for serialization
-  Matrix() = default;
-
-  double& operator()(size_t i, size_t j) noexcept {
-    return data_[i + j * number_of_rows_];
-  }
-  const double& operator()(size_t i, size_t j) const noexcept {
-    return data_[i + j * number_of_rows_];
-  }
-
-  double* data() noexcept { return data_.data(); }
-  const double* data() const noexcept { return data_.data(); }
-
-  decltype(auto) begin() { return data_.begin(); }
-  decltype(auto) begin() const { return data_.begin(); }
-
-  decltype(auto) end() { return data_.end(); }
-  decltype(auto) end() const { return data_.end(); }
-
-  size_t rows() const noexcept { return number_of_rows_; }
-  size_t columns() const noexcept { return number_of_columns_; }
-
-  /// Charm++ serialization
-  void pup(PUP::er& p);  // NOLINT
-
- private:
-  size_t number_of_rows_{0};
-  size_t number_of_columns_{0};
-  std::vector<double> data_;
-};
-
-/// Stream operator for Matrix
-std::ostream& operator<<(std::ostream& os, const Matrix& m);
-
-/// Equivalence operator for Matrix
-bool operator==(const Matrix& lhs, const Matrix& rhs);
-
-/// Inequivalence operator for Matrix
-bool operator!=(const Matrix& lhs, const Matrix& rhs);
+/// Charm++ serialization
+void operator|(PUP::er& p, Matrix& matrix);

--- a/src/IO/H5/Dat.hpp
+++ b/src/IO/H5/Dat.hpp
@@ -13,12 +13,9 @@
 #include <string>
 #include <vector>
 
+#include "DataStructures/Matrix.hpp"
 #include "IO/H5/Object.hpp"
 #include "IO/H5/OpenGroup.hpp"
-
-/// \cond
-class Matrix;
-/// \endcond
 
 namespace h5 {
 /*!

--- a/src/NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp
+++ b/src/NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp
@@ -8,8 +8,9 @@
 
 #include <cstddef>
 
+#include "DataStructures/Matrix.hpp"
+
 class DataVector;
-class Matrix;
 
 /// \ingroup SpectralGroup
 /// Basis functions, derivative matrices, etc. for spectral-type methods

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -488,6 +488,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   const DataVector expected_d3(2, 13.);
   const auto magnitude_d3 = magnitude(d3);
   CHECK_ITERABLE_APPROX(expected_d3, magnitude_d3);
+
+  // Test Matrix-Vector multiplication
+  const Matrix A{{2., 1.}, {-3., 4.}};
+  const DataVector a{0.5, 1.};
+  CHECK_ITERABLE_APPROX(apply_matrix(A, a), DataVector({2., 2.5}));
+  CHECK_ITERABLE_APPROX(apply_matrix(a, A), DataVector({-2., 4.5}));
 }
 
 // [[OutputRegex, Must copy into same size]]

--- a/tests/Unit/DataStructures/Test_Matrix.cpp
+++ b/tests/Unit/DataStructures/Test_Matrix.cpp
@@ -15,21 +15,27 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Matrix", "[DataStructures][Unit]") {
   Matrix matrix(3, 5, 1.0);
   CHECK(matrix.rows() == 3);
   CHECK(matrix.columns() == 5);
-  const double* a_ptr = matrix.data();
-  std::stringstream ss;
+  // const double* a_ptr = matrix.data();
+  // std::stringstream ss;
   for (size_t i = 0; i < matrix.rows(); ++i) {
-    ss << "{ ";
+    // ss << "{ ";
     for (size_t j = 0; j < matrix.columns(); ++j) {
       CHECK(1.0 == matrix(i, j));
+      // TODO: Do we really need this test? It checks the data layout, which
+      // should be irrelevant as long as all functionality works correctly.
       // clang-tidy: do not use pointer arithmetic
-      CHECK(&a_ptr[i + j * matrix.rows()] == &matrix(i, j));  // NOLINT
-      ss << matrix(i, j) << " ";
+      // CHECK(&a_ptr[i * matrix.columns() + j] == &matrix(i, j));  // NOLINT
+      // ss << matrix(i, j) << " ";
     }
-    ss << "}\n";
+    // ss << "}\n";
   }
-  std::stringstream os;
-  os << matrix;
-  CHECK(ss.str() == os.str());
+  // TODO: Do we really need this test, too? Blaze provides a nicely
+  // formatted `<<` that's not straight-forward to reproduce here due to
+  // number padding. If this exact formatting is required somewhere it
+  // should be their responsibility to enforce it and test it.
+  // std::stringstream os;
+  // os << matrix;
+  // CHECK(ss.str() == os.str());
 
   test_copy_semantics(matrix);
   auto matrix_copy = matrix;


### PR DESCRIPTION
## Proposed changes

This PR serves as a basis to discuss how we want to wrap commonly used BLAS functions, as raised in the issue #216. It is by no means a finished implementation. Please let me know your thoughts.

- BLAS functions require knowledge of the memory layout, but in our code this is abstracted away into `DataVector` and `Matrix`. This knowledge should be private to these classes.
- As an example, let's take `DefiniteIntegral.cpp`: The arguments passed to `dgemm_` and `ddot_` include redundant information, such as the length of `DataVector`s that is available in the class, as well as knowledge of the memory layout that `DefiniteIntegral.cpp` shouldn't implicitly assume, such as the `LDA`, `LDB` and `LDC` arguments.
- I implemented a tentative suggestion in this PR. Here, the comma operator takes the place of a dot product, as it does in the [Blaze](https://bitbucket.org/blaze-lib/blaze) library. I wrapped `dgemm_`, `dgemv_` and `ddot_`.
- Note that often we use the BLAS functions for tensor product operations, e.g. to apply a derivative matrix in a particular dimension. For this, we need functionality to reshape the data layout like it is currently done in `Transpose.hpp`. However, this should be private to `DataVector` and `Matrix`. To show this, I implemented a `Matrix` constructor that reshapes a `DataVector` into a `Matrix` with the help of some `extents`, so that the columns represent the last dimension of the grid. This functionality should probably be implemented some place else, though.
- I refactored `DefiniteIntegral.cpp` to reflect the usage of the implementation. It is much cleaner and doesn't require knowledge that is private to the data structures, but not ideal yet (see `DefiniteIntegral.cpp` and comments therein).

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->