### PR TITLE
Clean up unused variables in tests

### DIFF
--- a/tests/Unit/ControlSystem/Test_PiecewisePolynomial.cpp
+++ b/tests/Unit/ControlSystem/Test_PiecewisePolynomial.cpp
@@ -17,7 +17,6 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial",
   const double dt = 0.6;
   const double final_time = 4.0;
   const constexpr size_t deriv_order = 3;
-  const constexpr size_t ret_deriv_order = 1;
 
   // test two component system (x**3 and x**2)
   const std::array<DataVector, deriv_order + 1> init_func{
@@ -92,7 +91,6 @@ SPECTRE_TEST_CASE(
     "Unit.ControlSystem.FunctionsOfTime.PiecewisePolynomial.WithinRoundoff",
     "[ControlSystem][Unit]") {
   const constexpr size_t deriv_order = 3;
-  const size_t n_derivs = 3;
   const std::array<DataVector, deriv_order + 1> init_func{
       {{1.0, 1.0}, {3.0, 2.0}, {6.0, 2.0}, {6.0, 0.0}}};
   FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func);
@@ -151,7 +149,6 @@ SPECTRE_TEST_CASE(
   ERROR_TEST();
   // two component system (x**3 and x**2)
   const constexpr size_t deriv_order = 3;
-  const size_t n_derivs = 3;
   const std::array<DataVector, deriv_order + 1> init_func{
       {{1.0, 1.0}, {3.0, 2.0}, {6.0, 2.0}, {6.0, 0.0}}};
   FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(1.0, init_func);

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -371,8 +371,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_locked_get",
       3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
   db::mutate<test_databox_tags::Tag0, test_databox_tags::Tag1>(
       original_box, [&original_box](double& tag0, std::vector<double>& tag1) {
-        const auto& compute_tag0 =
-            db::get<test_databox_tags::ComputeTag0>(original_box);
+        db::get<test_databox_tags::ComputeTag0>(original_box);
         tag0 = 10.32;
         tag1[0] = 837.2;
       });
@@ -394,8 +393,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_locked_get_lazy",
   db::mutate<test_databox_tags::Tag0, test_databox_tags::Tag1>(
       original_box,
       [&original_box](double& /*tag0*/, std::vector<double>& /*tag1*/) {
-        const auto& compute_tag0 =
-            original_box.template get_lazy<test_databox_tags::ComputeTag0>();
+        original_box.template get_lazy<test_databox_tags::ComputeTag0>();
       });
 }
 
@@ -835,7 +833,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Variables",
   db::mutate<Tags::Variables<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>>(
       box, [](auto& vars) {
-        const auto size = vars.number_of_grid_points();
         get<test_databox_tags::ScalarTag>(vars).get() = 6.0;
       });
 
@@ -872,7 +869,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Variables",
   db::mutate<Tags::Variables<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>>(
       box, [](auto& vars) {
-        const auto size = vars.number_of_grid_points();
         get<test_databox_tags::ScalarTag>(vars).get() = 4.0;
         get<test_databox_tags::VectorTag>(vars) =
             tnsr::I<DataVector, 3>(DataVector(2, 6.));

--- a/tests/Unit/DataStructures/Test_Deferred.cpp
+++ b/tests/Unit/DataStructures/Test_Deferred.cpp
@@ -310,7 +310,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Deferred.UpdateArgsError2",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   auto def = make_deferred<double>(func{});
-  auto& mutate = def.mutate();
+  def.mutate();
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -1265,7 +1265,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   tnsr::Abb<double, 3, Frame::Grid> tensor(1_st);
-  auto& t = tensor[1000];
+  tensor[1000];
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -1277,7 +1277,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   const tnsr::Abb<double, 3, Frame::Grid> tensor(1_st);
-  const auto& t = tensor[1000];
+  tensor[1000];
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -1289,7 +1289,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   Scalar<double> tensor(1_st);
-  const auto& t = tensor.multiplicity(1000);
+  tensor.multiplicity(1000);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -1301,7 +1301,7 @@ SPECTRE_TEST_CASE("Unit.Serialization.Tensor",
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   tnsr::I<double, 3, Frame::Grid> tensor(1_st);
-  const auto& t = tensor.get_tensor_index(1000);
+  tensor.get_tensor_index(1000);
   ERROR("Bad test end");
 #endif
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
@@ -49,9 +49,11 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf2Maps",
 
   CHECK(affine_map_xy(point_A) == point_a);
   CHECK(affine_map_xy(point_B) == point_b);
+  CHECK(affine_map_xy(point_xi) == point_x);
 
   CHECK(affine_map_xy.inverse(point_a) == point_A);
   CHECK(affine_map_xy.inverse(point_b) == point_B);
+  CHECK(affine_map_xy.inverse(point_x) == point_xi);
 
   const double inv_jacobian_00 = (xB - xA) / (xb - xa);
   const double inv_jacobian_11 = (yB - yA) / (yb - ya);
@@ -161,7 +163,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf3Maps",
   const double eta = 0.5 * (yA + yB);
   const double y = yb * (eta - yA) / (yB - yA) + ya * (yB - eta) / (yB - yA);
   const double zeta = 0.5 * (zA + zB);
-  const double z = zb * (eta - zA) / (zB - zA) + za * (zB - eta) / (zB - zA);
+  const double z = zb * (zeta - zA) / (zB - zA) + za * (zB - zeta) / (zB - zA);
 
   const std::array<double, 3> point_A{{xA, yA, zA}};
   const std::array<double, 3> point_B{{xB, yB, zB}};
@@ -172,9 +174,11 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf3Maps",
 
   CHECK(affine_map_xyz(point_A) == point_a);
   CHECK(affine_map_xyz(point_B) == point_b);
+  CHECK(affine_map_xyz(point_xi) == point_x);
 
   CHECK(affine_map_xyz.inverse(point_a) == point_A);
   CHECK(affine_map_xyz.inverse(point_b) == point_B);
+  CHECK(affine_map_xyz.inverse(point_x) == point_xi);
 
   const double inv_jacobian_00 = (xB - xA) / (xb - xa);
   const double inv_jacobian_11 = (yB - yA) / (yb - ya);

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -100,8 +100,6 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equidistant",
   CHECK(map_lower_eta(random_left_edge)[1] ==
         approx(-random_inner_radius_lower_eta / sqrt(2.0)));
 
-  const double dxi = 1e-5;
-  const double deta = 1e-5;
   const double xi = real_dis(gen);
   CAPTURE_PRECISE(xi);
   const double eta = real_dis(gen);
@@ -211,8 +209,6 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equiangular",
   CHECK(map_lower_eta(random_left_edge)[1] ==
         approx(-random_inner_radius_lower_eta / sqrt(2.0)));
 
-  const double dxi = 1e-5;
-  const double deta = 1e-5;
   const double xi = real_dis(gen);
   CAPTURE_PRECISE(xi);
   const double eta = real_dis(gen);

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -146,7 +146,6 @@ void test_refinement_levels_of_neighbors(
     const auto& element_id = key_value.first;
     const auto& element = key_value.second;
     for (const auto& direction_neighbors : element.neighbors()) {
-      const auto& direction = direction_neighbors.first;
       const auto& neighbors = direction_neighbors.second;
       const auto& orientation = neighbors.orientation();
       for (size_t d = 0; d < VolumeDim; ++d) {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -5,7 +5,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <sys/types.h>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -133,7 +133,6 @@ void test_initialize_element(const ElementId<Dim>& element_id,
                                        my_block.coordinate_map().get_clone()};
   Element<Dim> element = create_initial_element(element_id, my_block);
   Index<Dim> extents{domain_creator.initial_extents()[element_id.block_id()]};
-  const auto num_grid_points = extents.product();
   auto logical_coords = logical_coordinates(extents);
   auto inertial_coords = map(logical_coords);
   CHECK(db::get<Tags::LogicalCoordinates<Dim>>(box) == logical_coords);

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -65,7 +65,6 @@ SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
 SPECTRE_TEST_CASE("Unit.IO.H5.FileMove", "[Unit][IO][H5]") {
   const std::string h5_file_name("Unit.IO.H5.FileMove.h5");
   const std::string h5_file_name2("Unit.IO.H5.FileMove2.h5");
-  const uint32_t version_number = 4;
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }
@@ -95,7 +94,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorObjectNotExist", "[Unit][IO][H5]") {
     file_system::rm(file_name, true);
   }
   h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
-  const std::string& header = my_file.get<h5::Header>("/Dummy").get_header();
+  my_file.get<h5::Header>("/Dummy").get_header();
 }
 
 // [[OutputRegex, All HDF5 file names must end in '.h5'. The path and file name
@@ -166,7 +165,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorObjectNotExistConst", "[Unit][IO][H5]") {
     file_system::rm(file_name, true);
   }
   const h5::H5File<h5::AccessType::ReadWrite> my_file(file_name);
-  const std::string& header = my_file.get<h5::Header>("/Dummy").get_header();
+  my_file.get<h5::Header>("/Dummy").get_header();
 }
 
 // [[OutputRegex, Cannot insert an Object that already exists. Failed to add
@@ -186,8 +185,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.FileErrorObjectAlreadyExists", "[Unit][IO][H5]") {
     error_file.append(std::vector<double>{0, 0.1, 0.2, 0.3});
   }
   {
-    auto& error_file =
-        my_file.insert<h5::Dat>("/L2_errors//", legend, version_number);
+    my_file.insert<h5::Dat>("/L2_errors//", legend, version_number);
   }
 }
 

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_NewtonRaphson.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_NewtonRaphson.cpp
@@ -110,8 +110,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.NewtonRaphson.DataVector",
     return std::make_pair(2. - square(x), -2. * x);
   };
 
