### PR TITLE
Projection matrices

### DIFF
--- a/src/DataStructures/Matrix.hpp
+++ b/src/DataStructures/Matrix.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "DataStructures/DenseMatrix.hpp"
+#include "DataStructures/DenseMatrix.hpp"  // IWYU pragma: export
 
 /*!
  * \ingroup DataStructuresGroup

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Spectral)
 
 set(LIBRARY_SOURCES
     Legendre.cpp
+    Projection.cpp
     Spectral.cpp
     )
 

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -4,9 +4,11 @@
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <initializer_list>
 #include <ostream>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "Domain/Mesh.hpp"
 #include "ErrorHandling/Assert.hpp"
@@ -100,9 +102,129 @@ const Matrix& projection_matrix_mortar_to_element(
                    mortar_mesh.extents(0));
     }
 
-    case MortarSize::UpperHalf:
-    case MortarSize::LowerHalf:
-      ERROR("h-refinement not yet implemented");
+    case MortarSize::UpperHalf: {
+      const static StaticCache<
+          Matrix, CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
+          CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
+          cache([](const size_t encoded_quadrature_element,
+                   const size_t extents_element,
+                   const size_t encoded_quadrature_mortar,
+                   const size_t extents_mortar) noexcept {
+            if (extents_element > extents_mortar) {
+              return Matrix{};
+            }
+            const Mesh<1> mesh_element(
+                extents_element, Basis::Legendre,
+                decode_quadrature(encoded_quadrature_element));
+            const Mesh<1> mesh_mortar(
+                extents_mortar, Basis::Legendre,
+                decode_quadrature(encoded_quadrature_mortar));
+
+            // The transformation from the small interval to the large
+            // interval in spectral space.  This is a rearranged
+            // version of the equation given in the header.  This form
+            // was easier to code.
+            const auto spectral_transformation = [](
+                const size_t large_index, const size_t small_index) noexcept {
+              ASSERT(large_index >= small_index,
+                     "Above-diagonal entries are zero.  Don't use them.");
+              double result = 1.;
+              for (size_t i = (large_index - small_index) / 2; i > 0; --i) {
+                result = 1 - result *
+                                 ((large_index + small_index + 3 - 2 * i) *
+                                  (large_index + small_index + 2 - 2 * i) *
+                                  (large_index - small_index + 2 - 2 * i) *
+                                  (large_index - small_index + 1 - 2 * i)) /
+                                 (2 * i * (2 * large_index + 1 - 2 * i) *
+                                  (large_index + 2 - 2 * i) *
+                                  (large_index + 1 - 2 * i));
+              }
+
+              for (size_t i = 1; i <= large_index - small_index; ++i) {
+                result *= 1. + (large_index + small_index + 1.) / i;
+              }
+              result /= pow(2., large_index + 1);
+              return result;
+            };
+
+            const auto& spectral_to_grid_element =
+                spectral_to_grid_points_matrix(mesh_element);
+            const auto& grid_to_spectral_mortar =
+                grid_points_to_spectral_matrix(mesh_mortar);
+
+            Matrix temp(extents_element, extents_element, 0.);
+            for (size_t j = 0; j < extents_element; ++j) {
+              for (size_t k = j; k < extents_element; ++k) {
+                const double transformation_entry =
+                    spectral_transformation(k, j);
+                for (size_t i = 0; i < extents_element; ++i) {
+                  temp(i, j) +=
+                      spectral_to_grid_element(i, k) * transformation_entry;
+                }
+              }
+            }
+
+            Matrix projection(extents_element, extents_mortar, 0.);
+            for (size_t i = 0; i < extents_element; ++i) {
+              for (size_t j = 0; j < extents_mortar; ++j) {
+                for (size_t k = 0; k < extents_element; ++k) {
+                  projection(i, j) +=
+                      temp(i, k) * grid_to_spectral_mortar(k, j);
+                }
+              }
+            }
+
+            return projection;
+          });
+      return cache(encode_quadrature(element_mesh.quadrature(0)),
+                   element_mesh.extents(0),
+                   encode_quadrature(mortar_mesh.quadrature(0)),
+                   mortar_mesh.extents(0));
+    }
+
+    case MortarSize::LowerHalf: {
+      const static StaticCache<
+          Matrix, CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
+          CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
+          cache([](const size_t encoded_quadrature_element,
+                   const size_t extents_element,
+                   const size_t encoded_quadrature_mortar,
+                   const size_t extents_mortar) noexcept {
+            if (extents_element > extents_mortar) {
+              return Matrix{};
+            }
+            const Mesh<1> mesh_element(
+                extents_element, Basis::Legendre,
+                decode_quadrature(encoded_quadrature_element));
+            const Mesh<1> mesh_mortar(
+                extents_mortar, Basis::Legendre,
+                decode_quadrature(encoded_quadrature_mortar));
+
+            // The lower-half matrices are generated from the upper-half
+            // matrices using symmetry.
+            const auto& projection_upper_half =
+                projection_matrix_mortar_to_element(MortarSize::UpperHalf,
+                                                    mesh_element, mesh_mortar);
+
+            Matrix projection_lower_half(extents_element, extents_mortar);
+            for (size_t i = 0; i < extents_element; ++i) {
+              for (size_t j = 0; j < extents_mortar; ++j) {
+                projection_lower_half(i, j) = projection_upper_half(
+                    extents_element - i - 1, extents_mortar - j - 1);
+              }
+            }
+
+            return projection_lower_half;
+          });
+      return cache(encode_quadrature(element_mesh.quadrature(0)),
+                   element_mesh.extents(0),
+                   encode_quadrature(mortar_mesh.quadrature(0)),
+                   mortar_mesh.extents(0));
+    }
 
     default:
       ERROR("Invalid MortarSize");
@@ -127,6 +249,23 @@ const Matrix& projection_matrix_element_to_mortar(
          << element_mesh.extents(0) << ")");
 
   // Element-to-mortar projections are always interpolations.
+  const auto make_interpolators = [](auto interval_transform) noexcept {
+    return [interval_transform = std::move(interval_transform)](
+        const size_t encoded_quadrature_mortar,
+        const size_t extents_mortar,
+        const size_t encoded_quadrature_element,
+        const size_t extents_element) noexcept {
+      if (extents_mortar < extents_element) {
+        return Matrix{};
+      }
+      const Mesh<1> mesh_element(extents_element, Basis::Legendre,
+                                 decode_quadrature(encoded_quadrature_element));
+      const Mesh<1> mesh_mortar(extents_mortar, Basis::Legendre,
+                                decode_quadrature(encoded_quadrature_mortar));
+      return interpolation_matrix(
+          mesh_element, interval_transform(collocation_points(mesh_mortar)));
+    };
+  };
 
   switch (size) {
     case MortarSize::Full: {
@@ -135,32 +274,44 @@ const Matrix& projection_matrix_element_to_mortar(
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
           CacheRange<0, supported_quadratures.size()>,
           CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
-          cache([](const size_t encoded_quadrature_mortar,
-                   const size_t extents_mortar,
-                   const size_t encoded_quadrature_element,
-                   const size_t extents_element) noexcept {
-            if (extents_mortar < extents_element) {
-              return Matrix{};
-            }
-            const Mesh<1> mesh_element(
-                extents_element, Basis::Legendre,
-                decode_quadrature(encoded_quadrature_element));
-            const Mesh<1> mesh_mortar(
-                extents_mortar, Basis::Legendre,
-                decode_quadrature(encoded_quadrature_mortar));
-
-            return interpolation_matrix(mesh_element,
-                                        collocation_points(mesh_mortar));
-          });
+          cache(make_interpolators([](const DataVector& x) noexcept {
+            return x;
+          }));
       return cache(encode_quadrature(mortar_mesh.quadrature(0)),
                    mortar_mesh.extents(0),
                    encode_quadrature(element_mesh.quadrature(0)),
                    element_mesh.extents(0));
     }
 
-    case MortarSize::UpperHalf:
-    case MortarSize::LowerHalf:
-      ERROR("h-refinement not yet implemented");
+    case MortarSize::UpperHalf: {
+      const static StaticCache<
+          Matrix, CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
+          CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
+          cache(make_interpolators([](const DataVector& x) noexcept {
+            return DataVector(0.5 * (x + 1.));
+          }));
+      return cache(encode_quadrature(mortar_mesh.quadrature(0)),
+                   mortar_mesh.extents(0),
+                   encode_quadrature(element_mesh.quadrature(0)),
+                   element_mesh.extents(0));
+    }
+
+    case MortarSize::LowerHalf: {
+      const static StaticCache<
+          Matrix, CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
+          CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
+          cache(make_interpolators([](const DataVector& x) noexcept {
+            return DataVector(0.5 * (x - 1.));
+          }));
+      return cache(encode_quadrature(mortar_mesh.quadrature(0)),
+                   mortar_mesh.extents(0),
+                   encode_quadrature(element_mesh.quadrature(0)),
+                   element_mesh.extents(0));
+    }
 
     default:
       ERROR("Invalid MortarSize");

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -1,0 +1,170 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+
+#include <algorithm>
+#include <initializer_list>
+#include <ostream>
+
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Mesh.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/StaticCache.hpp"
+
+namespace Spectral {
+
+namespace {
+constexpr auto supported_quadratures = {Quadrature::Gauss,
+                                        Quadrature::GaussLobatto};
+
+size_t encode_quadrature(const Quadrature quadrature) noexcept {
+  return static_cast<size_t>(std::find(supported_quadratures.begin(),
+                                       supported_quadratures.end(),
+                                       quadrature) -
+                             supported_quadratures.begin());
+}
+
+Quadrature decode_quadrature(const size_t encoded) noexcept {
+  return *(supported_quadratures.begin() + encoded);
+}
+
+void check_quadrature_supported(const Quadrature quadrature) noexcept {
+  ASSERT(std::find(supported_quadratures.begin(), supported_quadratures.end(),
+                   quadrature) != supported_quadratures.end(),
+         "Unsupported quadrature: " << quadrature);
+}
+}  // namespace
+
+const Matrix& projection_matrix_mortar_to_element(
+    const MortarSize size, const Mesh<1>& element_mesh,
+    const Mesh<1>& mortar_mesh) noexcept {
+  ASSERT(element_mesh.basis(0) == Basis::Legendre and
+             mortar_mesh.basis(0) == Basis::Legendre,
+         "Projections only implemented on Legendre basis");
+  check_quadrature_supported(element_mesh.quadrature(0));
+  check_quadrature_supported(mortar_mesh.quadrature(0));
+  ASSERT(
+      element_mesh.extents(0) <= maximum_number_of_points<Basis::Legendre> and
+          mortar_mesh.extents(0) <= maximum_number_of_points<Basis::Legendre>,
+      "Mesh has more points than supported by its quadrature.");
+  ASSERT(element_mesh.extents(0) <= mortar_mesh.extents(0),
+         "Requested projection matrix from mortar with fewer points ("
+         << mortar_mesh.extents(0) << ") than the element ("
+         << element_mesh.extents(0) << ")");
+
+  switch (size) {
+    case MortarSize::Full: {
+      const static StaticCache<
+          Matrix, CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
+          CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
+          cache([](const size_t encoded_quadrature_element,
+                   const size_t extents_element,
+                   const size_t encoded_quadrature_mortar,
+                   const size_t extents_mortar) noexcept {
+            if (extents_element > extents_mortar) {
+              return Matrix{};
+            }
+            const Mesh<1> mesh_element(
+                extents_element, Basis::Legendre,
+                decode_quadrature(encoded_quadrature_element));
+            const Mesh<1> mesh_mortar(
+                extents_mortar, Basis::Legendre,
+                decode_quadrature(encoded_quadrature_mortar));
+
+            // The projection in spectral space is just a truncation
+            // of the modes.
+            const auto& spectral_to_grid_element =
+                spectral_to_grid_points_matrix(mesh_element);
+            const auto& grid_to_spectral_mortar =
+                grid_points_to_spectral_matrix(mesh_mortar);
+            Matrix projection(extents_element, extents_mortar, 0.);
+            for (size_t i = 0; i < extents_element; ++i) {
+              for (size_t j = 0; j < extents_mortar; ++j) {
+                for (size_t k = 0; k < extents_element; ++k) {
+                  projection(i, j) += spectral_to_grid_element(i, k) *
+                                      grid_to_spectral_mortar(k, j);
+                }
+              }
+            }
+
+            return projection;
+          });
+      return cache(encode_quadrature(element_mesh.quadrature(0)),
+                   element_mesh.extents(0),
+                   encode_quadrature(mortar_mesh.quadrature(0)),
+                   mortar_mesh.extents(0));
+    }
+
+    case MortarSize::UpperHalf:
+    case MortarSize::LowerHalf:
+      ERROR("h-refinement not yet implemented");
+
+    default:
+      ERROR("Invalid MortarSize");
+  }
+}
+
+const Matrix& projection_matrix_element_to_mortar(
+    const MortarSize size, const Mesh<1>& mortar_mesh,
+    const Mesh<1>& element_mesh) noexcept {
+  ASSERT(mortar_mesh.basis(0) == Basis::Legendre and
+             element_mesh.basis(0) == Basis::Legendre,
+         "Projections only implemented on Legendre basis");
+  check_quadrature_supported(mortar_mesh.quadrature(0));
+  check_quadrature_supported(element_mesh.quadrature(0));
+  ASSERT(
+      mortar_mesh.extents(0) <= maximum_number_of_points<Basis::Legendre> and
+          element_mesh.extents(0) <= maximum_number_of_points<Basis::Legendre>,
+      "Mesh has more points than supported by its quadrature.");
+  ASSERT(mortar_mesh.extents(0) >= element_mesh.extents(0),
+         "Requested projection matrix to mortar with fewer points ("
+         << mortar_mesh.extents(0) << ") than the element ("
+         << element_mesh.extents(0) << ")");
+
+  // Element-to-mortar projections are always interpolations.
+
+  switch (size) {
+    case MortarSize::Full: {
+      const static StaticCache<
+          Matrix, CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>,
+          CacheRange<0, supported_quadratures.size()>,
+          CacheRange<2, maximum_number_of_points<Basis::Legendre> + 1>>
+          cache([](const size_t encoded_quadrature_mortar,
+                   const size_t extents_mortar,
+                   const size_t encoded_quadrature_element,
+                   const size_t extents_element) noexcept {
+            if (extents_mortar < extents_element) {
+              return Matrix{};
+            }
+            const Mesh<1> mesh_element(
+                extents_element, Basis::Legendre,
+                decode_quadrature(encoded_quadrature_element));
+            const Mesh<1> mesh_mortar(
+                extents_mortar, Basis::Legendre,
+                decode_quadrature(encoded_quadrature_mortar));
+
+            return interpolation_matrix(mesh_element,
+                                        collocation_points(mesh_mortar));
+          });
+      return cache(encode_quadrature(mortar_mesh.quadrature(0)),
+                   mortar_mesh.extents(0),
+                   encode_quadrature(element_mesh.quadrature(0)),
+                   element_mesh.extents(0));
+    }
+
+    case MortarSize::UpperHalf:
+    case MortarSize::LowerHalf:
+      ERROR("h-refinement not yet implemented");
+
+    default:
+      ERROR("Invalid MortarSize");
+  }
+}
+
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Matrix.hpp"  // IWYU pragma: keep
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace Spectral {
+
+/// The portion of an element covered by a mortar.
+enum class MortarSize { Full, UpperHalf, LowerHalf };
+
+/*!
+ * \brief The projection matrix from a 1D mortar to an element.
+ *
+ * \details
+ * The projection matrices returned by this function (and by
+ * projection_matrix_element_to_mortar()) define orthogonal projection
+ * operators between the spaces of functions on the boundary of the
+ * element and the mortar.  These projections are usually the correct
+ * way to transfer data onto and off of the mortars.
+ */
+const Matrix& projection_matrix_mortar_to_element(
+    MortarSize size, const Mesh<1>& element_mesh,
+    const Mesh<1>& mortar_mesh) noexcept;
+
+/// The projection matrix from a 1D element to a mortar.  See
+/// projection_matrix_mortar_to_element() for details.
+const Matrix& projection_matrix_element_to_mortar(
+    MortarSize size, const Mesh<1>& mortar_mesh,
+    const Mesh<1>& element_mesh) noexcept;
+
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -26,6 +26,15 @@ enum class MortarSize { Full, UpperHalf, LowerHalf };
  * operators between the spaces of functions on the boundary of the
  * element and the mortar.  These projections are usually the correct
  * way to transfer data onto and off of the mortars.
