### PR TITLE
Add Isentropic Vortex

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/Tags.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Tags.hpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+namespace NewtonianEuler {
+namespace Tags {
+
+/// The mass density of the fluid.
+template <typename DataType>
+struct MassDensity : db::SimpleTag {
+  using type = Scalar<DataType>;
+  static std::string name() noexcept { return "MassDensity"; }
+};
+
+/// The momentum density of the fluid.
+template <typename DataType, size_t Dim, typename VolumeFrame = Frame::Inertial>
+struct MomentumDensity : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, VolumeFrame>;
+  static std::string name() noexcept { return "MomentumDensity"; }
+};
+
+/// The energy density of the fluid.
+template <typename DataType>
+struct EnergyDensity : db::SimpleTag {
+  using type = Scalar<DataType>;
+  static std::string name() noexcept { return "EnergyDensity"; }
+};
+
+/// The macroscopic or flow velocity of the fluid.
+template <typename DataType, size_t Dim, typename VolumeFrame = Frame::Inertial>
+struct Velocity : db::SimpleTag {
+  using type = tnsr::I<DataType, Dim, VolumeFrame>;
+  static std::string name() noexcept { return "Velocity"; }
+};
+
+/// The specific internal energy of the fluid.
+template <typename DataType>
+struct SpecificInternalEnergy : db::SimpleTag {
+  using type = Scalar<DataType>;
+  static std::string name() noexcept { return "SpecificInternalEnergy"; }
+};
+
+/// The fluid pressure.
+template <typename DataType>
+struct Pressure : db::SimpleTag {
+  using type = Scalar<DataType>;
+  static std::string name() noexcept { return "Pressure"; }
+};
+
+}  // namespace Tags
+}  // namespace NewtonianEuler

