### PR TITLE
Additions for RotatedBricks 2

### DIFF
--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -158,6 +158,19 @@ std::array<size_t, two_to_the(VolumeDim)> discrete_rotation(
         corners_of_aligned) noexcept;
 
 /// \ingroup ComputationalDomainGroup
+/// \brief The CoordinateMaps for a rectilinear domain of n-cubes.
+///
+/// Allows for both Affine and Equiangular maps.
+template <typename TargetFrame, size_t VolumeDim>
+std::vector<
+    std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
+maps_for_rectilinear_domains(
+    const Index<VolumeDim>& domain_extents,
+    const std::array<std::vector<double>, VolumeDim>& block_demarcations,
+    const std::vector<Index<VolumeDim>>& block_indices_to_exclude,
+    bool use_equiangular_map) noexcept;
+
+/// \ingroup ComputationalDomainGroup
 /// Iterates over the corners of a VolumeDim-dimensional cube.
 template <size_t VolumeDim>
 class VolumeCornerIterator {

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -586,9 +586,13 @@ void test_vci_1d() {
   CHECK(vci);
   CHECK(vci() == std::array<Side, 1>{{Side::Lower}});
   CHECK(vci.coords_of_corner() == std::array<double, 1>{{-1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}});
   ++vci;
   CHECK(vci() == std::array<Side, 1>{{Side::Upper}});
   CHECK(vci.coords_of_corner() == std::array<double, 1>{{1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<1>, 1>{{Direction<1>::upper_xi()}});
   ++vci;
   CHECK(not vci);
 
@@ -599,6 +603,13 @@ void test_vci_1d() {
   CHECK(vci2.global_corner_number() == 3);
   ++vci2;
   CHECK(not vci2);
+
+  // Check setup_from_local_corner_number
+  VolumeCornerIterator<1> vci3{1};
+  CHECK(vci3() == std::array<Side, 1>{{Side::Upper}});
+  CHECK(vci3.coords_of_corner() == std::array<double, 1>{{1.0}});
+  CHECK(vci3.directions_of_corner() ==
+        std::array<Direction<1>, 1>{{Direction<1>::upper_xi()}});
 }
 
 void test_vci_2d() {
@@ -606,15 +617,27 @@ void test_vci_2d() {
   CHECK(vci);
   CHECK(vci() == std::array<Side, 2>{{Side::Lower, Side::Lower}});
   CHECK(vci.coords_of_corner() == std::array<double, 2>{{-1.0, -1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<2>, 2>{
+            {Direction<2>::lower_xi(), Direction<2>::lower_eta()}});
   ++vci;
   CHECK(vci() == std::array<Side, 2>{{Side::Upper, Side::Lower}});
   CHECK(vci.coords_of_corner() == std::array<double, 2>{{1.0, -1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<2>, 2>{
+            {Direction<2>::upper_xi(), Direction<2>::lower_eta()}});
   ++vci;
   CHECK(vci() == std::array<Side, 2>{{Side::Lower, Side::Upper}});
   CHECK(vci.coords_of_corner() == std::array<double, 2>{{-1.0, 1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<2>, 2>{
+            {Direction<2>::lower_xi(), Direction<2>::upper_eta()}});
   ++vci;
   CHECK(vci() == std::array<Side, 2>{{Side::Upper, Side::Upper}});
   CHECK(vci.coords_of_corner() == std::array<double, 2>{{1.0, 1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<2>, 2>{
+            {Direction<2>::upper_xi(), Direction<2>::upper_eta()}});
   ++vci;
   CHECK(not vci);
 
@@ -629,6 +652,14 @@ void test_vci_2d() {
   CHECK(vci2.global_corner_number() == 11);
   ++vci2;
   CHECK(not vci2);
+
+  // Check setup_from_local_corner_number
+  VolumeCornerIterator<2> vci3{2};
+  CHECK(vci3() == std::array<Side, 2>{{Side::Lower, Side::Upper}});
+  CHECK(vci3.coords_of_corner() == std::array<double, 2>{{-1.0, 1.0}});
+  CHECK(vci3.directions_of_corner() ==
+        std::array<Direction<2>, 2>{
+            {Direction<2>::lower_xi(), Direction<2>::upper_eta()}});
 }
 
 void test_vci_3d() {
@@ -636,27 +667,59 @@ void test_vci_3d() {
   CHECK(vci);
   CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Lower, Side::Lower}});
   CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, -1.0, -1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<3>, 3>{{Direction<3>::lower_xi(),
+                                     Direction<3>::lower_eta(),
+                                     Direction<3>::lower_zeta()}});
   ++vci;
   CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Lower, Side::Lower}});
   CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, -1.0, -1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                     Direction<3>::lower_eta(),
+                                     Direction<3>::lower_zeta()}});
   ++vci;
   CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Upper, Side::Lower}});
   CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, 1.0, -1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<3>, 3>{{Direction<3>::lower_xi(),
+                                     Direction<3>::upper_eta(),
+                                     Direction<3>::lower_zeta()}});
   ++vci;
   CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Upper, Side::Lower}});
   CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, 1.0, -1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                     Direction<3>::upper_eta(),
