### PR TITLE
Add functionality to Pypp for testing analytic solutions

### DIFF
--- a/src/Utilities/MakeWithValue.hpp
+++ b/src/Utilities/MakeWithValue.hpp
@@ -38,11 +38,13 @@ SPECTRE_ALWAYS_INLINE R make_with_value(const T& input, double value) {
 
 namespace MakeWithValueImpls {
 /// \brief Returns a double initialized to `value` (`input` is ignored)
-template <>
-SPECTRE_ALWAYS_INLINE double MakeWithValueImpl<double, double>::apply(
-    const double& /* input */, const double value) {
-  return value;
-}
+template <typename T>
+struct MakeWithValueImpl<double, T> {
+  static SPECTRE_ALWAYS_INLINE double apply(const T& /* input */,
+                                            const double value) {
+    return value;
+  }
+};
 
 /// \brief Makes a `std::array`; each element of the `std::array`
 /// must be `make_with_value`-creatable from a `T`.

--- a/tests/Unit/PointwiseFunctions/EquationsOfState/TestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/EquationsOfState/TestHelpers.hpp
@@ -68,9 +68,7 @@ void check_impl(const std::unique_ptr<::EquationsOfState::EquationOfState<
         func, *eos, "TestFunctions",
         python_function_prefix + "_pressure_from_density",
         {{random_value_bounds[0], random_value_bounds[Is + 1]...}},
-        std::make_tuple(
-            make_with_value<Scalar<T>>(used_for_size, member_args)...),
-        used_for_size);
+        std::make_tuple(member_args...), used_for_size);
     make_overloader(
         [&](const std::integral_constant<size_t, 1>& /*thermodynamic_dim*/,
             auto eos_for_type) {
@@ -87,9 +85,7 @@ void check_impl(const std::unique_ptr<::EquationsOfState::EquationOfState<
               {{std::make_pair(random_value_bounds[0].first * 1.0e4,
                                random_value_bounds[0].second * 1.0e4),
                 random_value_bounds[Is + 1]...}},
-              std::make_tuple(
-                  make_with_value<Scalar<T>>(used_for_size, member_args)...),
-              used_for_size);
+              std::make_tuple(member_args...), used_for_size);
         },
         [](const auto& /*meta*/, const auto& /*meta*/) {})(
         std::integral_constant<size_t, ThermodynamicDim>{},
@@ -102,8 +98,7 @@ void check_impl(const std::unique_ptr<::EquationsOfState::EquationOfState<
                        : std::string(python_function_prefix +
                                      "_newt_specific_enthalpy_from_density"),
         {{random_value_bounds[0], random_value_bounds[Is + 1]...}},
-        std::make_tuple(
-            make_with_value<Scalar<T>>(used_for_size, member_args)...),
+        std::make_tuple(member_args...),
         used_for_size);
     INFO("Done\nTesting specific_internal_energy_from_density...")
     pypp::check_with_random_values<sizeof...(Is) + 1>(
@@ -111,16 +106,14 @@ void check_impl(const std::unique_ptr<::EquationsOfState::EquationOfState<
         "TestFunctions",
         python_function_prefix + "_specific_internal_energy_from_density",
         {{random_value_bounds[0], random_value_bounds[Is + 1]...}},
-        std::make_tuple(
-            make_with_value<Scalar<T>>(used_for_size, member_args)...),
+        std::make_tuple(member_args...),
         used_for_size);
     INFO("Done\nTesting chi_from_density...")
     pypp::check_with_random_values<sizeof...(Is) + 1>(
         func = &EoS::chi_from_density, *eos, "TestFunctions",
         python_function_prefix + "_chi_from_density",
         {{random_value_bounds[0], random_value_bounds[Is + 1]...}},
-        std::make_tuple(
-            make_with_value<Scalar<T>>(used_for_size, member_args)...),
+        std::make_tuple(member_args...),
         used_for_size);
     INFO("Done\nTesting kappa_times_p_over_rho_squared_from_density...")
     pypp::check_with_random_values<sizeof...(Is) + 1>(
@@ -128,8 +121,7 @@ void check_impl(const std::unique_ptr<::EquationsOfState::EquationOfState<
         "TestFunctions",
         python_function_prefix + "_kappa_times_p_over_rho_squared_from_density",
         {{random_value_bounds[0], random_value_bounds[Is + 1]...}},
-        std::make_tuple(
-            make_with_value<Scalar<T>>(used_for_size, member_args)...),
+        std::make_tuple(member_args...),
         used_for_size);
     INFO("Done\n\n")
   };

--- a/tests/Unit/Pypp/CheckWithRandomValues.hpp
+++ b/tests/Unit/Pypp/CheckWithRandomValues.hpp
@@ -45,7 +45,7 @@ void check_with_random_values_impl(
     const std::tuple<MemberArgs...>& member_args, const T& used_for_size,
     tmpl::list<ArgumentTypes...> /*argument_types*/,
     std::index_sequence<ArgumentIs...> /*index_argument_types*/,
-    std::index_sequence<MemberArgsIs...> /*index_member_args*/) noexcept {
+    std::index_sequence<MemberArgsIs...> /*index_member_args*/) {
   // Note: generator and distributions cannot be const.
   using f_info = tt::function_info<cpp20::remove_cvref_t<F>>;
   using ResultType = typename f_info::return_type;
@@ -88,7 +88,7 @@ void check_with_random_values_impl(
     tmpl::list<ArgumentTypes...> /*argument_types*/,
     std::index_sequence<ResultIs...> /*index_return_types*/,
     std::index_sequence<ArgumentIs...> /*index_argument_types*/,
-    std::index_sequence<MemberArgsIs...> /*index_member_args*/) noexcept {
+    std::index_sequence<MemberArgsIs...> /*index_member_args*/) {
   // Note: generator and distributions cannot be const.
   std::tuple<ReturnTypes...> results{
       make_with_value<ReturnTypes>(used_for_size, 0.0)...};
@@ -180,7 +180,7 @@ void check_with_random_values(
         lower_and_upper_bounds,
     const T& used_for_size,
     const typename std::random_device::result_type seed =
-        std::random_device{}()) noexcept {
+        std::random_device{}()) {
   INFO("seed: " << seed);
   std::mt19937 generator(seed);
   using f_info = tt::function_info<cpp20::remove_cvref_t<F>>;
@@ -261,7 +261,7 @@ void check_with_random_values(
         lower_and_upper_bounds,
     const T& used_for_size,
     const typename std::random_device::result_type seed =
-        std::random_device{}()) noexcept {
+        std::random_device{}()) {
   INFO("seed: " << seed);
   std::mt19937 generator(seed);
   using f_info = tt::function_info<cpp20::remove_cvref_t<F>>;
@@ -368,7 +368,7 @@ void check_with_random_values(
         lower_and_upper_bounds,
     const std::tuple<MemberArgs...>& member_args, const T& used_for_size,
     const typename std::random_device::result_type seed =
-        std::random_device{}()) noexcept {
+        std::random_device{}()) {
   INFO("seed: " << seed);
   std::mt19937 generator(seed);
   using f_info = tt::function_info<cpp20::remove_cvref_t<F>>;
@@ -460,7 +460,7 @@ void check_with_random_values(
         lower_and_upper_bounds,
     const std::tuple<MemberArgs...>& member_args, const T& used_for_size,
     const typename std::random_device::result_type seed =
-        std::random_device{}()) noexcept {
+        std::random_device{}()) {
   INFO("seed: " << seed);
   std::mt19937 generator(seed);
   using f_info = tt::function_info<cpp20::remove_cvref_t<F>>;

--- a/tests/Unit/Pypp/CheckWithRandomValues.hpp
+++ b/tests/Unit/Pypp/CheckWithRandomValues.hpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
@@ -64,7 +65,7 @@ template <typename ReturnType, typename = std::nullptr_t>
 struct ForwardToPyppImpl {
   template <typename MemberArg, typename UsedForSize>
   static decltype(auto) apply(const MemberArg& member_arg,
-                    const UsedForSize& /*used_for_size*/) noexcept {
+                              const UsedForSize& /*used_for_size*/) noexcept {
     return member_arg;
   }
 };
@@ -77,7 +78,7 @@ struct ForwardToPyppImpl<
                  is_same_v<typename ReturnType::value_type, DataVector>>> {
   template <typename MemberArg, typename UsedForSize>
   static decltype(auto) apply(const MemberArg& member_arg,
-                    const UsedForSize& used_for_size) noexcept {
+                              const UsedForSize& used_for_size) noexcept {
     return ConvertToTensorImpl<MemberArg, UsedForSize>::apply(member_arg,
                                                               used_for_size);
   }
@@ -93,6 +94,51 @@ decltype(auto) forward_to_pypp(const MemberArg& member_arg,
                                const UsedForSize& used_for_size) noexcept {
   return ForwardToPyppImpl<PyppReturn>::apply(member_arg, used_for_size);
 }
+
+template <class F, class T, class TagsList, class Klass, class... ReturnTypes,
+          class... ArgumentTypes, class... MemberArgs, size_t... ResultIs,
+          size_t... ArgumentIs, size_t... MemberArgsIs>
+void check_with_random_values_impl(
+    F&& f, const Klass& klass, const std::string& module_name,
+    const std::vector<std::string>& function_names, std::mt19937 generator,
+    std::array<std::uniform_real_distribution<>, sizeof...(ArgumentTypes)>
+        distributions,
+    const std::tuple<MemberArgs...>& member_args, const T& used_for_size,
+    tmpl::list<ReturnTypes...> /*return_types*/,
+    tmpl::list<ArgumentTypes...> /*argument_types*/,
+    std::index_sequence<ResultIs...> /*index_return_types*/,
+    std::index_sequence<ArgumentIs...> /*index_argument_types*/,
+    std::index_sequence<MemberArgsIs...> /*index_member_args*/,
+    TagsList /*meta*/) {
+  // Note: generator and distributions cannot be const.
+  std::tuple<ArgumentTypes...> args{
+      make_with_value<ArgumentTypes>(used_for_size, 0.0)...};
+  // We fill with random values after initialization because the order of
+  // evaluation is not guaranteed for a constructor call and so then knowing
+  // the seed would not lead to reproducible results.
+  (void)std::initializer_list<char>{(
+      (void)fill_with_random_values(
+          make_not_null(&std::get<ArgumentIs>(args)), make_not_null(&generator),
+          make_not_null(&(distributions[ArgumentIs]))),
+      '0')...};
+
+  size_t count = 0;
+  tmpl::for_each<TagsList>([&f, &klass, &args, &used_for_size, &member_args,
+                            &module_name, &function_names, &count](auto tag) {
+    (void)used_for_size;  // Avoid compiler warning
+    using Tag = tmpl::type_from<decltype(tag)>;
+    const auto result =
+        tuples::get<Tag>((klass.*f)(std::get<ArgumentIs>(args)...));
+    CHECK_ITERABLE_APPROX(
+        result,
+        (pypp::call<std::decay_t<decltype(result)>>(
+            module_name, function_names[count], std::get<ArgumentIs>(args)...,
+            forward_to_pypp<std::decay_t<decltype(result)>>(
+                std::get<MemberArgsIs>(member_args), used_for_size)...)));
+    count++;
+  });
+}
+
 template <class F, class T, class Klass, class... ArgumentTypes,
           class... MemberArgs, size_t... ArgumentIs, size_t... MemberArgsIs>
 void check_with_random_values_impl(
@@ -103,7 +149,8 @@ void check_with_random_values_impl(
     const std::tuple<MemberArgs...>& member_args, const T& used_for_size,
     tmpl::list<ArgumentTypes...> /*argument_types*/,
     std::index_sequence<ArgumentIs...> /*index_argument_types*/,
-    std::index_sequence<MemberArgsIs...> /*index_member_args*/) {
+    std::index_sequence<MemberArgsIs...> /*index_member_args*/,
+    NoSuchType /*meta*/) {
   // Note: generator and distributions cannot be const.
   using f_info = tt::function_info<cpp20::remove_cvref_t<F>>;
   using ResultType = typename f_info::return_type;
@@ -147,7 +194,8 @@ void check_with_random_values_impl(
     tmpl::list<ArgumentTypes...> /*argument_types*/,
     std::index_sequence<ResultIs...> /*index_return_types*/,
     std::index_sequence<ArgumentIs...> /*index_argument_types*/,
-    std::index_sequence<MemberArgsIs...> /*index_member_args*/) {
+    std::index_sequence<MemberArgsIs...> /*index_member_args*/,
+    NoSuchType /* meta */) {
   // Note: generator and distributions cannot be const.
   std::tuple<ReturnTypes...> results{
       make_with_value<ReturnTypes>(used_for_size, 0.0)...};
@@ -184,6 +232,7 @@ void check_with_random_values_impl(
   const auto helper = [&module_name, &function_names, &args, &results,
                        &member_args, &used_for_size](auto result_i) {
     (void)member_args;  // avoid compiler warning
+    (void)used_for_size;  // avoid compiler warning
     constexpr size_t iter = decltype(result_i)::value;
     CHECK_ITERABLE_APPROX(
         std::get<iter>(results),
@@ -277,7 +326,7 @@ void check_with_random_values(
       std::forward<F>(f), NoSuchType{}, module_name, function_name, generator,
       std::move(distributions), std::tuple<>{}, used_for_size, argument_types{},
       std::make_index_sequence<tmpl::size<argument_types>::value>{},
-      std::make_index_sequence<0>{});
+      std::make_index_sequence<0>{}, NoSuchType{});
 }
 
 /*!
@@ -374,7 +423,7 @@ void check_with_random_values(
       argument_types{},
       std::make_index_sequence<tmpl::size<return_types>::value>{},
       std::make_index_sequence<tmpl::size<argument_types>::value>{},
-      std::make_index_sequence<0>{});
+      std::make_index_sequence<0>{}, NoSuchType{});
 }
 
 /*!
@@ -390,11 +439,11 @@ void check_with_random_values(
  * argument `used_for_size` is used for constructing the arguments of `f` by
  * calling `make_with_value<ArgumentType>(used_for_size, 0.0)`.
  *
- * \note You must explicitly pass the number of bounds you will be passing as
- * the first template parameter, the rest will be inferred.
+ * \note You must explicitly pass the number of bounds you will be passing
+ * as the first template parameter, the rest will be inferred.
  *
- * \note If you have a test fail you can replay the scenario by feeding in the
- * seed that was printed out in the failed test as the last argument.
+ * \note If you have a test fail you can replay the scenario by feeding in
+ * the seed that was printed out in the failed test as the last argument.
  *
  * \param f The member function to test
  * \param klass the object on which to invoke `f`
@@ -465,12 +514,12 @@ void check_with_random_values(
       std::forward<F>(f), klass, module_name, function_name, generator,
       std::move(distributions), member_args, used_for_size, argument_types{},
       std::make_index_sequence<tmpl::size<argument_types>::value>{},
-      std::make_index_sequence<sizeof...(MemberArgs)>{});
+      std::make_index_sequence<sizeof...(MemberArgs)>{}, NoSuchType{});
 }
 
 /*!
- * \brief Tests a member function of a class returning by `gsl::not_null` by
- * comparing the result to a python function
+ * \brief Tests a member function of a class returning by either `gsl::not_null`
+ * or `TaggedTuple` by comparing the result to a python function
  *
  * Tests the function `f` by comparing the result to that of the python
  * functions `function_names` in the file `module_name`. An instance of the
@@ -484,6 +533,12 @@ void check_with_random_values(
  * initialized with random values rather than to signaling `NaN`s. This means
  * functions do not need to support receiving a signaling `NaN` in their return
  * argument to be tested using this function.
+ *
+ * If `TagsList` is passed as a `tmpl::list`, then `f` is expected to
+ * return a TaggedTuple. The result of each python function will be
+ * compared with calling `tuples::get` on the result of `f`. The order of the
+ * tags within `TagsList` should match the order of the functions in
+ * `function_names`
  *
  * \note You must explicitly pass the number of bounds you will be passing as
  * the first template parameter, the rest will be inferred.
@@ -510,7 +565,8 @@ void check_with_random_values(
  * specified when debugging a failure with a particular set of random numbers,
  * in general it should be left to the default value.
  */
-template <size_t NumberOfBounds, class F, class T, class... MemberArgs>
+template <size_t NumberOfBounds, typename TagsList = NoSuchType, class F,
+          class T, class... MemberArgs>
 void check_with_random_values(
     F&& f,
     const typename tt::function_info<cpp20::remove_cvref_t<F>>::class_type&
@@ -536,14 +592,17 @@ void check_with_random_values(
                                      tmpl::size<argument_types>>,
                       TestHelpers_detail::RemoveNotNull<tmpl::_1>>;
 
-  static_assert(number_of_not_null::value != 0,
-                "You must return at least one argument by gsl::not_null when"
-                "passing the python function names as a vector<string>. If "
-                "your function returns by value do not pass the function name "
-                "as a vector<string> but just a string.");
   static_assert(
-      cpp17::is_same_v<typename f_info::return_type, void>,
-      "A function returning by gsl::not_null must have a void return type.");
+      number_of_not_null::value != 0 or tt::is_a_v<tmpl::list, TagsList>,
+      "You must either return at least one argument by gsl::not_null when"
+      "passing the python function names as a vector<string>, or return by "
+      "value using a TaggedTuple. If your function returns by value with a "
+      "type that is not a TaggedTuple do not pass the function name as a "
+      "vector<string> but just a string.");
+  static_assert(cpp17::is_same_v<typename f_info::return_type, void> or
+                    tt::is_a_v<tmpl::list, TagsList>,
+                "The function must either return by gsl::not_null and have a "
+                "void return type, or return by TaggedTuple");
   static_assert(tmpl::size<argument_types>::value != 0,
                 "The function 'f' must take at least one argument.");
   static_assert(NumberOfBounds == 1 or
@@ -551,10 +610,12 @@ void check_with_random_values(
                 "The number of lower and upper bound pairs must be either 1 or "
                 "equal to the number of arguments taken by f that are not "
                 "gsl::not_null.");
-  if (function_names.size() != number_of_not_null::value) {
+  if (function_names.size() != number_of_not_null::value and
+      not tt::is_a_v<tmpl::list, TagsList>) {
     ERROR(
-        "The number of python functions passed must be the same as the number"
-        "of gsl::not_null arguments in the C++ function. The order of the "
+        "If testing a function that returns by gsl::not_null, the number of "
+        "python functions passed must be the same as the number of "
+        "gsl::not_null arguments in the C++ function. The order of the "
         "python functions must also be the same as the order of the "
         "gsl::not_null arguments.");
   }
@@ -573,6 +634,6 @@ void check_with_random_values(
       argument_types{},
       std::make_index_sequence<tmpl::size<return_types>::value>{},
       std::make_index_sequence<tmpl::size<argument_types>::value>{},
-      std::make_index_sequence<sizeof...(MemberArgs)>{});
+      std::make_index_sequence<sizeof...(MemberArgs)>{}, TagsList{});
 }
 }  // namespace pypp

--- a/tests/Unit/Pypp/PyppPyTests.py
+++ b/tests/Unit/Pypp/PyppPyTests.py
@@ -220,5 +220,15 @@ def check2_by_value1_class1(t0, t1, a):
 def check2_by_value2_class1(t0, t1, a, b):
     return 2.0 * t0 + 5.0 * a + t1 * b
 
+
 def permute_array(a):
     return [a[2], a[0], a[1]]
+
+
+def check_solution_scalar(x, t, a, b):
+    return np.dot(x, b) + a - t
+
+
+def check_solution_vector(x, t, a, b):
+    # b is passed in as a list so must be explicitly converted to an array
+    return a * x - t * np.array(b)

--- a/tests/Unit/Pypp/PyppPyTests.py
+++ b/tests/Unit/Pypp/PyppPyTests.py
@@ -124,6 +124,10 @@ def convert_tnsr_aBcc_successful(a):
     return bool(np.all(a == tnsr_aBcc()))
 
 
+def test_function_of_time(x, t):
+    return 2 * x[0] + x[1] - x[2] - t
+
+
 # Used to test tensor of datavectors
 def identity(a):
     return a

--- a/tests/Unit/Pypp/PyppPyTests.py
+++ b/tests/Unit/Pypp/PyppPyTests.py
@@ -197,12 +197,20 @@ def check_by_value2_class(t0, a, b):
     return t0 + 5.0 * a + b
 
 
+def check_by_value3_class(t0, a, b, c):
+    return t0 + 5.0 * a + b + c[0] - 2.0 * c[1] - c[2]
+
+
 def check2_by_value1_class(t0, t1, a):
     return t0 + t1 + 5.0 * a
 
 
 def check2_by_value2_class(t0, t1, a, b):
     return t0 + 5.0 * a + t1 * b
+
+
+def check2_by_value3_class(t0, t1, a, b, c):
+    return t0 * c[0] + 5.0 * a + t1 * b + c[1] - c[2]
 
 
 def check2_by_value1_class1(t0, t1, a):

--- a/tests/Unit/Pypp/Test_Pypp.cpp
+++ b/tests/Unit/Pypp/Test_Pypp.cpp
@@ -359,6 +359,22 @@ SPECTRE_TEST_CASE("Unit.Pypp.EinSum", "[Pypp][Unit]") {
   test_einsum<DataVector>(DataVector(5));
 }
 
+SPECTRE_TEST_CASE("Unit.Pypp.FunctionsOfTime", "[Pypp][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};
+  const tnsr::i<double, 3> x_d{{{3.4, 4.2, 5.8}}};
+  const tnsr::i<DataVector, 3> x_dv{
+      {{DataVector(8, 3.4), DataVector(8, 4.2), DataVector(8, 5.8)}}};
+  const double t = -9.2;
+  const auto check = [](const auto& x, const double time) {
+    CHECK((2 * x.get(0) + x.get(1) - x.get(2) - time) ==
+          (pypp::call<Scalar<typename std::decay_t<decltype(x)>::value_type>>(
+               "PyppPyTests", "test_function_of_time", x, time)
+               .get()));
+  };
+  check(x_d, t);
+  check(x_dv, t);
+}
+
 namespace {
 template <typename T>
 void check_single_not_null0(const gsl::not_null<T*> result,

--- a/tests/Unit/Pypp/Test_Pypp.cpp
+++ b/tests/Unit/Pypp/Test_Pypp.cpp
@@ -16,6 +16,8 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/Pypp.hpp"
 #include "tests/Unit/Pypp/PyppFundamentals.hpp"
@@ -731,6 +733,41 @@ class RandomValuesTests {
   std::array<double, 3> c_{};
 };
 
+struct AnalyticSolutionTest {
+  template <typename T>
+  struct Var1 {
+    using type = Scalar<T>;
+  };
+  template <typename T>
+  struct Var2 {
+    using type = tnsr::I<T, 3>;
+  };
+
+  AnalyticSolutionTest(const double a, const std::array<double, 3>& b)
+      : a_(a), b_(b) {}
+
+  template <typename T>
+  tuples::TaggedTuple<Var1<T>, Var2<T>> solution(const tnsr::i<T, 3>& x,
+                                                 const double t) const
+      noexcept {
+    auto sol =
+        make_with_value<tuples::TaggedTuple<Var1<T>, Var2<T>>>(x.get(0), 0.);
+    auto& scalar = tuples::get<Var1<T>>(sol);
+    auto& vector = tuples::get<Var2<T>>(sol);
+
+    for (size_t i = 0; i < 3; ++i) {
+      scalar.get() += x.get(i) * gsl::at(b_, i);
+      vector.get(i) = a_ * x.get(i) - gsl::at(b_, i) * t;
+    }
+    scalar.get() += a_ - t;
+    return sol;
+  }
+
+ private:
+  double a_;
+  std::array<double, 3> b_;
+};
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Pypp.CheckWithPython", "[Pypp][Unit]") {
@@ -1181,4 +1218,24 @@ SPECTRE_TEST_CASE("Unit.Pypp.CheckWithPython", "[Pypp][Unit]") {
       test_class, "PyppPyTests",
       {"check2_by_value2_class", "check2_by_value2_class1"}, {{{-10.0, 10.0}}},
       std::make_tuple(a, b), scalar_dv);
+}
+
+SPECTRE_TEST_CASE("Unit.Pypp.AnalyticSolution", "[Pypp][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{"Pypp/"};
+  const double a = 4.3;
+  const std::array<double, 3> b{{-1.3, 5.6, -0.2}};
+  AnalyticSolutionTest solution{a, b};
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<
+      1, tmpl::list<AnalyticSolutionTest::Var1<double>,
+                    AnalyticSolutionTest::Var2<double>>>(
+      &AnalyticSolutionTest::solution<double>, solution, "PyppPyTests",
+      {"check_solution_scalar", "check_solution_vector"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), a);
+  pypp::check_with_random_values<
+      1, tmpl::list<AnalyticSolutionTest::Var1<DataVector>,
+                    AnalyticSolutionTest::Var2<DataVector>>>(
+      &AnalyticSolutionTest::solution<DataVector>, solution, "PyppPyTests",
+      {"check_solution_scalar", "check_solution_vector"}, {{{-10.0, 10.0}}},
+      std::make_tuple(a, b), used_for_size);
 }

--- a/tests/Unit/Utilities/Test_MakeWithValue.cpp
+++ b/tests/Unit/Utilities/Test_MakeWithValue.cpp
@@ -67,6 +67,12 @@ void test_make_tagged_tuple() {
 SPECTRE_TEST_CASE("Unit.DataStructures.MakeWithValue",
                   "[DataStructures][Unit]") {
   check_make_with_value(8.3, 1.3, 8.3);
+  check_make_with_value(8.3, tnsr::i<double, 3>{{{1.3, 8.3, 3.4}}}, 8.3);
+  check_make_with_value(8.3, DataVector{8, 2.3}, 8.3);
+  check_make_with_value(
+      8.3, tnsr::i<DataVector, 3>{{{DataVector{8, 2.3}, DataVector{8, 9.8},
+                                    DataVector{8, -1.2}}}},
+      8.3);
   check_make_with_value(Scalar<double>(8.3), 1.3, 8.3);
   check_make_with_value(tnsr::I<double, 3, Frame::Grid>(8.3), 1.3, 8.3);
   check_make_with_value(8.3, tnsr::I<double, 3, Frame::Grid>(1.3), 8.3);


### PR DESCRIPTION
## Proposed changes

Allows Pypp to check some types of analytic solutions (things like PlaneWave can't be checked using this framework). Analytic solutions which have doubles or arrays as member variables, and return the solution by TaggedTuple can be checked with Pypp with this PR. 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`


