### PR TITLE
Add wrapper for lapack generalized eigenvalue dggev

### DIFF
--- a/cmake/SpectreParseTests.py
+++ b/cmake/SpectreParseTests.py
@@ -19,6 +19,7 @@ allowed_tags = [
                 "GeneralizedHarmonic",
                 "H5",
                 "IO",
+                "LinearAlgebra",
                 "LinearOperators",
                 "NumericalAlgorithms",
                 "Options",

--- a/src/NumericalAlgorithms/CMakeLists.txt
+++ b/src/NumericalAlgorithms/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(LinearAlgebra)
 add_subdirectory(LinearOperators)
 add_subdirectory(RootFinding)
 add_subdirectory(Spectral)

--- a/src/NumericalAlgorithms/LinearAlgebra/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearAlgebra/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY LinearAlgebra)
+
+set(LIBRARY_SOURCES
+  FindGeneralizedEigenvalues.cpp
+  )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  )

--- a/src/NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.cpp
+++ b/src/NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.cpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.hpp"
+
+#include <cstddef>
+#include <ostream>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+
+// LAPACK routine to do the generalized eigenvalue problem
+extern "C" {
+extern void dggev_(char*, char*, int*, double*, int*, double*, int*, double*,
+                   double*, double*, double*, int*, double*, int*, double*,
+                   int*, int*);
+}
+
+void find_generalized_eigenvalues(
+    const gsl::not_null<DataVector*> eigenvalues_real_part,
+    const gsl::not_null<DataVector*> eigenvalues_imaginary_part,
+    const gsl::not_null<Matrix*> eigenvectors, Matrix matrix_a,
+    Matrix matrix_b) noexcept {
+  // Sanity checks on the sizes of the vectors and matrices
+  const size_t number_of_rows = matrix_a.rows();
+  ASSERT(number_of_rows == matrix_a.columns(),
+         "Matrix A should be square, but A has "
+             << matrix_a.rows() << " rows and " << matrix_a.columns()
+             << " columns.");
+  ASSERT(number_of_rows == matrix_b.rows() and
+             number_of_rows == matrix_b.columns(),
+         "Matrix A and matrix B should be the same size, but A has "
+             << matrix_a.rows() << " rows and " << matrix_a.columns()
+             << " columns, while B has " << matrix_b.rows() << " rows and "
+             << matrix_b.columns() << " columns.");
+  ASSERT(number_of_rows == eigenvectors->rows() and
+             number_of_rows == eigenvectors->columns(),
+         "Matrix A and matrix eigenvectors should have the same size, "
+             "but A has " << matrix_a.rows() << " rows and "
+             << matrix_a.columns() << " columns, while the eigenvectors matrix "
+             << "has " << eigenvectors->rows() << " rows and "
+             << eigenvectors->columns() << " columns.");
+  ASSERT(number_of_rows == eigenvalues_real_part->size() and
+             number_of_rows == eigenvalues_imaginary_part->size(),
+         "eigenvalues DataVector sizes should equal number of columns "
+         "in Matrix A, but A has "
+             << matrix_a.columns()
+             << " columns, while the real eigenvalues DataVector size is "
+             << eigenvalues_real_part->size()
+             << " and the imaginary eigenvalues DataVector size is "
+             << eigenvalues_imaginary_part->size() << ".");
+
+  // Set up parameters for the lapack call
+  // Lapack uses chars to decide whether to compute the left eigenvectors,
+  // the right eigenvectors, both, or neither. 'N' means do not compute,
+  // 'V' means do compute. Note: not const because lapack does not want this
+  // option const.
+  char compute_left_eigenvectors = 'N';
+  char compute_right_eigenvectors = 'V';
+
+  // Lapack expects the sizes to be ints, not size_t.
+  // NOTE: not const because lapack function dggev_() arguments
+  // are not const.
+  auto matrix_and_vector_size = static_cast<int>(number_of_rows);
+
+  // Lapack splits the eigenvalues into unnormalized real and imaginary
+  // parts, which it calls alphar and alphai, and a normalization,
+  // which it calls beta. The real and imaginary parts of the eigenvalues are
+  // found by dividing the unnormalized results by the normalization.
+  DataVector eigenvalue_normalization(number_of_rows, 0.0);
+
+  // Lapack uses a work vector, that should have a size 8N
+  // for doing eigenvalue problems with NxN matrices
+  // Note: a non-const int, not size_t, because lapack wants a non-const int
+  int work_size = number_of_rows * 8;
+  std::vector<double> lapack_work(static_cast<size_t>(work_size), 0.0);
+
+  //  Lapack uses an integer called info to return its status
+  //  info = 0 : success
+  //  info = -i: ith argument had bad value
+  //  info > 0: some other failure
+  int info = 0;
+
+  dggev_(&compute_left_eigenvectors, &compute_right_eigenvectors,
+         &matrix_and_vector_size, matrix_a.data(), &matrix_and_vector_size,
+         matrix_b.data(), &matrix_and_vector_size,
+         eigenvalues_real_part->data(), eigenvalues_imaginary_part->data(),
+         eigenvalue_normalization.data(), eigenvectors->data(),
+         &matrix_and_vector_size, eigenvectors->data(), &matrix_and_vector_size,
+         lapack_work.data(), &work_size, &info);
+
+  if (UNLIKELY(info != 0)) {
+    ERROR(
+        "Lapack failed to compute generalized eigenvectors. Lapack's dggev "
+        "INFO = "
+        << info);
+  }
+
+  *eigenvalues_real_part /= eigenvalue_normalization;
+  *eigenvalues_imaginary_part /= eigenvalue_normalization;
+}

