### PR TITLE
Additions for RotatedBricks 1

### DIFF
--- a/src/DataStructures/Index.hpp
+++ b/src/DataStructures/Index.hpp
@@ -110,6 +110,13 @@ class Index {
   std::array<size_t, Dim> indices_;
 };
 
+/// \ingroup DataStructuresGroup
+/// Get the collapsed index into a 1D array of the data corresponding to this
+/// Index. Note that the first dimension of the Index varies fastest when
+/// computing the collapsed index.
+template <size_t N>
+size_t collapsed_index(const Index<N>& index, const Index<N>& extents) noexcept;
+
 template <size_t N>
 std::ostream& operator<<(std::ostream& os, const Index<N>& i);
 

--- a/src/DataStructures/IndexIterator.cpp
+++ b/src/DataStructures/IndexIterator.cpp
@@ -7,7 +7,10 @@
 
 template <size_t Dim>
 IndexIterator<Dim>::IndexIterator(Index<Dim> extents)
-    : extents_(std::move(extents)), index_(0), offset_(0), valid_(true) {}
+    : extents_(std::move(extents)),
+      index_(0),
+      collapsed_index_(0),
+      valid_(true) {}
 
 template <size_t Dim>
 IndexIterator<Dim>& IndexIterator<Dim>::operator++() {
@@ -22,7 +25,7 @@ IndexIterator<Dim>& IndexIterator<Dim>::operator++() {
       break;
     }
   }
-  ++offset_;
+  ++collapsed_index_;
   return *this;
 }
 

--- a/src/DataStructures/IndexIterator.hpp
+++ b/src/DataStructures/IndexIterator.hpp
@@ -48,13 +48,14 @@ class IndexIterator {
   /// currently represents
   const Index<Dim>& operator()() const noexcept { return index_; }
 
-  /// Get the offset into a 1D array whose first dimension is assumed to vary
-  /// fastest
-  size_t offset() const noexcept { return offset_; }
+  /// Get the collapsed index into a 1D array of the data corresponding to the
+  /// current Index of the IndexIterator. Note that the first dimension of the
+  /// Index varies fastest when computing the collapsed index.
+  size_t collapsed_index() const noexcept { return collapsed_index_; }
 
  private:
   const Index<Dim> extents_{};
   Index<Dim> index_{};
-  size_t offset_{0};
+  size_t collapsed_index_{0};
   bool valid_{false};
 };

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -67,6 +67,20 @@ void set_periodic_boundaries(
         neighbors_of_all_blocks);
 
 /// \ingroup ComputationalDomainGroup
+/// \brief The corners for a rectilinear domain made of n-cubes.
+///
+/// The `domain_extents` argument holds the number of blocks to have
+/// in each dimension. The blocks all have aligned orientations by
+/// construction. The `block_indices_to_exclude` argument allows the user
+/// to selectively exclude blocks from the resulting domain. This allows
+/// for the creation of non-trivial shapes such as the net for a tesseract.
+template <size_t VolumeDim>
+std::vector<std::array<size_t, two_to_the(VolumeDim)>>
+corners_for_rectilinear_domains(const Index<VolumeDim>& domain_extents,
+                                const std::vector<Index<VolumeDim>>&
+                                    block_indices_to_exclude = {}) noexcept;
+
+/// \ingroup ComputationalDomainGroup
 /// These are the CoordinateMaps of the Wedge3Ds used in the Sphere, Shell, and
 /// binary compact object DomainCreators. This function can also be used to
 /// wrap the Sphere or Shell in a cube made of six Wedge3Ds.

--- a/src/Domain/LogicalCoordinates.cpp
+++ b/src/Domain/LogicalCoordinates.cpp
@@ -25,7 +25,7 @@ tnsr::I<DataVector, VolumeDim, Frame::Logical> logical_coordinates(
     const auto& collocation_points_in_this_dim =
         Basis::lgl::collocation_points(extents[d]);
     for (IndexIterator<VolumeDim> index(extents); index; ++index) {
-      logical_x.get(d)[index.offset()] =
+      logical_x.get(d)[index.collapsed_index()] =
           collocation_points_in_this_dim[index()[d]];
     }
   }