--- a/src/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
@@ -2,4 +2,5 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(EinsteinSolutions)
+add_subdirectory(NewtonianEulerSolutions)
 add_subdirectory(WaveEquation)

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY NewtonianEulerSolutions)
+
+set(LIBRARY_SOURCES
+    IsentropicVortex.cpp
+    )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  )

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/IsentropicVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/IsentropicVortex.cpp
@@ -1,0 +1,141 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/IsentropicVortex.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <ostream>
+
+#include "DataStructures/DataVector.hpp"                   // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/// \cond
+namespace NewtonianEuler {
+namespace Solutions {
+
+IsentropicVortex::IsentropicVortex(
+    const double adiabatic_index, IsentropicVortex::Center::type center,
+    IsentropicVortex::MeanVelocity::type mean_velocity, const double strength)
+    : adiabatic_index_(adiabatic_index),
+      // clang-tidy: do not std::move trivial types.
+      center_(std::move(center)),  // NOLINT
+      // clang-tidy: do not std::move trivial types.
+      mean_velocity_(std::move(mean_velocity)),  // NOLINT
+      strength_(strength) {
+  ASSERT(adiabatic_index_ > 1.0 and adiabatic_index_ < 2.0,
+         "The adiabatic index must be in the range (1, 2). The value given "
+         "was "
+             << adiabatic_index_ << ".");
+  ASSERT(strength_ >= 0.0,
+         "The strength must be non-negative. The value given "
+         "was "
+             << strength_ << ".");
+}
+
+void IsentropicVortex::pup(PUP::er& p) noexcept {
+  p | adiabatic_index_;
+  p | center_;
+  p | mean_velocity_;
+  p | strength_;
+}
+
+template <typename DataType>
+tuples::TaggedTupleTypelist<IsentropicVortex::primitive_t<DataType>>
+IsentropicVortex::primitive_variables(const tnsr::I<DataType, 3>& x,
+                                      const double t) const noexcept {
+  const auto adiabatic_index_minus_one = adiabatic_index_ - 1.0;
+
+  const auto x_tilde = [&x, &t, this ]() noexcept {
+    auto l_x_tilde = make_with_value<tnsr::I<DataType, 2>>(x, 0.0);
+    // Note: x_tilde has only 2 components as it is used to
+    // compute a distance on a plane perpendicular to the z-axis.
+    for (size_t i = 0; i < 2; ++i) {
+      l_x_tilde.get(i) =
+          x.get(i) - gsl::at(center_, i) - t * gsl::at(mean_velocity_, i);
+    }
+    return l_x_tilde;
+  }
+  ();
+
+  auto result = make_with_value<
+      tuples::TaggedTupleTypelist<IsentropicVortex::primitive_t<DataType>>>(
+      x, 0.0);
+
+  const DataType temp = 0.5 * strength_ *
+                        exp(0.5 - 0.5 * get(dot_product(x_tilde, x_tilde))) /
+                        M_PI;
+
+  get<Tags::MassDensity<DataType>>(result) = Scalar<DataType>(pow(
+      1.0 - 0.5 * adiabatic_index_minus_one * temp * temp / adiabatic_index_,
+      1.0 / adiabatic_index_minus_one));
+
+  auto velocity = make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    velocity.get(i) = gsl::at(mean_velocity_, i);
+  }
+  velocity.get(0) -= x_tilde.get(1) * temp;
+  velocity.get(1) += x_tilde.get(0) * temp;
+
+  get<Tags::Velocity<DataType, 3>>(result) = std::move(velocity);
+
+  get<Tags::SpecificInternalEnergy<DataType>>(result) =
+      Scalar<DataType>(pow(get(get<Tags::MassDensity<DataType>>(result)),
+                           adiabatic_index_minus_one) /
+                       adiabatic_index_minus_one);
+
+  return result;
+}
+
+template <typename DataType>
+tuples::TaggedTupleTypelist<IsentropicVortex::conservative_t<DataType>>
+IsentropicVortex::conservative_variables(const tnsr::I<DataType, 3>& x,
+                                         const double t) const noexcept {
+  const auto primitives = primitive_variables(x, t);
+
+  auto result = make_with_value<
+      tuples::TaggedTupleTypelist<IsentropicVortex::conservative_t<DataType>>>(
+      x, 0.0);
+
+  get<Tags::MassDensity<DataType>>(result) =
+      get<Tags::MassDensity<DataType>>(primitives);
+
+  conservative_from_primitive(
+      make_not_null(&get<Tags::MomentumDensity<DataType, 3>>(result)),
+      make_not_null(&get<Tags::EnergyDensity<DataType>>(result)),
+      get<Tags::MassDensity<DataType>>(primitives),
+      get<Tags::Velocity<DataType, 3>>(primitives),
+      get<Tags::SpecificInternalEnergy<DataType>>(primitives));
+
+  return result;
+}
+
+}  // namespace Solutions
+}  // namespace NewtonianEuler
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template tuples::TaggedTupleTypelist<                                      \
+      NewtonianEuler::Solutions::IsentropicVortex::primitive_t<DTYPE(data)>> \
+  NewtonianEuler::Solutions::IsentropicVortex::primitive_variables(          \
+      const tnsr::I<DTYPE(data), 3>& x, const double t) const noexcept;      \
+  template tuples::TaggedTupleTypelist<                                      \
+      NewtonianEuler::Solutions::IsentropicVortex::conservative_t<DTYPE(     \
+          data)>>                                                            \
+  NewtonianEuler::Solutions::IsentropicVortex::conservative_variables(       \
+      const tnsr::I<DTYPE(data), 3>& x, const double t) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/IsentropicVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/IsentropicVortex.hpp
@@ -1,0 +1,166 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Utilities/MakeArray.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace NewtonianEuler {
+namespace Solutions {
+
+/*!
+ * \ingroup NewtonianEulerSolutionsGroup
+ * \brief Newtonian isentropic vortex in Cartesian coordinates
+ *
+ * The analytic solution to the 2-D Newtonian Euler system
+ * representing the slow advection of an incompressible, isentropic
+ * vortex \ref vortex_ref "[1]". The initial condition is the superposition of a
+ * mean uniform flow with a gaussian-profile vortex. When embedded in
+ * 3-D space, the isentropic vortex is still a solution to the corresponding 3-D
+ * system if the velocity along the third axis is a constant. In Cartesian
+ * coordinates \f$(x, y, z)\f$, and using dimensionless units, the primitive
+ * quantities at a given time \f$t\f$ are then
+ *
+ * \f{align*}
+ * \rho &= \left[1 - \dfrac{(\gamma - 1)\beta^2}{8\gamma\pi^2}\exp\left(
+ * 1 - r^2\right)\right]^{1/(\gamma - 1)}, \\
+ * v_x &= U - \dfrac{\beta\tilde y}{2\pi}\exp\left(\dfrac{1 - r^2}{2}\right),\\
+ * v_y &= V + \dfrac{\beta\tilde x}{2\pi}\exp\left(\dfrac{1 - r^2}{2}\right),\\
+ * v_z &= W,\\
+ * \epsilon &= \frac{\rho^{\gamma - 1}}{\gamma - 1},
+ * \f}
+ *
+ * with
+ *
+ * \f{align*}
+ * r^2 &= {\tilde x}^2 + {\tilde y}^2,\\
+ * \tilde x &= x - X_0 - U t,\\
+ * \tilde y &= y - Y_0 - V t,
+ * \f}
+ *
+ * where \f$(X_0, Y_0)\f$ is the position of the vortex on the \f$(x, y)\f$
+ * plane at \f$t = 0\f$, \f$(U, V, W)\f$ are the components of the mean flow
+ * velocity, \f$\beta\f$ is the vortex strength, and \f$\gamma\f$ is the
+ * adiabatic index. The pressure \f$p\f$ is then obtained from the dimensionless
+ * polytropic relation
+ *
+ * \f{align*}
+ * p = \rho^\gamma.
+ * \f}
+ *
+ * On the other hand, if the velocity along the \f$z-\f$axis is not a constant
+ * but a function of the \f$z\f$ coordinate, the resulting modified isentropic
+ * vortex is still a solution to the Newtonian Euler system, but with source
+ * terms that are proportional to \f$dv_z/dz\f$ (See IsentropicVortexSource.)
+ *
+ * \anchor vortex_ref [1] H.C Yee, N.D Sandham, M.J Djomehri, Low-dissipative
+ * high-order shock-capturing methods using characteristic-based filters, J.
+ * Comput. Phys. [150 (1999) 199](http://dx.doi.org/10.1006/jcph.1998.6177)
+ */
+class IsentropicVortex {
+ public:
+  /// The adiabatic index of the fluid.
+  struct AdiabaticIndex {
+    using type = double;
+    static constexpr OptionString help = {"The adiabatic index of the fluid."};
+    // Note: bounds only valid for an ideal gas.
+    static type lower_bound() { return 1.0; }
+    static type upper_bound() { return 2.0; }
+  };
+
+  /// The position of the center of the vortex at \f$t = 0\f$
+  struct Center {
+    using type = std::array<double, 3>;
+    static constexpr OptionString help = {
+        "The coordinates of the center of the vortex at t = 0."};
+    static type default_value() { return {{0.0, 0.0, 0.0}}; }
+  };
+
+  /// The mean flow velocity.
+  struct MeanVelocity {
+    using type = std::array<double, 3>;
+    static constexpr OptionString help = {"The mean flow velocity."};
+  };
+
+  /// The strength of the vortex.
+  struct Strength {
+    using type = double;
+    static constexpr OptionString help = {"The strength of the vortex."};
+    static type lower_bound() { return 0.0; }
+  };
+
+  using options = tmpl::list<AdiabaticIndex, Center, MeanVelocity, Strength>;
+  static constexpr OptionString help = {"Newtonian Isentropic Vortex."};
+
+  IsentropicVortex() = default;
+  IsentropicVortex(const IsentropicVortex& /*rhs*/) = delete;
+  IsentropicVortex& operator=(const IsentropicVortex& /*rhs*/) = delete;
+  IsentropicVortex(IsentropicVortex&& /*rhs*/) noexcept = default;
+  IsentropicVortex& operator=(IsentropicVortex&& /*rhs*/) noexcept = default;
+  ~IsentropicVortex() = default;
+
+  IsentropicVortex(double adiabatic_index, Center::type center,
+                   MeanVelocity::type mean_velocity, double strength);
+
+  explicit IsentropicVortex(CkMigrateMessage* /*unused*/) noexcept {}
+
+  template <typename DataType>
+  using primitive_t =
+      tmpl::list<Tags::MassDensity<DataType>, Tags::Velocity<DataType, 3>,
+                 Tags::SpecificInternalEnergy<DataType>>;
+
+  template <typename DataType>
+  using conservative_t = tmpl::list<Tags::MassDensity<DataType>,
+                                    Tags::MomentumDensity<DataType, 3>,
+                                    Tags::EnergyDensity<DataType>>;
+
+  template <typename DataType>
+  tuples::TaggedTupleTypelist<primitive_t<DataType>> primitive_variables(
+      const tnsr::I<DataType, 3>& x, double t) const noexcept;
+
+  template <typename DataType>
+  tuples::TaggedTupleTypelist<conservative_t<DataType>> conservative_variables(
+      const tnsr::I<DataType, 3>& x, double t) const noexcept;
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
+
+  constexpr double adiabatic_index() const noexcept { return adiabatic_index_; }
+  constexpr const Center::type& center() const noexcept { return center_; }
+  constexpr const MeanVelocity::type& mean_velocity() const noexcept {
+    return mean_velocity_;
+  }
+  constexpr double strength() const noexcept { return strength_; }
+
+ private:
+  double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
+  Center::type center_ = {{0.0, 0.0, 0.0}};
+  MeanVelocity::type mean_velocity_ =
+      make_array<3>(std::numeric_limits<double>::signaling_NaN());
+  double strength_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+inline constexpr bool operator==(const IsentropicVortex& lhs,
+                                 const IsentropicVortex& rhs) noexcept {
+  return lhs.adiabatic_index() == rhs.adiabatic_index() and
+         lhs.center() == rhs.center() and
+         lhs.mean_velocity() == rhs.mean_velocity() and
+         lhs.strength() == rhs.strength();
+}
+
+inline constexpr bool operator!=(const IsentropicVortex& lhs,
+                                 const IsentropicVortex& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace Solutions
+}  // namespace NewtonianEuler

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/Solution.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/Solution.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace NewtonianEuler {
+/*!
+ * \ingroup AnalyticSolutions
+ * Holds classes implementing a solution to the Newtonian Euler system.
+ */
+namespace Solutions {}
+}  // namespace NewtonianEuler

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
@@ -2,4 +2,5 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(EinsteinSolutions)
+add_subdirectory(NewtonianEulerSolutions)
 add_subdirectory(WaveEquation)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_NewtonianEulerSolutions")
+
+set(LIBRARY_SOURCES
+  Test_IsentropicVortex.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/"
+  "${LIBRARY_SOURCES}"
+  "NewtonianEulerSolutions"
+  )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/TestFunctions.py
@@ -1,0 +1,48 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Functions for testing IsentropicVortex.cpp
+def mass_density(x, t, adiabatic_index, center, mean_velocity, strength):
+    x_tilde = x - center - t * np.array(mean_velocity)
+    temp = (1.0 - strength * strength * (adiabatic_index - 1.0) *
+            np.exp(1.0 - np.dot(x_tilde[:2], x_tilde[:2])) /
+            (8.0 * adiabatic_index * np.pi**2))
+    return np.power(temp, 1.0 / (adiabatic_index - 1.0))
+
+
+def velocity(x, t, adiabatic_index, center, mean_velocity, strength):
+    x_tilde = x - center - t * np.array(mean_velocity)
+    temp = (0.5 * strength *
+            np.exp(0.5 * (1.0 - np.dot(x_tilde[:2], x_tilde[:2]))) / np.pi)
+    velocity = np.copy(mean_velocity)
+    velocity[0] -= x_tilde[1] * temp
+    velocity[1] += x_tilde[0] * temp
+    return velocity
+
+
+def specific_internal_energy(x, t, adiabatic_index, center, mean_velocity,
+                             strength):
+    return (np.power(mass_density(x, t, adiabatic_index, center, mean_velocity,
+                                  strength), adiabatic_index - 1.0) /
+            (adiabatic_index - 1.0))
+
+
+def momentum_density(x, t, adiabatic_index, center, mean_velocity, strength):
+    return (mass_density(x, t, adiabatic_index, center, mean_velocity,
+                         strength) *
+            velocity(x, t, adiabatic_index, center, mean_velocity, strength))
+
+
+def energy_density(x, t, adiabatic_index, center, mean_velocity, strength):
+    veloc = velocity(x, t, adiabatic_index, center, mean_velocity, strength)
+    return (mass_density(x, t,
+                        adiabatic_index, center, mean_velocity, strength)
+            * (0.5 * np.dot(veloc, veloc) +
+               specific_internal_energy(x, t, adiabatic_index, center,
+                                        mean_velocity, strength)))
+
+
+# End functions for testing IsentropicVortex.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/Test_IsentropicVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/Test_IsentropicVortex.cpp
@@ -1,0 +1,175 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataVector.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/IsentropicVortex.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+void test_create_from_options() noexcept {
+  test_creation<NewtonianEuler::Solutions::IsentropicVortex>(
+      "  AdiabaticIndex: 1.43\n"
+      "  Center: [2.3, -1.3, -0.6]\n"
+      "  MeanVelocity: [-0.3, 0.1, 0.7]\n"
+      "  Strength: 3.76");
+}
+
+void test_move() noexcept {
+  NewtonianEuler::Solutions::IsentropicVortex vortex(
+      1.32, {{3.2, -4.1, 9.0}}, {{0.43, 0.31, -0.68}}, 1.65);
+  NewtonianEuler::Solutions::IsentropicVortex vortex_copy(
+      1.32, {{3.2, -4.1, 9.0}}, {{0.43, 0.31, -0.68}}, 1.65);
+  test_move_semantics(std::move(vortex), vortex_copy);  //  NOLINT
+}
+
+void test_serialize() noexcept {
+  NewtonianEuler::Solutions::IsentropicVortex vortex(
+      1.5, {{3.2, 0.1, -1.3}}, {{0.2, -0.25, 0.41}}, 1.65);
+  test_serialization(vortex);
+}
+
+template <typename DataType>
+void test_variables(const DataType& used_for_size) noexcept {
+  const double adiabatic_index = 1.56;
+  const std::array<double, 3> center = {{0.15, -0.02, 1.9}};
+  const std::array<double, 3> mean_velocity = {{1.2, 0.43, 0.5}};
+  const double strength = 2.0;
+
+  pypp::check_with_random_values<
+      1, tmpl::list<NewtonianEuler::Tags::MassDensity<DataType>,
+                    NewtonianEuler::Tags::Velocity<DataType, 3>,
+                    NewtonianEuler::Tags::SpecificInternalEnergy<DataType>>>(
+      &NewtonianEuler::Solutions::IsentropicVortex::primitive_variables<
+          DataType>,
+      NewtonianEuler::Solutions::IsentropicVortex(adiabatic_index, center,
+                                                  mean_velocity, strength),
+      "TestFunctions", {"mass_density", "velocity", "specific_internal_energy"},
+      {{{-1.0, 1.0}}},
+      std::make_tuple(adiabatic_index, center, mean_velocity, strength),
+      used_for_size);
+
+  pypp::check_with_random_values<
+      1, tmpl::list<NewtonianEuler::Tags::MassDensity<DataType>,
+                    NewtonianEuler::Tags::MomentumDensity<DataType, 3>,
+                    NewtonianEuler::Tags::EnergyDensity<DataType>>>(
+      &NewtonianEuler::Solutions::IsentropicVortex::conservative_variables<
+          DataType>,
+      NewtonianEuler::Solutions::IsentropicVortex(adiabatic_index, center,
+                                                  mean_velocity, strength),
+      "TestFunctions", {"mass_density", "momentum_density", "energy_density"},
+      {{{-1.0, 1.0}}},
+      std::make_tuple(adiabatic_index, center, mean_velocity, strength),
+      used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEulerSolns.Vortex",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions"};
+
+  test_create_from_options();
+  test_serialize();
+  test_move();
+
+  test_variables(std::numeric_limits<double>::signaling_NaN());
+  test_variables(DataVector(5));
+}
+
+struct Vortex {
+  using type = NewtonianEuler::Solutions::IsentropicVortex;
+  static constexpr OptionString help = {"A Newtonian isentropic vortex."};
+};
+
+// [[OutputRegex, The adiabatic index must be in the range \(1, 2\)]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEulerSolns.VortexAdIndex",
+    "[Unit][PointwiseFunctions]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  NewtonianEuler::Solutions::IsentropicVortex test_vortex(
+      0.9, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}}, 2.5);
+  NewtonianEuler::Solutions::IsentropicVortex another_test_vortex(
+      2.2, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}}, 2.5);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The strength must be non-negative.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEulerSolns.VortexStrength",
+    "[Unit][PointwiseFunctions]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  NewtonianEuler::Solutions::IsentropicVortex test_vortex(
+      1.3, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}}, -1.7);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, In string:.*At line 2 column 19:.Value 0.4 is below the lower
+// bound of 1.]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEulerSolns.VortexAdIndexOLo",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<Vortex>> test_options("");
+  test_options.parse(
+      "Vortex:\n"
+      "  AdiabaticIndex: 0.4\n"
+      "  Center: [2.3, -1.3, -0.6]\n"
+      "  MeanVelocity: [-0.3, 0.1, 0.7]\n"
+      "  Strength: 3.76");
+  test_options.get<Vortex>();
+}
+
+// [[OutputRegex, In string:.*At line 2 column 19:.Value 2.7 is above the upper
+// bound of 2.]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEulerSolns.VortexAdIndexOUp",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<Vortex>> test_options("");
+  test_options.parse(
+      "Vortex:\n"
+      "  AdiabaticIndex: 2.7\n"
+      "  Center: [1.4, -0.1, 2.3]\n"
+      "  MeanVelocity: [0.56, 0.2, -0.16]\n"
+      "  Strength: 1.53");
+  test_options.get<Vortex>();
+}
+
+// [[OutputRegex, In string:.*At line 5 column 13:.Value -0.2 is below the lower
+// bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEulerSolns.VortexStrengthO",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<Vortex>> test_options("");
+  test_options.parse(
+      "Vortex:\n"
+      "  AdiabaticIndex: 1.4\n"
+      "  Center: [-3.9, 1.1, 4.5]\n"
+      "  MeanVelocity: [0.1, 0.0, 0.65]\n"
+      "  Strength: -0.2");
+  test_options.get<Vortex>();
+}


### PR DESCRIPTION
## Proposed changes

- Add Tags for the Newtonian Euler system
- Add Isentropic Vortex solution

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