+ *
+ * The half-interval projections are based on an equation derived by
+ * Saul.  This shows that the projection from the spectral basis for
+ * the entire interval to the spectral basis for the upper half
+ * interval is
+ * \f{equation*}
+ * T_{jk} = \frac{2 j + 1}{2} 2^j \sum_{n=0}^{j-k} \binom{j}{k+n}
+ * \binom{(j + k + n - 1)/2}{j} \frac{(k + n)!^2}{(2 k + n + 1)! n!}
+ * \f}
  */
 const Matrix& projection_matrix_mortar_to_element(
     MortarSize size, const Mesh<1>& element_mesh,

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -4,6 +4,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
 #include <algorithm>
+#include <ostream>
 #include <type_traits>
 #include <utility>
 
@@ -20,6 +21,23 @@
 #include "Utilities/StaticCache.hpp"
 
 namespace Spectral {
+
+std::ostream& operator<<(std::ostream& os,
+                         const Basis& basis) noexcept {
+  switch (basis) {
+    case Basis::Legendre: return os << "Legendre";
+    default: ERROR("Invalid basis");
+  }
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const Quadrature& quadrature) noexcept {
+  switch (quadrature) {
+    case Quadrature::Gauss: return os << "Gauss";
+    case Quadrature::GaussLobatto: return os << "GaussLobatto";
+    default: ERROR("Invalid quadrature");
+  }
+}
 
 // Forward declarations with basis-specific implementations
 

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <cstddef>
+#include <iosfwd>
 #include <limits>
 
 /// \cond
@@ -44,6 +45,10 @@ namespace Spectral {
  */
 enum class Basis { Legendre };
 
+/// \cond HIDDEN_SYMBOLS
+std::ostream& operator<<(std::ostream& os, const Basis& basis) noexcept;
+/// \endcond
+
 /*!
  * \ingroup SpectralGroup
  * \brief The choice of quadrature method to compute integration weights.
@@ -54,6 +59,11 @@ enum class Basis { Legendre };
  * domain boundary.
  */
 enum class Quadrature { Gauss, GaussLobatto };
+
+/// \cond HIDDEN_SYMBOLS
+std::ostream& operator<<(std::ostream& os,
+                         const Quadrature& quadrature) noexcept;
+/// \endcond
 
 /*!
  * \brief Minimum number of possible collocation points for a quadrature type.

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Spectral")
 set(LIBRARY_SOURCES
   Test_LegendreGauss.cpp
   Test_LegendreGaussLobatto.cpp
+  Test_Projection.cpp
   Test_Spectral.cpp
   )
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
@@ -1,0 +1,123 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <initializer_list>  // IWYU pragma: keep
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Mesh.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+namespace {
+constexpr auto quadratures = {Spectral::Quadrature::Gauss,
+                              Spectral::Quadrature::GaussLobatto};
+
+DataVector apply_matrix(const Matrix& m, const DataVector& v) noexcept {
+  ASSERT(m.columns() == v.size(), "Bad apply_matrix");
+  DataVector result(m.rows(), 0.);
+  for (size_t i = 0; i < m.rows(); ++i) {
+    for (size_t j = 0; j < m.columns(); ++j) {
+      result[i] += m(i, j) * v[j];
+    }
+  }
+  return result;
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.p.mortar_to_element",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  for (const auto& quadrature_dest : quadratures) {
+    for (size_t num_points_dest = 2;
+         num_points_dest <=
+             Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+         ++num_points_dest) {
+      const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
+                              quadrature_dest);
+      CAPTURE(mesh_dest);
+      for (const auto& quadrature_source : quadratures) {
+        for (size_t num_points_source = num_points_dest;
+             num_points_source <=
+                 Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+             ++num_points_source) {
+          const Mesh<1> mesh_source(
+              num_points_source, Spectral::Basis::Legendre, quadrature_source);
+          CAPTURE(mesh_source);
+          const auto& points_source = Spectral::collocation_points(mesh_source);
+          const auto& projection = projection_matrix_mortar_to_element(
+              Spectral::MortarSize::Full, mesh_dest, mesh_source);
+          for (size_t test_order = 0;
+               test_order < num_points_source;
+               ++test_order) {
+            CAPTURE(test_order);
+            const DataVector source_data = pow(points_source, test_order);
+            const DataVector projected_data =
+                apply_matrix(projection, source_data);
+            // Projection matrices can be defined as the matrices which
+            // make the error in the destination space orthogonal to the
+            // destination space.  We interpolate back to the higher
+            // dimensional source space to check.
+            const DataVector interpolated_projected_data = apply_matrix(
+                Spectral::interpolation_matrix(mesh_dest, points_source),
+                projected_data);
+            const DataVector error = interpolated_projected_data - source_data;
+
+            for (size_t orthogonality_test_order = 0;
+                 orthogonality_test_order < num_points_dest;
+                 ++orthogonality_test_order) {
+              // This integral might not be evaluated exactly for the
+              // highest order polynomials, but it will correctly
+              // determine orthogonality.
+              CHECK(definite_integral(
+                        error * pow(points_source, orthogonality_test_order),
+                        mesh_source) == approx(0.));
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.p.element_to_mortar",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  for (const auto& quadrature_dest : quadratures) {
+    for (size_t num_points_dest = 2;
+         num_points_dest <=
+             Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+         ++num_points_dest) {
+      const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
+                              quadrature_dest);
+      CAPTURE(mesh_dest);
+      const auto& points_dest = Spectral::collocation_points(mesh_dest);
+      for (const auto& quadrature_source : quadratures) {
+        for (size_t num_points_source = 2;
+             num_points_source <= num_points_dest;
+             ++num_points_source) {
+          const Mesh<1> mesh_source(
+              num_points_source, Spectral::Basis::Legendre, quadrature_source);
+          CAPTURE(mesh_source);
+          const auto& points_source = Spectral::collocation_points(mesh_source);
+          const auto& projection = projection_matrix_element_to_mortar(
+              Spectral::MortarSize::Full, mesh_dest, mesh_source);
+          for (size_t test_order = 0;
+               test_order < num_points_source;
+               ++test_order) {
+            CAPTURE(test_order);
+            const DataVector source_data = pow(points_source, test_order);
+            const DataVector projected_data =
+                apply_matrix(projection, source_data);
+            // The function is contained in the destination space, so
+            // projection should not alter it.
+            CHECK_ITERABLE_APPROX(projected_data, pow(points_dest, test_order));
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
@@ -121,3 +121,184 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.p.element_to_mortar",
     }
   }
 }
+
+namespace {
+DataVector to_upper_half(const DataVector& p) noexcept {
+  return 0.5 * (p + 1.);
+}
+
+DataVector to_lower_half(const DataVector& p) noexcept {
+  return 0.5 * (p - 1.);
+}
+
+// `to_element_self` (`to_element_other`) is the function mapping the
+// [-1,1] interval to the half that we are (are not) interpolating
+// from.
+template <typename F1, typename F2>
+void check_mortar_to_element_projection(const Spectral::MortarSize mortar_size,
+                                        const Mesh<1>& mesh_element,
+                                        const Mesh<1>& mesh_self_mortar,
+                                        F1&& to_element_self,
+                                        F2&& to_element_other) noexcept {
+  // Notation for variables in this function:
+  // _self indicates the half of the interval we projected from.
+  // _other indicates the half of the interval we did not project from.
+  // _element indicates the coordinate system on the large interval.
+  // _mortar indicates the coordinate system on one of the small intervals.
+
+  const auto& projection = projection_matrix_mortar_to_element(
+      mortar_size, mesh_element, mesh_self_mortar);
+
+  const size_t num_points_self_mortar = mesh_self_mortar.extents(0);
+  const size_t num_points_element = mesh_element.extents(0);
+  const auto& points_self_mortar =
+      Spectral::collocation_points(mesh_self_mortar);
+
+  for (size_t test_order = 0;
+       test_order < num_points_self_mortar;
+       ++test_order) {
+    CAPTURE(test_order);
+    const auto test_func_self_mortar = [test_order](const auto& x) noexcept {
+      return pow(x, test_order);
+    };
+
+    const DataVector data_self_mortar =
+        test_func_self_mortar(points_self_mortar);
+    const DataVector projected_data_element =
+        apply_matrix(projection, data_self_mortar);
+
+    // Test points for each half in each coordinate system.  These
+    // have to have one extra point because LGL quadrature is not
+    // sufficiently good.
+    const Mesh<1> test_mesh_self_mortar(mesh_self_mortar.extents(0) + 1,
+                                        mesh_self_mortar.basis(0),
+                                        mesh_self_mortar.quadrature(0));
+    const auto& test_points_self_mortar =
+        Spectral::collocation_points(test_mesh_self_mortar);
+    // We don't need to represent the initial function on the other
+    // mortar.
+    const Mesh<1> test_mesh_element(mesh_element.extents(0) + 1,
+                                    mesh_element.basis(0),
+                                    mesh_element.quadrature(0));
+    const auto& test_points_other_mortar =
+        Spectral::collocation_points(test_mesh_element);
+    const auto& test_points_self_element =
+        to_element_self(test_points_self_mortar);
+    const auto& test_points_other_element =
+        to_element_other(test_points_other_mortar);
+
+    // To get the error for the half we projected from, we first
+    // interpolate to the mortar at the test points, and then subtract
+    // the test function at those points.
+    const DataVector error_self_mortar =
+        apply_matrix(Spectral::interpolation_matrix(mesh_element,
+                                                    test_points_self_element),
+                     projected_data_element) -
+        test_func_self_mortar(test_points_self_mortar);
+    // For the other half's error we can just interpolate, since the
+    // source function is zero.
+    const DataVector error_other_mortar = apply_matrix(
+        Spectral::interpolation_matrix(mesh_element, test_points_other_element),
+        projected_data_element);
+
+    for (size_t orthogonality_test_order = 0;
+         orthogonality_test_order < num_points_element;
+         ++orthogonality_test_order) {
+      CAPTURE(orthogonality_test_order);
+      // Make sure we're using the same test function for both halves.
+      // This does not have to be the same as the test function above.
+      const DataVector test_function_self_mortar =
+          pow(test_points_self_element, orthogonality_test_order);
+      const DataVector test_function_other_mortar =
+          pow(test_points_other_element, orthogonality_test_order);
+      CHECK(definite_integral(error_self_mortar * test_function_self_mortar,
+                              test_mesh_self_mortar) ==
+            approx(-definite_integral(
+                error_other_mortar * test_function_other_mortar,
+                test_mesh_element)));
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.h.mortar_to_element",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  for (const auto& quadrature_dest : quadratures) {
+    for (size_t num_points_dest = 2;
+         // We need one extra point to do the quadrature later.
+         num_points_dest <=
+             Spectral::maximum_number_of_points<Spectral::Basis::Legendre> - 1;
+         ++num_points_dest) {
+      const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
+                              quadrature_dest);
+      CAPTURE(mesh_dest);
+      for (const auto& quadrature_source : quadratures) {
+        for (size_t num_points_source = num_points_dest;
+             num_points_source <=
+                 Spectral::maximum_number_of_points<Spectral::Basis::Legendre> -
+                 1;
+             ++num_points_source) {
+          const Mesh<1> mesh_source(
+              num_points_source, Spectral::Basis::Legendre, quadrature_source);
+          CAPTURE(mesh_source);
+          check_mortar_to_element_projection(Spectral::MortarSize::UpperHalf,
+                                             mesh_dest, mesh_source,
+                                             to_upper_half, to_lower_half);
+          check_mortar_to_element_projection(Spectral::MortarSize::LowerHalf,
+                                             mesh_dest, mesh_source,
+                                             to_lower_half, to_upper_half);
+        }
+      }
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection.h.element_to_mortar",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  for (const auto& quadrature_dest : quadratures) {
+    for (size_t num_points_dest = 2;
+         num_points_dest <=
+             Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+         ++num_points_dest) {
+      const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
+                              quadrature_dest);
+      CAPTURE(mesh_dest);
+      const auto& points_dest = Spectral::collocation_points(mesh_dest);
+      for (const auto& quadrature_source : quadratures) {
+        for (size_t num_points_source = 2;
+             num_points_source <= num_points_dest;
+             ++num_points_source) {
+          const Mesh<1> mesh_source(
+              num_points_source, Spectral::Basis::Legendre, quadrature_source);
+          CAPTURE(mesh_source);
+          const auto& points_source = Spectral::collocation_points(mesh_source);
+          for (size_t test_order = 0;
+               test_order < num_points_source;
+               ++test_order) {
+            CAPTURE(test_order);
+            const DataVector source_data = pow(points_source, test_order);
+
+            // The function is contained in the destination space, so
+            // projection should not alter it.
+            {
+              const auto& projection = projection_matrix_element_to_mortar(
+                  Spectral::MortarSize::UpperHalf, mesh_dest, mesh_source);
+              const DataVector projected_data =
+                  apply_matrix(projection, source_data);
+              CHECK_ITERABLE_APPROX(
+                  projected_data, pow(to_upper_half(points_dest), test_order));
+            }
+            {
+              const auto& projection = projection_matrix_element_to_mortar(
+                  Spectral::MortarSize::LowerHalf, mesh_dest, mesh_source);
+              const DataVector projected_data =
+                  apply_matrix(projection, source_data);
+              CHECK_ITERABLE_APPROX(
+                  projected_data, pow(to_lower_half(points_dest), test_order));
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -8,12 +8,22 @@
 
 #include <cmath>
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "Domain/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/Blas.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.streaming",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  CHECK(get_output(Spectral::Basis::Legendre) == "Legendre");
+
+  CHECK(get_output(Spectral::Quadrature::Gauss) == "Gauss");
+  CHECK(get_output(Spectral::Quadrature::GaussLobatto) == "GaussLobatto");
+}
 
 namespace {
 

--- a/tools/Iwyu/iwyu.imp
+++ b/tools/Iwyu/iwyu.imp
@@ -9,6 +9,10 @@
               "\"Utilities/TMPL.hpp\"", public]},
 
   { include: ["@<blaze/.*>", private,
+              "\"DataStructures/DenseMatrix.hpp\"", public]},
+  { include: ["@<blaze/.*>", private,
+              "\"DataStructures/DenseVector.hpp\"", public]},
+  { include: ["@<blaze/.*>", private,
               "\"Utilities/PointerVector.hpp\"", private]},
 
   { include: ["<ckmessage.h>", private,


### PR DESCRIPTION
This PR is dependent on #659 for making the Spectral namespace show up in Doxygen.  There is a "deleteme" commit to make it show up for review purposes.

There are two FIXME notes in the code relating to referencing "Saul's notes" because that is not a very useful reference if someone who doesn't know what is going on wants to understand the code.  I don't know what to do about this.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