--- a/src/NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.hpp
+++ b/src/NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.hpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines function find_generalized_eigenvalues.
+
+#pragma once
+
+/// \cond
+class DataVector;
+class Matrix;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Solve the generalized eigenvalue problem for two matrices.
+ *
+ * This function uses the lapack routine dggev
+ * (http://www.netlib.org/lapack/explore-3.1.1-html/dggev.f.html)
+ * to solve the
+ * generalized eigenvalue problem \f$A v_a =\lambda_a B v_a \f$
+ * for the generalized eigenvalues \f$\lambda_a\f$ and corresponding
+ * eigenvectors \f$v_a\f$.
+ * `matrix_a` and `matrix_b` are each a `Matrix`; they correspond to square
+ * matrices \f$A\f$ and \f$B\f$ that are the same dimension \f$N\f$.
+ * `eigenvalues_real_part` is a `DataVector` of size \f$N\f$ that
+ * will store the real parts of the eigenvalues,
+ * `eigenvalues_imaginary_part` is a `DataVector` of size \f$N\f$
+ * that will store the imaginary parts of the eigenvalues.
+ * Complex eigenvalues always form complex conjugate pairs, and
+ * the \f$j\f$ and \f$j+1\f$ eigenvalues will have the forms
+ * \f$a+ib\f$ and \f$a-ib\f$, respectively. The eigenvectors
+ * are returned as the columns of a square `Matrix` of dimension \f$N\f$
+ * called `eigenvectors`. If eigenvalue \f$j\f$ is real, then column \f$j\f$ of
+ * `eigenvectors` is
+ * the corresponding eigenvector. If eigenvalue \f$j\f$ and \f$j+1\f$ are
+ * complex-conjugate pairs, then the eigenvector for
+ * eigenvalue \f$j\f$ is (column j) + \f$i\f$ (column j+1), and the
+ * eigenvector for eigenvalue \f$j+1\f$ is (column j) - \f$i\f$ (column j+1).
+ *
+ */
+void find_generalized_eigenvalues(
+    gsl::not_null<DataVector*> eigenvalues_real_part,
+    gsl::not_null<DataVector*> eigenvalues_imaginary_part,
+    gsl::not_null<Matrix*> eigenvectors, Matrix matrix_a,
+    Matrix matrix_b) noexcept;

--- a/tests/Unit/NumericalAlgorithms/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_subdirectory(DiscontinuousGalerkin)
 add_subdirectory(Interpolation)
+add_subdirectory(LinearAlgebra)
 add_subdirectory(LinearOperators)
 add_subdirectory(RootFinding)
 add_subdirectory(Spectral)

--- a/tests/Unit/NumericalAlgorithms/LinearAlgebra/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearAlgebra/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_LinearAlgebra")
+
+set(LIBRARY_SOURCES
+  Test_FindGeneralizedEigenvalues.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "NumericalAlgorithms/LinearAlgebra/"
+  "${LIBRARY_SOURCES}"
+  "LinearAlgebra"
+  )

--- a/tests/Unit/NumericalAlgorithms/LinearAlgebra/Test_FindGeneralizedEigenvalues.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearAlgebra/Test_FindGeneralizedEigenvalues.cpp
@@ -1,0 +1,116 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+void test_find_generalized_eigenvalues(const Matrix& matrix_a,
+                                       const Matrix& matrix_b,
+                                       const size_t eigenvector_size,
+                                       const size_t eigenvalue_size) {
+  // Set up vectors and a matrix to store the eigenvalues and eigenvectors
+  DataVector eigenvalues_real_part(eigenvalue_size, 0.0);
+  DataVector eigenvalues_im_part(eigenvalue_size, 0.0);
+  Matrix eigenvectors(eigenvector_size, eigenvector_size, 0.0);
+
+  find_generalized_eigenvalues(&eigenvalues_real_part, &eigenvalues_im_part,
+                               &eigenvectors, matrix_a, matrix_b);
+
+  // Expected eigenvalues and eigenvectors
+  constexpr double expected_larger_eigenvalue = 10.099019513592784;
+  constexpr double expected_smaller_eigenvalue = -0.09901951359278449;
+  // We are testing a 2x2 matrix. Eigenvectors have two components.
+  // Normalize the eigenvectors so the second component is 1.
+  // Store the remaining components of the expected eigenvectors.
+  constexpr double expected_larger_eigenvector_value = 0.819803902718557;
+  constexpr double expected_smaller_eigenvector_value = -1.2198039027185574;
+
+  CHECK(eigenvalues_im_part[0] == approx(0.0));
+  CHECK(eigenvalues_im_part[1] == approx(0.0));
+  CHECK(max(eigenvalues_real_part) == approx(expected_larger_eigenvalue));
+  CHECK(min(eigenvalues_real_part) == approx(expected_smaller_eigenvalue));
+
+  // We don't know which order the eigenvalues are returned by lapack, so
+  // check which eigenvalue is larger and then verify that the corresponding
+  // eigenvector's nontrivial component has the expected value.
+  if (eigenvalues_real_part[0] > eigenvalues_real_part[1]) {
+    CHECK(eigenvectors(0, 0) / eigenvectors(1, 0) ==
+          approx(expected_larger_eigenvector_value));
+    CHECK(eigenvectors(0, 1) / eigenvectors(1, 1) ==
+          approx(expected_smaller_eigenvector_value));
+  } else {
+    CHECK(eigenvectors(0, 0) / eigenvectors(1, 0) ==
+          approx(expected_smaller_eigenvector_value));
+    CHECK(eigenvectors(0, 1) / eigenvectors(1, 1) ==
+          approx(expected_larger_eigenvector_value));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearAlgebra.GeneralizedEigenvalue",
+                  "[NumericalAlgorithms][LinearAlgebra][Unit]") {
+  Matrix matrix_a({{1.0, 2.0}, {-3.0, -4.0}});
+  Matrix matrix_b({{4.0, -3.0}, {-2.0, 1.0}});
+  test_find_generalized_eigenvalues(matrix_a, matrix_b, 2, 2);
+}
+
+// [[OutputRegex, Matrix A should be square]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.LinearAlgebra.GeneralizedEigenvalueAssertSquare",
+    "[NumericalAlgorithms][LinearAlgebra][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Matrix matrix_a(std::vector<std::vector<double>>({{1.0}, {-3.0}}));
+  Matrix matrix_b({{4.0, -3.0}, {-2.0, 1.0}});
+  test_find_generalized_eigenvalues(matrix_a, matrix_b, 2, 2);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Matrix A and matrix B should be the same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.LinearAlgebra.GeneralizedEigenvalueAssertABSameSize",
+    "[NumericalAlgorithms][LinearAlgebra][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Matrix matrix_a({{1.0, 2.0}, {-3.0, -4.0}});
+  Matrix matrix_b(std::vector<std::vector<double>>{{4.0}});
+  test_find_generalized_eigenvalues(matrix_a, matrix_b, 2, 2);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Matrix A and matrix eigenvectors should have the same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.LinearAlgebra.GeneralizedEigenvalueAssertSizeEigenvectors",
+    "[NumericalAlgorithms][LinearAlgebra][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Matrix matrix_a({{1.0, 2.0}, {-3.0, -4.0}});
+  Matrix matrix_b({{4.0, -3.0}, {-2.0, 1.0}});
+  test_find_generalized_eigenvalues(matrix_a, matrix_b, 1, 2);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, eigenvalues DataVector sizes should equal number of columns]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.LinearAlgebra.GeneralizedEigenvalueAssertSizeEigenvalues",
+    "[NumericalAlgorithms][LinearAlgebra][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Matrix matrix_a({{1.0, 2.0}, {-3.0, -4.0}});
+  Matrix matrix_b({{4.0, -3.0}, {-2.0, 1.0}});
+  test_find_generalized_eigenvalues(matrix_a, matrix_b, 2, 1);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}


### PR DESCRIPTION
## Proposed changes

This pull request implements a wrapper for the LAPACK generalized eigenvalue function, dggev_(). This is not currently wrapped by Blaze or any other library in our list of requirements, but it is a necessary ingredient to measuring black-hole spin.

The generalized eigenvalue problem is, given matrices A and B, find eigenvalues lambda and vectors x such that A x = lambda B x.

The input and output of the wrapper all are built-in classes (Matrix and DataVector). The test checks that some generic 2x2 matricies have the correct eigenvalues and eigenvectors, comparing to hard-coded solutions that I computed with Mathematica.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
