### PR TITLE
Replace db::Label with static method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ include(SetupPch)
 # dependencies on the PCH if necessary.
 include(SetupClangFormat)
 include(SetupClangTidy)
+include(SetupIwyu)
 include(SetupCppCheck)
 include(SetupDoxygen)
 include(CodeCoverageDetection)

--- a/cmake/SetupIwyu.cmake
+++ b/cmake/SetupIwyu.cmake
@@ -1,0 +1,87 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+function(add_iwyu_tool_targets IWYU_TOOL)
+  # Run IWYU in parallel using half the available cores. On single
+  # core machines using only 1 core
+  include(ProcessorCount)
+  ProcessorCount(N)
+  math(EXPR N "${N} / 2")
+  if(${N} EQUAL 0)
+    set(N 1)
+  endif()
+
+  # IWYU for a single file
+  add_custom_target(
+    iwyu
+    COMMAND ${IWYU_TOOL}
+    -j ${N}
+    -p ${CMAKE_BINARY_DIR}
+    \${FILE}
+    --
+    --mapping_file=${CMAKE_SOURCE_DIR}/tools/Iwyu/iwyu.imp
+    )
+  add_dependencies(
+    iwyu
+    ${MODULES_TO_DEPEND_ON}
+    )
+  set_target_properties(
+    iwyu
+    PROPERTIES EXCLUDE_FROM_ALL TRUE
+    )
+
+  # IWYU for all files modified between two hashes
+  add_custom_target(
+    iwyu-hash
+    COMMAND
+    ${CMAKE_SOURCE_DIR}/.travis/RunIncludeWhatYouUse.sh
+    ${CMAKE_BINARY_DIR}
+    ${CMAKE_SOURCE_DIR}
+    ${IWYU_TOOL}
+    ${N}
+    \${HASH}
+    )
+  add_dependencies(
+    iwyu-hash
+    ${MODULES_TO_DEPEND_ON}
+    )
+  set_target_properties(
+    iwyu-hash
+    PROPERTIES EXCLUDE_FROM_ALL TRUE
+    )
+endfunction(add_iwyu_tool_targets IWYU_TOOL)
+
+if(NOT ${USE_PCH})
+  set(IWYU_REQUIRED_VERSION 0.9)
+  find_program(IWYU_BINARY include-what-you-use)
+  find_program(IWYU_TOOL iwyu_tool.py)
+  if("${IWYU_TOOL}" STREQUAL "IWYU_TOOL-NOTFOUND")
+    message(STATUS "Could not find include-what-you-use iwyu_tool.py")
+  else("${IWYU_TOOL}" STREQUAL "IWYU_TOOL-NOTFOUND")
+    # Parse IWYU version
+    execute_process(
+      COMMAND ${IWYU_BINARY} --version
+      OUTPUT_VARIABLE IWYU_VERSION_STRING
+      )
+    string(
+      REPLACE "include-what-you-use " ""
+      IWYU_VERSION_STRING "${IWYU_VERSION_STRING}")
+    string(FIND ${IWYU_VERSION_STRING} " " IWYU_VERSION_END)
+    string(SUBSTRING ${IWYU_VERSION_STRING} 0 ${IWYU_VERSION_END} IWYU_VERSION)
+    if(${IWYU_VERSION} VERSION_LESS ${IWYU_REQUIRED_VERSION})
+      message(STATUS
+        "include-what-you-use version must be ${IWYU_REQUIRED_VERSION} "
+        "but found ${IWYU_VERSION}")
+      set(IWYU_TOOL "IWYU_TOOL-NOTFOUND")
+    else(${IWYU_VERSION} VERSION_LESS ${IWYU_REQUIRED_VERSION})
+      message(STATUS "iwyu include-what-you-use: ${IWYU_BINARY}")
+      message(STATUS "iwyu iwyu_tool.py: ${IWYU_TOOL}")
+      message(STATUS "iwyu vers: ${IWYU_VERSION}")
+      add_iwyu_tool_targets(${IWYU_TOOL})
+    endif(${IWYU_VERSION} VERSION_LESS ${IWYU_REQUIRED_VERSION})
+  endif("${IWYU_TOOL}" STREQUAL "IWYU_TOOL-NOTFOUND")
+else()
+  message(STATUS
+    "iwyu: Cannot use include-what-you-use with precompiled header. "
+    "Pass USE_PCH=OFF to CMake to disable the precompiled header.")
+endif(NOT ${USE_PCH})

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -140,19 +140,19 @@
  * is never evaluated.
  *
  * Simple tags must have a member type alias `type` that is the type of the data
- * to be stored and a `static constexpr db::Label label` that is the name of the
- * tag. Simple tags must inherit from `db::SimpleTag`.
+ * to be stored and a `static std::string name()` method that returns the name
+ * of the tag. Simple tags must inherit from `db::SimpleTag`.
  *
- * Compute tags must also have a `static constexpr db::Label label` that is the
- * name of the tag, but they cannot have a `type` type alias. Instead, compute
- * tags must have a static member function or static member function pointer
- * named `function`. `function` can be a function template if necessary. The
- * `function` must take all its arguments by `const` reference. The arguments to
- * the function are retrieved using tags from the DataBox that the compute tag
- * is in. The tags for the arguments are set in the member type alias
- * `argument_tags`, which must be a `tmpl::list` of the tags corresponding to
- * each argument. Note that the order of the tags in the `argument_list` is the
- * order that they will be passed to the function. Compute tags must inherit
+ * Compute tags must also have a `static std::string name()` method that returns
+ * the name of the tag, but they cannot have a `type` type alias. Instead,
+ * compute tags must have a static member function or static member function
+ * pointer named `function`. `function` can be a function template if necessary.
+ * The `function` must take all its arguments by `const` reference. The
+ * arguments to the function are retrieved using tags from the DataBox that the
+ * compute tag is in. The tags for the arguments are set in the member type
+ * alias `argument_tags`, which must be a `tmpl::list` of the tags corresponding
+ * to each argument. Note that the order of the tags in the `argument_list` is
+ * the order that they will be passed to the function. Compute tags must inherit
  * from `db::ComputeTag`.
  *
  * Here is an example of a simple tag:

--- a/src/ApparentHorizons/StrahlkorperDataBox.hpp
+++ b/src/ApparentHorizons/StrahlkorperDataBox.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 #include "ApparentHorizons/Strahlkorper.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -48,7 +49,7 @@ using SecondDeriv = tnsr::ii<DataVector, 3, Frame>;
 /// Tag referring to a `::Strahlkorper`
 template <typename Frame>
 struct Strahlkorper : db::SimpleTag {
-  static constexpr db::Label label = "Strahlkorper";
+  static std::string name() noexcept { return "Strahlkorper"; }
   using type = ::Strahlkorper<Frame>;
 };
 
