### PR TITLE
Add Strahlkorper spin magnitude

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,6 +162,7 @@ before_install:
       brew install jemalloc;
       brew install gsl;
       brew install hdf5;
+      brew install openblas;
 
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
       chmod +x miniconda.sh;
@@ -311,6 +312,8 @@ script:
              -D LIBXSMM_ROOT=$HOME/libxsmm/build
              -D YAMLCPP_ROOT=$HOME/yaml-cpp/
              -D MACOSX_MIN=10.11
+             -D BLAS_openblas_LIBRARY=/usr/local/opt/openblas/lib/libopenblas.dylib
+             -D LAPACK_openblas_LIBRARY=/usr/local/opt/openblas/lib/libopenblas.dylib
              -D CMAKE_BUILD_TYPE=${BUILD_TYPE}
              ${TRAVIS_BUILD_DIR}
     && make test-executables -j2

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -191,7 +191,7 @@ Scalar<DataVector> area_element(
  * The argument `unit_normal_vector` can be found by raising the
  * index of the one-form returned by `StrahlkorperGr::unit_normal_oneform`.
  * The argument `tangents` is a Tangents that can be obtained from the
- * StrahlkorperDataBox using the "Tangents" tag.
+ * StrahlkorperDataBox using the `StrahlkorperTags::Tangents` tag.
  */
 template <typename Frame>
 Scalar<DataVector> spin_function(
@@ -201,4 +201,44 @@ Scalar<DataVector> spin_function(
     const Scalar<DataVector>& area_element,
     const tnsr::ii<DataVector, 3, Frame>& extrinsic_curvature) noexcept;
 
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Spin magnitude measured on a 2D `Strahlkorper`.
+ *
+ * \details Measures the quasilocal spin magnitude of a Strahlkorper, by
+ * inserting \f$\alpha=1\f$ into Eq. (10) of https://arxiv.org/abs/0907.0280
+ * and dividing by \f$8\pi\f$ to yield the spin magnitude. The
+ * spin magnitude is a Euclidean norm of surface integrals over the horizon
+ * \f$S = \frac{1}{8\pi}\oint z \Omega dA\f$,
+ * where \f$\Omega\f$ is obtained via `StrahlkorperGr::spin_function()`,
+ * \f$dA\f$ is the area element, and \f$z\f$ (the "spin potential") is a
+ * solution of a generalized eigenproblem given by Eq. (9) of
+ * https://arxiv.org/abs/0907.0280. Specifically,
+ * \f$\nabla^4 z + \nabla \cdot (R\nabla z) = \lambda \nabla^2 z\f$, where
+ * \f$R\f$ is obtained via `StrahlkorperGr::ricci_scalar()`. The spin
+ * magnitude is the Euclidean norm of the three values of \f$S\f$ obtained from
+ * the eigenvectors \f$z\f$ with the 3 smallest-magnitude
+ * eigenvalues \f$\lambda\f$. Note that this formulation of the eigenproblem
+ * uses the "Owen" normalization, Eq. (A9) and surrounding discussion in
+ * https://arxiv.org/abs/0805.4192.
+ * The eigenvectors are normalized  with the "Kerr normalization",
+ * Eq. (A22) of https://arxiv.org/abs/0805.4192.
+ * The argument `spatial_metric` is the metric of the 3D spatial slice
+ * evaluated on the `Strahlkorper`.
+ * The argument `tangents` can be obtained from the StrahlkorperDataBox
+ * using the `StrahlkorperTags::Tangents` tag, and the argument
+ * `unit_normal_vector` can
+ * be found by raising the index of the one-form returned by
+ * `StrahlkorperGr::unit_normal_one_form`.
+ * The argument `ylm` is the `YlmSpherepack` of the `Strahlkorper`.
+ * The argument `area_element`
+ * can be computed via `StrahlkorperGr::area_element`.
+ */
+template <typename Frame>
+double dimensionful_spin_magnitude(
+    const Scalar<DataVector>& ricci_scalar,
+    const Scalar<DataVector>& spin_function,
+    const tnsr::ii<DataVector, 3, Frame>& spatial_metric,
+    const StrahlkorperTags::StrahlkorperTags_detail::Jacobian<Frame>& tangents,
+    const YlmSpherepack& ylm, const Scalar<DataVector>& area_element) noexcept;
 }  // namespace StrahlkorperGr

--- a/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Christoffel.cpp
@@ -26,7 +26,7 @@ tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
   }
   return christoffel;
 }
