### PR TITLE
Add documentation and support for Singularity

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -121,6 +121,9 @@ RUN git clone https://charm.cs.illinois.edu/gerrit/charm && \
     git checkout ${CHARM_GIT_TAG}  && \
     ./build charm++ multicore-linux64 gcc ${PARALLEL_MAKE_ARG} -g -O0  && \
     ./build charm++ multicore-linux64 clang ${PARALLEL_MAKE_ARG} -g -O0
+RUN wget https://raw.githubusercontent.com/sxs-collaboration/spectre/develop/support/Charm/v6.8.patch &&\
+    cd /work/charm &&\
+    git apply /work/v6.8.patch
 
 WORKDIR /work
 
@@ -132,3 +135,15 @@ RUN echo 'spack load catch' >> /root/.bashrc && \
     echo 'spack load libxsmm' >> /root/.bashrc && \
     echo 'spack load yaml-cpp' >> /root/.bashrc && \
     echo 'spack load benchmark' >> /root/.bashrc
+
+# - Set the environment variable SPECTRE_CONTAINER so we can check if we are
+#   inside a container (0 is true in bash)
+# - The singularity containers work better if the locale is set properly
+ENV SPECTRE_CONTAINER 0
+RUN apt-get update && apt-get install -y \
+    locales language-pack-fi language-pack-en && \
+    export LANGUAGE=en_US.UTF-8 && \
+    export LANG=en_US.UTF-8 && \
+    export LC_ALL=en_US.UTF-8 && \
+    locale-gen en_US.UTF-8 && \
+    dpkg-reconfigure locales

--- a/containers/Dockerfile.travis
+++ b/containers/Dockerfile.travis
@@ -63,10 +63,6 @@ COPY known_hosts /root/.ssh/known_hosts
 # builds) to the Docker image
 COPY ccache /root/.ccache
 
-# Apply Charm++ patch
-WORKDIR /work/charm
-RUN git apply /work/spectre/support/Charm/${CHARM_PATCH}
-
 # Create build directory
 RUN mkdir /work/build_${BUILD_TYPE}_${CC}
 WORKDIR /work/build_${BUILD_TYPE}_${CC}

--- a/containers/SingularityLoad.sh
+++ b/containers/SingularityLoad.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+if [ $SPECTRE_CONTAINER ]; then
+    . /etc/profile.d/lmod.sh
+    # Need to remove any existing modules in case the user had
+    # those loaded in their bashrc and they started the shell using
+    # `singularity exec spectre.img /bin/bash`
+    module purge
+    export PATH=/work/spack/bin:$PATH
+    . /work/spack/share/spack/setup-env.sh
+    spack load catch
+    spack load brigand
+    spack load blaze
+    spack load gsl
+    spack load libxsmm
+    spack load yaml-cpp
+    spack load benchmark
+fi

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -83,11 +83,9 @@ To build with the docker image:
    Within the container, SPECTRE_ROOT is available and
    CHARM_DIR is /work/charm. For the following steps, stay inside the docker
    container as root.
-4. `cd` into /work/charm, and apply the Charm++ patch by
-   running `git apply SPECTRE_ROOT/support/Charm/v6.8.patch`.
-5. Make a build directory somewhere inside the container, e.g.
+4. Make a build directory somewhere inside the container, e.g.
    /work/spectre-build-gcc, and cd into it.
-6. Build SpECTRE with
+5. Build SpECTRE with
    `cmake -D CHARM_ROOT=/work/charm/multicore-linux64-gcc SPECTRE_ROOT`
    then
    `make -jN`
@@ -125,6 +123,52 @@ Notes:
     container are different, commands like `git commit` run *from
     outside the container* will die with `No such file or directory`.
   * To compile with clang, the cmake command is
+```
+    cmake -D CMAKE_CXX_COMPILER=clang++ \
+          -D CMAKE_C_COMPILER=clang \
+          -D CMAKE_Fortran_COMPILER=gfortran \
+          -D CHARM_ROOT=/work/charm/multicore-linux64-clang SPECTRE_ROOT
+```
+
+## Using Singularity to obtain a SpECTRE environment
+
+[Singularity](http://singularity.lbl.gov/index.html) is a container alternative
+to Docker with better security and nicer integration.
+
+To use Singularity you must:
+
+1. Build [Singularity](http://singularity.lbl.gov/index.html) and add it to your
+   `$PATH`
+2. `cd` to the directory where you want to store the SpECTRE Singularity image,
+   source, and build directories, let's call it WORKDIR. The WORKDIR must be
+   somewhere in your home directory. If this does not work for you, follow the
+   Singularity instructions on setting up additional [bind
+   points](http://singularity.lbl.gov/docs-mount). Once inside the WORKDIR,
+   clone SpECTRE into `WORKDIR/SPECTRE_ROOT`.
+3. Run `singularity build spectre.img
+   docker://sxscollaboration/spectrebuildenv:latest`.
+4. To start the container run `singularity shell spectre.img` and you
+   will be dropped into a bash shell. The first thing you will always need to do
+   when entering the container is:
+   `. SPECTRE_HOME/containers/SingularityLoad.sh`
+5. Run `cd SPECTRE_HOME && mkdir build && cd build` to set up a build
+   directory.
+6. To build SpECTRE run `cmake -D
+   CHARM_ROOT=/work/charm/multicore-linux64-gcc SPECTRE_ROOT` followed by
+   `make -jN` where `N` is the number of cores to build on in parallel.
+
+Notes:
+- You should edit source files in SPECTRE_ROOT in a separate terminal outside
+  the container, and use the container only for compiling and running the code.
+- Unlike Docker, Singularity does not keep the state between runs. However, it
+  shares the home directory with the host OS so you should do all your work
+  somewhere in your home directory.
+- To run more than one container just do `singularity shell spectre.img` in
+  another terminal.
+- Since the data you modify lives on the host OS there is no need to worry about
+  losing any data, needing to clean up old containers, or sharing data between
+  containers and the host.
+- To build with clang, the CMake command is:
 ```
     cmake -D CMAKE_CXX_COMPILER=clang++ \
           -D CMAKE_C_COMPILER=clang \


### PR DESCRIPTION
## Proposed changes

Singularity is a container alternative to Docker and can use Docker
containers. It integrates more readily with the host OS and does not require
root privileges to get set up.

The documentation is built and will be available at: http://gh.nilsdeppe.com/spectre/pr_701

Breaks:
- Travis Dockerfile, every PR needs to be rebased

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
