### PR TITLE
Add InterpolateVariablesToPoints.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Interpolation)
 
 set(LIBRARY_SOURCES
   BarycentricRational.cpp
+  IrregularInterpolant.cpp
   )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IrregularInterpolant.hpp"
+
+#include <array>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+template <size_t Dim>
+Matrix interpolation_matrix(
+    const Index<Dim>& mesh,
+    const tnsr::I<DataVector, Dim, Frame::Logical>& points) noexcept;
+
+template <>
+Matrix interpolation_matrix(
+    const Index<1>& mesh,
+    const tnsr::I<DataVector, 1, Frame::Logical>& points) noexcept {
+  // For 1d interpolation matrix, simply return the legendre-gauss-lobatto
+  // matrix.
+  return Basis::lgl::interpolation_matrix(mesh[0], get<0>(points));
+}
+
+template <>
+Matrix interpolation_matrix(
+    const Index<2>& mesh,
+    const tnsr::I<DataVector, 2, Frame::Logical>& points) noexcept {
+  const std::array<Matrix, 2> matrices{
+      {Basis::lgl::interpolation_matrix(mesh[0], get<0>(points)),
+       Basis::lgl::interpolation_matrix(mesh[1], get<1>(points))}};
+
+  const auto number_of_points = get<0>(points).size();
+  Matrix result(number_of_points, mesh.product());
+  // First dimension of DataVector varies fastest.
+  for (size_t j = 0, s = 0; j < mesh[1]; ++j) {
+    for (size_t i = 0; i < mesh[0]; ++i) {
+      for (size_t p = 0; p < number_of_points; ++p) {
+        result(p, s) = matrices[0](p, i) * matrices[1](p, j);
+      }
+      ++s;
+    }
+  }
+  return result;
+}
+
+template <>
+Matrix interpolation_matrix(
+    const Index<3>& mesh,
+    const tnsr::I<DataVector, 3, Frame::Logical>& points) noexcept {
+  const std::array<Matrix, 3> matrices{
+      {Basis::lgl::interpolation_matrix(mesh[0], get<0>(points)),
+       Basis::lgl::interpolation_matrix(mesh[1], get<1>(points)),
+       Basis::lgl::interpolation_matrix(mesh[2], get<2>(points))}};
+
+  const auto number_of_points = get<0>(points).size();
+  Matrix result(number_of_points, mesh.product());
+  // First dimension of DataVector varies fastest.
+  for (size_t k = 0, s = 0; k < mesh[2]; ++k) {
+    for (size_t j = 0; j < mesh[1]; ++j) {
+      for (size_t i = 0; i < mesh[0]; ++i) {
+        for (size_t p = 0; p < number_of_points; ++p) {
+          result(p, s) =
+              matrices[0](p, i) * matrices[1](p, j) * matrices[2](p, k);
+        }
+        ++s;
+      }
+    }
+  }
+  return result;
+}
+}  // namespace
+
+namespace intrp {
+
+template <size_t Dim>
+Irregular<Dim>::Irregular() = default;
+
+template <size_t Dim>
+Irregular<Dim>::Irregular(
+    const Index<Dim>& source_mesh,
+    const tnsr::I<DataVector, Dim, Frame::Logical>& target_points) noexcept
+    : interpolation_matrix_(interpolation_matrix(source_mesh, target_points)) {}
+
+template <size_t Dim>
+void Irregular<Dim>::pup(PUP::er& p) noexcept {
+  p | interpolation_matrix_;
+}
+
+template <size_t Dim>
+bool operator!=(const Irregular<Dim>& lhs, const Irregular<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+template class Irregular<1>;
+template class Irregular<2>;
+template class Irregular<3>;
+template bool operator!=(const Irregular<1>& lhs,
+                         const Irregular<1>& rhs) noexcept;
+template bool operator!=(const Irregular<2>& lhs,
+                         const Irregular<2>& rhs) noexcept;
+template bool operator!=(const Irregular<3>& lhs,
+                         const Irregular<3>& rhs) noexcept;
+
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Index;
+namespace PUP {
+class er;
+}  // namespace PUP
+// IWYU pragma: no_forward_declare Variables
+/// \endcond
+
+namespace intrp {
+
+/// \ingroup NumericalAlgorithmsGroup
+/// Interpolates a `Variables` onto an arbitrary set of points.
+template <size_t Dim>
+class Irregular {
+ public:
+  Irregular(
+      const Index<Dim>& source_mesh,
+      const tnsr::I<DataVector, Dim, Frame::Logical>& target_points) noexcept;
+  Irregular();
+
+  // clang-tidy: no runtime references
+  /// Serialization for Charm++
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  //@{
+  /// Performs the interpolation on a `Variables` with grid points corresponding
+  /// to the `Index<Dim>` specified in the constructor.
+  /// The result is a `Variables` whose internal `DataVector` goes over the
+  /// list of target_points that were specified in the constructor.
+  /// \note for the void function, `result` will be resized to the proper size.
+  template <typename TagsList>
+  void interpolate(gsl::not_null<Variables<TagsList>*> result,
+                   const Variables<TagsList>& vars) const noexcept;
+  template <typename TagsList>
+  Variables<TagsList> interpolate(const Variables<TagsList>& vars) const
+      noexcept;
+  //@}
+
+ private:
+  friend bool operator==(const Irregular& lhs, const Irregular& rhs) noexcept {
+    return lhs.interpolation_matrix_ == rhs.interpolation_matrix_;
+  }
+  Matrix interpolation_matrix_;
+};
+
+template <size_t Dim>
+template <typename TagsList>
+void Irregular<Dim>::interpolate(
+    const gsl::not_null<Variables<TagsList>*> result,
+    const Variables<TagsList>& vars) const noexcept {
+  // For matrix multiplication of Interp . Source = Result:
+  //   matrix Interp is m rows by k columns
+  //   matrix Source is k rows by n columns
+  //   matrix Result is m rows by n columns
+  const size_t m = interpolation_matrix_.rows();
+  const size_t k = interpolation_matrix_.columns();
+  const size_t n = vars.number_of_independent_components;
+  ASSERT(k == vars.number_of_grid_points(),
+         "Number of grid points in source 'vars', "
+             << vars.number_of_grid_points()
+             << ",\n disagrees with the size of the source_mesh, " << k
+             << ", that was passed into the constructor");
+  if (result->number_of_grid_points() != m) {
+    *result = Variables<TagsList>(m, 0.);
+  }
+  dgemm_('n', 'n', m, n, k, 1.0, interpolation_matrix_.data(), m, vars.data(),
+         k, 0.0, result->data(), m);
+}
+
+template <size_t Dim>
+template <typename TagsList>
+Variables<TagsList> Irregular<Dim>::interpolate(
+    const Variables<TagsList>& vars) const noexcept {
+  Variables<TagsList> result;
+  interpolate(make_not_null(&result), vars);
+  return result;
+}
+
+template <size_t Dim>
+bool operator!=(const Irregular<Dim>& lhs,
+                const Irregular<Dim>& rhs) noexcept;
+
+}  // namespace intrp
+

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_NumericalInterpolation")
 
 set(LIBRARY_SOURCES
   Test_BarycentricRational.cpp
+  Test_IrregularInterpolant.cpp
   Test_LagrangePolynomial.cpp
   )
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -1,0 +1,196 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <random>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/IndexIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/MathFunctions/TensorProduct.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+// IWYU pragma: no_forward_declare MathFunction
+// IWYU pragma: no_forward_declare PowX
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+using Affine = CoordinateMaps::Affine;
+using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+const double inertial_coord_min = -0.3;
+const double inertial_coord_max = 0.7;
+
+template <size_t VolumeDim>
+auto make_affine_map() noexcept;
+
+template <>
+auto make_affine_map<1>() noexcept {
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max});
+}
+
+template <>
+auto make_affine_map<2>() noexcept {
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine2D{Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max},
+               Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max}});
+}
+
+template <>
+auto make_affine_map<3>() noexcept {
+  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine3D{Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max},
+               Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max},
+               Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max}});
+}
+
+namespace TestTags {
+
+template <size_t Dim>
+struct Vector : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+  static std::string name() noexcept { return "Vector"; }
+  static auto fill_values(const MathFunctions::TensorProduct<Dim>& f,
+                          const tnsr::I<DataVector, Dim>& x) noexcept {
+    auto result = make_with_value<tnsr::I<DataVector, Dim>>(x, 0.);
+    const auto f_of_x = f(x);
+    for (size_t d = 0; d < Dim; ++d) {
+      result.get(d) = (d + 0.5) * get(f_of_x);
+    }
+    return result;
+  }
+};
+
+template <size_t Dim>
+struct SymmetricTensor : db::SimpleTag {
+  using type = tnsr::ii<DataVector, Dim>;
+  static std::string name() noexcept { return "SymmetricTensor"; }
+  static auto fill_values(const MathFunctions::TensorProduct<Dim>& f,
+                          const tnsr::I<DataVector, Dim>& x) noexcept {
+    auto result = make_with_value<tnsr::ii<DataVector, Dim>>(x, 0.);
+    const auto f_of_x = f(x);
+    for (size_t i = 0; i < Dim; ++i) {
+      for (size_t j = i; j < Dim; ++j) {  // Symmetry
+        result.get(i, j) = (i + j + 0.33) * get(f_of_x);
+      }
+    }
+    return result;
+  }
+};
+
+}  // namespace TestTags
+
+template <size_t Dim>
+void test_interpolate_to_points(const Index<Dim>& mesh) noexcept {
+  // Fill target interpolation coordinates with random values
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed" << seed);
+  std::uniform_real_distribution<> dist(inertial_coord_min, inertial_coord_max);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_dist = make_not_null(&dist);
+
+  const size_t number_of_points = 6;
+  const auto target_x_inertial =
+      make_with_random_values<tnsr::I<DataVector, Dim>>(
+          nn_generator, nn_dist, DataVector(number_of_points));
+
+  const auto coordinate_map = make_affine_map<Dim>();
+  const auto target_x = coordinate_map.inverse(target_x_inertial);
+
+  // Set up interpolator. Need do this only once.
+  const intrp::Irregular<Dim> irregular_interpolant(mesh, target_x);
+  test_serialization(irregular_interpolant);
+
+  // ... but we construct another interpolator to test operator!=
+  {
+    auto target_x_new = target_x;
+    target_x_new.get(0)[0] *= 0.98;  // Change one point slightly.
+    const intrp::Irregular<Dim> irregular_interpolant_new(mesh, target_x_new);
+    CHECK(irregular_interpolant_new != irregular_interpolant);
+  }
+
+  // Coordinates on Legendre-Gauss-Lobatto grid
+  const auto src_x = coordinate_map(logical_coordinates(mesh));
+
+  // Set up variables
+  using tags =
+      tmpl::list<TestTags::Vector<Dim>, TestTags::SymmetricTensor<Dim>>;
+  Variables<tags> src_vars(mesh.product());
+  Variables<tags> expected_dest_vars(number_of_points);
+
+  // We will make polynomials of the form x^a y^b z^c ...
+  // for all a,b,c, that result in exact interpolation.
+  // IndexIterator loops over "a,b,c"
+  for (IndexIterator<Dim> iter(mesh); iter; ++iter) {
+    // Set up analytic solution.  We fill a Variables with this solution,
+    // interpolate to arbitrary points, and then check that the
+    // values at arbitrary points match this solution.
+    // We choose polynomials so that interpolation is exact.
+    std::array<std::unique_ptr<MathFunction<1>>, Dim> functions;
+    for (size_t d = 0; d < Dim; ++d) {
+      gsl::at(functions, d) = std::make_unique<MathFunctions::PowX>(iter()[d]);
+    }
+    MathFunctions::TensorProduct<Dim> f(1.0, std::move(functions));
+
+    // Fill source and expected destination Variables with analytic solution.
+    tmpl::for_each<tags>([
+      &f, &src_x, &target_x_inertial, &src_vars, &expected_dest_vars
+    ](auto tag) noexcept {
+      using Tag = tmpl::type_from<decltype(tag)>;
+      get<Tag>(src_vars) = Tag::fill_values(f, src_x);
+      get<Tag>(expected_dest_vars) = Tag::fill_values(f, target_x_inertial);
+    });
+
+    // Interpolate
+    // (g++ 7.2.0 does not allow `const auto dest_vars` here)
+    const Variables<tags> dest_vars =
+        irregular_interpolant.interpolate(src_vars);
+
+    tmpl::for_each<tags>([&dest_vars, &expected_dest_vars ](auto tag) noexcept {
+      using Tag = tmpl::type_from<decltype(tag)>;
+      CHECK_ITERABLE_APPROX(get<Tag>(dest_vars), get<Tag>(expected_dest_vars));
+    });
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
+                  "[Unit][NumericalAlgorithms]") {
+  const size_t start_points = 4;
+  const size_t end_points = 6;
+  for (size_t n0 = start_points; n0 < end_points; ++n0) {
+    test_interpolate_to_points<1>(Index<1>(n0));
+    for (size_t n1 = start_points; n1 < end_points; ++n1) {
+      test_interpolate_to_points<2>(Index<2>(n0, n1));
+      for (size_t n2 = start_points; n2 < end_points; ++n2) {
+        test_interpolate_to_points<3>(Index<3>(n0, n1, n2));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add a function that interpolates a Variables onto an arbitrary set of points.  Actually two functions: one that takes the target points and produces a matrix for interpolation, and another function that takes this matrix and a Variables and does the interpolation.

This will be used for horizon finding (interpolation onto Strahlkorper points), wave extraction (interpolation onto a world tube or onto an extraction surface), and possibly visualization.

UPDATE: Instead of two functions, this is now a class.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