@@ -47,14 +47,14 @@ tnsr::I<DataVector, VolumeDim, Frame::Logical> interface_logical_coordinates(
 
   for (IndexIterator<VolumeDim - 1> index(extents); index; ++index) {
     for (size_t d = 0; d < sliced_away_dim; ++d) {
-      logical_x.get(d)[index.offset()] =
+      logical_x.get(d)[index.collapsed_index()] =
           gsl::at(collocation_points_in_each_dim, d)[index()[d]];
     }
     logical_x[sliced_away_dim] =
         (Side::Lower == direction.side() ? DataVector(extents.product(), -1.0)
                                          : DataVector(extents.product(), 1.0));
     for (size_t d = sliced_away_dim; d < VolumeDim - 1; ++d) {
-      logical_x.get(d + 1)[index.offset()] =
+      logical_x.get(d + 1)[index.collapsed_index()] =
           gsl::at(collocation_points_in_each_dim, d)[index()[d]];
     }
   }

--- a/tests/Unit/DataStructures/Test_IndexIterator.cpp
+++ b/tests/Unit/DataStructures/Test_IndexIterator.cpp
@@ -20,32 +20,32 @@ SPECTRE_TEST_CASE("Unit.DataStructures.IndexIterator",
   CHECK(index_iterator);
   CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 0 and
          index_iterator()[2] == 0));
-  CHECK(index_iterator.offset() == 0);
+  CHECK(index_iterator.collapsed_index() == 0);
   ++index_iterator;
   CHECK(index_iterator);
   CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 1 and
          index_iterator()[2] == 0));
-  CHECK(index_iterator.offset() == 1);
+  CHECK(index_iterator.collapsed_index() == 1);
   ++index_iterator;
   CHECK(index_iterator);
   CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 0 and
          index_iterator()[2] == 1));
-  CHECK(index_iterator.offset() == 2);
+  CHECK(index_iterator.collapsed_index() == 2);
   ++index_iterator;
   CHECK(index_iterator);
   CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 1 and
          index_iterator()[2] == 1));
-  CHECK(index_iterator.offset() == 3);
+  CHECK(index_iterator.collapsed_index() == 3);
   ++index_iterator;
   CHECK(index_iterator);
   CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 0 and
          index_iterator()[2] == 2));
-  CHECK(index_iterator.offset() == 4);
+  CHECK(index_iterator.collapsed_index() == 4);
   ++index_iterator;
   CHECK(index_iterator);
   CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 1 and
          index_iterator()[2] == 2));
-  CHECK(index_iterator.offset() == 5);
+  CHECK(index_iterator.collapsed_index() == 5);
   ++index_iterator;
   CHECK(not index_iterator);
 

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -18,6 +18,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -33,39 +33,6 @@ template <size_t VolumeDim>
 class ElementId;
 /// \endcond
 
-// Iterates over the logical corners of a VolumeDim-dimensional cube.
-template <size_t VolumeDim>
-class VolumeCornerIterator {
- public:
-  VolumeCornerIterator() noexcept = default;
-  explicit VolumeCornerIterator(size_t index) noexcept : index_(index) {}
-  void operator++() noexcept {
-    ++index_;
-    for (size_t i = 0; i < VolumeDim; i++) {
-      gsl::at(coords_of_corner_, i) = 2.0 * get_nth_bit(index_, i) - 1.0;
-      gsl::at(array_sides_, i) =
-          2 * get_nth_bit(index_, i) - 1 == 1 ? Side::Upper : Side::Lower;
-    }
-  }
-  explicit operator bool() const noexcept {
-    return index_ < two_to_the(VolumeDim);
-  }
-  const std::array<Side, VolumeDim>& operator()() const noexcept {
-    return array_sides_;
-  }
-  const std::array<Side, VolumeDim>& operator*() const noexcept {
-    return array_sides_;
-  }
-  const std::array<double, VolumeDim>& coords_of_corner() const noexcept {
-    return coords_of_corner_;
-  }
-
- private:
-  size_t index_ = 0;
-  std::array<Side, VolumeDim> array_sides_ = make_array<VolumeDim>(Side::Lower);
-  std::array<double, VolumeDim> coords_of_corner_ = make_array<VolumeDim>(-1.0);
-};
-
 // Test that the Blocks in the Domain are constructed correctly.
 template <size_t VolumeDim>
 void test_domain_construction(

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -576,3 +576,72 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.BNSCorners", "[Domain][Unit]") {
   }
   CHECK(generated_corners == expected_corners);
 }
