### PR TITLE
Make normals for Newtonian Euler covariant

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.cpp
@@ -18,7 +18,7 @@ template <size_t Dim>
 std::array<DataVector, Dim + 2> characteristic_speeds(
     const tnsr::I<DataVector, Dim>& velocity,
     const Scalar<DataVector>& sound_speed_squared,
-    const tnsr::I<DataVector, Dim>& normal) noexcept {
+    const tnsr::i<DataVector, Dim>& normal) noexcept {
   const DataVector sound_speed = sqrt(get(sound_speed_squared));
 
   auto characteristic_speeds =
@@ -38,7 +38,7 @@ std::array<DataVector, Dim + 2> characteristic_speeds(
   NewtonianEuler::characteristic_speeds(              \
       const tnsr::I<DataVector, DIM(data)>& velocity, \
       const Scalar<DataVector>& sound_speed_squared,  \
-      const tnsr::I<DataVector, DIM(data)>& normal) noexcept;
+      const tnsr::i<DataVector, DIM(data)>& normal) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
@@ -36,6 +36,6 @@ template <size_t Dim>
 std::array<DataVector, Dim + 2> characteristic_speeds(
     const tnsr::I<DataVector, Dim>& velocity,
     const Scalar<DataVector>& sound_speed_squared,
-    const tnsr::I<DataVector, Dim>& normal) noexcept;
+    const tnsr::i<DataVector, Dim>& normal) noexcept;
 
 }  // namespace NewtonianEuler

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -398,11 +398,11 @@ void test_initial_domain(const Domain<VolumeDim, Frame::Inertial>& domain,
 }
 
 template <size_t SpatialDim, typename SpatialFrame>
