### PR TITLE
Add StaticCache

### DIFF
--- a/src/Utilities/StaticCache.hpp
+++ b/src/Utilities/StaticCache.hpp
@@ -1,0 +1,120 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <utility>
+
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace StaticCache_detail {
+template <typename T, typename... Ranges>
+class StaticCacheImpl;
+
+template <typename T, typename Range0, typename... Ranges>
+class StaticCacheImpl<T, Range0, Ranges...> {
+  template <typename>
+  struct construction_helper;
+
+  template <size_t... RangeValues>
+  struct construction_helper<std::index_sequence<RangeValues...>> {
+    template <typename Generator, typename... Args>
+    constexpr static std::array<StaticCacheImpl<T, Ranges...>, Range0::size>
+    construct(Generator&& generator, const Args... args) noexcept {
+      return {{StaticCacheImpl<T, Ranges...>(generator, args...,
+                                             RangeValues + Range0::start)...}};
+    }
+  };
+
+ public:
+  template <typename Generator, typename... Args,
+            Requires<not cpp17::is_same_v<std::decay_t<Generator>,
+                                          StaticCacheImpl>> = nullptr>
+  explicit constexpr StaticCacheImpl(Generator&& generator,
+                                     const Args... args) noexcept
+      : data_(construction_helper<
+              std::make_index_sequence<Range0::size>>::construct(generator,
+                                                                 args...)) {}
+
+  template <typename... Args>
+  const T& operator()(const size_t first_index, const Args... rest) const
+      noexcept {
+    ASSERT(Range0::start <= first_index and first_index < Range0::end,
+           "Index out of range: " << Range0::start << " <= " << first_index
+           << " < " << Range0::end);
+    return gsl::at(data_, first_index - Range0::start)(rest...);
+  }
+
+ private:
+  std::array<StaticCacheImpl<T, Ranges...>, Range0::size> data_;
+};
+
+template <typename T>
+class StaticCacheImpl<T> {
+ public:
+  template <typename Generator, typename... Args,
+            Requires<not cpp17::is_same_v<std::decay_t<Generator>,
+                                          StaticCacheImpl>> = nullptr>
+  explicit constexpr StaticCacheImpl(Generator&& generator,
+                                     const Args... args) noexcept
+      : data_(generator(args...)) {}
+
+  const T& operator()() const noexcept { return data_; }
+
+ private:
+  T data_;
+};
+}  // namespace StaticCache_detail
+
+/// \ingroup UtilitiesGroup
+/// A cache of objects intended to be stored in a static variable.
+///
+/// Objects can be accessed using several `size_t` arguments in the
+/// ranges specified as template parameters.  The CacheRange template
+/// parameters give first and one-past-last values for the valid
+/// ranges for each argument.
+///
+/// \example
+/// \snippet Test_StaticCache.cpp static_cache
+///
+/// \tparam T type held in the cache
+/// \tparam Ranges ranges of valid indices
+template <typename T, typename... Ranges>
+class StaticCache {
+ public:
+  /// Initialize the cache.  All objects will be created by calling
+  /// `generator` before the constructor returns.
+  // clang-tidy: misc-forwarding-reference-overload - fixed with
+  // Requires, but clang-tidy can't recognize that.
+  template <typename Generator,
+            Requires<not cpp17::is_same_v<std::decay_t<Generator>,
+                                          StaticCache>> = nullptr>
+  explicit constexpr StaticCache(Generator&& generator) noexcept  // NOLINT
+      : data_(generator) {}
+
+  template <typename... Args>
+  const T& operator()(const Args... indices) const noexcept {
+    static_assert(sizeof...(Args) == sizeof...(Ranges),
+                  "Number of arguments must match number of ranges.");
+    return data_(static_cast<size_t>(indices)...);
+  }
+
+ private:
+  StaticCache_detail::StaticCacheImpl<T, Ranges...> data_;
+};
+
+/// \ingroup UtilitiesGroup
+/// Range of values for StaticCache indices.  The `Start` is inclusive
+/// and the `End` is exclusive.  The range must not be empty.
+template <size_t Start, size_t End>
+struct CacheRange {
+  static_assert(Start < End, "CacheRange must include at least one value");
+  constexpr static size_t start = Start;
+  constexpr static size_t end = End;
+  constexpr static size_t size = end - start;
+};

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIBRARY_SOURCES
   Test_PrettyType.cpp
   Test_Rational.cpp
   Test_Requires.cpp
+  Test_StaticCache.cpp
   Test_StdArrayHelpers.cpp
   Test_StdHelpers.cpp
   Test_TaggedTuple.cpp

--- a/tests/Unit/Utilities/Test_StaticCache.cpp
+++ b/tests/Unit/Utilities/Test_StaticCache.cpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/StaticCache.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
+  /// [static_cache]
+  const static StaticCache<size_t, CacheRange<0, 3>, CacheRange<3, 5>> cache(
+      [](const size_t a, const size_t b) noexcept { return a + b; });
+  CHECK(cache(0, 3) == 3);  // smallest entry
+  CHECK(cache(2, 4) == 6);  // largest entry
+  /// [static_cache]
+
+  std::vector<std::pair<size_t, size_t>> calls;
+  const StaticCache<size_t, CacheRange<0, 3>, CacheRange<3, 5>> cache2([&calls](
+      const size_t a, const size_t b) noexcept {
+    calls.emplace_back(a, b);
+    return a + b;
+  });
+  CHECK(calls.size() == 6);
+  // Creation order is not specified.
+  std::sort(calls.begin(), calls.end());
+  const decltype(calls) expected_calls{{0, 3}, {0, 4}, {1, 3},
+                                       {1, 4}, {2, 3}, {2, 4}};
+  CHECK(calls == expected_calls);
+  for (const auto& call : expected_calls) {
+    CHECK(cache2(call.first, call.second) == call.first + call.second);
+  }
+  CHECK(calls == expected_calls);
+
+  size_t small_calls = 0;
+  const StaticCache<size_t> small_cache([&small_calls]() noexcept {
+    ++small_calls;
+    return size_t{5};
+  });
+  CHECK(small_calls == 1);
+  CHECK(small_cache() == 5);
+  CHECK(small_calls == 1);
+}
+
+// [[OutputRegex, Index out of range: 3 <= 2 < 5]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.StaticCache.out_of_range.low",
+                               "[Utilities][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  StaticCache<size_t, CacheRange<3, 5>> cache([](const size_t x) noexcept {
+    return x;
+  });
+  cache(2);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Index out of range: 3 <= 5 < 5]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.StaticCache.out_of_range.high",
+                               "[Utilities][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  StaticCache<size_t, CacheRange<3, 5>> cache([](const size_t x) noexcept {
+    return x;
+  });
+  cache(5);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}


### PR DESCRIPTION
Split from #669.  See there for discussion.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