+
+namespace {
+void test_vci_1d() {
+  VolumeCornerIterator<1> vci{};
+  CHECK(vci);
+  CHECK(vci() == std::array<Side, 1>{{Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 1>{{-1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 1>{{Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 1>{{1.0}});
+  ++vci;
+  CHECK(not vci);
+}
+
+void test_vci_2d() {
+  VolumeCornerIterator<2> vci{};
+  CHECK(vci);
+  CHECK(vci() == std::array<Side, 2>{{Side::Lower, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 2>{{-1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 2>{{Side::Upper, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 2>{{1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 2>{{Side::Lower, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 2>{{-1.0, 1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 2>{{Side::Upper, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 2>{{1.0, 1.0}});
+  ++vci;
+  CHECK(not vci);
+}
+
+void test_vci_3d() {
+  VolumeCornerIterator<3> vci{};
+  CHECK(vci);
+  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Lower, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, -1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Lower, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, -1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Upper, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, 1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Upper, Side::Lower}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, 1.0, -1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Lower, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, -1.0, 1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Lower, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, -1.0, 1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Upper, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, 1.0, 1.0}});
+  ++vci;
+  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Upper, Side::Upper}});
+  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, 1.0, 1.0}});
+  ++vci;
+  CHECK(not vci);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.VolumeCornerIterator",
+                  "[Domain][Unit]") {
+  test_vci_1d();
+  test_vci_2d();
+  test_vci_3d();
+}

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
@@ -21,6 +22,8 @@
 #include "Domain/Direction.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Domain/Side.hpp"
+#include "ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -588,6 +591,14 @@ void test_vci_1d() {
   CHECK(vci.coords_of_corner() == std::array<double, 1>{{1.0}});
   ++vci;
   CHECK(not vci);
+
+  VolumeCornerIterator<1> vci2{Index<1>{2}, Index<1>{7}};
+  CHECK(vci2);
+  CHECK(vci2.global_corner_number() == 2);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 3);
+  ++vci2;
+  CHECK(not vci2);
 }
 
 void test_vci_2d() {
@@ -606,6 +617,18 @@ void test_vci_2d() {
   CHECK(vci.coords_of_corner() == std::array<double, 2>{{1.0, 1.0}});
   ++vci;
   CHECK(not vci);
+
+  VolumeCornerIterator<2> vci2{Index<2>{1, 2}, Index<2>{3, 4}};
+  CHECK(vci2);
+  CHECK(vci2.global_corner_number() == 7);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 8);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 10);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 11);
+  ++vci2;
+  CHECK(not vci2);
 }
 
 void test_vci_3d() {
@@ -636,6 +659,26 @@ void test_vci_3d() {
   CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, 1.0, 1.0}});
   ++vci;
   CHECK(not vci);
+
+  VolumeCornerIterator<3> vci2{Index<3>{1, 1, 1}, Index<3>{4, 4, 4}};
+  CHECK(vci2);
+  CHECK(vci2.global_corner_number() == 21);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 22);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 25);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 26);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 37);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 38);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 41);
+  ++vci2;
+  CHECK(vci2.global_corner_number() == 42);
+  ++vci2;
+  CHECK(not vci2);
 }
 }  // namespace
 
@@ -644,4 +687,16 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.VolumeCornerIterator",
   test_vci_1d();
   test_vci_2d();
   test_vci_3d();