@@ -56,7 +57,7 @@ struct Strahlkorper : db::SimpleTag {
 /// Doesn't depend on the shape of the surface.
 template <typename Frame>
 struct ThetaPhi : db::ComputeTag {
-  static constexpr db::Label label = "ThetaPhi";
+  static std::string name() noexcept { return "ThetaPhi"; }
   static StrahlkorperTags_detail::ThetaPhi<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper) noexcept;
   using argument_tags = tmpl::list<Strahlkorper<Frame>>;
@@ -66,7 +67,7 @@ struct ThetaPhi : db::ComputeTag {
 /// Doesn't depend on the shape of the surface.
 template <typename Frame>
 struct Rhat : db::ComputeTag {
-  static constexpr db::Label label = "Rhat";
+  static std::string name() noexcept { return "Rhat"; }
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
@@ -79,7 +80,7 @@ struct Rhat : db::ComputeTag {
 /// `Jacobian` doesn't depend on the shape of the surface.
 template <typename Frame>
 struct Jacobian : db::ComputeTag {
-  static constexpr db::Label label = "Jacobian";
+  static std::string name() noexcept { return "Jacobian"; }
   static StrahlkorperTags_detail::Jacobian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
@@ -91,7 +92,7 @@ struct Jacobian : db::ComputeTag {
 /// `InvJacobian` doesn't depend on the shape of the surface.
 template <typename Frame>
 struct InvJacobian : db::ComputeTag {
-  static constexpr db::Label label = "InvJacobian";
+  static std::string name() noexcept { return "InvJacobian"; }
   static StrahlkorperTags_detail::InvJacobian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
@@ -103,7 +104,7 @@ struct InvJacobian : db::ComputeTag {
 /// `InvHessian` doesn't depend on the shape of the surface.
 template <typename Frame>
 struct InvHessian : db::ComputeTag {
-  static constexpr db::Label label = "InvHessian";
+  static std::string name() noexcept { return "InvHessian"; }
   static StrahlkorperTags_detail::InvHessian<Frame> function(
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
   using argument_tags = tmpl::list<ThetaPhi<Frame>>;
@@ -113,7 +114,7 @@ struct InvHessian : db::ComputeTag {
 /// point of the surface.
 template <typename Frame>
 struct Radius : db::ComputeTag {
-  static constexpr db::Label label = "Radius";
+  static std::string name() noexcept { return "Radius"; }
   SPECTRE_ALWAYS_INLINE static auto function(
       const ::Strahlkorper<Frame>& strahlkorper) noexcept {
     return strahlkorper.ylm_spherepack().spec_to_phys(
@@ -127,7 +128,7 @@ struct Radius : db::ComputeTag {
 /// on the surface.
 template <typename Frame>
 struct CartesianCoords : db::ComputeTag {
-  static constexpr db::Label label = "CartesianCoords";
+  static std::string name() noexcept { return "CartesianCoords"; }
   static StrahlkorperTags_detail::Vector<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<Rhat<Frame>>& r_hat) noexcept;
@@ -143,7 +144,7 @@ struct CartesianCoords : db::ComputeTag {
 /// for this operation.
 template <typename Frame>
 struct DxRadius : db::ComputeTag {
-  static constexpr db::Label label = "DxRadius";
+  static std::string name() noexcept { return "DxRadius"; }
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<InvJacobian<Frame>>& inv_jac) noexcept;
@@ -160,7 +161,7 @@ struct DxRadius : db::ComputeTag {
 /// for this operation.
 template <typename Frame>
 struct D2xRadius : db::ComputeTag {
-  static constexpr db::Label label = "D2xRadius";
+  static std::string name() noexcept { return "D2xRadius"; }
   static StrahlkorperTags_detail::SecondDeriv<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<InvJacobian<Frame>>& inv_jac,
@@ -174,7 +175,7 @@ struct D2xRadius : db::ComputeTag {
 /// where \f$r_{\rm surf}=r_{\rm surf}(\theta(x,y,z),\phi(x,y,z))\f$.
 template <typename Frame>
 struct LaplacianRadius : db::ComputeTag {
-  static constexpr db::Label label = "LaplacianRadius";
+  static std::string name() noexcept { return "LaplacianRadius"; }
   static DataVector function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<ThetaPhi<Frame>>& theta_phi) noexcept;
@@ -193,7 +194,7 @@ struct LaplacianRadius : db::ComputeTag {
 /// (it is not "normalized"; normalization requires a metric).
 template <typename Frame>
 struct NormalOneForm : db::ComputeTag {
-  static constexpr db::Label label = "NormalOneForm";
+  static std::string name() noexcept { return "NormalOneForm"; }
   static StrahlkorperTags_detail::OneForm<Frame> function(
       const db::item_type<DxRadius<Frame>>& dx_radius,
       const db::item_type<Rhat<Frame>>& r_hat) noexcept;
@@ -217,7 +218,7 @@ struct NormalOneForm : db::ComputeTag {
 /// a one-form) is metric-dependent.
 template <typename Frame>
 struct Tangents : db::ComputeTag {
-  static constexpr db::Label label = "Tangents";
+  static std::string name() noexcept { return "Tangents"; }
   static StrahlkorperTags_detail::Jacobian<Frame> function(
       const ::Strahlkorper<Frame>& strahlkorper, const DataVector& radius,
       const db::item_type<Rhat<Frame>>& r_hat,

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
@@ -25,7 +26,7 @@ namespace Tags {
 /// \brief Prefix indicating a time derivative
 template <typename Tag>
 struct dt : db::PrefixTag, db::SimpleTag {
-  static constexpr db::Label label = "dt";
+  static std::string name() noexcept { return "dt"; }
   using type = db::item_type<Tag>;
   using tag = Tag;
 };
@@ -44,7 +45,7 @@ struct Flux<Tag, VolumeDim, Fr,
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Up, Fr>;
   using tag = Tag;
-  static constexpr db::Label label = "Flux";
+  static std::string name() noexcept { return "Flux"; }
 };
 
 template <typename Tag, typename VolumeDim, typename Fr>
@@ -53,7 +54,7 @@ struct Flux<Tag, VolumeDim, Fr,
     : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::Label label = "Flux";
+  static std::string name() noexcept { return "Flux"; }
 };
 /// \endcond
 
@@ -64,7 +65,7 @@ template <typename Tag>
 struct NormalDotFlux : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::Label label = "NormalDotFlux";
+  static std::string name() noexcept { return "NormalDotFlux"; }
   static constexpr bool should_be_sliced_to_boundary = false;
 };
 
@@ -75,6 +76,6 @@ template <typename Tag>
 struct NormalDotNumericalFlux : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::Label label = "NormalDotNumericalFlux";
+  static std::string name() noexcept { return "NormalDotNumericalFlux"; }
 };
 }  // namespace Tags

--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
@@ -47,7 +49,7 @@ namespace Tags {
 /// The Euclidean magnitude of a (co)vector
 template <typename Tag>
 struct EuclideanMagnitude : db::ComputeTag {
-  static constexpr db::Label label = "EuclideanMagnitude";
+  static std::string name() noexcept { return "EuclideanMagnitude"; }
   static constexpr Scalar<DataVector> (*function)(const db::item_type<Tag>&) =
       magnitude;
   using argument_tags = tmpl::list<Tag>;
@@ -59,7 +61,7 @@ struct EuclideanMagnitude : db::ComputeTag {
 /// MagnitudeTag.
 template <typename Tag, typename MagnitudeTag>
 struct Normalized : db::ComputeTag {
-  static constexpr db::Label label = "Normalized";
+  static std::string name() noexcept { return "Normalized"; }
   static constexpr auto function(
       const db::item_type<Tag>&
           vector_in,  // Compute items need to take const references

--- a/src/DataStructures/Tensor/Structure.hpp
+++ b/src/DataStructures/Tensor/Structure.hpp
@@ -13,7 +13,7 @@
 #include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/Tensor/Symmetry.hpp"
 #include "ErrorHandling/Assert.hpp"
-#include "Utilities/Array.hpp"
+#include "Utilities/Array.hpp"  // IWYU pragma: export
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -32,7 +34,18 @@ struct Variables : db::SimpleTag {
                 "The TagsList passed to Tags::Variables is not a typelist");
   using tags_list = TagsList;
   using type = ::Variables<TagsList>;
-  static constexpr db::Label label = "Variables";
+  static std::string name() noexcept {
+    std::string tag_name{"Variables("};
+    size_t iter = 0;
+    tmpl::for_each<TagsList>([&tag_name, &iter ](auto tag) noexcept {
+      tag_name += tmpl::type_from<decltype(tag)>::name();
+      if (iter + 1 != tmpl::size<TagsList>::value) {
+        tag_name += ",";
+      }
+      iter++;
+    });
+    return tag_name + ")";
+  }
 };
 }  // namespace Tags
 
@@ -47,8 +60,8 @@ class Variables;
  * into it.
  *
  * The `Tags` are `struct`s that must have a public type alias `type` whose
- * value must be a `Tensor<DataVector, ...>`, a `static constexpr
- * db::Label` variable named `label`, and must derive off of
+ * value must be a `Tensor<DataVector, ...>`, a `static' method `name()` that
+ * returns a `std::string` of the tag name, and must derive off of
  * `db::SimpleTag`. In general, they should be DataBoxTags that are not compute
  * items. For example,
  *

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -68,7 +69,7 @@ namespace Tags {
 /// The unnormalized face normal one form
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct UnnormalizedFaceNormal : db::ComputeTag {
-  static constexpr db::Label label = "UnnormalizedFaceNormal";
+  static std::string name() noexcept { return "UnnormalizedFaceNormal"; }
   static constexpr tnsr::i<DataVector, VolumeDim, Frame> (*function)(
       const ::Index<VolumeDim - 1>&, const ::ElementMap<VolumeDim, Frame>&,
       const ::Direction<VolumeDim>&) = unnormalized_face_normal;

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -56,7 +57,7 @@ namespace Tags {
 /// The ::Element associated with the DataBox
 template <size_t VolumeDim>
 struct Element : db::SimpleTag {
-  static constexpr db::Label label = "Element";
+  static std::string name() noexcept { return "Element"; }
   using type = ::Element<VolumeDim>;
 };
 
@@ -65,7 +66,7 @@ struct Element : db::SimpleTag {
 /// The extents of DataVectors in the DataBox
 template <size_t VolumeDim>
 struct Extents : db::SimpleTag {
-  static constexpr db::Label label = "Extents";
+  static std::string name() noexcept { return "Extents"; }
   using type = ::Index<VolumeDim>;
 };
 
@@ -74,7 +75,7 @@ struct Extents : db::SimpleTag {
 /// The logical coordinates in the Element
 template <size_t VolumeDim>
 struct LogicalCoordinates : db::ComputeTag {
-  static constexpr db::Label label = "LogicalCoordinates";
+  static std::string name() noexcept { return "LogicalCoordinates"; }
   using argument_tags = tmpl::list<Tags::Extents<VolumeDim>>;
   static constexpr auto function = logical_coordinates<VolumeDim>;
 };
@@ -84,7 +85,7 @@ struct LogicalCoordinates : db::ComputeTag {
 /// The coordinate map from logical to grid coordinate
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct ElementMap : db::SimpleTag {
-  static constexpr db::Label label = "ElementMap";
+  static std::string name() noexcept { return "ElementMap"; }
   using type = ::ElementMap<VolumeDim, Frame>;
 };
 
@@ -95,7 +96,7 @@ struct ElementMap : db::SimpleTag {
 template <class MapTag, class SourceCoordsTag>
 struct Coordinates : db::ComputeTag, db::PrefixTag {
   using tag = MapTag;
-  static constexpr db::Label label = "Coordinates";
+  static std::string name() noexcept { return "Coordinates"; }
   static constexpr auto function(
       const db::item_type<MapTag>& element_map,
       const db::item_type<SourceCoordsTag>& source_coords) noexcept {
@@ -112,7 +113,7 @@ struct Coordinates : db::ComputeTag, db::PrefixTag {
 template <typename MapTag, typename SourceCoordsTag>
 struct InverseJacobian : db::ComputeTag, db::PrefixTag {
   using tag = MapTag;
-  static constexpr db::Label label = "InverseJacobian";
+  static std::string name() noexcept { return "InverseJacobian"; }
   static constexpr auto function(
       const db::item_type<MapTag>& element_map,
       const db::item_type<SourceCoordsTag>& source_coords) noexcept {
@@ -126,7 +127,7 @@ struct InverseJacobian : db::ComputeTag, db::PrefixTag {
 /// The set of directions to neighboring Elements
 template <size_t VolumeDim>
 struct InternalDirections : db::ComputeTag {
-  static constexpr db::Label label = "InternalDirections";
+  static std::string name() noexcept { return "InternalDirections"; }
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
     std::unordered_set<::Direction<VolumeDim>> result;
@@ -291,7 +292,7 @@ struct InterfaceBase
     : db::PrefixTag,
       Interface_detail::InterfaceImpl<db::is_compute_item_v<FunctionTag>,
                                       DirectionsTag, NameTag, FunctionTag> {
-  static constexpr db::Label label = "Interface";
+  static std::string name() noexcept { return "Interface"; }
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -299,7 +300,7 @@ struct InterfaceBase
 /// ::Direction to an interface
 template <size_t VolumeDim>
 struct Direction : db::SimpleTag {
-  static constexpr db::Label label = "Direction";
+  static std::string name() noexcept { return "Direction"; }
   using type = ::Direction<VolumeDim>;
 };
 
@@ -307,7 +308,7 @@ struct Direction : db::SimpleTag {
 template <typename DirectionsTag, size_t VolumeDim>
 struct Interface<DirectionsTag, Direction<VolumeDim>> : db::PrefixTag,
                                                         db::ComputeTag {
-  static constexpr db::Label label = "Interface";
+  static std::string name() noexcept { return "Interface"; }
   using tag = Direction<VolumeDim>;
   static constexpr auto function(
       const std::unordered_set<::Direction<VolumeDim>>& directions) noexcept {

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -16,27 +17,27 @@ class DataVector;
 namespace CurvedScalarWave {
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Psi";
+  static std::string name() noexcept { return "Psi"; }
 };
 
 struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Pi";
+  static std::string name() noexcept { return "Pi"; }
 };
 
 template <size_t Dim>
 struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim>;
-  static constexpr db::Label label = "Phi";
+  static std::string name() noexcept { return "Phi"; }
 };
 
 struct ConstraintGamma1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "ConstraintGamma1";
+  static std::string name() noexcept { return "ConstraintGamma1"; }
 };
 
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "ConstraintGamma2";
+  static std::string name() noexcept { return "ConstraintGamma2"; }
 };
 }  // namespace CurvedScalarWave

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include <string>
+
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 
 class DataVector;
 
@@ -19,7 +22,7 @@ namespace GeneralizedHarmonic {
 template <size_t Dim, typename Frame>
 struct Pi : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
-  static constexpr db::Label label = "Pi";
+  static std::string name() noexcept { return "Pi"; }
 };
 
 /*!
@@ -31,29 +34,29 @@ struct Pi : db::SimpleTag {
 template <size_t Dim, typename Frame>
 struct Phi : db::SimpleTag {
   using type = tnsr::iaa<DataVector, Dim, Frame>;
-  static constexpr db::Label label = "Phi";
+  static std::string name() noexcept { return "Phi"; }
 };
 
 struct ConstraintGamma0 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "ConstraintGamma0";
+  static std::string name() noexcept { return "ConstraintGamma0"; }
 };
 struct ConstraintGamma1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "ConstraintGamma1";
+  static std::string name() noexcept { return "ConstraintGamma1"; }
 };
 struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "ConstraintGamma2";
+  static std::string name() noexcept { return "ConstraintGamma2"; }
 };
 template <size_t Dim, typename Frame>
 struct GaugeH : db::SimpleTag {
   using type = tnsr::a<DataVector, Dim, Frame>;
-  static constexpr db::Label label = "GaugeH";
+  static std::string name() noexcept { return "GaugeH"; }
 };
 template <size_t Dim, typename Frame>
 struct SpacetimeDerivGaugeH : db::SimpleTag {
   using type = tnsr::ab<DataVector, Dim, Frame>;
-  static constexpr db::Label label = "SpacetimeDerivGaugeH";
+  static std::string name() noexcept { return "SpacetimeDerivGaugeH"; }
 };
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -14,18 +15,18 @@ namespace RelativisticEuler {
 namespace Valencia {
 struct TildeD : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label_t label = "TildeD";
+  static std::string name() noexcept { "TildeD"; }
 };
 
 struct TildeTau : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label_t label = "TildeTau";
+  static std::string name() noexcept { "TildeTau"; }
 };
 
 template <size_t Dim>
 struct TildeS : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
-  static constexpr db::Label_t label = "TildeS";
+  static std::string name() noexcept { "TildeS"; }
 };
 }  // namespace Valencia
 }  // namespace RelativisticEuler

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -126,7 +126,7 @@ struct UpwindFlux {
  private:
   struct NormalTimesFluxPi {
     using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
-    static constexpr db::Label label = "NormalTimesFluxPi";
+    static std::string name() noexcept { return "NormalTimesFluxPi"; }
   };
 
  public:

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -16,20 +17,20 @@ class DataVector;
 namespace ScalarWave {
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Psi";
+  static std::string name() noexcept { return "Psi"; }
   static constexpr bool should_be_sliced_to_boundary = true;
 };
 
 struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Pi";
+  static std::string name() noexcept { return "Pi"; }
   static constexpr bool should_be_sliced_to_boundary = true;
 };
 
 template <size_t Dim>
 struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
-  static constexpr db::Label label = "Phi";
+  static std::string name() noexcept { return "Phi"; }
   static constexpr bool should_be_sliced_to_boundary = true;
 };
 }  // namespace ScalarWave

--- a/src/Executables/Benchmark/Benchmark.cpp
+++ b/src/Executables/Benchmark/Benchmark.cpp
@@ -2,6 +2,7 @@
 // See LICENSE.txt for details.
 
 #include <benchmark/benchmark.h>
+#include <string>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -68,12 +69,12 @@ namespace {
 template <size_t Dim>
 struct Kappa : db::SimpleTag {
   using type = tnsr::abb<DataVector, Dim, Frame::Grid>;
-  static constexpr db::Label label = "Kappa";
+  static std::string name() noexcept { return "Kappa"; }
 };
 template <size_t Dim>
 struct Psi : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame::Grid>;
-  static constexpr db::Label label = "Psi";
+  static std::string name() noexcept { return "Psi"; }
 };
 
 // clang-tidy: don't pass be non-const reference

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <boost/functional/hash.hpp>
+#include <string>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -14,7 +15,7 @@
 namespace Tags {
 template <typename Tag, size_t VolumeDim>
 struct Mortars : db::PrefixTag, db::SimpleTag {
-  static constexpr db::Label label = "Mortar";
+  static std::string name() noexcept { return "Mortar"; }
   using tag = Tag;
   using Key = std::pair<::Direction<VolumeDim>, ::ElementId<VolumeDim>>;
   using type = std::unordered_map<Key, db::item_type<Tag>, boost::hash<Key>>;

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <tuple>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -78,7 +79,7 @@ struct div_impl<Tag, Frame, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
       "the first index is not in the specified Frame");
   using type = TensorMetafunctions::remove_first_index<db::item_type<Tag>>;
   using tag = Tag;
-  static constexpr db::Label label = "div";
+  static std::string name() noexcept { return "div"; }
 };
 
 template <typename... FluxTags, typename InverseJacobianTag>
@@ -91,7 +92,7 @@ struct div_impl<tmpl::list<FluxTags...>, InverseJacobianTag,
   using flux_tags = tmpl::list<FluxTags...>;
 
  public:
-  static constexpr db::Label label = "div";
+  static std::string name() noexcept { return "div"; }
   static constexpr auto function =
       divergence<flux_tags, derivative_frame_index::dim,
                  typename derivative_frame_index::Frame>;

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Variables.hpp"
@@ -104,7 +105,7 @@ struct deriv_impl<Tag, VolumeDim, Frame,
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;
-  static constexpr db::Label label = "deriv";
+  static std::string name() noexcept { return "deriv"; }
 };
 
 // Partial derivatives with derivative index in the frame related to the logical
@@ -122,7 +123,7 @@ struct deriv_impl<
   using variables_tags = tmpl::list<VariablesTags...>;
 
  public:
-  static constexpr db::Label label = "deriv";
+  static std::string name() noexcept { return "deriv"; }
   static constexpr auto function =
       partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
                           derivative_frame_index::dim,
@@ -139,7 +140,7 @@ struct deriv_impl<tmpl::list<VariablesTags...>, tmpl::list<DerivativeTags...>,
                   std::integral_constant<T, Dim>,
                   Requires<(0 < Dim and 4 > Dim)>> : db::ComputeTag {
   using variables_tags = tmpl::list<VariablesTags...>;
-  static constexpr db::Label label = "deriv";
+  static std::string name() noexcept { return "deriv"; }
   static constexpr auto function =
       logical_partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
                                   Dim>;

--- a/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "GrTagsDeclarations.hpp"
@@ -12,79 +14,83 @@ namespace Tags {
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeMetric : db::SimpleTag {
   using type = tnsr::aa<DataType, Dim, Frame>;
-  static constexpr db::Label label = "SpacetimeMetric";
+  static std::string name() noexcept { return "SpacetimeMetric"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct InverseSpacetimeMetric : db::SimpleTag {
   using type = tnsr::AA<DataType, Dim, Frame>;
-  static constexpr db::Label label = "InverseSpacetimeMetric";
+  static std::string name() noexcept { return "InverseSpacetimeMetric"; }
 };
 
 template <size_t Dim, typename Frame, typename DataType>
 struct SpatialMetric : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
-  static constexpr db::Label label = "SpatialMetric";
+  static std::string name() noexcept { return "SpatialMetric"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct InverseSpatialMetric : db::SimpleTag {
   using type = tnsr::II<DataType, Dim, Frame>;
-  static constexpr db::Label label = "InverseSpatialMetric";
+  static std::string name() noexcept { return "InverseSpatialMetric"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SqrtDetSpatialMetric : db::SimpleTag {
   using type = Scalar<DataType>;
-  static constexpr db::Label label = "SqrtDetSpatialMetric";
+  static std::string name() noexcept { return "SqrtDetSpatialMetric"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct Shift : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
-  static constexpr db::Label label = "Shift";
+  static std::string name() noexcept { return "Shift"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct Lapse : db::SimpleTag {
   using type = Scalar<DataType>;
-  static constexpr db::Label label = "Lapse";
+  static std::string name() noexcept { return "Lapse"; }
 };
 
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::abb<DataType, Dim, Frame>;
-  static constexpr db::Label label = "SpacetimeChristoffelFirstKind";
+  static std::string name() noexcept { return "SpacetimeChristoffelFirstKind"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::Abb<DataType, Dim, Frame>;
-  static constexpr db::Label label = "SpactimeChristoffelSecondKind";
+  static std::string name() noexcept { return "SpactimeChristoffelSecondKind"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeNormalOneForm : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
-  static constexpr db::Label label = "SpacetimeNormalOneForm";
+  static std::string name() noexcept { return "SpacetimeNormalOneForm"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeNormalVector : db::SimpleTag {
   using type = tnsr::A<DataType, Dim, Frame>;
-  static constexpr db::Label label = "SpacetimeNormalVector";
+  static std::string name() noexcept { return "SpacetimeNormalVector"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceSpacetimeChristoffelFirstKind : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
-  static constexpr db::Label label = "TraceSpacetimeChristoffelFirstKind";
+  static std::string name() noexcept {
+    return "TraceSpacetimeChristoffelFirstKind";
+  }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceSpatialChristoffelSecondKind : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
-  static constexpr db::Label label = "TraceSpatialChristoffelSecondKind";
+  static std::string name() noexcept {
+    return "TraceSpatialChristoffelSecondKind";
+  }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct ExtrinsicCurvature : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
-  static constexpr db::Label label = "ExtrinsicCurvature";
+  static std::string name() noexcept { return "ExtrinsicCurvature"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
 struct TraceExtrinsicCurvature : db::SimpleTag {
   using type = Scalar<DataType>;
-  static constexpr db::Label label = "TraceExtrinsicCurvature";
+  static std::string name() noexcept { return "TraceExtrinsicCurvature"; }
 };
 }  // namespace Tags
 }  // namespace gr

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -8,6 +8,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <unordered_map>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -25,7 +26,7 @@ namespace Tags {
 /// \ingroup TimeGroup
 /// \brief Tag for ::TimeId for the algorithm state
 struct TimeId : db::SimpleTag {
-  static constexpr db::Label label = "TimeId";
+  static std::string name() noexcept { return "TimeId"; }
   using type = ::TimeId;
 };
 
@@ -33,7 +34,7 @@ struct TimeId : db::SimpleTag {
 /// \ingroup TimeGroup
 /// \brief Tag for step size
 struct TimeStep : db::SimpleTag {
-  static constexpr db::Label label = "TimeStep";
+  static std::string name() noexcept { return "TimeStep"; }
   using type = ::TimeDelta;
 };
 
@@ -45,7 +46,7 @@ inline ::Time time_from_id(const ::TimeId& id) noexcept { return id.time; }
 /// \ingroup TimeGroup
 /// \brief Tag for compute item for current ::Time (from TimeId)
 struct Time : db::ComputeTag {
-  static constexpr db::Label label = "Time";
+  static std::string name() noexcept { return "Time"; }
   static constexpr auto function = TimeTags_detail::time_from_id;
   using argument_tags = tmpl::list<TimeId>;
 };
@@ -54,7 +55,7 @@ struct Time : db::ComputeTag {
 /// \ingroup TimeGroup
 /// \brief Tag for compute item for current time as a double
 struct TimeValue : db::ComputeTag {
-  static constexpr db::Label label = "TimeValue";
+  static std::string name() noexcept { return "TimeValue"; }
   static auto function(const ::Time& t) noexcept { return t.value(); }
   using argument_tags = tmpl::list<Time>;
 };
@@ -67,7 +68,7 @@ struct TimeValue : db::ComputeTag {
 /// \tparam DtTag tag for the time derivative of the variables
 template <typename Tag, typename DtTag>
 struct HistoryEvolvedVariables : db::PrefixTag, db::SimpleTag {
-  static constexpr db::Label label = "HistoryEvolvedVariables";
+  static std::string name() noexcept { return "HistoryEvolvedVariables"; }
   using tag = Tag;
   using type = TimeSteppers::History<db::item_type<Tag>, db::item_type<DtTag>>;
 };
@@ -80,7 +81,7 @@ struct HistoryEvolvedVariables : db::PrefixTag, db::SimpleTag {
 /// \tparam Tag tag for boundary variables
 template <typename Key, typename Tag, typename Hash = std::hash<Key>>
 struct HistoryBoundaryVariables : db::PrefixTag, db::SimpleTag {
-  static constexpr db::Label label = "HistoryBoundaryVariables";
+  static std::string name() noexcept { return "HistoryBoundaryVariables"; }
   using tag = Tag;
   using type = std::unordered_map<Key, db::item_type<Tag>, Hash>;
 };

--- a/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
+++ b/tests/Unit/DataStructures/TensorEagerMath/Test_Magnitude.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <string>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -132,11 +133,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.Magnitude",
 
 namespace {
 struct Vector : db::SimpleTag {
-  static constexpr db::Label label = "Vector";
+  static std::string name() noexcept { return "Vector"; }
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
 };
 struct Covector : db::SimpleTag {
-  static constexpr db::Label label = "Covector";
+  static std::string name() noexcept { return "Covector"; }
   using type = tnsr::i<DataVector, 2, Frame::Grid>;
 };
 }  // namespace

--- a/tests/Unit/DataStructures/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/Test_BaseTags.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -26,7 +27,7 @@ struct VectorBase : db::BaseTag {};
 template <int I>
 struct Vector : db::SimpleTag, VectorBase<I> {
   using type = std::vector<double>;
-  static constexpr db::Label label = "Vector";
+  static std::string name() noexcept { return "Vector"; }
 };
 /// [vector_base_definitions]
 
@@ -37,14 +38,14 @@ struct ArrayBase : db::BaseTag {};
 template <int I>
 struct Array : virtual db::SimpleTag, ArrayBase<I> {
   using type = std::array<int, 3>;
-  static constexpr db::Label label = "Array";
+  static std::string name() noexcept { return "Array"; }
 };
 /// [array_base_definitions]
 
 /// [compute_template_base_tags]
 template <int I, int VectorBaseIndex = 0, int... VectorBaseExtraIndices>
 struct ArrayComputeBase : Array<I>, db::ComputeTag {
-  static constexpr db::Label label = "ArrayComputeBase";
+  static std::string name() noexcept { return "ArrayComputeBase"; }
 
   static std::array<int, 3> function(const std::vector<double>& t) noexcept {
     return {{static_cast<int>(t.size()), static_cast<int>(t[0]), -8}};
@@ -213,12 +214,12 @@ struct ParentBase : db::BaseTag {};
 
 template <size_t N, bool Compute = false, bool DependsOnComputeItem = false>
 struct Parent : ParentBase<N>, db::SimpleTag {
-  static constexpr db::Label label = "Parent";
+  static std::string name() noexcept { return "Parent"; }
   using type = std::pair<Boxed<int>, Boxed<double>>;
 };
 template <size_t N, bool DependsOnComputeItem>
 struct Parent<N, true, DependsOnComputeItem> : ParentBase<N>, db::ComputeTag {
-  static constexpr db::Label label = "Parent";
+  static std::string name() noexcept { return "Parent"; }
   static auto function(
       const std::pair<Boxed<int>, Boxed<double>>& arg) noexcept {
     return std::make_pair(
@@ -230,14 +231,14 @@ struct Parent<N, true, DependsOnComputeItem> : ParentBase<N>, db::ComputeTag {
 
 template <size_t N>
 struct First : FirstBase<N>, db::SimpleTag {
-  static constexpr db::Label label = "First";
+  static std::string name() noexcept { return "First"; }
   using type = Boxed<int>;
 
   static constexpr size_t index = 0;
 };
 template <size_t N>
 struct Second : SecondBase<N>, db::SimpleTag {
-  static constexpr db::Label label = "Second";
+  static std::string name() noexcept { return "Second"; }
   using type = Boxed<double>;
 
   static constexpr size_t index = 1;
@@ -254,7 +255,7 @@ struct ComputeMultiplyByTwo : MultiplyByTwo<N0, N1>, db::ComputeTag {
   static auto function(const T0& t0, const T1& t1) noexcept {
     return *t0 * *t1;
   }
-  static constexpr db::Label label = "MultiplyByTwo";
+  static std::string name() noexcept { return "MultiplyByTwo"; }
   using argument_tags = tmpl::list<First<N0>, Second<N1>>;
 };
 }  // namespace TestTags

--- a/tests/Unit/DataStructures/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/Test_DataBox.cpp
@@ -51,45 +51,45 @@ namespace test_databox_tags {
 /// [databox_tag_example]
 struct Tag0 : db::SimpleTag {
   using type = double;
-  static constexpr db::Label label = "Tag0";
+  static std::string name() noexcept { return "Tag0"; }
 };
 /// [databox_tag_example]
 struct Tag1 : db::SimpleTag {
   using type = std::vector<double>;
-  static constexpr db::Label label = "Tag1";
+  static std::string name() noexcept { return "Tag1"; }
 };
 struct Tag2 : db::SimpleTag {
   using type = std::string;
-  static constexpr db::Label label = "Tag2";
+  static std::string name() noexcept { return "Tag2"; }
 };
 struct Tag3 : db::SimpleTag {
   using type = std::string;
-  static constexpr db::Label label = "Tag3";
+  static std::string name() noexcept { return "Tag3"; }
 };
 
 /// [databox_compute_item_tag_example]
 struct ComputeTag0 : db::ComputeTag {
-  static constexpr db::Label label = "ComputeTag0";
+  static std::string name() noexcept { return "ComputeTag0"; }
   static constexpr auto function = multiply_by_two;
   using argument_tags = tmpl::list<Tag0>;
 };
 
 /// [databox_compute_item_tag_example]
 struct ComputeTag1 : db::ComputeTag {
-  static constexpr db::Label label = "ComputeTag1";
+  static std::string name() noexcept { return "ComputeTag1"; }
   static constexpr auto function = append_word;
   using argument_tags = tmpl::list<Tag2, ComputeTag0>;
 };
 
 struct TagTensor : db::ComputeTag {
-  static constexpr db::Label label = "TagTensor";
+  static std::string name() noexcept { return "TagTensor"; }
   static constexpr auto function = get_tensor;
   using argument_tags = tmpl::list<>;
 };
 
 /// [compute_item_tag_function]
 struct ComputeLambda0 : db::ComputeTag {
-  static constexpr db::Label label = "ComputeLambda0";
+  static std::string name() noexcept { return "ComputeLambda0"; }
   static constexpr double function(const double& a) { return 3.0 * a; }
   using argument_tags = tmpl::list<Tag0>;
 };
@@ -97,7 +97,7 @@ struct ComputeLambda0 : db::ComputeTag {
 
 /// [compute_item_tag_no_tags]
 struct ComputeLambda1 : db::ComputeTag {
-  static constexpr db::Label label = "ComputeLambda1";
+  static std::string name() noexcept { return "ComputeLambda1"; }
   static constexpr double function() { return 7.0; }
   using argument_tags = tmpl::list<>;
 };
@@ -108,7 +108,9 @@ template <typename Tag>
 struct TagPrefix : db::PrefixTag, db::SimpleTag {
   using type = typename Tag::type;
   using tag = Tag;
-  static constexpr db::Label label = "TagPrefix";
+  static std::string name() noexcept {
+    return "TagPrefix(" + Tag::name() + ")";
+  }
 };
 /// [databox_prefix_tag_example]
 }  // namespace test_databox_tags
@@ -144,11 +146,6 @@ static_assert(
 static_assert(std::is_same<decltype(db::create_from<db::RemoveTags<>>(Box_t{})),
                            Box_t>::value,
               "Failed testing no-op create_from");
-
-static_assert(db::DataBox_detail::tag_has_label_v<test_databox_tags::Tag0>,
-              "Failed testing db::tag_has_label");
-static_assert(db::DataBox_detail::tag_has_label_v<test_databox_tags::TagTensor>,
-              "Failed testing db::tag_has_label");
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
@@ -267,12 +264,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox", "[Unit][DataStructures]") {
 
 namespace ArgumentTypeTags {
 struct NonCopyable : db::SimpleTag {
-  static constexpr db::Label label = "NonCopyable";
+  static std::string name() noexcept { return "NonCopyable"; }
   using type = ::NonCopyable;
 };
 template <size_t N>
 struct String : db::SimpleTag {
-  static constexpr db::Label label = "String";
+  static std::string name() noexcept { return "String"; }
   using type = std::string;
 };
 }  // namespace ArgumentTypeTags
@@ -431,7 +428,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.get_item_from_box",
       db::get_item_from_box<std::string>(original_box, "Tag2");
   CHECK(added_string == "My Sample String"s);
   /// [databox_name_prefix]
-  CHECK(db::get_item_from_box<double>(original_box, "TagPrefixTag0") == 8.7);
+  CHECK(db::get_item_from_box<double>(original_box, "TagPrefix(Tag0)") == 8.7);
   /// [databox_name_prefix]
 }
 
@@ -539,14 +536,14 @@ namespace {
 auto get_vector() { return tnsr::I<DataVector, 3, Frame::Grid>(5_st, 2.0); }
 
 struct Var1 : db::ComputeTag {
-  static constexpr db::Label label = "Var1";
+  static std::string name() noexcept { return "Var1"; }
   static constexpr auto function = get_vector;
   using argument_tags = tmpl::list<>;
 };
 
 struct Var2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Var2";
+  static std::string name() noexcept { return "Var2"; }
 };
 
 template <class Tag, class VolumeDim, class Frame>
@@ -554,7 +551,9 @@ struct PrefixTag0 : db::PrefixTag, db::SimpleTag {
   using type = TensorMetafunctions::prepend_spatial_index<
       db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
   using tag = Tag;
-  static constexpr db::Label label = "PrefixTag0";
+  static std::string name() noexcept {
+    return "PrefixTag0(" + tag::name() + ")";
+  }
 };
 
 using two_vars = tmpl::list<Var1, Var2>;
@@ -593,35 +592,35 @@ static_assert(
 namespace test_databox_tags {
 struct ScalarTag : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "ScalarTag";
+  static std::string name() noexcept { return "ScalarTag"; }
 };
 struct VectorTag : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::Label label = "VectorTag";
+  static std::string name() noexcept { return "VectorTag"; }
 };
 struct ScalarTag2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "ScalarTag2";
+  static std::string name() noexcept { return "ScalarTag2"; }
 };
 struct VectorTag2 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::Label label = "VectorTag2";
+  static std::string name() noexcept { return "VectorTag2"; }
 };
 struct ScalarTag3 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "ScalarTag3";
+  static std::string name() noexcept { return "ScalarTag3"; }
 };
 struct VectorTag3 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::Label label = "VectorTag3";
+  static std::string name() noexcept { return "VectorTag3"; }
 };
 struct ScalarTag4 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "ScalarTag4";
+  static std::string name() noexcept { return "ScalarTag4"; }
 };
 struct VectorTag4 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3>;
-  static constexpr db::Label label = "VectorTag4";
+  static std::string name() noexcept { return "VectorTag4"; }
 };
 }  // namespace test_databox_tags
 
@@ -676,37 +675,37 @@ namespace test_databox_tags {
 struct MultiplyScalarByTwo : db::ComputeTag {
   using variables_tags =
       tmpl::list<test_databox_tags::ScalarTag2, test_databox_tags::VectorTag2>;
-  static constexpr db::Label label = "MultiplyScalarByTwo";
+  static std::string name() noexcept { return "MultiplyScalarByTwo"; }
   static constexpr auto function = multiply_scalar_by_two;
   using argument_tags = tmpl::list<test_databox_tags::ScalarTag>;
 };
 
 struct MultiplyScalarByFour : db::ComputeTag {
-  static constexpr db::Label label = "MultiplyScalarByFour";
+  static std::string name() noexcept { return "MultiplyScalarByFour"; }
   static constexpr auto function = multiply_scalar_by_four;
   using argument_tags = tmpl::list<test_databox_tags::ScalarTag2>;
 };
 
 struct MultiplyScalarByThree : db::ComputeTag {
-  static constexpr db::Label label = "MultiplyScalarByThree";
+  static std::string name() noexcept { return "MultiplyScalarByThree"; }
   static constexpr auto function = multiply_scalar_by_three;
   using argument_tags = tmpl::list<test_databox_tags::MultiplyScalarByFour>;
 };
 
 struct DivideScalarByThree : db::ComputeTag {
-  static constexpr db::Label label = "DivideScalarByThree";
+  static std::string name() noexcept { return "DivideScalarByThree"; }
   static constexpr auto function = divide_scalar_by_three;
   using argument_tags = tmpl::list<test_databox_tags::MultiplyScalarByThree>;
 };
 
 struct DivideScalarByTwo : db::ComputeTag {
-  static constexpr db::Label label = "DivideScalarByTwo";
+  static std::string name() noexcept { return "DivideScalarByTwo"; }
   static constexpr auto function = divide_scalar_by_two;
   using argument_tags = tmpl::list<test_databox_tags::DivideScalarByThree>;
 };
 
 struct MultiplyVariablesByTwo : db::ComputeTag {
-  static constexpr db::Label label = "MultiplyVariablesByTwo";
+  static std::string name() noexcept { return "MultiplyVariablesByTwo"; }
   static constexpr auto function = multiply_variables_by_two;
   using argument_tags = tmpl::list<Tags::Variables<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>>;
@@ -869,11 +868,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Variables",
 namespace {
 struct Tag1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Tag1";
+  static std::string name() noexcept { return "Tag1"; }
 };
 struct Tag2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Tag2";
+  static std::string name() noexcept { return "Tag2"; }
 };
 }  // namespace
 
@@ -930,14 +929,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.reset_compute_items",
 namespace ExtraResetTags {
 struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Var";
+  static std::string name() noexcept { return "Var"; }
 };
 struct Int : db::SimpleTag {
   using type = int;
-  static constexpr db::Label label = "Int";
+  static std::string name() noexcept { return "Int"; }
 };
 struct CheckReset : db::ComputeTag {
-  static constexpr db::Label label = "CheckReset";
+  static std::string name() noexcept { return "CheckReset"; }
   static auto function(
       const ::Variables<tmpl::list<Var>>& /*unused*/) noexcept {
     static bool first_call = true;
@@ -1149,18 +1148,18 @@ void mutate_variables(
 namespace test_databox_tags {
 struct MutateComputeTag0 : db::ComputeTag {
   using return_type = std::vector<double>;
-  static constexpr db::Label label = "MutateComputeTag0";
+  static std::string name() noexcept { return "MutateComputeTag0"; }
   static constexpr auto function = multiply_by_two_mutate;
   using argument_tags = tmpl::list<Tag0>;
 };
 struct NonMutateComputeTag0 : db::ComputeTag {
-  static constexpr db::Label label = "NonMutateComputeTag0";
+  static std::string name() noexcept { return "NonMutateComputeTag0"; }
   static constexpr auto function = multiply_by_two_non_mutate;
   using argument_tags = tmpl::list<Tag0>;
 };
 /// [databox_mutating_compute_item_tag]
 struct MutateVariablesCompute : db::ComputeTag {
-  static constexpr db::Label label = "MutateVariablesCompute";
+  static std::string name() noexcept { return "MutateVariablesCompute"; }
   static constexpr auto function = mutate_variables;
   using return_type = Variables<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>;
@@ -1280,17 +1279,17 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutating_compute_item",
 namespace DataBoxTest_detail {
 struct vector : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
-  static constexpr db::Label label = "vector";
+  static std::string name() noexcept { return "vector"; }
 };
 
 struct scalar : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "scalar";
+  static std::string name() noexcept { return "scalar"; }
 };
 
 struct vector2 : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
-  static constexpr db::Label label = "vector2";
+  static std::string name() noexcept { return "vector2"; }
 };
 }  // namespace DataBoxTest_detail
 
@@ -1502,12 +1501,12 @@ class Boxed {
 
 template <size_t N, bool Compute = false, bool DependsOnComputeItem = false>
 struct Parent : db::SimpleTag {
-  static constexpr db::Label label = "Parent";
+  static std::string name() noexcept { return "Parent"; }
   using type = std::pair<Boxed<int>, Boxed<double>>;
 };
 template <size_t N, bool DependsOnComputeItem>
 struct Parent<N, true, DependsOnComputeItem> : db::ComputeTag {
-  static constexpr db::Label label = "Parent";
+  static std::string name() noexcept { return "Parent"; }
   static auto function(
       const std::pair<Boxed<int>, Boxed<double>>& arg) noexcept {
     count++;
@@ -1524,14 +1523,14 @@ int Parent<N, true, DependsOnComputeItem>::count = 0;
 
 template <size_t N>
 struct First : db::SimpleTag {
-  static constexpr db::Label label = "First";
+  static std::string name() noexcept { return "First"; }
   using type = Boxed<int>;
 
   static constexpr size_t index = 0;
 };
 template <size_t N>
 struct Second : db::SimpleTag {
-  static constexpr db::Label label = "Second";
+  static std::string name() noexcept { return "Second"; }
   using type = Boxed<double>;
 
   static constexpr size_t index = 1;
@@ -1619,12 +1618,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Subitems",
 namespace test_databox_tags {
 struct Tag0Int : db::SimpleTag {
   using type = int;
-  static constexpr db::Label label = "Tag0Int";
+  static std::string name() noexcept { return "Tag0Int"; }
 };
 /// [overload_compute_tag_type]
 template <typename ArgumentTag>
 struct OverloadType : db::ComputeTag {
-  static constexpr db::Label label = "OverloadType";
+  static std::string name() noexcept { return "OverloadType"; }
 
   static constexpr double function(const int& a) noexcept { return 5 * a; }
 
@@ -1636,7 +1635,7 @@ struct OverloadType : db::ComputeTag {
 /// [overload_compute_tag_number_of_args]
 template <typename ArgumentTag0, typename ArgumentTag1 = void>
 struct OverloadNumberOfArgs : db::ComputeTag {
-  static constexpr db::Label label = "OverloadNumberOfArgs";
+  static std::string name() noexcept { return "OverloadNumberOfArgs"; }
 
   static constexpr double function(const double& a) noexcept { return 3.2 * a; }
 
@@ -1654,7 +1653,7 @@ struct OverloadNumberOfArgs : db::ComputeTag {
 /// [overload_compute_tag_template]
 template <typename ArgumentTag>
 struct ComputeTemplate : db::ComputeTag {
-  static constexpr db::Label label = "ComputeTemplate";
+  static std::string name() noexcept { return "ComputeTemplate"; }
 
   template <typename T>
   static constexpr T function(const T& a) noexcept {
@@ -1708,7 +1707,7 @@ struct MyTag1 {
 };
 
 struct TupleTag : db::SimpleTag {
-  static constexpr db::Label label = "TupleTag";
+  static std::string name() noexcept { return "TupleTag"; }
   using type = tuples::TaggedTuple<MyTag0, MyTag1>;
 };
 }  // namespace
@@ -1887,14 +1886,14 @@ int CountingFunc<Id>::count = 0;
 
 template <int Id>
 struct CountingTag : db::ComputeTag {
-  static constexpr db::Label label = "CountingTag";
+  static std::string name() noexcept { return "CountingTag"; }
   static constexpr auto function = CountingFunc<Id>::apply;
   using argument_tags = tmpl::list<>;
 };
 
 template <size_t SecondId>
 struct CountingTagDouble : db::ComputeTag {
-  static constexpr db::Label label = "CountingTag";
+  static std::string name() noexcept { return "CountingTag"; }
   static double function(const test_subitems::Boxed<double>& t) {
     count++;
     return *t * 6.0;

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -32,16 +32,18 @@
 namespace VariablesTestTags_detail {
 /// [simple_variables_tag]
 struct vector : db::SimpleTag {
-  static constexpr db::Label label = "vector";
+  static std::string name() noexcept { return "vector"; }
   using type = tnsr::I<DataVector, 3, Frame::Grid>;
 };
 /// [simple_variables_tag]
 
 struct scalar : db::SimpleTag {
+  static std::string name() noexcept { return "scalar"; }
   using type = Scalar<DataVector>;
 };
 
 struct scalar2 : db::SimpleTag {
+  static std::string name() noexcept { return "scalar2"; }
   using type = Scalar<DataVector>;
 };
 
@@ -50,7 +52,7 @@ template <class Tag>
 struct PrefixTag0 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::Label label = "PrefixTag0";
+  static std::string name() noexcept { return "PrefixTag0"; }
 };
 /// [prefix_variables_tag]
 
@@ -58,21 +60,21 @@ template <class Tag>
 struct PrefixTag1 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::Label label = "PrefixTag1";
+  static std::string name() noexcept { return "PrefixTag1"; }
 };
 
 template <class Tag>
 struct PrefixTag2 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::Label label = "PrefixTag2";
+  static std::string name() noexcept { return "PrefixTag2"; }
 };
 
 template <class Tag>
 struct PrefixTag3 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static constexpr db::Label label = "PrefixTag3";
+  static std::string name() noexcept { return "PrefixTag3"; }
 };
 }  // namespace VariablesTestTags_detail
 
@@ -159,6 +161,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
   // Check self-assignment
   v = v;
   CHECK(v == v2);
+
+  CHECK(
+      Tags::Variables<tmpl::list<VariablesTestTags_detail::vector,
+                                 VariablesTestTags_detail::scalar,
+                                 VariablesTestTags_detail::scalar2>>::name() ==
+      "Variables(vector,scalar,scalar2)");
 }
 
 // [[OutputRegex, Must copy into same size]]

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <memory>
 #include <pup.h>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -124,7 +125,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ElementMap", "[Unit][Domain]") {
 
 namespace {
 struct Directions : db::SimpleTag {
-  static constexpr db::Label label = "Directions";
+  static std::string name() noexcept { return "Directions"; }
   using type = std::unordered_set<Direction<2>>;
 };
 }  // namespace

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <functional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -41,24 +42,24 @@ struct NoCopy {
 
 namespace TestTags {
 struct Int : db::SimpleTag {
-  static constexpr db::Label label = "Int";
+  static std::string name() noexcept { return "Int"; }
   using type = int;
 };
 
 struct Double : db::SimpleTag {
-  static constexpr db::Label label = "Double";
+  static std::string name() noexcept { return "Double"; }
   using type = double;
 };
 
 template <size_t N>
 struct NoCopy : db::SimpleTag {
-  static constexpr db::Label label = "NoCopy";
+  static std::string name() noexcept { return "NoCopy"; }
   using type = ::NoCopy<N>;
 };
 
 template <typename Tag>
 struct Negate : db::PrefixTag, db::ComputeTag {
-  static constexpr db::Label label = "Negate";
+  static std::string name() noexcept { return "Negate"; }
   using tag = Tag;
   static constexpr auto function(const db::item_type<Tag>& x) noexcept {
     return -x;
@@ -67,7 +68,7 @@ struct Negate : db::PrefixTag, db::ComputeTag {
 };
 
 struct AddThree : db::ComputeTag {
-  static constexpr db::Label label = "AddThree";
+  static std::string name() noexcept { return "AddThree"; }
   static constexpr auto function(const int x) noexcept { return x + 3; }
   using argument_tags = tmpl::list<Int>;
   using volume_tags = tmpl::list<Int>;
@@ -75,7 +76,7 @@ struct AddThree : db::ComputeTag {
 
 template <size_t VolumeDim>
 struct ComplexComputeItem : db::ComputeTag {
-  static constexpr db::Label label = "ComplexComputeItem";
+  static std::string name() noexcept { return "ComplexComputeItem"; }
   static constexpr auto function(const int i, const double d,
                                  const ::NoCopy<1>& /*unused*/,
                                  const ::NoCopy<2>& /*unused*/) noexcept {
@@ -87,7 +88,7 @@ struct ComplexComputeItem : db::ComputeTag {
 
 template <typename>
 struct TemplatedDirections : db::SimpleTag {
-  static constexpr db::Label label = "TemplatedDirections";
+  static std::string name() noexcept { return "TemplatedDirections"; }
   using type = std::unordered_set<Direction<3>>;
 };
 }  // namespace TestTags
@@ -181,7 +182,7 @@ namespace {
 constexpr size_t dim = 2;
 
 struct Dirs : db::ComputeTag {
-  static constexpr db::Label label = "Dirs";
+  static std::string name() noexcept { return "Dirs"; }
   static auto function() noexcept {
     return std::unordered_set<Direction<dim>>{Direction<dim>::lower_xi(),
                                               Direction<dim>::upper_eta()};
@@ -191,7 +192,7 @@ struct Dirs : db::ComputeTag {
 
 template <size_t N>
 struct Var : db::SimpleTag {
-  static constexpr db::Label label = "Var";
+  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary =
       N == 3 or N == 30 or  // sliced_simple_item_tag below
@@ -200,7 +201,7 @@ struct Var : db::SimpleTag {
 
 template <size_t VolumeDim>
 struct Compute : db::ComputeTag {
-  static constexpr db::Label label = "Compute";
+  static std::string name() noexcept { return "Compute"; }
   static auto function(const Index<VolumeDim>& extents) {
     auto ret = Variables<tmpl::list<Var<VolumeDim>, Var<10 * VolumeDim>>>(
         extents.product(), VolumeDim);
@@ -327,7 +328,7 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.Slice", "[Unit][Domain]") {
 namespace partial_slice {
 template <size_t N>
 struct Scalar : db::SimpleTag {
-  static constexpr db::Label label = "Scalar";
+  static std::string name() noexcept { return "Scalar"; }
   using type = ::Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary = N == 0;
 };
@@ -335,14 +336,14 @@ struct Scalar : db::SimpleTag {
 constexpr size_t vector_dim = 3;
 template <size_t N>
 struct Vector : db::SimpleTag {
-  static constexpr db::Label label = "Vector";
+  static std::string name() noexcept { return "Vector"; }
   using type = tnsr::i<DataVector, vector_dim, Frame::Logical>;
   static constexpr bool should_be_sliced_to_boundary = N == 1;
 };
 
 template <size_t VolumeDim>
 struct ComputedVars : db::ComputeTag {
-  static constexpr db::Label label = "ComputedVars";
+  static std::string name() noexcept { return "ComputedVars"; }
   static auto function(const Index<VolumeDim>& extents) noexcept {
     const DataVector volume_data{
       11., 10., 9., 8., 7., 6., 5., 4., 3., 2., 1., 0.};

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
@@ -3,6 +3,8 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <string>
+
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "Domain/ElementId.hpp"
@@ -15,11 +17,11 @@
 namespace {
 struct var_tag : db::SimpleTag {
   using type = int;
-  static constexpr db::Label label = "var_tag";
+  static std::string name() noexcept { return "var_tag"; }
 };
 struct dt_var_tag : db::SimpleTag {
   using type = int;
-  static constexpr db::Label label = "dt_var_tag";
+  static std::string name() noexcept { return "dt_var_tag"; }
 };
 
 struct ComputeDuDt {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -47,7 +48,7 @@ class er;
 namespace {
 struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Var";
+  static std::string name() noexcept { return "Var"; }
   static constexpr bool should_be_sliced_to_boundary = true;
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <memory>
 #include <pup.h>
+#include <string>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -42,19 +43,19 @@
 
 namespace {
 struct Var : db::SimpleTag {
-  static constexpr db::Label label = "Var";
+  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary = false;
 };
 
 struct Var2 : db::SimpleTag {
-  static constexpr db::Label label = "Var2";
+  static std::string name() noexcept { return "Var2"; }
   using type = tnsr::ii<DataVector, 2>;
   static constexpr bool should_be_sliced_to_boundary = false;
 };
 
 struct OtherArg : db::SimpleTag {
-  static constexpr db::Label label = "OtherArg";
+  static std::string name() noexcept { return "OtherArg"; }
   using type = double;
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <memory>
 #include <pup.h>
+#include <string>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -51,12 +52,12 @@
 
 namespace {
 struct Var : db::SimpleTag {
-  static constexpr db::Label label = "Var";
+  static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
 };
 
 struct OtherData : db::SimpleTag {
-  static constexpr db::Label label = "OtherData";
+  static std::string name() noexcept { return "OtherData"; }
   using type = Scalar<DataVector>;
   static constexpr bool should_be_sliced_to_boundary = false;
 };
@@ -64,7 +65,7 @@ struct OtherData : db::SimpleTag {
 class NumericalFlux {
  public:
   struct ExtraData : db::SimpleTag {
-    static constexpr db::Label label = "ExtraTag";
+    static std::string name() noexcept { return "ExtraTag"; }
     using type = tnsr::I<DataVector, 1>;
   };
 

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
+#include <string>
 #include <type_traits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -66,7 +67,7 @@ auto make_affine_map<3>() noexcept {
 template <size_t Dim, typename Frame>
 struct Flux1 : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim, Frame>;
-  static constexpr db::Label label = "Flux1";
+  static std::string name() noexcept { return "Flux1"; }
   static auto flux(const MathFunctions::TensorProduct<Dim>& f,
                    const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
     auto result = make_with_value<tnsr::I<DataVector, Dim, Frame>>(x, 0.);
@@ -91,7 +92,7 @@ struct Flux1 : db::SimpleTag {
 template <size_t Dim, typename Frame>
 struct Flux2 : db::SimpleTag {
   using type = tnsr::Ij<DataVector, Dim, Frame>;
-  static constexpr db::Label label = "Flux2";
+  static std::string name() noexcept { return "Flux2"; }
   static auto flux(const MathFunctions::TensorProduct<Dim>& f,
                    const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
     auto result = make_with_value<tnsr::Ij<DataVector, Dim, Frame>>(x, 0.);
@@ -186,7 +187,7 @@ namespace {
 template <class MapType>
 struct MapTag : db::SimpleTag {
   using type = MapType;
-  static constexpr db::Label label = "MapTag";
+  static std::string name() noexcept { return "MapTag"; }
 };
 
 template <size_t Dim, typename Frame = Frame::Inertial>

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
+#include <string>
 #include <type_traits>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -36,7 +37,7 @@ namespace {
 template <size_t Dim, class Frame = ::Frame::Grid>
 struct Var1 : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame>;
-  static constexpr db::Label label = "Var1";
+  static std::string name() noexcept { return "Var1"; }
   static auto f(const std::array<size_t, Dim>& coeffs,
                 const tnsr::I<DataVector, Dim, Frame>& x) {
     tnsr::i<DataVector, Dim, Frame> result(x.begin()->size(), 0.);
@@ -74,7 +75,7 @@ struct Var1 : db::SimpleTag {
 
 struct Var2 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Var2";
+  static std::string name() noexcept { return "Var2"; }
   template <size_t Dim, class Frame>
   static auto f(const std::array<size_t, Dim>& coeffs,
                 const tnsr::I<DataVector, Dim, Frame>& x) {
@@ -446,7 +447,7 @@ void test_logical_derivatives_compute_item(
 template <class MapType>
 struct MapTag : db::SimpleTag {
   using type = MapType;
-  static constexpr db::Label label = "MapTag";
+  static std::string name() noexcept { return "MapTag"; }
 };
 
 template <size_t Dim, typename T>

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <functional>
 #include <pup.h>
+#include <string>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -72,22 +73,22 @@ struct ElementId {};
 /// \endcond
 
 struct CountActionsCalled : db::SimpleTag {
-  static constexpr db::Label label = "CountActionsCalled";
+  static std::string name() noexcept { return "CountActionsCalled"; }
   using type = int;
 };
 
 struct Int0 : db::SimpleTag {
-  static constexpr db::Label label = "Int0";
+  static std::string name() noexcept { return "Int0"; }
   using type = int;
 };
 
 struct Int1 : db::SimpleTag {
-  static constexpr db::Label label = "Int1";
+  static std::string name() noexcept { return "Int1"; }
   using type = int;
 };
 
 struct TemporalId : db::SimpleTag {
-  static constexpr db::Label label = "TemporalId";
+  static std::string name() noexcept { return "TemporalId"; }
   using type = TestAlgorithmArrayInstance;
 };
 

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <string>
 #include <tuple>
 #include <vector>
 
@@ -44,12 +45,12 @@ struct NodegroupParallelComponent;
 
 namespace Tags {
 struct vector_of_array_indexs : db::SimpleTag {
-  static constexpr db::Label label = "vector_of_array_indexs";
+  static std::string name() noexcept { return "vector_of_array_indexs"; }
   using type = std::vector<int>;
 };
 
 struct total_receives_on_node : db::SimpleTag {
-  static constexpr db::Label label = "total_receives_on_node";
+  static std::string name() noexcept { return "total_receives_on_node"; }
   using type = int;
 };
 }  // namespace Tags

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -5,6 +5,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <string>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -36,17 +37,17 @@ class DataBox;
 
 namespace Tags {
 struct Int0 : db::SimpleTag {
-  static constexpr db::Label label = "Int0";
+  static std::string name() noexcept { return "Int0"; }
   using type = int;
 };
 
 struct Int1 : db::SimpleTag {
-  static constexpr db::Label label = "Int1";
+  static std::string name() noexcept { return "Int1"; }
   using type = int;
 };
 
 struct CountActionsCalled : db::SimpleTag {
-  static constexpr db::Label label = "CountActionsCalled";
+  static std::string name() noexcept { return "CountActionsCalled"; }
   using type = int;
 };
 

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
+#include <string>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -151,13 +152,13 @@ void test_tensor_product(
 
 struct Var1 : db::SimpleTag {
   using type = Scalar<DataVector>;
-  static constexpr db::Label label = "Var1";
+  static std::string name() noexcept { return "Var1"; }
 };
 
 template <size_t VolumeDim>
 struct Var2 : db::SimpleTag {
   using type = tnsr::i<DataVector, VolumeDim, Frame::Inertial>;
-  static constexpr db::Label label = "Var2";
+  static std::string name() noexcept { return "Var2"; }
 };
 
 template <size_t VolumeDim>

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <tuple>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -23,7 +24,7 @@
 
 namespace {
 struct Var : db::SimpleTag {
-  static constexpr db::Label label = "Var";
+  static std::string name() noexcept { return "Var"; }
   using type = double;
 };
 

--- a/tools/ClangTidyHash.sh
+++ b/tools/ClangTidyHash.sh
@@ -16,21 +16,21 @@ HASH=$3
 ###############################################################################
 cd $SOURCE_DIR
 # Get list of non-deleted files
-MODIFIED_FILES=''
+MODIFIED_FILES=()
 
 for FILENAME in `git diff --name-only ${HASH} HEAD`
 do
     if [ -f $FILENAME ] \
            && [ ${FILENAME: -4} == ".cpp" ] \
            && ! grep -q "FILE_IS_COMPILATION_TEST" $FILENAME; then
-        MODIFIED_FILES="${MODIFIED_FILES} $FILENAME"
+        MODIFIED_FILES+=("$FILENAME")
     fi
 done
 
 # Go to build directory and then run clang-tidy, writing output to file
 cd ${BUILD_DIR}
 
-for FILENAME in $MODIFIED_FILES
+for FILENAME in ${MODIFIED_FILES[@]}
 do
     printf "\n\nRunning clang-tidy on file $FILENAME\n"
     make clang-tidy FILE=$SOURCE_DIR/${FILENAME}


### PR DESCRIPTION
## Proposed changes

- The `db::Label label` in tags is replaced with `std::string name() noexcept`. This allows more flexibility for naming tags. This is useful for retrieving items from the DataBox using the string for observing.
- Add IWYU make targets

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
