### PR TITLE
Add Conservative from Primitive for Newtonian Euler

### DIFF
--- a/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/src/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY NewtonianEuler)
 
 set(LIBRARY_SOURCES
     Characteristics.cpp
+    ConservativeFromPrimitive.cpp
     Fluxes.cpp
     PrimitiveFromConservative.cpp
     )

--- a/src/Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.cpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace NewtonianEuler {
+
+template <size_t Dim, typename DataType>
+void conservative_from_primitive(
+    const gsl::not_null<tnsr::I<DataType, Dim>*> momentum_density,
+    const gsl::not_null<Scalar<DataType>*> energy_density,
+    const Scalar<DataType>& mass_density,
+    const tnsr::I<DataType, Dim>& velocity,
+    const Scalar<DataType>& specific_internal_energy) noexcept {
+  for (size_t i = 0; i < Dim; ++i) {
+    momentum_density->get(i) = get(mass_density) * velocity.get(i);
+  }
+
+  get(*energy_density) =
+      get(mass_density) * (0.5 * get(dot_product(velocity, velocity)) +
+                           get(specific_internal_energy));
+}
+
+}  // namespace NewtonianEuler
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template void NewtonianEuler::conservative_from_primitive(                  \
+      const gsl::not_null<tnsr::I<DTYPE(data), DIM(data)>*> momentum_density, \
+      const gsl::not_null<Scalar<DTYPE(data)>*> energy_density,               \
+      const Scalar<DTYPE(data)>& mass_density,                                \
+      const tnsr::I<DTYPE(data), DIM(data)>& velocity,                        \
+      const Scalar<DTYPE(data)>& specific_internal_energy) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))
+
+#undef DIM
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond

--- a/src/Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace NewtonianEuler {
+
+/*!
+ * \brief Compute the conservative variables from the primitive variables.
+ *
+ * \f{align*}
+ * S^i &= \rho v^i \\
+ * e &= \dfrac{1}{2}\rho v^2 + \rho\epsilon
+ * \f}
+ *
+ * where \f$S^i\f$ is the momentum density, \f$e\f$ is the energy density,
+ * \f$\rho\f$ is the mass density, \f$v^i\f$ is the velocity, \f$v^2\f$ is its
+ * magnitude squared, and \f$\epsilon\f$ is the specific internal energy.
+ */
+template <size_t Dim, typename DataType>
+void conservative_from_primitive(
+    gsl::not_null<tnsr::I<DataType, Dim>*> momentum_density,
+    gsl::not_null<Scalar<DataType>*> energy_density,
+    const Scalar<DataType>& mass_density,
+    const tnsr::I<DataType, Dim>& velocity,
+    const Scalar<DataType>& specific_internal_energy) noexcept;
+
+}  // namespace NewtonianEuler

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_NewtonianEuler")
 
 set(LIBRARY_SOURCES
   Test_Characteristics.cpp
+  Test_ConservativeFromPrimitive.cpp
   Test_Fluxes.cpp
   Test_PrimitiveFromConservative.cpp
   )

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/TestFunctions.py
@@ -18,6 +18,19 @@ def characteristic_speeds(velocity, sound_speed_squared, normal):
 # End functions for testing Characteristics.cpp
 
 
+# Functions for testing ConservativeFromPrimitive.cpp
+def momentum_density(mass_density, velocity, specific_internal_energy):
+    return mass_density * velocity
+
+
+def energy_density(mass_density, velocity, specific_internal_energy):
+    return (0.5 * mass_density * np.dot(velocity, velocity) +
+            mass_density * specific_internal_energy)
+
+
+# End functions for testing ConservativeFromPrimitive.cpp
+
+
 # Functions for testing Fluxes.cpp
 def mass_density_flux(momentum_density, energy_density, velocity, pressure):
     return momentum_density

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Characteristics.cpp
@@ -12,6 +12,7 @@
 #include "Domain/Direction.hpp"
 #include "Evolution/Systems/NewtonianEuler/Characteristics.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/Pypp.hpp"
@@ -65,13 +66,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Characteristics",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/NewtonianEuler"};
 
