### PR TITLE
Add functions computing lapse, shift, 3metric from 4metric.

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -35,6 +35,15 @@ tnsr::aa<DataType, SpatialDim, Frame> spacetime_metric(
 
 /*!
  * \ingroup GeneralRelativityGroup
+ * \brief Compute spatial metric from spacetime metric.
+ * \details Simply pull out the spatial components.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> spatial_metric(
+    const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
  * \brief Compute inverse spacetime metric from inverse spatial metric, lapse
  * and shift
  *
@@ -53,6 +62,41 @@ tnsr::AA<DataType, SpatialDim, Frame> inverse_spacetime_metric(
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::II<DataType, SpatialDim, Frame>&
         inverse_spatial_metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute shift from spacetime metric and inverse spatial metric.
+ *
+ * \details Computes
+ * \f{align}
+ *    N^i &= g^{ij} \psi_{jt}
+ * \f}
+ * where \f$ N^i\f$, \f$ g^{ij}\f$, and \f$\psi_{ab}\f$ are the shift, inverse
+ * spatial metric, and spacetime metric.
+ * This can be derived, e.g., from Eqs. 2.121--2.122 of Baumgarte & Shapiro.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::I<DataType, SpatialDim, Frame> shift(
+    const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric,
+    const tnsr::II<DataType, SpatialDim, Frame>&
+        inverse_spatial_metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute lapse from shift and spacetime metric
+ *
+ * \details Computes
+ * \f{align}
+ *    N &= \sqrt{N^i \psi_{it}-\psi_{tt}}
+ * \f}
+ * where \f$ N \f$, \f$ N^i\f$, and \f$\psi_{ab}\f$ are the lapse, shift,
+ * and spacetime metric.
+ * This can be derived, e.g., from Eqs. 2.121--2.122 of Baumgarte & Shapiro.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+Scalar<DataType> lapse(
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric) noexcept;
 
 /*!
  * \ingroup GeneralRelativityGroup


### PR DESCRIPTION
## Proposed changes

Given spacetime metric, add functions that compute lapse, shift, and spatial_metric.

This will be used for horizon finding and for generalized harmonic evolution.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