+}
+
+// [[OutputRegex, Index out of range.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.VolumeCornerIterator.Assert", "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto extents = Index<3>{4, 4, 4};
+  auto failed_index_with = Index<3>{2, 3, 4};
+  static_cast<void>(VolumeCornerIterator<3>{failed_index_with, extents});
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
 }

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -700,3 +700,73 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.VolumeCornerIterator",
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.CornersForRectilinearDomains",
+                  "[Domain][Unit]") {
+  std::vector<std::array<size_t, 2>> corners_for_a_1d_road{
+      {{0, 1}}, {{1, 2}}, {{2, 3}}};
+  std::vector<std::array<size_t, 4>> corners_for_a_2d_vertical_tower{
+      {{0, 1, 2, 3}}, {{2, 3, 4, 5}}, {{4, 5, 6, 7}}};
+  std::vector<std::array<size_t, 4>> corners_for_a_2d_horizontal_wall{
+      {{0, 1, 4, 5}}, {{1, 2, 5, 6}}, {{2, 3, 6, 7}}};
+  std::vector<std::array<size_t, 4>> corners_for_a_2d_field{
+      {{0, 1, 3, 4}}, {{1, 2, 4, 5}}, {{3, 4, 6, 7}}, {{4, 5, 7, 8}}};
+  // This 2D net of a cube does not have its boundaries identified.
+  std::vector<std::array<size_t, 4>> corners_for_a_2d_net_of_a_cube{
+      {{1, 2, 5, 6}},    {{5, 6, 9, 10}},    {{8, 9, 12, 13}},
+      {{9, 10, 13, 14}}, {{10, 11, 14, 15}}, {{13, 14, 17, 18}}};
+  std::vector<std::array<size_t, 8>> corners_for_a_3d_cube{
+      {{0, 1, 3, 4, 9, 10, 12, 13}},      {{1, 2, 4, 5, 10, 11, 13, 14}},
+      {{3, 4, 6, 7, 12, 13, 15, 16}},     {{4, 5, 7, 8, 13, 14, 16, 17}},
+      {{9, 10, 12, 13, 18, 19, 21, 22}},  {{10, 11, 13, 14, 19, 20, 22, 23}},
+      {{12, 13, 15, 16, 21, 22, 24, 25}}, {{13, 14, 16, 17, 22, 23, 25, 26}}};
+  std::vector<std::array<size_t, 8>> corners_for_a_rubiks_cube_with_hole{
+      {{0, 1, 4, 5, 16, 17, 20, 21}},
+      {{1, 2, 5, 6, 17, 18, 21, 22}},
+      {{2, 3, 6, 7, 18, 19, 22, 23}},
+      {{4, 5, 8, 9, 20, 21, 24, 25}},
+      {{5, 6, 9, 10, 21, 22, 25, 26}},
+      {{6, 7, 10, 11, 22, 23, 26, 27}},
+      {{8, 9, 12, 13, 24, 25, 28, 29}},
+      {{9, 10, 13, 14, 25, 26, 29, 30}},
+      {{10, 11, 14, 15, 26, 27, 30, 31}},
+
+      {{16, 17, 20, 21, 32, 33, 36, 37}},
+      {{17, 18, 21, 22, 33, 34, 37, 38}},
+      {{18, 19, 22, 23, 34, 35, 38, 39}},
+      {{20, 21, 24, 25, 36, 37, 40, 41}},
+      /*central block is skipped!*/
+      {{22, 23, 26, 27, 38, 39, 42, 43}},
+      {{24, 25, 28, 29, 40, 41, 44, 45}},
+      {{25, 26, 29, 30, 41, 42, 45, 46}},
+      {{26, 27, 30, 31, 42, 43, 46, 47}},
+
+      {{32, 33, 36, 37, 48, 49, 52, 53}},
+      {{33, 34, 37, 38, 49, 50, 53, 54}},
+      {{34, 35, 38, 39, 50, 51, 54, 55}},
+      {{36, 37, 40, 41, 52, 53, 56, 57}},
+      {{37, 38, 41, 42, 53, 54, 57, 58}},
+      {{38, 39, 42, 43, 54, 55, 58, 59}},
+      {{40, 41, 44, 45, 56, 57, 60, 61}},
+      {{41, 42, 45, 46, 57, 58, 61, 62}},
+      {{42, 43, 46, 47, 58, 59, 62, 63}}};
+
+  CHECK(corners_for_rectilinear_domains(Index<1>{3}) == corners_for_a_1d_road);
+  CHECK(corners_for_rectilinear_domains(Index<2>{1, 3}) ==
+        corners_for_a_2d_vertical_tower);
+  CHECK(corners_for_rectilinear_domains(Index<2>{3, 1}) ==
+        corners_for_a_2d_horizontal_wall);
+  CHECK(corners_for_rectilinear_domains(Index<2>{2, 2}) ==
+        corners_for_a_2d_field);
+  CHECK(corners_for_rectilinear_domains(
+            Index<2>{3, 4},
+            std::vector<Index<2>>{Index<2>{0, 0}, Index<2>{2, 0},
+                                  Index<2>{0, 1}, Index<2>{2, 1},
+                                  Index<2>{0, 3}, Index<2>{2, 3}}) ==
+        corners_for_a_2d_net_of_a_cube);
+  CHECK(corners_for_rectilinear_domains(Index<3>{2, 2, 2}) ==
+        corners_for_a_3d_cube);
+  CHECK(corners_for_rectilinear_domains(
+            Index<3>{3, 3, 3}, std::vector<Index<3>>{Index<3>{1, 1, 1}}) ==
+        corners_for_a_rubiks_cube_with_hole);
+}

