### PR TITLE
Various minor cleanup, better errors

### DIFF
--- a/src/DataStructures/Index.hpp
+++ b/src/DataStructures/Index.hpp
@@ -11,6 +11,7 @@
 #include <limits>
 #include <ostream>
 
+#include "ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/Requires.hpp"
@@ -81,6 +82,8 @@ class Index {
   /// \param d the element to remove.
   template <size_t N = Dim, Requires<(N > 0)> = nullptr>
   Index<Dim - 1> slice_away(const size_t d) const noexcept {
+    ASSERT(d < Dim,
+           "Can't slice dimension " << d << " from an Index<" << Dim << ">");
     std::array<size_t, Dim - 1> t{};
     for (size_t i = 0; i < Dim; ++i) {
       if (i < d) {

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -84,11 +84,6 @@ class Tensor<X, Symm, IndexList<Indices...>> {
       "allowed. While other types are technically possible it is not "
       "clear that Tensor is the correct container for them. Please "
       "seek advice on the topic by discussing with the SpECTRE developers.");
-  /// The number of \ref SpacetimeIndex "TensorIndexType"'s
-  ///
-  /// Note: Scalars need to have 1 so we can still store their data.
-  static constexpr auto num_tensor_indices = sizeof...(Indices) == 0;
-
   /// The Tensor_detail::Structure for the particular tensor index structure
   ///
   /// Each tensor index structure, e.g. \f$T_{ab}\f$, \f$T_a{}^b\f$ or

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -580,3 +580,15 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.add_slice_to_data",
                    3233233., 3240034.}}}}) ==
         get<VariablesTestTags_detail::vector>(vars));
 }
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.Variables.assign_to_default",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+  #ifdef SPECTRE_DEBUG
+  Variables<tmpl::list<VariablesTestTags_detail::scalar>> vars;
+  get<VariablesTestTags_detail::scalar>(vars) = Scalar<DataVector>{{{{0.}}}};
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}

--- a/tests/Unit/TestingFramework.hpp
+++ b/tests/Unit/TestingFramework.hpp
@@ -144,6 +144,8 @@ struct check_iterable_approx<
                 not tt::is_a_v<std::unordered_set, T>>> {
   // clang-tidy: non-const reference
   static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
+    CAPTURE_PRECISE(a);
+    CAPTURE_PRECISE(b);
     auto a_it = a.begin();
     auto b_it = b.begin();
     CHECK(a_it != a.end());
@@ -170,6 +172,8 @@ struct check_iterable_approx<T, Requires<tt::is_a_v<std::unordered_set, T>>> {
   // clang-tidy: non-const reference
   static void apply(const T& a, const T& b,
                     Approx& /*appx*/ = approx) {  // NOLINT
+    CAPTURE_PRECISE(a);
+    CAPTURE_PRECISE(b);
     // Approximate comparison of unordered sets is difficult
     CHECK(a == b);
   }
@@ -180,6 +184,8 @@ struct check_iterable_approx<
     T, Requires<tt::is_maplike_v<T> and tt::is_iterable_v<T>>> {
   // clang-tidy: non-const reference
   static void apply(const T& a, const T& b, Approx& appx = approx) {  // NOLINT
+    CAPTURE_PRECISE(a);
+    CAPTURE_PRECISE(b);
     for (const auto& kv : a) {
       const auto& key = kv.first;
       try {


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
