### PR TITLE
Split ComputeBoundaryFlux action into receiving and computing parts

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -3,15 +3,30 @@
 
 #pragma once
 
+#include <cstddef>
+#include <memory>
+#include <vector>
+
 #include "AlgorithmArray.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/DomainCreators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/ElementId.hpp"  // IWYU pragma: keep
 #include "Domain/ElementIndex.hpp"
 #include "Domain/InitialElementIds.hpp"
-#include "Domain/Tags.hpp"
 #include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
-#include "Time/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"  // IWYU pragma: keep
+#include "Time/Time.hpp"
 #include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
 
 template <class Metavariables, class ActionList>
 struct DgElementArray {
@@ -25,9 +40,9 @@ struct DgElementArray {
   using action_list = ActionList;
   using array_index = ElementIndex<volume_dim>;
 
-  using initial_databox = db::compute_databox_type<
-      typename dg::Actions::InitializeElement<volume_dim>::
-          template return_tag_list<typename Metavariables::system>>;
+  using initial_databox =
+      db::compute_databox_type<typename dg::Actions::InitializeElement<
+          volume_dim>::template return_tag_list<Metavariables>>;
 
   using options = tmpl::list<typename Metavariables::domain_creator_tag,
                              OptionTags::InitialTime, OptionTags::DeltaT>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -15,6 +15,7 @@
 #include "Evolution/Actions/ComputeVolumeDuDt.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Evolution/Systems/ScalarWave/System.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesGlobalTimeStepping.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
@@ -50,7 +51,8 @@ struct EvolutionMetavars {
       tmpl::list<Actions::ComputeVolumeDuDt<Dim>,
                  dg::Actions::ComputeNonconservativeBoundaryFluxes,
                  dg::Actions::SendDataForFluxes,
-                 dg::Actions::ComputeBoundaryFlux<EvolutionMetavars>,
+                 dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
+                 dg::Actions::ApplyBoundaryFluxesGlobalTimeStepping,
                  Actions::UpdateU, Actions::AdvanceTime, Actions::FinalTime>>>;
 
   static constexpr OptionString help{

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -29,6 +29,7 @@
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/FinalTime.hpp"
 #include "Time/Actions/UpdateU.hpp"
+#include "Time/Tags.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -36,6 +37,7 @@ template <size_t Dim>
 struct EvolutionMetavars {
   // Customization/"input options" to simulation
   using system = ScalarWave::System<Dim>;
+  using temporal_id = Tags::TimeId;
   using analytic_solution_tag =
       CacheTags::AnalyticSolution<ScalarWave::Solutions::PlaneWave<Dim>>;
   using normal_dot_numerical_flux =

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesGlobalTimeStepping.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesGlobalTimeStepping.hpp
@@ -1,0 +1,134 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/IndexToSliceAt.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+template <typename TagsList>
+class Variables;
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+namespace Tags {
+template <size_t VolumeDim>
+struct Extents;
+}  // namespace Tags
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace dg {
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief Compute boundary contribution to the time derivative for
+/// use in global time stepping.
+///
+/// Uses:
+/// - ConstGlobalCache: Metavariables::normal_dot_numerical_flux
+/// - DataBox: Tags::Extents<volume_dim>,
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   db::add_tag_prefix<Tags::dt, variables_tag>,
+///   FluxCommunicationTypes<Metavariables>::mortar_data_tag
+struct ApplyBoundaryFluxesGlobalTimeStepping {
+ private:
+  template <typename Flux, typename... NumericalFluxTags, typename... SelfTags,
+            typename... PackagedTags, typename... ArgumentTags,
+            typename... Args>
+  static void apply_normal_dot_numerical_flux(
+      const gsl::not_null<Variables<tmpl::list<NumericalFluxTags...>>*>
+          numerical_fluxes,
+      const Flux& flux,
+      const Variables<tmpl::list<SelfTags...>>& self_packaged_data,
+      const Variables<tmpl::list<PackagedTags...>>&
+          neighbor_packaged_data) noexcept {
+    flux(make_not_null(&get<NumericalFluxTags>(*numerical_fluxes))...,
+         get<PackagedTags>(self_packaged_data)...,
+         get<PackagedTags>(neighbor_packaged_data)...);
+  }
+
+ public:
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using system = typename Metavariables::system;
+    constexpr size_t volume_dim = system::volume_dim;
+    using variables_tag = typename system::variables_tag;
+    using dt_variables_tag = db::add_tag_prefix<Tags::dt, variables_tag>;
+
+    using flux_comm_types = FluxCommunicationTypes<Metavariables>;
+
+    using normal_dot_numerical_flux_tag =
+        db::add_tag_prefix<Tags::NormalDotNumericalFlux, variables_tag>;
+
+    using mortar_data_tag = typename flux_comm_types::mortar_data_tag;
+    db::mutate<dt_variables_tag, mortar_data_tag>(
+        make_not_null(&box),
+        [&cache](
+            const gsl::not_null<db::item_type<dt_variables_tag>*> dt_vars,
+            const gsl::not_null<db::item_type<mortar_data_tag>*> mortar_data,
+            const db::item_type<Tags::Extents<volume_dim>>& extents) noexcept {
+          const auto& normal_dot_numerical_flux_computer =
+              get<typename Metavariables::normal_dot_numerical_flux>(cache);
+
+          for (auto& this_mortar_data : *mortar_data) {
+            const auto& mortar_id = this_mortar_data.first;
+            const auto& direction = mortar_id.first;
+            const size_t dimension = direction.dimension();
+
+            const auto data = this_mortar_data.second.extract();
+            const auto& local_mortar_data = data.first;
+            const auto& remote_mortar_data = data.second;
+
+            // Compute numerical flux
+            db::item_type<normal_dot_numerical_flux_tag>
+                normal_dot_numerical_fluxes(
+                    extents.slice_away(dimension).product(), 0.0);
+            apply_normal_dot_numerical_flux(
+                make_not_null(&normal_dot_numerical_fluxes),
+                normal_dot_numerical_flux_computer, local_mortar_data,
+                remote_mortar_data);
+
+            // Projections need to happen here.
+
+            db::item_type<dt_variables_tag> lifted_data(dg::lift_flux(
+                local_mortar_data, std::move(normal_dot_numerical_fluxes),
+                extents[dimension],
+                get<typename flux_comm_types::MagnitudeOfFaceNormal>(
+                    local_mortar_data)));
+
+            add_slice_to_data(dt_vars, lifted_data, extents,
+                              dimension, index_to_slice_at(extents, direction));
+          }
+        },
+        db::get<Tags::Extents<volume_dim>>(box));
+
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>  // IWYU pragma: keep
+#include <cstddef>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/Direction.hpp"  // IWYU pragma: keep
+#include "Domain/ElementId.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Time/TimeId.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace dg {
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief Types related to flux communication.
+template <typename Metavariables>
+struct FluxCommunicationTypes {
+ private:
+  using system = typename Metavariables::system;
+  static constexpr size_t volume_dim = system::volume_dim;
+
+ public:
+  /// The type of the Variables sent to neighboring elements.
+  using PackagedData = Variables<
+      typename Metavariables::normal_dot_numerical_flux::type::package_tags>;
+
+  /// The DataBox tag for the normal fluxes of the evolved variables.
+  using normal_dot_fluxes_tag =
+      db::add_tag_prefix<Tags::NormalDotFlux, typename system::variables_tag>;
+
+  /// Variables tag for storing the magnitude of the face normal in
+  /// the LocalData.
+  struct MagnitudeOfFaceNormal {
+    using type = Scalar<DataVector>;
+  };
+
+  /// The type of the Variables needed for the local part of the flux
+  /// numerical flux computations.  Contains the PackagedData, the
+  /// normal fluxes, and MagnitudeOfFaceNormal.
+  using LocalData = Variables<tmpl::remove_duplicates<tmpl::append<
+      typename db::item_type<normal_dot_fluxes_tag>::tags_list,
+      typename PackagedData::tags_list, tmpl::list<MagnitudeOfFaceNormal>>>>;
+
+  /// The DataBox tag for the data stored on the mortars.
+  using mortar_data_tag = Tags::Mortars<
+      Tags::SimpleBoundaryData<LocalData, PackagedData>, volume_dim>;
+
+  /// The inbox tag for flux communication.
+  struct FluxesTag {
+    using temporal_id = TimeId;
+    using type = std::unordered_map<
+        TimeId, std::unordered_map<
+                    std::pair<Direction<volume_dim>, ElementId<volume_dim>>,
+                    PackagedData,
+                    boost::hash<std::pair<Direction<volume_dim>,
+                                          ElementId<volume_dim>>>>>;
+  };
+};
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
@@ -17,7 +17,6 @@
 #include "Domain/Direction.hpp"  // IWYU pragma: keep
 #include "Domain/ElementId.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
-#include "Time/TimeId.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace dg {
@@ -52,18 +51,22 @@ struct FluxCommunicationTypes {
       typename PackagedData::tags_list, tmpl::list<MagnitudeOfFaceNormal>>>>;
 
   /// The DataBox tag for the data stored on the mortars.
-  using mortar_data_tag = Tags::Mortars<
-      Tags::SimpleBoundaryData<LocalData, PackagedData>, volume_dim>;
+  using mortar_data_tag =
+      Tags::Mortars<Tags::SimpleBoundaryData<
+                        db::item_type<typename Metavariables::temporal_id>,
+                        LocalData, PackagedData>,
+                    volume_dim>;
 
   /// The inbox tag for flux communication.
   struct FluxesTag {
-    using temporal_id = TimeId;
+    using temporal_id = db::item_type<typename Metavariables::temporal_id>;
     using type = std::unordered_map<
-        TimeId, std::unordered_map<
-                    std::pair<Direction<volume_dim>, ElementId<volume_dim>>,
-                    PackagedData,
-                    boost::hash<std::pair<Direction<volume_dim>,
-                                          ElementId<volume_dim>>>>>;
+        temporal_id,
+        std::unordered_map<
+            std::pair<Direction<volume_dim>, ElementId<volume_dim>>,
+            PackagedData,
+            boost::hash<
+                std::pair<Direction<volume_dim>, ElementId<volume_dim>>>>>;
   };
 };
 }  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp
@@ -1,0 +1,88 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/none.hpp>
+#include <boost/optional.hpp>
+#include <ostream>
+#include <pup.h>  // IWYU pragma: keep
+#include <utility>
+
+#include "ErrorHandling/Assert.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/BoostHelpers.hpp"  // IWYU pragma: keep
+
+namespace dg {
+
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief Storage of boundary data on two sides of a mortar
+///
+/// Typically, values are inserted into this container by the flux
+/// communication actions.
+template <typename LocalVars, typename RemoteVars>
+class SimpleBoundaryData {
+ public:
+  /// Add a value.  This function must be called once between calls to
+  /// extract.
+  //@{
+  void local_insert(Time time, LocalVars vars) noexcept;
+  void remote_insert(Time time, RemoteVars vars) noexcept;
+  //@}
+
+  /// Return the inserted data and reset the state to empty.
+  std::pair<LocalVars, RemoteVars> extract() noexcept;
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  Time time_;
+  boost::optional<LocalVars> local_data_;
+  boost::optional<RemoteVars> remote_data_;
+};
+
+template <typename LocalVars, typename RemoteVars>
+void SimpleBoundaryData<LocalVars, RemoteVars>::local_insert(
+    Time time, LocalVars vars) noexcept {
+  ASSERT(not local_data_, "Already received local data.");
+  ASSERT(not remote_data_ or time == time_,
+         "Received local data at time " << time
+         << " but already have remote data at time " << time_);
+  time_ = time;
+  local_data_ = std::move(vars);
+}
+
+template <typename LocalVars, typename RemoteVars>
+void SimpleBoundaryData<LocalVars, RemoteVars>::remote_insert(
+    Time time, RemoteVars vars) noexcept {
+  ASSERT(not remote_data_, "Already received remote data.");
+  ASSERT(not local_data_ or time == time_,
+         "Received remote data at time " << time
+         << " but already have local data at time " << time_);
+  time_ = time;
+  remote_data_ = std::move(vars);
+}
+
+template <typename LocalVars, typename RemoteVars>
+std::pair<LocalVars, RemoteVars>
+SimpleBoundaryData<LocalVars, RemoteVars>::extract() noexcept {
+  ASSERT(local_data_ and remote_data_,
+         "Tried to extract boundary data, but do not have "
+         << (local_data_ ? "remote" : remote_data_ ? "local" : "any")
+         << " data.");
+  const auto result =
+      std::make_pair(std::move(*local_data_), std::move(*remote_data_));
+  local_data_ = boost::none;
+  remote_data_ = boost::none;
+  return result;
+}
+
+template <typename LocalVars, typename RemoteVars>
+void SimpleBoundaryData<LocalVars, RemoteVars>::pup(PUP::er& p) noexcept {
+  p | time_;
+  p | local_data_;
+  p | remote_data_;
+}
+
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -19,10 +19,10 @@ namespace Tags {
 /// \ingroup DataBoxTags
 /// \ingroup DiscontinuousGalerkinGroup
 /// \brief Simple boundary communication data
-template <typename LocalData, typename RemoteData>
+template <typename TemporalId, typename LocalData, typename RemoteData>
 struct SimpleBoundaryData : db::SimpleTag {
   static std::string name() noexcept { return "SimpleBoundaryData"; }
-  using type = dg::SimpleBoundaryData<LocalData, RemoteData>;
+  using type = dg::SimpleBoundaryData<TemporalId, LocalData, RemoteData>;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -3,16 +3,28 @@
 
 #pragma once
 
-#include <boost/functional/hash.hpp>
+#include <boost/functional/hash.hpp>  // IWYU pragma: keep
+#include <cstddef>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "Domain/Direction.hpp"
-#include "Domain/ElementId.hpp"
+#include "Domain/Direction.hpp"  // IWYU pragma: keep
+#include "Domain/ElementId.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
 #include "Options/Options.hpp"
 
 namespace Tags {
+/// \ingroup DataBoxTags
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief Simple boundary communication data
+template <typename LocalData, typename RemoteData>
+struct SimpleBoundaryData : db::SimpleTag {
+  static std::string name() noexcept { return "SimpleBoundaryData"; }
+  using type = dg::SimpleBoundaryData<LocalData, RemoteData>;
+};
+
 /// \ingroup DataBoxTagsGroup
 /// \ingroup DiscontinuousGalerkinGroup
 /// Data on mortars, indexed by (Direction, ElementId) pairs

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -13,9 +13,12 @@
 #include "Options/Options.hpp"
 
 namespace Tags {
+/// \ingroup DataBoxTagsGroup
+/// \ingroup DiscontinuousGalerkinGroup
+/// Data on mortars, indexed by (Direction, ElementId) pairs
 template <typename Tag, size_t VolumeDim>
 struct Mortars : db::PrefixTag, db::SimpleTag {
-  static std::string name() noexcept { return "Mortar"; }
+  static std::string name() noexcept { return "Mortars"; }
   using tag = Tag;
   using Key = std::pair<::Direction<VolumeDim>, ::ElementId<VolumeDim>>;
   using type = std::unordered_map<Key, db::item_type<Tag>, boost::hash<Key>>;

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -175,7 +175,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   /// [using_db_get]
   const auto& tag0 = db::get<test_databox_tags::Tag0>(original_box);
   /// [using_db_get]
-  CHECK(db::get<test_databox_tags::Tag0>(original_box) == 3.14);
+  CHECK(tag0 == 3.14);
   // Check retrieving chained compute item result
   CHECK(db::get<test_databox_tags::ComputeTag1>(original_box) ==
         "My Sample String6.28"s);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -30,6 +30,7 @@
 #include "Domain/SegmentId.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"  // IWYU pragma: keep
@@ -80,11 +81,17 @@ struct SystemAnalyticSolution {
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };
 
+template <size_t Dim>
 struct System {
+  static constexpr size_t volume_dim = Dim;
   using variables_tag = Tags::Variables<tmpl::list<Var>>;
   using gradients_tags = tmpl::list<Var>;
   template <typename Tag>
   using magnitude_tag = Tags::EuclideanMagnitude<Tag>;
+};
+
+struct NormalDotNumericalFluxTag {
+  using type = struct { using package_tags = tmpl::list<Var>; };
 };
 
 template <size_t Dim>
@@ -100,7 +107,8 @@ using component = ActionTesting::MockArrayComponent<
 template <size_t Dim>
 struct Metavariables {
   using component_list = tmpl::list<component<Dim>>;
-  using system = System;
+  using system = System<Dim>;
+  using normal_dot_numerical_flux = NormalDotNumericalFluxTag;
 };
 
 template <size_t Dim, typename DomainCreatorType>
@@ -151,8 +159,9 @@ void test_initialize_element(const ElementId<Dim>& element_id,
         }()));
   {
     const auto& history = db::get<Tags::HistoryEvolvedVariables<
-        typename System::variables_tag,
-        db::add_tag_prefix<Tags::dt, typename System::variables_tag>>>(box);
+        typename System<Dim>::variables_tag,
+        db::add_tag_prefix<Tags::dt, typename System<Dim>::variables_tag>>>(
+        box);
     TimeSteppers::AdamsBashforthN stepper(4, false);
     CHECK(history.size() == stepper.number_of_past_steps());
     const SystemAnalyticSolution solution{};
@@ -184,8 +193,8 @@ void test_initialize_element(const ElementId<Dim>& element_id,
                                        Tags::LogicalCoordinates<Dim>>>(box)) ==
         map.inv_jacobian(logical_coords));
   CHECK((db::get<
-            Tags::deriv<typename System::variables_tag::tags_list,
-                        typename System::gradients_tags,
+            Tags::deriv<typename System<Dim>::variables_tag::tags_list,
+                        typename System<Dim>::gradients_tags,
                         Tags::InverseJacobian<Tags::ElementMap<Dim>,
                                               Tags::LogicalCoordinates<Dim>>>>(
             box)) == ([&inertial_coords, &extents, &map, &logical_coords]() {
@@ -195,9 +204,15 @@ void test_initialize_element(const ElementId<Dim>& element_id,
           return partial_derivatives<tmpl::list<Var>>(
               vars, extents, map.inv_jacobian(logical_coords));
         }()));
-  CHECK((db::get<db::add_tag_prefix<Tags::dt, typename System::variables_tag>>(
+  CHECK((db::get<
+            db::add_tag_prefix<Tags::dt, typename System<Dim>::variables_tag>>(
             box)) ==
         Variables<tmpl::list<Tags::dt<Var>>>(extents.product(), 0.0));
+
+  CHECK(db::get<typename dg::FluxCommunicationTypes<
+            Metavariables<Dim>>::mortar_data_tag>(box)
+            .size() == element.number_of_neighbors());
+
   (void)db::get<Tags::Interface<Tags::InternalDirections<Dim>,
                                 Tags::UnnormalizedFaceNormal<Dim>>>(box);
   using magnitude_tag =
@@ -208,7 +223,7 @@ void test_initialize_element(const ElementId<Dim>& element_id,
       Tags::InternalDirections<Dim>,
       Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>, magnitude_tag>>>(box);
   (void)db::get<Tags::Interface<Tags::InternalDirections<Dim>,
-                                typename System::variables_tag>>(box);
+                                typename System<Dim>::variables_tag>>(box);
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -108,6 +108,7 @@ template <size_t Dim>
 struct Metavariables {
   using component_list = tmpl::list<component<Dim>>;
   using system = System<Dim>;
+  using temporal_id = Tags::TimeId;
   using normal_dot_numerical_flux = NormalDotNumericalFluxTag;
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
+  Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
   Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
   Actions/Test_FluxCommunication.cpp
   PARENT_SCOPE

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
@@ -1,0 +1,170 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <tuple>
+// IWYU pragma: no_include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"  // IWYU pragma: keep
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesGlobalTimeStepping.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+/// \cond
+// IWYU pragma: no_forward_declare Tensor
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace {
+struct Var : db::SimpleTag {
+  static std::string name() noexcept { return "Var"; }
+  using type = Scalar<DataVector>;
+};
+
+class NumericalFlux {
+ public:
+  struct ExtraData : db::SimpleTag {
+  static std::string name() noexcept { return "ExtraData"; }
+    using type = tnsr::I<DataVector, 1>;
+  };
+
+  using package_tags = tmpl::list<ExtraData, Var>;
+
+  void operator()(const gsl::not_null<Scalar<DataVector>*> numerical_flux_var,
+                  const tnsr::I<DataVector, 1>& extra_data_local,
+                  const Scalar<DataVector>& var_local,
+                  const tnsr::I<DataVector, 1>& extra_data_remote,
+                  const Scalar<DataVector>& var_remote) const {
+    get(*numerical_flux_var) = 10. * get(var_local) + 1000. * get(var_remote);
+    CHECK(get<0>(extra_data_local) == 3. * get<0>(extra_data_remote));
+  }
+
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+struct NumericalFluxTag {
+  using type = NumericalFlux;
+};
+
+struct System {
+  static constexpr const size_t volume_dim = 2;
+  using variables_tag = Tags::Variables<tmpl::list<Var>>;
+};
+
+struct Metavariables;
+
+using component = ActionTesting::MockArrayComponent<
+    Metavariables, ElementIndex<2>, tmpl::list<NumericalFluxTag>,
+    tmpl::list<dg::Actions::ApplyBoundaryFluxesGlobalTimeStepping>>;
+
+struct Metavariables {
+  using system = System;
+  using component_list = tmpl::list<component>;
+
+  using normal_dot_numerical_flux = NumericalFluxTag;
+};
+
+using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
+using mortar_data_tag = typename flux_comm_types::mortar_data_tag;
+using LocalData = typename flux_comm_types::LocalData;
+using PackagedData = typename flux_comm_types::PackagedData;
+using MagnitudeOfFaceNormal = typename flux_comm_types::MagnitudeOfFaceNormal;
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.DiscontinuousGalerkin.Actions.ApplyBoundaryFluxesGlobalTimeStepping",
+    "[Unit][NumericalAlgorithms][Actions]") {
+  ActionTesting::ActionRunner<Metavariables> runner{{NumericalFlux{}}};
+
+  const Index<2> extents{{{3, 3}}};
+  const ElementId<2> id(0);
+
+  const Variables<tmpl::list<Tags::dt<Var>>> initial_dt(extents.product(), 5.);
+
+  const auto make_mortar_data = [](
+      const Scalar<DataVector>& local_var,
+      const Scalar<DataVector>& remote_var,
+      const tnsr::I<DataVector, 1>& local_extra_data,
+      const tnsr::I<DataVector, 1>& remote_extra_data,
+      const Scalar<DataVector>& local_flux,
+      const Scalar<DataVector>& local_magnitude_face_normal) noexcept {
+    const Slab slab(0., 1.);
+    dg::SimpleBoundaryData<LocalData, PackagedData> data;
+
+    LocalData local_data(3);
+    get<Tags::NormalDotFlux<Var>>(local_data) = local_flux;
+    get<NumericalFlux::ExtraData>(local_data) = local_extra_data;
+    get<Var>(local_data) = local_var;
+    get<MagnitudeOfFaceNormal>(local_data) = local_magnitude_face_normal;
+    data.local_insert(slab.start(), std::move(local_data));
+
+    PackagedData remote_data(3);
+    get<NumericalFlux::ExtraData>(remote_data) = remote_extra_data;
+    get<Var>(remote_data) = remote_var;
+    data.remote_insert(slab.start(), std::move(remote_data));
+
+    return data;
+  };
+
+  mortar_data_tag::type mortar_data{
+      {{Direction<2>::upper_xi(), id},
+       make_mortar_data(
+           Scalar<DataVector>{{{{1., 2., 3.}}}},         // local var
+           Scalar<DataVector>{{{{7., 8., 9.}}}},         // remote var
+           tnsr::I<DataVector, 1>{{{{15., 18., 21.}}}},  // local ExtraData
+           tnsr::I<DataVector, 1>{{{{5., 6., 7.}}}},     // remote ExtraData
+           Scalar<DataVector>{{{{-1., -3., -5.}}}},      // flux
+           Scalar<DataVector>{{{{2., 2., 2.}}}})},       // normal magnitude
+      {{Direction<2>::lower_eta(), id},
+       make_mortar_data(
+           Scalar<DataVector>{{{{4., 5., 6.}}}},         // local var
+           Scalar<DataVector>{{{{10., 11., 12.}}}},      // remote var
+           tnsr::I<DataVector, 1>{{{{12., 15., 18.}}}},  // local ExtraData
+           tnsr::I<DataVector, 1>{{{{4., 5., 6.}}}},     // remote ExtraData
+           Scalar<DataVector>{{{{-2., -4., -6.}}}},      // flux
+           Scalar<DataVector>{{{{3., 3., 3.}}}})}};      // normal magnitude
+
+  auto box = db::create<db::AddSimpleTags<
+      Tags::Extents<2>, Tags::dt<Tags::Variables<tmpl::list<Tags::dt<Var>>>>,
+      mortar_data_tag>>(extents, initial_dt, std::move(mortar_data));
+
+  const auto out_box = get<0>(
+      runner
+          .apply<component, dg::Actions::ApplyBoundaryFluxesGlobalTimeStepping>(
+              box, id));
+
+  // F* - F = 10 * local_var + 1000 * remote_var - local_flux
+  const DataVector xi_flux = {0., 0., 7011.,
+                              0., 0., 8023.,
+                              0., 0., 9035.};
+  const DataVector eta_flux = {10042., 11054., 12066.,
+                               0., 0., 0.,
+                               0., 0., 0.};
+  // These factors are (see Kopriva 8.42)
+  // -3[based on extents] * magnitude_of_normal
+  CHECK_ITERABLE_APPROX(get(db::get<Tags::dt<Var>>(out_box)),
+                        initial_dt - 6. * xi_flux - 9. * eta_flux);
+}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 #include <array>
-#include <cmath>
+// IWYU pragma: no_include <boost/functional/hash/extensions.hpp>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -14,6 +14,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -36,15 +37,15 @@
 #include "Domain/OrientationMap.hpp"
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
-#include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
@@ -87,20 +88,7 @@ class NumericalFlux {
         3. * get<1>(interface_unit_normal);
   }
 
-  void operator()(
-      const gsl::not_null<Scalar<DataVector>*> normal_dot_numerical_flux,
-      const tnsr::I<DataVector, 1>& extra_data_interior,
-      const Scalar<DataVector>& packaged_var_interior,
-      const tnsr::I<DataVector, 1>& extra_data_exterior,
-      const Scalar<DataVector>& packaged_var_exterior) const noexcept {
-    get(*normal_dot_numerical_flux) =
-        1.1 * get(packaged_var_interior) + 100. * get(packaged_var_exterior);
-    // We can't easily get an expected value in here, so this
-    // expression is chosen so similar errors on the two interfaces
-    // are unlikely to cancel out.  We tune the exterior data we feed
-    // in to make it pass.
-    CHECK(get<0>(extra_data_exterior) == 2. * get<0>(extra_data_interior) + 1.);
-  }
+  // void operator()(...) is unused
 
   // clang-tidy: do not use references
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
@@ -120,12 +108,13 @@ struct System {
 
 struct Metavariables;
 using send_data_for_fluxes = dg::Actions::SendDataForFluxes;
-using compute_boundary_flux = dg::Actions::ComputeBoundaryFlux<Metavariables>;
+using receive_data_for_fluxes =
+    dg::Actions::ReceiveDataForFluxes<Metavariables>;
 
 using component =
     ActionTesting::MockArrayComponent<Metavariables, ElementIndex<2>,
                                       tmpl::list<NumericalFluxTag>,
-                                      tmpl::list<compute_boundary_flux>>;
+                                      tmpl::list<receive_data_for_fluxes>>;
 
 struct Metavariables {
   using system = System;
@@ -134,30 +123,39 @@ struct Metavariables {
   using normal_dot_numerical_flux = NumericalFluxTag;
 };
 
-using dt_variables_tag = Tags::dt<Tags::Variables<tmpl::list<Tags::dt<Var>>>>;
-using fluxes_tag = compute_boundary_flux::FluxesTag;
-using history_tag = Tags::Mortars<System::variables_tag, 2>;
-
 template <typename Tag>
 using interface_tag = Tags::Interface<Tags::InternalDirections<2>, Tag>;
 
-using normal_dot_fluxes_tag = interface_tag<
-    db::add_tag_prefix<Tags::NormalDotFlux, System::variables_tag>>;
+using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
+using mortar_data_tag = typename flux_comm_types::mortar_data_tag;
+using LocalData = typename flux_comm_types::LocalData;
+using PackagedData = typename flux_comm_types::PackagedData;
+using MagnitudeOfFaceNormal = typename flux_comm_types::MagnitudeOfFaceNormal;
+using normal_dot_fluxes_tag =
+    interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>;
+
+using fluxes_tag = typename flux_comm_types::FluxesTag;
+
 using other_data_tag = interface_tag<Tags::Variables<tmpl::list<OtherData>>>;
 
 using compute_items = db::AddComputeTags<
-    Tags::InternalDirections<2>, interface_tag<Tags::Direction<2>>,
+    Tags::Time, Tags::InternalDirections<2>, interface_tag<Tags::Direction<2>>,
     interface_tag<Tags::Extents<1>>,
     interface_tag<Tags::UnnormalizedFaceNormal<2>>,
     interface_tag<Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<2>>>,
     interface_tag<Tags::Normalized<
         Tags::UnnormalizedFaceNormal<2>,
         Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<2>>>>>;
+
+Scalar<DataVector> reverse(Scalar<DataVector> x) noexcept {
+  std::reverse(get(x).begin(), get(x).end());
+  return x;
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
                   "[Unit][NumericalAlgorithms][Actions]") {
-  ActionTesting::ActionRunner<Metavariables> runner{{}};
+  ActionTesting::ActionRunner<Metavariables> runner{{NumericalFlux{}}};
 
   const Slab slab(1., 3.);
   const TimeId time_id{8, slab.start(), 0};
@@ -195,9 +193,31 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
                                          CoordinateMaps::Affine>(xi_map,
                                                                  eta_map));
 
+  const auto neighbor_directions = {Direction<2>::lower_xi(),
+                                    Direction<2>::upper_xi(),
+                                    Direction<2>::upper_eta()};
+  const struct {
+    std::unordered_map<Direction<2>, Scalar<DataVector>> fluxes;
+    std::unordered_map<Direction<2>, Scalar<DataVector>> other_data;
+    std::unordered_map<Direction<2>, Scalar<DataVector>> remote_fluxes;
+    std::unordered_map<Direction<2>, Scalar<DataVector>> remote_other_data;
+  } data{
+      {{Direction<2>::lower_xi(), Scalar<DataVector>{{{{1., 2., 3.}}}}},
+       {Direction<2>::upper_xi(), Scalar<DataVector>{{{{4., 5., 6.}}}}},
+       {Direction<2>::upper_eta(), Scalar<DataVector>{{{{7., 8., 9.}}}}}},
+      {{Direction<2>::lower_xi(), Scalar<DataVector>{{{{10., 11., 12.}}}}},
+       {Direction<2>::upper_xi(), Scalar<DataVector>{{{{13., 14., 15.}}}}},
+       {Direction<2>::upper_eta(), Scalar<DataVector>{{{{16., 17., 18.}}}}}},
+      {{Direction<2>::lower_xi(), Scalar<DataVector>{{{{19., 20., 21.}}}}},
+       {Direction<2>::upper_xi(), Scalar<DataVector>{{{{22., 23., 24.}}}}},
+       {Direction<2>::upper_eta(), Scalar<DataVector>{{{{25., 26., 27.}}}}}},
+      {{Direction<2>::lower_xi(), Scalar<DataVector>{{{{28., 29., 30.}}}}},
+       {Direction<2>::upper_xi(), Scalar<DataVector>{{{{31., 32., 33.}}}}},
+       {Direction<2>::upper_eta(), Scalar<DataVector>{{{{34., 35., 36.}}}}}}};
+
   auto start_box = [
     &extents, &time_id, &self_id, &west_id, &east_id, &south_id,
-    &block_orientation, &coordmap
+    &block_orientation, &coordmap, &neighbor_directions, &data
   ]() noexcept {
     const Element<2> element(
         self_id, {{Direction<2>::lower_xi(), {{west_id}, block_orientation}},
@@ -206,54 +226,42 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
 
     auto map = ElementMap<2, Frame::Inertial>(self_id, coordmap->get_clone());
 
-    // The initial value for dt_variables checks that it isn't
-    // improperly zeroed.
-    db::item_type<dt_variables_tag> dt_variables(extents.product(), 3.0);
     db::item_type<normal_dot_fluxes_tag> normal_dot_fluxes;
-    {
-      const auto set_flux_in_direction = [&normal_dot_fluxes](
-          const Direction<2>& direction, const DataVector& flux) noexcept {
-        auto& flux_vars = normal_dot_fluxes[direction];
-        flux_vars.initialize(3);
-        get(get<Tags::NormalDotFlux<Var>>(flux_vars)) = flux;
-      };
-      set_flux_in_direction(Direction<2>::lower_xi(), {1., 2., 3.});
-      set_flux_in_direction(Direction<2>::upper_xi(), {4., 5., 6.});
-      set_flux_in_direction(Direction<2>::upper_eta(), {7., 8., 9.});
+    for (const auto& direction : neighbor_directions) {
+      auto& flux_vars = normal_dot_fluxes[direction];
+      flux_vars.initialize(3);
+      get<Tags::NormalDotFlux<Var>>(flux_vars) = data.fluxes.at(direction);
     }
 
     db::item_type<other_data_tag> other_data;
-    {
-      const auto set_other_data_in_direction = [&other_data](
-          const Direction<2>& direction, const DataVector& data) noexcept {
-        auto& other_data_vars = other_data[direction];
-        other_data_vars.initialize(3);
-        get(get<OtherData>(other_data_vars)) = data;
-      };
-      set_other_data_in_direction(Direction<2>::lower_xi(), {15., 25., 35.});
-      set_other_data_in_direction(Direction<2>::upper_xi(), {45., 55., 65.});
-      set_other_data_in_direction(Direction<2>::upper_eta(), {75., 85., 95.});
+    for (const auto& direction : neighbor_directions) {
+      auto& other_data_vars = other_data[direction];
+      other_data_vars.initialize(3);
+      get<OtherData>(other_data_vars) = data.other_data.at(direction);
     }
+
+    db::item_type<mortar_data_tag> mortar_history{};
+    mortar_history[std::make_pair(Direction<2>::lower_xi(), west_id)];
+    mortar_history[std::make_pair(Direction<2>::upper_xi(), east_id)];
+    mortar_history[std::make_pair(Direction<2>::upper_eta(), south_id)];
 
     return db::create<
         db::AddSimpleTags<Tags::TimeId, Tags::Extents<2>, Tags::Element<2>,
-                          Tags::ElementMap<2>, dt_variables_tag,
-                          normal_dot_fluxes_tag, other_data_tag>,
+                          Tags::ElementMap<2>, normal_dot_fluxes_tag,
+                          other_data_tag, mortar_data_tag>,
         compute_items>(time_id, extents, element, std::move(map),
-                       std::move(dt_variables), std::move(normal_dot_fluxes),
-                       std::move(other_data));
+                       std::move(normal_dot_fluxes), std::move(other_data),
+                       std::move(mortar_history));
   }();
 
   auto sent_box = std::get<0>(
       runner.apply<component, send_data_for_fluxes>(start_box, self_id));
 
-  // The check in NumericalFlux::operator() (and the final dt check)
-  // verify that the action sends the correct values, but we need to
-  // check that it sends the correct number of messages to the correct
-  // places.
+  // Here, we just check that messages are sent to the correct places.
+  // We will check the received values on the central element later.
   {
-    CHECK((runner.nonempty_inboxes<component, fluxes_tag>()) ==
-          (std::unordered_set<ElementIndex<2>>{west_id, east_id, south_id}));
+    CHECK(runner.nonempty_inboxes<component, fluxes_tag>() ==
+          std::unordered_set<ElementIndex<2>>{west_id, east_id, south_id});
     const auto check_sent_data = [&runner, &time_id, &self_id](
         const ElementId<2>& id, const Direction<2>& direction) noexcept {
       const auto& inboxes = runner.inboxes<component>();
@@ -269,99 +277,131 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
     check_sent_data(south_id, Direction<2>::lower_eta());
   }
 
-  // Now check ComputeBoundaryFlux
+  // Now check ReceiveDataForFluxes
   const auto send_data = [&extents, &runner, &self_id, &time_id, &coordmap](
       const ElementId<2>& id, const Direction<2>& direction,
-      const OrientationMap<2>& orientation, const DataVector& normal_dot_fluxes,
-      const DataVector& other_data) noexcept {
+      const OrientationMap<2>& orientation,
+      const Scalar<DataVector>& normal_dot_fluxes,
+      const Scalar<DataVector>& other_data) noexcept {
     const Element<2> element(id, {{direction, {{self_id}, orientation}}});
     auto map = ElementMap<2, Frame::Inertial>(id, coordmap->get_clone());
 
     db::item_type<normal_dot_fluxes_tag> normal_dot_fluxes_map{};
-    normal_dot_fluxes_map[direction].initialize(normal_dot_fluxes.size());
-    get(get<Tags::NormalDotFlux<Var>>(normal_dot_fluxes_map[direction])) =
+    normal_dot_fluxes_map[direction].initialize(get(normal_dot_fluxes).size());
+    get<Tags::NormalDotFlux<Var>>(normal_dot_fluxes_map[direction]) =
         normal_dot_fluxes;
 
     db::item_type<other_data_tag> other_data_map{};
-    other_data_map[direction].initialize(other_data.size());
-    get(get<OtherData>(other_data_map[direction])) = other_data;
+    other_data_map[direction].initialize(get(other_data).size());
+    get<OtherData>(other_data_map[direction]) = other_data;
 
-    auto box =
-        db::create<db::AddSimpleTags<Tags::TimeId, Tags::Extents<2>,
-                                     Tags::Element<2>, Tags::ElementMap<2>,
-                                     normal_dot_fluxes_tag, other_data_tag>,
-                   compute_items>(time_id, extents, element, std::move(map),
-                                  std::move(normal_dot_fluxes_map),
-                                  std::move(other_data_map));
+    db::item_type<mortar_data_tag> mortar_history{};
+    mortar_history[std::make_pair(direction, self_id)];
+
+    auto box = db::create<
+        db::AddSimpleTags<Tags::TimeId, Tags::Extents<2>, Tags::Element<2>,
+                          Tags::ElementMap<2>, normal_dot_fluxes_tag,
+                          other_data_tag, mortar_data_tag>,
+        compute_items>(time_id, extents, element, std::move(map),
+                       std::move(normal_dot_fluxes_map),
+                       std::move(other_data_map), std::move(mortar_history));
 
     runner.apply<component, send_data_for_fluxes>(box, id);
   };
 
-  // The `other_data` (second DataVector argument) for each send is
-  // chosen to satisfy the check in NumericalFlux::operator().  For
-  // that, we want (with I<> and E<> indicating interior and exterior)
-  // E<other_data> = 1 + 2 I<other_data>
-  //    + 4 I<normal>_0 - 2 E<normal>_0 + 6 I<normal>_1 - 3 E<normal>_1
-  // Note that these are unit normals, and remember the eta map is
-  // reversing so the normals point the wrong way with respect to the
-  // logical coordinates.
   CHECK_FALSE(
-      (runner.is_ready<component, compute_boundary_flux>(sent_box, self_id)));
-  // 0 = I<normal>_0 = E<normal>_0, 1 = E<normal>_1 = - I<normal>_1
-  // => E<other_data> = 2 I<other_data> - 8
-  send_data(south_id, Direction<2>::lower_eta(), {}, {11., 12., 13.},
-            {142., 162., 182.});
+      (runner.is_ready<component, receive_data_for_fluxes>(sent_box, self_id)));
+  send_data(south_id, Direction<2>::lower_eta(), {},
+            data.remote_fluxes.at(Direction<2>::upper_eta()),
+            data.remote_other_data.at(Direction<2>::upper_eta()));
   CHECK_FALSE(
-      (runner.is_ready<component, compute_boundary_flux>(sent_box, self_id)));
-  // 0 = I<normal>_1 = E<normal>_1, 1 = I<normal>_0 = - E<normal>_0
-  // => E<other_data> = 2 I<other_data> + 7
-  send_data(east_id, Direction<2>::lower_xi(), {}, {21., 22., 23.},
-            {97., 117., 137.});
+      (runner.is_ready<component, receive_data_for_fluxes>(sent_box, self_id)));
+  send_data(east_id, Direction<2>::lower_xi(), {},
+            data.remote_fluxes.at(Direction<2>::upper_xi()),
+            data.remote_other_data.at(Direction<2>::upper_xi()));
   CHECK_FALSE(
-      (runner.is_ready<component, compute_boundary_flux>(sent_box, self_id)));
-  // 0 = I<normal>_1 = E<normal>_0, 1 = E<normal>_1 = - I<normal>_0
-  // => E<other_data> = 2 I<other_data> - 6
-  // And the data order is reversed due to the block alignment.
+      (runner.is_ready<component, receive_data_for_fluxes>(sent_box, self_id)));
   send_data(west_id, Direction<2>::lower_eta(), block_orientation.inverse_map(),
-            {31., 32., 33.}, {64., 44., 24.});
-  CHECK((runner.is_ready<component, compute_boundary_flux>(sent_box, self_id)));
+            data.remote_fluxes.at(Direction<2>::lower_xi()),
+            data.remote_other_data.at(Direction<2>::lower_xi()));
+  CHECK(runner.is_ready<component, receive_data_for_fluxes>(sent_box, self_id));
 
   auto received_box = std::get<0>(
-      runner.apply<component, compute_boundary_flux>(sent_box, self_id));
+      runner.apply<component, receive_data_for_fluxes>(sent_box, self_id));
 
   CHECK(tuples::get<fluxes_tag>(runner.inboxes<component>()[self_id]).empty());
 
-  const double element_length_xi =
-      0.25 * abs(xi_map(std::array<double, 1>{{1.}})[0] -
-                 xi_map(std::array<double, 1>{{-1.}})[0]);
-  const double element_length_eta =
-      0.5 * abs(eta_map(std::array<double, 1>{{1.}})[0] -
-                eta_map(std::array<double, 1>{{-1.}})[0]);
+  db::mutate<mortar_data_tag>(make_not_null(&received_box), [
+    &west_id, &east_id, &south_id, &data
+  ](const gsl::not_null<db::item_type<mortar_data_tag>*>
+        mortar_history) noexcept {
+    CHECK(mortar_history->size() == 3);
+    const auto check_mortar = [&mortar_history](
+        const std::pair<Direction<2>, ElementId<2>>& mortar_id,
+        const Scalar<DataVector>& local_flux,
+        const Scalar<DataVector>& remote_flux,
+        const Scalar<DataVector>& local_other,
+        const Scalar<DataVector>& remote_other,
+        const tnsr::i<DataVector, 2>& local_normal,
+        const tnsr::i<DataVector, 2>& remote_normal) noexcept {
+      LocalData local_data(3);
+      get<Tags::NormalDotFlux<Var>>(local_data) = local_flux;
+      get<MagnitudeOfFaceNormal>(local_data) = magnitude(local_normal);
+      auto normalized_local_normal = local_normal;
+      for (auto& x : normalized_local_normal) {
+        x /= get(get<MagnitudeOfFaceNormal>(local_data));
+      }
+      PackagedData local_packaged(3);
+      NumericalFlux{}.package_data(&local_packaged, local_flux, local_flux,
+                                   local_other, normalized_local_normal);
+      local_data.assign_subset(local_packaged);
 
-  // Prefactor and weight as in Kopriva 8.42.  Equal to
-  // -2/(element length)/w_0  with  w_0 = 2/(N(N-1))  where here N=3.
-  const double xi_lift = -6. / element_length_xi;
-  const double eta_lift = -6. / element_length_eta;
-  // n.(F* - F)
-  // For the test we set n.F* = 11 n.F + 1000 n.F_nbr, so
-  //      n.(F* - F) = 10 n.F + 1000 n.F_nbr
-  const DataVector xi_boundaries{33010., 0., 21040.,
-                                 32020., 0., 22050.,
-                                 31030., 0., 23060.};
-  const DataVector eta_boundaries{0., 0., 0.,
-                                  0., 0., 0.,
-                                  11070., 12080., 13090.};
+      const auto magnitude_remote_normal = magnitude(remote_normal);
+      auto normalized_remote_normal = remote_normal;
+      for (auto& x : normalized_remote_normal) {
+        x /= get(magnitude_remote_normal);
+      }
+      PackagedData remote_packaged(3);
+      NumericalFlux{}.package_data(&remote_packaged, remote_flux, remote_flux,
+                                   remote_other, normalized_remote_normal);
+      // Cannot be inlined because of CHECK implementation.
+      const auto expected =
+          std::make_pair(std::move(local_data), std::move(remote_packaged));
+      CHECK(mortar_history->at(mortar_id).extract() == expected);
+    };
 
-  // 3.0 is the time derivative put in at the start.
-  CHECK_ITERABLE_APPROX(
-      get(get<Tags::dt<Var>>(db::get<dt_variables_tag>(received_box))),
-      xi_lift * xi_boundaries + eta_lift * eta_boundaries + 3.0);
+    // Remote side is inverted
+    check_mortar(
+        std::make_pair(Direction<2>::lower_xi(), west_id),
+        data.fluxes.at(Direction<2>::lower_xi()),
+        reverse(data.remote_fluxes.at(Direction<2>::lower_xi())),
+        data.other_data.at(Direction<2>::lower_xi()),
+        reverse(data.remote_other_data.at(Direction<2>::lower_xi())),
+        tnsr::i<DataVector, 2>{{{DataVector{3, -2.0}, DataVector{3, 0.0}}}},
+        tnsr::i<DataVector, 2>{{{DataVector{3, 0.0}, DataVector{3, 0.5}}}});
+    check_mortar(
+        std::make_pair(Direction<2>::upper_xi(), east_id),
+        data.fluxes.at(Direction<2>::upper_xi()),
+        data.remote_fluxes.at(Direction<2>::upper_xi()),
+        data.other_data.at(Direction<2>::upper_xi()),
+        data.remote_other_data.at(Direction<2>::upper_xi()),
+        tnsr::i<DataVector, 2>{{{DataVector{3, 2.0}, DataVector{3, 0.0}}}},
+        tnsr::i<DataVector, 2>{{{DataVector{3, -2.0}, DataVector{3, 0.0}}}});
+    check_mortar(
+        std::make_pair(Direction<2>::upper_eta(), south_id),
+        data.fluxes.at(Direction<2>::upper_eta()),
+        data.remote_fluxes.at(Direction<2>::upper_eta()),
+        data.other_data.at(Direction<2>::upper_eta()),
+        data.remote_other_data.at(Direction<2>::upper_eta()),
+        tnsr::i<DataVector, 2>{{{DataVector{3, 0.0}, DataVector{3, -1.0}}}},
+        tnsr::i<DataVector, 2>{{{DataVector{3, 0.0}, DataVector{3, 1.0}}}});
+  });
 }
 
 SPECTRE_TEST_CASE(
     "Unit.DiscontinuousGalerkin.Actions.FluxCommunication.NoNeighbors",
     "[Unit][NumericalAlgorithms][Actions]") {
-  ActionTesting::ActionRunner<Metavariables> runner{{}};
+  ActionTesting::ActionRunner<Metavariables> runner{{NumericalFlux{}}};
 
   const Slab slab(1., 3.);
   const TimeId time_id{8, slab.start(), 0};
@@ -378,25 +418,26 @@ SPECTRE_TEST_CASE(
                                                   CoordinateMaps::Affine>(
                        {-1., 1., 3., 7.}, {-1., 1., -2., 4.})));
 
-  db::item_type<dt_variables_tag> dt_variables(extents.product(), 3.0);
   auto start_box = db::create<
       db::AddSimpleTags<Tags::TimeId, Tags::Extents<2>, Tags::Element<2>,
-                        Tags::ElementMap<2>, dt_variables_tag,
-                        normal_dot_fluxes_tag, other_data_tag>,
-      compute_items>(
-      time_id, extents, element, std::move(map), std::move(dt_variables),
-      db::item_type<normal_dot_fluxes_tag>{}, db::item_type<other_data_tag>{});
+                        Tags::ElementMap<2>, normal_dot_fluxes_tag,
+                        other_data_tag, mortar_data_tag>,
+      compute_items>(time_id, extents, element, std::move(map),
+                     db::item_type<normal_dot_fluxes_tag>{},
+                     db::item_type<other_data_tag>{},
+                     db::item_type<mortar_data_tag>{});
 
   auto sent_box = std::get<0>(
       runner.apply<component, send_data_for_fluxes>(start_box, self_id));
 
-  CHECK((runner.nonempty_inboxes<component, fluxes_tag>().empty()));
+  CHECK(db::get<mortar_data_tag>(sent_box).empty());
+  CHECK(runner.nonempty_inboxes<component, fluxes_tag>().empty());
 
-  CHECK((runner.is_ready<component, compute_boundary_flux>(sent_box, self_id)));
+  CHECK(runner.is_ready<component, receive_data_for_fluxes>(sent_box, self_id));
 
   const auto received_box = std::get<0>(
-      runner.apply<component, compute_boundary_flux>(sent_box, self_id));
+      runner.apply<component, receive_data_for_fluxes>(sent_box, self_id));
 
-  CHECK(db::get<dt_variables_tag>(received_box) ==
-        db::item_type<dt_variables_tag>(extents.product(), 3.0));
+  CHECK(db::get<mortar_data_tag>(received_box).empty());
+  CHECK(runner.nonempty_inboxes<component, fluxes_tag>().empty());
 }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_NumericalDiscontinuousGalerkin")
 
 set(LIBRARY_SOURCES
   Test_LiftFlux.cpp
+  Test_SimpleBoundaryData.cpp
   )
 
 add_subdirectory(Actions)

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleBoundaryData.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleBoundaryData.cpp
@@ -3,6 +3,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <cstddef>
 #include <string>
 // for __decay_and_strip<>::__type
 // IWYU pragma: no_include <type_traits>
@@ -10,51 +11,45 @@
 
 #include "ErrorHandling/Error.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
-#include "Time/Slab.hpp"
-#include "Time/Time.hpp"
 #include "Utilities/Literals.hpp"  // IWYU pragma: keep
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
-  const Slab slab(0., 1.);
-
-  dg::SimpleBoundaryData<std::string, double> data;
+  dg::SimpleBoundaryData<size_t, std::string, double> data;
   data = serialize_and_deserialize(data);
-  data.local_insert(slab.start(), "string 1");
+  data.local_insert(0, "string 1");
   data = serialize_and_deserialize(data);
-  data.remote_insert(slab.start(), 1.234);
+  data.remote_insert(0, 1.234);
   CHECK(data.extract() == std::make_pair("string 1"s, 1.234));
   data = serialize_and_deserialize(data);
-  data.remote_insert(slab.start(), 2.345);
+  data.remote_insert(1, 2.345);
   data = serialize_and_deserialize(data);
-  data.local_insert(slab.start(), "string 2");
+  data.local_insert(1, "string 2");
   CHECK(data.extract() == std::make_pair("string 2"s, 2.345));
 }
 
-// [[OutputRegex, Received local data at time Slab\[0,1\]:1/1 but
-// already have remote data at time Slab\[0,1\]:0/1]]
+// [[OutputRegex, Received local data at 1, but already have remote
+// data at 0]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData.wrong_time.local",
                                "[Unit][Time]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const Slab slab(0., 1.);
-  dg::SimpleBoundaryData<std::string, double> data;
-  data.remote_insert(slab.start(), 0.);
-  data.local_insert(slab.end(), "");
+  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  data.remote_insert(0, 0.);
+  data.local_insert(1, "");
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
-// [[OutputRegex, Received remote data at time Slab\[0,1\]:0/1 but
-// already have local data at time Slab\[0,1\]:1/1]]
+// [[OutputRegex, Received remote data at 0, but already have local
+// data at 1]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData.wrong_time.remote",
                                "[Unit][Time]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const Slab slab(0., 1.);
-  dg::SimpleBoundaryData<std::string, double> data;
-  data.local_insert(slab.end(), "");
-  data.remote_insert(slab.start(), 0.);
+  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  data.local_insert(1, "");
+  data.remote_insert(0, 0.);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -64,10 +59,9 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
     "Unit.Time.SimpleBoundaryData.double_insert.local", "[Unit][Time]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const Slab slab(0., 1.);
-  dg::SimpleBoundaryData<std::string, double> data;
-  data.local_insert(slab.end(), "");
-  data.local_insert(slab.end(), "");
+  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  data.local_insert(1, "");
+  data.local_insert(1, "");
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -77,10 +71,9 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
     "Unit.Time.SimpleBoundaryData.double_insert.remote", "[Unit][Time]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const Slab slab(0., 1.);
-  dg::SimpleBoundaryData<std::string, double> data;
-  data.remote_insert(slab.start(), 0.);
-  data.remote_insert(slab.start(), 0.);
+  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  data.remote_insert(0, 0.);
+  data.remote_insert(0, 0.);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -90,8 +83,7 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
     "Unit.Time.SimpleBoundaryData.bad_extract.none", "[Unit][Time]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const Slab slab(0., 1.);
-  dg::SimpleBoundaryData<std::string, double> data;
+  dg::SimpleBoundaryData<size_t, std::string, double> data;
   data.extract();
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
@@ -102,9 +94,8 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
     "Unit.Time.SimpleBoundaryData.bad_extract.no_remote", "[Unit][Time]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const Slab slab(0., 1.);
-  dg::SimpleBoundaryData<std::string, double> data;
-  data.local_insert(slab.end(), "");
+  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  data.local_insert(1, "");
   data.extract();
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
@@ -115,9 +106,8 @@ SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
     "Unit.Time.SimpleBoundaryData.bad_extract.no_local", "[Unit][Time]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  const Slab slab(0., 1.);
-  dg::SimpleBoundaryData<std::string, double> data;
-  data.remote_insert(slab.start(), 0.);
+  dg::SimpleBoundaryData<size_t, std::string, double> data;
+  data.remote_insert(0, 0.);
   data.extract();
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleBoundaryData.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_SimpleBoundaryData.cpp
@@ -1,0 +1,124 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+// for __decay_and_strip<>::__type
+// IWYU pragma: no_include <type_traits>
+#include <utility>
+
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Literals.hpp"  // IWYU pragma: keep
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData", "[Unit][Time]") {
+  const Slab slab(0., 1.);
+
+  dg::SimpleBoundaryData<std::string, double> data;
+  data = serialize_and_deserialize(data);
+  data.local_insert(slab.start(), "string 1");
+  data = serialize_and_deserialize(data);
+  data.remote_insert(slab.start(), 1.234);
+  CHECK(data.extract() == std::make_pair("string 1"s, 1.234));
+  data = serialize_and_deserialize(data);
+  data.remote_insert(slab.start(), 2.345);
+  data = serialize_and_deserialize(data);
+  data.local_insert(slab.start(), "string 2");
+  CHECK(data.extract() == std::make_pair("string 2"s, 2.345));
+}
+
+// [[OutputRegex, Received local data at time Slab\[0,1\]:1/1 but
+// already have remote data at time Slab\[0,1\]:0/1]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData.wrong_time.local",
+                               "[Unit][Time]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const Slab slab(0., 1.);
+  dg::SimpleBoundaryData<std::string, double> data;
+  data.remote_insert(slab.start(), 0.);
+  data.local_insert(slab.end(), "");
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Received remote data at time Slab\[0,1\]:0/1 but
+// already have local data at time Slab\[0,1\]:1/1]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Time.SimpleBoundaryData.wrong_time.remote",
+                               "[Unit][Time]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const Slab slab(0., 1.);
+  dg::SimpleBoundaryData<std::string, double> data;
+  data.local_insert(slab.end(), "");
+  data.remote_insert(slab.start(), 0.);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Already received local data]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Time.SimpleBoundaryData.double_insert.local", "[Unit][Time]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const Slab slab(0., 1.);
+  dg::SimpleBoundaryData<std::string, double> data;
+  data.local_insert(slab.end(), "");
+  data.local_insert(slab.end(), "");
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Already received remote data]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Time.SimpleBoundaryData.double_insert.remote", "[Unit][Time]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const Slab slab(0., 1.);
+  dg::SimpleBoundaryData<std::string, double> data;
+  data.remote_insert(slab.start(), 0.);
+  data.remote_insert(slab.start(), 0.);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Tried to extract boundary data, but do not have any data]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Time.SimpleBoundaryData.bad_extract.none", "[Unit][Time]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const Slab slab(0., 1.);
+  dg::SimpleBoundaryData<std::string, double> data;
+  data.extract();
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Tried to extract boundary data, but do not have remote data]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Time.SimpleBoundaryData.bad_extract.no_remote", "[Unit][Time]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const Slab slab(0., 1.);
+  dg::SimpleBoundaryData<std::string, double> data;
+  data.local_insert(slab.end(), "");
+  data.extract();
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Tried to extract boundary data, but do not have local data]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Time.SimpleBoundaryData.bad_extract.no_local", "[Unit][Time]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const Slab slab(0., 1.);
+  dg::SimpleBoundaryData<std::string, double> data;
+  data.remote_insert(slab.start(), 0.);
+  data.extract();
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}

--- a/tests/Unit/Utilities/Test_BoostHelpers.cpp
+++ b/tests/Unit/Utilities/Test_BoostHelpers.cpp
@@ -3,6 +3,8 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <string>
 
 #include "Utilities/BoostHelpers.hpp"  // IWYU pragma: associated
@@ -14,7 +16,8 @@ static_assert(
                      make_boost_variant_over<tmpl::list<double, int, char>>>,
     "Failed testing make_variant_over");
 
-SPECTRE_TEST_CASE("Unit.Utilities.BoostHelpers.Pup", "[Unit][Utilities]") {
+SPECTRE_TEST_CASE("Unit.Utilities.BoostHelpers.Variant.Pup",
+                  "[Unit][Utilities]") {
   // The order of checks is arbitrary but jumps around to make sure that it is
   // general enough to catch bugs.
   boost::variant<int, double, char, std::string> var{"aoeu"};
@@ -36,11 +39,17 @@ SPECTRE_TEST_CASE("Unit.Utilities.BoostHelpers.Pup", "[Unit][Utilities]") {
   CHECK(boost::get<double>(var) == boost::get<double>(var2));
 }
 
-SPECTRE_TEST_CASE("Unit.Utilities.BoostHelpers.VariantNames",
+SPECTRE_TEST_CASE("Unit.Utilities.BoostHelpers.Variant.Names",
                   "[Unit][Utilities]") {
   boost::variant<int, double, char, std::string> var{"aoeu"};
   CHECK(type_of_current_state(var) == "std::string");
   CHECK(type_of_current_state(var = 1) == "int");
   CHECK(type_of_current_state(var = 'A') == "char");
   CHECK(type_of_current_state(var = 2.8) == "double");
+}
+
+SPECTRE_TEST_CASE("Unit.Utilities.BoostHelpers.Optional.Pup",
+                  "[Unit][Utilities]") {
+  test_serialization(boost::optional<double>{});
+  test_serialization(boost::optional<double>{1.2});
 }

--- a/tools/Iwyu/iwyu.imp
+++ b/tools/Iwyu/iwyu.imp
@@ -41,6 +41,11 @@
   { include: ["<pythonrun.h>", private,
               "<Python.h>", public]},
 
+  { include: ["<boost/optional/optional.hpp>", public,
+              "<boost/optional.hpp>", public]},
+  { include: ["<boost/optional/detail/optional_relops.hpp>", public,
+              "<boost/optional.hpp>", public]},
+
   { symbol: ["db::DataBox", private,
              "\"DataStructures/DataBox/DataBox.hpp\"", public]},
   { symbol: ["Tensor", private,


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
