### PR TITLE
Allow non-time identification for flux communication

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -28,6 +28,7 @@
 #include "Time/Actions/AdvanceTime.hpp"
 #include "Time/Actions/FinalTime.hpp"
 #include "Time/Actions/UpdateU.hpp"
+#include "Time/Tags.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -47,22 +48,19 @@ struct EvolutionMetavars {
 
   using component_list = tmpl::list<DgElementArray<
       EvolutionMetavars,
-      tmpl::list<Actions::ComputeVolumeDuDt<Dim>,
-                 dg::Actions::ComputeNonconservativeBoundaryFluxes,
-                 dg::Actions::SendDataForFluxes,
-                 dg::Actions::ComputeBoundaryFlux<EvolutionMetavars>,
-                 Actions::UpdateU, Actions::AdvanceTime, Actions::FinalTime>>>;
+      tmpl::list<
+          Actions::ComputeVolumeDuDt<Dim>,
+          dg::Actions::ComputeNonconservativeBoundaryFluxes,
+          dg::Actions::SendDataForFluxes<Tags::TimeId>,
+          dg::Actions::ComputeBoundaryFlux<EvolutionMetavars, Tags::TimeId>,
+          Actions::UpdateU, Actions::AdvanceTime, Actions::FinalTime>>>;
 
   static constexpr OptionString help{
       "Evolve a Scalar Wave in Dim spatial dimension.\n\n"
       "The analytic solution is: PlaneWave\n"
       "The numerical flux is:    UpwindFlux\n"};
 
-  enum class Phase {
-    Initialization,
-    Evolve,
-    Exit
-  };
+  enum class Phase { Initialization, Evolve, Exit };
 
   static Phase determine_next_phase(
       const Phase& current_phase,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
@@ -10,6 +10,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Tags.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -118,8 +118,9 @@ struct System {
 };
 
 struct Metavariables;
-using send_data_for_fluxes = dg::Actions::SendDataForFluxes;
-using compute_boundary_flux = dg::Actions::ComputeBoundaryFlux<Metavariables>;
+using send_data_for_fluxes = dg::Actions::SendDataForFluxes<Tags::TimeId>;
+using compute_boundary_flux =
+    dg::Actions::ComputeBoundaryFlux<Metavariables, Tags::TimeId>;
 
 using component =
     ActionTesting::MockArrayComponent<Metavariables, ElementIndex<2>,


### PR DESCRIPTION
## Proposed changes

This PR templates `SendDataForFluxes` and `ComputeBoundaryFlux` on the tag to be used for identifying the temporal state the sent and received fluxes correspond to. This is to decouple the logic from `TimeId` and make it applicable also to elliptic problems where time is replaced by an `IterationId`.

**What breaks:**
- Code that uses `SendDataForFluxes` and `ComputeBoundaryFlux` must provide an additional template parameter `TemporalIdTag` for both. Pass `Tags::TimeId` here to retain the same functionality as before.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->