### PR TITLE
Various small fixes

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -749,19 +749,19 @@ then typically look as follows:
  * \f$10^{-14}\f$ (i.e. `std::numeric_limits<double>::%epsilon()*100`).
  * When possible, we recommend using `approx` for fuzzy comparisons as follows:
  * \example
- * \snippet TestFramework.cpp approx_default
+ * \snippet Test_TestingFramework.cpp approx_default
  *
  * For checks that need more control over the precision (e.g. an algorithm in
  * which round-off errors accumulate to a higher level), we recommend using
  * the `approx` helper with a one-time tolerance adjustment. A comment
  * should explain the reason for the adjustment:
  * \example
- * \snippet TestFramework.cpp approx_single_custom
+ * \snippet Test_TestingFramework.cpp approx_single_custom
  *
  * For tests in which the same precision adjustment is re-used many times, a new
  * helper object can be created from Catch's `Approx` with a custom precision:
  * \example
- * \snippet TestFramework.cpp approx_new_custom
+ * \snippet Test_TestingFramework.cpp approx_new_custom
  *
  * Note: We provide the `approx` object because Catch's `Approx` defaults to a
  * very loose tolerance (`std::numeric_limits<float>::%epsilon()*100`, or

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -76,7 +76,7 @@ class Variables<tmpl::list<Tags...>> {
   /// \cond
   // If you encounter an error of the `size()` function not existing you are
   // not filling the Variables with Tensors. Variables can be generalized to
-  // holding containers other than Tensor by having the contaiers have a
+  // holding containers other than Tensor by having the containers have a
   // `size()` function that in most cases should return 1. For Tensors the
   // `size()` function returns the number of independent components.
   template <typename State, typename Element>

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 set(executable RunTests)
 
-set(SPECTRE_TESTS "TestFramework.cpp")
+set(SPECTRE_TESTS "Test_TestingFramework.cpp")
 
 set(SPECTRE_COMPILATION_TESTS "TestCompilationFramework.cpp")
 

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -3,7 +3,10 @@
 
 set(executable RunTests)
 
-set(SPECTRE_TESTS "Test_TestingFramework.cpp")
+set(SPECTRE_TESTS
+    "Test_TestHelpers.cpp"
+    "Test_TestingFramework.cpp"
+    )
 
 set(SPECTRE_COMPILATION_TESTS "TestCompilationFramework.cpp")
 
@@ -25,8 +28,6 @@ add_subdirectory(Pypp)
 add_subdirectory(TestUtilities)
 add_subdirectory(Time)
 add_subdirectory(Utilities)
-
-set(SPECTRE_TESTS "${SPECTRE_TESTS};Test_TestHelpers.cpp")
 
 add_charm_module(${executable})
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "tests/Unit/TestingFramework.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
@@ -11,7 +13,6 @@
 #include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
 #include "Utilities/Literals.hpp"
-#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 void test_definite_integral_1d(const Index<1>& extents) {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "tests/Unit/TestingFramework.hpp"
+
 #include <algorithm>
 #include <array>
 #include <cstddef>
@@ -27,7 +29,6 @@
 #include "PointwiseFunctions/MathFunctions/TensorProduct.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestingFramework.hpp"
 
 template <size_t VolumeDim>
 class MathFunction;

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Linearize.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "tests/Unit/TestingFramework.hpp"
+
 #include <cmath>
 #include <cstddef>
 
@@ -12,7 +14,6 @@
 #include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
 #include "Utilities/Blas.hpp"
-#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Linearize",
                   "[NumericalAlgorithms][LinearOperators][Unit]") {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "tests/Unit/TestingFramework.hpp"
+
 #include <cmath>
 #include <cstddef>
 #include <numeric>
@@ -12,7 +14,6 @@
 #include "NumericalAlgorithms/LinearOperators/Linearize.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
-#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.MeanValue",
                   "[NumericalAlgorithms][LinearOperators][Unit]") {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "tests/Unit/TestingFramework.hpp"
+
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -28,7 +30,6 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestingFramework.hpp"
 
 namespace {
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "tests/Unit/TestingFramework.hpp"
+
 #include <algorithm>
 #include <cstddef>
 
@@ -10,7 +12,6 @@
 #include "NumericalAlgorithms/LinearOperators/Transpose.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestingFramework.hpp"
 
 template <typename TagsList>
 class Variables;

--- a/tests/Unit/TestFramework.cpp
+++ b/tests/Unit/TestFramework.cpp
@@ -26,7 +26,7 @@ SPECTRE_TEST_CASE("TestFramework.Approx", "[Unit]") {
   CHECK(1.0 == approx(1.0 + 5e-13).epsilon(1e-12));
   /// [approx_single_custom]
   /// [approx_new_custom]
-  // The checks in this test need tolerance 1d-12 for X reason.
+  // The checks in this test need tolerance 1e-12 for X reason.
   Approx my_approx = Approx::custom().epsilon(1e-12);
   CHECK(1.0 == my_approx(1.0 + 5e-13));
   CHECK(1.0 != my_approx(1.0 + 5e-12));

--- a/tests/Unit/Test_TestHelpers.cpp
+++ b/tests/Unit/Test_TestHelpers.cpp
@@ -17,7 +17,7 @@
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 #include "tests/Unit/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Test.TestHelpers", "[Unit]") {
+SPECTRE_TEST_CASE("Unit.TestHelpers", "[Unit]") {
   std::vector<double> vector{0, 1, 2, 3};
   test_iterators(vector);
   test_reverse_iterators(vector);
@@ -87,7 +87,7 @@ SPECTRE_TEST_CASE("Test.TestHelpers", "[Unit]") {
   }
 }
 
-SPECTRE_TEST_CASE("Test.TestHelpers.Derivative", "[Unit]") {
+SPECTRE_TEST_CASE("Unit.TestHelpers.Derivative", "[Unit]") {
   {  // 3D Test
     const std::array<double, 3> x{{1.2, -3.4, 1.3}};
     const double delta = 1.e-2;

--- a/tests/Unit/Test_TestingFramework.cpp
+++ b/tests/Unit/Test_TestingFramework.cpp
@@ -6,7 +6,7 @@
 #include "Parallel/Abort.hpp"
 #include "tests/Unit/TestingFramework.hpp"
 
-SPECTRE_TEST_CASE("TestFramework.Approx", "[Unit]") {
+SPECTRE_TEST_CASE("Unit.TestingFramework.Approx", "[Unit]") {
   /// [approx_test]
   CHECK(1.0 == approx(1.0 + 1e-15));
   CHECK(1.0 != approx(1.0 + 1e-13));
@@ -35,7 +35,7 @@ SPECTRE_TEST_CASE("TestFramework.Approx", "[Unit]") {
 
 /// [error_test]
 // [[OutputRegex, I failed]]
-[[noreturn]] SPECTRE_TEST_CASE("TestFramework.Abort", "[Unit]") {
+[[noreturn]] SPECTRE_TEST_CASE("Unit.TestingFramework.Abort", "[Unit]") {
   ERROR_TEST();
   /// [error_test]
   Parallel::abort("I failed");

--- a/tests/Unit/Test_TestingFramework.cpp
+++ b/tests/Unit/Test_TestingFramework.cpp
@@ -1,10 +1,11 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "tests/Unit/TestingFramework.hpp"
+
 #include <cmath>
 
 #include "Parallel/Abort.hpp"
-#include "tests/Unit/TestingFramework.hpp"
 
 SPECTRE_TEST_CASE("Unit.TestingFramework.Approx", "[Unit]") {
   /// [approx_test]

--- a/tests/Unit/TestingFramework.hpp
+++ b/tests/Unit/TestingFramework.hpp
@@ -92,7 +92,7 @@ std::string format_capture_precise(const T& t) noexcept {
  * tighter tolerance through the `approx` static object.
  *
  * \example
- * \snippet TestFramework.cpp approx_test
+ * \snippet Test_TestingFramework.cpp approx_test
  */
 // clang-tidy: static object creation may throw exception
 static Approx approx =                                          // NOLINT
@@ -225,7 +225,7 @@ struct check_iterable_approx<
  * the SPECTRE_TEST_CASE.
  *
  * \example
- * \snippet TestFramework.cpp error_test
+ * \snippet Test_TestingFramework.cpp error_test
  */
 #define ERROR_TEST()                                      \
   do {                                                    \


### PR DESCRIPTION
## Proposed changes

Various small fixes: typoes, inconsistent naming, incorrect ordering of the TestingFramework include, etc.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`