+                                     Direction<3>::lower_zeta()}});
   ++vci;
   CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Lower, Side::Upper}});
   CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, -1.0, 1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<3>, 3>{{Direction<3>::lower_xi(),
+                                     Direction<3>::lower_eta(),
+                                     Direction<3>::upper_zeta()}});
   ++vci;
   CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Lower, Side::Upper}});
   CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, -1.0, 1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                     Direction<3>::lower_eta(),
+                                     Direction<3>::upper_zeta()}});
   ++vci;
   CHECK(vci() == std::array<Side, 3>{{Side::Lower, Side::Upper, Side::Upper}});
   CHECK(vci.coords_of_corner() == std::array<double, 3>{{-1.0, 1.0, 1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<3>, 3>{{Direction<3>::lower_xi(),
+                                     Direction<3>::upper_eta(),
+                                     Direction<3>::upper_zeta()}});
   ++vci;
   CHECK(vci() == std::array<Side, 3>{{Side::Upper, Side::Upper, Side::Upper}});
   CHECK(vci.coords_of_corner() == std::array<double, 3>{{1.0, 1.0, 1.0}});
+  CHECK(vci.directions_of_corner() ==
+        std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                     Direction<3>::upper_eta(),
+                                     Direction<3>::upper_zeta()}});
   ++vci;
   CHECK(not vci);
 
@@ -679,6 +742,15 @@ void test_vci_3d() {
   CHECK(vci2.global_corner_number() == 42);
   ++vci2;
   CHECK(not vci2);
+
+  // Check setup_from_local_corner_number
+  VolumeCornerIterator<3> vci3{5};
+  CHECK(vci3() == std::array<Side, 3>{{Side::Upper, Side::Lower, Side::Upper}});
+  CHECK(vci3.coords_of_corner() == std::array<double, 3>{{1.0, -1.0, 1.0}});
+  CHECK(vci3.directions_of_corner() ==
+        std::array<Direction<3>, 3>{{Direction<3>::upper_xi(),
+                                     Direction<3>::lower_eta(),
+                                     Direction<3>::upper_zeta()}});
 }
 }  // namespace
 
@@ -769,4 +841,51 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.CornersForRectilinearDomains",
   CHECK(corners_for_rectilinear_domains(
             Index<3>{3, 3, 3}, std::vector<Index<3>>{Index<3>{1, 1, 1}}) ==
         corners_for_a_rubiks_cube_with_hole);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.DiscreteRotation.CornerNumbers",