-  const DataVector dv(5);
-
-  test_characteristic_speeds<1>(dv);
-  test_characteristic_speeds<2>(dv);
-  test_characteristic_speeds<3>(dv);
-
-  test_with_normal_along_coordinate_axes<1>(dv);
-  test_with_normal_along_coordinate_axes<2>(dv);
-  test_with_normal_along_coordinate_axes<3>(dv);
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_characteristic_speeds, (1, 2, 3))
+  CHECK_FOR_DATAVECTORS(test_with_normal_along_coordinate_axes, (1, 2, 3))
 }

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_ConservativeFromPrimitive.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_ConservativeFromPrimitive.cpp
@@ -1,0 +1,41 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace {
+
+template <size_t Dim, typename DataType>
+void test_conservative_from_primitive(const DataType& used_for_size) {
+  pypp::check_with_random_values<3>(
+      &NewtonianEuler::conservative_from_primitive<Dim, DataType>,
+      "TestFunctions", {"momentum_density", "energy_density"},
+      {{{-1.0, 1.0}, {-2.0, 2.0}, {-3.0, 3.0}}}, used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.NewtonianEuler.ConservativeFromPrimitive",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/NewtonianEuler"};
+
+  const double d = std::numeric_limits<double>::signaling_NaN();
+  test_conservative_from_primitive<1>(d);
+  test_conservative_from_primitive<2>(d);
+  test_conservative_from_primitive<3>(d);
+
+  const DataVector dv(5);
+  test_conservative_from_primitive<1>(dv);
+  test_conservative_from_primitive<2>(dv);
+  test_conservative_from_primitive<3>(dv);
+}

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_ConservativeFromPrimitive.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_ConservativeFromPrimitive.cpp
@@ -4,7 +4,6 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <cstddef>
-#include <limits>
 
 #include "DataStructures/DataVector.hpp"
 #include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
@@ -29,13 +28,6 @@ SPECTRE_TEST_CASE(
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/NewtonianEuler"};
 
-  const double d = std::numeric_limits<double>::signaling_NaN();
-  test_conservative_from_primitive<1>(d);
-  test_conservative_from_primitive<2>(d);
-  test_conservative_from_primitive<3>(d);
-
-  const DataVector dv(5);
-  test_conservative_from_primitive<1>(dv);
-  test_conservative_from_primitive<2>(dv);
-  test_conservative_from_primitive<3>(dv);
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_conservative_from_primitive, (1, 2, 3))
 }

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Fluxes.cpp
@@ -5,7 +5,7 @@
 
 #include <cstddef>
 
-#include "DataStructures/DataVector.hpp"
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/NewtonianEuler/Fluxes.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
@@ -27,8 +27,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Fluxes",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/NewtonianEuler"};
 
-  const DataVector dv(5);
-  test_fluxes<1>(dv);
-  test_fluxes<2>(dv);
-  test_fluxes<3>(dv);
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_fluxes, (1, 2, 3))
 }

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_PrimitiveFromConservative.cpp
@@ -4,7 +4,6 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <cstddef>
-#include <limits>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -39,19 +38,7 @@ SPECTRE_TEST_CASE(
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/NewtonianEuler"};
 
-  const double d = std::numeric_limits<double>::signaling_NaN();
-  test_velocity<1>(d);
-  test_velocity<2>(d);
-  test_velocity<3>(d);
-  test_primitive_from_conservative<1>(d);
-  test_primitive_from_conservative<2>(d);
-  test_primitive_from_conservative<3>(d);
-
-  const DataVector dv(5);
-  test_velocity<1>(dv);
-  test_velocity<2>(dv);
-  test_velocity<3>(dv);
-  test_primitive_from_conservative<1>(dv);
-  test_primitive_from_conservative<2>(dv);
-  test_primitive_from_conservative<3>(dv);
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_velocity, (1, 2, 3))
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_primitive_from_conservative, (1, 2, 3))
 }

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_ConservativeFromPrimitive.cpp
@@ -4,7 +4,6 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <cstddef>
-#include <limits>
 
 #include "DataStructures/DataVector.hpp"
 #include "Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp"
