### PR TITLE
Test Pointwise GR functions Pypp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,6 +151,7 @@ before_install:
       export CHARM_VERSION=6.8.0;
       export BLAZE_VERSION=3.2;
       export HDF5_VERSION=1.8.17;
+      export NUMPY_VERSION=1.14;
       export SPECTRE_MIN_MACOS=-mmacosx-version-min=10.11;
       cd $HOME;
       rm  /usr/local/include/c++;
@@ -161,6 +162,18 @@ before_install:
       brew install gsl;
 
       brew install hdf5;
+
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+      chmod +x miniconda.sh;
+      ./miniconda.sh -b -p /Users/travis/mc;
+      export PATH=/Users/travis/mc/bin:$PATH;
+
+      conda info;
+      conda update --yes conda;
+      conda create -n osx_env --yes python=$TRAVIS_PYTHON_VERSION;
+      source activate osx_env;
+
+      conda install -y numpy=$NUMPY_VERSION;
 
       ccache -z;
       git clone https://github.com/hfp/libxsmm.git;

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -30,6 +30,8 @@ installation_on_clusters "Installation on clusters" page.
 * [yaml-cpp](https://github.com/jbeder/yaml-cpp) built from a commit more
   recent than November 2016 (versions newer than 0.5.3 should work once any
   are released)
+* [Python](https://www.python.org/) 2.7, or 3.5 or later
+* [NumPy](http://www.numpy.org/) 1.10 or later
 
 #### Optional:
 * [Doxygen](http://www.stack.nl/~dimitri/doxygen/index.html) — to generate

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTests.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTests.py
@@ -137,3 +137,16 @@ def ricci_tensor(christoffel, deriv_christoffel):
 
 
 # End tests for Test_Ricci.cpp
+
+# Begin tests for Test_IndexManipulation.cpp
+
+
+def raise_or_lower_first_index(tensor, metric):
+    return np.einsum("ij,ikl", metric, tensor)
+
+
+def trace_last_indices(tensor, metric):
+    return np.einsum("ij,kij", metric, tensor)
+
+
+# Endtests for Test_IndexManipulation.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTests.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTests.py
@@ -97,3 +97,31 @@ def extrinsic_curvature(lapse, shift, deriv_shift, spatial_metric,
 
 
 # End tests for Test_ComputeSpacetimeQuantities.cpp
+
+# Begin tests for Test_ComputeGhQuantities.cpp
+
+
+def gh_pi(lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric,
+          phi):
+    return (np.einsum("iab,i", phi, shift) - dt_spacetime_metric(
+        lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric)
+            ) / lapse
+
+
+def gh_gauge_source(lapse, dt_lapse, deriv_lapse, shift, dt_shift, deriv_shift,
+                    spatial_metric, tr_extrinsic_curvature,
+                    trace_christoffel_last_indices):
+    dim = shift.size
+    source = np.zeros(dim + 1)
+    shift_dot_d_shift = np.einsum("k,ki", shift, deriv_shift)
+    inv_lapse = 1. / lapse
+    source[1:] = inv_lapse ** 2 * np.einsum("ij,j", spatial_metric,
+                                            dt_shift - shift_dot_d_shift) \
+                 + deriv_lapse / lapse - trace_christoffel_last_indices
+    source[0] = - dt_lapse * inv_lapse \
+                + inv_lapse * np.dot(shift, deriv_lapse) \
+                + np.dot(shift, source[1:]) - lapse * tr_extrinsic_curvature
+    return source
+
+
+# End tests for Test_ComputeGhQuantities.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTests.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTests.py
@@ -8,3 +8,92 @@ def christoffel_first_kind(d_metric):
     dim = d_metric.shape[0]
     return 0.5 * np.array([[[d_metric[b, c, a] + d_metric[a, c, b] - d_metric[
         c, a, b] for b in range(dim)] for a in range(dim)] for c in range(dim)])
+
+
+def dt_spacetime_metric(lapse, dt_lapse, shift, dt_shift, spatial_metric,
+                        dt_spatial_metric):
+    dim = shift.size
+    dt_psi = np.zeros([dim + 1, dim + 1])
+    dt_psi[0, 0] = - 2 * lapse * dt_lapse \
+                   + 2 * np.einsum("mn,m,n", spatial_metric, shift, dt_shift) \
+                   + np.einsum("m,n,mn", shift, shift, dt_spatial_metric)
+    dt_psi[1:, 0] = np.einsum("mi,m", spatial_metric, dt_shift) \
+                    + np.einsum("m,mi", shift, dt_spatial_metric)
+    dt_psi[1:, 1:] = dt_spatial_metric
+    dt_psi[0, 1:] = dt_psi[1:, 0]  # Symmetrise
+    return dt_psi
+
+
+def spatial_deriv_spacetime_metric(lapse, deriv_lapse, shift, deriv_shift,
+                                   spatial_metric, deriv_spatial_metric):
+    dim = shift.size
+    deriv_psi = np.zeros([dim, dim + 1, dim + 1])
+    deriv_psi[:, 0, 0] = - 2. * lapse * deriv_lapse \
+                         + 2. * np.einsum("mn,m,kn->k",
+                                          spatial_metric, shift, deriv_shift) \
+                         + np.einsum("m,n,kmn->k",
+                                     shift, shift, deriv_spatial_metric)
+    deriv_psi[:, 1:, 0] = np.einsum("mi,km->ki", spatial_metric, deriv_shift) \
+                          + np.einsum("m,kmi->ki", shift, deriv_spatial_metric)
+    deriv_psi[:, 1:, 1:] = deriv_spatial_metric
+    deriv_psi[:, 0, 1:] = deriv_psi[:, 1:, 0]  # Symmetrise
+    return deriv_psi
+
+
+# Begin tests for Test_ComputeSpacetimeQuantities.cpp
+
+
+def spacetime_metric(lapse, shift, spatial_metric):
+    dim = shift.size
+    psi = np.zeros([dim + 1, dim + 1])
+    psi[0, 0] = -lapse**2 + np.einsum("m,n,mn", shift, shift, spatial_metric)
+    psi[1:, 0] = np.einsum("mi,m->i", spatial_metric, shift)
+    psi[0, 1:] = psi[1:, 0]
+    psi[1:, 1:] = spatial_metric
+    return psi
+
+
+def inverse_spacetime_metric(lapse, shift, inverse_spatial_metric):
+    dim = shift.size
+    inv_psi = np.zeros([dim + 1, dim + 1])
+    inv_psi[0, 0] = -1. / lapse**2
+    inv_psi[1:, 0] = shift / lapse**2
+    inv_psi[0, 1:] = inv_psi[1:, 0]
+    inv_psi[1:,
+            1:] = inverse_spatial_metric - np.outer(shift, shift) / lapse**2
+    return inv_psi
+
+
+def derivatives_of_spacetime_metric(lapse, dt_lapse, deriv_lapse, shift,
+                                    dt_shift, deriv_shift, spatial_metric,
+                                    dt_spatial_metric, deriv_spatial_metric):
+    dim = shift.size
+    d4_psi = np.zeros([dim + 1, dim + 1, dim + 1])
+    # Spatial derivatives
+    d4_psi[0, :, :] = dt_spacetime_metric(lapse, dt_lapse, shift, dt_shift,
+                                          spatial_metric, dt_spatial_metric)
+    d4_psi[1:, :, :] = spatial_deriv_spacetime_metric(
+        lapse, deriv_lapse, shift, deriv_shift, spatial_metric,
+        deriv_spatial_metric)
+    return d4_psi
+
+
+def spacetime_normal_vector(lapse, shift):
+    dim = shift.size
+    vector = np.zeros([dim + 1])
+    vector[0] = 1. / lapse
+    vector[1:] = -shift / lapse
+    return vector
+
+
+def extrinsic_curvature(lapse, shift, deriv_shift, spatial_metric,
+                        dt_spatial_metric, deriv_spatial_metric):
+    ext_curve = np.einsum("k,kij", shift, deriv_spatial_metric) \
+                + np.einsum("ki,jk", spatial_metric, deriv_shift) \
+                + np.einsum("kj,ik", spatial_metric, deriv_shift) \
+                - dt_spatial_metric
+    ext_curve *= 0.5 / lapse
+    return ext_curve
+
+
+# End tests for Test_ComputeSpacetimeQuantities.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTests.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTests.py
@@ -125,3 +125,15 @@ def gh_gauge_source(lapse, dt_lapse, deriv_lapse, shift, dt_shift, deriv_shift,
 
 
 # End tests for Test_ComputeGhQuantities.cpp
+
+# Begin tests for Test_Ricci.cpp
+
+
+def ricci_tensor(christoffel, deriv_christoffel):
+    return (np.einsum("ccab", deriv_christoffel) - 0.5 * (np.einsum(
+        "bcac", deriv_christoffel) + np.einsum("acbc", deriv_christoffel)) +
+            np.einsum("dab,ccd", christoffel, christoffel) -
+            np.einsum("dac,cbd", christoffel, christoffel))
+
+
+# End tests for Test_Ricci.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -11,252 +11,28 @@
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "Utilities/Gsl.hpp"
-#include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
 namespace {
-void test_compute_1d_phi(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const auto phi = GeneralizedHarmonic::phi(
-      make_lapse(0.), make_deriv_lapse<dim>(0.), make_shift<dim>(0.),
-      make_deriv_shift<dim>(0.), make_spatial_metric<dim>(0.),
-      make_deriv_spatial_metric<dim>(0.));
-
-  CHECK(phi.get(0, 0, 0) == approx(2.0));
-  CHECK(phi.get(0, 0, 1) == approx(10.0));
-  CHECK(phi.get(0, 1, 1) == approx(3.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      GeneralizedHarmonic::phi(
-          make_lapse(used_for_size), make_deriv_lapse<dim>(used_for_size),
-          make_shift<dim>(used_for_size), make_deriv_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_deriv_spatial_metric<dim>(used_for_size)),
-      phi);
+template <size_t Dim, typename DataType>
+void test_compute_phi(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &GeneralizedHarmonic::phi<Dim, Frame::Inertial, DataType>, "GrTests",
+      "spatial_deriv_spacetime_metric", {{{-10., 10.}}}, used_for_size);
 }
-
-void test_compute_2d_phi(const DataVector& used_for_size) {
-  const size_t dim = 2;
-  const auto phi = GeneralizedHarmonic::phi(
-      make_lapse(0.), make_deriv_lapse<dim>(0.), make_shift<dim>(0.),
-      make_deriv_shift<dim>(0.), make_spatial_metric<dim>(0.),
-      make_deriv_spatial_metric<dim>(0.));
-
-  CHECK(phi.get(0, 0, 0) == approx(330.0));
-  CHECK(phi.get(0, 0, 1) == approx(42.0));
-  CHECK(phi.get(0, 0, 2) == approx(84.0));
-  CHECK(phi.get(0, 1, 1) == approx(3.0));
-  CHECK(phi.get(0, 1, 2) == approx(6.0));
-  CHECK(phi.get(0, 2, 2) == approx(12.0));
-  CHECK(phi.get(1, 0, 0) == approx(294.0));
-  CHECK(phi.get(1, 0, 1) == approx(42.0));
-  CHECK(phi.get(1, 0, 2) == approx(81.0));
-  CHECK(phi.get(1, 1, 1) == approx(4.0));
-  CHECK(phi.get(1, 1, 2) == approx(7.0));
-  CHECK(phi.get(1, 2, 2) == approx(13.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      GeneralizedHarmonic::phi(
-          make_lapse(used_for_size), make_deriv_lapse<dim>(used_for_size),
-          make_shift<dim>(used_for_size), make_deriv_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_deriv_spatial_metric<dim>(used_for_size)),
-      phi);
+template <size_t Dim, typename DataType>
+void test_compute_pi(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &GeneralizedHarmonic::pi<Dim, Frame::Inertial, DataType>, "GrTests",
+      "gh_pi", {{{-10., 10.}}}, used_for_size);
 }
-
-void test_compute_3d_phi(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const auto phi = GeneralizedHarmonic::phi(
-      make_lapse(0.), make_deriv_lapse<dim>(0.), make_shift<dim>(0.),
-      make_deriv_shift<dim>(0.), make_spatial_metric<dim>(0.),
-      make_deriv_spatial_metric<dim>(0.));
-
-  CHECK(phi.get(0, 0, 0) == approx(2421.0));
-  CHECK(phi.get(0, 0, 1) == approx(108.0));
-  CHECK(phi.get(0, 0, 2) == approx(216.0));
-  CHECK(phi.get(0, 0, 3) == approx(324.0));
-  CHECK(phi.get(0, 1, 1) == approx(3.0));
-  CHECK(phi.get(0, 1, 2) == approx(6.0));
-  CHECK(phi.get(0, 1, 3) == approx(9.0));
-  CHECK(phi.get(0, 2, 2) == approx(12.0));
-  CHECK(phi.get(0, 2, 3) == approx(18.0));
-  CHECK(phi.get(0, 3, 3) == approx(27.0));
-  CHECK(phi.get(1, 0, 0) == approx(2274.0));
-  CHECK(phi.get(1, 0, 1) == approx(108.0));
-  CHECK(phi.get(1, 0, 2) == approx(210.0));
-  CHECK(phi.get(1, 0, 3) == approx(312.0));
-  CHECK(phi.get(1, 1, 1) == approx(4.0));
-  CHECK(phi.get(1, 1, 2) == approx(7.0));
-  CHECK(phi.get(1, 1, 3) == approx(10.0));
-  CHECK(phi.get(1, 2, 2) == approx(13.0));
-  CHECK(phi.get(1, 2, 3) == approx(19.0));
-  CHECK(phi.get(1, 3, 3) == approx(28.0));
-  CHECK(phi.get(2, 0, 0) == approx(2127.0));
-  CHECK(phi.get(2, 0, 1) == approx(108.0));
-  CHECK(phi.get(2, 0, 2) == approx(204.0));
-  CHECK(phi.get(2, 0, 3) == approx(300.0));
-  CHECK(phi.get(2, 1, 1) == approx(5.0));
-  CHECK(phi.get(2, 1, 2) == approx(8.0));
-  CHECK(phi.get(2, 1, 3) == approx(11.0));
-  CHECK(phi.get(2, 2, 2) == approx(14.0));
-  CHECK(phi.get(2, 2, 3) == approx(20.0));
-  CHECK(phi.get(2, 3, 3) == approx(29.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      GeneralizedHarmonic::phi(
-          make_lapse(used_for_size), make_deriv_lapse<dim>(used_for_size),
-          make_shift<dim>(used_for_size), make_deriv_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_deriv_spatial_metric<dim>(used_for_size)),
-      phi);
-}
-
-void test_compute_1d_pi(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const auto pi = GeneralizedHarmonic::pi(
-      make_lapse(0.), make_dt_lapse(0.), make_shift<dim>(0.),
-      make_dt_shift<dim>(0.), make_spatial_metric<dim>(0.),
-      make_dt_spatial_metric<dim>(0.),
-      make_spatial_deriv_spacetime_metric<dim>(0.));
-
-  CHECK(pi.get(0, 0) == approx(31. / 3.));
-  CHECK(pi.get(0, 1) == approx(5. / 3.));
-  CHECK(pi.get(1, 1) == approx(4.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      GeneralizedHarmonic::pi(
-          make_lapse(used_for_size), make_dt_lapse(used_for_size),
-          make_shift<dim>(used_for_size), make_dt_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_dt_spatial_metric<dim>(used_for_size),
-          make_spatial_deriv_spacetime_metric<dim>(used_for_size)),
-      pi);
-}
-
-void test_compute_2d_pi(const DataVector& used_for_size) {
-  const size_t dim = 2;
-  const auto pi = GeneralizedHarmonic::pi(
-      make_lapse(0.), make_dt_lapse(0.), make_shift<dim>(0.),
-      make_dt_shift<dim>(0.), make_spatial_metric<dim>(0.),
-      make_dt_spatial_metric<dim>(0.),
-      make_spatial_deriv_spacetime_metric<dim>(0.));
-
-  CHECK(pi.get(0, 0) == approx(-71. / 3.));
-  CHECK(pi.get(0, 1) == approx(10. / 3.));
-  CHECK(pi.get(0, 2) == approx(8. / 3.));
-  CHECK(pi.get(1, 1) == approx(44. / 3.));
-  CHECK(pi.get(1, 2) == approx(65. / 3.));
-  CHECK(pi.get(2, 2) == approx(97. / 3.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      GeneralizedHarmonic::pi(
-          make_lapse(used_for_size), make_dt_lapse(used_for_size),
-          make_shift<dim>(used_for_size), make_dt_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_dt_spatial_metric<dim>(used_for_size),
-          make_spatial_deriv_spacetime_metric<dim>(used_for_size)),
-      pi);
-}
-
-void test_compute_3d_pi(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const auto pi = GeneralizedHarmonic::pi(
-      make_lapse(0.), make_dt_lapse(0.), make_shift<dim>(0.),
-      make_dt_shift<dim>(0.), make_spatial_metric<dim>(0.),
-      make_dt_spatial_metric<dim>(0.),
-      make_spatial_deriv_spacetime_metric<dim>(0.));
-
-  CHECK(pi.get(0, 0) == approx(-1216. / 3.));
-  CHECK(pi.get(0, 1) == approx(2. / 3.));
-  CHECK(pi.get(0, 2) == approx(-20. / 3.));
-  CHECK(pi.get(0, 3) == approx(-14.0));
-  CHECK(pi.get(1, 1) == approx(104. / 3.));
-  CHECK(pi.get(1, 2) == approx(155. / 3.));
-  CHECK(pi.get(1, 3) == approx(206. / 3.));
-  CHECK(pi.get(2, 2) == approx(232. / 3.));
-  CHECK(pi.get(2, 3) == approx(103.0));
-  CHECK(pi.get(3, 3) == approx(412. / 3.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      GeneralizedHarmonic::pi(
-          make_lapse(used_for_size), make_dt_lapse(used_for_size),
-          make_shift<dim>(used_for_size), make_dt_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_dt_spatial_metric<dim>(used_for_size),
-          make_spatial_deriv_spacetime_metric<dim>(used_for_size)),
-      pi);
-}
-
-void test_compute_1d_gauge_source(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const auto gauge_source = GeneralizedHarmonic::gauge_source(
-      make_lapse(0.), make_dt_lapse(0.), make_deriv_lapse<dim>(0.),
-      make_shift<dim>(0.), make_dt_shift<dim>(0.), make_deriv_shift<dim>(0.),
-      make_spatial_metric<dim>(0.), make_trace_extrinsic_curvature(0.),
-      make_trace_spatial_christoffel_first_kind<dim>(0.));
-
-  CHECK(gauge_source.get(0) == approx(-41. / 3.));
-  CHECK(gauge_source.get(1) == approx(13. / 6.));
-
-  check_tensor_doubles_approx_equals_tensor_datavectors(
-      GeneralizedHarmonic::gauge_source(
-          make_lapse(used_for_size), make_dt_lapse(used_for_size),
-          make_deriv_lapse<dim>(used_for_size), make_shift<dim>(used_for_size),
-          make_dt_shift<dim>(used_for_size),
-          make_deriv_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_trace_extrinsic_curvature(used_for_size),
-          make_trace_spatial_christoffel_first_kind<dim>(used_for_size)),
-      gauge_source);
-}
-
-void test_compute_2d_gauge_source(const DataVector& used_for_size) {
-  const size_t dim = 2;
-  const auto gauge_source = GeneralizedHarmonic::gauge_source(
-      make_lapse(0.), make_dt_lapse(0.), make_deriv_lapse<dim>(0.),
-      make_shift<dim>(0.), make_dt_shift<dim>(0.), make_deriv_shift<dim>(0.),
-      make_spatial_metric<dim>(0.), make_trace_extrinsic_curvature(0.),
-      make_trace_spatial_christoffel_first_kind<dim>(0.));
-
-  CHECK(gauge_source.get(0) == approx(-400. / 9.));
-  CHECK(gauge_source.get(1) == approx(-395. / 90.));
-  CHECK(gauge_source.get(2) == approx(-124. / 9.));
-
-  check_tensor_doubles_approx_equals_tensor_datavectors(
-      GeneralizedHarmonic::gauge_source(
-          make_lapse(used_for_size), make_dt_lapse(used_for_size),
-          make_deriv_lapse<dim>(used_for_size), make_shift<dim>(used_for_size),
-          make_dt_shift<dim>(used_for_size),
-          make_deriv_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_trace_extrinsic_curvature(used_for_size),
-          make_trace_spatial_christoffel_first_kind<dim>(used_for_size)),
-      gauge_source);
-}
-
-void test_compute_3d_gauge_source(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const auto gauge_source = GeneralizedHarmonic::gauge_source(
-      make_lapse(0.), make_dt_lapse(0.), make_deriv_lapse<dim>(0.),
-      make_shift<dim>(0.), make_dt_shift<dim>(0.), make_deriv_shift<dim>(0.),
-      make_spatial_metric<dim>(0.), make_trace_extrinsic_curvature(0.),
-      make_trace_spatial_christoffel_first_kind<dim>(0.));
-
-  CHECK(gauge_source.get(0) == approx(-1444. / 3.));
-  CHECK(gauge_source.get(1) == approx(-187. / 6.));
-  CHECK(gauge_source.get(2) == approx(-202. / 3.));
-  CHECK(gauge_source.get(3) == approx(-207. / 2.));
-
-  check_tensor_doubles_approx_equals_tensor_datavectors(
-      GeneralizedHarmonic::gauge_source(
-          make_lapse(used_for_size), make_dt_lapse(used_for_size),
-          make_deriv_lapse<dim>(used_for_size), make_shift<dim>(used_for_size),
-          make_dt_shift<dim>(used_for_size),
-          make_deriv_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_trace_extrinsic_curvature(used_for_size),
-          make_trace_spatial_christoffel_first_kind<dim>(used_for_size)),
-      gauge_source);
+template <size_t Dim, typename DataType>
+void test_compute_gauge_source(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &GeneralizedHarmonic::gauge_source<Dim, Frame::Inertial, DataType>,
+      "GrTests", "gh_gauge_source", {{{-10., 10.}}}, used_for_size);
 }
 
 template <size_t Dim, typename T>
@@ -329,20 +105,13 @@ void test_compute_extrinsic_curvature_and_deriv_metric(const T& used_for_size) {
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.GhQuantities",
                   "[PointwiseFunctions][Unit]") {
-  const DataVector dv(2);
-  test_compute_1d_phi(dv);
-  test_compute_2d_phi(dv);
-  test_compute_3d_phi(dv);
-  test_compute_1d_pi(dv);
-  test_compute_2d_pi(dv);
-  test_compute_3d_pi(dv);
-  test_compute_1d_gauge_source(dv);
-  test_compute_2d_gauge_source(dv);
-  test_compute_3d_gauge_source(dv);
-  test_compute_extrinsic_curvature_and_deriv_metric<1>(0.);
-  test_compute_extrinsic_curvature_and_deriv_metric<2>(0.);
-  test_compute_extrinsic_curvature_and_deriv_metric<3>(0.);
-  test_compute_extrinsic_curvature_and_deriv_metric<1>(dv);
-  test_compute_extrinsic_curvature_and_deriv_metric<2>(dv);
-  test_compute_extrinsic_curvature_and_deriv_metric<3>(dv);
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_phi, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_pi, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_gauge_source, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(
+      test_compute_extrinsic_curvature_and_deriv_metric, (1, 2, 3));
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -11,377 +11,61 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "Utilities/Gsl.hpp"
-#include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
 namespace {
-void test_compute_1d_spacetime_metric(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const auto psi = gr::spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
-                                        make_spatial_metric<dim>(0.));
-
-  CHECK(psi.get(0, 0) == approx(-8.0));
-  CHECK(psi.get(0, 1) == approx(1.0));
-  CHECK(psi.get(1, 1) == approx(1.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::spacetime_metric(make_lapse(used_for_size),
-                           make_shift<dim>(used_for_size),
-                           make_spatial_metric<dim>(used_for_size)),
-      psi);
+template <size_t Dim, typename DataType>
+void test_compute_spacetime_metric(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &gr::spacetime_metric<Dim, Frame::Inertial, DataType>, "GrTests",
+      "spacetime_metric", {{{-10., 10.}}}, used_for_size);
 }
-
-void test_compute_2d_spacetime_metric(const DataVector& used_for_size) {
-  const size_t dim = 2;
-  const auto psi = gr::spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
-                                        make_spatial_metric<dim>(0.));
-
-  CHECK(psi.get(0, 0) == approx(16.0));
-  CHECK(psi.get(0, 1) == approx(5.0));
-  CHECK(psi.get(0, 2) == approx(10.0));
-  CHECK(psi.get(1, 1) == approx(1.0));
-  CHECK(psi.get(1, 2) == approx(2.0));
-  CHECK(psi.get(2, 2) == approx(4.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::spacetime_metric(make_lapse(used_for_size),
-                           make_shift<dim>(used_for_size),
-                           make_spatial_metric<dim>(used_for_size)),
-      psi);
+template <size_t Dim, typename DataType>
+void test_compute_inverse_spacetime_metric(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &gr::inverse_spacetime_metric<Dim, Frame::Inertial, DataType>, "GrTests",
+      "inverse_spacetime_metric", {{{-10., 10.}}}, used_for_size);
 }
-
-void test_compute_3d_spacetime_metric(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const auto psi = gr::spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
-                                        make_spatial_metric<dim>(0.));
-
-  CHECK(psi.get(0, 0) == approx(187.0));
-  CHECK(psi.get(0, 1) == approx(14.0));
-  CHECK(psi.get(0, 2) == approx(28.0));
-  CHECK(psi.get(0, 3) == approx(42.0));
-  CHECK(psi.get(1, 1) == approx(1.0));
-  CHECK(psi.get(1, 2) == approx(2.0));
-  CHECK(psi.get(1, 3) == approx(3.0));
-  CHECK(psi.get(2, 2) == approx(4.0));
-  CHECK(psi.get(2, 3) == approx(6.0));
-  CHECK(psi.get(3, 3) == approx(9.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::spacetime_metric(make_lapse(used_for_size),
-                           make_shift<dim>(used_for_size),
-                           make_spatial_metric<dim>(used_for_size)),
-      psi);
+template <size_t Dim, typename DataType>
+void test_compute_derivatives_of_spacetime_metric(
+    const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &gr::derivatives_of_spacetime_metric<Dim, Frame::Inertial, DataType>,
+      "GrTests", "derivatives_of_spacetime_metric", {{{-10., 10.}}},
+      used_for_size);
 }
-
-void test_compute_1d_inverse_spacetime_metric(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const auto inverse_spacetime_metric =
-      gr::inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
-                                   make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(inverse_spacetime_metric.get(0, 0) == approx(-1. / 9.));
-  CHECK(inverse_spacetime_metric.get(0, 1) == approx(1. / 9.));
-  CHECK(inverse_spacetime_metric.get(1, 1) == approx(8. / 9.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::inverse_spacetime_metric(
-          make_lapse(used_for_size), make_shift<dim>(used_for_size),
-          make_inverse_spatial_metric<dim>(used_for_size)),
-      inverse_spacetime_metric);
+template <size_t Dim, typename DataType>
+void test_compute_spacetime_normal_vector(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &gr::spacetime_normal_vector<Dim, Frame::Inertial, DataType>, "GrTests",
+      "spacetime_normal_vector", {{{-10., 10.}}}, used_for_size);
 }
+template <size_t Dim, typename DataType>
+void test_compute_spacetime_normal_one_form(const DataType& used_for_size) {
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed = " << seed);
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+  const auto lapse = make_with_random_values<Scalar<DataType>>(
+      make_not_null(&generator), make_not_null(&distribution), used_for_size);
 
-void test_compute_2d_inverse_spacetime_metric(const DataVector& used_for_size) {
-  const size_t dim = 2;
-  const auto inverse_spacetime_metric =
-      gr::inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
-                                   make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(inverse_spacetime_metric.get(0, 0) == approx(-1. / 9.));
-  CHECK(inverse_spacetime_metric.get(0, 1) == approx(1. / 9.));
-  CHECK(inverse_spacetime_metric.get(0, 2) == approx(2. / 9.));
-  CHECK(inverse_spacetime_metric.get(1, 1) == approx(8. / 9.));
-  CHECK(inverse_spacetime_metric.get(1, 2) == approx(16. / 9.));
-  CHECK(inverse_spacetime_metric.get(2, 2) == approx(32. / 9.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::inverse_spacetime_metric(
-          make_lapse(used_for_size), make_shift<dim>(used_for_size),
-          make_inverse_spatial_metric<dim>(used_for_size)),
-      inverse_spacetime_metric);
-}
-
-void test_compute_3d_inverse_spacetime_metric(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const auto inverse_spacetime_metric =
-      gr::inverse_spacetime_metric(make_lapse(0.), make_shift<dim>(0.),
-                                   make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(inverse_spacetime_metric.get(0, 0) == approx(-1. / 9.));
-  CHECK(inverse_spacetime_metric.get(0, 1) == approx(1. / 9.));
-  CHECK(inverse_spacetime_metric.get(0, 2) == approx(2. / 9.));
-  CHECK(inverse_spacetime_metric.get(0, 3) == approx(3. / 9.));
-  CHECK(inverse_spacetime_metric.get(1, 1) == approx(8. / 9.));
-  CHECK(inverse_spacetime_metric.get(1, 2) == approx(16. / 9.));
-  CHECK(inverse_spacetime_metric.get(1, 3) == approx(24. / 9.));
-  CHECK(inverse_spacetime_metric.get(2, 2) == approx(32. / 9.));
-  CHECK(inverse_spacetime_metric.get(2, 3) == approx(48. / 9.));
-  CHECK(inverse_spacetime_metric.get(3, 3) == approx(8.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::inverse_spacetime_metric(
-          make_lapse(used_for_size), make_shift<dim>(used_for_size),
-          make_inverse_spatial_metric<dim>(used_for_size)),
-      inverse_spacetime_metric);
-}
-
-void test_compute_1d_derivatives_spacetime_metric(
-    const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const auto d_spacetime_metric = gr::derivatives_of_spacetime_metric(
-      make_lapse(0.), make_dt_lapse(0.), make_deriv_lapse<dim>(0.),
-      make_shift<dim>(0.), make_dt_shift<dim>(0.), make_deriv_shift<dim>(0.),
-      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
-      make_deriv_spatial_metric<dim>(0.));
-
-  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(-28.0));
-  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(1.0));
-  CHECK(d_spacetime_metric.get(0, 1, 1) == approx(0.0));
-  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(2.0));
-  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(10.0));
-  CHECK(d_spacetime_metric.get(1, 1, 1) == approx(3.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::derivatives_of_spacetime_metric(
-          make_lapse(used_for_size), make_dt_lapse(used_for_size),
-          make_deriv_lapse<dim>(used_for_size), make_shift<dim>(used_for_size),
-          make_dt_shift<dim>(used_for_size),
-          make_deriv_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_dt_spatial_metric<dim>(used_for_size),
-          make_deriv_spatial_metric<dim>(used_for_size)),
-      d_spacetime_metric);
-}
-
-void test_compute_2d_derivatives_spacetime_metric(
-    const DataVector& used_for_size) {
-  const size_t dim = 2;
-  const auto d_spacetime_metric = gr::derivatives_of_spacetime_metric(
-      make_lapse(0.), make_dt_lapse(0.), make_deriv_lapse<dim>(0.),
-      make_shift<dim>(0.), make_dt_shift<dim>(0.), make_deriv_shift<dim>(0.),
-      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
-      make_deriv_spatial_metric<dim>(0.));
-
-  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(82.0));
-  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(12.0));
-  CHECK(d_spacetime_metric.get(0, 0, 2) == approx(25.0));
-  CHECK(d_spacetime_metric.get(0, 1, 1) == approx(0.0));
-  CHECK(d_spacetime_metric.get(0, 1, 2) == approx(1.0));
-  CHECK(d_spacetime_metric.get(0, 2, 2) == approx(2.0));
-  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(330.0));
-  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(42.0));
-  CHECK(d_spacetime_metric.get(1, 0, 2) == approx(84.0));
-  CHECK(d_spacetime_metric.get(1, 1, 1) == approx(3.0));
-  CHECK(d_spacetime_metric.get(1, 1, 2) == approx(6.0));
-  CHECK(d_spacetime_metric.get(1, 2, 2) == approx(12.0));
-  CHECK(d_spacetime_metric.get(2, 0, 0) == approx(294.0));
-  CHECK(d_spacetime_metric.get(2, 0, 1) == approx(42.0));
-  CHECK(d_spacetime_metric.get(2, 0, 2) == approx(81.0));
-  CHECK(d_spacetime_metric.get(2, 1, 1) == approx(4.0));
-  CHECK(d_spacetime_metric.get(2, 1, 2) == approx(7.0));
-  CHECK(d_spacetime_metric.get(2, 2, 2) == approx(13.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::derivatives_of_spacetime_metric(
-          make_lapse(used_for_size), make_dt_lapse(used_for_size),
-          make_deriv_lapse<dim>(used_for_size), make_shift<dim>(used_for_size),
-          make_dt_shift<dim>(used_for_size),
-          make_deriv_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_dt_spatial_metric<dim>(used_for_size),
-          make_deriv_spatial_metric<dim>(used_for_size)),
-      d_spacetime_metric);
-}
-
-void test_compute_3d_derivatives_spacetime_metric(
-    const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const auto d_spacetime_metric = gr::derivatives_of_spacetime_metric(
-      make_lapse(0.), make_dt_lapse(0.), make_deriv_lapse<dim>(0.),
-      make_shift<dim>(0.), make_dt_shift<dim>(0.), make_deriv_shift<dim>(0.),
-      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
-      make_deriv_spatial_metric<dim>(0.));
-
-  CHECK(d_spacetime_metric.get(0, 0, 0) == approx(1242.0));
-  CHECK(d_spacetime_metric.get(0, 0, 1) == approx(50.0));
-  CHECK(d_spacetime_metric.get(0, 0, 2) == approx(98.0));
-  CHECK(d_spacetime_metric.get(0, 0, 3) == approx(146.0));
-  CHECK(d_spacetime_metric.get(0, 1, 1) == approx(0.0));
-  CHECK(d_spacetime_metric.get(0, 1, 2) == approx(1.0));
-  CHECK(d_spacetime_metric.get(0, 1, 3) == approx(2.0));
-  CHECK(d_spacetime_metric.get(0, 2, 2) == approx(2.0));
-  CHECK(d_spacetime_metric.get(0, 2, 3) == approx(3.0));
-  CHECK(d_spacetime_metric.get(0, 3, 3) == approx(4.0));
-  CHECK(d_spacetime_metric.get(1, 0, 0) == approx(2421.0));
-  CHECK(d_spacetime_metric.get(1, 0, 1) == approx(108.0));
-  CHECK(d_spacetime_metric.get(1, 0, 2) == approx(216.0));
-  CHECK(d_spacetime_metric.get(1, 0, 3) == approx(324.0));
-  CHECK(d_spacetime_metric.get(1, 1, 1) == approx(3.0));
-  CHECK(d_spacetime_metric.get(1, 1, 2) == approx(6.0));
-  CHECK(d_spacetime_metric.get(1, 1, 3) == approx(9.0));
-  CHECK(d_spacetime_metric.get(1, 2, 2) == approx(12.0));
-  CHECK(d_spacetime_metric.get(1, 2, 3) == approx(18.0));
-  CHECK(d_spacetime_metric.get(1, 3, 3) == approx(27.0));
-  CHECK(d_spacetime_metric.get(2, 0, 0) == approx(2274.0));
-  CHECK(d_spacetime_metric.get(2, 0, 1) == approx(108.0));
-  CHECK(d_spacetime_metric.get(2, 0, 2) == approx(210.0));
-  CHECK(d_spacetime_metric.get(2, 0, 3) == approx(312.0));
-  CHECK(d_spacetime_metric.get(2, 1, 1) == approx(4.0));
-  CHECK(d_spacetime_metric.get(2, 1, 2) == approx(7.0));
-  CHECK(d_spacetime_metric.get(2, 1, 3) == approx(10.0));
-  CHECK(d_spacetime_metric.get(2, 2, 2) == approx(13.0));
-  CHECK(d_spacetime_metric.get(2, 2, 3) == approx(19.0));
-  CHECK(d_spacetime_metric.get(2, 3, 3) == approx(28.0));
-  CHECK(d_spacetime_metric.get(3, 0, 0) == approx(2127.0));
-  CHECK(d_spacetime_metric.get(3, 0, 1) == approx(108.0));
-  CHECK(d_spacetime_metric.get(3, 0, 2) == approx(204.0));
-  CHECK(d_spacetime_metric.get(3, 0, 3) == approx(300.0));
-  CHECK(d_spacetime_metric.get(3, 1, 1) == approx(5.0));
-  CHECK(d_spacetime_metric.get(3, 1, 2) == approx(8.0));
-  CHECK(d_spacetime_metric.get(3, 1, 3) == approx(11.0));
-  CHECK(d_spacetime_metric.get(3, 2, 2) == approx(14.0));
-  CHECK(d_spacetime_metric.get(3, 2, 3) == approx(20.0));
-  CHECK(d_spacetime_metric.get(3, 3, 3) == approx(29.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::derivatives_of_spacetime_metric(
-          make_lapse(used_for_size), make_dt_lapse(used_for_size),
-          make_deriv_lapse<dim>(used_for_size), make_shift<dim>(used_for_size),
-          make_dt_shift<dim>(used_for_size),
-          make_deriv_shift<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size),
-          make_dt_spatial_metric<dim>(used_for_size),
-          make_deriv_spatial_metric<dim>(used_for_size)),
-      d_spacetime_metric);
-}
-
-template <size_t Dim>
-void test_compute_spacetime_normal_one_form(const DataVector& used_for_size) {
   const auto spacetime_normal_one_form =
-      gr::spacetime_normal_one_form<Dim, Frame::Inertial>(make_lapse(0.));
-
-  CHECK(spacetime_normal_one_form.get(0) == approx(-3.0));
+      gr::spacetime_normal_one_form<Dim, Frame::Inertial>(lapse);
+  CHECK_ITERABLE_APPROX(spacetime_normal_one_form.get(0), -lapse.get());
   for (size_t i = 0; i < Dim; ++i) {
-    CHECK(spacetime_normal_one_form.get(i + 1) == 0.);
+    CHECK_ITERABLE_APPROX(spacetime_normal_one_form.get(i + 1),
+                          make_with_value<DataType>(used_for_size, 0.));
   }
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::spacetime_normal_one_form<Dim, Frame::Inertial>(
-          make_lapse(used_for_size)),
-      spacetime_normal_one_form);
 }
-
-void test_compute_1d_spacetime_normal_vector(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const auto spacetime_normal_vector =
-      gr::spacetime_normal_vector(make_lapse(0.), make_shift<dim>(0.));
-
-  CHECK(spacetime_normal_vector.get(0) == approx(1. / 3.));
-  CHECK(spacetime_normal_vector.get(1) == approx(-1. / 3.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::spacetime_normal_vector(make_lapse(used_for_size),
-                                  make_shift<dim>(used_for_size)),
-      spacetime_normal_vector);
-}
-void test_compute_2d_spacetime_normal_vector(const DataVector& used_for_size) {
-  const size_t dim = 2;
-  const auto spacetime_normal_vector =
-      gr::spacetime_normal_vector(make_lapse(0.), make_shift<dim>(0.));
-
-  CHECK(spacetime_normal_vector.get(0) == approx(1. / 3.));
-  CHECK(spacetime_normal_vector.get(1) == approx(-1. / 3.));
-  CHECK(spacetime_normal_vector.get(2) == approx(-2. / 3.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::spacetime_normal_vector(make_lapse(used_for_size),
-                                  make_shift<dim>(used_for_size)),
-      spacetime_normal_vector);
-}
-void test_compute_3d_spacetime_normal_vector(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const auto spacetime_normal_vector =
-      gr::spacetime_normal_vector(make_lapse(0.), make_shift<dim>(0.));
-
-  CHECK(spacetime_normal_vector.get(0) == approx(1. / 3.));
-  CHECK(spacetime_normal_vector.get(1) == approx(-1. / 3.));
-  CHECK(spacetime_normal_vector.get(2) == approx(-2. / 3.));
-  CHECK(spacetime_normal_vector.get(3) == approx(-1.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::spacetime_normal_vector(make_lapse(used_for_size),
-                                  make_shift<dim>(used_for_size)),
-      spacetime_normal_vector);
-}
-
-void test_compute_1d_extrinsic_curvature(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const auto extrinsic_curvature = gr::extrinsic_curvature(
-      make_lapse(0.), make_shift<dim>(0.), make_deriv_shift<dim>(0.),
-      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
-      make_deriv_spatial_metric<dim>(0.));
-
-  CHECK(extrinsic_curvature.get(0, 0) == approx(17. / 6.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::extrinsic_curvature(make_lapse(used_for_size),
-                              make_shift<dim>(used_for_size),
-                              make_deriv_shift<dim>(used_for_size),
-                              make_spatial_metric<dim>(used_for_size),
-                              make_dt_spatial_metric<dim>(used_for_size),
-                              make_deriv_spatial_metric<dim>(used_for_size)),
-      extrinsic_curvature);
-}
-void test_compute_2d_extrinsic_curvature(const DataVector& used_for_size) {
-  const size_t dim = 2;
-  const auto extrinsic_curvature = gr::extrinsic_curvature(
-      make_lapse(0.), make_shift<dim>(0.), make_deriv_shift<dim>(0.),
-      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
-      make_deriv_spatial_metric<dim>(0.));
-
-  CHECK(extrinsic_curvature.get(0, 0) == approx(65. / 6.));
-  CHECK(extrinsic_curvature.get(0, 1) == approx(97. / 6.));
-  CHECK(extrinsic_curvature.get(1, 1) == approx(22.0));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::extrinsic_curvature(make_lapse(used_for_size),
-                              make_shift<dim>(used_for_size),
-                              make_deriv_shift<dim>(used_for_size),
-                              make_spatial_metric<dim>(used_for_size),
-                              make_dt_spatial_metric<dim>(used_for_size),
-                              make_deriv_spatial_metric<dim>(used_for_size)),
-      extrinsic_curvature);
-}
-void test_compute_3d_extrinsic_curvature(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const auto extrinsic_curvature = gr::extrinsic_curvature(
-      make_lapse(0.), make_shift<dim>(0.), make_deriv_shift<dim>(0.),
-      make_spatial_metric<dim>(0.), make_dt_spatial_metric<dim>(0.),
-      make_deriv_spatial_metric<dim>(0.));
-
-  CHECK(extrinsic_curvature.get(0, 0) == approx(79. / 3.));
-  CHECK(extrinsic_curvature.get(0, 1) == approx(235. / 6.));
-  CHECK(extrinsic_curvature.get(0, 2) == approx(52.0));
-  CHECK(extrinsic_curvature.get(1, 1) == approx(53.0));
-  CHECK(extrinsic_curvature.get(1, 2) == approx(2005. / 30.));
-  CHECK(extrinsic_curvature.get(2, 2) == approx(245. / 3.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      gr::extrinsic_curvature(make_lapse(used_for_size),
-                              make_shift<dim>(used_for_size),
-                              make_deriv_shift<dim>(used_for_size),
-                              make_spatial_metric<dim>(used_for_size),
-                              make_dt_spatial_metric<dim>(used_for_size),
-                              make_deriv_spatial_metric<dim>(used_for_size)),
-      extrinsic_curvature);
+template <size_t Dim, typename DataType>
+void test_compute_extrinsic_curvature(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &gr::extrinsic_curvature<Dim, Frame::Inertial, DataType>, "GrTests",
+      "extrinsic_curvature", {{{-10., 10.}}}, used_for_size);
 }
 
 template <size_t Dim, typename T>
@@ -432,29 +116,21 @@ void test_compute_spatial_metric_lapse_shift(const T& used_for_size) {
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
                   "[PointwiseFunctions][Unit]") {
-  const DataVector dv(2);
-  test_compute_1d_spacetime_metric(dv);
-  test_compute_2d_spacetime_metric(dv);
-  test_compute_3d_spacetime_metric(dv);
-  test_compute_1d_inverse_spacetime_metric(dv);
-  test_compute_2d_inverse_spacetime_metric(dv);
-  test_compute_3d_inverse_spacetime_metric(dv);
-  test_compute_1d_derivatives_spacetime_metric(dv);
-  test_compute_2d_derivatives_spacetime_metric(dv);
-  test_compute_3d_derivatives_spacetime_metric(dv);
-  test_compute_spacetime_normal_one_form<1>(dv);
-  test_compute_spacetime_normal_one_form<2>(dv);
-  test_compute_spacetime_normal_one_form<3>(dv);
-  test_compute_1d_spacetime_normal_vector(dv);
-  test_compute_2d_spacetime_normal_vector(dv);
-  test_compute_3d_spacetime_normal_vector(dv);
-  test_compute_1d_extrinsic_curvature(dv);
-  test_compute_2d_extrinsic_curvature(dv);
-  test_compute_3d_extrinsic_curvature(dv);
-  test_compute_spatial_metric_lapse_shift<1>(0.0);
-  test_compute_spatial_metric_lapse_shift<2>(0.0);
-  test_compute_spatial_metric_lapse_shift<3>(0.0);
-  test_compute_spatial_metric_lapse_shift<1>(dv);
-  test_compute_spatial_metric_lapse_shift<2>(dv);
-  test_compute_spatial_metric_lapse_shift<3>(dv);
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spacetime_metric, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_inverse_spacetime_metric,
+                                    (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(
+      test_compute_derivatives_of_spacetime_metric, (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spacetime_normal_vector,
+                                    (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spacetime_normal_one_form,
+                                    (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spatial_metric_lapse_shift,
+                                    (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_extrinsic_curvature,
+                                    (1, 2, 3));
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_IndexManipulation.cpp
@@ -8,462 +8,64 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
-#include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_include <boost/preprocessor/arithmetic/dec.hpp>
+// IWYU pragma: no_include <boost/preprocessor/repetition/enum.hpp>
+// IWYU pragma: no_include <boost/preprocessor/tuple/reverse.hpp>
 
 namespace {
-void test_1d_spatial_raise(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const tnsr::Ijj<double, dim> raised_tensor = raise_or_lower_first_index(
-      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(raised_tensor.get(0, 0, 0) == approx(3.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_first_index(
-          make_deriv_spatial_metric<dim>(used_for_size),
-          make_inverse_spatial_metric<dim>(used_for_size)),
-      raised_tensor);
-
-  const tnsr::I<double, dim> shift = raise_or_lower_index(
-      make_lower_shift<dim>(0.), make_inverse_spatial_metric<dim>(0.));
-  CHECK(get<0>(shift) == approx(1.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_index(make_lower_shift<dim>(used_for_size),
-                           make_inverse_spatial_metric<dim>(used_for_size)),
-      shift);
+template <size_t Dim, UpLo UpOrLo, IndexType Index, typename DataType>
+void test_raise_or_lower_first_index(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &raise_or_lower_first_index<
+          DataType,
+          Tensor_detail::TensorIndexType<Dim, UpOrLo, Frame::Inertial, Index>,
+          Tensor_detail::TensorIndexType<Dim, UpLo::Lo, Frame::Inertial,
+                                         Index>>,
+      "GrTests", "raise_or_lower_first_index", {{{-10., 10.}}}, used_for_size);
 }
 
-void test_1d_spatial_lower(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const tnsr::ijj<double, dim> lowered_tensor =
-      raise_or_lower_first_index(make_spatial_christoffel_second_kind<dim>(0.),
-                                 make_spatial_metric<dim>(0.));
-
-  CHECK(lowered_tensor.get(0, 0, 0) == approx(4.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_first_index(
-          make_spatial_christoffel_second_kind<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size)),
-      lowered_tensor);
-
-  const tnsr::i<double, dim> lowered_shift =
-      raise_or_lower_index(make_shift<dim>(0.), make_spatial_metric<dim>(0.));
-  CHECK(get<0>(lowered_shift) == approx(1.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_index(make_shift<dim>(used_for_size),
-                           make_spatial_metric<dim>(used_for_size)),
-      lowered_shift);
+template <size_t Dim, UpLo UpOrLo, IndexType Index, typename DataType>
+void test_raise_or_lower(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &raise_or_lower_index<DataType, Tensor_detail::TensorIndexType<
+                                          Dim, UpOrLo, Frame::Inertial, Index>>,
+      "numpy", "matmul", {{{-10., 10.}}}, used_for_size);
 }
-
-void test_2d_spatial_raise(const DataVector& used_for_size) {
-  const size_t dim = 2;
-
-  const tnsr::Ijj<double, dim> raised_tensor = raise_or_lower_first_index(
-      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(raised_tensor.get(0, 0, 0) == approx(11));
-  CHECK(raised_tensor.get(0, 0, 1) == approx(20));
-  CHECK(raised_tensor.get(0, 1, 1) == approx(38));
-  CHECK(raised_tensor.get(1, 0, 0) == approx(22));
-  CHECK(raised_tensor.get(1, 0, 1) == approx(40));
-  CHECK(raised_tensor.get(1, 1, 1) == approx(76));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_first_index(
-          make_deriv_spatial_metric<dim>(used_for_size),
-          make_inverse_spatial_metric<dim>(used_for_size)),
-      raised_tensor);
-
-  const tnsr::I<double, dim> shift = raise_or_lower_index(
-      make_lower_shift<dim>(0.), make_inverse_spatial_metric<dim>(0.));
-  CHECK(get<0>(shift) == approx(5.));
-  CHECK(get<1>(shift) == approx(10.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_index(make_lower_shift<dim>(used_for_size),
-                           make_inverse_spatial_metric<dim>(used_for_size)),
-      shift);
+template <size_t Dim, IndexType TypeOfIndex, typename DataType>
+void test_trace_last_indices(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &trace_last_indices<Dim, Frame::Inertial, TypeOfIndex, DataType>,
+      "GrTests", "trace_last_indices", {{{-10., 10.}}}, used_for_size);
 }
-
-void test_2d_spatial_lower(const DataVector& used_for_size) {
-  const size_t dim = 2;
-
-  const tnsr::ijj<double, dim> lowered_tensor =
-      raise_or_lower_first_index(make_spatial_christoffel_second_kind<dim>(0.),
-                                 make_spatial_metric<dim>(0.));
-
-  CHECK(lowered_tensor.get(0, 0, 0) == approx(10));
-  CHECK(lowered_tensor.get(0, 0, 1) == approx(22));
-  CHECK(lowered_tensor.get(0, 1, 1) == approx(46));
-  CHECK(lowered_tensor.get(1, 0, 0) == approx(20));
-  CHECK(lowered_tensor.get(1, 0, 1) == approx(44));
-  CHECK(lowered_tensor.get(1, 1, 1) == approx(92));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_first_index(
-          make_spatial_christoffel_second_kind<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size)),
-      lowered_tensor);
-
-  const tnsr::i<double, dim> lowered_shift =
-      raise_or_lower_index(make_shift<dim>(0.), make_spatial_metric<dim>(0.));
-  CHECK(get<0>(lowered_shift) == approx(5.));
-  CHECK(get<1>(lowered_shift) == approx(10.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_index(make_shift<dim>(used_for_size),
-                           make_spatial_metric<dim>(used_for_size)),
-      lowered_shift);
-}
-
-void test_3d_spatial_raise(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const tnsr::Ijj<double, dim> raised_tensor = raise_or_lower_first_index(
-      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(raised_tensor.get(0, 0, 0) == approx(26));
-  CHECK(raised_tensor.get(0, 0, 1) == approx(44));
-  CHECK(raised_tensor.get(0, 0, 2) == approx(62));
-  CHECK(raised_tensor.get(0, 1, 1) == approx(80));
-  CHECK(raised_tensor.get(0, 1, 2) == approx(116));
-  CHECK(raised_tensor.get(0, 2, 2) == approx(170));
-  CHECK(raised_tensor.get(1, 0, 0) == approx(52));
-  CHECK(raised_tensor.get(1, 0, 1) == approx(88));
-  CHECK(raised_tensor.get(1, 0, 2) == approx(124));
-  CHECK(raised_tensor.get(1, 1, 1) == approx(160));
-  CHECK(raised_tensor.get(1, 1, 2) == approx(232));
-  CHECK(raised_tensor.get(1, 2, 2) == approx(340));
-  CHECK(raised_tensor.get(2, 0, 0) == approx(78));
-  CHECK(raised_tensor.get(2, 0, 1) == approx(132));
-  CHECK(raised_tensor.get(2, 0, 2) == approx(186));
-  CHECK(raised_tensor.get(2, 1, 1) == approx(240));
-  CHECK(raised_tensor.get(2, 1, 2) == approx(348));
-  CHECK(raised_tensor.get(2, 2, 2) == approx(510));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_first_index(
-          make_deriv_spatial_metric<dim>(used_for_size),
-          make_inverse_spatial_metric<dim>(used_for_size)),
-      raised_tensor);
-
-  const tnsr::I<double, dim> shift = raise_or_lower_index(
-      make_lower_shift<dim>(0.), make_inverse_spatial_metric<dim>(0.));
-  CHECK(get<0>(shift) == approx(14.));
-  CHECK(get<1>(shift) == approx(28.));
-  CHECK(get<2>(shift) == approx(42.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_index(make_lower_shift<dim>(used_for_size),
-                           make_inverse_spatial_metric<dim>(used_for_size)),
-      shift);
-}
-
-void test_3d_spatial_lower(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const tnsr::ijj<double, dim> lowered_tensor =
-      raise_or_lower_first_index(make_spatial_christoffel_second_kind<dim>(0.),
-                                 make_spatial_metric<dim>(0.));
-
-  CHECK(lowered_tensor.get(0, 0, 0) == approx(16));
-  CHECK(lowered_tensor.get(0, 0, 1) == approx(40));
-  CHECK(lowered_tensor.get(0, 0, 2) == approx(64));
-  CHECK(lowered_tensor.get(0, 1, 1) == approx(88));
-  CHECK(lowered_tensor.get(0, 1, 2) == approx(136));
-  CHECK(lowered_tensor.get(0, 2, 2) == approx(208));
-  CHECK(lowered_tensor.get(1, 0, 0) == approx(32));
-  CHECK(lowered_tensor.get(1, 0, 1) == approx(80));
-  CHECK(lowered_tensor.get(1, 0, 2) == approx(128));
-  CHECK(lowered_tensor.get(1, 1, 1) == approx(176));
-  CHECK(lowered_tensor.get(1, 1, 2) == approx(272));
-  CHECK(lowered_tensor.get(1, 2, 2) == approx(416));
-  CHECK(lowered_tensor.get(2, 0, 0) == approx(48));
-  CHECK(lowered_tensor.get(2, 0, 1) == approx(120));
-  CHECK(lowered_tensor.get(2, 0, 2) == approx(192));
-  CHECK(lowered_tensor.get(2, 1, 1) == approx(264));
-  CHECK(lowered_tensor.get(2, 1, 2) == approx(408));
-  CHECK(lowered_tensor.get(2, 2, 2) == approx(624));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_first_index(
-          make_spatial_christoffel_second_kind<dim>(used_for_size),
-          make_spatial_metric<dim>(used_for_size)),
-      lowered_tensor);
-
-  const tnsr::i<double, dim> lowered_shift =
-      raise_or_lower_index(make_shift<dim>(0.), make_spatial_metric<dim>(0.));
-  CHECK(get<0>(lowered_shift) == approx(14.));
-  CHECK(get<1>(lowered_shift) == approx(28.));
-  CHECK(get<2>(lowered_shift) == approx(42.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_index(make_shift<dim>(used_for_size),
-                           make_spatial_metric<dim>(used_for_size)),
-      lowered_shift);
-}
-
-void test_3d_spacetime_raise(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const tnsr::Abb<double, dim> raised_tensor =
-      raise_or_lower_first_index(make_spacetime_deriv_spacetime_metric<dim>(0.),
-                                 make_inverse_spacetime_metric<dim>(0.));
-
-  CHECK(raised_tensor.get(0, 0, 0) == approx(-272));
-  CHECK(raised_tensor.get(0, 0, 1) == approx(-544));
-  CHECK(raised_tensor.get(0, 0, 2) == approx(-816));
-  CHECK(raised_tensor.get(0, 0, 3) == approx(-1088));
-  CHECK(raised_tensor.get(0, 1, 1) == approx(-1088));
-  CHECK(raised_tensor.get(0, 1, 2) == approx(-1632));
-  CHECK(raised_tensor.get(0, 1, 3) == approx(-2176));
-  CHECK(raised_tensor.get(0, 2, 2) == approx(-2448));
-  CHECK(raised_tensor.get(0, 2, 3) == approx(-3264));
-  CHECK(raised_tensor.get(0, 3, 3) == approx(-4352));
-  CHECK(raised_tensor.get(1, 0, 0) == approx(-408));
-  CHECK(raised_tensor.get(1, 0, 1) == approx(-816));
-  CHECK(raised_tensor.get(1, 0, 2) == approx(-1224));
-  CHECK(raised_tensor.get(1, 0, 3) == approx(-1632));
-  CHECK(raised_tensor.get(1, 1, 1) == approx(-1632));
-  CHECK(raised_tensor.get(1, 1, 2) == approx(-2448));
-  CHECK(raised_tensor.get(1, 1, 3) == approx(-3264));
-  CHECK(raised_tensor.get(1, 2, 2) == approx(-3672));
-  CHECK(raised_tensor.get(1, 2, 3) == approx(-4896));
-  CHECK(raised_tensor.get(1, 3, 3) == approx(-6528));
-  CHECK(raised_tensor.get(2, 0, 0) == approx(-544));
-  CHECK(raised_tensor.get(2, 0, 1) == approx(-1088));
-  CHECK(raised_tensor.get(2, 0, 2) == approx(-1632));
-  CHECK(raised_tensor.get(2, 0, 3) == approx(-2176));
-  CHECK(raised_tensor.get(2, 1, 1) == approx(-2176));
-  CHECK(raised_tensor.get(2, 1, 2) == approx(-3264));
-  CHECK(raised_tensor.get(2, 1, 3) == approx(-4352));
-  CHECK(raised_tensor.get(2, 2, 2) == approx(-4896));
-  CHECK(raised_tensor.get(2, 2, 3) == approx(-6528));
-  CHECK(raised_tensor.get(2, 3, 3) == approx(-8704));
-  CHECK(raised_tensor.get(3, 0, 0) == approx(-680));
-  CHECK(raised_tensor.get(3, 0, 1) == approx(-1360));
-  CHECK(raised_tensor.get(3, 0, 2) == approx(-2040));
-  CHECK(raised_tensor.get(3, 0, 3) == approx(-2720));
-  CHECK(raised_tensor.get(3, 1, 1) == approx(-2720));
-  CHECK(raised_tensor.get(3, 1, 2) == approx(-4080));
-  CHECK(raised_tensor.get(3, 1, 3) == approx(-5440));
-  CHECK(raised_tensor.get(3, 2, 2) == approx(-6120));
-  CHECK(raised_tensor.get(3, 2, 3) == approx(-8160));
-  CHECK(raised_tensor.get(3, 3, 3) == approx(-10880));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_first_index(
-          make_spacetime_deriv_spacetime_metric<dim>(used_for_size),
-          make_inverse_spacetime_metric<dim>(used_for_size)),
-      raised_tensor);
-
-  const tnsr::A<double, dim> raised_one_form = raise_or_lower_index(
-      make_dummy_one_form<dim>(0.), make_inverse_spacetime_metric<dim>(0.));
-  CHECK(get<0>(raised_one_form) == approx(-160.));
-  CHECK(get<1>(raised_one_form) == approx(-240.));
-  CHECK(get<2>(raised_one_form) == approx(-320.));
-  CHECK(get<3>(raised_one_form) == approx(-400.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_index(make_dummy_one_form<dim>(used_for_size),
-                           make_inverse_spacetime_metric<dim>(used_for_size)),
-      raised_one_form);
-}
-
-void test_3d_spacetime_lower(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const tnsr::abb<double, dim> lowered_tensor = raise_or_lower_first_index(
-      make_spacetime_christoffel_second_kind<dim>(0.),
-      make_spacetime_metric<dim>(0.));
-
-  CHECK(lowered_tensor.get(0, 0, 0) == approx(-432));
-  CHECK(lowered_tensor.get(0, 0, 1) == approx(-864));
-  CHECK(lowered_tensor.get(0, 0, 2) == approx(-1296));
-  CHECK(lowered_tensor.get(0, 0, 3) == approx(-1728));
-  CHECK(lowered_tensor.get(0, 1, 1) == approx(-1296));
-  CHECK(lowered_tensor.get(0, 1, 2) == approx(-1944));
-  CHECK(lowered_tensor.get(0, 1, 3) == approx(-2592));
-  CHECK(lowered_tensor.get(0, 2, 2) == approx(-2592));
-  CHECK(lowered_tensor.get(0, 2, 3) == approx(-3456));
-  CHECK(lowered_tensor.get(0, 3, 3) == approx(-4320));
-  CHECK(lowered_tensor.get(1, 0, 0) == approx(-648));
-  CHECK(lowered_tensor.get(1, 0, 1) == approx(-1296));
-  CHECK(lowered_tensor.get(1, 0, 2) == approx(-1944));
-  CHECK(lowered_tensor.get(1, 0, 3) == approx(-2592));
-  CHECK(lowered_tensor.get(1, 1, 1) == approx(-1944));
-  CHECK(lowered_tensor.get(1, 1, 2) == approx(-2916));
-  CHECK(lowered_tensor.get(1, 1, 3) == approx(-3888));
-  CHECK(lowered_tensor.get(1, 2, 2) == approx(-3888));
-  CHECK(lowered_tensor.get(1, 2, 3) == approx(-5184));
-  CHECK(lowered_tensor.get(1, 3, 3) == approx(-6480));
-  CHECK(lowered_tensor.get(2, 0, 0) == approx(-864));
-  CHECK(lowered_tensor.get(2, 0, 1) == approx(-1728));
-  CHECK(lowered_tensor.get(2, 0, 2) == approx(-2592));
-  CHECK(lowered_tensor.get(2, 0, 3) == approx(-3456));
-  CHECK(lowered_tensor.get(2, 1, 1) == approx(-2592));
-  CHECK(lowered_tensor.get(2, 1, 2) == approx(-3888));
-  CHECK(lowered_tensor.get(2, 1, 3) == approx(-5184));
-  CHECK(lowered_tensor.get(2, 2, 2) == approx(-5184));
-  CHECK(lowered_tensor.get(2, 2, 3) == approx(-6912));
-  CHECK(lowered_tensor.get(2, 3, 3) == approx(-8640));
-  CHECK(lowered_tensor.get(3, 0, 0) == approx(-1080));
-  CHECK(lowered_tensor.get(3, 0, 1) == approx(-2160));
-  CHECK(lowered_tensor.get(3, 0, 2) == approx(-3240));
-  CHECK(lowered_tensor.get(3, 0, 3) == approx(-4320));
-  CHECK(lowered_tensor.get(3, 1, 1) == approx(-3240));
-  CHECK(lowered_tensor.get(3, 1, 2) == approx(-4860));
-  CHECK(lowered_tensor.get(3, 1, 3) == approx(-6480));
-  CHECK(lowered_tensor.get(3, 2, 2) == approx(-6480));
-  CHECK(lowered_tensor.get(3, 2, 3) == approx(-8640));
-  CHECK(lowered_tensor.get(3, 3, 3) == approx(-10800));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_first_index(
-          make_spacetime_christoffel_second_kind<dim>(used_for_size),
-          make_spacetime_metric<dim>(used_for_size)),
-      lowered_tensor);
-
-  const tnsr::a<double, dim> lowered_vector = raise_or_lower_index(
-      make_dummy_vector<dim>(0.), make_spacetime_metric<dim>(0.));
-  CHECK(get<0>(lowered_vector) == approx(-160.));
-  CHECK(get<1>(lowered_vector) == approx(-240.));
-  CHECK(get<2>(lowered_vector) == approx(-320.));
-  CHECK(get<3>(lowered_vector) == approx(-400.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      raise_or_lower_index(make_dummy_vector<dim>(used_for_size),
-                           make_spacetime_metric<dim>(used_for_size)),
-      lowered_vector);
-}
-void test_1d_spatial_trace(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const tnsr::i<double, dim> covector = trace_last_indices(
-      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(covector.get(0) == approx(3.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      trace_last_indices(make_deriv_spatial_metric<dim>(used_for_size),
-                         make_inverse_spatial_metric<dim>(used_for_size)),
-      covector);
-}
-
-void test_2d_spatial_trace(const DataVector& used_for_size) {
-  const size_t dim = 2;
-  const tnsr::i<double, dim> covector = trace_last_indices(
-      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(covector.get(0) == approx(75));
-  CHECK(covector.get(1) == approx(84));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      trace_last_indices(make_deriv_spatial_metric<dim>(used_for_size),
-                         make_inverse_spatial_metric<dim>(used_for_size)),
-      covector);
-}
-
-void test_3d_spatial_trace(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const tnsr::i<double, dim> covector = trace_last_indices(
-      make_deriv_spatial_metric<dim>(0.), make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(covector.get(0) == approx(588));
-  CHECK(covector.get(1) == approx(624));
-  CHECK(covector.get(2) == approx(660));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      trace_last_indices(make_deriv_spatial_metric<dim>(used_for_size),
-                         make_inverse_spatial_metric<dim>(used_for_size)),
-      covector);
-}
-
-void test_3d_spacetime_trace(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const tnsr::a<double, dim> vector =
-      trace_last_indices(make_spacetime_deriv_spacetime_metric<dim>(0.),
-                         make_inverse_spacetime_metric<dim>(0.));
-
-  CHECK(vector.get(0) == approx(-9600));
-  CHECK(vector.get(1) == approx(-12800));
-  CHECK(vector.get(2) == approx(-16000));
-  CHECK(vector.get(3) == approx(-19200));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      trace_last_indices(
-          make_spacetime_deriv_spacetime_metric<dim>(used_for_size),
-          make_inverse_spacetime_metric<dim>(used_for_size)),
-      vector);
-}
-void test_1d_spatial_trace_tensor_type_aa(const DataVector& used_for_size) {
-  const size_t dim = 1;
-  const Scalar<double> scalar = trace(make_dt_spatial_metric<dim>(0.),
-                                      make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(scalar.get() == approx(0.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      trace(make_dt_spatial_metric<dim>(used_for_size),
-            make_inverse_spatial_metric<dim>(used_for_size)),
-      scalar);
-}
-
-void test_2d_spatial_trace_tensor_type_aa(const DataVector& used_for_size) {
-  const size_t dim = 2;
-  const Scalar<double> scalar = trace(make_dt_spatial_metric<dim>(0.),
-                                      make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(scalar.get() == approx(12.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      trace(make_dt_spatial_metric<dim>(used_for_size),
-            make_inverse_spatial_metric<dim>(used_for_size)),
-      scalar);
-}
-
-void test_3d_spatial_trace_tensor_type_aa(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const Scalar<double> scalar = trace(make_dt_spatial_metric<dim>(0.),
-                                      make_inverse_spatial_metric<dim>(0.));
-
-  CHECK(scalar.get() == approx(96.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      trace(make_dt_spatial_metric<dim>(used_for_size),
-            make_inverse_spatial_metric<dim>(used_for_size)),
-      scalar);
-}
-void test_3d_spacetime_trace_tensor_type_aa(const DataVector& used_for_size) {
-  const size_t dim = 3;
-  const Scalar<double> scalar = trace(make_dt_spacetime_metric<dim>(0.),
-                                      make_inverse_spacetime_metric<dim>(0.));
-
-  CHECK(scalar.get() == approx(-1548.));
-
-  check_tensor_doubles_equals_tensor_datavectors(
-      trace(make_dt_spacetime_metric<dim>(used_for_size),
-            make_inverse_spacetime_metric<dim>(used_for_size)),
-      scalar);
+template <size_t Dim, IndexType TypeOfIndex, typename DataType>
+void test_trace(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &trace<Dim, Frame::Inertial, TypeOfIndex, DataType>, "numpy", "tensordot",
+      {{{-10., 10.}}}, used_for_size);
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.IndexManipulation",
                   "[PointwiseFunctions][Unit]") {
-  const DataVector dv(2);
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
 
-  test_1d_spatial_raise(dv);
-  test_2d_spatial_raise(dv);
-  test_3d_spatial_raise(dv);
-  test_1d_spatial_lower(dv);
-  test_2d_spatial_lower(dv);
-  test_3d_spatial_lower(dv);
-  test_3d_spacetime_raise(dv);
-  test_3d_spacetime_lower(dv);
-  test_1d_spatial_trace(dv);
-  test_2d_spatial_trace(dv);
-  test_3d_spatial_trace(dv);
-  test_3d_spacetime_trace(dv);
-  test_1d_spatial_trace_tensor_type_aa(dv);
-  test_2d_spatial_trace_tensor_type_aa(dv);
-  test_3d_spatial_trace_tensor_type_aa(dv);
-  test_3d_spacetime_trace_tensor_type_aa(dv);
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_raise_or_lower_first_index, (1, 2, 3),
+                                    (UpLo::Lo, UpLo::Up),
+                                    (IndexType::Spatial, IndexType::Spacetime));
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_raise_or_lower, (1, 2, 3),
+                                    (UpLo::Lo, UpLo::Up),
+                                    (IndexType::Spatial, IndexType::Spacetime));
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_trace_last_indices, (1, 2, 3),
+                                    (IndexType::Spatial, IndexType::Spacetime));
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_trace, (1, 2, 3),
+                                    (IndexType::Spatial, IndexType::Spacetime));
 }

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
@@ -4,150 +4,33 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <cstddef>
-#include <limits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
-#include "Utilities/MakeWithValue.hpp"
-#include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_include <boost/preprocessor/arithmetic/dec.hpp>
+// IWYU pragma: no_include <boost/preprocessor/repetition/enum.hpp>
+// IWYU pragma: no_include <boost/preprocessor/tuple/reverse.hpp>
 
 namespace {
-template <typename DataType>
-void test_1d_spatial_ricci(const DataType& used_for_size) {
-  constexpr size_t spatial_dim = 1;
-  const auto ricci = gr::ricci_tensor(
-      make_spatial_christoffel_second_kind<spatial_dim>(
-          used_for_size),
-      make_deriv_spatial_christoffel_second_kind<spatial_dim>(
-          used_for_size));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
-                        make_with_value<DataType>(used_for_size, 0.));
-}
-
-template <typename DataType>
-void test_2d_spatial_ricci(const DataType& used_for_size) {
-  constexpr size_t spatial_dim = 2;
-  const auto ricci = gr::ricci_tensor(
-      make_spatial_christoffel_second_kind<spatial_dim>(
-          used_for_size),
-      make_deriv_spatial_christoffel_second_kind<spatial_dim>(
-          used_for_size));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
-                        make_with_value<DataType>(used_for_size, -9.));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 1),
-                        make_with_value<DataType>(used_for_size, 5.5));
-  CHECK_ITERABLE_APPROX(ricci.get(1, 1),
-                        make_with_value<DataType>(used_for_size, 20.));
-}
-
-template <typename DataType>
-void test_3d_spatial_ricci(const DataType& used_for_size) {
-  constexpr size_t spatial_dim = 3;
-  const auto ricci = gr::ricci_tensor(
-      make_spatial_christoffel_second_kind<spatial_dim>(
-          used_for_size),
-      make_deriv_spatial_christoffel_second_kind<spatial_dim>(
-          used_for_size));
-
-  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
-                        make_with_value<DataType>(used_for_size, -65.));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 1),
-                        make_with_value<DataType>(used_for_size, 2.5));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 2),
-                        make_with_value<DataType>(used_for_size, 70.));
-  CHECK_ITERABLE_APPROX(ricci.get(1, 1),
-                        make_with_value<DataType>(used_for_size, 46.));
-  CHECK_ITERABLE_APPROX(ricci.get(1, 2),
-                        make_with_value<DataType>(used_for_size, 89.5));
-  CHECK_ITERABLE_APPROX(ricci.get(2, 2),
-                        make_with_value<DataType>(used_for_size, 109.));
-}
-
-template <typename DataType>
-void test_1d_spacetime_ricci(const DataType& used_for_size) {
-  constexpr size_t spatial_dim = 1;
-  const auto ricci = gr::ricci_tensor(
-      make_spacetime_christoffel_second_kind<spatial_dim>(
-          used_for_size),
-      make_deriv_spacetime_christoffel_second_kind<spatial_dim>(
-          used_for_size));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
-                        make_with_value<DataType>(used_for_size, -46.));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 1),
-                        make_with_value<DataType>(used_for_size, 28.));
-  CHECK_ITERABLE_APPROX(ricci.get(1, 1),
-                        make_with_value<DataType>(used_for_size, -16.));
-}
-
-template <typename DataType>
-void test_2d_spacetime_ricci(const DataType& used_for_size) {
-  constexpr size_t spatial_dim = 2;
-  const auto ricci = gr::ricci_tensor(
-      make_spacetime_christoffel_second_kind<spatial_dim>(
-          used_for_size),
-      make_deriv_spacetime_christoffel_second_kind<spatial_dim>(
-          used_for_size));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
-                        make_with_value<DataType>(used_for_size, -406.));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 1),
-                        make_with_value<DataType>(used_for_size, -32.));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 2),
-                        make_with_value<DataType>(used_for_size, 217.));
-  CHECK_ITERABLE_APPROX(ricci.get(1, 1),
-                        make_with_value<DataType>(used_for_size, -178.));
-  CHECK_ITERABLE_APPROX(ricci.get(1, 2),
-                        make_with_value<DataType>(used_for_size, 143.5));
-  CHECK_ITERABLE_APPROX(ricci.get(2, 2),
-                        make_with_value<DataType>(used_for_size, -201.));
-}
-
-template <typename DataType>
-void test_3d_spacetime_ricci(const DataType& used_for_size) {
-  constexpr size_t spatial_dim = 3;
-  const auto ricci = gr::ricci_tensor(
-      make_spacetime_christoffel_second_kind<spatial_dim>(
-          used_for_size),
-      make_deriv_spacetime_christoffel_second_kind<spatial_dim>(
-          used_for_size));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
-                        make_with_value<DataType>(used_for_size, -1928.));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 1),
-                        make_with_value<DataType>(used_for_size, -700.));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 2),
-                        make_with_value<DataType>(used_for_size, 283.));
-  CHECK_ITERABLE_APPROX(ricci.get(0, 3),
-                        make_with_value<DataType>(used_for_size, 940.));
-  CHECK_ITERABLE_APPROX(ricci.get(1, 1),
-                        make_with_value<DataType>(used_for_size, -1300.));
-  CHECK_ITERABLE_APPROX(ricci.get(1, 2),
-                        make_with_value<DataType>(used_for_size, 82.5));
-  CHECK_ITERABLE_APPROX(ricci.get(1, 3),
-                        make_with_value<DataType>(used_for_size, 968.));
-  CHECK_ITERABLE_APPROX(ricci.get(2, 2),
-                        make_with_value<DataType>(used_for_size, -629.));
-  CHECK_ITERABLE_APPROX(ricci.get(2, 3),
-                        make_with_value<DataType>(used_for_size, 335.5));
-  CHECK_ITERABLE_APPROX(ricci.get(3, 3),
-                        make_with_value<DataType>(used_for_size, -1176.));
+template <size_t Dim, IndexType TypeOfIndex, typename DataType>
+void test_ricci(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &gr::ricci_tensor<Dim, Frame::Inertial, TypeOfIndex, DataType>, "GrTests",
+      "ricci_tensor", {{{-10., 10.}}}, used_for_size);
 }
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.Ricci.",
                   "[PointwiseFunctions][Unit]") {
-  const double d(std::numeric_limits<double>::signaling_NaN());
-  test_1d_spatial_ricci(d);
-  test_2d_spatial_ricci(d);
-  test_3d_spatial_ricci(d);
-  test_1d_spacetime_ricci(d);
-  test_2d_spacetime_ricci(d);
-  test_3d_spacetime_ricci(d);
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/GeneralRelativity/");
 
-  const DataVector dv(5);
-  test_1d_spatial_ricci(dv);
-  test_2d_spatial_ricci(dv);
-  test_3d_spatial_ricci(dv);
-  test_1d_spacetime_ricci(dv);
-  test_2d_spacetime_ricci(dv);
-  test_3d_spacetime_ricci(dv);
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_ricci, (1, 2, 3),
+                                    (IndexType::Spatial, IndexType::Spacetime));
 }

--- a/tests/Unit/Pypp/PyppPyTests.py
+++ b/tests/Unit/Pypp/PyppPyTests.py
@@ -60,8 +60,12 @@ def ndarray_of_floats():
 # These are used to check converting to a Tensor works
 
 
-def scalar():
+def scalar_from_double():
     return 0.8
+
+
+def scalar_from_ndarray():
+    return np.array(0.8)
 
 
 def vector():
@@ -96,8 +100,12 @@ def tnsr_aBcc():
 # Test conversion from Tensor to numpy array works
 
 
-def convert_scalar_successful(a):
-    return a == scalar()
+def convert_scalar_to_ndarray_successful(a):
+    return bool(np.all(a == scalar_from_ndarray()))
+
+
+def convert_scalar_to_double_unsuccessful(a):
+    return not isinstance(scalar_from_double(), type(a))
 
 
 def convert_vector_successful(a):

--- a/tests/Unit/Pypp/Test_Pypp.cpp
+++ b/tests/Unit/Pypp/Test_Pypp.cpp
@@ -197,7 +197,10 @@ SPECTRE_TEST_CASE("Unit.Pypp.Tensor.Double", "[Pypp][Unit]") {
   }();
 
   // Check converting from Tensor to ndarray
-  CHECK(pypp::call<bool>("PyppPyTests", "convert_scalar_successful", scalar));
+  CHECK(pypp::call<bool>("PyppPyTests", "convert_scalar_to_ndarray_successful",
+                         scalar));
+  CHECK(pypp::call<bool>("PyppPyTests", "convert_scalar_to_double_unsuccessful",
+                         scalar));
   CHECK(pypp::call<bool>("PyppPyTests", "convert_vector_successful", vector));
   CHECK(pypp::call<bool>("PyppPyTests", "convert_tnsr_ia_successful", tnsr_ia));
   CHECK(pypp::call<bool>("PyppPyTests", "convert_tnsr_AA_successful", tnsr_AA));
@@ -209,7 +212,10 @@ SPECTRE_TEST_CASE("Unit.Pypp.Tensor.Double", "[Pypp][Unit]") {
                          tnsr_aBcc));
 
   // Check converting from ndarray to Tensor
-  CHECK(scalar == (pypp::call<Scalar<double>>("PyppPyTests", "scalar")));
+  CHECK(scalar ==
+        (pypp::call<Scalar<double>>("PyppPyTests", "scalar_from_double")));
+  CHECK(scalar ==
+        (pypp::call<Scalar<double>>("PyppPyTests", "scalar_from_ndarray")));
   CHECK(vector == (pypp::call<tnsr::A<double, 3>>("PyppPyTests", "vector")));
   CHECK(tnsr_ia == (pypp::call<tnsr::ia<double, 3>>("PyppPyTests", "tnsr_ia")));
   CHECK(tnsr_AA == (pypp::call<tnsr::AA<double, 3>>("PyppPyTests", "tnsr_AA")));


### PR DESCRIPTION
## Proposed changes

Replaces the tests in tests/Unit/PointwiseFunctions/GeneralRelativity with ones that use Pypp.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`
