### PR TITLE
Add functions to compute K_ij and d_k g_ij from GH variables.

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
@@ -131,6 +131,41 @@ tnsr::a<DataType, SpatialDim, Frame> gauge_source(
 
   return gauge_source_h;
 }
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  auto ex_curv = make_with_value<tnsr::ii<DataType, SpatialDim, Frame>>(pi, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      for (size_t a = 0; a <= SpatialDim; ++a) {
+        ex_curv.get(i, j) += 0.5 *
+                             (phi.get(i, j + 1, a) + phi.get(j, i + 1, a)) *
+                             spacetime_normal_vector.get(a);
+      }
+      ex_curv.get(i, j) += 0.5 * pi.get(i + 1, j + 1);
+    }
+  }
+  return ex_curv;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ijj<DataType, SpatialDim, Frame> deriv_spatial_metric(
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  auto deriv_spatial_metric =
+      make_with_value<tnsr::ijj<DataType, SpatialDim, Frame>>(phi, 0.);
+  for (size_t k = 0; k < SpatialDim; ++k) {
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t j = i; j < SpatialDim; ++j) {
+        deriv_spatial_metric.get(k, i, j) = phi.get(k, i + 1, j + 1);
+      }
+    }
+  }
+  return deriv_spatial_metric;
+}
+
 }  // namespace GeneralizedHarmonic
 
 /// \cond