@@ -27,13 +26,6 @@ SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.ConservativeFromPrimitive",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/RelativisticEuler/Valencia"};
 
-  const double d = std::numeric_limits<double>::signaling_NaN();
-  test_conservative_from_primitive<1>(d);
-  test_conservative_from_primitive<2>(d);
-  test_conservative_from_primitive<3>(d);
-
-  const DataVector dv(5);
-  test_conservative_from_primitive<1>(dv);
-  test_conservative_from_primitive<2>(dv);
-  test_conservative_from_primitive<3>(dv);
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_conservative_from_primitive, (1, 2, 3))
 }

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Equations.cpp
@@ -5,7 +5,7 @@
 
 #include <cstddef>
 
-#include "DataStructures/DataVector.hpp"
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/RelativisticEuler/Valencia/Equations.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
@@ -26,8 +26,6 @@ SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.Equations",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/RelativisticEuler/Valencia"};
 
-  const DataVector dv(5);
-  test_source_terms<1>(dv);
-  test_source_terms<2>(dv);
-  test_source_terms<3>(dv);
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_source_terms, (1, 2, 3))
 }

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_Fluxes.cpp
@@ -5,7 +5,7 @@
 
 #include <cstddef>
 
-#include "DataStructures/DataVector.hpp"
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
@@ -26,8 +26,6 @@ SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.Fluxes",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/RelativisticEuler/Valencia"};
 
-  const DataVector dv(5);
-  test_fluxes<1>(dv);
-  test_fluxes<2>(dv);
-  test_fluxes<3>(dv);
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_fluxes, (1, 2, 3))
 }

--- a/tests/Unit/Pypp/CheckWithRandomValues.hpp
+++ b/tests/Unit/Pypp/CheckWithRandomValues.hpp
@@ -6,21 +6,32 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 // IWYU pragma: begin_exports
+#include <boost/preprocessor/arithmetic/inc.hpp>
 #include <boost/preprocessor/comparison/equal.hpp>
+#include <boost/preprocessor/comparison/not_equal.hpp>
+#include <boost/preprocessor/control/expr_iif.hpp>
 #include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/debug/assert.hpp>
+#include <boost/preprocessor/detail/check.hpp>
 #include <boost/preprocessor/list/adt.hpp>
+#include <boost/preprocessor/list/fold_right.hpp>
 #include <boost/preprocessor/list/for_each.hpp>
 #include <boost/preprocessor/list/for_each_product.hpp>
 #include <boost/preprocessor/list/to_tuple.hpp>
 #include <boost/preprocessor/list/transform.hpp>
+#include <boost/preprocessor/logical/compl.hpp>
 #include <boost/preprocessor/logical/not.hpp>
+#include <boost/preprocessor/punctuation/is_begin_parens.hpp>
+#include <boost/preprocessor/repetition/for.hpp>
+#include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>
 #include <boost/preprocessor/tuple/enum.hpp>
 #include <boost/preprocessor/tuple/pop_front.hpp>
 #include <boost/preprocessor/tuple/push_back.hpp>
 #include <boost/preprocessor/tuple/push_front.hpp>
+#include <boost/preprocessor/tuple/rem.hpp>
 #include <boost/preprocessor/tuple/size.hpp>
+#include <boost/preprocessor/tuple/to_array.hpp>
 #include <boost/preprocessor/tuple/to_list.hpp>
 #include <boost/preprocessor/variadic/elem.hpp>
 #include <boost/preprocessor/variadic/to_list.hpp>

--- a/tools/Iwyu/boost-all.imp
+++ b/tools/Iwyu/boost-all.imp
@@ -5648,4 +5648,8 @@
                 "<boost/preprocessor/arithmetic/sub.hpp>", public]},
     { include: ["<boost/smart_ptr/make_shared_object.hpp>", public,
                 "<boost/make_shared.hpp>", public]},
+    { include: ["<boost/vmd/detail/is_empty.hpp>", private,
+                "<boost/vmd/is_empty.hpp>", public]},
+    { include: ["<boost/preprocessor/punctuation/detail/is_begin_parens.hpp>", private,
+                "<boost/preprocessor/punctuation/is_begin_parens.hpp>", public]},
 ]


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
