### PR TITLE
Construct Strahlkorper from options.

### DIFF
--- a/src/ApparentHorizons/Strahlkorper.hpp
+++ b/src/ApparentHorizons/Strahlkorper.hpp
@@ -8,6 +8,7 @@
 
 #include "ApparentHorizons/YlmSpherepack.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "Options/Options.hpp"
 #include "Utilities/ForceInline.hpp"
 
 namespace PUP {
@@ -19,12 +20,38 @@ class er;
 template <typename Frame>
 class Strahlkorper {
  public:
+  struct Lmax {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Strahlkorper is expanded in Ylms up to l=Lmax"};
+  };
+  struct Radius {
+    using type = double;
+    static constexpr OptionString help = {"Radius of spherical Strahlkorper"};
+  };
+  struct Center {
+    using type = std::array<double, 3>;
+    static constexpr OptionString help = {"Center of spherical Strahlkorper"};
+  };
+  using options = tmpl::list<Lmax, Radius, Center>;
+
+  static constexpr OptionString help{
+      "A star-shaped surface expressed as an expansion in spherical "
+      "harmonics.\n"
+      "Currently only a spherical Strahlkorper can be constructed from\n"
+      "Options.  To do this, specify parameters Center, Radius, and Lmax."};
+
   // Pup needs default constructor
   Strahlkorper() = default;
 
   /// Construct a sphere of radius `radius` with a given center.
   Strahlkorper(size_t l_max, size_t m_max, double radius,
                std::array<double, 3> center) noexcept;
+
+  /// Construct a sphere of radius `radius`, setting `m_max`=`l_max`.
+  Strahlkorper(size_t l_max, double radius,
+               std::array<double, 3> center) noexcept
+      : Strahlkorper(l_max, l_max, radius, center) {}
 
   /// Construct a Strahlkorper from a DataVector containing the radius
   /// at the collocation points.
@@ -123,6 +150,17 @@ class Strahlkorper {
   std::array<double, 3> center_{{0.0, 0.0, 0.0}};
   DataVector strahlkorper_coefs_ = DataVector(ylm_.spectral_size(), 0.0);
 };
+
+namespace OptionTags {
+/// \ingroup OptionTagsGroup
+/// \ingroup SurfacesGroup
+/// The input file tag for a Strahlkorper.
+template <typename Frame>
+struct Strahlkorper {
+  using type = ::Strahlkorper<Frame>;
+  static constexpr OptionString help{"A star-shaped surface"};
+};
+} // namespace OptionTags
 
 template <typename Frame>
 bool operator==(const Strahlkorper<Frame>& lhs,

--- a/tests/Unit/ApparentHorizons/Test_Strahlkorper.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Strahlkorper.cpp
@@ -8,15 +8,17 @@
 #include <cmath>
 #include <cstddef>
 #include <random>
-#include <type_traits>
+#include <string>
 
 #include "ApparentHorizons/SpherepackIterator.hpp"
 #include "ApparentHorizons/Strahlkorper.hpp"
 #include "ApparentHorizons/YlmSpherepack.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+#include "Options/ParseOptions.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 /// \cond
@@ -151,6 +153,18 @@ void test_constructor_with_different_coefs(Func function) {
   CHECK_ITERABLE_APPROX(strahlkorper_test1.coefficients(),
                         strahlkorper_test2.coefficients());
 }
+
+void test_construct_from_options() {
+  Options<tmpl::list<OptionTags::Strahlkorper<Frame::Inertial>>> opts("");
+  opts.parse(
+      "Strahlkorper:\n"
+      " Lmax : 6\n"
+      " Center: [1.,2.,3.]\n"
+      " Radius: 4.5\n");
+  CHECK(opts.get<OptionTags::Strahlkorper<Frame::Inertial>>() ==
+        Strahlkorper<Frame::Inertial>(6, 6, 4.5, {{1., 2., 3.}}));
+}
+
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.Strahlkorper",
@@ -178,6 +192,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.Strahlkorper",
     coefs[0] += sqrt(8.0) * add_to_r;
     return Strahlkorper<Frame::Inertial>(std::move(sk));
   });
+  test_construct_from_options();
 }
 
 SPECTRE_TEST_CASE("Unit.ApparentHorizons.Strahlkorper.Serialization",


### PR DESCRIPTION
Currently only constructs a spherical Strahlkorper.

## Proposed changes

Now you can construct a Strahlkorper from Options.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
