### PR TITLE
Update Valencia tests to use pypp

### DIFF
--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/TestFunctions.py
@@ -1,0 +1,54 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Functions for testing ConservativeFromPrimitive.cpp
+def tilde_d(rest_mass_density, specific_internal_energy,
+            spatial_velocity_oneform, spatial_velocity_squared, lorentz_factor,
+            specific_enthalpy, pressure, sqrt_det_spatial_metric):
+    return lorentz_factor * rest_mass_density * sqrt_det_spatial_metric
+
+
+def tilde_tau(rest_mass_density, specific_internal_energy,
+              spatial_velocity_oneform, spatial_velocity_squared,
+              lorentz_factor, specific_enthalpy, pressure,
+              sqrt_det_spatial_metric):
+    return ((pressure * spatial_velocity_squared
+             + (lorentz_factor/(1.0 + lorentz_factor) * spatial_velocity_squared
+                + specific_internal_energy) * rest_mass_density)
+            * lorentz_factor**2 * sqrt_det_spatial_metric)
+
+
+def tilde_s(rest_mass_density, specific_internal_energy,
+            spatial_velocity_oneform, spatial_velocity_squared, lorentz_factor,
+            specific_enthalpy, pressure, sqrt_det_spatial_metric):
+    return (spatial_velocity_oneform * lorentz_factor**2 * specific_enthalpy
+            * rest_mass_density * sqrt_det_spatial_metric)
+
+
+# End functions for testing ConservativeFromPrimitive.cpp
+
+
+# Functions for testing Fluxes.cpp
+def tilde_d_flux(tilde_d, tilde_tau, tilde_s, lapse, shift,
+                 sqrt_det_spatial_metric, pressure, spatial_velocity):
+    return tilde_d * (lapse * spatial_velocity - shift)
+
+
+def tilde_tau_flux(tilde_d, tilde_tau, tilde_s, lapse, shift,
+                   sqrt_det_spatial_metric, pressure, spatial_velocity):
+    return (sqrt_det_spatial_metric * lapse * pressure * spatial_velocity
+            + tilde_tau * (lapse * spatial_velocity - shift))
+
+
+def tilde_s_flux(tilde_d, tilde_tau, tilde_s, lapse, shift,
+                 sqrt_det_spatial_metric, pressure, spatial_velocity):
+    result = np.outer(lapse * spatial_velocity - shift, tilde_s)
+    result += (sqrt_det_spatial_metric * lapse * pressure
+               * np.identity(shift.size))
+    return result
+
+
+# End functions for testing Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
@@ -5,130 +5,35 @@
 
 #include <cstddef>
 #include <limits>
