### PR TITLE
Add Spectral functions using Mesh

### DIFF
--- a/src/DataStructures/Mesh.cpp
+++ b/src/DataStructures/Mesh.cpp
@@ -3,8 +3,11 @@
 
 #include "DataStructures/Mesh.hpp"
 
+#include <algorithm>
+#include <ostream>
 #include <pup.h>  // IWYU pragma: keep
 
+#include "ErrorHandling/Assert.hpp"
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
 
@@ -12,21 +15,41 @@ template <size_t Dim>
 // clang-tidy: incorrectly reported redundancy in template expression
 template <size_t N, Requires<(N > 0 and N == Dim)>>  // NOLINT
 Mesh<Dim - 1> Mesh<Dim>::slice_away(const size_t d) const noexcept {
-  std::array<size_t, Dim - 1> slice_extents{};
-  std::array<Spectral::Basis, Dim - 1> slice_bases{};
-  std::array<Spectral::Quadrature, Dim - 1> slice_quadratures{};
-  for (size_t i = 0; i < Dim; ++i) {
-    if (i < d) {
-      gsl::at(slice_extents, i) = gsl::at(extents_.indices(), i);
-      gsl::at(slice_bases, i) = gsl::at(bases_, i);
-      gsl::at(slice_quadratures, i) = gsl::at(quadratures_, i);
-    } else if (i > d) {
-      gsl::at(slice_extents, i - 1) = gsl::at(extents_.indices(), i);
-      gsl::at(slice_bases, i - 1) = gsl::at(bases_, i);
-      gsl::at(slice_quadratures, i - 1) = gsl::at(quadratures_, i);
-    }
+  ASSERT(d < Dim, "Tried to slice away non-existing dimension "
+                      << d << " of " << Dim << "-dimensional mesh.");
+  std::array<size_t, Dim - 1> dims{};
+  for (size_t dim = 0; dim < d; dim++) {
+    gsl::at(dims, dim) = dim;
   }
-  return Mesh<Dim - 1>(slice_extents, slice_bases, slice_quadratures);
+  for (size_t dim = d + 1; dim < Dim; dim++) {
+    gsl::at(dims, dim - 1) = dim;
+  }
+  return slice_through(dims);
+}
+
+template <size_t Dim>
+template <size_t SliceDim, Requires<(SliceDim <= Dim)>>
+Mesh<SliceDim> Mesh<Dim>::slice_through(
+    const std::array<size_t, SliceDim>& dims) const noexcept {
+  // Check for duplicates in `dims`
+  auto sorted_dims = dims;
+  std::sort(sorted_dims.begin(), sorted_dims.end());
+  auto last_unique = std::unique(sorted_dims.begin(), sorted_dims.end());
+  ASSERT(last_unique == sorted_dims.end(),
+         "Dimensions to slice through contain duplicates.");
+  std::array<size_t, SliceDim> slice_extents{};
+  std::array<Spectral::Basis, SliceDim> slice_bases{};
+  std::array<Spectral::Quadrature, SliceDim> slice_quadratures{};
+  for (size_t i = 0; i < SliceDim; ++i) {
+    const auto& dim = gsl::at(dims, i);
+    ASSERT(dim < Dim, "Tried to slice through non-existing dimension "
+                          << dim << " of " << Dim << "-dimensional mesh.");
+    gsl::at(slice_extents, i) = gsl::at(extents_.indices(), dim);
+    gsl::at(slice_bases, i) = gsl::at(bases_, gsl::at(dims, i));
+    gsl::at(slice_quadratures, i) = gsl::at(quadratures_, gsl::at(dims, i));
+  }
+  return Mesh<SliceDim>(std::move(slice_extents), std::move(slice_bases),
+                        std::move(slice_quadratures));
 }
 
 /// \cond HIDDEN_SYMBOLS
@@ -59,6 +82,26 @@ bool operator!=(const Mesh<Dim>& lhs, const Mesh<Dim>& rhs) noexcept {
 #define INSTANTIATE_SLICE_AWAY(_, data)                                  \
   template Mesh<DIM(data) - 1> Mesh<DIM(data)>::slice_away(const size_t) \
       const noexcept;
+template Mesh<0> Mesh<0>::slice_through(const std::array<size_t, 0>&) const
+    noexcept;
+template Mesh<0> Mesh<1>::slice_through(const std::array<size_t, 0>&) const
+    noexcept;
+template Mesh<1> Mesh<1>::slice_through(const std::array<size_t, 1>&) const
+    noexcept;
+template Mesh<0> Mesh<2>::slice_through(const std::array<size_t, 0>&) const
+    noexcept;
+template Mesh<1> Mesh<2>::slice_through(const std::array<size_t, 1>&) const
+    noexcept;
+template Mesh<2> Mesh<2>::slice_through(const std::array<size_t, 2>&) const
+    noexcept;
+template Mesh<0> Mesh<3>::slice_through(const std::array<size_t, 0>&) const
+    noexcept;
+template Mesh<1> Mesh<3>::slice_through(const std::array<size_t, 1>&) const
+    noexcept;
+template Mesh<2> Mesh<3>::slice_through(const std::array<size_t, 2>&) const
+    noexcept;
+template Mesh<3> Mesh<3>::slice_through(const std::array<size_t, 3>&) const
+    noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE_MESH, (0, 1, 2, 3))
 GENERATE_INSTANTIATIONS(INSTANTIATE_SLICE_AWAY, (1, 2, 3))

--- a/src/NumericalAlgorithms/Spectral/LegendreGaussLobatto.cpp
+++ b/src/NumericalAlgorithms/Spectral/LegendreGaussLobatto.cpp
@@ -6,6 +6,7 @@
 #include "DataStructures/Matrix.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
+/// \cond
 namespace Basis {
 namespace lgl {
 
@@ -55,7 +56,6 @@ Matrix interpolation_matrix(size_t number_of_pts, const T& target_points) {
 }  // namespace lgl
 }  // namespace Basis
 
-/// \cond
 template Matrix Basis::lgl::interpolation_matrix(
     const size_t num_collocation_points, const DataVector& target_points);
 template Matrix Basis::lgl::interpolation_matrix(

--- a/src/NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp
+++ b/src/NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 
+/// \cond
 class DataVector;
 class Matrix;
 
@@ -57,3 +58,4 @@ Matrix interpolation_matrix(size_t number_of_pts, const T& target_points);
 static const size_t maximum_number_of_pts = 12;
 }  // namespace lgl
 }  // namespace Basis
+/// \endcond

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -15,6 +15,8 @@
 /// \cond
 class Matrix;
 class DataVector;
+template <size_t>
+class Mesh;
 /// \endcond
 
 /*!
@@ -24,8 +26,14 @@ class DataVector;
  *
  * \details The functions in this namespace provide low-level access to
  * collocation points, quadrature weights and associated matrices, such as for
- * differentiation and interpolation. They are templated on the enum cases of
- * the `Basis` and `Quadrature` types.
+ * differentiation and interpolation. They are available in two versions: either
+ * templated directly on the enum cases of the Spectral::Basis and
+ * Spectral::Quadrature types, or taking a one-dimensional Mesh as their
+ * argument.
+ *
+ * \note Generally you should prefer working with a Mesh. Use its
+ * Mesh::slice_through() method to retrieve the mesh in a particular dimension:
+ * \snippet Test_Spectral.cpp get_points_for_mesh
  */
 namespace Spectral {
 
@@ -55,7 +63,7 @@ enum class Quadrature { Gauss, GaussLobatto };
  * one collocation point.
  */
 template <Basis, Quadrature>
-constexpr size_t minimum_number_of_points(std::numeric_limits<size_t>::max());
+constexpr size_t minimum_number_of_points{std::numeric_limits<size_t>::max()};
 /// \cond
 template <Basis BasisType>
 constexpr size_t minimum_number_of_points<BasisType, Quadrature::Gauss> = 1;
@@ -78,11 +86,25 @@ template <Basis BasisType, Quadrature QuadratureType>
 const DataVector& collocation_points(size_t num_points) noexcept;
 
 /*!
+ * \brief Collocation points for a one-dimensional mesh.
+ *
+ * \see collocation_points(size_t)
+ */
+const DataVector& collocation_points(const Mesh<1>& mesh) noexcept;
+
+/*!
  * \brief Quadrature weights
  * \param num_points The number of collocation points
  */
 template <Basis BasisType, Quadrature QuadratureType>
 const DataVector& quadrature_weights(size_t num_points) noexcept;
+
+/*!
+ * \brief Quadrature weights for a one-dimensional mesh.
+ *
+ * \see quadrature_weights(size_t)
+ */
+const DataVector& quadrature_weights(const Mesh<1>& mesh) noexcept;
 
 /*!
  * \brief %Matrix used to compute the derivative of a function.
@@ -100,9 +122,16 @@ template <Basis BasisType, Quadrature QuadratureType>
 const Matrix& differentiation_matrix(size_t num_points) noexcept;
 
 /*!
- * \brief %Matrix used to interpolate to a set of target points.
+ * \brief Differentiation matrix for a one-dimensional mesh.
  *
- * \warning It is expected but not checked that the target points are inside
+ * \see differentiation_matrix(size_t)
+ */
+const Matrix& differentiation_matrix(const Mesh<1>& mesh) noexcept;
+
+/*!
+ * \brief %Matrix used to interpolate to the \p target_points.
+ *
+ * \warning It is expected but not checked that the \p target_points are inside
  * the interval covered by the `BasisType` in logical coordinates.
  *
  * \param num_points The number of collocation points
@@ -110,6 +139,16 @@ const Matrix& differentiation_matrix(size_t num_points) noexcept;
  */
 template <Basis BasisType, Quadrature QuadratureType, typename T>
 Matrix interpolation_matrix(size_t num_points, const T& target_points) noexcept;
+
+/*!
+ * \brief Interpolation matrix to the \p target_points for a one-dimensional
+ * mesh.
+ *
+ * \see interpolation_matrix(size_t, const T&)
+ */
+template <typename T>
+Matrix interpolation_matrix(const Mesh<1>& mesh,
+                            const T& target_points) noexcept;
 
 /*!
  * \brief %Matrix used to transform from the spectral coefficients (modes) of a
@@ -127,9 +166,19 @@ Matrix interpolation_matrix(size_t num_points, const T& target_points) noexcept;
  * \mathcal{V}_{ij}\widetilde{u}_j\f$.
  *
  * \param num_points The number of collocation points
+
+ * \see grid_points_to_spectral_matrix(size_t)
  */
 template <Basis BasisType, Quadrature QuadratureType>
 const Matrix& spectral_to_grid_points_matrix(size_t num_points) noexcept;
+
+/*!
+ * \brief Transformation matrix from modal to nodal coefficients for a
+ * one-dimensional mesh.
+ *
+ * \see spectral_to_grid_points_matrix(size_t)
+ */
+const Matrix& spectral_to_grid_points_matrix(const Mesh<1>& mesh) noexcept;
 
 /*!
  * \brief %Matrix used to transform from the nodal coefficients of a function to
@@ -137,8 +186,8 @@ const Matrix& spectral_to_grid_points_matrix(size_t num_points) noexcept;
  * _Vandermonde matrix_.
  *
  * \details This is the inverse to the Vandermonde matrix \f$\mathcal{V}\f$
- * computed in `spectral_to_grid_points_matrix`. It can be computed analytically
- * for Gauss quadrature by evaluating
+ * computed in spectral_to_grid_points_matrix(size_t). It can be computed
+ * analytically for Gauss quadrature by evaluating
  * \f$\mathcal{V}^{-1}_{ij}u_j=\widetilde{u}_i=\frac{(u,\Phi_i)}{\gamma_i}\f$
  * for a Lagrange basis function \f$u(x)=l_k(x)\f$ to find
  * \f$\mathcal{V}^{-1}_{ij}=\mathcal{V}_{ji}\frac{w_j}{\gamma_i}\f$ where the
@@ -146,9 +195,19 @@ const Matrix& spectral_to_grid_points_matrix(size_t num_points) noexcept;
  * square of the spectral basis function \f$\Phi_i\f$.
  *
  * \param num_points The number of collocation points
+ *
+ * \see spectral_to_grid_points_matrix(size_t)
  */
 template <Basis BasisType, Quadrature QuadratureType>
 const Matrix& grid_points_to_spectral_matrix(size_t num_points) noexcept;
+
+/*!
+ * \brief Transformation matrix from nodal to modal coefficients for a
+ * one-dimensional mesh.
+ *
+ * \see grid_points_to_spectral_matrix(size_t)
+ */
+const Matrix& grid_points_to_spectral_matrix(const Mesh<1>& mesh) noexcept;
 
 /*!
  * \brief %Matrix used to linearize a function.
@@ -156,11 +215,21 @@ const Matrix& grid_points_to_spectral_matrix(size_t num_points) noexcept;
  * \details Filters out all except the lowest two modes by applying
  * \f$\mathcal{V}^{-1}\cdot\mathrm{diag}(1,1,0,0,...)\cdot\mathcal{V}\f$ to the
  * nodal coefficients, where \f$\mathcal{V}\f$ is the Vandermonde matrix
- * computed in `spectral_to_grid_points_matrix`.
+ * computed in `spectral_to_grid_points_matrix(size_t)`.
  *
  * \param num_points The number of collocation points
+ *
+ * \see spectral_to_grid_points_matrix(size_t)
+ * \see grid_points_to_spectral_matrix(size_t)
  */
 template <Basis BasisType, Quadrature QuadratureType>
 const Matrix& linear_filter_matrix(size_t num_points) noexcept;
+
+/*!
+ * \brief Linear filter matrix for a one-dimensional mesh.
+ *
+ * \see linear_filter_matrix(size_t)
+ */
+const Matrix& linear_filter_matrix(const Mesh<1>& mesh) noexcept;
 
 }  // namespace Spectral

--- a/tests/Unit/DataStructures/Test_Mesh.cpp
+++ b/tests/Unit/DataStructures/Test_Mesh.cpp
@@ -206,21 +206,21 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Mesh", "[DataStructures][Unit]") {
               {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
                 Spectral::Quadrature::GaussLobatto}}});
   }
