### PR TITLE
Add DataVector dot product

### DIFF
--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -56,13 +56,14 @@ using std::abs;  // NOLINT
  * \ingroup DataStructuresGroup
  * \brief A class for storing data on a mesh.
  *
- * A Data holds an array of contiguous data and can be either owning (the array
- * is deleted when the Data goes out of scope) or non-owning, meaning it just
- * has a pointer to an array.
+ * A `DataVector` holds an array of contiguous data and can be either owning
+ * (the array is deleted when the `DataVector` goes out of scope) or non-owning,
+ * meaning it just has a pointer to an array.
  *
- * A variety of mathematical operations are supported with DataVectors. In
- * addition to the addition, subtraction, multiplication, division, etc. there
- * are the following element-wise operations:
+ * A variety of mathematical operations are supported with `DataVector`s. In
+ * addition to element-wise addition, subtraction, multiplication and division
+ * `DataVector`s support multiplication and division with `double`s and the
+ * following element-wise operations:
  *
  * - abs
  * - acos
@@ -95,6 +96,9 @@ using std::abs;  // NOLINT
  * - step_function: if less than zero returns zero, otherwise returns one
  * - tan
  * - tanh
+ *
+ * `DataVector`s also support a `dot_product` as well as a `magnitude`, which is
+ * the square root of the dot product with itself.
  */
 class DataVector {
   /// \cond HIDDEN_SYMBOLS
@@ -527,6 +531,32 @@ class DataVector {
       const DataVector& t) noexcept {
     return erfc(t.data_);
   }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) dot_product(
+      const DataVector& lhs, const DataVector& rhs) {
+    return dot(lhs.data_, rhs.data_);
+  }
+
+  template <typename VT, bool VF>
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) dot_product(
+      const blaze::Vector<VT, VF>& lhs, const DataVector& rhs) {
+    return dot(lhs, rhs.data_);
+  }
+
+  template <typename VT, bool VF>
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) dot_product(
+      const DataVector& lhs, const blaze::Vector<VT, VF>& rhs) {
+    return dot(lhs.data_, rhs);
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) magnitude_square(
+      const DataVector& t) {
+    return sqrLength(t.data_);
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) magnitude(const DataVector& t) {
+    return length(t.data_);
+  }
   // @}
 
   /// If less than zero returns zero, otherwise returns one
@@ -646,6 +676,24 @@ DataVector& DataVector::operator=(const blaze::Vector<VT, VF>& expression) {
   }
   data_ = expression;
   return *this;
+}
+
+template <typename VT, bool VF>
+SPECTRE_ALWAYS_INLINE decltype(auto) dot_product(
+    const blaze::Vector<VT, VF>& lhs, const blaze::Vector<VT, VF>& rhs) {
+  return dot(lhs, rhs);
+}
+
+template <typename VT, bool VF>
+SPECTRE_ALWAYS_INLINE decltype(auto) magnitude_square(
+    const blaze::DenseVector<VT, VF>& expression) {
+  return sqrLength(expression);
+}
+
+template <typename VT, bool VF>
+SPECTRE_ALWAYS_INLINE decltype(auto) magnitude(
+    const blaze::DenseVector<VT, VF>& expression) {
+  return length(expression);
 }
 /// \endcond
 

--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
@@ -44,7 +44,7 @@ double definite_integral<1>(const DataVector& integrand,
   ASSERT(num_points == extents.product(),
          "num_points = " << num_points << ", product = " << extents.product());
   const DataVector& weights = Basis::lgl::quadrature_weights(num_points);
-  return ddot_(num_points, weights.data(), 1, integrand.data(), 1);
+  return dot_product(weights, integrand);
 }
 
 /// \cond

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -6,8 +6,8 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <numeric>
-#include <stddef.h>
 
 #include "DataStructures/DataVector.hpp"
 #include "ErrorHandling/Error.hpp"
@@ -474,7 +474,40 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   dvectors1 -= dvectors2;
   CHECK_ITERABLE_APPROX(dvectors1, expected4);
 
-  // Test calculation of magnitude of DataVector
+  // Test dot product between DataVectors
+  CHECK_ITERABLE_APPROX(dot_product(t1, t2), -2.0);
+  CHECK_ITERABLE_APPROX(dot_product(t2, t1), -2.0);
+  CHECK_ITERABLE_APPROX(dot_product(t1, t3), 16.0);
+  CHECK_ITERABLE_APPROX(dot_product(t3, t1), 16.0);
+  CHECK_ITERABLE_APPROX(dot_product(t2, t3), -3.0);
+  CHECK_ITERABLE_APPROX(dot_product(t3, t2), -3.0);
+
+  // Test dot product between DataVectors and expressions
+  CHECK_ITERABLE_APPROX(dot_product(t1 * t2, t3), -5.0);
+  CHECK_ITERABLE_APPROX(dot_product(t1, t2 * t3), -5.0);
+  CHECK_ITERABLE_APPROX(dot_product(t1 + t2, t3), 13.0);
+  CHECK_ITERABLE_APPROX(dot_product(t1, t2 + t3), 14.0);
+  CHECK_ITERABLE_APPROX(dot_product(2.0 * t1, t3), 32.0);
+  CHECK_ITERABLE_APPROX(dot_product(t1, 2.0 * t3), 32.0);
+  CHECK_ITERABLE_APPROX(dot_product(t1 + t2, t1 + t3), 25.0);
+
+  // Test magnitude of DataVectors
+  CHECK_ITERABLE_APPROX(magnitude_square(t1), 14.0);
+  CHECK_ITERABLE_APPROX(magnitude(t1), sqrt(14.0));
+  CHECK_ITERABLE_APPROX(magnitude_square(t2), 0.3);
+  CHECK_ITERABLE_APPROX(magnitude(t2), sqrt(0.3));
+  CHECK_ITERABLE_APPROX(magnitude_square(t3), 54.0);
+  CHECK_ITERABLE_APPROX(magnitude(t3), sqrt(54.0));
+
+  // Test magnitude of expressions
+  CHECK_ITERABLE_APPROX(magnitude_square(t1 + t2), 10.3);
+  CHECK_ITERABLE_APPROX(magnitude(t1 + t2), sqrt(10.3));
+  CHECK_ITERABLE_APPROX(magnitude_square(t1 * t3), 88.0);
+  CHECK_ITERABLE_APPROX(magnitude(t1 * t3), sqrt(88.0));
+  CHECK_ITERABLE_APPROX(magnitude_square(2.0 * t1), 56.0);
+  CHECK_ITERABLE_APPROX(magnitude(2.0 * t1), sqrt(56.0));
+
+  // Test magnitude of arrays of DataVectors
   const std::array<DataVector, 1> d1{{DataVector{-2.5, 3.4}}};
   const DataVector expected_d1{2.5, 3.4};
   const auto magnitude_d1 = magnitude(d1);


### PR DESCRIPTION
## Proposed changes

This PR adds a `dot_product` overload that takes two `DataVector`s and computes their Euclidean inner product. This is to begin wrapping BLAS calls (in this case `ddot_`) with functions that abstract away knowledge of the memory layout that should be private to `DataVector`. The wrapper just forwards to the [Blaze](https://bitbucket.org/blaze-lib/blaze) implementation of `dot`.

The wrapper is used in `DefiniteIntegral.cpp` to give an example of how it simplifies the code. Further work to wrap `Matrix` algebra is being discussed in #666.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->