### PR TITLE
Allow having a TaggedTuple inside a DataBox

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -407,8 +407,8 @@ class TaggedDeferredTuple  // NOLINT
     if (&t == this) {
       return *this;
     }
-    expand_pack((::db::databox_detail::get<Tags>(*this) =
-                     ::db::databox_detail::get<Tags>(t))...);
+    ::expand_pack((::db::databox_detail::get<Tags>(*this) =
+                       ::db::databox_detail::get<Tags>(t))...);
     return *this;
   }
 
@@ -419,9 +419,9 @@ class TaggedDeferredTuple  // NOLINT
     if (&t == this) {
       return *this;
     }
-    expand_pack((::db::databox_detail::get<Tags>(*this) =
-                     std::forward<Deferred<item_type<Tags>>>(
-                         ::db::databox_detail::get<Tags>(t)))...);
+    ::expand_pack((::db::databox_detail::get<Tags>(*this) =
+                       std::forward<Deferred<item_type<Tags>>>(
+                           ::db::databox_detail::get<Tags>(t)))...);
     return *this;
   }
 
@@ -434,7 +434,7 @@ class TaggedDeferredTuple  // NOLINT
   operator=(TaggedDeferredTuple<UTags...> const& t) noexcept(
       tmpl2::flat_all_v<cpp17::is_nothrow_assignable_v<
           Deferred<item_type<Tags>>&, Deferred<item_type<UTags>> const&>...>) {
-    expand_pack((get<Tags>(*this) = get<UTags>(t))...);
+    ::expand_pack((get<Tags>(*this) = get<UTags>(t))...);
     return *this;
   }
 
@@ -447,8 +447,8 @@ class TaggedDeferredTuple  // NOLINT
   operator=(TaggedDeferredTuple<UTags...>&& t) noexcept(
       tmpl2::flat_all_v<cpp17::is_nothrow_assignable_v<
           Deferred<item_type<Tags>>&, Deferred<item_type<UTags>>&&>...>) {
-    expand_pack((get<Tags>(*this) = std::forward<Deferred<item_type<UTags>>>(
-                     get<UTags>(t)))...);
+    ::expand_pack((get<Tags>(*this) = std::forward<Deferred<item_type<UTags>>>(
+                       get<UTags>(t)))...);
     return *this;
   }
 };


### PR DESCRIPTION
## Proposed changes

- Fixes a bug where a TaggedTuple couldn't be in the DataBox if the DataBox was copy or move assigned.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