-} // namespace gr
+}  // namespace gr
 
 // Explicit Instantiations
 /// \cond
@@ -42,7 +42,8 @@ tnsr::abb<DataType, SpatialDim, Frame, Index> christoffel_first_kind(
           d_metric);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
-                        (Frame::Grid, Frame::Inertial),
+                        (Frame::Grid, Frame::Inertial,
+                         Frame::Spherical<Frame::Inertial>),
                         (IndexType::Spatial, IndexType::Spacetime))
 
 #undef DIM

--- a/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/IndexManipulation.cpp
@@ -140,7 +140,8 @@ Scalar<DataType> trace(
           metric) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
-                        (Frame::Grid, Frame::Inertial),
+                        (Frame::Grid, Frame::Inertial,
+                         Frame::Spherical<Frame::Inertial>),
                         (SpatialIndex, SpacetimeIndex), (UpLo::Lo, UpLo::Up),
                         (UpLo::Lo, UpLo::Up))
 

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -4,14 +4,19 @@
 #include "tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp"
 
 #include <cmath>
+#include <cstddef>
+#include <vector>
 
-#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
-#include "DataStructures/Tensor/EagerMath/Magnitude.hpp" // IWYU pragma: keep
+#include "ApparentHorizons/YlmSpherepack.hpp"
+#include "DataStructures/DataVector.hpp"                  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
 
 namespace TestHelpers {
 namespace Schwarzschild {
@@ -103,6 +108,129 @@ Scalar<DataType> horizon_radius(const std::array<DataType, 2>& theta_phi,
 
   return Scalar<DataType>{sqrt(radius_squared)};
 }
+
+template <typename DataType>
+Scalar<DataType> horizon_ricci_scalar(
+    const Scalar<DataType>& horizon_radius, const double& mass,
+    const double& dimensionless_spin_z) noexcept {
+  // Compute Kerr spin parameter a
+  // This is the magnitude of the dimensionless spin times the mass
+  double kerr_spin_a = mass * dimensionless_spin_z;
+
+  // Compute the Boyer-Lindquist horizon radius, r+
+  const double kerr_r_plus = mass + sqrt(square(mass) - square(kerr_spin_a));
+
+  // Get the Ricci scalar of the horizon, e.g. Eq. (119) of
+  // https://arxiv.org/abs/0706.0622
+  // The precise relation used here is derived in
+  // https://v2.overleaf.com/read/twdtxchyrtyv
+  Scalar<DataVector> ricci_scalar(
+      2.0 * (square(kerr_r_plus) + square(kerr_spin_a)) *
+      (3.0 * square(get(horizon_radius)) - 2.0 * square(kerr_r_plus) -
+       3.0 * square(kerr_spin_a)));
+  get(ricci_scalar) /= cube(-1.0 * square(get(horizon_radius)) +
+                               square(kerr_spin_a) + 2.0 * square(kerr_r_plus));
+  return ricci_scalar;
+}
+
+template <typename DataType>
+Scalar<DataType> horizon_ricci_scalar(
+    const Scalar<DataType>& horizon_radius_with_spin_on_z_axis,
+    const YlmSpherepack& ylm_with_spin_on_z_axis, const YlmSpherepack& ylm,
+    const double& mass,
+    const std::array<double, 3>& dimensionless_spin) noexcept {
+  // get the dimensionless spin magnitude and direction
+  const double spin_magnitude = magnitude(dimensionless_spin);
+  const double spin_theta =
+      atan2(sqrt(square(dimensionless_spin[0]) + square(dimensionless_spin[1])),
+            dimensionless_spin[2]);
+
+  // Return the aligned-spin result if spin is close enough to the z axis,
+  // to avoid a floating-point exception. The choice of eps here is arbitrary.
+  const double eps = 1.e-10;
+
+  // There are 2 YlmSpherepacks: i) ylm, for the actual black hole, with spin
+  // in a generic direction, and ii) ylm_with_spin_on_z_axis, for a black hole
+  // with the same spin magnitude but with the spin in the +z direction.
+  // To get the horizon Ricci scalar for the actual black hole, do this:
+  //    1. Find the horizon Ricci scalar for the aligned spin
+  //    2. Let the generic spin point in direction (spin_theta, spin_phi).
+  //       Rotate the ylm.theta_phi_points by -spin_phi about the z axis and
+  //       then by -spin_theta about the y axis, so the point
+  //       (spin_theta, spin_phi) is mapped to (0, 0), the +z axis.
+  //    3. Interpolate the aligned-spin Ricci scalar from step 1 at each
+  //       rotated point from step 2 to get the horizon Ricci scalar
+  //       for the corresponding (unrotated) ylm_theta_phi_points.
+
+  // Get the ricci scalar for a Kerr black hole with spin in the +z direction
+  // but same mass and spin magnitude
+  const auto ricci_scalar_with_spin_on_z_axis = horizon_ricci_scalar(
+      horizon_radius_with_spin_on_z_axis, mass, spin_magnitude);
+
+  // Is the spin aligned? If so, just return the aligned-spin scalar curvature
+  if (abs(spin_theta) < eps or abs(spin_theta - M_PI) < eps) {
+    return ricci_scalar_with_spin_on_z_axis;
+  }
+
+  const double spin_phi = atan2(dimensionless_spin[1], dimensionless_spin[0]);
+
+  // Get the theta and phi points on the original Strahlkorper, where the
+  // spin is not on the z axis
+  const auto& theta_phi_points = ylm.theta_phi_points();
+
+  // Loop over collocation points, rotating each point
+  std::vector<std::array<double, 2>> points;
+  for (size_t i = 0; i < get(ricci_scalar_with_spin_on_z_axis).size(); ++i) {
+    // Get (theta,phi) of the collocation point on the actual horizon
+    const double theta = theta_phi_points[0][i];
+    const double phi = theta_phi_points[1][i];
+
+    // Rotate the coordinates on the original Strahlkorper so that a point
+    // on the spin axis gets mapped to a point on the +z axis.
+    // This means the new coordinates are rotated from the old ones by
+    // -spin_phi about the z axis and then by -spin_theta about the y axis.
+    // The unrotated x,y,z coordinates are defined on the unit sphere:
+    // x = sin(theta)*cos(phi), y = sin(theta) * sin(phi), z = cos(theta)
+
+    const double x_new = cos(spin_theta) * cos(phi - spin_phi) * sin(theta) -
+                         cos(theta) * sin(spin_theta);
+    const double y_new = sin(theta) * sin(phi - spin_phi);
+    const double z_new = cos(theta) * cos(spin_theta) +
+                         cos(phi - spin_phi) * sin(theta) * sin(spin_theta);
+
+    // Since I'm rotating on the unit sphere, the radius of the unrotated and
+    // new points is unity.
+    const double theta_new = atan2(sqrt(square(x_new) + square(y_new)), z_new);
+    double phi_new = (abs(theta_new) > eps and abs(theta_new - M_PI) > eps)
+                         ? atan2(y_new, x_new)
+                         : 0.0;
+    // Ensure phi_new is between 0 and 2 pi.
+    if (phi_new < 0.0) {
+      phi_new += 2.0 * M_PI;
+    }
+
+    // Add the point to the list of points to interpolate to
+    points.emplace_back(std::array<double, 2>{{theta_new, phi_new}});
+  }
+
+  // Interpolate ricci_scalar_with_spin_on_z_axis onto the new points
+  auto interpolation_info =
+      ylm_with_spin_on_z_axis.set_up_interpolation_info(points);
+  std::vector<double> ricci_scalar_interpolated(interpolation_info.size());
+  ylm_with_spin_on_z_axis.interpolate(
+      &ricci_scalar_interpolated, get(ricci_scalar_with_spin_on_z_axis).data(),
+      interpolation_info);
+
+  // Load the interpolated values into the DataVector ricci_scalar
+  Scalar<DataVector> ricci_scalar =
+      make_with_value<Scalar<DataVector>>(theta_phi_points[0], 0.0);
+  for (size_t i = 0; i < get(ricci_scalar_with_spin_on_z_axis).size(); ++i) {
+    get(ricci_scalar)[i] = ricci_scalar_interpolated[i];
+  }
+
+  return ricci_scalar;
+}
+
 }  // namespace Kerr
 }  // namespace TestHelpers
 