-tnsr::I<DataVector, SpatialDim, SpatialFrame> euclidean_basis_vector(
+tnsr::i<DataVector, SpatialDim, SpatialFrame> euclidean_basis_vector(
     const Direction<SpatialDim>& direction,
     const DataVector& used_for_size) noexcept {
   auto basis_vector =
-      make_with_value<tnsr::I<DataVector, SpatialDim, SpatialFrame>>(
+      make_with_value<tnsr::i<DataVector, SpatialDim, SpatialFrame>>(
           used_for_size, 0.0);
 
   basis_vector.get(direction.axis()) =
@@ -436,7 +436,7 @@ tnsr::I<DataVector, SpatialDim, SpatialFrame> euclidean_basis_vector(
 #define INSTANTIATE2(_, data)                                                  \
   template void test_physical_separation(                                      \
       const std::vector<Block<DIM(data), FRAME(data)>>& blocks) noexcept;      \
-  template tnsr::I<DataVector, DIM(data), FRAME(data)> euclidean_basis_vector( \
+  template tnsr::i<DataVector, DIM(data), FRAME(data)> euclidean_basis_vector( \
       const Direction<DIM(data)>& direction,                                   \
       const DataVector& used_for_size) noexcept;
 

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -100,6 +100,6 @@ void test_initial_domain(const Domain<VolumeDim, Frame::Inertial>& domain,
 
 // Euclidean basis vector along the given `Direction` and in the given `Frame`.
 template <size_t SpatialDim, typename SpatialFrame = Frame::Inertial>
-tnsr::I<DataVector, SpatialDim, SpatialFrame> euclidean_basis_vector(
+tnsr::i<DataVector, SpatialDim, SpatialFrame> euclidean_basis_vector(
     const Direction<SpatialDim>& direction,
     const DataVector& used_for_size) noexcept;

--- a/tests/Unit/Domain/Test_DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainTestHelpers.cpp
@@ -90,7 +90,7 @@ template <size_t SpatialDim, typename SpatialFrame>
 void test_euclidean_basis_vectors(const DataVector& used_for_size) noexcept {
   for (const auto& direction : Direction<SpatialDim>::all_directions()) {
     auto expected =
-        make_with_value<tnsr::I<DataVector, SpatialDim, SpatialFrame>>(
+        make_with_value<tnsr::i<DataVector, SpatialDim, SpatialFrame>>(
             used_for_size, 0.0);
     expected.get(direction.axis()) =
         make_with_value<DataVector>(used_for_size, direction.sign());

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
@@ -34,3 +34,16 @@ def energy_density_flux(momentum_density, energy_density, velocity, pressure):
 
 
 # End functions for testing Fluxes.cpp
+
+
+# Functions for testing PrimitiveFromConservative.cpp
+def velocity(mass_density, momentum_density, energy_density = None):
+    return (momentum_density / mass_density)
+
+
+def specific_internal_energy(mass_density, momentum_density, energy_density):
+    veloc = velocity(mass_density, momentum_density, energy_density)
+    return (energy_density / mass_density - 0.5 * np.dot(veloc, veloc))
+
+
+# End functions for testing PrimitiveFromConservative.cpp

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
@@ -5,85 +5,30 @@
 
 #include <cstddef>
 #include <limits>
-#include <random>
 
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"  // delete when py
-#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/NewtonianEuler/PrimitiveFromConservative.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeWithValue.hpp"
-#include "tests/Utilities/MakeWithRandomValues.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
 namespace {
 
 template <size_t Dim, typename DataType>
-tnsr::I<DataType, Dim> expected_velocity(
-    const Scalar<DataType>& mass_density,
-    const tnsr::I<DataType, Dim>& momentum_density) noexcept {
-  auto result = make_with_value<tnsr::I<DataType, Dim>>(mass_density, 0.0);
-  const DataType one_over_mass_density = 1.0 / get(mass_density);
-  for (size_t i = 0; i < Dim; ++i) {
-    result.get(i) = momentum_density.get(i) * one_over_mass_density;
-  }
-  return result;
+void test_velocity(const DataType& used_for_size) {
+  pypp::check_with_random_values<2>(
+      static_cast<tnsr::I<DataType, Dim> (*)(const Scalar<DataType>&,
+                                             const tnsr::I<DataType, Dim>&)>(
+          &NewtonianEuler::velocity<Dim, DataType>),
+      "TestFunctions", "velocity", {{{-1.0, 1.0}, {-2.0, 2.0}}}, used_for_size);
 }
 
 template <size_t Dim, typename DataType>
-Scalar<DataType> expected_specific_internal_energy(
-    const Scalar<DataType>& mass_density,
-    const tnsr::I<DataType, Dim>& momentum_density,
-    const Scalar<DataType>& energy_density) noexcept {
-  const auto velocity =
-      NewtonianEuler::velocity(mass_density, momentum_density);
-  return Scalar<DataType>{-0.5 * get(dot_product(velocity, velocity)) +
-                          get(energy_density) / get(mass_density)};
-}
-
-template <size_t Dim, typename DataType>
-void test_velocity(
-    const gsl::not_null<std::mt19937*> generator,
-    const gsl::not_null<std::uniform_real_distribution<>*> distribution,
-    const DataType& used_for_size) noexcept {
-  const auto mass_density = make_with_random_values<Scalar<DataType>>(
-      generator, distribution, used_for_size);
-  const auto momentum_density = make_with_random_values<tnsr::I<DataType, Dim>>(
-      generator, distribution, used_for_size);
-
-  const auto velocity =
-      NewtonianEuler::velocity(mass_density, momentum_density);
-  const auto exp_velocity = expected_velocity(mass_density, momentum_density);
-  for (size_t i = 0; i < Dim; ++i) {
-    CHECK_ITERABLE_APPROX(exp_velocity.get(i), velocity.get(i));
-  }
-}
-
-template <size_t Dim, typename DataType>
-void test_primitive_from_conservative(
-    const gsl::not_null<std::mt19937*> generator,
-    const gsl::not_null<std::uniform_real_distribution<>*> distribution,
-    const DataType& used_for_size) noexcept {
-  const auto mass_density = make_with_random_values<Scalar<DataType>>(
-      generator, distribution, used_for_size);
-  const auto momentum_density = make_with_random_values<tnsr::I<DataType, Dim>>(
-      generator, distribution, used_for_size);
-  const auto energy_density = make_with_random_values<Scalar<DataType>>(
-      generator, distribution, used_for_size);
-
-  auto velocity = make_with_value<tnsr::I<DataType, Dim>>(used_for_size, 0.0);
-  auto specific_internal_energy =
-      make_with_value<Scalar<DataType>>(used_for_size, 0.0);
-  NewtonianEuler::primitive_from_conservative(
-      make_not_null(&velocity), make_not_null(&specific_internal_energy),
-      mass_density, momentum_density, energy_density);
-
-  const auto exp_velocity = expected_velocity(mass_density, momentum_density);
-  for (size_t i = 0; i < Dim; ++i) {
-    CHECK_ITERABLE_APPROX(exp_velocity.get(i), velocity.get(i));
-  }
-  CHECK_ITERABLE_APPROX(expected_specific_internal_energy(
-                            mass_density, momentum_density, energy_density),
-                        specific_internal_energy);
+void test_primitive_from_conservative(const DataType& used_for_size) {
+  pypp::check_with_random_values<3>(
+      &NewtonianEuler::primitive_from_conservative<Dim, DataType>,
+      "TestFunctions", {"velocity", "specific_internal_energy"},
+      {{{-1.0, 1.0}, {-2.0, 2.0}, {-3.0, 3.0}}}, used_for_size);
 }
 
 }  // namespace
@@ -91,28 +36,22 @@ void test_primitive_from_conservative(
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.NewtonianEuler.PrimitiveFromConservative",
     "[Unit][Evolution]") {
-  std::random_device r;
-  const auto seed = r();
-  std::mt19937 generator(seed);
-  INFO("seed = " << seed);
-  std::uniform_real_distribution<> distribution(0.0, 1.0);
-
-  const auto nn_generator = make_not_null(&generator);
-  const auto nn_distribution = make_not_null(&distribution);
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/NewtonianEuler"};
 
   const double d = std::numeric_limits<double>::signaling_NaN();
-  test_velocity<1>(nn_generator, nn_distribution, d);
-  test_velocity<2>(nn_generator, nn_distribution, d);
-  test_velocity<3>(nn_generator, nn_distribution, d);
-  test_primitive_from_conservative<1>(nn_generator, nn_distribution, d);
-  test_primitive_from_conservative<2>(nn_generator, nn_distribution, d);
-  test_primitive_from_conservative<3>(nn_generator, nn_distribution, d);
+  test_velocity<1>(d);
+  test_velocity<2>(d);
+  test_velocity<3>(d);
+  test_primitive_from_conservative<1>(d);
+  test_primitive_from_conservative<2>(d);
+  test_primitive_from_conservative<3>(d);
 
   const DataVector dv(5);
-  test_velocity<1>(nn_generator, nn_distribution, dv);
-  test_velocity<2>(nn_generator, nn_distribution, dv);
-  test_velocity<3>(nn_generator, nn_distribution, dv);
-  test_primitive_from_conservative<1>(nn_generator, nn_distribution, dv);
-  test_primitive_from_conservative<2>(nn_generator, nn_distribution, dv);
-  test_primitive_from_conservative<3>(nn_generator, nn_distribution, dv);
+  test_velocity<1>(dv);
+  test_velocity<2>(dv);
+  test_velocity<3>(dv);
+  test_primitive_from_conservative<1>(dv);
+  test_primitive_from_conservative<2>(dv);
+  test_primitive_from_conservative<3>(dv);
 }


### PR DESCRIPTION
## Proposed changes

- Make normals in the characteristics covariant.
- Replace tests for the primitives by python functions.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