-#include <random>
 
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp"
-#include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeWithValue.hpp"
-#include "tests/Utilities/MakeWithRandomValues.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
 namespace {
-template <typename DataType>
-Scalar<DataType> expected_tilde_d(
-    const Scalar<DataType>& rest_mass_density,
-    const Scalar<DataType>& lorentz_factor,
-    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept {
-  auto result = make_with_value<Scalar<DataType>>(rest_mass_density, 0.);
-  get(result) = get(lorentz_factor) * get(rest_mass_density) *
-                get(sqrt_det_spatial_metric);
-  return result;
-}
-
-template <typename DataType>
-Scalar<DataType> expected_tilde_tau(
-    const Scalar<DataType>& rest_mass_density,
-    const Scalar<DataType>& specific_internal_energy,
-    const Scalar<DataType>& spatial_velocity_squared,
-    const Scalar<DataType>& lorentz_factor, const Scalar<DataType>& pressure,
-    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept {
-  auto result = make_with_value<Scalar<DataType>>(rest_mass_density, 0.);
-  get(result) = (get(pressure) * get(spatial_velocity_squared) +
-                 (get(lorentz_factor) / (1.0 + get(lorentz_factor)) *
-                      get(spatial_velocity_squared) +
-                  get(specific_internal_energy)) *
-                     get(rest_mass_density)) *
-                square(get(lorentz_factor)) * get(sqrt_det_spatial_metric);
-  return result;
-}
-
-template <typename DataType, size_t Dim>
-tnsr::i<DataType, Dim> expected_tilde_s(
-    const Scalar<DataType>& rest_mass_density,
-    const tnsr::i<DataType, Dim, Frame::Inertial>& spatial_velocity_oneform,
-    const Scalar<DataType>& lorentz_factor,
-    const Scalar<DataType>& specific_enthalpy,
-    const Scalar<DataType>& sqrt_det_spatial_metric) noexcept {
-  auto result = make_with_value<tnsr::i<DataType, Dim>>(rest_mass_density, 0.);
-  for (size_t i = 0; i < Dim; ++i) {
-    result.get(i) = spatial_velocity_oneform.get(i) *
-                    square(get(lorentz_factor)) * get(specific_enthalpy) *
-                    get(rest_mass_density) * get(sqrt_det_spatial_metric);
-  }
-  return result;
-}
 
 template <size_t Dim, typename DataType>
-void test_conservative_from_primitive(
-    const gsl::not_null<std::mt19937*> generator,
-    const gsl::not_null<std::uniform_real_distribution<>*> distribution,
-    const DataType& used_for_size) noexcept {
-  const auto rest_mass_density = make_with_random_values<Scalar<DataType>>(
-      generator, distribution, used_for_size);
-  const auto specific_internal_energy =
-      make_with_random_values<Scalar<DataType>>(generator, distribution,
-                                                used_for_size);
-  const auto spatial_velocity_squared =
-      make_with_random_values<Scalar<DataType>>(generator, distribution,
-                                                used_for_size);
-  const auto lorentz_factor = make_with_random_values<Scalar<DataType>>(
-      generator, distribution, used_for_size);
-  const auto specific_enthalpy = make_with_random_values<Scalar<DataType>>(
-      generator, distribution, used_for_size);
-  const auto pressure = make_with_random_values<Scalar<DataType>>(
-      generator, distribution, used_for_size);
-  const auto sqrt_det_spatial_metric =
-      make_with_random_values<Scalar<DataType>>(generator, distribution,
-                                                used_for_size);
-  const auto spatial_velocity_oneform =
-      make_with_random_values<tnsr::i<DataType, Dim>>(generator, distribution,
-                                                      used_for_size);
-
-  auto tilde_d = make_with_value<Scalar<DataType>>(used_for_size, 0.);
-  auto tilde_tau = make_with_value<Scalar<DataType>>(used_for_size, 0.);
-  auto tilde_s = make_with_value<tnsr::i<DataType, Dim>>(used_for_size, 0.);
-
-  RelativisticEuler::Valencia::conservative_from_primitive(
-      make_not_null(&tilde_d), make_not_null(&tilde_tau),
-      make_not_null(&tilde_s), rest_mass_density, specific_internal_energy,
-      spatial_velocity_oneform, spatial_velocity_squared, lorentz_factor,
-      specific_enthalpy, pressure, sqrt_det_spatial_metric);
-  CHECK_ITERABLE_APPROX(expected_tilde_d(rest_mass_density, lorentz_factor,
-                                         sqrt_det_spatial_metric),
-                        tilde_d);
-  CHECK_ITERABLE_APPROX(
-      expected_tilde_tau(rest_mass_density, specific_internal_energy,
-                         spatial_velocity_squared, lorentz_factor, pressure,
-                         sqrt_det_spatial_metric),
-      tilde_tau);
-  CHECK_ITERABLE_APPROX(
-      expected_tilde_s(rest_mass_density, spatial_velocity_oneform,
-                       lorentz_factor, specific_enthalpy,
-                       sqrt_det_spatial_metric),
-      tilde_s);
+void test_conservative_from_primitive(const DataType& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      &RelativisticEuler::Valencia::conservative_from_primitive<DataType, Dim>,
+      "TestFunctions", {"tilde_d", "tilde_tau", "tilde_s"}, {{{0.0, 1.0}}},
+      used_for_size);
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.ConservativeFromPrimitive",
                   "[Unit][RelativisticEuler]") {
-  std::random_device r;
-  const auto seed = r();
-  std::mt19937 generator(seed);
-  INFO("seed = " << seed);
-  std::uniform_real_distribution<> distribution(0.0, 1.0);
-
-  const auto nn_generator = make_not_null(&generator);
-  const auto nn_distribution = make_not_null(&distribution);
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/RelativisticEuler/Valencia"};
 
   const double d = std::numeric_limits<double>::signaling_NaN();
-  test_conservative_from_primitive<1>(nn_generator, nn_distribution, d);
-  test_conservative_from_primitive<2>(nn_generator, nn_distribution, d);
-  test_conservative_from_primitive<3>(nn_generator, nn_distribution, d);
+  test_conservative_from_primitive<1>(d);
+  test_conservative_from_primitive<2>(d);
+  test_conservative_from_primitive<3>(d);
 
   const DataVector dv(5);
-  test_conservative_from_primitive<1>(nn_generator, nn_distribution, dv);
-  test_conservative_from_primitive<2>(nn_generator, nn_distribution, dv);
-  test_conservative_from_primitive<3>(nn_generator, nn_distribution, dv);
+  test_conservative_from_primitive<1>(dv);
+  test_conservative_from_primitive<2>(dv);
+  test_conservative_from_primitive<3>(dv);
 }

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Fluxes.cpp
@@ -3,139 +3,31 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <array>
 #include <cstddef>
-#include <random>
 
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeWithValue.hpp"
-#include "tests/Utilities/MakeWithRandomValues.hpp"
-
-// IWYU pragma: no_forward_declare Tensor
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
 namespace {
 
 template <size_t Dim>
-tnsr::I<DataVector, Dim, Frame::Inertial> expected_tilde_d_flux(
-    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& lapse,
-    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
-    const tnsr::I<DataVector, Dim, Frame::Inertial>&
-        spatial_velocity) noexcept {
-  auto result = make_with_value<tnsr::I<DataVector, Dim>>(lapse, 0.);
-  for (size_t i = 0; i < Dim; ++i) {
-    result.get(i) =
-        get(tilde_d) * (get(lapse) * spatial_velocity.get(i) - shift.get(i));
-  }
-  return result;
-}
-
-template <size_t Dim>
-tnsr::I<DataVector, Dim, Frame::Inertial> expected_tilde_tau_flux(
-    const Scalar<DataVector>& tilde_tau, const Scalar<DataVector>& lapse,
-    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const Scalar<DataVector>& pressure,
-    const tnsr::I<DataVector, Dim, Frame::Inertial>&
-        spatial_velocity) noexcept {
-  auto result = make_with_value<tnsr::I<DataVector, Dim>>(lapse, 0.);
-  for (size_t i = 0; i < Dim; ++i) {
-    result.get(i) =
-        get(sqrt_det_spatial_metric) * get(lapse) * get(pressure) *
-            spatial_velocity.get(i) +
-        get(tilde_tau) * (get(lapse) * spatial_velocity.get(i) - shift.get(i));
-  }
-  return result;
-}
-
-template <size_t Dim>
-tnsr::Ij<DataVector, Dim, Frame::Inertial> expected_tilde_s_flux(
-    const tnsr::i<DataVector, Dim, Frame::Inertial>& tilde_s,
-    const Scalar<DataVector>& lapse,
-    const tnsr::I<DataVector, Dim, Frame::Inertial>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const Scalar<DataVector>& pressure,
-    const tnsr::I<DataVector, Dim, Frame::Inertial>&
-        spatial_velocity) noexcept {
-  auto result = make_with_value<tnsr::Ij<DataVector, Dim>>(lapse, 0.);
-  for (size_t i = 0; i < Dim; ++i) {
-    result.get(i, i) =
-        get(sqrt_det_spatial_metric) * get(lapse) * get(pressure);
-    for (size_t j = 0; j < Dim; ++j) {
-      result.get(i, j) += tilde_s.get(j) *
-                          (get(lapse) * spatial_velocity.get(i) - shift.get(i));
-    }
-  }
-  return result;
-}
-
-template <size_t Dim>
-void test_fluxes(
-    const gsl::not_null<std::mt19937*> generator,
-    const gsl::not_null<std::uniform_real_distribution<>*> distribution,
-    const DataVector& used_for_size) noexcept {
-  const auto tilde_d = make_with_random_values<Scalar<DataVector>>(
-      generator, distribution, used_for_size);
-  const auto tilde_tau = make_with_random_values<Scalar<DataVector>>(
-      generator, distribution, used_for_size);
-  const auto tilde_s = make_with_random_values<tnsr::i<DataVector, Dim>>(
-      generator, distribution, used_for_size);
-  const auto lapse = make_with_random_values<Scalar<DataVector>>(
-      generator, distribution, used_for_size);
-  const auto pressure = make_with_random_values<Scalar<DataVector>>(
-      generator, distribution, used_for_size);
-  const auto sqrt_det_spatial_metric =
-      make_with_random_values<Scalar<DataVector>>(generator, distribution,
-                                                  used_for_size);
-  const auto shift = make_with_random_values<tnsr::I<DataVector, Dim>>(
-      generator, distribution, used_for_size);
-  const auto spatial_velocity =
-      make_with_random_values<tnsr::I<DataVector, Dim>>(generator, distribution,
-                                                        used_for_size);
-
-  auto tilde_d_flux =
-      make_with_value<tnsr::I<DataVector, Dim>>(used_for_size, 0.);
-  auto tilde_tau_flux =
-      make_with_value<tnsr::I<DataVector, Dim>>(used_for_size, 0.);
-  auto tilde_s_flux =
-      make_with_value<tnsr::Ij<DataVector, Dim>>(used_for_size, 0.);
-
-  RelativisticEuler::Valencia::fluxes(
-      make_not_null(&tilde_d_flux), make_not_null(&tilde_tau_flux),
-      make_not_null(&tilde_s_flux), tilde_d, tilde_tau, tilde_s, lapse, shift,
-      sqrt_det_spatial_metric, pressure, spatial_velocity);
-
-  CHECK_ITERABLE_APPROX(
-      expected_tilde_d_flux(tilde_d, lapse, shift, spatial_velocity),
-      tilde_d_flux);
-
-  CHECK_ITERABLE_APPROX(
-      expected_tilde_tau_flux(tilde_tau, lapse, shift, sqrt_det_spatial_metric,
-                              pressure, spatial_velocity),
-      tilde_tau_flux);
-
-  CHECK_ITERABLE_APPROX(
-      expected_tilde_s_flux(tilde_s, lapse, shift, sqrt_det_spatial_metric,
-                            pressure, spatial_velocity),
-      tilde_s_flux);
+void test_fluxes(const DataVector& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &RelativisticEuler::Valencia::fluxes<Dim>, "TestFunctions",
+      {"tilde_d_flux", "tilde_tau_flux", "tilde_s_flux"}, {{{0.0, 1.0}}},
+      used_for_size);
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.Fluxes",
                   "[Unit][RelativisticEuler]") {
-  std::random_device r;
-  const auto seed = r();
-  std::mt19937 generator(seed);
-  INFO("seed = " << seed);
-  std::uniform_real_distribution<> distribution(0.0, 1.0);
-
-  const auto nn_generator = make_not_null(&generator);
-  const auto nn_distribution = make_not_null(&distribution);
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/RelativisticEuler/Valencia"};
 
   const DataVector dv(5);
-  test_fluxes<1>(nn_generator, nn_distribution, dv);
-  test_fluxes<2>(nn_generator, nn_distribution, dv);
-  test_fluxes<3>(nn_generator, nn_distribution, dv);
+  test_fluxes<1>(dv);
+  test_fluxes<2>(dv);
+  test_fluxes<3>(dv);
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