-  auto root = RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower,
-                                         upper, digits);
+  RootFinder::newton_raphson(func_and_deriv_lambda, guess, lower, upper,
+                             digits);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -171,18 +171,12 @@ struct SingletonParallelComponent {
   using initial_databox = db::compute_databox_type<tmpl::list<>>;
 
   static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
-    auto& local_cache = *(global_cache.ckLocalBranch());
-  }
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& /*global_cache*/) {}
 
   static void execute_next_global_actions(
-      const typename Metavariables::Phase next_phase,
-      const Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
-    if (next_phase == Metavariables::Phase::CallArrayReduce) {
-      auto& local_cache = *(global_cache.ckLocalBranch());
-      return;
-    }
-  }
+      const typename Metavariables::Phase /*next_phase*/,
+      const Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*global_cache*/) {}
 };
 
 template <class Metavariables>

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
@@ -3,10 +3,10 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <cstddef>
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <string>
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
@@ -107,6 +107,14 @@ void test_schwarzschild(const DataType& used_for_size) noexcept {
   get(expected_lapse) = 1.0 / sqrt(1.0 + 2.0 * mass / r);
   CHECK_ITERABLE_APPROX(lapse, expected_lapse);
 
+  auto expected_d_lapse =
+      make_with_value<tnsr::i<DataType, 3, Frame::Inertial>>(x, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    expected_d_lapse.get(i) =
+        mass * x.get(i) * one_over_r_cubed * cube(get(lapse));
+  }
+  CHECK_ITERABLE_APPROX(d_lapse, expected_d_lapse);
+
   auto expected_shift =
       make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.0);
   for (size_t i = 0; i < 3; ++i) {
@@ -115,13 +123,18 @@ void test_schwarzschild(const DataType& used_for_size) noexcept {
   }
   CHECK_ITERABLE_APPROX(shift, expected_shift);
 
-  auto expected_d_lapse =
-      make_with_value<tnsr::i<DataType, 3, Frame::Inertial>>(x, 0.0);
-  for (size_t i = 0; i < 3; ++i) {
-    expected_d_lapse.get(i) =
-        mass * x.get(i) * one_over_r_cubed * cube(get(lapse));
+  auto expected_d_shift =
+      make_with_value<tnsr::iJ<DataType, 3, Frame::Inertial>>(x, 0.0);
+  for (size_t j = 0; j < 3; ++j) {
+    expected_d_shift.get(j, j) =
+        2.0 * mass * one_over_r_squared * square(get(lapse));
+    for (size_t i = 0; i < 3; ++i) {
+      expected_d_shift.get(j, i) -=
+          4.0 * mass * x.get(j) * x.get(i) * square(one_over_r_squared) *
+          square(get(lapse)) * (1 - mass / r * square(get(lapse)));
+    }
   }
-  CHECK_ITERABLE_APPROX(d_lapse, expected_d_lapse);
+  CHECK_ITERABLE_APPROX(d_shift, expected_d_shift);
 
   auto expected_g =
       make_with_value<tnsr::ii<DataType, 3, Frame::Inertial>>(x, 0.0);

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
@@ -448,7 +448,6 @@ void test_3d_spacetime_trace_tensor_type_aa(const DataVector& used_for_size) {
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.IndexManipulation",
                   "[PointwiseFunctions][Unit]") {
-  const size_t dim = 3;
   const DataVector dv(2);
 
   test_1d_spatial_raise(dv);

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -20,7 +20,7 @@
 #include "Domain/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
-#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"
 #include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
 #include "PointwiseFunctions/MathFunctions/TensorProduct.hpp"

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -131,7 +131,6 @@ void test_tensor_product(
     std::array<std::unique_ptr<MathFunction<1>>, VolumeDim>&& functions,
     const std::array<size_t, VolumeDim>& powers) noexcept {
   const auto coordinate_map = make_affine_map<VolumeDim>();
-  const size_t number_of_grid_points = extents.product();
   const auto x = coordinate_map(logical_coordinates(extents));
   MathFunctions::TensorProduct<VolumeDim> f(scale, std::move(functions));
   CHECK_ITERABLE_APPROX(f(x), expected_value(x, powers, scale));


### PR DESCRIPTION
## Proposed changes

Probably because of a Catch upgrade, gcc has decided to start warning me about unused variables in the tests.  In addition to the expected noise, this actually caught two cases where things were computed but then not checked.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