@@ -155,6 +190,15 @@ tnsr::a<DataType, SpatialDim, Frame> gauge_source(
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& dt_shift,           \
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                      \
+  GeneralizedHarmonic::extrinsic_curvature(                                   \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_normal_vector,                                            \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
+  template tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>                     \
+  GeneralizedHarmonic::deriv_spatial_metric(                                  \
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
   template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
   GeneralizedHarmonic::gauge_source(                                          \

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -93,4 +93,40 @@ tnsr::a<DataType, SpatialDim, Frame> gauge_source(
     const tnsr::i<DataType, SpatialDim, Frame>&
         trace_christoffel_last_indices) noexcept;
 
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes extrinsic curvature from generalized harmonic variables
+ *        and the spacetime normal vector.
+ *
+ * \details If \f$ \Pi_{ab} \f$ and \f$ \phi_{iab} \f$ are the generalized
+ * harmonic conjugate momentum and spatial derivative variables, and if
+ * \f$n^a\f$ is the spacetime normal vector, then the extrinsic curvature
+ * is computed as
+ * \f{align}
+ *     K_{ij} &= \frac{1}{2} \Pi_{ij} + \phi_{(ij)a} n^a
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes spatial derivatives of the spatial metric from
+ *        the generalized harmonic spatial derivative variable.
+ *
+ * \details If \f$ \phi_{kab} \f$ is the generalized
+ * harmonic spatial derivative variable, then the derivatives of the
+ * spatial metric are
+ * \f{align}
+ *      \partial_k g_{ij} &= \phi_{kij}
+ * \f}
+ *
+ * This quantity is needed for computing spatial Christoffel symbols.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ijj<DataType, SpatialDim, Frame> deriv_spatial_metric(
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
 }  // namespace GeneralizedHarmonic

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -13,19 +13,19 @@
 namespace GeneralizedHarmonic {
 /*!
  * \ingroup GeneralRelativityGroup
- * \brief Computes the auxiliary variable \f$\phi_{iab}\f$ used by the
+ * \brief Computes the auxiliary variable \f$\Phi_{iab}\f$ used by the
  * generalized harmonic formulation of Einstein's equations.
  *
  * \details If \f$ N, N^i\f$ and \f$ g_{ij} \f$ are the lapse, shift and spatial
- * metric respectively, then \f$\phi_{iab} \f$ is computed as
+ * metric respectively, then \f$\Phi_{iab} \f$ is computed as
  *
  * \f{align}
- *     \phi_{ktt} &= - 2 N \partial_k N
+ *     \Phi_{ktt} &= - 2 N \partial_k N
  *                 + 2 g_{mn} N^m \partial_k N^n
  *                 + N^m N^n \partial_k g_{mn} \\
- *     \phi_{kti} &= g_{mi} \partial_k N^m
+ *     \Phi_{kti} &= g_{mi} \partial_k N^m
  *                 + N^m \partial_k g_{mi} \\
- *     \phi_{kij} &= \partial_k g_{ij}
+ *     \Phi_{kij} &= \partial_k g_{ij}
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -44,9 +44,9 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
  * \f$ \psi_{ab} \f$.
  *
  * \details If \f$ N, N^i\f$ are the lapse and shift
- * respectively, and \f$ \phi_{iab} = \partial_i \psi_{ab} \f$ then
+ * respectively, and \f$ \Phi_{iab} = \partial_i \psi_{ab} \f$ then
  * \f$\Pi_{\mu\nu} = -(1/N) ( \partial_t \psi_{\mu\nu}  -
- *      N^m \phi_{m\mu\nu}) \f$ where \f$ \partial_t \psi_{ab} \f$ is computed
+ *      N^m \Phi_{m\mu\nu}) \f$ where \f$ \partial_t \psi_{ab} \f$ is computed
  * as
  *
  * \f{align}
@@ -98,12 +98,12 @@ tnsr::a<DataType, SpatialDim, Frame> gauge_source(
  * \brief Computes extrinsic curvature from generalized harmonic variables
  *        and the spacetime normal vector.
  *
- * \details If \f$ \Pi_{ab} \f$ and \f$ \phi_{iab} \f$ are the generalized
+ * \details If \f$ \Pi_{ab} \f$ and \f$ \Phi_{iab} \f$ are the generalized
  * harmonic conjugate momentum and spatial derivative variables, and if
  * \f$n^a\f$ is the spacetime normal vector, then the extrinsic curvature
  * is computed as
  * \f{align}
- *     K_{ij} &= \frac{1}{2} \Pi_{ij} + \phi_{(ij)a} n^a
+ *     K_{ij} &= \frac{1}{2} \Pi_{ij} + \Phi_{(ij)a} n^a
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -117,11 +117,11 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
  * \brief Computes spatial derivatives of the spatial metric from
  *        the generalized harmonic spatial derivative variable.
  *
- * \details If \f$ \phi_{kab} \f$ is the generalized
+ * \details If \f$ \Phi_{kab} \f$ is the generalized
  * harmonic spatial derivative variable, then the derivatives of the
  * spatial metric are
  * \f{align}
- *      \partial_k g_{ij} &= \phi_{kij}
+ *      \partial_k g_{ij} &= \Phi_{kij}
  * \f}
  *
  * This quantity is needed for computing spatial Christoffel symbols.

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -4,11 +4,15 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <cstddef>
+#include <random>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "Utilities/Gsl.hpp"
 #include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 namespace {
 void test_compute_1d_phi(const DataVector& used_for_size) {
@@ -254,6 +258,73 @@ void test_compute_3d_gauge_source(const DataVector& used_for_size) {
           make_trace_spatial_christoffel_first_kind<dim>(used_for_size)),
       gauge_source);
 }
+
+template <size_t Dim, typename T>
+void test_compute_extrinsic_curvature_and_deriv_metric(const T& used_for_size) {
+  // Set up random values for lapse, shift, spatial_metric,
+  // and their derivatives.
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed" << seed);
+  std::uniform_real_distribution<> dist(-1., 1.);
+  std::uniform_real_distribution<> dist_positive(1., 2.);
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_dist = make_not_null(&dist);
+  const auto nn_dist_positive = make_not_null(&dist_positive);
+
+  const auto lapse = make_with_random_values<Scalar<T>>(
+      nn_generator, nn_dist_positive, used_for_size);
+  const auto shift = make_with_random_values<tnsr::I<T, Dim>>(
+      nn_generator, nn_dist, used_for_size);
+  const auto spatial_metric = [&]() {
+    auto spatial_metric_l = make_with_random_values<tnsr::ii<T, Dim>>(
+        nn_generator, nn_dist, used_for_size);
+    // Make sure spatial_metric isn't singular by adding
+    // large enough positive diagonal values.
+    for (size_t i = 0; i < Dim; ++i) {
+      spatial_metric_l.get(i, i) += 4.0;
+    }
+    return spatial_metric_l;
+  }();
+  const auto dt_lapse = make_with_random_values<Scalar<T>>(
+      nn_generator, nn_dist_positive, used_for_size);
+  const auto deriv_lapse = make_with_random_values<tnsr::i<T, Dim>>(
+      nn_generator, nn_dist_positive, used_for_size);
+  const auto dt_shift = make_with_random_values<tnsr::I<T, Dim>>(
+      nn_generator, nn_dist, used_for_size);
+  const auto deriv_shift = make_with_random_values<tnsr::iJ<T, Dim>>(
+      nn_generator, nn_dist, used_for_size);
+  const auto deriv_spatial_metric = make_with_random_values<tnsr::ijj<T, Dim>>(
+      nn_generator, nn_dist, used_for_size);
+  const auto dt_spatial_metric = make_with_random_values<tnsr::ii<T, Dim>>(
+      nn_generator, nn_dist, used_for_size);
+
+  // Make extrinsic curvature, spacetime_normal_vector, and generalized
+  // harmonic pi,psi variables in a way that is already independently tested.
+  const auto extrinsic_curvature =
+      gr::extrinsic_curvature(lapse, shift, deriv_shift, spatial_metric,
+                              dt_spatial_metric, deriv_spatial_metric);
+  const auto spacetime_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+  const auto phi =
+      GeneralizedHarmonic::phi(lapse, deriv_lapse, shift, deriv_shift,
+                               spatial_metric, deriv_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+
+  // Compute extrinsic curvature and deriv_spatial_metric from generalized
+  // harmonic variables and make sure we get the same result.
+  const auto extrinsic_curvature_test =
+      GeneralizedHarmonic::extrinsic_curvature(spacetime_normal_vector, pi,
+                                               phi);
+  const auto deriv_spatial_metric_test =
+      GeneralizedHarmonic::deriv_spatial_metric(phi);
+
+  CHECK_ITERABLE_APPROX(extrinsic_curvature, extrinsic_curvature_test);
+  CHECK_ITERABLE_APPROX(deriv_spatial_metric, deriv_spatial_metric_test);
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
@@ -268,4 +339,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
   test_compute_1d_gauge_source(dv);
   test_compute_2d_gauge_source(dv);
   test_compute_3d_gauge_source(dv);
+  test_compute_extrinsic_curvature_and_deriv_metric<1>(0.);
+  test_compute_extrinsic_curvature_and_deriv_metric<2>(0.);
+  test_compute_extrinsic_curvature_and_deriv_metric<3>(0.);
+  test_compute_extrinsic_curvature_and_deriv_metric<1>(dv);
+  test_compute_extrinsic_curvature_and_deriv_metric<2>(dv);
+  test_compute_extrinsic_curvature_and_deriv_metric<3>(dv);
 }


### PR DESCRIPTION
## Proposed changes

Add new functions to compute extrinsic curvature and derivative of spatial metric, given
generalized harmonic variables.

This will be useful for horizon finding, and for computing spatial christoffel symbols in the
generalized harmonic evolution.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files)
  2. Blank line (only in cpp files)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