@@ -132,3 +260,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (3), (double, DataVector),
 template Scalar<DataVector> TestHelpers::Kerr::horizon_radius(
     const std::array<DataVector, 2>& theta_phi, const double& mass,
     const std::array<double, 3>& spin) noexcept;
+template Scalar<DataVector> TestHelpers::Kerr::horizon_ricci_scalar(
+    const Scalar<DataVector>& horizon_radius, const double& mass,
+    const double& dimensionless_spin_z) noexcept;
+template Scalar<DataVector> TestHelpers::Kerr::horizon_ricci_scalar(
+    const Scalar<DataVector>& horizon_radius_with_spin_on_z_axis,
+    const YlmSpherepack& ylm_with_spin_on_z_axis, const YlmSpherepack& ylm,
+    const double& mass, const std::array<double, 3>& spin) noexcept;

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
@@ -8,6 +8,10 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
+/// \cond
+class YlmSpherepack;
+/// \endcond
+
 namespace TestHelpers {
 namespace Schwarzschild {
 /*!
@@ -58,6 +62,36 @@ template <typename DataType>
 Scalar<DataType> horizon_radius(const std::array<DataType, 2>& theta_phi,
                                 const double& mass,
                                 const std::array<double, 3>& spin) noexcept;
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Kerr (Kerr-Schild) horizon ricci scalar (spin on z axis)
+ *
+ * \details
+ * Computes the 2-dimensional Ricci scalar \f$R\f$ on the
+ * horizon of a Kerr-Schild black hole with spin in the z direction
+ * in terms of mass `mass` and dimensionless spin `dimensionless_spin_z`.
+ */
+template <typename DataType>
+Scalar<DataType> horizon_ricci_scalar(
+    const Scalar<DataType>& horizon_radius, const double& mass,
+    const double& dimensionless_spin_z) noexcept;
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Kerr (Kerr-Schild) horizon ricci scalar (generic spin)
+ *
+ * \details
+ * Computes the 2-dimensional Ricci scalar \f$R\f$ on the
+ * horizon of a Kerr-Schild black hole with generic spin
+ * in terms of mass `mass` and dimensionless spin `dimensionless_spin`.
+ */
+template <typename DataType>
+Scalar<DataType> horizon_ricci_scalar(
+    const Scalar<DataType>& horizon_radius_with_spin_on_z_axis,
+    const YlmSpherepack& ylm_with_spin_on_z_axis, const YlmSpherepack& ylm,
+    const double& mass,
+    const std::array<double, 3>& dimensionless_spin) noexcept;
 
 }  // namespace Kerr
 }  // namespace TestHelpers


### PR DESCRIPTION
## Proposed changes

This pull request computes the approximate-Killing-vector spin magnitude. 

The approximate symmetries are computed by solving a generalized eigenvalue problem using lapack. Then, the spin is computed as a certain surface integral involving the approximate symmetries and the spin function. 

Given that this is the most complicated of all of the "StrahlkorperPhysicalQuantieies" PRs, I wanted to submit this so reviewers could start looking at, especially to get the big picture, even though the PRs it depends on are still under review.

The test uses Mathematica-generated code to compute the Kerr-Schild horizon Ricci scalar curvature, one of the ingredients. This isn't that great, but I couldn't find a better way to get this quantity: it has no simple, analytic expression, and spectre currently can't (as far as I understand) compute it numerically. (Computing numerical derivatives in the volume and then interpolating onto the surface is not yet supported, right?)

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
