### PR TITLE
Add a base tag mechanism and function template support to DataBox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,7 +160,6 @@ before_install:
       brew install jemalloc;
       brew install gsl;
 
-      brew tap homebrew/science;
       brew install hdf5;
 
       ccache -z;

--- a/src/ApparentHorizons/StrahlkorperDataBox.hpp
+++ b/src/ApparentHorizons/StrahlkorperDataBox.hpp
@@ -55,7 +55,7 @@ struct Strahlkorper : db::SimpleTag {
 /// \f$(\theta,\phi)\f$ on the grid.
 /// Doesn't depend on the shape of the surface.
 template <typename Frame>
-struct ThetaPhi : db::ComputeItemTag {
+struct ThetaPhi : db::ComputeTag {
   static constexpr db::DataBoxString label = "ThetaPhi";
   static StrahlkorperTags_detail::ThetaPhi<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper) noexcept;
@@ -65,7 +65,7 @@ struct ThetaPhi : db::ComputeItemTag {
 /// `Rhat(i)` is \f$\hat{r}^i = x_i/\sqrt{x^2+y^2+z^2}\f$ on the grid.
 /// Doesn't depend on the shape of the surface.
 template <typename Frame>
-struct Rhat : db::ComputeItemTag {
+struct Rhat : db::ComputeTag {
   static constexpr db::DataBoxString label = "Rhat";
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
@@ -78,7 +78,7 @@ struct Rhat : db::ComputeItemTag {
 /// Here \f$r\f$ means \f$\sqrt{x^2+y^2+z^2}\f$.
 /// `Jacobian` doesn't depend on the shape of the surface.
 template <typename Frame>
-struct Jacobian : db::ComputeItemTag {
+struct Jacobian : db::ComputeTag {
   static constexpr db::DataBoxString label = "Jacobian";
   static StrahlkorperTags_detail::Jacobian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
@@ -90,7 +90,7 @@ struct Jacobian : db::ComputeItemTag {
 /// Here \f$r\f$ means \f$\sqrt{x^2+y^2+z^2}\f$.
 /// `InvJacobian` doesn't depend on the shape of the surface.
 template <typename Frame>
-struct InvJacobian : db::ComputeItemTag {
+struct InvJacobian : db::ComputeTag {
   static constexpr db::DataBoxString label = "InvJacobian";
   static StrahlkorperTags_detail::InvJacobian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
@@ -102,7 +102,7 @@ struct InvJacobian : db::ComputeItemTag {
 /// `InvHessian` is not symmetric because the Jacobians are Pfaffian.
 /// `InvHessian` doesn't depend on the shape of the surface.
 template <typename Frame>
-struct InvHessian : db::ComputeItemTag {
+struct InvHessian : db::ComputeTag {
   static constexpr db::DataBoxString label = "InvHessian";
   static StrahlkorperTags_detail::InvHessian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
@@ -112,7 +112,7 @@ struct InvHessian : db::ComputeItemTag {
 /// (Euclidean) distance \f$r_{\rm surf}(\theta,\phi)\f$ from the center to each
 /// point of the surface.
 template <typename Frame>
-struct Radius : db::ComputeItemTag {
+struct Radius : db::ComputeTag {
   static constexpr db::DataBoxString label = "Radius";
   SPECTRE_ALWAYS_INLINE static auto function(
       const ::Strahlkorper<Frame>& strahlkorper) noexcept {
@@ -126,7 +126,7 @@ struct Radius : db::ComputeItemTag {
 /// the vector of \f$(x,y,z)\f$ coordinates of each point
 /// on the surface.
 template <typename Frame>
-struct CartesianCoords : db::ComputeItemTag {
+struct CartesianCoords : db::ComputeTag {
   static constexpr db::DataBoxString label = "CartesianCoords";
   static StrahlkorperTags_detail::Vector<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
@@ -142,7 +142,7 @@ struct CartesianCoords : db::ComputeItemTag {
 /// \f$r_{\rm surf}=r_{\rm surf}(\theta(x,y,z),\phi(x,y,z))\f$
 /// for this operation.
 template <typename Frame>
-struct DxRadius : db::ComputeItemTag {
+struct DxRadius : db::ComputeTag {
   static constexpr db::DataBoxString label = "DxRadius";
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
@@ -159,7 +159,7 @@ struct DxRadius : db::ComputeItemTag {
 /// \f$r_{\rm surf}=r_{\rm surf}(\theta(x,y,z),\phi(x,y,z))\f$
 /// for this operation.
 template <typename Frame>
-struct D2xRadius : db::ComputeItemTag {
+struct D2xRadius : db::ComputeTag {
   static constexpr db::DataBoxString label = "D2xRadius";
   static StrahlkorperTags_detail::SecondDeriv<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
@@ -173,7 +173,7 @@ struct D2xRadius : db::ComputeItemTag {
 /// This is \f$\eta^{ij}\partial^2 r_{\rm surf}/\partial x^i\partial x^j\f$,
 /// where \f$r_{\rm surf}=r_{\rm surf}(\theta(x,y,z),\phi(x,y,z))\f$.
 template <typename Frame>
-struct LaplacianRadius : db::ComputeItemTag {
+struct LaplacianRadius : db::ComputeTag {
   static constexpr db::DataBoxString label = "LaplacianRadius";
   static DataVector function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
@@ -192,7 +192,7 @@ struct LaplacianRadius : db::ComputeItemTag {
 /// (it is "normal" to the surface), but it does not have unit length
 /// (it is not "normalized"; normalization requires a metric).
 template <typename Frame>
-struct NormalOneForm : db::ComputeItemTag {
+struct NormalOneForm : db::ComputeTag {
   static constexpr db::DataBoxString label = "NormalOneForm";
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const db::item_type<DxRadius<Frame>>& dx_radius,
@@ -216,7 +216,7 @@ struct NormalOneForm : db::ComputeItemTag {
 /// since orthogonality between 2 vectors (as opposed to a vector and
 /// a one-form) is metric-dependent.
 template <typename Frame>
-struct Tangents : db::ComputeItemTag {
+struct Tangents : db::ComputeTag {
   static constexpr db::DataBoxString label = "Tangents";
   static StrahlkorperTags_detail::Jacobian<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,

--- a/src/ApparentHorizons/StrahlkorperDataBox.hpp
+++ b/src/ApparentHorizons/StrahlkorperDataBox.hpp
@@ -48,7 +48,7 @@ using SecondDeriv = tnsr::ii<DataVector, 3, Frame>;
 /// Tag referring to a `::Strahlkorper`
 template <typename Frame>
 struct Strahlkorper : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Strahlkorper";
+  static constexpr db::Label label = "Strahlkorper";
   using type = ::Strahlkorper<Frame>;
 };
 
@@ -56,7 +56,7 @@ struct Strahlkorper : db::SimpleTag {
 /// Doesn't depend on the shape of the surface.
 template <typename Frame>
 struct ThetaPhi : db::ComputeTag {
-  static constexpr db::DataBoxString label = "ThetaPhi";
+  static constexpr db::Label label = "ThetaPhi";
   static StrahlkorperTags_detail::ThetaPhi<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper) noexcept;
   using argument_tags = tmpl::list<Strahlkorper<Frame>>;
@@ -66,7 +66,7 @@ struct ThetaPhi : db::ComputeTag {
 /// Doesn't depend on the shape of the surface.
 template <typename Frame>
 struct Rhat : db::ComputeTag {
-  static constexpr db::DataBoxString label = "Rhat";
+  static constexpr db::Label label = "Rhat";
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
@@ -79,7 +79,7 @@ struct Rhat : db::ComputeTag {
 /// `Jacobian` doesn't depend on the shape of the surface.
 template <typename Frame>
 struct Jacobian : db::ComputeTag {
-  static constexpr db::DataBoxString label = "Jacobian";
+  static constexpr db::Label label = "Jacobian";
   static StrahlkorperTags_detail::Jacobian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
@@ -91,7 +91,7 @@ struct Jacobian : db::ComputeTag {
 /// `InvJacobian` doesn't depend on the shape of the surface.
 template <typename Frame>
 struct InvJacobian : db::ComputeTag {
-  static constexpr db::DataBoxString label = "InvJacobian";
+  static constexpr db::Label label = "InvJacobian";
   static StrahlkorperTags_detail::InvJacobian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
@@ -103,7 +103,7 @@ struct InvJacobian : db::ComputeTag {
 /// `InvHessian` doesn't depend on the shape of the surface.
 template <typename Frame>
 struct InvHessian : db::ComputeTag {
-  static constexpr db::DataBoxString label = "InvHessian";
+  static constexpr db::Label label = "InvHessian";
   static StrahlkorperTags_detail::InvHessian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
@@ -113,7 +113,7 @@ struct InvHessian : db::ComputeTag {
 /// point of the surface.
 template <typename Frame>
 struct Radius : db::ComputeTag {
-  static constexpr db::DataBoxString label = "Radius";
+  static constexpr db::Label label = "Radius";
   SPECTRE_ALWAYS_INLINE static auto function(
       const ::Strahlkorper<Frame>& strahlkorper) noexcept {
     return strahlkorper.ylm_spherepack().spec_to_phys(
@@ -127,7 +127,7 @@ struct Radius : db::ComputeTag {
 /// on the surface.
 template <typename Frame>
 struct CartesianCoords : db::ComputeTag {
-  static constexpr db::DataBoxString label = "CartesianCoords";
+  static constexpr db::Label label = "CartesianCoords";
   static StrahlkorperTags_detail::Vector<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<Rhat<Frame>>& r_hat) noexcept;
@@ -143,7 +143,7 @@ struct CartesianCoords : db::ComputeTag {
 /// for this operation.
 template <typename Frame>
 struct DxRadius : db::ComputeTag {
-  static constexpr db::DataBoxString label = "DxRadius";
+  static constexpr db::Label label = "DxRadius";
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<InvJacobian<Frame>>& inv_jac) noexcept;
@@ -160,7 +160,7 @@ struct DxRadius : db::ComputeTag {
 /// for this operation.
 template <typename Frame>
 struct D2xRadius : db::ComputeTag {
-  static constexpr db::DataBoxString label = "D2xRadius";
+  static constexpr db::Label label = "D2xRadius";
   static StrahlkorperTags_detail::SecondDeriv<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<InvJacobian<Frame>>& inv_jac,
@@ -174,7 +174,7 @@ struct D2xRadius : db::ComputeTag {
 /// where \f$r_{\rm surf}=r_{\rm surf}(\theta(x,y,z),\phi(x,y,z))\f$.
 template <typename Frame>
 struct LaplacianRadius : db::ComputeTag {
-  static constexpr db::DataBoxString label = "LaplacianRadius";
+  static constexpr db::Label label = "LaplacianRadius";
   static DataVector function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
@@ -193,7 +193,7 @@ struct LaplacianRadius : db::ComputeTag {
 /// (it is not "normalized"; normalization requires a metric).
 template <typename Frame>
 struct NormalOneForm : db::ComputeTag {
-  static constexpr db::DataBoxString label = "NormalOneForm";
+  static constexpr db::Label label = "NormalOneForm";
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const db::item_type<DxRadius<Frame>>& dx_radius,
       const db::item_type<Rhat<Frame>>& r_hat) noexcept;
@@ -217,7 +217,7 @@ struct NormalOneForm : db::ComputeTag {
 /// a one-form) is metric-dependent.
 template <typename Frame>
 struct Tangents : db::ComputeTag {
-  static constexpr db::DataBoxString label = "Tangents";
+  static constexpr db::Label label = "Tangents";
   static StrahlkorperTags_detail::Jacobian<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<Rhat<Frame>>& r_hat,

--- a/src/ApparentHorizons/StrahlkorperDataBox.hpp
+++ b/src/ApparentHorizons/StrahlkorperDataBox.hpp
@@ -47,7 +47,7 @@ using SecondDeriv = tnsr::ii<DataVector, 3, Frame>;
 
 /// Tag referring to a `::Strahlkorper`
 template <typename Frame>
-struct Strahlkorper : db::DataBoxTag {
+struct Strahlkorper : db::SimpleTag {
   static constexpr db::DataBoxString label = "Strahlkorper";
   using type = ::Strahlkorper<Frame>;
 };

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -349,12 +349,12 @@ class DataBox<tmpl::list<Tags...>>
   static_assert(
       tmpl2::flat_all_v<DataBox_detail::tag_has_label<Tags>::value...>,
       "Missing a label on a Tag. All Tags must have a static "
-      "constexpr db::DataBoxString member variable named 'label' with "
+      "constexpr db::Label member variable named 'label' with "
       "the name of the Tag.");
   static_assert(
       tmpl2::flat_all_v<DataBox_detail::tag_label_correct_type<Tags>::value...>,
       "One of the labels of the Tags in a DataBox has the incorrect "
-      "type. It should be a DataBoxString.");
+      "type. It should be a db::Label.");
 
  public:
   /*!

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1358,23 +1358,6 @@ struct Apply<tmpl::list<Tags...>> {
     return std::forward<F>(f)(::db::get<Tags>(box)...,
                               std::forward<Args>(args)...);
   }
-
-  template <typename F, typename BoxTags, typename... Args>
-  static constexpr auto apply_with_box(F&& f, const DataBox<BoxTags>& box,
-                                       Args&&... args) {
-    static_assert(
-        tt::is_callable_v<
-            F, DataBox<BoxTags>,
-            tmpl::conditional_t<cpp17::is_same_v<Tags, ::Tags::DataBox>,
-                                const DataBox<BoxTags>&, item_type<Tags>>...,
-            Args...>,
-        "Cannot call the function f with the list of tags and "
-        "arguments specified. Check that the Tags::type and the "
-        "types of the Args match the function f and that f is "
-        "receiving the correct type of DataBox.");
-    return std::forward<F>(f)(box, ::db::get<Tags>(box)...,
-                              std::forward<Args>(args)...);
-  }
 };
 }  // namespace DataBox_detail
 
@@ -1408,7 +1391,7 @@ struct Apply<tmpl::list<Tags...>> {
  * \example
  * \snippet Test_DataBox.cpp apply_example
  *
- * \see apply_with_box DataBox
+ * \see DataBox
  * \tparam TagsList typelist of Tags in the order that they are to be passed
  * to `f`
  * \param f the function to apply
@@ -1583,7 +1566,7 @@ constexpr bool check_mutate_apply_argument_tags(
  * and how to use `mutate_apply` with the class
  * \snippet Test_DataBox.cpp mutate_apply_apply_example
  *
- * \see apply apply_with_box
+ * \see box
  * \tparam MutateTags typelist of Tags to mutate
  * \tparam ArgumentTags typelist of additional items to retrieve from the
  * DataBox
@@ -1612,55 +1595,6 @@ inline constexpr auto mutate_apply(
   DataBox_detail::check_mutate_apply_argument_tags(BoxTags{}, ArgumentTags{});
   return DataBox_detail::mutate_apply(f, box, MutateTags{}, ArgumentTags{},
                                       std::forward<Args>(args)...);
-}
-
-/*!
- * \ingroup DataBoxGroup
- * \brief Apply the function `f` with argument Tags `TagList` from DataBox `box`
- * and `box` as the first argument
- *
- * \details
- * Apply the function `f` with arguments that are of type `Tags::type...` where
- * `Tags` is defined by `TagList = tmpl::list<Tags...>`. The arguments to `f`
- * are retrieved from the DataBox `box` and the first argument passed to `f` is
- * the DataBox.
- *
- * \usage
- * Given a function `func` that takes arguments of types `DataBox<BoxTags>`,
- * `T1`, `T2`, `A1` and `A2`. Let the Tags for the quantities of types `T1`
- * and `T2` in the DataBox `box` be `Tag1` and `Tag2`, and objects `a1` of type
- * `A1` and `a2` of type `A2`, then
- * \code
- * auto result = apply_with_box<tmpl::list<Tag1, Tag2>>(func, box, a1, a2);
- * \endcode
- * \return `decltype(func(box, box.get<Tag1>(), box.get<Tag2>(), a1, a2))`
- *
- * \semantics
- * For tags `Tags...` in a DataBox `box`, and a function `func` that takes
- * as its first argument a value of type`decltype(box)`,
- * `sizeof...(Tags)` arguments of types `typename Tags::type...`, and
- * `sizeof...(Args)` arguments of types `Args...`,
- * \code
- * result = func(box, box.get<Tags>()..., args...);
- * \endcode
- *
- * \example
- * \snippet Test_DataBox.cpp apply_with_box_example
- *
- * \see apply DataBox
- * \tparam TagsList typelist of Tags in the order that they are to be passed
- * to `f`
- * \param f the function to apply
- * \param box the DataBox out of which to retrieve the Tags and to pass to
- * f`
- * \param args the arguments to pass to the function that are not in the
- * DataBox, `box`
- */
-template <typename TagsList, typename F, typename BoxTags, typename... Args>
-inline constexpr auto apply_with_box(F&& f, const DataBox<BoxTags>& box,
-                                     Args&&... args) {
-  return DataBox_detail::Apply<TagsList>::apply_with_box(
-      std::forward<F>(f), box, std::forward<Args>(args)...);
 }
 
 /*!

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -343,7 +343,7 @@ class DataBox<tmpl::list<Tags...>>
     : private DataBox_detail::DataBoxLeaf<
           Tags, db::item_type<Tags, tmpl::list<Tags...>>>... {
   static_assert(
-      tmpl2::flat_all_v<cpp17::is_base_of_v<db::DataBoxTag, Tags>...>,
+      tmpl2::flat_all_v<is_non_base_tag_v<Tags>...>,
       "All structs used to Tag (compute) items in a DataBox must derive off of "
       "db::DataBoxTag");
   static_assert(
@@ -687,8 +687,7 @@ SPECTRE_ALWAYS_INLINE constexpr void
 DataBox<tmpl::list<Tags...>>::add_compute_item_to_box_impl(
     tmpl::list<ComputeItemArgumentsTags...> /*meta*/) noexcept {
   static_assert(
-      tmpl2::flat_all_v<
-          cpp17::is_base_of_v<db::DataBoxTag, ComputeItemArgumentsTags>...>,
+      tmpl2::flat_all_v<is_tag_v<ComputeItemArgumentsTags>...>,
       "Cannot have non-DataBoxTag arguments to a ComputeItem. Please make "
       "sure all the specified argument_tags in the ComputeItem derive from "
       "db::DataBoxTag.");

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -345,7 +345,7 @@ class DataBox<tmpl::list<Tags...>>
   static_assert(
       tmpl2::flat_all_v<is_non_base_tag_v<Tags>...>,
       "All structs used to Tag (compute) items in a DataBox must derive off of "
-      "db::DataBoxTag");
+      "db::SimpleTag");
   static_assert(
       tmpl2::flat_all_v<DataBox_detail::tag_has_label<Tags>::value...>,
       "Missing a label on a Tag. All Tags must have a static "
@@ -690,7 +690,7 @@ DataBox<tmpl::list<Tags...>>::add_compute_item_to_box_impl(
       tmpl2::flat_all_v<is_tag_v<ComputeItemArgumentsTags>...>,
       "Cannot have non-DataBoxTag arguments to a ComputeItem. Please make "
       "sure all the specified argument_tags in the ComputeItem derive from "
-      "db::DataBoxTag.");
+      "db::SimpleTag.");
   static_assert(not tmpl2::flat_any_v<
                     cpp17::is_same_v<ComputeItemArgumentsTags, ComputeItem>...>,
                 "A ComputeItem cannot take its own Tag as an argument.");

--- a/src/DataStructures/DataBox/DataBoxHelpers.hpp
+++ b/src/DataStructures/DataBox/DataBoxHelpers.hpp
@@ -21,7 +21,7 @@ struct get_item_from_variant_databox;
 
 template <typename Tag>
 struct get_item_from_variant_databox<
-    Tag, Requires<std::is_base_of<db::DataBoxTag, Tag>::value>>
+    Tag, Requires<std::is_base_of<db::SimpleTag, Tag>::value>>
     : boost::static_visitor<db::item_type<Tag>> {
   template <typename DataBox_t>
   constexpr db::item_type<Tag> operator()(DataBox_t& box) const {
@@ -31,7 +31,7 @@ struct get_item_from_variant_databox<
 
 template <typename TagType>
 struct get_item_from_variant_databox<
-    TagType, Requires<not std::is_base_of<db::DataBoxTag, TagType>::value>>
+    TagType, Requires<not std::is_base_of<db::SimpleTag, TagType>::value>>
     : boost::static_visitor<TagType> {
   explicit get_item_from_variant_databox(std::string name)
       : var_name(std::move(name)) {}

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Defines classes SimpleTag, PrefixTag, ComputeItemTag and several
+/// Defines classes SimpleTag, PrefixTag, ComputeTag and several
 /// functions for retrieving tag info
 
 #pragma once
@@ -115,7 +115,7 @@ struct BaseTag {};
  * \snippet Test_DataBox.cpp databox_name_prefix
  *
  *
- * \see DataBox DataBoxTag DataBoxString get_tag_name ComputeItemTag
+ * \see DataBox DataBoxTag DataBoxString get_tag_name ComputeTag
  */
 struct PrefixTag {};
 
@@ -160,7 +160,7 @@ struct PrefixTag {};
  *
  * \see DataBox SimpleTag DataBoxString get_tag_name PrefixTag
  */
-struct ComputeItemTag {};
+struct ComputeTag {};
 
 namespace DataBox_detail {
 template <typename TagList, typename Tag>
@@ -318,14 +318,13 @@ struct hash_databox_tag<Tag, Requires<tt::is_a_v<::Tags::Variables, Tag>>> {
 // @{
 /*!
  * \ingroup DataBoxGroup
- * \brief Check if `Tag` derives off of db::ComputeItemTag
+ * \brief Check if `Tag` derives off of db::ComputeTag
  */
 template <typename Tag, typename = std::nullptr_t>
 struct is_compute_item : std::false_type {};
 /// \cond HIDDEN_SYMBOLS
 template <typename Tag>
-struct is_compute_item<Tag,
-                       Requires<cpp17::is_base_of_v<db::ComputeItemTag, Tag>>>
+struct is_compute_item<Tag, Requires<cpp17::is_base_of_v<db::ComputeTag, Tag>>>
     : std::true_type {};
 /// \endcond
 
@@ -343,9 +342,8 @@ template <typename Tag, typename = std::nullptr_t>
 struct is_non_base_tag : std::false_type {};
 /// \cond
 template <typename Tag>
-struct is_non_base_tag<Tag,
-                       Requires<cpp17::is_base_of_v<db::ComputeItemTag, Tag> or
-                                cpp17::is_base_of_v<db::SimpleTag, Tag>>>
+struct is_non_base_tag<Tag, Requires<cpp17::is_base_of_v<db::ComputeTag, Tag> or
+                                     cpp17::is_base_of_v<db::SimpleTag, Tag>>>
     : std::true_type {};
 /// \endcond
 
@@ -362,7 +360,7 @@ template <typename Tag, typename = std::nullptr_t>
 struct is_tag : std::false_type {};
 /// \cond
 template <typename Tag>
-struct is_tag<Tag, Requires<cpp17::is_base_of_v<db::ComputeItemTag, Tag> or
+struct is_tag<Tag, Requires<cpp17::is_base_of_v<db::ComputeTag, Tag> or
                             cpp17::is_base_of_v<db::SimpleTag, Tag> or
                             cpp17::is_base_of_v<db::BaseTag, Tag>>>
     : std::true_type {};

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Defines classes DataBoxTag, PrefixTag, ComputeItemTag and several
+/// Defines classes SimpleTag, PrefixTag, ComputeItemTag and several
 /// functions for retrieving tag info
 
 #pragma once
@@ -57,11 +57,11 @@ using DataBoxString = const char* const;
  * \brief Tags for the DataBox inherit from this type
  *
  * \details
- * Used to mark a type as being a DataBoxTag so that it can be used in a
+ * Used to mark a type as being a SimpleTag so that it can be used in a
  * DataBox.
  *
  * \derivedrequires
- * - type alias `type` of the type this DataBoxTag represents
+ * - type alias `type` of the type this SimpleTag represents
  * - `static constexpr DataBoxString` that is the same as the type name
  *    and named `label`
  *
@@ -70,7 +70,7 @@ using DataBoxString = const char* const;
  *
  * \see DataBox PrefixTag DataBoxString get_tag_name
  */
-struct DataBoxTag {};
+struct SimpleTag {};
 
 /*!
  * \ingroup DataBoxGroup
@@ -82,10 +82,11 @@ struct DataBoxTag {};
  * that retrieving items from the DataBox or setting argument tags in compute
  * items can be done without any knowledge of the type of the item.
  *
- * The base tag must inherit off of `BaseTag` and NOT `DataBoxTag`. This is very
- * important for the implementation. Inheriting off both and not making the tag
- * either a simple item or compute item is undefined behavior and is likely to
- * end in extremely complicated compiler errors.
+ * To use the base mechanism the base tag must inherit off of
+ * `BaseTag` and NOT `SimpleTag`. This is very important for the
+ * implementation. Inheriting off both and not making the tag either a simple
+ * item or compute item is undefined behavior and is likely to end in extremely
+ * complicated compiler errors.
  */
 struct BaseTag {};
 
@@ -157,7 +158,7 @@ struct PrefixTag {};
  * which offers a lot of simplicity for very simple compute items.
  * \snippet Test_DataBox.cpp compute_item_tag_function
  *
- * \see DataBox DataBoxTag DataBoxString get_tag_name PrefixTag
+ * \see DataBox SimpleTag DataBoxString get_tag_name PrefixTag
  */
 struct ComputeItemTag {};
 
@@ -344,7 +345,7 @@ struct is_non_base_tag : std::false_type {};
 template <typename Tag>
 struct is_non_base_tag<Tag,
                        Requires<cpp17::is_base_of_v<db::ComputeItemTag, Tag> or
-                                cpp17::is_base_of_v<db::DataBoxTag, Tag>>>
+                                cpp17::is_base_of_v<db::SimpleTag, Tag>>>
     : std::true_type {};
 /// \endcond
 
@@ -362,7 +363,7 @@ struct is_tag : std::false_type {};
 /// \cond
 template <typename Tag>
 struct is_tag<Tag, Requires<cpp17::is_base_of_v<db::ComputeItemTag, Tag> or
-                            cpp17::is_base_of_v<db::DataBoxTag, Tag> or
+                            cpp17::is_base_of_v<db::SimpleTag, Tag> or
                             cpp17::is_base_of_v<db::BaseTag, Tag>>>
     : std::true_type {};
 /// \endcond
@@ -380,10 +381,10 @@ template <typename Tag, typename = std::nullptr_t>
 struct is_base_tag : std::false_type {};
 /// \cond HIDDEN_SYMBOLS
 template <typename Tag>
-struct is_base_tag<Tag,
-                   Requires<cpp17::is_base_of_v<db::BaseTag, Tag> and
-                            not cpp17::is_base_of_v<db::DataBoxTag, Tag> and
-                            not is_compute_item_v<Tag>>> : std::true_type {};
+struct is_base_tag<Tag, Requires<cpp17::is_base_of_v<db::BaseTag, Tag> and
+                                 not cpp17::is_base_of_v<db::SimpleTag, Tag> and
+                                 not is_compute_item_v<Tag>>> : std::true_type {
+};
 /// \endcond
 
 template <typename Tag>
@@ -426,7 +427,7 @@ struct item_type_impl {
                 ? 3
                 : is_compute_item_v<Tag>
                       ? 2
-                      : cpp17::is_base_of_v<db::DataBoxTag, Tag> ? 1 : 0>::
+                      : cpp17::is_base_of_v<db::SimpleTag, Tag> ? 1 : 0>::
       template f<TagList, Tag>;
 };
 
@@ -549,7 +550,7 @@ struct remove_tag_prefix_impl;
 template <typename UnprefixedTag, template <typename...> class Prefix,
           typename... Args>
 struct remove_tag_prefix_impl<Prefix<UnprefixedTag, Args...>> {
-  static_assert(cpp17::is_base_of_v<db::DataBoxTag, UnprefixedTag>,
+  static_assert(cpp17::is_base_of_v<db::SimpleTag, UnprefixedTag>,
                 "Unwrapped tag is not a DataBoxTag");
   using type = UnprefixedTag;
 };

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -2,7 +2,7 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Defines classes DataBoxTag, DataBoxPrefix, ComputeItemTag and several
+/// Defines classes DataBoxTag, PrefixTag, ComputeItemTag and several
 /// functions for retrieving tag info
 
 #pragma once
@@ -68,7 +68,7 @@ using DataBoxString = const char* const;
  * \example
  * \snippet Test_DataBox.cpp databox_tag_example
  *
- * \see DataBox DataBoxPrefix DataBoxString get_tag_name
+ * \see DataBox PrefixTag DataBoxString get_tag_name
  */
 struct DataBoxTag {};
 
@@ -103,11 +103,11 @@ struct BaseTag {};
  *
  * \derivedrequires
  * - type alias `tag` of the DataBoxTag that this tag is a prefix to
- * - type alias `type` that is the type that this DataBoxPrefix holds
+ * - type alias `type` that is the type that this PrefixTag holds
  * - DataBoxString `label` that is the prefix to the `tag`
  *
  * \example
- * A DataBoxPrefix tag has the structure:
+ * A PrefixTag tag has the structure:
  * \snippet Test_DataBox.cpp databox_prefix_tag_example
  *
  * The name used to retrieve a prefix tag from the DataBox is:
@@ -116,7 +116,7 @@ struct BaseTag {};
  *
  * \see DataBox DataBoxTag DataBoxString get_tag_name ComputeItemTag
  */
-struct DataBoxPrefix {};
+struct PrefixTag {};
 
 /*!
  * \ingroup DataBoxGroup
@@ -157,7 +157,7 @@ struct DataBoxPrefix {};
  * which offers a lot of simplicity for very simple compute items.
  * \snippet Test_DataBox.cpp compute_item_tag_function
  *
- * \see DataBox DataBoxTag DataBoxString get_tag_name DataBoxPrefix
+ * \see DataBox DataBoxTag DataBoxString get_tag_name PrefixTag
  */
 struct ComputeItemTag {};
 
@@ -252,19 +252,18 @@ struct check_tag_labels {
  *
  * \details
  * Given a DataBoxTag returns the name of the DataBoxTag as a std::string. If
- * the DataBoxTag is also a DataBoxPrefix then the prefix is added.
+ * the DataBoxTag is also a PrefixTag then the prefix is added.
  *
  * \tparam Tag the DataBoxTag whose name to get
  * \return string holding the DataBoxTag's name
  */
 template <typename Tag,
-          Requires<not cpp17::is_base_of_v<DataBoxPrefix, Tag>> = nullptr>
+          Requires<not cpp17::is_base_of_v<PrefixTag, Tag>> = nullptr>
 std::string get_tag_name() {
   return std::string(Tag::label);
 }
 /// \cond HIDDEN_SYMBOLS
-template <typename Tag,
-          Requires<cpp17::is_base_of_v<DataBoxPrefix, Tag>> = nullptr>
+template <typename Tag, Requires<cpp17::is_base_of_v<PrefixTag, Tag>> = nullptr>
 std::string get_tag_name() {
   return std::string(Tag::label) + get_tag_name<typename Tag::tag>();
 }
@@ -294,8 +293,7 @@ struct hash_databox_tag {
 };
 /// \cond HIDDEN_SYMBOLS
 template <typename Tag>
-struct hash_databox_tag<Tag,
-                        Requires<cpp17::is_base_of_v<DataBoxPrefix, Tag>>> {
+struct hash_databox_tag<Tag, Requires<cpp17::is_base_of_v<PrefixTag, Tag>>> {
   using value_type = size_t;
   static constexpr value_type value =
       cstring_hash(Tag::label) * hash_databox_tag<typename Tag::tag>::value;
@@ -587,7 +585,7 @@ struct remove_all_prefixes {
 template <template <class...> class F, class Tag, class... Args>
 struct remove_all_prefixes<F<Tag, Args...>, true> {
   using type = typename remove_all_prefixes<
-      Tag, cpp17::is_base_of_v<db::DataBoxPrefix, Tag>>::type;
+      Tag, cpp17::is_base_of_v<db::PrefixTag, Tag>>::type;
 };
 }  // namespace databox_detail
 
@@ -595,7 +593,7 @@ struct remove_all_prefixes<F<Tag, Args...>, true> {
 /// Completely remove all prefix tags from a Tag
 template <typename Tag>
 using remove_all_prefixes = typename databox_detail::remove_all_prefixes<
-    Tag, cpp17::is_base_of_v<db::DataBoxPrefix, Tag>>::type;
+    Tag, cpp17::is_base_of_v<db::PrefixTag, Tag>>::type;
 
 /// \ingroup DataBoxGroup
 /// Struct that can be specialized to allow DataBox items to have

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -116,7 +116,7 @@ struct BaseTag {};
  *
  * \see DataBox DataBoxTag DataBoxString get_tag_name ComputeItemTag
  */
-struct DataBoxPrefix : virtual DataBoxTag {};
+struct DataBoxPrefix {};
 
 /*!
  * \ingroup DataBoxGroup
@@ -159,7 +159,7 @@ struct DataBoxPrefix : virtual DataBoxTag {};
  *
  * \see DataBox DataBoxTag DataBoxString get_tag_name DataBoxPrefix
  */
-struct ComputeItemTag : virtual DataBoxTag {};
+struct ComputeItemTag {};
 
 namespace DataBox_detail {
 template <typename TagList, typename Tag>
@@ -316,25 +316,64 @@ struct hash_databox_tag<Tag, Requires<tt::is_a_v<::Tags::Variables, Tag>>> {
 // @}
 }  // namespace detail
 
+// @{
 /*!
  * \ingroup DataBoxGroup
- * \brief Check if `T` derives off of db::ComputeItemTag
+ * \brief Check if `Tag` derives off of db::ComputeItemTag
  */
-template <typename T, typename = std::nullptr_t>
+template <typename Tag, typename = std::nullptr_t>
 struct is_compute_item : std::false_type {};
 /// \cond HIDDEN_SYMBOLS
-template <typename T>
-struct is_compute_item<T, Requires<cpp17::is_base_of_v<db::ComputeItemTag, T>>>
+template <typename Tag>
+struct is_compute_item<Tag,
+                       Requires<cpp17::is_base_of_v<db::ComputeItemTag, Tag>>>
     : std::true_type {};
 /// \endcond
 
+template <typename Tag>
+constexpr bool is_compute_item_v = is_compute_item<Tag>::value;
+// @}
+
+// @{
 /*!
  * \ingroup DataBoxGroup
- * \brief Check if `T` derives off of db::ComputeItemTag
+ * \brief Check if `Tag` is a non-base DataBox tag. I.e. a SimpleTag or a
+ * ComputeTag
  */
-template <typename T>
-constexpr bool is_compute_item_v = is_compute_item<T>::value;
+template <typename Tag, typename = std::nullptr_t>
+struct is_non_base_tag : std::false_type {};
+/// \cond
+template <typename Tag>
+struct is_non_base_tag<Tag,
+                       Requires<cpp17::is_base_of_v<db::ComputeItemTag, Tag> or
+                                cpp17::is_base_of_v<db::DataBoxTag, Tag>>>
+    : std::true_type {};
+/// \endcond
 
+template <typename Tag>
+constexpr bool is_non_base_tag_v = is_non_base_tag<Tag>::value;
+// @}
+
+// @{
+/*!
+ * \ingroup DataBoxGroup
+ * \brief Check if `Tag` is a BaseTag, SimpleTag, or ComputeTag
+ */
+template <typename Tag, typename = std::nullptr_t>
+struct is_tag : std::false_type {};
+/// \cond
+template <typename Tag>
+struct is_tag<Tag, Requires<cpp17::is_base_of_v<db::ComputeItemTag, Tag> or
+                            cpp17::is_base_of_v<db::DataBoxTag, Tag> or
+                            cpp17::is_base_of_v<db::BaseTag, Tag>>>
+    : std::true_type {};
+/// \endcond
+
+template <typename Tag>
+constexpr bool is_tag_v = is_tag<Tag>::value;
+// @}
+
+// @{
 /*!
  * \ingroup DataBoxGroup
  * \brief Check if `Tag` is a base DataBox tag
@@ -349,12 +388,9 @@ struct is_base_tag<Tag,
                             not is_compute_item_v<Tag>>> : std::true_type {};
 /// \endcond
 
-/*!
- * \ingroup DataBoxGroup
- * \brief Check if `Tag` is a pure base DataBox tag
- */
 template <typename Tag>
 constexpr bool is_base_tag_v = is_base_tag<Tag>::value;
+// @}
 
 namespace DataBox_detail {
 template <class T, class = void>

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -50,7 +50,7 @@ namespace db {
  * \ingroup DataBoxGroup
  * \brief The string used to give a runtime name to a DataBoxTag
  */
-using DataBoxString = const char* const;
+using Label = const char* const;
 
 /*!
  * \ingroup DataBoxGroup
@@ -62,13 +62,13 @@ using DataBoxString = const char* const;
  *
  * \derivedrequires
  * - type alias `type` of the type this SimpleTag represents
- * - `static constexpr DataBoxString` that is the same as the type name
+ * - `static constexpr db::Label` that is the same as the type name
  *    and named `label`
  *
  * \example
  * \snippet Test_DataBox.cpp databox_tag_example
  *
- * \see DataBox PrefixTag DataBoxString get_tag_name
+ * \see DataBox PrefixTag db::Label get_tag_name
  */
 struct SimpleTag {};
 
@@ -105,7 +105,7 @@ struct BaseTag {};
  * \derivedrequires
  * - type alias `tag` of the DataBoxTag that this tag is a prefix to
  * - type alias `type` that is the type that this PrefixTag holds
- * - DataBoxString `label` that is the prefix to the `tag`
+ * - db::Label `label` that is the prefix to the `tag`
  *
  * \example
  * A PrefixTag tag has the structure:
@@ -115,7 +115,7 @@ struct BaseTag {};
  * \snippet Test_DataBox.cpp databox_name_prefix
  *
  *
- * \see DataBox DataBoxTag DataBoxString get_tag_name ComputeTag
+ * \see DataBox DataBoxTag db::Label get_tag_name ComputeTag
  */
 struct PrefixTag {};
 
@@ -158,7 +158,7 @@ struct PrefixTag {};
  * which offers a lot of simplicity for very simple compute items.
  * \snippet Test_DataBox.cpp compute_item_tag_function
  *
- * \see DataBox SimpleTag DataBoxString get_tag_name PrefixTag
+ * \see DataBox SimpleTag db::Label get_tag_name PrefixTag
  */
 struct ComputeTag {};
 
@@ -208,11 +208,11 @@ constexpr bool tag_has_label_v = tag_has_label<Tag>::value;
 // @{
 /*!
  * \ingroup DataBoxGroup
- * \brief Check if a Tag label has type DataBoxString
+ * \brief Check if a Tag label has type db::Label
  *
  * \details
  * For a type `T`, check that the static member variable named `label` has type
- * DataBoxString
+ * db::Label
  *
  * \usage
  * For any type `T`
@@ -229,7 +229,7 @@ struct tag_label_correct_type : std::false_type {};
 /// \cond HIDDEN_SYMBOLS
 template <typename T>
 struct tag_label_correct_type<
-    T, Requires<cpp17::is_same_v<DataBoxString, decltype(T::label)>>>
+    T, Requires<cpp17::is_same_v<db::Label, decltype(T::label)>>>
     : std::true_type {};
 /// \endcond
 // @}

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -24,7 +24,7 @@ namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a time derivative
 template <typename Tag>
-struct dt : db::DataBoxPrefix, db::DataBoxTag {
+struct dt : db::PrefixTag, db::DataBoxTag {
   static constexpr db::DataBoxString label = "dt";
   using type = db::item_type<Tag>;
   using tag = Tag;
@@ -39,8 +39,8 @@ struct Flux;
 /// \cond
 template <typename Tag, typename VolumeDim, typename Fr>
 struct Flux<Tag, VolumeDim, Fr,
-            Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::DataBoxPrefix, db::DataBoxTag {
+            Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>> : db::PrefixTag,
+                                                                db::DataBoxTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Up, Fr>;
   using tag = Tag;
@@ -50,7 +50,7 @@ struct Flux<Tag, VolumeDim, Fr,
 template <typename Tag, typename VolumeDim, typename Fr>
 struct Flux<Tag, VolumeDim, Fr,
             Requires<tt::is_a_v<::Variables, db::item_type<Tag>>>>
-    : db::DataBoxPrefix, db::DataBoxTag {
+    : db::PrefixTag, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "Flux";
@@ -61,7 +61,7 @@ struct Flux<Tag, VolumeDim, Fr,
 /// \brief Prefix indicating a boundary unit normal vector dotted into
 /// the flux
 template <typename Tag>
-struct NormalDotFlux : db::DataBoxPrefix, db::DataBoxTag {
+struct NormalDotFlux : db::PrefixTag, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "NormalDotFlux";
@@ -72,7 +72,7 @@ struct NormalDotFlux : db::DataBoxPrefix, db::DataBoxTag {
 /// \brief Prefix indicating a boundary unit normal vector dotted into
 /// the numerical flux
 template <typename Tag>
-struct NormalDotNumericalFlux : db::DataBoxPrefix, db::DataBoxTag {
+struct NormalDotNumericalFlux : db::PrefixTag, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "NormalDotNumericalFlux";

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -25,7 +25,7 @@ namespace Tags {
 /// \brief Prefix indicating a time derivative
 template <typename Tag>
 struct dt : db::PrefixTag, db::SimpleTag {
-  static constexpr db::DataBoxString label = "dt";
+  static constexpr db::Label label = "dt";
   using type = db::item_type<Tag>;
   using tag = Tag;
 };
@@ -44,7 +44,7 @@ struct Flux<Tag, VolumeDim, Fr,
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Up, Fr>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "Flux";
+  static constexpr db::Label label = "Flux";
 };
 
 template <typename Tag, typename VolumeDim, typename Fr>
@@ -53,7 +53,7 @@ struct Flux<Tag, VolumeDim, Fr,
     : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "Flux";
+  static constexpr db::Label label = "Flux";
 };
 /// \endcond
 
@@ -64,7 +64,7 @@ template <typename Tag>
 struct NormalDotFlux : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "NormalDotFlux";
+  static constexpr db::Label label = "NormalDotFlux";
   static constexpr bool should_be_sliced_to_boundary = false;
 };
 
@@ -75,6 +75,6 @@ template <typename Tag>
 struct NormalDotNumericalFlux : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "NormalDotNumericalFlux";
+  static constexpr db::Label label = "NormalDotNumericalFlux";
 };
 }  // namespace Tags

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -24,7 +24,7 @@ namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a time derivative
 template <typename Tag>
-struct dt : db::PrefixTag, db::DataBoxTag {
+struct dt : db::PrefixTag, db::SimpleTag {
   static constexpr db::DataBoxString label = "dt";
   using type = db::item_type<Tag>;
   using tag = Tag;
@@ -40,7 +40,7 @@ struct Flux;
 template <typename Tag, typename VolumeDim, typename Fr>
 struct Flux<Tag, VolumeDim, Fr,
             Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>> : db::PrefixTag,
-                                                                db::DataBoxTag {
+                                                                db::SimpleTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Up, Fr>;
   using tag = Tag;
@@ -50,7 +50,7 @@ struct Flux<Tag, VolumeDim, Fr,
 template <typename Tag, typename VolumeDim, typename Fr>
 struct Flux<Tag, VolumeDim, Fr,
             Requires<tt::is_a_v<::Variables, db::item_type<Tag>>>>
-    : db::PrefixTag, db::DataBoxTag {
+    : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "Flux";
@@ -61,7 +61,7 @@ struct Flux<Tag, VolumeDim, Fr,
 /// \brief Prefix indicating a boundary unit normal vector dotted into
 /// the flux
 template <typename Tag>
-struct NormalDotFlux : db::PrefixTag, db::DataBoxTag {
+struct NormalDotFlux : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "NormalDotFlux";
@@ -72,7 +72,7 @@ struct NormalDotFlux : db::PrefixTag, db::DataBoxTag {
 /// \brief Prefix indicating a boundary unit normal vector dotted into
 /// the numerical flux
 template <typename Tag>
-struct NormalDotNumericalFlux : db::PrefixTag, db::DataBoxTag {
+struct NormalDotNumericalFlux : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "NormalDotNumericalFlux";

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -24,7 +24,7 @@ namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a time derivative
 template <typename Tag>
-struct dt : db::DataBoxPrefix {
+struct dt : db::DataBoxPrefix, db::DataBoxTag {
   static constexpr db::DataBoxString label = "dt";
   using type = db::item_type<Tag>;
   using tag = Tag;
@@ -40,7 +40,7 @@ struct Flux;
 template <typename Tag, typename VolumeDim, typename Fr>
 struct Flux<Tag, VolumeDim, Fr,
             Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::DataBoxPrefix {
+    : db::DataBoxPrefix, db::DataBoxTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Up, Fr>;
   using tag = Tag;
@@ -50,7 +50,7 @@ struct Flux<Tag, VolumeDim, Fr,
 template <typename Tag, typename VolumeDim, typename Fr>
 struct Flux<Tag, VolumeDim, Fr,
             Requires<tt::is_a_v<::Variables, db::item_type<Tag>>>>
-    : db::DataBoxPrefix {
+    : db::DataBoxPrefix, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "Flux";
@@ -61,7 +61,7 @@ struct Flux<Tag, VolumeDim, Fr,
 /// \brief Prefix indicating a boundary unit normal vector dotted into
 /// the flux
 template <typename Tag>
-struct NormalDotFlux : db::DataBoxPrefix {
+struct NormalDotFlux : db::DataBoxPrefix, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "NormalDotFlux";
@@ -72,7 +72,7 @@ struct NormalDotFlux : db::DataBoxPrefix {
 /// \brief Prefix indicating a boundary unit normal vector dotted into
 /// the numerical flux
 template <typename Tag>
-struct NormalDotNumericalFlux : db::DataBoxPrefix {
+struct NormalDotNumericalFlux : db::DataBoxPrefix, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "NormalDotNumericalFlux";

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -47,7 +47,7 @@ namespace Tags {
 /// The Euclidean magnitude of a (co)vector
 template <typename Tag>
 struct EuclideanMagnitude : db::ComputeTag {
-  static constexpr db::DataBoxString label = "EuclideanMagnitude";
+  static constexpr db::Label label = "EuclideanMagnitude";
   static constexpr Scalar<DataVector> (*function)(const db::item_type<Tag>&) =
       magnitude;
   using argument_tags = tmpl::list<Tag>;
@@ -59,7 +59,7 @@ struct EuclideanMagnitude : db::ComputeTag {
 /// MagnitudeTag.
 template <typename Tag, typename MagnitudeTag>
 struct Normalized : db::ComputeTag {
-  static constexpr db::DataBoxString label = "Normalized";
+  static constexpr db::Label label = "Normalized";
   static constexpr auto function(
       const db::item_type<Tag>&
           vector_in,  // Compute items need to take const references

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -61,8 +61,10 @@ template <typename Tag, typename MagnitudeTag>
 struct Normalized : db::ComputeItemTag {
   static constexpr db::DataBoxString label = "Normalized";
   static constexpr auto function(
-      db::item_type<Tag> vector,
+      const db::item_type<Tag>&
+          vector_in,  // Compute items need to take const references
       const db::item_type<MagnitudeTag>& magnitude) noexcept {
+    auto vector = vector_in;
     for (size_t d = 0; d < vector.index_dim(0); ++d) {
       vector.get(d) /= get(magnitude);
     }

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -46,7 +46,7 @@ namespace Tags {
 /// \ingroup DataStructuresGroup
 /// The Euclidean magnitude of a (co)vector
 template <typename Tag>
-struct EuclideanMagnitude : db::ComputeItemTag {
+struct EuclideanMagnitude : db::ComputeTag {
   static constexpr db::DataBoxString label = "EuclideanMagnitude";
   static constexpr Scalar<DataVector> (*function)(const db::item_type<Tag>&) =
       magnitude;
@@ -58,7 +58,7 @@ struct EuclideanMagnitude : db::ComputeItemTag {
 /// The (co)vector represented by Tag normalized by its magnitude from
 /// MagnitudeTag.
 template <typename Tag, typename MagnitudeTag>
-struct Normalized : db::ComputeItemTag {
+struct Normalized : db::ComputeTag {
   static constexpr db::DataBoxString label = "Normalized";
   static constexpr auto function(
       const db::item_type<Tag>&

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -714,9 +714,12 @@ struct Subitems<TagList, Tag,
       const gsl::not_null<item_type<Tag>*> parent_value,
       const gsl::not_null<item_type<Subtag>*> sub_value) noexcept {
     auto& vars = get<Subtag>(*parent_value);
-    for (auto vars_it = vars.begin(), sub_var_it = sub_value->begin();
-         vars_it != vars.end(); ++vars_it, ++sub_var_it) {
-      sub_var_it->set_data_ref(&*vars_it);
+    // Only update the Tensor if the Variables has changed its allocation
+    if (vars.begin()->data() != sub_value->begin()->data()) {
+      for (auto vars_it = vars.begin(), sub_var_it = sub_value->begin();
+           vars_it != vars.end(); ++vars_it, ++sub_var_it) {
+        sub_var_it->set_data_ref(&*vars_it);
+      }
     }
   }
 

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -27,7 +27,7 @@ class Variables;
 
 namespace Tags {
 template <typename TagsList>
-struct Variables : db::DataBoxTag {
+struct Variables : db::SimpleTag {
   static_assert(tt::is_a<tmpl::list, TagsList>::value,
                 "The TagsList passed to Tags::Variables is not a typelist");
   using tags_list = TagsList;
@@ -49,7 +49,7 @@ class Variables;
  * The `Tags` are `struct`s that must have a public type alias `type` whose
  * value must be a `Tensor<DataVector, ...>`, a `static constexpr
  * db::DataBoxString` variable named `label`, and must derive off of
- * `db::DataBoxTag`. In general, they should be DataBoxTags that are not compute
+ * `db::SimpleTag`. In general, they should be DataBoxTags that are not compute
  * items. For example,
  *
  * \snippet Test_Variables.cpp simple_variables_tag

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -704,8 +704,9 @@ struct MakeWithValueImpl<Variables<TagListOut>, Variables<TagListIn>> {
 }  // namespace MakeWithValueImpls
 
 namespace db {
-template <typename Tag>
-struct Subitems<Tag, Requires<tt::is_a_v<Variables, item_type<Tag>>>> {
+template <typename TagList, typename Tag>
+struct Subitems<TagList, Tag,
+                Requires<tt::is_a_v<Variables, item_type<Tag, TagList>>>> {
   using type = typename item_type<Tag>::tags_list;
 
   template <typename Subtag>

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -32,7 +32,7 @@ struct Variables : db::SimpleTag {
                 "The TagsList passed to Tags::Variables is not a typelist");
   using tags_list = TagsList;
   using type = ::Variables<TagsList>;
-  static constexpr db::DataBoxString label = "Variables";
+  static constexpr db::Label label = "Variables";
 };
 }  // namespace Tags
 
@@ -48,7 +48,7 @@ class Variables;
  *
  * The `Tags` are `struct`s that must have a public type alias `type` whose
  * value must be a `Tensor<DataVector, ...>`, a `static constexpr
- * db::DataBoxString` variable named `label`, and must derive off of
+ * db::Label` variable named `label`, and must derive off of
  * `db::SimpleTag`. In general, they should be DataBoxTags that are not compute
  * items. For example,
  *

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -67,7 +67,7 @@ namespace Tags {
 /// \ingroup ComputationalDomain
 /// The unnormalized face normal one form
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
-struct UnnormalizedFaceNormal : db::ComputeItemTag {
+struct UnnormalizedFaceNormal : db::ComputeTag {
   static constexpr db::DataBoxString label = "UnnormalizedFaceNormal";
   static constexpr tnsr::i<DataVector, VolumeDim, Frame> (*function)(
       const ::Index<VolumeDim - 1>&, const ::ElementMap<VolumeDim, Frame>&,

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -68,7 +68,7 @@ namespace Tags {
 /// The unnormalized face normal one form
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct UnnormalizedFaceNormal : db::ComputeTag {
-  static constexpr db::DataBoxString label = "UnnormalizedFaceNormal";
+  static constexpr db::Label label = "UnnormalizedFaceNormal";
   static constexpr tnsr::i<DataVector, VolumeDim, Frame> (*function)(
       const ::Index<VolumeDim - 1>&, const ::ElementMap<VolumeDim, Frame>&,
       const ::Direction<VolumeDim>&) = unnormalized_face_normal;

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -55,7 +55,7 @@ namespace Tags {
 /// \ingroup ComputationalDomainGroup
 /// The ::Element associated with the DataBox
 template <size_t VolumeDim>
-struct Element : db::DataBoxTag {
+struct Element : db::SimpleTag {
   static constexpr db::DataBoxString label = "Element";
   using type = ::Element<VolumeDim>;
 };
@@ -64,7 +64,7 @@ struct Element : db::DataBoxTag {
 /// \ingroup ComputationalDomainGroup
 /// The extents of DataVectors in the DataBox
 template <size_t VolumeDim>
-struct Extents : db::DataBoxTag {
+struct Extents : db::SimpleTag {
   static constexpr db::DataBoxString label = "Extents";
   using type = ::Index<VolumeDim>;
 };
@@ -83,7 +83,7 @@ struct LogicalCoordinates : db::ComputeItemTag {
 /// \ingroup ComputationalDomainGroup
 /// The coordinate map from logical to grid coordinate
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
-struct ElementMap : db::DataBoxTag {
+struct ElementMap : db::SimpleTag {
   static constexpr db::DataBoxString label = "ElementMap";
   using type = ::ElementMap<VolumeDim, Frame>;
 };
@@ -264,7 +264,7 @@ struct InterfaceImpl;
 
 template <typename DirectionsTag, typename NameTag, typename FunctionTag>
 struct InterfaceImpl<false, DirectionsTag, NameTag, FunctionTag>
-    : db::DataBoxTag {
+    : db::SimpleTag {
   static_assert(cpp17::is_same_v<NameTag, FunctionTag>,
                 "Can't specify a function for a simple item tag");
   using tag = NameTag;
@@ -298,7 +298,7 @@ struct InterfaceBase
 /// \ingroup ComputationalDomainGroup
 /// ::Direction to an interface
 template <size_t VolumeDim>
-struct Direction : db::DataBoxTag {
+struct Direction : db::SimpleTag {
   static constexpr db::DataBoxString label = "Direction";
   using type = ::Direction<VolumeDim>;
 };

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -56,7 +56,7 @@ namespace Tags {
 /// The ::Element associated with the DataBox
 template <size_t VolumeDim>
 struct Element : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Element";
+  static constexpr db::Label label = "Element";
   using type = ::Element<VolumeDim>;
 };
 
@@ -65,7 +65,7 @@ struct Element : db::SimpleTag {
 /// The extents of DataVectors in the DataBox
 template <size_t VolumeDim>
 struct Extents : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Extents";
+  static constexpr db::Label label = "Extents";
   using type = ::Index<VolumeDim>;
 };
 
@@ -74,7 +74,7 @@ struct Extents : db::SimpleTag {
 /// The logical coordinates in the Element
 template <size_t VolumeDim>
 struct LogicalCoordinates : db::ComputeTag {
-  static constexpr db::DataBoxString label = "LogicalCoordinates";
+  static constexpr db::Label label = "LogicalCoordinates";
   using argument_tags = tmpl::list<Tags::Extents<VolumeDim>>;
   static constexpr auto function = logical_coordinates<VolumeDim>;
 };
@@ -84,7 +84,7 @@ struct LogicalCoordinates : db::ComputeTag {
 /// The coordinate map from logical to grid coordinate
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct ElementMap : db::SimpleTag {
-  static constexpr db::DataBoxString label = "ElementMap";
+  static constexpr db::Label label = "ElementMap";
   using type = ::ElementMap<VolumeDim, Frame>;
 };
 
@@ -95,7 +95,7 @@ struct ElementMap : db::SimpleTag {
 template <class MapTag, class SourceCoordsTag>
 struct Coordinates : db::ComputeTag, db::PrefixTag {
   using tag = MapTag;
-  static constexpr db::DataBoxString label = "Coordinates";
+  static constexpr db::Label label = "Coordinates";
   static constexpr auto function(
       const db::item_type<MapTag>& element_map,
       const db::item_type<SourceCoordsTag>& source_coords) noexcept {
@@ -112,7 +112,7 @@ struct Coordinates : db::ComputeTag, db::PrefixTag {
 template <typename MapTag, typename SourceCoordsTag>
 struct InverseJacobian : db::ComputeTag, db::PrefixTag {
   using tag = MapTag;
-  static constexpr db::DataBoxString label = "InverseJacobian";
+  static constexpr db::Label label = "InverseJacobian";
   static constexpr auto function(
       const db::item_type<MapTag>& element_map,
       const db::item_type<SourceCoordsTag>& source_coords) noexcept {
@@ -126,7 +126,7 @@ struct InverseJacobian : db::ComputeTag, db::PrefixTag {
 /// The set of directions to neighboring Elements
 template <size_t VolumeDim>
 struct InternalDirections : db::ComputeTag {
-  static constexpr db::DataBoxString label = "InternalDirections";
+  static constexpr db::Label label = "InternalDirections";
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
     std::unordered_set<::Direction<VolumeDim>> result;
@@ -291,7 +291,7 @@ struct InterfaceBase
     : db::PrefixTag,
       Interface_detail::InterfaceImpl<db::is_compute_item_v<FunctionTag>,
                                       DirectionsTag, NameTag, FunctionTag> {
-  static constexpr db::DataBoxString label = "Interface";
+  static constexpr db::Label label = "Interface";
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -299,7 +299,7 @@ struct InterfaceBase
 /// ::Direction to an interface
 template <size_t VolumeDim>
 struct Direction : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Direction";
+  static constexpr db::Label label = "Direction";
   using type = ::Direction<VolumeDim>;
 };
 
@@ -307,7 +307,7 @@ struct Direction : db::SimpleTag {
 template <typename DirectionsTag, size_t VolumeDim>
 struct Interface<DirectionsTag, Direction<VolumeDim>> : db::PrefixTag,
                                                         db::ComputeTag {
-  static constexpr db::DataBoxString label = "Interface";
+  static constexpr db::Label label = "Interface";
   using tag = Direction<VolumeDim>;
   static constexpr auto function(
       const std::unordered_set<::Direction<VolumeDim>>& directions) noexcept {

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -263,7 +263,8 @@ template <bool IsComputeItem, typename DirectionsTag, typename NameTag,
 struct InterfaceImpl;
 
 template <typename DirectionsTag, typename NameTag, typename FunctionTag>
-struct InterfaceImpl<false, DirectionsTag, NameTag, FunctionTag> {
+struct InterfaceImpl<false, DirectionsTag, NameTag, FunctionTag>
+    : db::DataBoxTag {
   static_assert(cpp17::is_same_v<NameTag, FunctionTag>,
                 "Can't specify a function for a simple item tag");
   using tag = NameTag;

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -93,7 +93,7 @@ struct ElementMap : db::DataBoxTag {
 /// The coordinates in the target frame of `MapTag`. The `SourceCoordsTag`'s
 /// frame must be the source frame of `MapTag`
 template <class MapTag, class SourceCoordsTag>
-struct Coordinates : db::ComputeItemTag, db::DataBoxPrefix {
+struct Coordinates : db::ComputeItemTag, db::PrefixTag {
   using tag = MapTag;
   static constexpr db::DataBoxString label = "Coordinates";
   static constexpr auto function(
@@ -110,7 +110,7 @@ struct Coordinates : db::ComputeItemTag, db::DataBoxPrefix {
 /// held by `SourceCoordsTag`. The coordinates must be in the source frame of
 /// the map.
 template <typename MapTag, typename SourceCoordsTag>
-struct InverseJacobian : db::ComputeItemTag, db::DataBoxPrefix {
+struct InverseJacobian : db::ComputeItemTag, db::PrefixTag {
   using tag = MapTag;
   static constexpr db::DataBoxString label = "InverseJacobian";
   static constexpr auto function(
@@ -288,7 +288,7 @@ struct InterfaceImpl<true, DirectionsTag, NameTag, FunctionTag>
 
 template <typename DirectionsTag, typename NameTag, typename FunctionTag>
 struct InterfaceBase
-    : db::DataBoxPrefix,
+    : db::PrefixTag,
       Interface_detail::InterfaceImpl<db::is_compute_item_v<FunctionTag>,
                                       DirectionsTag, NameTag, FunctionTag> {
   static constexpr db::DataBoxString label = "Interface";
@@ -305,8 +305,8 @@ struct Direction : db::DataBoxTag {
 
 /// \cond
 template <typename DirectionsTag, size_t VolumeDim>
-struct Interface<DirectionsTag, Direction<VolumeDim>>
-    : db::DataBoxPrefix, db::ComputeItemTag {
+struct Interface<DirectionsTag, Direction<VolumeDim>> : db::PrefixTag,
+                                                        db::ComputeItemTag {
   static constexpr db::DataBoxString label = "Interface";
   using tag = Direction<VolumeDim>;
   static constexpr auto function(

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -342,9 +342,10 @@ struct Interface<DirectionsTag, Extents<InterfaceDim>>
 }  // namespace Tags
 
 namespace db {
-template <typename DirectionsTag, typename VariablesTag>
-struct Subitems<Tags::Interface<DirectionsTag, VariablesTag>,
-                Requires<tt::is_a_v<Variables, item_type<VariablesTag>>>> {
+template <typename TagList, typename DirectionsTag, typename VariablesTag>
+struct Subitems<
+    TagList, Tags::Interface<DirectionsTag, VariablesTag>,
+    Requires<tt::is_a_v<Variables, item_type<VariablesTag, TagList>>>> {
   using type = tmpl::transform<
       typename item_type<VariablesTag>::tags_list,
       tmpl::bind<Tags::Interface, tmpl::pin<DirectionsTag>, tmpl::_1>>;

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -73,7 +73,7 @@ struct Extents : db::SimpleTag {
 /// \ingroup ComputationalDomainGroup
 /// The logical coordinates in the Element
 template <size_t VolumeDim>
-struct LogicalCoordinates : db::ComputeItemTag {
+struct LogicalCoordinates : db::ComputeTag {
   static constexpr db::DataBoxString label = "LogicalCoordinates";
   using argument_tags = tmpl::list<Tags::Extents<VolumeDim>>;
   static constexpr auto function = logical_coordinates<VolumeDim>;
@@ -93,7 +93,7 @@ struct ElementMap : db::SimpleTag {
 /// The coordinates in the target frame of `MapTag`. The `SourceCoordsTag`'s
 /// frame must be the source frame of `MapTag`
 template <class MapTag, class SourceCoordsTag>
-struct Coordinates : db::ComputeItemTag, db::PrefixTag {
+struct Coordinates : db::ComputeTag, db::PrefixTag {
   using tag = MapTag;
   static constexpr db::DataBoxString label = "Coordinates";
   static constexpr auto function(
@@ -110,7 +110,7 @@ struct Coordinates : db::ComputeItemTag, db::PrefixTag {
 /// held by `SourceCoordsTag`. The coordinates must be in the source frame of
 /// the map.
 template <typename MapTag, typename SourceCoordsTag>
-struct InverseJacobian : db::ComputeItemTag, db::PrefixTag {
+struct InverseJacobian : db::ComputeTag, db::PrefixTag {
   using tag = MapTag;
   static constexpr db::DataBoxString label = "InverseJacobian";
   static constexpr auto function(
@@ -125,7 +125,7 @@ struct InverseJacobian : db::ComputeItemTag, db::PrefixTag {
 /// \ingroup ComputationalDomainGroup
 /// The set of directions to neighboring Elements
 template <size_t VolumeDim>
-struct InternalDirections : db::ComputeItemTag {
+struct InternalDirections : db::ComputeTag {
   static constexpr db::DataBoxString label = "InternalDirections";
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
@@ -275,7 +275,7 @@ struct InterfaceImpl<false, DirectionsTag, NameTag, FunctionTag>
 
 template <typename DirectionsTag, typename NameTag, typename FunctionTag>
 struct InterfaceImpl<true, DirectionsTag, NameTag, FunctionTag>
-    : db::ComputeItemTag {
+    : db::ComputeTag {
   using tag = NameTag;
   using forwarded_argument_tags =
       interface_compute_item_argument_tags<DirectionsTag, FunctionTag>;
@@ -306,7 +306,7 @@ struct Direction : db::SimpleTag {
 /// \cond
 template <typename DirectionsTag, size_t VolumeDim>
 struct Interface<DirectionsTag, Direction<VolumeDim>> : db::PrefixTag,
-                                                        db::ComputeItemTag {
+                                                        db::ComputeTag {
   static constexpr db::DataBoxString label = "Interface";
   using tag = Direction<VolumeDim>;
   static constexpr auto function(
@@ -323,7 +323,7 @@ struct Interface<DirectionsTag, Direction<VolumeDim>> : db::PrefixTag,
 
 namespace detail {
 template <size_t VolumeDim>
-struct InterfaceExtents : db::ComputeItemTag {
+struct InterfaceExtents : db::ComputeTag {
   static constexpr auto function(
       const ::Direction<VolumeDim>& direction,
       const ::Index<VolumeDim>& volume_extents) noexcept {
@@ -402,7 +402,7 @@ template <size_t VolumeDim, typename>
 struct Slice;
 
 template <size_t VolumeDim, typename... SlicedTags>
-struct Slice<VolumeDim, tmpl::list<SlicedTags...>> : db::ComputeItemTag {
+struct Slice<VolumeDim, tmpl::list<SlicedTags...>> : db::ComputeTag {
   static constexpr auto function(
       const ::Index<VolumeDim>& extents,
       const ::Direction<VolumeDim>& direction,

--- a/src/ErrorHandling/StaticAssert.hpp
+++ b/src/ErrorHandling/StaticAssert.hpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines macro DEBUG_STATIC_ASSERT.
+
+#pragma once
+
+/*!
+ * \ingroup ErrorHandlingGroup
+ * \brief A `static_assert` that is only checked in Debug builds
+ */
+#ifdef SPECTRE_DEBUG
+#define DEBUG_STATIC_ASSERT(...) static_assert(__VA_ARGS__)
+#else   // ifdef  SPECTRE_DEBUG
+#define DEBUG_STATIC_ASSERT(...)
+#endif  // ifdef  SPECTRE_DEBUG

--- a/src/Evolution/Actions/ComputeVolumeDuDt.hpp
+++ b/src/Evolution/Actions/ComputeVolumeDuDt.hpp
@@ -7,6 +7,7 @@
 #include <tuple>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 
 /// \cond
@@ -52,7 +53,7 @@ struct ComputeVolumeDuDt {
     // Note: dt_variables is not zeroed and du_dt cannot assume this.
     db::mutate_apply<typename system::du_dt::return_tags,
                      typename system::du_dt::argument_tags>(
-        typename system::du_dt{}, box);
+        typename system::du_dt{}, make_not_null(&box));
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -16,27 +16,27 @@ class DataVector;
 namespace CurvedScalarWave {
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Psi";
+  static constexpr db::Label label = "Psi";
 };
 
 struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Pi";
+  static constexpr db::Label label = "Pi";
 };
 
 template <size_t Dim>
 struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim>;
-  static constexpr db::DataBoxString label = "Phi";
+  static constexpr db::Label label = "Phi";
 };
 
 struct ConstraintGamma1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "ConstraintGamma1";
+  static constexpr db::Label label = "ConstraintGamma1";
 };
 
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "ConstraintGamma2";
+  static constexpr db::Label label = "ConstraintGamma2";
 };
 }  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -14,28 +14,28 @@
 class DataVector;
 
 namespace CurvedScalarWave {
-struct Psi : db::DataBoxTag {
+struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Psi";
 };
 
-struct Pi : db::DataBoxTag {
+struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Pi";
 };
 
 template <size_t Dim>
-struct Phi : db::DataBoxTag {
+struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim>;
   static constexpr db::DataBoxString label = "Phi";
 };
 
-struct ConstraintGamma1 : db::DataBoxTag {
+struct ConstraintGamma1 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "ConstraintGamma1";
 };
 
-struct ConstraintGamma2 : db::DataBoxTag {
+struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "ConstraintGamma2";
 };

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -17,7 +17,7 @@ namespace GeneralizedHarmonic {
  * where \f$\phi_{iab}\f$ is the variable defined by the tag Phi.
  */
 template <size_t Dim, typename Frame>
-struct Pi : db::DataBoxTag {
+struct Pi : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "Pi";
 };
@@ -29,30 +29,30 @@ struct Pi : db::DataBoxTag {
  * \f$\phi_{iab} = \partial_i \psi_{ab}\f$
  */
 template <size_t Dim, typename Frame>
-struct Phi : db::DataBoxTag {
+struct Phi : db::SimpleTag {
   using type = tnsr::iaa<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "Phi";
 };
 
-struct ConstraintGamma0 : db::DataBoxTag {
+struct ConstraintGamma0 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "ConstraintGamma0";
 };
-struct ConstraintGamma1 : db::DataBoxTag {
+struct ConstraintGamma1 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "ConstraintGamma1";
 };
-struct ConstraintGamma2 : db::DataBoxTag {
+struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "ConstraintGamma2";
 };
 template <size_t Dim, typename Frame>
-struct GaugeH : db::DataBoxTag {
+struct GaugeH : db::SimpleTag {
   using type = tnsr::a<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "GaugeH";
 };
 template <size_t Dim, typename Frame>
-struct SpacetimeDerivGaugeH : db::DataBoxTag {
+struct SpacetimeDerivGaugeH : db::SimpleTag {
   using type = tnsr::ab<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "SpacetimeDerivGaugeH";
 };

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -19,7 +19,7 @@ namespace GeneralizedHarmonic {
 template <size_t Dim, typename Frame>
 struct Pi : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
-  static constexpr db::DataBoxString label = "Pi";
+  static constexpr db::Label label = "Pi";
 };
 
 /*!
@@ -31,29 +31,29 @@ struct Pi : db::SimpleTag {
 template <size_t Dim, typename Frame>
 struct Phi : db::SimpleTag {
   using type = tnsr::iaa<DataVector, Dim, Frame>;
-  static constexpr db::DataBoxString label = "Phi";
+  static constexpr db::Label label = "Phi";
 };
 
 struct ConstraintGamma0 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "ConstraintGamma0";
+  static constexpr db::Label label = "ConstraintGamma0";
 };
 struct ConstraintGamma1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "ConstraintGamma1";
+  static constexpr db::Label label = "ConstraintGamma1";
 };
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "ConstraintGamma2";
+  static constexpr db::Label label = "ConstraintGamma2";
 };
 template <size_t Dim, typename Frame>
 struct GaugeH : db::SimpleTag {
   using type = tnsr::a<DataVector, Dim, Frame>;
-  static constexpr db::DataBoxString label = "GaugeH";
+  static constexpr db::Label label = "GaugeH";
 };
 template <size_t Dim, typename Frame>
 struct SpacetimeDerivGaugeH : db::SimpleTag {
   using type = tnsr::ab<DataVector, Dim, Frame>;
-  static constexpr db::DataBoxString label = "SpacetimeDerivGaugeH";
+  static constexpr db::Label label = "SpacetimeDerivGaugeH";
 };
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
@@ -12,18 +12,18 @@ class DataVector;
 
 namespace RelativisticEuler {
 namespace Valencia {
-struct TildeD : db::DataBoxTag {
+struct TildeD : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString_t label = "TildeD";
 };
 
-struct TildeTau : db::DataBoxTag {
+struct TildeTau : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString_t label = "TildeTau";
 };
 
 template <size_t Dim>
-struct TildeS : db::DataBoxTag {
+struct TildeS : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
   static constexpr db::DataBoxString_t label = "TildeS";
 };

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
@@ -14,18 +14,18 @@ namespace RelativisticEuler {
 namespace Valencia {
 struct TildeD : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "TildeD";
+  static constexpr db::Label_t label = "TildeD";
 };
 
 struct TildeTau : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString_t label = "TildeTau";
+  static constexpr db::Label_t label = "TildeTau";
 };
 
 template <size_t Dim>
 struct TildeS : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
-  static constexpr db::DataBoxString_t label = "TildeS";
+  static constexpr db::Label_t label = "TildeS";
 };
 }  // namespace Valencia
 }  // namespace RelativisticEuler

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -126,7 +126,7 @@ struct UpwindFlux {
  private:
   struct NormalTimesFluxPi {
     using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
-    static constexpr db::DataBoxString label = "NormalTimesFluxPi";
+    static constexpr db::Label label = "NormalTimesFluxPi";
   };
 
  public:

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -14,20 +14,20 @@
 class DataVector;
 
 namespace ScalarWave {
-struct Psi : db::DataBoxTag {
+struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Psi";
   static constexpr bool should_be_sliced_to_boundary = true;
 };
 
-struct Pi : db::DataBoxTag {
+struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Pi";
   static constexpr bool should_be_sliced_to_boundary = true;
 };
 
 template <size_t Dim>
-struct Phi : db::DataBoxTag {
+struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
   static constexpr db::DataBoxString label = "Phi";
   static constexpr bool should_be_sliced_to_boundary = true;

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -16,20 +16,20 @@ class DataVector;
 namespace ScalarWave {
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Psi";
+  static constexpr db::Label label = "Psi";
   static constexpr bool should_be_sliced_to_boundary = true;
 };
 
 struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Pi";
+  static constexpr db::Label label = "Pi";
   static constexpr bool should_be_sliced_to_boundary = true;
 };
 
 template <size_t Dim>
 struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
-  static constexpr db::DataBoxString label = "Phi";
+  static constexpr db::Label label = "Phi";
   static constexpr bool should_be_sliced_to_boundary = true;
 };
 }  // namespace ScalarWave

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -68,12 +68,12 @@ namespace {
 template <size_t Dim>
 struct Kappa : db::SimpleTag {
   using type = tnsr::abb<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString label = "Kappa";
+  static constexpr db::Label label = "Kappa";
 };
 template <size_t Dim>
 struct Psi : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame::Grid>;
-  static constexpr db::DataBoxString label = "Psi";
+  static constexpr db::Label label = "Psi";
 };
 
 // clang-tidy: don't pass be non-const reference

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -66,12 +66,12 @@ namespace {
 // all_gradient routine for the GH system
 
 template <size_t Dim>
-struct Kappa : db::DataBoxTag {
+struct Kappa : db::SimpleTag {
   using type = tnsr::abb<DataVector, Dim, Frame::Grid>;
   static constexpr db::DataBoxString label = "Kappa";
 };
 template <size_t Dim>
-struct Psi : db::DataBoxTag {
+struct Psi : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame::Grid>;
   static constexpr db::DataBoxString label = "Psi";
 };

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -181,12 +181,14 @@ struct ComputeBoundaryFlux {
           local_mortar_data, std::move(normal_dot_numerical_fluxes),
           extents[dimension], magnitude_of_face_normal));
 
-      db::mutate<dt_variables_tag>(box, [
-        &lifted_data, &extents, &dimension, &direction
-      ](db::item_type<dt_variables_tag> & dt_vars) noexcept {
-        add_slice_to_data(make_not_null(&dt_vars), lifted_data, extents,
-                          dimension, index_to_slice_at(extents, direction));
-      });
+      db::mutate<dt_variables_tag>(
+          make_not_null(&box),
+          [&lifted_data, &extents, &dimension,
+           &direction ](const gsl::not_null<db::item_type<dt_variables_tag>*>
+                            dt_vars) noexcept {
+            add_slice_to_data(dt_vars, lifted_data, extents, dimension,
+                              index_to_slice_at(extents, direction));
+          });
     }
 
     return std::make_tuple(

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -13,7 +13,7 @@
 
 namespace Tags {
 template <typename Tag, size_t VolumeDim>
-struct Mortars : db::DataBoxPrefix, db::DataBoxTag {
+struct Mortars : db::PrefixTag, db::DataBoxTag {
   static constexpr db::DataBoxString label = "Mortar";
   using tag = Tag;
   using Key = std::pair<::Direction<VolumeDim>, ::ElementId<VolumeDim>>;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -14,7 +14,7 @@
 namespace Tags {
 template <typename Tag, size_t VolumeDim>
 struct Mortars : db::PrefixTag, db::SimpleTag {
-  static constexpr db::DataBoxString label = "Mortar";
+  static constexpr db::Label label = "Mortar";
   using tag = Tag;
   using Key = std::pair<::Direction<VolumeDim>, ::ElementId<VolumeDim>>;
   using type = std::unordered_map<Key, db::item_type<Tag>, boost::hash<Key>>;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -13,7 +13,7 @@
 
 namespace Tags {
 template <typename Tag, size_t VolumeDim>
-struct Mortars : db::DataBoxPrefix {
+struct Mortars : db::DataBoxPrefix, db::DataBoxTag {
   static constexpr db::DataBoxString label = "Mortar";
   using tag = Tag;
   using Key = std::pair<::Direction<VolumeDim>, ::ElementId<VolumeDim>>;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -13,7 +13,7 @@
 
 namespace Tags {
 template <typename Tag, size_t VolumeDim>
-struct Mortars : db::PrefixTag, db::DataBoxTag {
+struct Mortars : db::PrefixTag, db::SimpleTag {
   static constexpr db::DataBoxString label = "Mortar";
   using tag = Tag;
   using Key = std::pair<::Direction<VolumeDim>, ::ElementId<VolumeDim>>;

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -78,7 +78,7 @@ struct div_impl<Tag, Frame, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
       "the first index is not in the specified Frame");
   using type = TensorMetafunctions::remove_first_index<db::item_type<Tag>>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "div";
+  static constexpr db::Label label = "div";
 };
 
 template <typename... FluxTags, typename InverseJacobianTag>
@@ -91,7 +91,7 @@ struct div_impl<tmpl::list<FluxTags...>, InverseJacobianTag,
   using flux_tags = tmpl::list<FluxTags...>;
 
  public:
-  static constexpr db::DataBoxString label = "div";
+  static constexpr db::Label label = "div";
   static constexpr auto function =
       divergence<flux_tags, derivative_frame_index::dim,
                  typename derivative_frame_index::Frame>;

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -84,7 +84,7 @@ struct div_impl<Tag, Frame, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
 template <typename... FluxTags, typename InverseJacobianTag>
 struct div_impl<tmpl::list<FluxTags...>, InverseJacobianTag,
                 Requires<tt::is_a_v<Tensor, db::item_type<InverseJacobianTag>>>>
-    : db::ComputeItemTag {
+    : db::ComputeTag {
  private:
   using derivative_frame_index =
       tmpl::back<typename db::item_type<InverseJacobianTag>::index_list>;

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -70,7 +70,7 @@ namespace Tags {
 namespace Tags_detail {
 template <typename Tag, typename Frame>
 struct div_impl<Tag, Frame, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::PrefixTag, db::DataBoxTag {
+    : db::PrefixTag, db::SimpleTag {
   static_assert(
       cpp17::is_same_v<Frame,
                        std::tuple_element_t<

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -70,7 +70,7 @@ namespace Tags {
 namespace Tags_detail {
 template <typename Tag, typename Frame>
 struct div_impl<Tag, Frame, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::DataBoxPrefix {
+    : db::DataBoxPrefix, db::DataBoxTag {
   static_assert(
       cpp17::is_same_v<Frame,
                        std::tuple_element_t<

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -70,7 +70,7 @@ namespace Tags {
 namespace Tags_detail {
 template <typename Tag, typename Frame>
 struct div_impl<Tag, Frame, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::DataBoxPrefix, db::DataBoxTag {
+    : db::PrefixTag, db::DataBoxTag {
   static_assert(
       cpp17::is_same_v<Frame,
                        std::tuple_element_t<

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -115,7 +115,7 @@ struct deriv_impl<
     tmpl::list<VariablesTags...>, tmpl::list<DerivativeTags...>,
     InverseJacobianTag,
     Requires<tt::is_a_v<Tensor, db::item_type<InverseJacobianTag>>>>
-    : db::ComputeItemTag {
+    : db::ComputeTag {
  private:
   using derivative_frame_index =
       tmpl::back<typename db::item_type<InverseJacobianTag>::index_list>;
@@ -137,7 +137,7 @@ template <typename... VariablesTags, typename... DerivativeTags, typename T,
           T Dim>
 struct deriv_impl<tmpl::list<VariablesTags...>, tmpl::list<DerivativeTags...>,
                   std::integral_constant<T, Dim>,
-                  Requires<(0 < Dim and 4 > Dim)>> : db::ComputeItemTag {
+                  Requires<(0 < Dim and 4 > Dim)>> : db::ComputeTag {
   using variables_tags = tmpl::list<VariablesTags...>;
   static constexpr db::DataBoxString label = "deriv";
   static constexpr auto function =

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -100,7 +100,7 @@ namespace Tags_detail {
 template <typename Tag, typename VolumeDim, typename Frame>
 struct deriv_impl<Tag, VolumeDim, Frame,
                   Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::PrefixTag, db::DataBoxTag {
+    : db::PrefixTag, db::SimpleTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -100,7 +100,7 @@ namespace Tags_detail {
 template <typename Tag, typename VolumeDim, typename Frame>
 struct deriv_impl<Tag, VolumeDim, Frame,
                   Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::DataBoxPrefix, db::DataBoxTag {
+    : db::PrefixTag, db::DataBoxTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -104,7 +104,7 @@ struct deriv_impl<Tag, VolumeDim, Frame,
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "deriv";
+  static constexpr db::Label label = "deriv";
 };
 
 // Partial derivatives with derivative index in the frame related to the logical
@@ -122,7 +122,7 @@ struct deriv_impl<
   using variables_tags = tmpl::list<VariablesTags...>;
 
  public:
-  static constexpr db::DataBoxString label = "deriv";
+  static constexpr db::Label label = "deriv";
   static constexpr auto function =
       partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
                           derivative_frame_index::dim,
@@ -139,7 +139,7 @@ struct deriv_impl<tmpl::list<VariablesTags...>, tmpl::list<DerivativeTags...>,
                   std::integral_constant<T, Dim>,
                   Requires<(0 < Dim and 4 > Dim)>> : db::ComputeTag {
   using variables_tags = tmpl::list<VariablesTags...>;
-  static constexpr db::DataBoxString label = "deriv";
+  static constexpr db::Label label = "deriv";
   static constexpr auto function =
       logical_partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
                                   Dim>;

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -100,7 +100,7 @@ namespace Tags_detail {
 template <typename Tag, typename VolumeDim, typename Frame>
 struct deriv_impl<Tag, VolumeDim, Frame,
                   Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::DataBoxPrefix {
+    : db::DataBoxPrefix, db::DataBoxTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;

--- a/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
@@ -10,81 +10,81 @@
 namespace gr {
 namespace Tags {
 template <size_t Dim, typename Frame, typename DataType>
-struct SpacetimeMetric : db::DataBoxTag {
+struct SpacetimeMetric : db::SimpleTag {
   using type = tnsr::aa<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "SpacetimeMetric";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct InverseSpacetimeMetric : db::DataBoxTag {
+struct InverseSpacetimeMetric : db::SimpleTag {
   using type = tnsr::AA<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "InverseSpacetimeMetric";
 };
 
 template <size_t Dim, typename Frame, typename DataType>
-struct SpatialMetric : db::DataBoxTag {
+struct SpatialMetric : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "SpatialMetric";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct InverseSpatialMetric : db::DataBoxTag {
+struct InverseSpatialMetric : db::SimpleTag {
   using type = tnsr::II<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "InverseSpatialMetric";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct SqrtDetSpatialMetric : db::DataBoxTag {
+struct SqrtDetSpatialMetric : db::SimpleTag {
   using type = Scalar<DataType>;
   static constexpr db::DataBoxString label = "SqrtDetSpatialMetric";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct Shift : db::DataBoxTag {
+struct Shift : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "Shift";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct Lapse : db::DataBoxTag {
+struct Lapse : db::SimpleTag {
   using type = Scalar<DataType>;
   static constexpr db::DataBoxString label = "Lapse";
 };
 
 template <size_t Dim, typename Frame, typename DataType>
-struct SpacetimeChristoffelFirstKind : db::DataBoxTag {
+struct SpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::abb<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "SpacetimeChristoffelFirstKind";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct SpacetimeChristoffelSecondKind : db::DataBoxTag {
+struct SpacetimeChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Abb<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "SpactimeChristoffelSecondKind";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct SpacetimeNormalOneForm : db::DataBoxTag {
+struct SpacetimeNormalOneForm : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "SpacetimeNormalOneForm";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct SpacetimeNormalVector : db::DataBoxTag {
+struct SpacetimeNormalVector : db::SimpleTag {
   using type = tnsr::A<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "SpacetimeNormalVector";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct TraceSpacetimeChristoffelFirstKind : db::DataBoxTag {
+struct TraceSpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label =
       "TraceSpacetimeChristoffelFirstKind";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct TraceSpatialChristoffelSecondKind : db::DataBoxTag {
+struct TraceSpatialChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label =
       "TraceSpatialChristoffelSecondKind";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct ExtrinsicCurvature : db::DataBoxTag {
+struct ExtrinsicCurvature : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
   static constexpr db::DataBoxString label = "ExtrinsicCurvature";
 };
 template <size_t Dim, typename Frame, typename DataType>
-struct TraceExtrinsicCurvature : db::DataBoxTag {
+struct TraceExtrinsicCurvature : db::SimpleTag {
   using type = Scalar<DataType>;
   static constexpr db::DataBoxString label = "TraceExtrinsicCurvature";
 };

--- a/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
@@ -12,81 +12,79 @@ namespace Tags {
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeMetric : db::SimpleTag {
   using type = tnsr::aa<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "SpacetimeMetric";
+  static constexpr db::Label label = "SpacetimeMetric";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct InverseSpacetimeMetric : db::SimpleTag {
   using type = tnsr::AA<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "InverseSpacetimeMetric";
+  static constexpr db::Label label = "InverseSpacetimeMetric";
 };
 
 template <size_t Dim, typename Frame, typename DataType>
 struct SpatialMetric : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "SpatialMetric";
+  static constexpr db::Label label = "SpatialMetric";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct InverseSpatialMetric : db::SimpleTag {
   using type = tnsr::II<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "InverseSpatialMetric";
+  static constexpr db::Label label = "InverseSpatialMetric";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SqrtDetSpatialMetric : db::SimpleTag {
   using type = Scalar<DataType>;
-  static constexpr db::DataBoxString label = "SqrtDetSpatialMetric";
+  static constexpr db::Label label = "SqrtDetSpatialMetric";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct Shift : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "Shift";
+  static constexpr db::Label label = "Shift";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct Lapse : db::SimpleTag {
   using type = Scalar<DataType>;
-  static constexpr db::DataBoxString label = "Lapse";
+  static constexpr db::Label label = "Lapse";
 };
 
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::abb<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "SpacetimeChristoffelFirstKind";
+  static constexpr db::Label label = "SpacetimeChristoffelFirstKind";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Abb<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "SpactimeChristoffelSecondKind";
+  static constexpr db::Label label = "SpactimeChristoffelSecondKind";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeNormalOneForm : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "SpacetimeNormalOneForm";
+  static constexpr db::Label label = "SpacetimeNormalOneForm";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeNormalVector : db::SimpleTag {
   using type = tnsr::A<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "SpacetimeNormalVector";
+  static constexpr db::Label label = "SpacetimeNormalVector";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceSpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label =
-      "TraceSpacetimeChristoffelFirstKind";
+  static constexpr db::Label label = "TraceSpacetimeChristoffelFirstKind";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceSpatialChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label =
-      "TraceSpatialChristoffelSecondKind";
+  static constexpr db::Label label = "TraceSpatialChristoffelSecondKind";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct ExtrinsicCurvature : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
-  static constexpr db::DataBoxString label = "ExtrinsicCurvature";
+  static constexpr db::Label label = "ExtrinsicCurvature";
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceExtrinsicCurvature : db::SimpleTag {
   using type = Scalar<DataType>;
-  static constexpr db::DataBoxString label = "TraceExtrinsicCurvature";
+  static constexpr db::Label label = "TraceExtrinsicCurvature";
 };
 }  // namespace Tags
 }  // namespace gr

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -52,17 +52,16 @@ struct UpdateU {
 
     db::mutate<variables_tag, dt_variables_tag,
                Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>>(
-        box, [&cache](auto& vars, auto& dt_vars, auto& history,
-                      const auto& time, const auto& time_step) noexcept {
+        make_not_null(&box),
+        [&cache](const auto vars, const auto dt_vars, const auto history,
+                 const auto& time, const auto& time_step) noexcept {
           const auto& time_stepper =
               Parallel::get<CacheTags::TimeStepper>(cache);
 
-          history.insert(time, vars, std::move(dt_vars));
-          time_stepper.update_u(make_not_null(&vars), make_not_null(&history),
-                                time_step);
+          history->insert(time, *vars, std::move(*dt_vars));
+          time_stepper.update_u(vars, history, time_step);
         },
-        db::get<Tags::Time>(box),
-        db::get<Tags::TimeStep>(box));
+        db::get<Tags::Time>(box), db::get<Tags::TimeStep>(box));
 
     return std::forward_as_tuple(std::move(box));
   }

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -25,7 +25,7 @@ namespace Tags {
 /// \ingroup TimeGroup
 /// \brief Tag for ::TimeId for the algorithm state
 struct TimeId : db::SimpleTag {
-  static constexpr db::DataBoxString label = "TimeId";
+  static constexpr db::Label label = "TimeId";
   using type = ::TimeId;
 };
 
@@ -33,7 +33,7 @@ struct TimeId : db::SimpleTag {
 /// \ingroup TimeGroup
 /// \brief Tag for step size
 struct TimeStep : db::SimpleTag {
-  static constexpr db::DataBoxString label = "TimeStep";
+  static constexpr db::Label label = "TimeStep";
   using type = ::TimeDelta;
 };
 
@@ -45,7 +45,7 @@ inline ::Time time_from_id(const ::TimeId& id) noexcept { return id.time; }
 /// \ingroup TimeGroup
 /// \brief Tag for compute item for current ::Time (from TimeId)
 struct Time : db::ComputeTag {
-  static constexpr db::DataBoxString label = "Time";
+  static constexpr db::Label label = "Time";
   static constexpr auto function = TimeTags_detail::time_from_id;
   using argument_tags = tmpl::list<TimeId>;
 };
@@ -54,7 +54,7 @@ struct Time : db::ComputeTag {
 /// \ingroup TimeGroup
 /// \brief Tag for compute item for current time as a double
 struct TimeValue : db::ComputeTag {
-  static constexpr db::DataBoxString label = "TimeValue";
+  static constexpr db::Label label = "TimeValue";
   static auto function(const ::Time& t) noexcept { return t.value(); }
   using argument_tags = tmpl::list<Time>;
 };
@@ -67,7 +67,7 @@ struct TimeValue : db::ComputeTag {
 /// \tparam DtTag tag for the time derivative of the variables
 template <typename Tag, typename DtTag>
 struct HistoryEvolvedVariables : db::PrefixTag, db::SimpleTag {
-  static constexpr db::DataBoxString label = "HistoryEvolvedVariables";
+  static constexpr db::Label label = "HistoryEvolvedVariables";
   using tag = Tag;
   using type = TimeSteppers::History<db::item_type<Tag>, db::item_type<DtTag>>;
 };
@@ -80,7 +80,7 @@ struct HistoryEvolvedVariables : db::PrefixTag, db::SimpleTag {
 /// \tparam Tag tag for boundary variables
 template <typename Key, typename Tag, typename Hash = std::hash<Key>>
 struct HistoryBoundaryVariables : db::PrefixTag, db::SimpleTag {
-  static constexpr db::DataBoxString label = "HistoryBoundaryVariables";
+  static constexpr db::Label label = "HistoryBoundaryVariables";
   using tag = Tag;
   using type = std::unordered_map<Key, db::item_type<Tag>, Hash>;
 };

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -44,7 +44,7 @@ inline ::Time time_from_id(const ::TimeId& id) noexcept { return id.time; }
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Tag for compute item for current ::Time (from TimeId)
-struct Time : db::ComputeItemTag {
+struct Time : db::ComputeTag {
   static constexpr db::DataBoxString label = "Time";
   static constexpr auto function = TimeTags_detail::time_from_id;
   using argument_tags = tmpl::list<TimeId>;
@@ -53,7 +53,7 @@ struct Time : db::ComputeItemTag {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Tag for compute item for current time as a double
-struct TimeValue : db::ComputeItemTag {
+struct TimeValue : db::ComputeTag {
   static constexpr db::DataBoxString label = "TimeValue";
   static auto function(const ::Time& t) noexcept { return t.value(); }
   using argument_tags = tmpl::list<Time>;

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -66,7 +66,7 @@ struct TimeValue : db::ComputeItemTag {
 /// \tparam Tag tag for the variables
 /// \tparam DtTag tag for the time derivative of the variables
 template <typename Tag, typename DtTag>
-struct HistoryEvolvedVariables : db::DataBoxPrefix {
+struct HistoryEvolvedVariables : db::DataBoxPrefix, db::DataBoxTag {
   static constexpr db::DataBoxString label = "HistoryEvolvedVariables";
   using tag = Tag;
   using type = TimeSteppers::History<db::item_type<Tag>, db::item_type<DtTag>>;
@@ -79,7 +79,7 @@ struct HistoryEvolvedVariables : db::DataBoxPrefix {
 /// \tparam Key type identifying a boundary
 /// \tparam Tag tag for boundary variables
 template <typename Key, typename Tag, typename Hash = std::hash<Key>>
-struct HistoryBoundaryVariables : db::DataBoxPrefix {
+struct HistoryBoundaryVariables : db::DataBoxPrefix, db::DataBoxTag {
   static constexpr db::DataBoxString label = "HistoryBoundaryVariables";
   using tag = Tag;
   using type = std::unordered_map<Key, db::item_type<Tag>, Hash>;

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -24,7 +24,7 @@ namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Tag for ::TimeId for the algorithm state
-struct TimeId : db::DataBoxTag {
+struct TimeId : db::SimpleTag {
   static constexpr db::DataBoxString label = "TimeId";
   using type = ::TimeId;
 };
@@ -32,7 +32,7 @@ struct TimeId : db::DataBoxTag {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Tag for step size
-struct TimeStep : db::DataBoxTag {
+struct TimeStep : db::SimpleTag {
   static constexpr db::DataBoxString label = "TimeStep";
   using type = ::TimeDelta;
 };
@@ -66,7 +66,7 @@ struct TimeValue : db::ComputeItemTag {
 /// \tparam Tag tag for the variables
 /// \tparam DtTag tag for the time derivative of the variables
 template <typename Tag, typename DtTag>
-struct HistoryEvolvedVariables : db::PrefixTag, db::DataBoxTag {
+struct HistoryEvolvedVariables : db::PrefixTag, db::SimpleTag {
   static constexpr db::DataBoxString label = "HistoryEvolvedVariables";
   using tag = Tag;
   using type = TimeSteppers::History<db::item_type<Tag>, db::item_type<DtTag>>;
@@ -79,7 +79,7 @@ struct HistoryEvolvedVariables : db::PrefixTag, db::DataBoxTag {
 /// \tparam Key type identifying a boundary
 /// \tparam Tag tag for boundary variables
 template <typename Key, typename Tag, typename Hash = std::hash<Key>>
-struct HistoryBoundaryVariables : db::PrefixTag, db::DataBoxTag {
+struct HistoryBoundaryVariables : db::PrefixTag, db::SimpleTag {
   static constexpr db::DataBoxString label = "HistoryBoundaryVariables";
   using tag = Tag;
   using type = std::unordered_map<Key, db::item_type<Tag>, Hash>;

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -66,7 +66,7 @@ struct TimeValue : db::ComputeItemTag {
 /// \tparam Tag tag for the variables
 /// \tparam DtTag tag for the time derivative of the variables
 template <typename Tag, typename DtTag>
-struct HistoryEvolvedVariables : db::DataBoxPrefix, db::DataBoxTag {
+struct HistoryEvolvedVariables : db::PrefixTag, db::DataBoxTag {
   static constexpr db::DataBoxString label = "HistoryEvolvedVariables";
   using tag = Tag;
   using type = TimeSteppers::History<db::item_type<Tag>, db::item_type<DtTag>>;
@@ -79,7 +79,7 @@ struct HistoryEvolvedVariables : db::DataBoxPrefix, db::DataBoxTag {
 /// \tparam Key type identifying a boundary
 /// \tparam Tag tag for boundary variables
 template <typename Key, typename Tag, typename Hash = std::hash<Key>>
-struct HistoryBoundaryVariables : db::DataBoxPrefix, db::DataBoxTag {
+struct HistoryBoundaryVariables : db::PrefixTag, db::DataBoxTag {
   static constexpr db::DataBoxString label = "HistoryBoundaryVariables";
   using tag = Tag;
   using type = std::unordered_map<Key, db::item_type<Tag>, Hash>;

--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -17,6 +17,8 @@
 /// \endcond
 #include <brigand/brigand.hpp>
 
+#include <initializer_list>
+
 #include "Utilities/Digraph.hpp"
 #include "Utilities/ForceInline.hpp"
 
@@ -537,9 +539,27 @@ constexpr bool flat_any_v = flat_any<Bs...>::value;
  * \snippet Utilities/Test_TMPL.cpp expand_pack_example
  *
  * \see tuple_fold tuple_counted_fold tuple_transform std::tuple
+ * EXPAND_PACK_LEFT_TO_RIGHT
  */
 template <typename... Ts>
 constexpr void expand_pack(Ts&&...) noexcept {}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Expand a parameter pack evaluating the terms from left to right.
+ *
+ * The parameter pack inside the argument to the macro must not be expanded
+ * since the macro will do the expansion correctly for you. In the below example
+ * a parameter pack of `std::integral_constant<size_t, I>` is passed to the
+ * function. The closure `lambda` is used to sum up the values of all the `Ts`.
+ * Note that the `Ts` passed to `EXPAND_PACK_LEFT_TO_RIGHT` is not expanded.
+ *
+ * \snippet Utilities/Test_TMPL.cpp expand_pack_left_to_right
+ *
+ * \see tuple_fold tuple_counted_fold tuple_transform std::tuple expand_pack
+ */
+#define EXPAND_PACK_LEFT_TO_RIGHT(...) \
+  (void)std::initializer_list<char> { ((void)(__VA_ARGS__), '0')... }
 
 /*!
  * \ingroup UtilitiesGroup

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_DataStructures")
 
 set(LIBRARY_SOURCES
+  Test_BaseTags.cpp
   Test_DataBox.cpp
   Test_DataBoxTag.cpp
   Test_DataVector.cpp

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
@@ -131,11 +131,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
 }
 
 namespace {
-struct Vector : db::DataBoxTag {
+struct Vector : db::SimpleTag {
   static constexpr db::DataBoxString label = "Vector";
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
 };
-struct Covector : db::DataBoxTag {
+struct Covector : db::SimpleTag {
   static constexpr db::DataBoxString label = "Covector";
   using type = tnsr::i<DataVector, 2, Frame::Grid>;
 };

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
@@ -132,11 +132,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
 
 namespace {
 struct Vector : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Vector";
+  static constexpr db::Label label = "Vector";
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
 };
 struct Covector : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Covector";
+  static constexpr db::Label label = "Covector";
   using type = tnsr::i<DataVector, 2, Frame::Grid>;
 };
 }  // namespace

--- a/tests/Unit/DataStructures/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/Test_BaseTags.cpp
@@ -24,7 +24,7 @@ struct VectorBase : db::BaseTag {};
 template <int I>
 struct Vector : db::SimpleTag, VectorBase<I> {
   using type = std::vector<double>;
-  static constexpr db::DataBoxString label = "Vector";
+  static constexpr db::Label label = "Vector";
 };
 
 template <int I>
@@ -33,12 +33,12 @@ struct ArrayBase : db::BaseTag {};
 template <int I>
 struct Array : virtual db::SimpleTag, ArrayBase<I> {
   using type = std::array<int, 3>;
-  static constexpr db::DataBoxString label = "Array";
+  static constexpr db::Label label = "Array";
 };
 
 template <int I, int VectorBaseIndex = 0, int... VectorBaseExtraIndices>
 struct ArrayComputeBase : Array<I>, db::ComputeTag {
-  static constexpr db::DataBoxString label = "ArrayComputeBase";
+  static constexpr db::Label label = "ArrayComputeBase";
 
   static std::array<int, 3> function(const std::vector<double>& t) noexcept {
     return {{static_cast<int>(t.size()), static_cast<int>(t[0]), -8}};
@@ -190,12 +190,12 @@ struct ParentBase : db::BaseTag {};
 
 template <size_t N, bool Compute = false, bool DependsOnComputeItem = false>
 struct Parent : ParentBase<N>, db::SimpleTag {
-  static constexpr db::DataBoxString label = "Parent";
+  static constexpr db::Label label = "Parent";
   using type = std::pair<Boxed<int>, Boxed<double>>;
 };
 template <size_t N, bool DependsOnComputeItem>
 struct Parent<N, true, DependsOnComputeItem> : ParentBase<N>, db::ComputeTag {
-  static constexpr db::DataBoxString label = "Parent";
+  static constexpr db::Label label = "Parent";
   static auto function(
       const std::pair<Boxed<int>, Boxed<double>>& arg) noexcept {
     return std::make_pair(
@@ -207,14 +207,14 @@ struct Parent<N, true, DependsOnComputeItem> : ParentBase<N>, db::ComputeTag {
 
 template <size_t N>
 struct First : FirstBase<N>, db::SimpleTag {
-  static constexpr db::DataBoxString label = "First";
+  static constexpr db::Label label = "First";
   using type = Boxed<int>;
 
   static constexpr size_t index = 0;
 };
 template <size_t N>
 struct Second : SecondBase<N>, db::SimpleTag {
-  static constexpr db::DataBoxString label = "Second";
+  static constexpr db::Label label = "Second";
   using type = Boxed<double>;
 
   static constexpr size_t index = 1;
@@ -231,7 +231,7 @@ struct ComputeMultiplyByTwo : MultiplyByTwo<N0, N1>, db::ComputeTag {
   static auto function(const T0& t0, const T1& t1) noexcept {
     return *t0 * *t1;
   }
-  static constexpr db::DataBoxString label = "MultiplyByTwo";
+  static constexpr db::Label label = "MultiplyByTwo";
   using argument_tags = tmpl::list<First<N0>, Second<N1>>;
 };
 }  // namespace TestTags

--- a/tests/Unit/DataStructures/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/Test_BaseTags.cpp
@@ -1,0 +1,339 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+namespace {
+namespace TestTags {
+template <int I>
+struct VectorBase : db::BaseTag {};
+
+template <int I>
+struct Vector : db::DataBoxTag, VectorBase<I> {
+  using type = std::vector<double>;
+  static constexpr db::DataBoxString label = "Vector";
+};
+
+template <int I>
+struct ArrayBase : db::BaseTag {};
+
+template <int I>
+struct Array : virtual db::DataBoxTag, ArrayBase<I> {
+  using type = std::array<int, 3>;
+  static constexpr db::DataBoxString label = "Array";
+};
+
+template <int I, int VectorBaseIndex = 0, int... VectorBaseExtraIndices>
+struct ArrayComputeBase : Array<I>, db::ComputeItemTag {
+  static constexpr db::DataBoxString label = "ArrayComputeBase";
+
+  static std::array<int, 3> function(const std::vector<double>& t) noexcept {
+    return {{static_cast<int>(t.size()), static_cast<int>(t[0]), -8}};
+  }
+
+  template <typename... Args>
+  static std::array<int, 2 + sizeof...(Args)> function(
+      const std::vector<double>& t, const Args&... args) noexcept {
+    return {{static_cast<int>(t.size()), static_cast<int>(t[0]),
+             static_cast<int>(args[0])...}};
+  }
+
+  using argument_tags = tmpl::list<VectorBase<VectorBaseIndex>,
+                                   VectorBase<VectorBaseExtraIndices>...>;
+};
+}  // namespace TestTags
+
+void test_non_subitems() {
+  // Test "easy case" where there are no subitems. Test:
+  // - `get`ing an item by a base tag
+  // - `mutate`ing an item by a base tag
+  // - using a base tag as the argument in a compute item
+  // - `get`ing a compute item by base tag
+  // - `get`ing a compute item by its simple tag
+  auto box = db::create<db::AddSimpleTags<TestTags::Vector<0>>,
+                        db::AddComputeTags<TestTags::ArrayComputeBase<0>>>(
+      std::vector<double>{-10.0, 10.0});
+  CHECK(db::get<TestTags::VectorBase<0>>(box) ==
+        std::vector<double>{-10.0, 10.0});
+  CHECK(db::get<TestTags::Array<0>>(box) == std::array<int, 3>{{2, -10, -8}});
+  db::mutate<TestTags::VectorBase<0>>(box,
+                                      [](auto& vector) { vector[0] = 101.8; });
+  CHECK(db::get<TestTags::VectorBase<0>>(box) ==
+        std::vector<double>{101.8, 10.0});
+  CHECK(db::get<TestTags::ArrayBase<0>>(box) ==
+        std::array<int, 3>{{2, 101, -8}});
+  CHECK(db::get<TestTags::Array<0>>(box) == std::array<int, 3>{{2, 101, -8}});
+  CHECK(db::get<TestTags::ArrayComputeBase<0>>(box) ==
+        std::array<int, 3>{{2, 101, -8}});
+
+  // - adding compute item that uses a base tag as its argument
+  const auto box2 =  // Add compute item that uses base tag as its argument
+      db::create_from<db::RemoveTags<>, db::AddSimpleTags<>,
+                      db::AddComputeTags<TestTags::ArrayComputeBase<1>>>(box);
+  CHECK(db::get<TestTags::ArrayBase<1>>(box2) ==
+        std::array<int, 3>{{2, 101, -8}});
+  CHECK(db::get<TestTags::ArrayComputeBase<1>>(box2) ==
+        std::array<int, 3>{{2, 101, -8}});
+  const auto box3 =
+      db::create_from<db::RemoveTags<TestTags::ArrayComputeBase<1>>>(box2);
+  CHECK(db::get<TestTags::VectorBase<0>>(box3) ==
+        std::vector<double>{101.8, 10.0});
+  CHECK(db::get<TestTags::ArrayBase<0>>(box3) ==
+        std::array<int, 3>{{2, 101, -8}});
+  CHECK(db::get<TestTags::ArrayComputeBase<0>>(box3) ==
+        std::array<int, 3>{{2, 101, -8}});
+
+  // - adding a new simple item and a compute item that uses it and an
+  //   existing item via a base tag. This is implemented as a function
+  //   template compute item to also test that compute items can be function
+  //   templates.
+  // - mutate one of the arguments that are template parameters of the compute
+  //   item and also a base tag
+  auto box4 = db::create_from<
+      db::RemoveTags<>,
+      db::AddSimpleTags<TestTags::Vector<1>, TestTags::Vector<2>>,
+      db::AddComputeTags<TestTags::ArrayComputeBase<1, 0, 1, 2>>>(
+      box, std::vector<double>{-7.1, 8.9}, std::vector<double>{103.1, -73.2});
+  CHECK(db::get<TestTags::ArrayBase<1>>(box4) ==
+        std::array<int, 4>{{2, 101, -7, 103}});
+  db::mutate<TestTags::VectorBase<2>>(box4,
+                                      [](auto& vector) { vector[0] = 408.8; });
+  CHECK(db::get<TestTags::ArrayBase<1>>(box4) ==
+        std::array<int, 4>{{2, 101, -7, 408}});
+
+  // - removing a compute item that uses a base tag as its argument
+  // - removing a compute item by its base tag
+  const auto box5 =
+      db::create_from<db::RemoveTags<TestTags::ArrayBase<1>>>(box4);
+  CHECK(db::get<TestTags::VectorBase<1>>(box5) ==
+        std::vector<double>{-7.1, 8.9});
+  CHECK(db::get<TestTags::VectorBase<2>>(box5) ==
+        std::vector<double>{408.8, -73.2});
+
+  // - removing a compute item and its dependencies by the base tags
+  const auto box6 = db::create_from<
+      db::RemoveTags<TestTags::VectorBase<1>, TestTags::VectorBase<2>,
+                     TestTags::ArrayBase<1>>>(box4);
+  CHECK(db::get<TestTags::VectorBase<0>>(box6) ==
+        std::vector<double>{101.8, 10.0});
+  CHECK(db::get<TestTags::ArrayBase<0>>(box6) ==
+        std::array<int, 3>{{2, 101, -8}});
+}
+
+namespace TestTags {
+// We can't use raw fundamental types as subitems because subitems
+// need to have a reference-like nature.
+template <typename T>
+class Boxed {
+ public:
+  explicit Boxed(std::shared_ptr<T> data) noexcept : data_(std::move(data)) {}
+  Boxed() = default;
+  // The multiple copy constructors (assignment operators) are needed
+  // to prevent users from modifying compute item values.
+  Boxed(const Boxed&) = delete;
+  Boxed(Boxed&) = default;
+  Boxed(Boxed&&) = default;
+  Boxed& operator=(const Boxed&) = delete;
+  Boxed& operator=(Boxed&) = default;
+  Boxed& operator=(Boxed&&) = default;
+  ~Boxed() = default;
+
+  T& operator*() noexcept { return *data_; }
+  const T& operator*() const noexcept { return *data_; }
+
+  // clang-tidy: no non-const references
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    if (p.isUnpacking()) {
+      T t{};
+      p | t;
+      data_ = std::make_shared<T>(std::move(t));
+    } else {
+      p | *data_;
+    }
+  }
+
+ private:
+  std::shared_ptr<T> data_;
+};
+
+template <typename T>
+bool operator==(const Boxed<T>& lhs, const Boxed<T>& rhs) noexcept {
+  return *lhs == *rhs;
+}
+
+template <typename T>
+bool operator!=(const Boxed<T>& lhs, const Boxed<T>& rhs) noexcept {
+  return not(*lhs == *rhs);
+}
+
+template <size_t N>
+struct FirstBase : db::BaseTag {};
+
+template <size_t N>
+struct SecondBase : db::BaseTag {};
+
+template <size_t N>
+struct ParentBase : db::BaseTag {};
+
+template <size_t N, bool Compute = false, bool DependsOnComputeItem = false>
+struct Parent : ParentBase<N>, db::DataBoxTag {
+  static constexpr db::DataBoxString label = "Parent";
+  using type = std::pair<Boxed<int>, Boxed<double>>;
+};
+template <size_t N, bool DependsOnComputeItem>
+struct Parent<N, true, DependsOnComputeItem> : ParentBase<N>,
+                                               db::ComputeItemTag {
+  static constexpr db::DataBoxString label = "Parent";
+  static auto function(
+      const std::pair<Boxed<int>, Boxed<double>>& arg) noexcept {
+    return std::make_pair(
+        Boxed<int>(std::make_shared<int>(*arg.first + 1)),
+        Boxed<double>(std::make_shared<double>(*arg.second * 2.)));
+  }
+  using argument_tags = tmpl::list<ParentBase<N - 1>>;
+};
+
+template <size_t N>
+struct First : FirstBase<N>, db::DataBoxTag {
+  static constexpr db::DataBoxString label = "First";
+  using type = Boxed<int>;
+
+  static constexpr size_t index = 0;
+};
+template <size_t N>
+struct Second : SecondBase<N>, db::DataBoxTag {
+  static constexpr db::DataBoxString label = "Second";
+  using type = Boxed<double>;
+
+  static constexpr size_t index = 1;
+};
+
+template <size_t N0, size_t N1>
+struct MultiplyByTwo : db::BaseTag {};
+
+template <size_t N0, size_t N1>
+struct ComputeMultiplyByTwo : MultiplyByTwo<N0, N1>, db::ComputeItemTag {
+  // We use a function template and auto return type solely to test that these
+  // work correctly with the DataBox.
+  template <typename T0, typename T1>
+  static auto function(const T0& t0, const T1& t1) noexcept {
+    return *t0 * *t1;
+  }
+  static constexpr db::DataBoxString label = "MultiplyByTwo";
+  using argument_tags = tmpl::list<First<N0>, Second<N1>>;
+};
+}  // namespace TestTags
+}  // namespace
+
+namespace db {
+template <typename TagList, size_t N, bool Compute, bool DependsOnComputeItem>
+struct Subitems<TagList, TestTags::Parent<N, Compute, DependsOnComputeItem>> {
+  using type = tmpl::list<TestTags::First<N>, TestTags::Second<N>>;
+  using tag = TestTags::Parent<N, Compute>;
+
+  // The argument types to create_item are template parameters instead of
+  // gsl::not_null<item_type<tag>*> and gsl::not_null<item_type<Subtag>*> to
+  // test that the code works correctly if create_item is a function template
+  template <typename Subtag, typename T0, typename T1>
+  static void create_item(const T0 parent_value, const T1 sub_value) noexcept {
+    *sub_value = std::get<Subtag::index>(*parent_value);
+  }
+
+  // We use the template parameter T instead of item_type<tag, TagList> just to
+  // test that create_compute_time functions can be function templates too
+  template <typename Subtag, typename T>
+  static auto create_compute_item(const T& parent_value) noexcept {
+    // clang-tidy: do not use const_cast
+    // We need a non-const object to set up the aliasing since in the
+    // simple-item case the alias can be used to modify the original
+    // item.  That should not be allowed for compute items, but the
+    // DataBox will only allow access to a const version of the result
+    // and we ensure in the definition of Boxed that that will not
+    // allow modification of the original item.
+    return const_cast<item_type<Subtag, TagList>&>(  // NOLINT
+        std::get<Subtag::index>(parent_value));
+  }
+};
+}  // namespace db
+
+namespace {
+void test_subitems_tags() {
+  // Test subitems cases:
+  // - `get`ing a subitem by a base tag
+  // - `get`ing a subitem of a compute item by base tag
+  auto box = db::create<db::AddSimpleTags<TestTags::Parent<0>>,
+                        db::AddComputeTags<TestTags::Parent<1, true>>>(
+      std::make_pair(TestTags::Boxed<int>(std::make_shared<int>(5)),
+                     TestTags::Boxed<double>(std::make_shared<double>(3.5))));
+  CHECK(*db::get<TestTags::FirstBase<0>>(box) == 5);
+  CHECK(*db::get<TestTags::SecondBase<0>>(box) == 3.5);
+  CHECK(db::get<TestTags::ParentBase<0>>(box) ==
+        std::make_pair(TestTags::Boxed<int>(std::make_shared<int>(5)),
+                       TestTags::Boxed<double>(std::make_shared<double>(3.5))));
+  CHECK(*db::get<TestTags::FirstBase<1>>(box) == 6);
+  CHECK(*db::get<TestTags::SecondBase<1>>(box) == 7.0);
+  CHECK(db::get<TestTags::ParentBase<1>>(box) ==
+        std::make_pair(TestTags::Boxed<int>(std::make_shared<int>(6)),
+                       TestTags::Boxed<double>(std::make_shared<double>(7.0))));
+
+  // - `mutate`ing a subitem by a base tag
+  db::mutate<TestTags::FirstBase<0>>(
+      box, [](TestTags::Boxed<int> & first) noexcept { *first = -3; });
+  CHECK(*db::get<TestTags::FirstBase<0>>(box) == -3);
+  CHECK(*db::get<TestTags::SecondBase<0>>(box) == 3.5);
+  CHECK(db::get<TestTags::ParentBase<0>>(box) ==
+        std::make_pair(TestTags::Boxed<int>(std::make_shared<int>(-3)),
+                       TestTags::Boxed<double>(std::make_shared<double>(3.5))));
+  CHECK(*db::get<TestTags::FirstBase<1>>(box) == -2);
+  CHECK(*db::get<TestTags::SecondBase<1>>(box) == 7.0);
+  CHECK(db::get<TestTags::ParentBase<1>>(box) ==
+        std::make_pair(TestTags::Boxed<int>(std::make_shared<int>(-2)),
+                       TestTags::Boxed<double>(std::make_shared<double>(7.0))));
+
+  // - adding a compute item that uses subitems via base tags, one that's
+  //   already in the box another that's being added
+  auto box2 =
+      db::create_from<db::RemoveTags<>, db::AddSimpleTags<>,
+                      db::AddComputeTags<TestTags::ComputeMultiplyByTwo<0, 1>>>(
+          box);
+  CHECK(db::get<TestTags::MultiplyByTwo<0, 1>>(box2) == -3 * 7.0);
+
+  // - using a subitem by base tag as the argument to a compute item (make
+  //   sure mutating works correctly, both if mutating the base and if
+  //   mutating the collection)
+  // - Test mutating the Subitem itself rather than one of the subitems.
+  auto box3 =
+      db::create_from<db::RemoveTags<>, db::AddSimpleTags<TestTags::Parent<2>>,
+                      db::AddComputeTags<TestTags::ComputeMultiplyByTwo<0, 2>>>(
+          box, std::make_pair(
+                   TestTags::Boxed<int>(std::make_shared<int>(8)),
+                   TestTags::Boxed<double>(std::make_shared<double>(9.5))));
+  CHECK(db::get<TestTags::MultiplyByTwo<0, 2>>(box3) == -3 * 9.5);
+  db::mutate<TestTags::FirstBase<0>>(
+      box3, [](TestTags::Boxed<int> & first) noexcept { *first = 4; });
+  CHECK(db::get<TestTags::MultiplyByTwo<0, 2>>(box3) == 4 * 9.5);
+  db::mutate<TestTags::ParentBase<0>>(
+      box3, [](std::pair<TestTags::Boxed<int>, TestTags::Boxed<double>> &
+               parent0) noexcept { *parent0.first = 8; });
+  CHECK(db::get<TestTags::MultiplyByTwo<0, 2>>(box3) == 8 * 9.5);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.BaseTags",
+                  "[Unit][DataStructures]") {
+  test_non_subitems();
+  test_subitems_tags();
+}

--- a/tests/Unit/DataStructures/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/Test_BaseTags.cpp
@@ -37,7 +37,7 @@ struct Array : virtual db::SimpleTag, ArrayBase<I> {
 };
 
 template <int I, int VectorBaseIndex = 0, int... VectorBaseExtraIndices>
-struct ArrayComputeBase : Array<I>, db::ComputeItemTag {
+struct ArrayComputeBase : Array<I>, db::ComputeTag {
   static constexpr db::DataBoxString label = "ArrayComputeBase";
 
   static std::array<int, 3> function(const std::vector<double>& t) noexcept {
@@ -194,8 +194,7 @@ struct Parent : ParentBase<N>, db::SimpleTag {
   using type = std::pair<Boxed<int>, Boxed<double>>;
 };
 template <size_t N, bool DependsOnComputeItem>
-struct Parent<N, true, DependsOnComputeItem> : ParentBase<N>,
-                                               db::ComputeItemTag {
+struct Parent<N, true, DependsOnComputeItem> : ParentBase<N>, db::ComputeTag {
   static constexpr db::DataBoxString label = "Parent";
   static auto function(
       const std::pair<Boxed<int>, Boxed<double>>& arg) noexcept {
@@ -225,7 +224,7 @@ template <size_t N0, size_t N1>
 struct MultiplyByTwo : db::BaseTag {};
 
 template <size_t N0, size_t N1>
-struct ComputeMultiplyByTwo : MultiplyByTwo<N0, N1>, db::ComputeItemTag {
+struct ComputeMultiplyByTwo : MultiplyByTwo<N0, N1>, db::ComputeTag {
   // We use a function template and auto return type solely to test that these
   // work correctly with the DataBox.
   template <typename T0, typename T1>

--- a/tests/Unit/DataStructures/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/Test_BaseTags.cpp
@@ -22,7 +22,7 @@ template <int I>
 struct VectorBase : db::BaseTag {};
 
 template <int I>
-struct Vector : db::DataBoxTag, VectorBase<I> {
+struct Vector : db::SimpleTag, VectorBase<I> {
   using type = std::vector<double>;
   static constexpr db::DataBoxString label = "Vector";
 };
@@ -31,7 +31,7 @@ template <int I>
 struct ArrayBase : db::BaseTag {};
 
 template <int I>
-struct Array : virtual db::DataBoxTag, ArrayBase<I> {
+struct Array : virtual db::SimpleTag, ArrayBase<I> {
   using type = std::array<int, 3>;
   static constexpr db::DataBoxString label = "Array";
 };
@@ -189,7 +189,7 @@ template <size_t N>
 struct ParentBase : db::BaseTag {};
 
 template <size_t N, bool Compute = false, bool DependsOnComputeItem = false>
-struct Parent : ParentBase<N>, db::DataBoxTag {
+struct Parent : ParentBase<N>, db::SimpleTag {
   static constexpr db::DataBoxString label = "Parent";
   using type = std::pair<Boxed<int>, Boxed<double>>;
 };
@@ -207,14 +207,14 @@ struct Parent<N, true, DependsOnComputeItem> : ParentBase<N>,
 };
 
 template <size_t N>
-struct First : FirstBase<N>, db::DataBoxTag {
+struct First : FirstBase<N>, db::SimpleTag {
   static constexpr db::DataBoxString label = "First";
   using type = Boxed<int>;
 
   static constexpr size_t index = 0;
 };
 template <size_t N>
-struct Second : SecondBase<N>, db::DataBoxTag {
+struct Second : SecondBase<N>, db::SimpleTag {
   static constexpr db::DataBoxString label = "Second";
   using type = Boxed<double>;
 

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -165,7 +165,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
   static_assert(
       std::is_same<
           decltype(original_box),
-          db::DataBox<db::databox_detail::expand_subitems<
+          db::DataBox<db::DataBox_detail::expand_subitems<
               tmpl::list<test_databox_tags::Tag0, test_databox_tags::Tag1,
                          test_databox_tags::Tag2>,
               tmpl::list<test_databox_tags::ComputeTag0,
@@ -379,26 +379,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_locked_get",
         db::get<test_databox_tags::ComputeTag0>(original_box);
         tag0 = 10.32;
         tag1[0] = 837.2;
-      });
-}
-
-// [[OutputRegex, Unable to retrieve a \(compute\) item 'ComputeTag0' from the
-// DataBox from within a call to mutate. You must pass these either through the
-// capture list of the lambda or the constructor of a class, this restriction
-// exists to avoid complexity]]
-SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_locked_get_lazy",
-                  "[Unit][DataStructures]") {
-  ERROR_TEST();
-  auto original_box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2>,
-      db::AddComputeTags<test_databox_tags::ComputeTag0,
-                         test_databox_tags::ComputeTag1>>(
-      3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
-  db::mutate<test_databox_tags::Tag0, test_databox_tags::Tag1>(
-      original_box,
-      [&original_box](double& /*tag0*/, std::vector<double>& /*tag1*/) {
-        original_box.template get_lazy<test_databox_tags::ComputeTag0>();
       });
 }
 

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -495,44 +495,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.apply",
   db::apply<tmpl::list<>>(NonCopyableFunctor{}, original_box);
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.apply_with_box",
-                  "[Unit][DataStructures]") {
-  auto original_box = db::create<
-      db::AddSimpleTags<test_databox_tags::Tag0, test_databox_tags::Tag1,
-                        test_databox_tags::Tag2>,
-      db::AddComputeTags<test_databox_tags::ComputeTag0,
-                         test_databox_tags::ComputeTag1>>(
-      3.14, std::vector<double>{8.7, 93.2, 84.7}, "My Sample String"s);
-  auto check_result_no_args = [](const auto& box,
-                                 const std::string& sample_string,
-                                 const auto& computed_string) {
-    CHECK(sample_string == "My Sample String"s);
-    CHECK(computed_string == "My Sample String6.28"s);
-    CHECK(db::get<test_databox_tags::Tag1>(box) ==
-          (std::vector<double>{8.7, 93.2, 84.7}));
-  };
-  db::apply_with_box<
-      tmpl::list<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>>(
-      check_result_no_args, original_box);
-
-  /// [apply_with_box_example]
-  auto check_result_args = [](const auto& box, const std::string& sample_string,
-                              const std::string& computed_string,
-                              const std::vector<int>& vector) {
-    CHECK(sample_string == "My Sample String"s);
-    CHECK(computed_string == "My Sample String6.28"s);
-    CHECK(db::get<test_databox_tags::Tag1>(box) ==
-          (std::vector<double>{8.7, 93.2, 84.7}));
-    CHECK((vector == std::vector<int>{1, 4, 8}));
-  };
-  db::apply_with_box<
-      tmpl::list<test_databox_tags::Tag2, test_databox_tags::ComputeTag1>>(
-      check_result_args, original_box, std::vector<int>{1, 4, 8});
-  /// [apply_with_box_example]
-
-  db::apply_with_box<tmpl::list<>>(NonCopyableFunctor{}, original_box);
-}
-
 // [[OutputRegex, Could not find the tag named "TagTensor__" in the DataBox]]
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.HelpersBadTensorFromBox",
                   "[Unit][DataStructures]") {

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -105,7 +105,7 @@ struct ComputeLambda1 : db::ComputeItemTag {
 
 /// [databox_prefix_tag_example]
 template <typename Tag>
-struct TagPrefix : db::DataBoxPrefix {
+struct TagPrefix : db::DataBoxPrefix, db::DataBoxTag {
   using type = typename Tag::type;
   using tag = Tag;
   static constexpr db::DataBoxString label = "TagPrefix";
@@ -576,7 +576,7 @@ struct Var2 : db::DataBoxTag {
 };
 
 template <class Tag, class VolumeDim, class Frame>
-struct PrefixTag0 : db::DataBoxPrefix {
+struct PrefixTag0 : db::DataBoxPrefix, db::DataBoxTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -51,45 +51,45 @@ namespace test_databox_tags {
 /// [databox_tag_example]
 struct Tag0 : db::SimpleTag {
   using type = double;
-  static constexpr db::DataBoxString label = "Tag0";
+  static constexpr db::Label label = "Tag0";
 };
 /// [databox_tag_example]
 struct Tag1 : db::SimpleTag {
   using type = std::vector<double>;
-  static constexpr db::DataBoxString label = "Tag1";
+  static constexpr db::Label label = "Tag1";
 };
 struct Tag2 : db::SimpleTag {
   using type = std::string;
-  static constexpr db::DataBoxString label = "Tag2";
+  static constexpr db::Label label = "Tag2";
 };
 struct Tag3 : db::SimpleTag {
   using type = std::string;
-  static constexpr db::DataBoxString label = "Tag3";
+  static constexpr db::Label label = "Tag3";
 };
 
 /// [databox_compute_item_tag_example]
 struct ComputeTag0 : db::ComputeTag {
-  static constexpr db::DataBoxString label = "ComputeTag0";
+  static constexpr db::Label label = "ComputeTag0";
   static constexpr auto function = multiply_by_two;
   using argument_tags = tmpl::list<Tag0>;
 };
 
 /// [databox_compute_item_tag_example]
 struct ComputeTag1 : db::ComputeTag {
-  static constexpr db::DataBoxString label = "ComputeTag1";
+  static constexpr db::Label label = "ComputeTag1";
   static constexpr auto function = append_word;
   using argument_tags = tmpl::list<Tag2, ComputeTag0>;
 };
 
 struct TagTensor : db::ComputeTag {
-  static constexpr db::DataBoxString label = "TagTensor";
+  static constexpr db::Label label = "TagTensor";
   static constexpr auto function = get_tensor;
   using argument_tags = tmpl::list<>;
 };
 
 /// [compute_item_tag_function]
 struct ComputeLambda0 : db::ComputeTag {
-  static constexpr db::DataBoxString label = "ComputeLambda0";
+  static constexpr db::Label label = "ComputeLambda0";
   static constexpr double function(const double& a) { return 3.0 * a; }
   using argument_tags = tmpl::list<Tag0>;
 };
@@ -97,7 +97,7 @@ struct ComputeLambda0 : db::ComputeTag {
 
 /// [compute_item_tag_no_tags]
 struct ComputeLambda1 : db::ComputeTag {
-  static constexpr db::DataBoxString label = "ComputeLambda1";
+  static constexpr db::Label label = "ComputeLambda1";
   static constexpr double function() { return 7.0; }
   using argument_tags = tmpl::list<>;
 };
@@ -108,7 +108,7 @@ template <typename Tag>
 struct TagPrefix : db::PrefixTag, db::SimpleTag {
   using type = typename Tag::type;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "TagPrefix";
+  static constexpr db::Label label = "TagPrefix";
 };
 /// [databox_prefix_tag_example]
 }  // namespace test_databox_tags
@@ -264,12 +264,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
 
 namespace ArgumentTypeTags {
 struct NonCopyable : db::SimpleTag {
-  static constexpr db::DataBoxString label = "NonCopyable";
+  static constexpr db::Label label = "NonCopyable";
   using type = ::NonCopyable;
 };
 template <size_t N>
 struct String : db::SimpleTag {
-  static constexpr db::DataBoxString label = "String";
+  static constexpr db::Label label = "String";
   using type = std::string;
 };
 }  // namespace ArgumentTypeTags
@@ -565,14 +565,14 @@ namespace {
 auto get_vector() { return tnsr::I<DataVector, 3, Frame::Grid>(5_st, 2.0); }
 
 struct Var1 : db::ComputeTag {
-  static constexpr db::DataBoxString label = "Var1";
+  static constexpr db::Label label = "Var1";
   static constexpr auto function = get_vector;
   using argument_tags = tmpl::list<>;
 };
 
 struct Var2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Var2";
+  static constexpr db::Label label = "Var2";
 };
 
 template <class Tag, class VolumeDim, class Frame>
@@ -580,7 +580,7 @@ struct PrefixTag0 : db::PrefixTag, db::SimpleTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "PrefixTag0";
+  static constexpr db::Label label = "PrefixTag0";
 };
 
 using two_vars = tmpl::list<Var1, Var2>;
@@ -619,35 +619,35 @@ static_assert(
 namespace test_databox_tags {
 struct ScalarTag : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "ScalarTag";
+  static constexpr db::Label label = "ScalarTag";
 };
 struct VectorTag : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::DataBoxString label = "VectorTag";
+  static constexpr db::Label label = "VectorTag";
 };
 struct ScalarTag2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "ScalarTag2";
+  static constexpr db::Label label = "ScalarTag2";
 };
 struct VectorTag2 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::DataBoxString label = "VectorTag2";
+  static constexpr db::Label label = "VectorTag2";
 };
 struct ScalarTag3 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "ScalarTag3";
+  static constexpr db::Label label = "ScalarTag3";
 };
 struct VectorTag3 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::DataBoxString label = "VectorTag3";
+  static constexpr db::Label label = "VectorTag3";
 };
 struct ScalarTag4 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "ScalarTag4";
+  static constexpr db::Label label = "ScalarTag4";
 };
 struct VectorTag4 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::DataBoxString label = "VectorTag4";
+  static constexpr db::Label label = "VectorTag4";
 };
 }  // namespace test_databox_tags
 
@@ -702,37 +702,37 @@ namespace test_databox_tags {
 struct MultiplyScalarByTwo : db::ComputeTag {
   using variables_tags =
       tmpl::list<test_databox_tags::ScalarTag2, test_databox_tags::VectorTag2>;
-  static constexpr db::DataBoxString label = "MultiplyScalarByTwo";
+  static constexpr db::Label label = "MultiplyScalarByTwo";
   static constexpr auto function = multiply_scalar_by_two;
   using argument_tags = tmpl::list<test_databox_tags::ScalarTag>;
 };
 
 struct MultiplyScalarByFour : db::ComputeTag {
-  static constexpr db::DataBoxString label = "MultiplyScalarByFour";
+  static constexpr db::Label label = "MultiplyScalarByFour";
   static constexpr auto function = multiply_scalar_by_four;
   using argument_tags = tmpl::list<test_databox_tags::ScalarTag2>;
 };
 
 struct MultiplyScalarByThree : db::ComputeTag {
-  static constexpr db::DataBoxString label = "MultiplyScalarByThree";
+  static constexpr db::Label label = "MultiplyScalarByThree";
   static constexpr auto function = multiply_scalar_by_three;
   using argument_tags = tmpl::list<test_databox_tags::MultiplyScalarByFour>;
 };
 
 struct DivideScalarByThree : db::ComputeTag {
-  static constexpr db::DataBoxString label = "DivideScalarByThree";
+  static constexpr db::Label label = "DivideScalarByThree";
   static constexpr auto function = divide_scalar_by_three;
   using argument_tags = tmpl::list<test_databox_tags::MultiplyScalarByThree>;
 };
 
 struct DivideScalarByTwo : db::ComputeTag {
-  static constexpr db::DataBoxString label = "DivideScalarByTwo";
+  static constexpr db::Label label = "DivideScalarByTwo";
   static constexpr auto function = divide_scalar_by_two;
   using argument_tags = tmpl::list<test_databox_tags::DivideScalarByThree>;
 };
 
 struct MultiplyVariablesByTwo : db::ComputeTag {
-  static constexpr db::DataBoxString label = "MultiplyVariablesByTwo";
+  static constexpr db::Label label = "MultiplyVariablesByTwo";
   static constexpr auto function = multiply_variables_by_two;
   using argument_tags = tmpl::list<Tags::Variables<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>>;
@@ -892,11 +892,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Variables",
 namespace {
 struct Tag1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Tag1";
+  static constexpr db::Label label = "Tag1";
 };
 struct Tag2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Tag2";
+  static constexpr db::Label label = "Tag2";
 };
 }  // namespace
 
@@ -951,14 +951,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.reset_compute_items",
 namespace ExtraResetTags {
 struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Var";
+  static constexpr db::Label label = "Var";
 };
 struct Int : db::SimpleTag {
   using type = int;
-  static constexpr db::DataBoxString label = "Int";
+  static constexpr db::Label label = "Int";
 };
 struct CheckReset : db::ComputeTag {
-  static constexpr db::DataBoxString label = "CheckReset";
+  static constexpr db::Label label = "CheckReset";
   static auto function(
       const ::Variables<tmpl::list<Var>>& /*unused*/) noexcept {
     static bool first_call = true;
@@ -1169,18 +1169,18 @@ void mutate_variables(
 namespace test_databox_tags {
 struct MutateComputeTag0 : db::ComputeTag {
   using return_type = std::vector<double>;
-  static constexpr db::DataBoxString label = "MutateComputeTag0";
+  static constexpr db::Label label = "MutateComputeTag0";
   static constexpr auto function = multiply_by_two_mutate;
   using argument_tags = tmpl::list<Tag0>;
 };
 struct NonMutateComputeTag0 : db::ComputeTag {
-  static constexpr db::DataBoxString label = "NonMutateComputeTag0";
+  static constexpr db::Label label = "NonMutateComputeTag0";
   static constexpr auto function = multiply_by_two_non_mutate;
   using argument_tags = tmpl::list<Tag0>;
 };
 /// [databox_mutating_compute_item_tag]
 struct MutateVariablesCompute : db::ComputeTag {
-  static constexpr db::DataBoxString label = "MutateVariablesCompute";
+  static constexpr db::Label label = "MutateVariablesCompute";
   static constexpr auto function = mutate_variables;
   using return_type = Variables<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>;
@@ -1298,17 +1298,17 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutating_compute_item",
 namespace DataBoxTest_detail {
 struct vector : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
-  static constexpr db::DataBoxString label = "vector";
+  static constexpr db::Label label = "vector";
 };
 
 struct scalar : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "scalar";
+  static constexpr db::Label label = "scalar";
 };
 
 struct vector2 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
-  static constexpr db::DataBoxString label = "vector2";
+  static constexpr db::Label label = "vector2";
 };
 }  // namespace DataBoxTest_detail
 
@@ -1520,12 +1520,12 @@ class Boxed {
 
 template <size_t N, bool Compute = false, bool DependsOnComputeItem = false>
 struct Parent : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Parent";
+  static constexpr db::Label label = "Parent";
   using type = std::pair<Boxed<int>, Boxed<double>>;
 };
 template <size_t N, bool DependsOnComputeItem>
 struct Parent<N, true, DependsOnComputeItem> : db::ComputeTag {
-  static constexpr db::DataBoxString label = "Parent";
+  static constexpr db::Label label = "Parent";
   static auto function(
       const std::pair<Boxed<int>, Boxed<double>>& arg) noexcept {
     count++;
@@ -1542,14 +1542,14 @@ int Parent<N, true, DependsOnComputeItem>::count = 0;
 
 template <size_t N>
 struct First : db::SimpleTag {
-  static constexpr db::DataBoxString label = "First";
+  static constexpr db::Label label = "First";
   using type = Boxed<int>;
 
   static constexpr size_t index = 0;
 };
 template <size_t N>
 struct Second : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Second";
+  static constexpr db::Label label = "Second";
   using type = Boxed<double>;
 
   static constexpr size_t index = 1;
@@ -1644,7 +1644,7 @@ struct MyTag1 {
 };
 
 struct TupleTag : db::SimpleTag {
-  static constexpr db::DataBoxString label = "TupleTag";
+  static constexpr db::Label label = "TupleTag";
   using type = tuples::TaggedTuple<MyTag0, MyTag1>;
 };
 }  // namespace
@@ -1823,14 +1823,14 @@ int CountingFunc<Id>::count = 0;
 
 template <int Id>
 struct CountingTag : db::ComputeTag {
-  static constexpr db::DataBoxString label = "CountingTag";
+  static constexpr db::Label label = "CountingTag";
   static constexpr auto function = CountingFunc<Id>::apply;
   using argument_tags = tmpl::list<>;
 };
 
 template <size_t SecondId>
 struct CountingTagDouble : db::ComputeTag {
-  static constexpr db::DataBoxString label = "CountingTag";
+  static constexpr db::Label label = "CountingTag";
   static double function(const test_subitems::Boxed<double>& t) {
     count++;
     return *t * 6.0;

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -49,20 +49,20 @@ auto get_tensor() { return tnsr::A<double, 3, Frame::Grid>{{{7.82, 8, 3, 9}}}; }
 
 namespace test_databox_tags {
 /// [databox_tag_example]
-struct Tag0 : db::DataBoxTag {
+struct Tag0 : db::SimpleTag {
   using type = double;
   static constexpr db::DataBoxString label = "Tag0";
 };
 /// [databox_tag_example]
-struct Tag1 : db::DataBoxTag {
+struct Tag1 : db::SimpleTag {
   using type = std::vector<double>;
   static constexpr db::DataBoxString label = "Tag1";
 };
-struct Tag2 : db::DataBoxTag {
+struct Tag2 : db::SimpleTag {
   using type = std::string;
   static constexpr db::DataBoxString label = "Tag2";
 };
-struct Tag3 : db::DataBoxTag {
+struct Tag3 : db::SimpleTag {
   using type = std::string;
   static constexpr db::DataBoxString label = "Tag3";
 };
@@ -105,7 +105,7 @@ struct ComputeLambda1 : db::ComputeItemTag {
 
 /// [databox_prefix_tag_example]
 template <typename Tag>
-struct TagPrefix : db::PrefixTag, db::DataBoxTag {
+struct TagPrefix : db::PrefixTag, db::SimpleTag {
   using type = typename Tag::type;
   using tag = Tag;
   static constexpr db::DataBoxString label = "TagPrefix";
@@ -263,12 +263,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
 }
 
 namespace ArgumentTypeTags {
-struct NonCopyable : db::DataBoxTag {
+struct NonCopyable : db::SimpleTag {
   static constexpr db::DataBoxString label = "NonCopyable";
   using type = ::NonCopyable;
 };
 template <size_t N>
-struct String : db::DataBoxTag {
+struct String : db::SimpleTag {
   static constexpr db::DataBoxString label = "String";
   using type = std::string;
 };
@@ -570,13 +570,13 @@ struct Var1 : db::ComputeItemTag {
   using argument_tags = tmpl::list<>;
 };
 
-struct Var2 : db::DataBoxTag {
+struct Var2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Var2";
 };
 
 template <class Tag, class VolumeDim, class Frame>
-struct PrefixTag0 : db::PrefixTag, db::DataBoxTag {
+struct PrefixTag0 : db::PrefixTag, db::SimpleTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;
@@ -617,35 +617,35 @@ static_assert(
 }  // namespace
 
 namespace test_databox_tags {
-struct ScalarTag : db::DataBoxTag {
+struct ScalarTag : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "ScalarTag";
 };
-struct VectorTag : db::DataBoxTag {
+struct VectorTag : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
   static constexpr db::DataBoxString label = "VectorTag";
 };
-struct ScalarTag2 : db::DataBoxTag {
+struct ScalarTag2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "ScalarTag2";
 };
-struct VectorTag2 : db::DataBoxTag {
+struct VectorTag2 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
   static constexpr db::DataBoxString label = "VectorTag2";
 };
-struct ScalarTag3 : db::DataBoxTag {
+struct ScalarTag3 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "ScalarTag3";
 };
-struct VectorTag3 : db::DataBoxTag {
+struct VectorTag3 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
   static constexpr db::DataBoxString label = "VectorTag3";
 };
-struct ScalarTag4 : db::DataBoxTag {
+struct ScalarTag4 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "ScalarTag4";
 };
-struct VectorTag4 : db::DataBoxTag {
+struct VectorTag4 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
   static constexpr db::DataBoxString label = "VectorTag4";
 };
@@ -890,11 +890,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Variables",
 }
 
 namespace {
-struct Tag1 : db::DataBoxTag {
+struct Tag1 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Tag1";
 };
-struct Tag2 : db::DataBoxTag {
+struct Tag2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Tag2";
 };
@@ -949,11 +949,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.reset_compute_items",
 }
 
 namespace ExtraResetTags {
-struct Var : db::DataBoxTag {
+struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Var";
 };
-struct Int : db::DataBoxTag {
+struct Int : db::SimpleTag {
   using type = int;
   static constexpr db::DataBoxString label = "Int";
 };
@@ -1296,17 +1296,17 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutating_compute_item",
 }
 
 namespace DataBoxTest_detail {
-struct vector : db::DataBoxTag {
+struct vector : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
   static constexpr db::DataBoxString label = "vector";
 };
 
-struct scalar : db::DataBoxTag {
+struct scalar : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "scalar";
 };
 
-struct vector2 : db::DataBoxTag {
+struct vector2 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
   static constexpr db::DataBoxString label = "vector2";
 };
@@ -1519,7 +1519,7 @@ class Boxed {
 };
 
 template <size_t N, bool Compute = false, bool DependsOnComputeItem = false>
-struct Parent : db::DataBoxTag {
+struct Parent : db::SimpleTag {
   static constexpr db::DataBoxString label = "Parent";
   using type = std::pair<Boxed<int>, Boxed<double>>;
 };
@@ -1541,14 +1541,14 @@ template <size_t N, bool DependsOnComputeItem>
 int Parent<N, true, DependsOnComputeItem>::count = 0;
 
 template <size_t N>
-struct First : db::DataBoxTag {
+struct First : db::SimpleTag {
   static constexpr db::DataBoxString label = "First";
   using type = Boxed<int>;
 
   static constexpr size_t index = 0;
 };
 template <size_t N>
-struct Second : db::DataBoxTag {
+struct Second : db::SimpleTag {
   static constexpr db::DataBoxString label = "Second";
   using type = Boxed<double>;
 
@@ -1643,7 +1643,7 @@ struct MyTag1 {
   using type = double;
 };
 
-struct TupleTag : db::DataBoxTag {
+struct TupleTag : db::SimpleTag {
   static constexpr db::DataBoxString label = "TupleTag";
   using type = tuples::TaggedTuple<MyTag0, MyTag1>;
 };

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -68,27 +68,27 @@ struct Tag3 : db::SimpleTag {
 };
 
 /// [databox_compute_item_tag_example]
-struct ComputeTag0 : db::ComputeItemTag {
+struct ComputeTag0 : db::ComputeTag {
   static constexpr db::DataBoxString label = "ComputeTag0";
   static constexpr auto function = multiply_by_two;
   using argument_tags = tmpl::list<Tag0>;
 };
 
 /// [databox_compute_item_tag_example]
-struct ComputeTag1 : db::ComputeItemTag {
+struct ComputeTag1 : db::ComputeTag {
   static constexpr db::DataBoxString label = "ComputeTag1";
   static constexpr auto function = append_word;
   using argument_tags = tmpl::list<Tag2, ComputeTag0>;
 };
 
-struct TagTensor : db::ComputeItemTag {
+struct TagTensor : db::ComputeTag {
   static constexpr db::DataBoxString label = "TagTensor";
   static constexpr auto function = get_tensor;
   using argument_tags = tmpl::list<>;
 };
 
 /// [compute_item_tag_function]
-struct ComputeLambda0 : db::ComputeItemTag {
+struct ComputeLambda0 : db::ComputeTag {
   static constexpr db::DataBoxString label = "ComputeLambda0";
   static constexpr double function(const double& a) { return 3.0 * a; }
   using argument_tags = tmpl::list<Tag0>;
@@ -96,7 +96,7 @@ struct ComputeLambda0 : db::ComputeItemTag {
 /// [compute_item_tag_function]
 
 /// [compute_item_tag_no_tags]
-struct ComputeLambda1 : db::ComputeItemTag {
+struct ComputeLambda1 : db::ComputeTag {
   static constexpr db::DataBoxString label = "ComputeLambda1";
   static constexpr double function() { return 7.0; }
   using argument_tags = tmpl::list<>;
@@ -564,7 +564,7 @@ namespace {
 
 auto get_vector() { return tnsr::I<DataVector, 3, Frame::Grid>(5_st, 2.0); }
 
-struct Var1 : db::ComputeItemTag {
+struct Var1 : db::ComputeTag {
   static constexpr db::DataBoxString label = "Var1";
   static constexpr auto function = get_vector;
   using argument_tags = tmpl::list<>;
@@ -699,7 +699,7 @@ auto multiply_variables_by_two(
 }  // namespace
 
 namespace test_databox_tags {
-struct MultiplyScalarByTwo : db::ComputeItemTag {
+struct MultiplyScalarByTwo : db::ComputeTag {
   using variables_tags =
       tmpl::list<test_databox_tags::ScalarTag2, test_databox_tags::VectorTag2>;
   static constexpr db::DataBoxString label = "MultiplyScalarByTwo";
@@ -707,31 +707,31 @@ struct MultiplyScalarByTwo : db::ComputeItemTag {
   using argument_tags = tmpl::list<test_databox_tags::ScalarTag>;
 };
 
-struct MultiplyScalarByFour : db::ComputeItemTag {
+struct MultiplyScalarByFour : db::ComputeTag {
   static constexpr db::DataBoxString label = "MultiplyScalarByFour";
   static constexpr auto function = multiply_scalar_by_four;
   using argument_tags = tmpl::list<test_databox_tags::ScalarTag2>;
 };
 
-struct MultiplyScalarByThree : db::ComputeItemTag {
+struct MultiplyScalarByThree : db::ComputeTag {
   static constexpr db::DataBoxString label = "MultiplyScalarByThree";
   static constexpr auto function = multiply_scalar_by_three;
   using argument_tags = tmpl::list<test_databox_tags::MultiplyScalarByFour>;
 };
 
-struct DivideScalarByThree : db::ComputeItemTag {
+struct DivideScalarByThree : db::ComputeTag {
   static constexpr db::DataBoxString label = "DivideScalarByThree";
   static constexpr auto function = divide_scalar_by_three;
   using argument_tags = tmpl::list<test_databox_tags::MultiplyScalarByThree>;
 };
 
-struct DivideScalarByTwo : db::ComputeItemTag {
+struct DivideScalarByTwo : db::ComputeTag {
   static constexpr db::DataBoxString label = "DivideScalarByTwo";
   static constexpr auto function = divide_scalar_by_two;
   using argument_tags = tmpl::list<test_databox_tags::DivideScalarByThree>;
 };
 
-struct MultiplyVariablesByTwo : db::ComputeItemTag {
+struct MultiplyVariablesByTwo : db::ComputeTag {
   static constexpr db::DataBoxString label = "MultiplyVariablesByTwo";
   static constexpr auto function = multiply_variables_by_two;
   using argument_tags = tmpl::list<Tags::Variables<
@@ -957,7 +957,7 @@ struct Int : db::SimpleTag {
   using type = int;
   static constexpr db::DataBoxString label = "Int";
 };
-struct CheckReset : db::ComputeItemTag {
+struct CheckReset : db::ComputeTag {
   static constexpr db::DataBoxString label = "CheckReset";
   static auto function(
       const ::Variables<tmpl::list<Var>>& /*unused*/) noexcept {
@@ -1167,19 +1167,19 @@ void mutate_variables(
 }  // namespace
 
 namespace test_databox_tags {
-struct MutateComputeTag0 : db::ComputeItemTag {
+struct MutateComputeTag0 : db::ComputeTag {
   using return_type = std::vector<double>;
   static constexpr db::DataBoxString label = "MutateComputeTag0";
   static constexpr auto function = multiply_by_two_mutate;
   using argument_tags = tmpl::list<Tag0>;
 };
-struct NonMutateComputeTag0 : db::ComputeItemTag {
+struct NonMutateComputeTag0 : db::ComputeTag {
   static constexpr db::DataBoxString label = "NonMutateComputeTag0";
   static constexpr auto function = multiply_by_two_non_mutate;
   using argument_tags = tmpl::list<Tag0>;
 };
 /// [databox_mutating_compute_item_tag]
-struct MutateVariablesCompute : db::ComputeItemTag {
+struct MutateVariablesCompute : db::ComputeTag {
   static constexpr db::DataBoxString label = "MutateVariablesCompute";
   static constexpr auto function = mutate_variables;
   using return_type = Variables<
@@ -1524,7 +1524,7 @@ struct Parent : db::SimpleTag {
   using type = std::pair<Boxed<int>, Boxed<double>>;
 };
 template <size_t N, bool DependsOnComputeItem>
-struct Parent<N, true, DependsOnComputeItem> : db::ComputeItemTag {
+struct Parent<N, true, DependsOnComputeItem> : db::ComputeTag {
   static constexpr db::DataBoxString label = "Parent";
   static auto function(
       const std::pair<Boxed<int>, Boxed<double>>& arg) noexcept {
@@ -1822,14 +1822,14 @@ template <int Id>
 int CountingFunc<Id>::count = 0;
 
 template <int Id>
-struct CountingTag : db::ComputeItemTag {
+struct CountingTag : db::ComputeTag {
   static constexpr db::DataBoxString label = "CountingTag";
   static constexpr auto function = CountingFunc<Id>::apply;
   using argument_tags = tmpl::list<>;
 };
 
 template <size_t SecondId>
-struct CountingTagDouble : db::ComputeItemTag {
+struct CountingTagDouble : db::ComputeTag {
   static constexpr db::DataBoxString label = "CountingTag";
   static double function(const test_subitems::Boxed<double>& t) {
     count++;

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -105,7 +105,7 @@ struct ComputeLambda1 : db::ComputeItemTag {
 
 /// [databox_prefix_tag_example]
 template <typename Tag>
-struct TagPrefix : db::DataBoxPrefix, db::DataBoxTag {
+struct TagPrefix : db::PrefixTag, db::DataBoxTag {
   using type = typename Tag::type;
   using tag = Tag;
   static constexpr db::DataBoxString label = "TagPrefix";
@@ -576,7 +576,7 @@ struct Var2 : db::DataBoxTag {
 };
 
 template <class Tag, class VolumeDim, class Frame>
-struct PrefixTag0 : db::DataBoxPrefix, db::DataBoxTag {
+struct PrefixTag0 : db::PrefixTag, db::DataBoxTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -1040,7 +1040,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_apply",
   /// [mutate_apply_example]
   db::mutate_apply<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>,
-      tmpl::list<>>(test_databox_mutate_apply{}, box,
+      tmpl::list<>>(test_databox_mutate_apply{}, make_not_null(&box),
                     db::get<test_databox_tags::Tag2>(box));
   /// [mutate_apply_example]
   CHECK(approx(db::get<test_databox_tags::ComputeTag0>(box)) == 3.14 * 2.0);
@@ -1066,7 +1066,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_apply",
         get<2>(*vector) *= 5.0;
         CHECK(tag2 == "My Sample String"s);
       },
-      box);
+      make_not_null(&box));
   /// [mutate_apply_apply_example]
   CHECK(approx(db::get<test_databox_tags::ComputeTag0>(box)) == 3.14 * 2.0);
   CHECK(db::get<test_databox_tags::ScalarTag>(box) ==
@@ -1093,7 +1093,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_apply",
         get<2>(get<test_databox_tags::VectorTag>(*vars)) *= 5.0;
         CHECK(tag2 == "My Sample String"s);
       },
-      box);
+      make_not_null(&box));
 
   CHECK(approx(db::get<test_databox_tags::ComputeTag0>(box)) == 3.14 * 2.0);
   CHECK(db::get<test_databox_tags::ScalarTag>(box) ==

--- a/tests/Unit/DataStructures/Test_DataBoxTag.cpp
+++ b/tests/Unit/DataStructures/Test_DataBoxTag.cpp
@@ -15,13 +15,13 @@ struct Var : db::DataBoxTag {
 };
 
 template <typename Tag>
-struct Prefix : db::DataBoxPrefix, db::DataBoxTag {
+struct Prefix : db::PrefixTag, db::DataBoxTag {
   using tag = Tag;
   using type = db::item_type<Tag>;
 };
 
 template <typename Tag, typename Arg1, typename Arg2>
-struct PrefixWithArgs : db::DataBoxPrefix, db::DataBoxTag {
+struct PrefixWithArgs : db::PrefixTag, db::DataBoxTag {
   using tag = Tag;
   using type = db::item_type<Tag>;
 };

--- a/tests/Unit/DataStructures/Test_DataBoxTag.cpp
+++ b/tests/Unit/DataStructures/Test_DataBoxTag.cpp
@@ -10,18 +10,18 @@
 class DataVector;
 
 namespace {
-struct Var : db::DataBoxTag {
+struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
 template <typename Tag>
-struct Prefix : db::PrefixTag, db::DataBoxTag {
+struct Prefix : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
   using type = db::item_type<Tag>;
 };
 
 template <typename Tag, typename Arg1, typename Arg2>
-struct PrefixWithArgs : db::PrefixTag, db::DataBoxTag {
+struct PrefixWithArgs : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
   using type = db::item_type<Tag>;
 };

--- a/tests/Unit/DataStructures/Test_DataBoxTag.cpp
+++ b/tests/Unit/DataStructures/Test_DataBoxTag.cpp
@@ -15,13 +15,13 @@ struct Var : db::DataBoxTag {
 };
 
 template <typename Tag>
-struct Prefix : db::DataBoxPrefix {
+struct Prefix : db::DataBoxPrefix, db::DataBoxTag {
   using tag = Tag;
   using type = db::item_type<Tag>;
 };
 
 template <typename Tag, typename Arg1, typename Arg2>
-struct PrefixWithArgs : db::DataBoxPrefix {
+struct PrefixWithArgs : db::DataBoxPrefix, db::DataBoxTag {
   using tag = Tag;
   using type = db::item_type<Tag>;
 };

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -47,7 +47,7 @@ struct scalar2 : db::DataBoxTag {
 
 /// [prefix_variables_tag]
 template <class Tag>
-struct PrefixTag0 : db::DataBoxPrefix, db::DataBoxTag {
+struct PrefixTag0 : db::PrefixTag, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag0";
@@ -55,21 +55,21 @@ struct PrefixTag0 : db::DataBoxPrefix, db::DataBoxTag {
 /// [prefix_variables_tag]
 
 template <class Tag>
-struct PrefixTag1 : db::DataBoxPrefix, db::DataBoxTag {
+struct PrefixTag1 : db::PrefixTag, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag1";
 };
 
 template <class Tag>
-struct PrefixTag2 : db::DataBoxPrefix, db::DataBoxTag {
+struct PrefixTag2 : db::PrefixTag, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag2";
 };
 
 template <class Tag>
-struct PrefixTag3 : db::DataBoxPrefix, db::DataBoxTag {
+struct PrefixTag3 : db::PrefixTag, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag3";

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -47,7 +47,7 @@ struct scalar2 : db::DataBoxTag {
 
 /// [prefix_variables_tag]
 template <class Tag>
-struct PrefixTag0 : db::DataBoxPrefix {
+struct PrefixTag0 : db::DataBoxPrefix, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag0";
@@ -55,21 +55,21 @@ struct PrefixTag0 : db::DataBoxPrefix {
 /// [prefix_variables_tag]
 
 template <class Tag>
-struct PrefixTag1 : db::DataBoxPrefix {
+struct PrefixTag1 : db::DataBoxPrefix, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag1";
 };
 
 template <class Tag>
-struct PrefixTag2 : db::DataBoxPrefix {
+struct PrefixTag2 : db::DataBoxPrefix, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag2";
 };
 
 template <class Tag>
-struct PrefixTag3 : db::DataBoxPrefix {
+struct PrefixTag3 : db::DataBoxPrefix, db::DataBoxTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag3";

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -31,23 +31,23 @@
 
 namespace VariablesTestTags_detail {
 /// [simple_variables_tag]
-struct vector : db::DataBoxTag {
+struct vector : db::SimpleTag {
   static constexpr db::DataBoxString label = "vector";
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
 };
 /// [simple_variables_tag]
 
-struct scalar : db::DataBoxTag {
+struct scalar : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
-struct scalar2 : db::DataBoxTag {
+struct scalar2 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
 /// [prefix_variables_tag]
 template <class Tag>
-struct PrefixTag0 : db::PrefixTag, db::DataBoxTag {
+struct PrefixTag0 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag0";
@@ -55,21 +55,21 @@ struct PrefixTag0 : db::PrefixTag, db::DataBoxTag {
 /// [prefix_variables_tag]
 
 template <class Tag>
-struct PrefixTag1 : db::PrefixTag, db::DataBoxTag {
+struct PrefixTag1 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag1";
 };
 
 template <class Tag>
-struct PrefixTag2 : db::PrefixTag, db::DataBoxTag {
+struct PrefixTag2 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag2";
 };
 
 template <class Tag>
-struct PrefixTag3 : db::PrefixTag, db::DataBoxTag {
+struct PrefixTag3 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static constexpr db::DataBoxString label = "PrefixTag3";

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -32,7 +32,7 @@
 namespace VariablesTestTags_detail {
 /// [simple_variables_tag]
 struct vector : db::SimpleTag {
-  static constexpr db::DataBoxString label = "vector";
+  static constexpr db::Label label = "vector";
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
 };
 /// [simple_variables_tag]
@@ -50,7 +50,7 @@ template <class Tag>
 struct PrefixTag0 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "PrefixTag0";
+  static constexpr db::Label label = "PrefixTag0";
 };
 /// [prefix_variables_tag]
 
@@ -58,21 +58,21 @@ template <class Tag>
 struct PrefixTag1 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "PrefixTag1";
+  static constexpr db::Label label = "PrefixTag1";
 };
 
 template <class Tag>
 struct PrefixTag2 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "PrefixTag2";
+  static constexpr db::Label label = "PrefixTag2";
 };
 
 template <class Tag>
 struct PrefixTag3 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::DataBoxString label = "PrefixTag3";
+  static constexpr db::Label label = "PrefixTag3";
 };
 }  // namespace VariablesTestTags_detail
 

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -124,7 +124,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ElementMap", "[Unit][Domain]") {
 
 namespace {
 struct Directions : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Directions";
+  static constexpr db::Label label = "Directions";
   using type = std::unordered_set<Direction<2>>;
 };
 }  // namespace

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -123,7 +123,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ElementMap", "[Unit][Domain]") {
 }
 
 namespace {
-struct Directions : db::DataBoxTag {
+struct Directions : db::SimpleTag {
   static constexpr db::DataBoxString label = "Directions";
   using type = std::unordered_set<Direction<2>>;
 };

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -39,18 +39,18 @@ struct NoCopy {
 };
 
 namespace TestTags {
-struct Int : db::DataBoxTag {
+struct Int : db::SimpleTag {
   static constexpr db::DataBoxString label = "Int";
   using type = int;
 };
 
-struct Double : db::DataBoxTag {
+struct Double : db::SimpleTag {
   static constexpr db::DataBoxString label = "Double";
   using type = double;
 };
 
 template <size_t N>
-struct NoCopy : db::DataBoxTag {
+struct NoCopy : db::SimpleTag {
   static constexpr db::DataBoxString label = "NoCopy";
   using type = ::NoCopy<N>;
 };
@@ -85,7 +85,7 @@ struct ComplexComputeItem : db::ComputeItemTag {
 };
 
 template <typename>
-struct TemplatedDirections : db::DataBoxTag {
+struct TemplatedDirections : db::SimpleTag {
   static constexpr db::DataBoxString label = "TemplatedDirections";
   using type = std::unordered_set<Direction<3>>;
 };
@@ -189,7 +189,7 @@ struct Dirs : db::ComputeItemTag {
 };
 
 template <size_t N>
-struct Var : db::DataBoxTag {
+struct Var : db::SimpleTag {
   static constexpr db::DataBoxString label = "Var";
   using type = Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary =
@@ -325,7 +325,7 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.Slice", "[Unit][Domain]") {
 
 namespace partial_slice {
 template <size_t N>
-struct Scalar : db::DataBoxTag {
+struct Scalar : db::SimpleTag {
   static constexpr db::DataBoxString label = "Scalar";
   using type = ::Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary = N == 0;
@@ -333,7 +333,7 @@ struct Scalar : db::DataBoxTag {
 
 constexpr size_t vector_dim = 3;
 template <size_t N>
-struct Vector : db::DataBoxTag {
+struct Vector : db::SimpleTag {
   static constexpr db::DataBoxString label = "Vector";
   using type = tnsr::i<DataVector, vector_dim, Frame::Logical>;
   static constexpr bool should_be_sliced_to_boundary = N == 1;

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -22,6 +22,7 @@
 #include "Domain/ElementId.hpp"
 #include "Domain/Neighbors.hpp"  // IWYU pragma: keep
 #include "Domain/Tags.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -275,8 +276,8 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.Subitems", "[Unit][Domain]") {
         make_interface_tensor({5., 5., 5.}, {5., 5., 5., 5.}));
 
   db::mutate<Tags::Interface<Dirs, Var<0>>>(
-      box, [](auto& boundary_tensor) noexcept {
-        get(boundary_tensor.at(Direction<dim>::lower_xi())) *= 3.;
+      make_not_null(&box), [](const auto boundary_tensor) noexcept {
+        get(boundary_tensor->at(Direction<dim>::lower_xi())) *= 3.;
       });
   CHECK((db::get<Tags::Interface<Dirs, Var<0>>>(box)) ==
         make_interface_tensor(3. * boundary_vars_xi, boundary_vars_eta));

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -56,7 +56,7 @@ struct NoCopy : db::DataBoxTag {
 };
 
 template <typename Tag>
-struct Negate : db::DataBoxPrefix, db::ComputeItemTag {
+struct Negate : db::PrefixTag, db::ComputeItemTag {
   static constexpr db::DataBoxString label = "Negate";
   using tag = Tag;
   static constexpr auto function(const db::item_type<Tag>& x) noexcept {

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -40,24 +40,24 @@ struct NoCopy {
 
 namespace TestTags {
 struct Int : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Int";
+  static constexpr db::Label label = "Int";
   using type = int;
 };
 
 struct Double : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Double";
+  static constexpr db::Label label = "Double";
   using type = double;
 };
 
 template <size_t N>
 struct NoCopy : db::SimpleTag {
-  static constexpr db::DataBoxString label = "NoCopy";
+  static constexpr db::Label label = "NoCopy";
   using type = ::NoCopy<N>;
 };
 
 template <typename Tag>
 struct Negate : db::PrefixTag, db::ComputeTag {
-  static constexpr db::DataBoxString label = "Negate";
+  static constexpr db::Label label = "Negate";
   using tag = Tag;
   static constexpr auto function(const db::item_type<Tag>& x) noexcept {
     return -x;
@@ -66,7 +66,7 @@ struct Negate : db::PrefixTag, db::ComputeTag {
 };
 
 struct AddThree : db::ComputeTag {
-  static constexpr db::DataBoxString label = "AddThree";
+  static constexpr db::Label label = "AddThree";
   static constexpr auto function(const int x) noexcept { return x + 3; }
   using argument_tags = tmpl::list<Int>;
   using volume_tags = tmpl::list<Int>;
@@ -74,7 +74,7 @@ struct AddThree : db::ComputeTag {
 
 template <size_t VolumeDim>
 struct ComplexComputeItem : db::ComputeTag {
-  static constexpr db::DataBoxString label = "ComplexComputeItem";
+  static constexpr db::Label label = "ComplexComputeItem";
   static constexpr auto function(const int i, const double d,
                                  const ::NoCopy<1>& /*unused*/,
                                  const ::NoCopy<2>& /*unused*/) noexcept {
@@ -86,7 +86,7 @@ struct ComplexComputeItem : db::ComputeTag {
 
 template <typename>
 struct TemplatedDirections : db::SimpleTag {
-  static constexpr db::DataBoxString label = "TemplatedDirections";
+  static constexpr db::Label label = "TemplatedDirections";
   using type = std::unordered_set<Direction<3>>;
 };
 }  // namespace TestTags
@@ -180,7 +180,7 @@ namespace {
 constexpr size_t dim = 2;
 
 struct Dirs : db::ComputeTag {
-  static constexpr db::DataBoxString label = "Dirs";
+  static constexpr db::Label label = "Dirs";
   static auto function() noexcept {
     return std::unordered_set<Direction<dim>>{Direction<dim>::lower_xi(),
                                               Direction<dim>::upper_eta()};
@@ -190,7 +190,7 @@ struct Dirs : db::ComputeTag {
 
 template <size_t N>
 struct Var : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Var";
+  static constexpr db::Label label = "Var";
   using type = Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary =
       N == 3 or N == 30 or  // sliced_simple_item_tag below
@@ -199,7 +199,7 @@ struct Var : db::SimpleTag {
 
 template <size_t VolumeDim>
 struct Compute : db::ComputeTag {
-  static constexpr db::DataBoxString label = "Compute";
+  static constexpr db::Label label = "Compute";
   static auto function(const Index<VolumeDim>& extents) {
     auto ret = Variables<tmpl::list<Var<VolumeDim>, Var<10 * VolumeDim>>>(
         extents.product(), VolumeDim);
@@ -326,7 +326,7 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.Slice", "[Unit][Domain]") {
 namespace partial_slice {
 template <size_t N>
 struct Scalar : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Scalar";
+  static constexpr db::Label label = "Scalar";
   using type = ::Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary = N == 0;
 };
@@ -334,14 +334,14 @@ struct Scalar : db::SimpleTag {
 constexpr size_t vector_dim = 3;
 template <size_t N>
 struct Vector : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Vector";
+  static constexpr db::Label label = "Vector";
   using type = tnsr::i<DataVector, vector_dim, Frame::Logical>;
   static constexpr bool should_be_sliced_to_boundary = N == 1;
 };
 
 template <size_t VolumeDim>
 struct ComputedVars : db::ComputeTag {
-  static constexpr db::DataBoxString label = "ComputedVars";
+  static constexpr db::Label label = "ComputedVars";
   static auto function(const Index<VolumeDim>& extents) noexcept {
     const DataVector volume_data{
       11., 10., 9., 8., 7., 6., 5., 4., 3., 2., 1., 0.};

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -56,7 +56,7 @@ struct NoCopy : db::SimpleTag {
 };
 
 template <typename Tag>
-struct Negate : db::PrefixTag, db::ComputeItemTag {
+struct Negate : db::PrefixTag, db::ComputeTag {
   static constexpr db::DataBoxString label = "Negate";
   using tag = Tag;
   static constexpr auto function(const db::item_type<Tag>& x) noexcept {
@@ -65,7 +65,7 @@ struct Negate : db::PrefixTag, db::ComputeItemTag {
   using argument_tags = tmpl::list<Tag>;
 };
 
-struct AddThree : db::ComputeItemTag {
+struct AddThree : db::ComputeTag {
   static constexpr db::DataBoxString label = "AddThree";
   static constexpr auto function(const int x) noexcept { return x + 3; }
   using argument_tags = tmpl::list<Int>;
@@ -73,7 +73,7 @@ struct AddThree : db::ComputeItemTag {
 };
 
 template <size_t VolumeDim>
-struct ComplexComputeItem : db::ComputeItemTag {
+struct ComplexComputeItem : db::ComputeTag {
   static constexpr db::DataBoxString label = "ComplexComputeItem";
   static constexpr auto function(const int i, const double d,
                                  const ::NoCopy<1>& /*unused*/,
@@ -179,7 +179,7 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
 namespace {
 constexpr size_t dim = 2;
 
-struct Dirs : db::ComputeItemTag {
+struct Dirs : db::ComputeTag {
   static constexpr db::DataBoxString label = "Dirs";
   static auto function() noexcept {
     return std::unordered_set<Direction<dim>>{Direction<dim>::lower_xi(),
@@ -198,7 +198,7 @@ struct Var : db::SimpleTag {
 };
 
 template <size_t VolumeDim>
-struct Compute : db::ComputeItemTag {
+struct Compute : db::ComputeTag {
   static constexpr db::DataBoxString label = "Compute";
   static auto function(const Index<VolumeDim>& extents) {
     auto ret = Variables<tmpl::list<Var<VolumeDim>, Var<10 * VolumeDim>>>(
@@ -340,7 +340,7 @@ struct Vector : db::SimpleTag {
 };
 
 template <size_t VolumeDim>
-struct ComputedVars : db::ComputeItemTag {
+struct ComputedVars : db::ComputeTag {
   static constexpr db::DataBoxString label = "ComputedVars";
   static auto function(const Index<VolumeDim>& extents) noexcept {
     const DataVector volume_data{

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
@@ -15,11 +15,11 @@
 namespace {
 struct var_tag : db::SimpleTag {
   using type = int;
-  static constexpr db::DataBoxString label = "var_tag";
+  static constexpr db::Label label = "var_tag";
 };
 struct dt_var_tag : db::SimpleTag {
   using type = int;
-  static constexpr db::DataBoxString label = "dt_var_tag";
+  static constexpr db::Label label = "dt_var_tag";
 };
 
 struct ComputeDuDt {

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
@@ -13,11 +13,11 @@
 #include "tests/Unit/ActionTesting.hpp"
 
 namespace {
-struct var_tag : db::DataBoxTag {
+struct var_tag : db::SimpleTag {
   using type = int;
   static constexpr db::DataBoxString label = "var_tag";
 };
-struct dt_var_tag : db::DataBoxTag {
+struct dt_var_tag : db::SimpleTag {
   using type = int;
   static constexpr db::DataBoxString label = "dt_var_tag";
 };

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -47,7 +47,7 @@ class er;
 namespace {
 struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Var";
+  static constexpr db::Label label = "Var";
   static constexpr bool should_be_sliced_to_boundary = true;
 };
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -45,7 +45,7 @@ class er;
 }  // namespace PUP
 
 namespace {
-struct Var : db::DataBoxTag {
+struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Var";
   static constexpr bool should_be_sliced_to_boundary = true;

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -76,7 +76,7 @@ void check_du_dt(const size_t npts, const double time) {
 
   db::mutate_apply<typename ScalarWave::ComputeDuDt<Dim>::return_tags,
                    typename ScalarWave::ComputeDuDt<Dim>::argument_tags>(
-      ScalarWave::ComputeDuDt<Dim>{}, box);
+      ScalarWave::ComputeDuDt<Dim>{}, make_not_null(&box));
 
   CHECK_ITERABLE_APPROX(
       db::get<Tags::dt<ScalarWave::Pi>>(box),

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -41,19 +41,19 @@
 // IWYU pragma: no_forward_declare Variables
 
 namespace {
-struct Var : db::DataBoxTag {
+struct Var : db::SimpleTag {
   static constexpr db::DataBoxString label = "Var";
   using type = Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary = false;
 };
 
-struct Var2 : db::DataBoxTag {
+struct Var2 : db::SimpleTag {
   static constexpr db::DataBoxString label = "Var2";
   using type = tnsr::ii<DataVector, 2>;
   static constexpr bool should_be_sliced_to_boundary = false;
 };
 
-struct OtherArg : db::DataBoxTag {
+struct OtherArg : db::SimpleTag {
   static constexpr db::DataBoxString label = "OtherArg";
   using type = double;
 };

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -42,19 +42,19 @@
 
 namespace {
 struct Var : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Var";
+  static constexpr db::Label label = "Var";
   using type = Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary = false;
 };
 
 struct Var2 : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Var2";
+  static constexpr db::Label label = "Var2";
   using type = tnsr::ii<DataVector, 2>;
   static constexpr bool should_be_sliced_to_boundary = false;
 };
 
 struct OtherArg : db::SimpleTag {
-  static constexpr db::DataBoxString label = "OtherArg";
+  static constexpr db::Label label = "OtherArg";
   using type = double;
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -50,12 +50,12 @@
 // IWYU pragma: no_forward_declare Variables
 
 namespace {
-struct Var : db::DataBoxTag {
+struct Var : db::SimpleTag {
   static constexpr db::DataBoxString label = "Var";
   using type = Scalar<DataVector>;
 };
 
-struct OtherData : db::DataBoxTag {
+struct OtherData : db::SimpleTag {
   static constexpr db::DataBoxString label = "OtherData";
   using type = Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary = false;
@@ -63,7 +63,7 @@ struct OtherData : db::DataBoxTag {
 
 class NumericalFlux {
  public:
-  struct ExtraData : db::DataBoxTag {
+  struct ExtraData : db::SimpleTag {
     static constexpr db::DataBoxString label = "ExtraTag";
     using type = tnsr::I<DataVector, 1>;
   };

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -51,12 +51,12 @@
 
 namespace {
 struct Var : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Var";
+  static constexpr db::Label label = "Var";
   using type = Scalar<DataVector>;
 };
 
 struct OtherData : db::SimpleTag {
-  static constexpr db::DataBoxString label = "OtherData";
+  static constexpr db::Label label = "OtherData";
   using type = Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary = false;
 };
@@ -64,7 +64,7 @@ struct OtherData : db::SimpleTag {
 class NumericalFlux {
  public:
   struct ExtraData : db::SimpleTag {
-    static constexpr db::DataBoxString label = "ExtraTag";
+    static constexpr db::Label label = "ExtraTag";
     using type = tnsr::I<DataVector, 1>;
   };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -27,7 +27,7 @@
 #include "Utilities/TypeTraits.hpp"
 
 namespace {
-struct Var : db::DataBoxTag {
+struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -66,7 +66,7 @@ auto make_affine_map<3>() noexcept {
 template <size_t Dim, typename Frame>
 struct Flux1 : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim, Frame>;
-  static constexpr db::DataBoxString label = "Flux1";
+  static constexpr db::Label label = "Flux1";
   static auto flux(const MathFunctions::TensorProduct<Dim>& f,
                    const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
     auto result = make_with_value<tnsr::I<DataVector, Dim, Frame>>(x, 0.);
@@ -91,7 +91,7 @@ struct Flux1 : db::SimpleTag {
 template <size_t Dim, typename Frame>
 struct Flux2 : db::SimpleTag {
   using type = tnsr::Ij<DataVector, Dim, Frame>;
-  static constexpr db::DataBoxString label = "Flux2";
+  static constexpr db::Label label = "Flux2";
   static auto flux(const MathFunctions::TensorProduct<Dim>& f,
                    const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
     auto result = make_with_value<tnsr::Ij<DataVector, Dim, Frame>>(x, 0.);
@@ -186,7 +186,7 @@ namespace {
 template <class MapType>
 struct MapTag : db::SimpleTag {
   using type = MapType;
-  static constexpr db::DataBoxString label = "MapTag";
+  static constexpr db::Label label = "MapTag";
 };
 
 template <size_t Dim, typename Frame = Frame::Inertial>

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -64,7 +64,7 @@ auto make_affine_map<3>() noexcept {
 }
 
 template <size_t Dim, typename Frame>
-struct Flux1 : db::DataBoxTag {
+struct Flux1 : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "Flux1";
   static auto flux(const MathFunctions::TensorProduct<Dim>& f,
@@ -89,7 +89,7 @@ struct Flux1 : db::DataBoxTag {
 };
 
 template <size_t Dim, typename Frame>
-struct Flux2 : db::DataBoxTag {
+struct Flux2 : db::SimpleTag {
   using type = tnsr::Ij<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "Flux2";
   static auto flux(const MathFunctions::TensorProduct<Dim>& f,
@@ -184,7 +184,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Divergence",
 
 namespace {
 template <class MapType>
-struct MapTag : db::DataBoxTag {
+struct MapTag : db::SimpleTag {
   using type = MapType;
   static constexpr db::DataBoxString label = "MapTag";
 };

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -34,7 +34,7 @@
 namespace {
 
 template <size_t Dim, class Frame = ::Frame::Grid>
-struct Var1 : db::DataBoxTag {
+struct Var1 : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame>;
   static constexpr db::DataBoxString label = "Var1";
   static auto f(const std::array<size_t, Dim>& coeffs,
@@ -72,7 +72,7 @@ struct Var1 : db::DataBoxTag {
   }
 };
 
-struct Var2 : db::DataBoxTag {
+struct Var2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Var2";
   template <size_t Dim, class Frame>
@@ -444,7 +444,7 @@ void test_logical_derivatives_compute_item(
 }
 
 template <class MapType>
-struct MapTag : db::DataBoxTag {
+struct MapTag : db::SimpleTag {
   using type = MapType;
   static constexpr db::DataBoxString label = "MapTag";
 };

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -36,7 +36,7 @@ namespace {
 template <size_t Dim, class Frame = ::Frame::Grid>
 struct Var1 : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame>;
-  static constexpr db::DataBoxString label = "Var1";
+  static constexpr db::Label label = "Var1";
   static auto f(const std::array<size_t, Dim>& coeffs,
                 const tnsr::I<DataVector, Dim, Frame>& x) {
     tnsr::i<DataVector, Dim, Frame> result(x.begin()->size(), 0.);
@@ -74,7 +74,7 @@ struct Var1 : db::SimpleTag {
 
 struct Var2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Var2";
+  static constexpr db::Label label = "Var2";
   template <size_t Dim, class Frame>
   static auto f(const std::array<size_t, Dim>& coeffs,
                 const tnsr::I<DataVector, Dim, Frame>& x) {
@@ -446,7 +446,7 @@ void test_logical_derivatives_compute_item(
 template <class MapType>
 struct MapTag : db::SimpleTag {
   using type = MapType;
-  static constexpr db::DataBoxString label = "MapTag";
+  static constexpr db::Label label = "MapTag";
 };
 
 template <size_t Dim, typename T>

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -71,22 +71,22 @@ struct ElementId {};
 /// \endcond
 
 struct CountActionsCalled : db::SimpleTag {
-  static constexpr db::DataBoxString label = "CountActionsCalled";
+  static constexpr db::Label label = "CountActionsCalled";
   using type = int;
 };
 
 struct Int0 : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Int0";
+  static constexpr db::Label label = "Int0";
   using type = int;
 };
 
 struct Int1 : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Int1";
+  static constexpr db::Label label = "Int1";
   using type = int;
 };
 
 struct TemporalId : db::SimpleTag {
-  static constexpr db::DataBoxString label = "TemporalId";
+  static constexpr db::Label label = "TemporalId";
   using type = TestAlgorithmArrayInstance;
 };
 

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -70,22 +70,22 @@ struct hash<TestAlgorithmArrayInstance> {
 struct ElementId {};
 /// \endcond
 
-struct CountActionsCalled : db::DataBoxTag {
+struct CountActionsCalled : db::SimpleTag {
   static constexpr db::DataBoxString label = "CountActionsCalled";
   using type = int;
 };
 
-struct Int0 : db::DataBoxTag {
+struct Int0 : db::SimpleTag {
   static constexpr db::DataBoxString label = "Int0";
   using type = int;
 };
 
-struct Int1 : db::DataBoxTag {
+struct Int1 : db::SimpleTag {
   static constexpr db::DataBoxString label = "Int1";
   using type = int;
 };
 
-struct TemporalId : db::DataBoxTag {
+struct TemporalId : db::SimpleTag {
   static constexpr db::DataBoxString label = "TemporalId";
   using type = TestAlgorithmArrayInstance;
 };

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -22,6 +22,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
 #include "Parallel/Printf.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -92,16 +93,17 @@ struct nodegroup_receive {
                          NodegroupParallelComponent<TestMetavariables>>,
         "The ParallelComponent is not deduced to be the right type");
     db::mutate<Tags::vector_of_array_indexs, Tags::total_receives_on_node>(
-        box, [&id_of_array](std::vector<int>& array_indexs,
-                            int& total_receives_on_node) {
-          if (static_cast<int>(array_indexs.size()) !=
+        make_not_null(&box),
+        [&id_of_array](const gsl::not_null<std::vector<int>*> array_indexs,
+                       const gsl::not_null<int*> total_receives_on_node) {
+          if (static_cast<int>(array_indexs->size()) !=
               number_of_1d_array_elements_per_core *
                   Parallel::procs_on_node(Parallel::my_node())) {
-            array_indexs[static_cast<size_t>(id_of_array)]++;
+            (*array_indexs)[static_cast<size_t>(id_of_array)]++;
           }
-          std::for_each(array_indexs.begin(), array_indexs.end(),
+          std::for_each(array_indexs->begin(), array_indexs->end(),
                         [](int& t) { t++; });
-          total_receives_on_node++;
+          ++*total_receives_on_node;
         });
   }
 };
@@ -147,16 +149,17 @@ struct nodegroup_threaded_receive {
                     const NodeLock& node_lock, const int& id_of_array) {
     Parallel::lock(node_lock);
     db::mutate<Tags::vector_of_array_indexs, Tags::total_receives_on_node>(
-        box, [&id_of_array](std::vector<int>& array_indexs,
-                            int& total_receives_on_node) {
-          if (static_cast<int>(array_indexs.size()) !=
+        make_not_null(&box),
+        [&id_of_array](const gsl::not_null<std::vector<int>*> array_indexs,
+                       const gsl::not_null<int*> total_receives_on_node) {
+          if (static_cast<int>(array_indexs->size()) !=
               number_of_1d_array_elements_per_core *
                   Parallel::procs_on_node(Parallel::my_node())) {
-            array_indexs[static_cast<size_t>(id_of_array)]++;
+            (*array_indexs)[static_cast<size_t>(id_of_array)]++;
           }
-          std::for_each(array_indexs.begin(), array_indexs.end(),
+          std::for_each(array_indexs->begin(), array_indexs->end(),
                         [](int& t) { t++; });
-          total_receives_on_node++;
+          ++*total_receives_on_node;
         });
     Parallel::unlock(node_lock);
   }

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -43,12 +43,12 @@ struct NodegroupParallelComponent;
 
 namespace Tags {
 struct vector_of_array_indexs : db::SimpleTag {
-  static constexpr db::DataBoxString label = "vector_of_array_indexs";
+  static constexpr db::Label label = "vector_of_array_indexs";
   using type = std::vector<int>;
 };
 
 struct total_receives_on_node : db::SimpleTag {
-  static constexpr db::DataBoxString label = "total_receives_on_node";
+  static constexpr db::Label label = "total_receives_on_node";
   using type = int;
 };
 }  // namespace Tags

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -42,12 +42,12 @@ template <class Metavariables>
 struct NodegroupParallelComponent;
 
 namespace Tags {
-struct vector_of_array_indexs : db::DataBoxTag {
+struct vector_of_array_indexs : db::SimpleTag {
   static constexpr db::DataBoxString label = "vector_of_array_indexs";
   using type = std::vector<int>;
 };
 
-struct total_receives_on_node : db::DataBoxTag {
+struct total_receives_on_node : db::SimpleTag {
   static constexpr db::DataBoxString label = "total_receives_on_node";
   using type = int;
 };

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -35,17 +35,17 @@ class DataBox;
 
 namespace Tags {
 struct Int0 : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Int0";
+  static constexpr db::Label label = "Int0";
   using type = int;
 };
 
 struct Int1 : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Int1";
+  static constexpr db::Label label = "Int1";
   using type = int;
 };
 
 struct CountActionsCalled : db::SimpleTag {
-  static constexpr db::DataBoxString label = "CountActionsCalled";
+  static constexpr db::Label label = "CountActionsCalled";
   using type = int;
 };
 

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -23,6 +23,7 @@
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Main.hpp"
 #include "Parallel/Printf.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -195,7 +196,10 @@ struct AddIntValue10 {
       /// [broadcast_to_group]
     }
     db::mutate<Tags::CountActionsCalled>(
-        box, [](int& count_actions_called) { count_actions_called++; });
+        make_not_null(&box),
+        [](const gsl::not_null<int*> count_actions_called) {
+          ++*count_actions_called;
+        });
     const bool terminate_algorithm =
         db::get<Tags::CountActionsCalled>(box) >= 15;
     return std::make_tuple(
@@ -219,8 +223,12 @@ struct IncrementInt0 {
                                    ArrayParallelComponent<TestMetavariables>>,
                   "The ParallelComponent is not deduced to be the right type");
     db::mutate<Tags::CountActionsCalled>(
-        box, [](int& count_actions_called) { count_actions_called++; });
-    db::mutate<Tags::Int0>(box, [](int& int0) { int0++; });
+        make_not_null(&box),
+        [](const gsl::not_null<int*> count_actions_called) {
+          ++*count_actions_called;
+        });
+    db::mutate<Tags::Int0>(make_not_null(&box),
+                           [](const gsl::not_null<int*> int0) { ++*int0; });
     return std::forward_as_tuple(std::move(box));
   }
 };
@@ -240,7 +248,10 @@ struct RemoveInt0 {
                   "The ParallelComponent is not deduced to be the right type");
     SPECTRE_PARALLEL_REQUIRE(db::get<Tags::Int0>(box) == 11);
     db::mutate<Tags::CountActionsCalled>(
-        box, [](int& count_actions_called) { count_actions_called++; });
+        make_not_null(&box),
+        [](const gsl::not_null<int*> count_actions_called) {
+          ++*count_actions_called;
+        });
     return std::make_tuple(
         db::create_from<tmpl::list<Tags::Int0>>(std::move(box)));
   }

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -34,17 +34,17 @@ class DataBox;
 }  // namespace db
 
 namespace Tags {
-struct Int0 : db::DataBoxTag {
+struct Int0 : db::SimpleTag {
   static constexpr db::DataBoxString label = "Int0";
   using type = int;
 };
 
-struct Int1 : db::DataBoxTag {
+struct Int1 : db::SimpleTag {
   static constexpr db::DataBoxString label = "Int1";
   using type = int;
 };
 
-struct CountActionsCalled : db::DataBoxTag {
+struct CountActionsCalled : db::SimpleTag {
   static constexpr db::DataBoxString label = "CountActionsCalled";
   using type = int;
 };

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -151,13 +151,13 @@ void test_tensor_product(
 
 struct Var1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::DataBoxString label = "Var1";
+  static constexpr db::Label label = "Var1";
 };
 
 template <size_t VolumeDim>
 struct Var2 : db::SimpleTag {
   using type = tnsr::i<DataVector, VolumeDim, Frame::Inertial>;
-  static constexpr db::DataBoxString label = "Var2";
+  static constexpr db::Label label = "Var2";
 };
 
 template <size_t VolumeDim>

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -149,13 +149,13 @@ void test_tensor_product(
                         expected_second_derivs(point, powers, scale));
 }
 
-struct Var1 : db::DataBoxTag {
+struct Var1 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static constexpr db::DataBoxString label = "Var1";
 };
 
 template <size_t VolumeDim>
-struct Var2 : db::DataBoxTag {
+struct Var2 : db::SimpleTag {
   using type = tnsr::i<DataVector, VolumeDim, Frame::Inertial>;
   static constexpr db::DataBoxString label = "Var2";
 };

--- a/tests/Unit/Time/Actions/Test_FinalTime.cpp
+++ b/tests/Unit/Time/Actions/Test_FinalTime.cpp
@@ -12,6 +12,7 @@
 #include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 
@@ -46,10 +47,9 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.FinalTime", "[Unit][Time][Actions]") {
 
   for (const auto& test : tests) {
     db::mutate<Tags::TimeId, Tags::TimeStep>(
-        box,
-        [&test](auto& time_id, auto& time_step) {
-          time_id.time = test.time;
-          time_step = test.time_step;
+        make_not_null(&box), [&test](const auto time_id, const auto time_step) {
+          time_id->time = test.time;
+          *time_step = test.time_step;
         });
 
     bool terminate;

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -22,7 +22,7 @@
 #include "tests/Unit/ActionTesting.hpp"
 
 namespace {
-struct Var : db::DataBoxTag {
+struct Var : db::SimpleTag {
   static constexpr db::DataBoxString label = "Var";
   using type = double;
 };

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -23,7 +23,7 @@
 
 namespace {
 struct Var : db::SimpleTag {
-  static constexpr db::DataBoxString label = "Var";
+  static constexpr db::Label label = "Var";
   using type = double;
 };
 

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -72,14 +72,15 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
 
   for (size_t substep = 0; substep < 3; ++substep) {
     db::mutate<dt_variables_tag, Tags::TimeId>(
-        box,
-        [&rhs, &substep, &substep_times ](double& dt_vars,
-                                          TimeId& local_time_id,
-                                          const double& vars) noexcept {
-          local_time_id.time = gsl::at(substep_times, substep);
-          local_time_id.substep = substep;
+        make_not_null(&box),
+        [&rhs, &substep, &substep_times ](
+            const gsl::not_null<double*> dt_vars,
+            const gsl::not_null<TimeId*> local_time_id,
+            const double& vars) noexcept {
+          local_time_id->time = gsl::at(substep_times, substep);
+          local_time_id->substep = substep;
 
-          dt_vars = rhs(local_time_id.time.value(), vars);
+          *dt_vars = rhs(local_time_id->time.value(), vars);
         },
         db::get<variables_tag>(box));
 

--- a/tests/Unit/Time/Test_EveryNSlabs.cpp
+++ b/tests/Unit/Time/Test_EveryNSlabs.cpp
@@ -15,6 +15,7 @@
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
 #include "Time/Triggers/TimeTriggers.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -43,7 +44,8 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.EveryNSlabs", "[Unit][Time]") {
   for (const bool expected :
        {false, false, false, false, false, true, false, false, true, false}) {
     CHECK(sent_trigger->is_triggered(box) == expected);
-    db::mutate<Tags::TimeId>(box,
-                             [](TimeId& time_id) { ++time_id.slab_number; });
+    db::mutate<Tags::TimeId>(
+        make_not_null(&box),
+        [](const gsl::not_null<TimeId*> time_id) { ++time_id->slab_number; });
   }
 }

--- a/tests/Unit/Time/Test_SpecifiedSlabs.cpp
+++ b/tests/Unit/Time/Test_SpecifiedSlabs.cpp
@@ -15,6 +15,7 @@
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
 #include "Time/Triggers/TimeTriggers.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -42,7 +43,8 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.SpecifiedSlabs", "[Unit][Time]") {
   for (const bool expected :
        {false, false, false, true, false, false, true, false, true, false}) {
     CHECK(sent_trigger->is_triggered(box) == expected);
-    db::mutate<Tags::TimeId>(box,
-                             [](TimeId& time_id) { ++time_id.slab_number; });
+    db::mutate<Tags::TimeId>(
+        make_not_null(&box),
+        [](const gsl::not_null<TimeId*> time_id) { ++time_id->slab_number; });
   }
 }

--- a/tests/Unit/Utilities/Test_TMPL.cpp
+++ b/tests/Unit/Utilities/Test_TMPL.cpp
@@ -73,3 +73,25 @@ SPECTRE_TEST_CASE("Unit.Utilities.get_first_argument", "[Unit][Utilities]") {
   CHECK(6 == get_first_argument(a1, a0, a2, a3));
   CHECK('7' == get_first_argument(a3, a1, a2, a0));
 }
+
+namespace {
+/// [expand_pack_left_to_right]
+template <typename... Ts>
+void test_expand_pack_left_to_right(const size_t expected,
+                                    tmpl::list<Ts...> /*meta*/) {
+  size_t sum = 0;
+  const auto lambda = [&sum](auto tag) { sum += decltype(tag)::value; };
+  EXPAND_PACK_LEFT_TO_RIGHT(lambda(Ts{}));
+  CHECK(sum == expected);
+}
+/// [expand_pack_left_to_right]
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Utilities.EXPAND_PACK_LEFT_TO_RIGHT",
+                  "[Unit][Utilities]") {
+  test_expand_pack_left_to_right(
+      10, tmpl::list<std::integral_constant<size_t, 2>,
+                     std::integral_constant<size_t, 4>,
+                     std::integral_constant<size_t, 1>,
+                     std::integral_constant<size_t, 3>>{});
+}


### PR DESCRIPTION
## Proposed changes

This adds 2 major and very closely related functionalities to DataBox:
- Compute items can now be function templates. This is done by having the
  function member be a function template, which then forwards to the free
  function.
- It is now possible to retrieve tags from the DataBox via a base tag
  mechanism. This is supported via two different styles: base tags and compute
  tags deriving off of a simple tag.
  For base tags the tag contains no members and must derive off of
  db::BaseDataBoxTags. It is then possible to retrieve the base tag MyBaseTag
  using db::get<MyBaseTag>(box). Note that it is also possible to mutate base
  tags (only if they are a simple item) by using db::mutate<MyBaseTag>(Box, ...)

  For compute items that derive off of simple tags the same approach applies,
  except that it is not possible to mutate the compute items (this rule hasn't
  changed)

Remaining TODOs:
- [ ] Write documentation
- [x] Rename ComputeItemTag to ComputeTag, DataBoxTag to SimpleTag
- [x] Clean up SimpleTag, ComputeTag, etc. inheritance

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