-}
-SPECTRE_TEST_CASE("Unit.Serialization.Mesh",
-                  "[DataStructures][Unit][Serialization]") {
-  test_serialization(Mesh<1>{3, Spectral::Basis::Legendre,
-                             Spectral::Quadrature::GaussLobatto});
-  test_serialization(Mesh<2>{
-      {{3, 2}},
-      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
-      {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}}});
-  test_serialization(
-      Mesh<3>{{{3, 2, 4}},
-              {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
-                Spectral::Basis::Legendre}},
-              {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
-                Spectral::Quadrature::GaussLobatto}}});
+
+  SECTION("Serialization") {
+    test_serialization(Mesh<1>{3, Spectral::Basis::Legendre,
+                               Spectral::Quadrature::GaussLobatto});
+    test_serialization(Mesh<2>{
+        {{3, 2}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}}});
+    test_serialization(Mesh<3>{
+        {{3, 2, 4}},
+        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+          Spectral::Basis::Legendre}},
+        {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+          Spectral::Quadrature::GaussLobatto}}});
+  }
 }
 
 // [[OutputRegex, Tried to slice through non-existing dimension]]


### PR DESCRIPTION
## Proposed changes

This PR adds functions to the `Spectral` namespace that take a `Mesh` and return the spectral quantity in a particular dimension. These complement the existing functions that are templated on the `Basis` and `Quadrature` with ones that use the runtime information carried by the `Mesh`. They will be the preferred way to retrieve the spectral quantities for instance in `PartialDerivatives.tpp`, `DefiniteIntegral.cpp` and other linear operators.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments
