### PR TITLE
Remove CheckInverse from TestMapHelpers

### DIFF
--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -165,7 +165,7 @@ void test_coordinate_map_implementation(const Map& map) {
  * \brief Checks that the CoordinateMap `map` functions as expected when used
  * with different argument types.
  */
-template <bool CheckInverse = true, typename Map, typename... Args>
+template <typename Map, typename... Args>
 void test_coordinate_map_argument_types(
     const Map& map, const std::array<double, Map::dim>& test_point,
     const Args&... args) {
@@ -200,8 +200,7 @@ void test_coordinate_map_argument_types(
   CHECK_ITERABLE_APPROX(
       map(add_reference_wrapper(make_array_data_vector(test_point)), args...),
       make_array_data_vector(mapped_point));
-
-  if (CheckInverse) {
+  {
     const auto expected = map.inverse(mapped_point, args...);
     CHECK_ITERABLE_APPROX(
         map.inverse(add_reference_wrapper(mapped_point), args...), expected);

--- a/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
@@ -45,7 +45,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Identity",
   CHECK(serialize_and_deserialize(map) == map);
   CHECK_FALSE(serialize_and_deserialize(map) != map);
 
-  test_coordinate_map_argument_types<true>(map, test_point1);
+  test_coordinate_map_argument_types(map, test_point1);
 }
 
 void test_bulged_cube(bool with_equiangular_map) {
@@ -87,7 +87,7 @@ void test_bulged_cube(bool with_equiangular_map) {
   CHECK(serialize_and_deserialize(map) == map);
   CHECK_FALSE(serialize_and_deserialize(map) != map);
 
-  test_coordinate_map_argument_types<true>(map, test_point1);
+  test_coordinate_map_argument_types(map, test_point1);
 
   test_inverse_map(map, test_point1);
   test_inverse_map(map, test_point2);

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -121,7 +121,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equidistant",
 
     test_coordinate_map_implementation(map);
 
-    test_coordinate_map_argument_types<true>(map, test_point);
+    test_coordinate_map_argument_types(map, test_point);
 
     test_inverse_map(map, test_point);
   }
@@ -230,7 +230,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equiangular",
 
     test_coordinate_map_implementation(map);
 
-    test_coordinate_map_argument_types<true>(map, test_point);
+    test_coordinate_map_argument_types(map, test_point);
 
     test_inverse_map(map, test_point);
   }


### PR DESCRIPTION
## Proposed changes
Closes #684 
<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
