### PR TITLE
Add a make_static_cache function

### DIFF
--- a/src/Utilities/StaticCache.hpp
+++ b/src/Utilities/StaticCache.hpp
@@ -82,6 +82,8 @@ class StaticCacheImpl<T> {
 /// \example
 /// \snippet Test_StaticCache.cpp static_cache
 ///
+/// \see make_static_cache
+///
 /// \tparam T type held in the cache
 /// \tparam Ranges ranges of valid indices
 template <typename T, typename... Ranges>
@@ -107,6 +109,14 @@ class StaticCache {
  private:
   StaticCache_detail::StaticCacheImpl<T, Ranges...> data_;
 };
+
+/// \ingroup UtilitiesGroup
+/// Create a StaticCache, inferring the cached type from the generator.
+template <typename... Ranges, typename Generator>
+auto make_static_cache(Generator&& generator) noexcept {
+  using CachedType = std::decay_t<decltype(generator((Ranges{}, size_t{})...))>;
+  return StaticCache<CachedType, Ranges...>(generator);
+}
 
 /// \ingroup UtilitiesGroup
 /// Range of values for StaticCache indices.  The `Start` is inclusive

--- a/tests/Unit/Utilities/Test_StaticCache.cpp
+++ b/tests/Unit/Utilities/Test_StaticCache.cpp
@@ -13,18 +13,20 @@
 
 SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
   /// [static_cache]
-  const static StaticCache<size_t, CacheRange<0, 3>, CacheRange<3, 5>> cache(
-      [](const size_t a, const size_t b) noexcept { return a + b; });
+  const static auto cache =
+      make_static_cache<CacheRange<0, 3>, CacheRange<3, 5>>([](
+          const size_t a, const size_t b) noexcept { return a + b; });
   CHECK(cache(0, 3) == 3);  // smallest entry
   CHECK(cache(2, 4) == 6);  // largest entry
   /// [static_cache]
 
   std::vector<std::pair<size_t, size_t>> calls;
-  const StaticCache<size_t, CacheRange<0, 3>, CacheRange<3, 5>> cache2([&calls](
-      const size_t a, const size_t b) noexcept {
-    calls.emplace_back(a, b);
-    return a + b;
-  });
+  const auto cache2 =
+      make_static_cache<CacheRange<0, 3>, CacheRange<3, 5>>([&calls](
+          const size_t a, const size_t b) noexcept {
+        calls.emplace_back(a, b);
+        return a + b;
+      });
   CHECK(calls.size() == 6);
   // Creation order is not specified.
   std::sort(calls.begin(), calls.end());
@@ -37,7 +39,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
   CHECK(calls == expected_calls);
 
   size_t small_calls = 0;
-  const StaticCache<size_t> small_cache([&small_calls]() noexcept {
+  const auto small_cache = make_static_cache([&small_calls]() noexcept {
     ++small_calls;
     return size_t{5};
   });
@@ -51,9 +53,8 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
                                "[Utilities][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  StaticCache<size_t, CacheRange<3, 5>> cache([](const size_t x) noexcept {
-    return x;
-  });
+  const auto cache = make_static_cache<CacheRange<3, 5>>([](
+      const size_t x) noexcept { return x; });
   cache(2);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
@@ -64,9 +65,8 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
                                "[Utilities][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  StaticCache<size_t, CacheRange<3, 5>> cache([](const size_t x) noexcept {
-    return x;
-  });
+  const auto cache = make_static_cache<CacheRange<3, 5>>([](
+      const size_t x) noexcept { return x; });
   cache(5);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