+                  "[Domain][Unit]") {
+  CHECK(std::array<size_t, 2>{{0, 1}} ==
+        discrete_rotation(OrientationMap<1>{std::array<Direction<1>, 1>{
+                              {Direction<1>::upper_xi()}}},
+                          std::array<size_t, 2>{{0, 1}}));
+  CHECK(std::array<size_t, 2>{{1, 0}} ==
+        discrete_rotation(OrientationMap<1>{std::array<Direction<1>, 1>{
+                              {Direction<1>::lower_xi()}}},
+                          std::array<size_t, 2>{{0, 1}}));
+
+  CHECK(std::array<size_t, 4>{{1, 4, 0, 3}} ==
+        discrete_rotation(
+            OrientationMap<2>(std::array<Direction<2>, 2>{
+                {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}),
+            std::array<size_t, 4>{{0, 1, 3, 4}}));
+  CHECK(std::array<size_t, 4>{{4, 0, 5, 1}} ==
+        discrete_rotation(
+            OrientationMap<2>(std::array<Direction<2>, 2>{
+                {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}),
+            std::array<size_t, 4>{{0, 1, 4, 5}}));
+  CHECK(std::array<size_t, 4>{{3, 1, 2, 0}} ==
+        discrete_rotation(
+            OrientationMap<2>(std::array<Direction<2>, 2>{
+                {Direction<2>::lower_eta(), Direction<2>::lower_xi()}}),
+            std::array<size_t, 4>{{0, 1, 2, 3}}));
+
+  CHECK(std::array<size_t, 8>{{9, 0, 12, 3, 10, 1, 13, 4}} ==
+        discrete_rotation(
+            OrientationMap<3>(std::array<Direction<3>, 3>{
+                {Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                 Direction<3>::upper_xi()}}),
+            std::array<size_t, 8>{{0, 1, 3, 4, 9, 10, 12, 13}}));
+  CHECK(std::array<size_t, 8>{{10, 13, 9, 12, 1, 4, 0, 3}} ==
+        discrete_rotation(
+            OrientationMap<3>(std::array<Direction<3>, 3>{
+                {Direction<3>::upper_eta(), Direction<3>::lower_xi(),
+                 Direction<3>::lower_zeta()}}),
+            std::array<size_t, 8>{{0, 1, 3, 4, 9, 10, 12, 13}}));
+  CHECK(std::array<size_t, 8>{{12, 3, 13, 4, 9, 0, 10, 1}} ==
+        discrete_rotation(
+            OrientationMap<3>(std::array<Direction<3>, 3>{
+                {Direction<3>::lower_zeta(), Direction<3>::upper_xi(),
+                 Direction<3>::lower_eta()}}),
+            std::array<size_t, 8>{{0, 1, 3, 4, 9, 10, 12, 13}}));
 }

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -15,6 +15,7 @@
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
@@ -888,4 +889,127 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.DiscreteRotation.CornerNumbers",
                 {Direction<3>::lower_zeta(), Direction<3>::upper_xi(),
                  Direction<3>::lower_eta()}}),
             std::array<size_t, 8>{{0, 1, 3, 4, 9, 10, 12, 13}}));
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.MapsForRectilinearDomains",
+                  "[Domain][Unit]") {
+  using Affine = CoordinateMaps::Affine;
+  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Equiangular = CoordinateMaps::Equiangular;
+  using Equiangular2D =
+      CoordinateMaps::ProductOf2Maps<Equiangular, Equiangular>;
+  using Equiangular3D =
+      CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
+
+  const std::vector<
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>
+      affine_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
+          Index<1>{3},
+          std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.7, 2.0}}},
+          {Index<1>{0}}, false);
+  const auto expected_affine_maps_1d =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Affine{-1., 1., 0.5, 1.7}, Affine{-1., 1., 1.7, 2.0});
+  for (size_t i = 0; i < affine_maps_1d.size(); i++) {
+    CHECK(*affine_maps_1d[i] == *expected_affine_maps_1d[i]);
+  }
+
+  const std::vector<
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 1>>>
+      equiangular_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
+          Index<1>{3},
+          std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.7, 2.0}}},
+          {Index<1>{1}}, true);
+  const auto expected_equiangular_maps_1d =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Equiangular{-1., 1., 0.0, 0.5}, Equiangular{-1., 1., 1.7, 2.0});
+  for (size_t i = 0; i < equiangular_maps_1d.size(); i++) {
+    CHECK(*equiangular_maps_1d[i] == *expected_equiangular_maps_1d[i]);
+  }
+
+  const std::vector<
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 2>>>
+      affine_maps_2d = maps_for_rectilinear_domains<Frame::Inertial>(
+          Index<2>{3, 2},
+          std::array<std::vector<double>, 2>{
+              {{0.0, 0.5, 1.7, 2.0}, {0.0, 1.0, 2.0}}},
+          {Index<2>{}}, false);
+  const auto expected_affine_maps_2d =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Affine2D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 0.0, 1.0}},
+          Affine2D{Affine{-1., 1., 0.5, 1.7}, Affine{-1., 1., 0.0, 1.0}},
+          Affine2D{Affine{-1., 1., 1.7, 2.0}, Affine{-1., 1., 0.0, 1.0}},
+          Affine2D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 1.0, 2.0}},
+          Affine2D{Affine{-1., 1., 0.5, 1.7}, Affine{-1., 1., 1.0, 2.0}},
+          Affine2D{Affine{-1., 1., 1.7, 2.0}, Affine{-1., 1., 1.0, 2.0}});
+  for (size_t i = 0; i < affine_maps_2d.size(); i++) {
+    CHECK(*affine_maps_2d[i] == *expected_affine_maps_2d[i]);
+  }
+
+  const std::vector<
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 2>>>
+      equiangular_maps_2d = maps_for_rectilinear_domains<Frame::Inertial>(
+          Index<2>{3, 2},
+          std::array<std::vector<double>, 2>{
+              {{0.0, 0.5, 1.7, 2.0}, {0.0, 1.0, 2.0}}},
+          {Index<2>{2, 1}}, true);
+  const auto expected_equiangular_maps_2d =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Equiangular2D{Equiangular{-1., 1., 0.0, 0.5},
+                        Equiangular{-1., 1., 0.0, 1.0}},
+          Equiangular2D{Equiangular{-1., 1., 0.5, 1.7},
+                        Equiangular{-1., 1., 0.0, 1.0}},
+          Equiangular2D{Equiangular{-1., 1., 1.7, 2.0},
+                        Equiangular{-1., 1., 0.0, 1.0}},
+          Equiangular2D{Equiangular{-1., 1., 0.0, 0.5},
+                        Equiangular{-1., 1., 1.0, 2.0}},
+          Equiangular2D{Equiangular{-1., 1., 0.5, 1.7},
+                        Equiangular{-1., 1., 1.0, 2.0}});
+  for (size_t i = 0; i < equiangular_maps_2d.size(); i++) {
+    CHECK(*equiangular_maps_2d[i] == *expected_equiangular_maps_2d[i]);
+  }
+
+  const std::vector<
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+      affine_maps_3d = maps_for_rectilinear_domains<Frame::Inertial>(
+          Index<3>{2, 2, 1},
+          std::array<std::vector<double>, 3>{
+              {{0.0, 0.5, 2.0}, {0.0, 1.0, 2.0}, {-0.4, 0.3}}},
+          {Index<3>{}}, false);
+  const auto expected_affine_maps_3d =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Affine3D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 0.0, 1.0},
+                   Affine{-1., 1., -0.4, 0.3}},
+          Affine3D{Affine{-1., 1., 0.5, 2.0}, Affine{-1., 1., 0.0, 1.0},
+                   Affine{-1., 1., -0.4, 0.3}},
+          Affine3D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 1.0, 2.0},
+                   Affine{-1., 1., -0.4, 0.3}},
+          Affine3D{Affine{-1., 1., 0.5, 2.0}, Affine{-1., 1., 1.0, 2.0},
+                   Affine{-1., 1., -0.4, 0.3}});
+  for (size_t i = 0; i < affine_maps_3d.size(); i++) {
+    CHECK(*affine_maps_3d[i] == *expected_affine_maps_3d[i]);
+  }
+
+  const std::vector<
+      std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+      equiangular_maps_3d = maps_for_rectilinear_domains<Frame::Inertial>(
+          Index<3>{2, 2, 1},
+          std::array<std::vector<double>, 3>{
+              {{0.0, 0.5, 2.0}, {0.0, 1.0, 2.0}, {-0.4, 0.3}}},
+          {Index<3>{0, 0, 0}}, true);
+  const auto expected_equiangular_maps_3d =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Equiangular3D{Equiangular{-1., 1., 0.5, 2.0},
+                        Equiangular{-1., 1., 0.0, 1.0},
+                        Equiangular{-1., 1., -0.4, 0.3}},
+          Equiangular3D{Equiangular{-1., 1., 0.0, 0.5},
+                        Equiangular{-1., 1., 1.0, 2.0},
+                        Equiangular{-1., 1., -0.4, 0.3}},
+          Equiangular3D{Equiangular{-1., 1., 0.5, 2.0},
+                        Equiangular{-1., 1., 1.0, 2.0},
+                        Equiangular{-1., 1., -0.4, 0.3}});
+  for (size_t i = 0; i < equiangular_maps_3d.size(); i++) {
+    CHECK(*equiangular_maps_3d[i] == *expected_equiangular_maps_3d[i]);
+  }
 }


### PR DESCRIPTION
## Proposed changes

Additions for RotatedBricks 1 gave the user the ability to produce the proper global corner numbering
for any n x m x l sized edifice of Blocks.

Additions for RotatedBricks 2 gives the user the ability to produce the corresponding CoordinateMaps for these Blocks.

Allows for the rotation of blocks "in place" within the context of domain creation:
Given a (n,m,l) edifice of aligned blocks, a user can select one or more blocks and change their orientation relative to the edifice - the corners algorithm will then deduce the correct relative orientations between all of these blocks and their neighbors.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
