### PR TITLE
Add instructions on local CI checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,31 +18,19 @@ At a high level, describe what this PR does.
 
 ### Code review checklist
 
-- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
-- Code has documentation and unit tests
-- Private member variables have a trailing underscore
-- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
-- Header order:
-  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
-  2. Blank line (only in cpp files and tests)
-  3. STL and externals (in alphabetical order)
-  4. Blank line
-  5. SpECTRE includes (in alphabetical order)
-- File lists in CMake are alphabetical
-- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
-- Mark objects `const` whenever possible
-- Almost always `auto`, except with expression templates, i.e. `DataVector`
-- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
-- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
-- Prefix commits addressing PR requests with `fixup`. These commits are flagged
-  by Travis so we do not accidentally merge them.
-- Include what you use, prefer forward declarations in hpp files.
-- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
-- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
-  `get<1>(tensor)`
+- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
+  instructions on how to perform the CI checks locally refer to the [Dev guide
+  on the Travis CI](https://spectre-code.org/travis_guide.html).
+- [ ] The code is documented and the documentation renders correctly. Run `make doc`
+  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
+  `index.html`.
+- [ ] The code follows the stylistic and code quality guidelines listed in the
+  [code review guide](https://spectre-code.org/code_review_guide.html).
 
 ### Further comments
 
 <!--
-If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+If this is a relatively large or complex change, kick off the discussion by
+explaining why you chose the solution you did and what alternatives you
+considered, etc...
 -->

--- a/docs/DevGuide/CodeReviewGuide.md
+++ b/docs/DevGuide/CodeReviewGuide.md
@@ -44,6 +44,7 @@ Stylistic Items:
 // ================================================================
 ```
 
+* File lists in CMake are alphabetical.
 * No blank lines surrounding Doxygen group comments
   (<code>// \@{</code> and <code>// \@}</code>).
 * Use the [alternative tokens]
@@ -78,9 +79,10 @@ Code Quality Items:
 * Prefer range-based for loops
 * Use `size_t` for positive integers rather than `int`, specifically when
   looping over containers. This is in compliance with what the STL uses.
-* Error messages should be helpful. An example of a bad error message is
-  "Size mismatch" which should read "The number of grid points in the matrix
-  'F' is not the same as the number of grid points in the determinant."
+* Error messages should be helpful. An example of a bad error message is "Size
+  mismatch". Instead this message could read "The number of grid points in the
+  matrix 'F' is not the same as the number of grid points in the determinant.",
+  along with the runtime values of the mentioned quantities if applicable.
 * Mark immutable objects as `const`
 * Make classes serializable by writing a `pup` function
 * If a class stores an object passed into a constructor the object should
@@ -104,3 +106,4 @@ Code Quality Items:
   `get<a, b>(tensor)` instead of the member `get` function.
 * All necessary header files must be included. In header files, prefer
   forward declarations if class definitions aren't necessary.
+* Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`.

--- a/docs/DevGuide/Travis.md
+++ b/docs/DevGuide/Travis.md
@@ -74,6 +74,31 @@ performed in the CHECK_FILES build.
 using a Linux OS, and the `AppleClang` compiler for `OS X`.
 * The `gcc Debug` build will fail if there are `doxygen` warnings.
 
+## How to perform the checks locally
+
+Before pushing to GitHub and waiting for Travis to perform the checks it is
+useful to perform at least the following tests locally:
+- **Unit tests:** Perform a `make test-executables` and then execute `ctest` to
+  run all unit tests. As for `make` you can append a `-jN` flag to `ctest` to
+  run in parallel on `N` cores. To run only a subset of the tests you can use
+  one of the other keywords that the tests are labeled with, such as `ctest -L
+  datastructures`. To run only particular tests you can also execute `ctest -R
+  TEST_NAME` instead, where `TEST_NAME` is a regular expression matching the
+  test identifiers such as `Unit.DataStructures.Mesh`. Pass the flag
+  `--output-on-failure` to get output from failed tests. Consult `ctest -h` for
+  further options.
+- **clang-tidy:** In a clang build directory, run `make clang-tidy
+  FILE=SOURCE_FILE` where `SOURCE_FILE` is a relative or absolute path to a
+  `.cpp` file. To perform this check for all source files that changed in your
+  pull request, `make clang-tidy-hash HASH=UPSTREAM_HEAD` where `UPSTREAM_HEAD`
+  is the hash of the commit that your pull request is based on, usually the
+  `HEAD` of the `upstream/develop` branch.
+- **IWYU:** Also just for the changed files in a pull request run `make
+  iwyu-hash HASH=UPSTREAM_HEAD`. Since IWYU requires `USE_PCH=OFF` you can
+  create a separate build directory and append `-D USE_PCH=OFF` to the usual
+  `cmake` call. Note that it is very easy to incorrectly install IWYU (if not
+  using the Docker container) and generate nonsense errors.
+
 ## Travis setup
 
 * The `gcc Debug` build runs code coverage for each Travis build.


### PR DESCRIPTION
## Proposed changes

This PR adds a section on how to perform the CI checks locally to https://spectre-code.org/travis_guide.html to address #700.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->