--- a/tests/Unit/Domain/Test_DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainTestHelpers.cpp
@@ -4,85 +4,14 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <algorithm>
-#include <array>
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Direction.hpp"
-#include "Domain/Side.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
-
-namespace {
-void test_vci_1d() {
-  VolumeCornerIterator<1> vci{};
-  CHECK(vci);
-  CHECK(vci() == std::array<Side, 1>{{Side::Lower}});
-  CHECK(vci.coords_of_corner() == std::array<double, 1>{{-1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 1>{{Side::Upper}});
-  CHECK(vci.coords_of_corner() == std::array<double, 1>{{1.0}});
-  ++vci;
-  CHECK(not vci);
-}
-
-void test_vci_2d() {
-  VolumeCornerIterator<2> vci{};
-  CHECK(vci);
-  CHECK(vci() == std::array<Side, 2>{{Side::Lower, Side::Lower}});
-  CHECK(vci.coords_of_corner() == std::array<double, 2>{{-1.0, -1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 2>{{Side::Upper, Side::Lower}});
-  CHECK(vci.coords_of_corner() == std::array<double, 2>{{1.0, -1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 2>{{Side::Lower, Side::Upper}});
-  CHECK(vci.coords_of_corner() == std::array<double, 2>{{-1.0, 1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 2>{{Side::Upper, Side::Upper}});
-  CHECK(vci.coords_of_corner() == std::array<double, 2>{{1.0, 1.0}});
-  ++vci;
-  CHECK(not vci);
-}
-
-void test_vci_3d() {
-  VolumeCornerIterator<3> vci{};
-  CHECK(vci);
-  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Lower, Side::Lower}});
-  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, -1.0, -1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Lower, Side::Lower}});
-  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, -1.0, -1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Upper, Side::Lower}});
-  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, 1.0, -1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Upper, Side::Lower}});
-  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, 1.0, -1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Lower, Side::Upper}});
-  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, -1.0, 1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Lower, Side::Upper}});
-  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, -1.0, 1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Upper, Side::Upper}});
-  CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, 1.0, 1.0}});
-  ++vci;
-  CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Upper, Side::Upper}});
-  CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, 1.0, 1.0}});
-  ++vci;
-  CHECK(not vci);
-}
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Domain.TestHelpers.VolumeCornerIterator",
-                  "[Domain][Unit]") {
-  test_vci_1d();
-  test_vci_2d();
-  test_vci_3d();
-}
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
@@ -40,7 +40,7 @@ void test_definite_integral_2d(const Index<2>& extents) {
   for (size_t a = 0; a < num_pts_in_x; ++a) {
     for (size_t b = 0; b < num_pts_in_y; ++b) {
       for (IndexIterator<2> index_it(extents); index_it; ++index_it) {
-        integrand[index_it.offset()] =
+        integrand[index_it.collapsed_index()] =
             pow(x[index_it()[0]], a) * pow(y[index_it()[1]], b);
       }
       if (0 == a % 2 and 0 == b % 2) {
@@ -65,9 +65,9 @@ void test_definite_integral_3d(const Index<3>& extents) {
     for (size_t b = 0; b < num_pts_in_y; ++b) {
       for (size_t c = 0; c < num_pts_in_z; ++c) {
         for (IndexIterator<3> index_it(extents); index_it; ++index_it) {
-          integrand[index_it.offset()] = pow(x[index_it()[0]], a) *
-                                         pow(y[index_it()[1]], b) *
-                                         pow(z[index_it()[2]], c);
+          integrand[index_it.collapsed_index()] = pow(x[index_it()[0]], a) *
+                                                  pow(y[index_it()[1]], b) *
+                                                  pow(z[index_it()[2]], c);
         }
         if (0 == a % 2 and 0 == b % 2 and 0 == c % 2) {
           CHECK(8.0 / ((a + 1.0) * (b + 1.0) * (c + 1.0)) ==

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
@@ -28,7 +28,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Linearize",
         const Index<3> extents(nx, ny, nz);
         DataVector u(extents.product());
         for (IndexIterator<3> i(extents); i; ++i) {
-          u[i.offset()] = exp(x[i()[0]]) * exp(y[i()[1]]) * exp(z[i()[2]]);
+          u[i.collapsed_index()] =
+              exp(x[i()[0]]) * exp(y[i()[1]]) * exp(z[i()[2]]);
         }
         DataVector u_lin = linearize(u, extents);
         for (size_t d = 0; d < 3; ++d) {
@@ -61,7 +62,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LinearizeALinearFunction",
         const Index<3> extents(nx, ny, nz);
         DataVector u(extents.product());
         for (IndexIterator<3> i(extents); i; ++i) {
-          u[i.offset()] = 3*x[i()[0]]+5*y[i()[1]]+z[i()[2]];
+          u[i.collapsed_index()] = 3 * x[i()[0]] + 5 * y[i()[1]] + z[i()[2]];
         }
         const DataVector u_lin = linearize(u, extents);
         CHECK_ITERABLE_APPROX(u, u_lin);
@@ -83,7 +84,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LinearizeInOneDim",
         const Index<3> extents(nx, ny, nz);
         DataVector u(extents.product());
         for (IndexIterator<3> i(extents); i; ++i) {
-          u[i.offset()] = exp(x[i()[0]]) * exp(y[i()[1]]) * exp(z[i()[2]]);
+          u[i.collapsed_index()] =
+              exp(x[i()[0]]) * exp(y[i()[1]]) * exp(z[i()[2]]);
         }
         for (size_t d = 0; d < 3; ++d) {
           DataVector u_lin = linearize(u, extents, d);

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
@@ -26,7 +26,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.MeanValue",
         const Index<3> extents(nx, ny, nz);
         DataVector u(extents.product());
         for (IndexIterator<3> i(extents); i; ++i) {
-          u[i.offset()] = exp(x[i()[0]]) * exp(y[i()[1]]) * exp(z[i()[2]]);
+          u[i.collapsed_index()] =
+              exp(x[i()[0]]) * exp(y[i()[1]]) * exp(z[i()[2]]);
         }
         const DataVector u_lin = linearize(u, extents);
         size_t n_pts = extents.product();
@@ -49,14 +50,14 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.MeanValueOnBoundary",
         const DataVector u_lin = [&extents, &x, &y, &z]() {
           DataVector temp(extents.product());
           for (IndexIterator<3> i(extents); i; ++i) {
-            temp[i.offset()] = x[i()[0]] + y[i()[1]] + z[i()[2]];
+            temp[i.collapsed_index()] = x[i()[0]] + y[i()[1]] + z[i()[2]];
           }
           return temp;
         }();
         const DataVector u_quad = [&extents, &x, &y]() {
           DataVector temp(extents.product());
           for (IndexIterator<3> i(extents); i; ++i) {
-            temp[i.offset()] = x[i()[0]] * y[i()[1]];
+            temp[i.collapsed_index()] = x[i()[0]] * y[i()[1]];
           }
           return temp;
         }();
@@ -105,7 +106,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.MeanValueOnBoundary1D",
     const DataVector u_lin = [&extents, &x]() {
       DataVector temp(extents.product());
       for (IndexIterator<1> i(extents); i; ++i) {
-        temp[i.offset()] = x[i()[0]];
+        temp[i.collapsed_index()] = x[i()[0]];
       }
       return temp;
     }();

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -166,10 +166,11 @@ void test_logical_partial_derivatives_2d(const Index<2>& extents) {
       const double expected_deta = (0 == b ? 0.0
                                            : b * (n + 1) * pow(xi[ii()[0]], a) *
                                                  pow(eta[ii()[1]], b - 1));
-      CHECK(du[0].data()[ii.collapsed_index() +
+      // clang-tidy: pointer arithmetic
+      CHECK(du[0].data()[ii.collapsed_index() +         // NOLINT
                          n * number_of_grid_points] ==  // NOLINT
             approx(expected_dxi));
-      CHECK(du[1].data()[ii.collapsed_index() +
+      CHECK(du[1].data()[ii.collapsed_index() +         // NOLINT
                          n * number_of_grid_points] ==  // NOLINT
             approx(expected_deta));
     }
@@ -211,13 +212,14 @@ void test_logical_partial_derivatives_3d(const Index<3>& extents) {
           (0 == c ? 0.0
                   : c * (n + 1) * pow(xi[ii()[0]], a) * pow(eta[ii()[1]], b) *
                         pow(zeta[ii()[2]], c - 1));
-      CHECK(du[0].data()[ii.collapsed_index() +
+      // clang-tidy: pointer arithmetic
+      CHECK(du[0].data()[ii.collapsed_index() +         // NOLINT
                          n * number_of_grid_points] ==  // NOLINT
             approx(expected_dxi));
-      CHECK(du[1].data()[ii.collapsed_index() +
+      CHECK(du[1].data()[ii.collapsed_index() +         // NOLINT
                          n * number_of_grid_points] ==  // NOLINT
             approx(expected_deta));
-      CHECK(du[2].data()[ii.collapsed_index() +
+      CHECK(du[2].data()[ii.collapsed_index() +         // NOLINT
                          n * number_of_grid_points] ==  // NOLINT
             approx(expected_dzeta));
     }

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -149,7 +149,7 @@ void test_logical_partial_derivatives_2d(const Index<2>& extents) {
   const size_t b = extents[1] - 1;
   for (size_t n = 0; n < u.number_of_independent_components; ++n) {
     for (IndexIterator<2> ii(extents); ii; ++ii) {
-      u.data()[ii.offset() + n * number_of_grid_points] =  // NOLINT
+      u.data()[ii.collapsed_index() + n * number_of_grid_points] =  // NOLINT
           (n + 1) * pow(xi[ii()[0]], a) * pow(eta[ii()[1]], b);
     }
   }
@@ -166,9 +166,11 @@ void test_logical_partial_derivatives_2d(const Index<2>& extents) {
       const double expected_deta = (0 == b ? 0.0
                                            : b * (n + 1) * pow(xi[ii()[0]], a) *
                                                  pow(eta[ii()[1]], b - 1));
-      CHECK(du[0].data()[ii.offset() + n * number_of_grid_points] ==  // NOLINT
+      CHECK(du[0].data()[ii.collapsed_index() +
+                         n * number_of_grid_points] ==  // NOLINT
             approx(expected_dxi));
-      CHECK(du[1].data()[ii.offset() + n * number_of_grid_points] ==  // NOLINT
+      CHECK(du[1].data()[ii.collapsed_index() +
+                         n * number_of_grid_points] ==  // NOLINT
             approx(expected_deta));
     }
   }
@@ -186,7 +188,7 @@ void test_logical_partial_derivatives_3d(const Index<3>& extents) {
   const size_t c = extents[2] - 1;
   for (size_t n = 0; n < u.number_of_independent_components; ++n) {
     for (IndexIterator<3> ii(extents); ii; ++ii) {
-      u.data()[ii.offset() + n * number_of_grid_points] =  // NOLINT
+      u.data()[ii.collapsed_index() + n * number_of_grid_points] =  // NOLINT
           (n + 1) * pow(xi[ii()[0]], a) * pow(eta[ii()[1]], b) *
           pow(zeta[ii()[2]], c);
     }
@@ -209,11 +211,14 @@ void test_logical_partial_derivatives_3d(const Index<3>& extents) {
           (0 == c ? 0.0
                   : c * (n + 1) * pow(xi[ii()[0]], a) * pow(eta[ii()[1]], b) *
                         pow(zeta[ii()[2]], c - 1));
-      CHECK(du[0].data()[ii.offset() + n * number_of_grid_points] ==  // NOLINT
+      CHECK(du[0].data()[ii.collapsed_index() +
+                         n * number_of_grid_points] ==  // NOLINT
             approx(expected_dxi));
-      CHECK(du[1].data()[ii.offset() + n * number_of_grid_points] ==  // NOLINT
+      CHECK(du[1].data()[ii.collapsed_index() +
+                         n * number_of_grid_points] ==  // NOLINT
             approx(expected_deta));
-      CHECK(du[2].data()[ii.offset() + n * number_of_grid_points] ==  // NOLINT
+      CHECK(du[2].data()[ii.collapsed_index() +
+                         n * number_of_grid_points] ==  // NOLINT
             approx(expected_dzeta));
     }
   }


### PR DESCRIPTION
## Proposed changes

This PR is for adding a function that will generate the global corner numbering for any n-dim
domain of blocks that have (n,m,l) blocks in the (x,y,z) directions. A future PR will add a function that builds off of this to easily generate the corners for arbitrarily orientated blocks. Together this will eliminate the need to draw pictures/diagrams of the ordered graph to deduce the proper labeling of the corners.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
