### PR TITLE
Fix and rework transpose documentation

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
@@ -20,21 +20,25 @@
 /// another function can operate on contiguous chunks of memory.
 ///
 /// \requires `transpose.size()` to be the product of `number_of_chunks` and
-/// `chunk_size, `u.size()` to be equal or greater than `transpose.size()`,
+/// `chunk_size`, `u.size()` to be equal or greater than `transpose.size()`,
 /// and that both `transpose` and `u` have a `data()` member function.
 ///
-/// \details The container `u` holds a contiguous array of data that is at least
-/// of size `number_of_chunks` times `chunk_size`.  The output `transpose` has
-/// its data arranged such that the first `number_of_chunks` elements in
-/// `transpose` will be the first element of each chunk of `u`.  The last
-/// `number_of_chunks` elements in `transpose` will be the last (i.e.
-/// `chunk_size`-th) element of each chunk of `u`.
+/// \details The container `u` holds a contiguous array of data,
+/// treated as a sequence of `number_of_chunks` contiguous sets of
+/// entries of size `chunk_size`.  The output `transpose` has its data
+/// arranged such that the first `number_of_chunks` elements in
+/// `transpose` will be the first element of each chunk of `u`.  The
+/// last `number_of_chunks` elements in `transpose` will be the last
+/// (i.e.  `chunk_size`-th) element of each chunk of `u`.  If
+/// `u.size()` is greater than `transpose.size()` the extra elements
+/// of `u` are ignored.
 ///
 /// \note This is equivalent to treating the first part of `u` as a matrix and
 /// filling `transpose` (or the returned object) with the transpose of that
 /// matrix.
 ///
 /// \example
+/// \snippet Test_Transpose.cpp transpose_matrix
 /// \snippet Test_Transpose.cpp transpose_by_not_null_example
 /// \snippet Test_Transpose.cpp return_transpose_example
 /// \snippet Test_Transpose.cpp partial_transpose_example

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
@@ -36,6 +36,18 @@ using one_var = tmpl::list<Var1<Dim>>;
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Transpose",
                   "[NumericalAlgorithms][LinearOperators][Unit]") {
+  // clang-format off
+  /// [transpose_matrix]
+  const DataVector matrix{ 1.,  2.,  3.,
+                           4.,  5.,  6.,
+                           7.,  8.,  9.,
+                          10., 11., 12.};
+  CHECK(transpose(matrix, 3, 4) == DataVector{1.,  4.,  7., 10.,
+                                              2.,  5.,  8., 11.,
+                                              3.,  6.,  9., 12.});
+  /// [transpose_matrix]
+  // clang-format on
+
   /// [return_transpose_example]
   const size_t chunk_size = 8;
   const size_t number_of_chunks = 2;


### PR DESCRIPTION
Includes a really basic example of how to transpose a matrix.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
