### PR TITLE
Add class ModalVector

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
     Index.cpp
     IndexIterator.cpp
     LeviCivitaIterator.cpp
+    ModalVector.cpp
     SliceIterator.cpp
     StripeIterator.cpp
     Tensor/TensorData.cpp

--- a/src/DataStructures/DataVector.cpp
+++ b/src/DataStructures/DataVector.cpp
@@ -3,112 +3,28 @@
 
 #include "DataStructures/DataVector.hpp"
 
-#include <algorithm>
-#include <pup.h>
+#include <algorithm>                  // IWYU pragma: keep
+#include <pup.h>                      // IWYU pragma: keep
 #include <utility>  // IWYU pragma: keep
 
 #include "Utilities/PrintHelpers.hpp"
 
-DataVector::DataVector(const size_t size, const double value) noexcept
-    : owned_data_(size, value) {
-  reset_pointer_vector();
-}
-
-DataVector::DataVector(double* start, size_t size) noexcept
-    : BaseType(start, size), owned_data_(0), owning_(false) {}
-
-template <class T, Requires<cpp17::is_same_v<T, double>>>
-DataVector::DataVector(std::initializer_list<T> list) noexcept
-    : owned_data_(std::move(list)) {
-  reset_pointer_vector();
-}
+/// Construct a DataVector with value(s)
+MAKE_EXPRESSION_VEC_DEF_CONSTRUCT_WITH_VALUE(DataVector)
 
 /// \cond HIDDEN_SYMBOLS
+/// Construct / Assign DataVector with / to DataVector reference or rvalue
 // clang-tidy: calling a base constructor other than the copy constructor.
 //             We reset the base class in reset_pointer_vector after calling its
 //             default constructor
-DataVector::DataVector(const DataVector& rhs) : BaseType{} {  // NOLINT
-  if (rhs.is_owning()) {
-    owned_data_ = rhs.owned_data_;
-  } else {
-    owned_data_.assign(rhs.begin(), rhs.end());
-  }
-  reset_pointer_vector();
-}
-
-DataVector& DataVector::operator=(const DataVector& rhs) {
-  if (this != &rhs) {
-    if (owning_) {
-      if (rhs.is_owning()) {
-        owned_data_ = rhs.owned_data_;
-      } else {
-        owned_data_.assign(rhs.begin(), rhs.end());
-      }
-      reset_pointer_vector();
-    } else {
-      ASSERT(rhs.size() == size(), "Must copy into same size, not "
-                                       << rhs.size() << " into " << size());
-      std::copy(rhs.begin(), rhs.end(), begin());
-    }
-  }
-  return *this;
-}
-
-DataVector::DataVector(DataVector&& rhs) noexcept {
-  owned_data_ = std::move(rhs.owned_data_);
-  ~*this = ~rhs;  // PointerVector is trivially copyable
-  owning_ = rhs.owning_;
-
-  rhs.owning_ = true;
-  rhs.reset();
-}
-
-DataVector& DataVector::operator=(DataVector&& rhs) noexcept {
-  if (this != &rhs) {
-    if (owning_) {
-      owned_data_ = std::move(rhs.owned_data_);
-      ~*this = ~rhs;  // PointerVector is trivially copyable
-      owning_ = rhs.owning_;
-    } else {
-      ASSERT(rhs.size() == size(), "Must copy into same size, not "
-                                       << rhs.size() << " into " << size());
-      std::copy(rhs.begin(), rhs.end(), begin());
-    }
-    rhs.owning_ = true;
-    rhs.reset();
-  }
-  return *this;
-}
+MAKE_EXPRESSION_VEC_DEF_CONSTRUCT_WITH_VEC(DataVector)
 /// \endcond
 
-void DataVector::pup(PUP::er& p) noexcept {  // NOLINT
-  auto my_size = size();
-  p | my_size;
-  if (my_size > 0) {
-    if (p.isUnpacking()) {
-      owning_ = true;
-      owned_data_.resize(my_size);
-      reset_pointer_vector();
-    }
-    PUParray(p, data(), size());
-  }
-}
+/// Define shift and (in)equivalence operators for DataVector with itself
+MAKE_EXPRESSION_VECMATH_OP_DEF_COMP_SELF(DataVector)
 
-std::ostream& operator<<(std::ostream& os, const DataVector& d) {
-  sequence_print_helper(os, d.begin(), d.end());
-  return os;
-}
-
-/// Equivalence operator for DataVector
-bool operator==(const DataVector& lhs, const DataVector& rhs) noexcept {
-  return lhs.size() == rhs.size() and
-         std::equal(lhs.begin(), lhs.end(), rhs.begin());
-}
-
-/// Inequivalence operator for DataVector
-bool operator!=(const DataVector& lhs, const DataVector& rhs) noexcept {
-  return not(lhs == rhs);
-}
+/// Charm++ object packing / unpacking
+MAKE_EXPRESSION_VEC_OP_PUP_CHARM(DataVector)
 
 /// \cond
 template DataVector::DataVector(std::initializer_list<double> list) noexcept;

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -126,7 +126,8 @@ using std::abs;  // NOLINT
  * - tanh
  */
 /// DataVector class
-MAKE_EXPRESSION_DATA_MODAL_VECTOR_CLASSES(DataVector)
+MAKE_EXPRESSION_DATA_MODAL_VECTOR_CLASSES(DataVector, double,
+    MAKE_EXPRESSION_MATH_ASSIGN_ADD_SUB_MUL_DIV(DataVector))
 
 /// Declare shift and (in)equivalence operators for DataVector with itself
 MAKE_EXPRESSION_VECMATH_OP_COMP_SELF(DataVector)
@@ -138,7 +139,8 @@ MAKE_EXPRESSION_VECMATH_OP_COMP_DV(DataVector)
 /// \endcond
 
 // Specialize the Blaze type traits to correctly handle DataVector
-MAKE_EXPRESSION_VECMATH_SPECIALIZE_BLAZE_ARITHMETIC_TRAITS(DataVector)
+MAKE_EXPRESSION_VECMATH_SPECIALIZE_BLAZE_ARITHMETIC_TRAITS_0(DataVector)
+MAKE_EXPRESSION_VECMATH_SPECIALIZE_BLAZE_ARITHMETIC_TRAITS_1(DataVector)
 
 // Specialize the Blaze {Unary,Binary}Map traits to correctly handle DataVector
 MAKE_EXPRESSION_VECMATH_SPECIALIZE_BLAZE_MAP_TRAITS(DataVector)

--- a/src/DataStructures/DataVector.hpp
+++ b/src/DataStructures/DataVector.hpp
@@ -6,29 +6,30 @@
 
 #pragma once
 
-#include <array>
+#include <array>                // IWYU pragma: keep
 #include <cmath>
-#include <cstddef>
+#include <cstddef>              // IWYU pragma: keep
 #include <functional>  // for std::reference_wrapper
-#include <initializer_list>
-#include <limits>
-#include <ostream>
-#include <type_traits>
-#include <vector>
+#include <initializer_list>     // IWYU pragma: keep
+#include <limits>               // IWYU pragma: keep
+#include <ostream>              // IWYU pragma: keep
+#include <type_traits>          // IWYU pragma: keep
+#include <vector>               // IWYU pragma: keep
 
-#include "ErrorHandling/Assert.hpp"
+#include "DataStructures/VectorMacros.hpp"
+#include "ErrorHandling/Assert.hpp"           // IWYU pragma: keep
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ForceInline.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Gsl.hpp"                  // IWYU pragma: keep
+#include "Utilities/MakeWithValue.hpp"        // IWYU pragma: keep
 #include "Utilities/PointerVector.hpp"
 #include "Utilities/Requires.hpp"
 
 /// \cond HIDDEN_SYMBOLS
 // IWYU pragma: no_forward_declare ConstantExpressions_detail::pow
-namespace PUP {
-class er;
-}  // namespace PUP
+namespace PUP {       // IWYU pragma: keep
+class er;             // IWYU pragma: keep
+} // namespace PUP    // IWYU pragma: keep
 
 // clang-tidy: no using declarations in header files
 //             We want the std::abs to be used
@@ -61,6 +62,7 @@ using std::abs;  // NOLINT
 // IWYU pragma: no_include <blaze/math/traits/BinaryMapTrait.h>
 // IWYU pragma: no_include <blaze/math/traits/UnaryMapTrait.h>
 // IWYU pragma: no_include <blaze/math/typetraits/TransposeFlag.h>
+// IWYU pragma: no_include "DataStructures/DataVector.hpp"
 
 // IWYU pragma: no_forward_declare blaze::DenseVector
 // IWYU pragma: no_forward_declare blaze::UnaryMapTrait
@@ -123,347 +125,40 @@ using std::abs;  // NOLINT
  * - tan
  * - tanh
  */
-class DataVector
-    : public PointerVector<double, blaze::unaligned, blaze::unpadded,
-                           blaze::defaultTransposeFlag, DataVector> {
-  /// \cond HIDDEN_SYMBOLS
-  static constexpr void private_asserts() noexcept {
-    static_assert(std::is_nothrow_move_constructible<DataVector>::value,
-                  "Missing move semantics");
-  }
-  /// \endcond
- public:
-  using value_type = double;
-  using allocator_type = std::allocator<value_type>;
-  using size_type = size_t;
-  using difference_type = std::ptrdiff_t;
-  using BaseType = PointerVector<double, blaze::unaligned, blaze::unpadded,
-                                 blaze::defaultTransposeFlag, DataVector>;
-  static constexpr bool transpose_flag = blaze::defaultTransposeFlag;
+/// DataVector class
+MAKE_EXPRESSION_DATA_MODAL_VECTOR_CLASSES(DataVector)
 
-  using BaseType::ElementType;
-  using TransposeType = DataVector;
-  using CompositeType = const DataVector&;
-
-  using BaseType::operator[];
-  using BaseType::begin;
-  using BaseType::cbegin;
-  using BaseType::cend;
-  using BaseType::data;
-  using BaseType::end;
-  using BaseType::size;
-
-  // @{
-  // Upcast to `BaseType`
-  const BaseType& operator~() const noexcept {
-    return static_cast<const BaseType&>(*this);
-  }
-  BaseType& operator~() noexcept { return static_cast<BaseType&>(*this); }
-  // @}
-
-  /// Create with the given size and value.
-  ///
-  /// \param size number of values
-  /// \param value the value to initialize each element.
-  explicit DataVector(
-      size_t size,
-      double value = std::numeric_limits<double>::signaling_NaN()) noexcept;
-
-  /// Create a non-owning DataVector that points to `start`
-  DataVector(double* start, size_t size) noexcept;
-
-  /// Create from an initializer list of doubles. All elements in the
-  /// `std::initializer_list` must have decimal points
-  template <class T, Requires<cpp17::is_same_v<T, double>> = nullptr>
-  DataVector(std::initializer_list<T> list) noexcept;
-
-  /// Empty DataVector
-  DataVector() noexcept = default;
-  /// \cond HIDDEN_SYMBOLS
-  ~DataVector() = default;
-
-  DataVector(const DataVector& rhs);
-  DataVector(DataVector&& rhs) noexcept;
-  DataVector& operator=(const DataVector& rhs);
-  DataVector& operator=(DataVector&& rhs) noexcept;
-
-  // This is a converting constructor. clang-tidy complains that it's not
-  // explicit, but we want it to allow conversion.
-  // clang-tidy: mark as explicit (we want conversion to DataVector)
-  template <typename VT, bool VF>
-  DataVector(const blaze::DenseVector<VT, VF>& expression) noexcept;  // NOLINT
-
-  template <typename VT, bool VF>
-  DataVector& operator=(const blaze::DenseVector<VT, VF>& expression) noexcept;
-  /// \endcond
-
-  MAKE_EXPRESSION_MATH_ASSIGN_PV(+=, DataVector)
-  MAKE_EXPRESSION_MATH_ASSIGN_PV(-=, DataVector)
-  MAKE_EXPRESSION_MATH_ASSIGN_PV(*=, DataVector)
-  MAKE_EXPRESSION_MATH_ASSIGN_PV(/=, DataVector)
-
-  DataVector& operator=(const double& rhs) noexcept {
-    ~*this = rhs;
-    return *this;
-  }
-
-  // @{
-  /// Set the DataVector to be a reference to another DataVector object
-  void set_data_ref(gsl::not_null<DataVector*> rhs) noexcept {
-    set_data_ref(rhs->data(), rhs->size());
-  }
-  void set_data_ref(double* start, size_t size) noexcept {
-    owned_data_ = decltype(owned_data_){};
-    (~*this).reset(start, size);
-    owning_ = false;
-  }
-  // @}
-
-  /// Returns true if the class owns the data
-  bool is_owning() const noexcept { return owning_; }
-
-  /// Serialization for Charm++
-  // clang-tidy: google-runtime-references
-  void pup(PUP::er& p) noexcept;  // NOLINT
-
- private:
-  SPECTRE_ALWAYS_INLINE void reset_pointer_vector() noexcept {
-    reset(owned_data_.data(), owned_data_.size());
-  }
-
-  /// \cond HIDDEN_SYMBOLS
-  std::vector<double, allocator_type> owned_data_;
-  bool owning_{true};
-  /// \endcond
-};
-
-/// Output operator for DataVector
-std::ostream& operator<<(std::ostream& os, const DataVector& d);
-
-/// Equivalence operator for DataVector
-bool operator==(const DataVector& lhs, const DataVector& rhs) noexcept;
-
-/// Inequivalence operator for DataVector
-bool operator!=(const DataVector& lhs, const DataVector& rhs) noexcept;
+/// Declare shift and (in)equivalence operators for DataVector with itself
+MAKE_EXPRESSION_VECMATH_OP_COMP_SELF(DataVector)
 
 /// \cond
-// Used for comparing DataVector to an expression
-template <typename VT, bool VF>
-bool operator==(const DataVector& lhs,
-                const blaze::DenseVector<VT, VF>& rhs) noexcept {
-  return lhs == DataVector(rhs);
-}
-
-template <typename VT, bool VF>
-bool operator!=(const DataVector& lhs,
-                const blaze::DenseVector<VT, VF>& rhs) noexcept {
-  return not(lhs == rhs);
-}
-
-template <typename VT, bool VF>
-bool operator==(const blaze::DenseVector<VT, VF>& lhs,
-                const DataVector& rhs) noexcept {
-  return DataVector(lhs) == rhs;
-}
-
-template <typename VT, bool VF>
-bool operator!=(const blaze::DenseVector<VT, VF>& lhs,
-                const DataVector& rhs) noexcept {
-  return not(lhs == rhs);
-}
+/// Define shift and (in)equivalence operators for DataVector with
+/// blaze::DenseVector
+MAKE_EXPRESSION_VECMATH_OP_COMP_DV(DataVector)
 /// \endcond
 
 // Specialize the Blaze type traits to correctly handle DataVector
-namespace blaze {
-template <>
-struct IsVector<DataVector> : std::true_type {};
+MAKE_EXPRESSION_VECMATH_SPECIALIZE_BLAZE_ARITHMETIC_TRAITS(DataVector)
 
-template <>
-struct TransposeFlag<DataVector> : BoolConstant<DataVector::transpose_flag> {};
-
-template <>
-struct AddTrait<DataVector, DataVector> {
-  using Type = DataVector;
-};
-
-template <>
-struct AddTrait<DataVector, double> {
-  using Type = DataVector;
-};
-
-template <>
-struct AddTrait<double, DataVector> {
-  using Type = DataVector;
-};
-
-template <>
-struct SubTrait<DataVector, DataVector> {
-  using Type = DataVector;
-};
-
-template <>
-struct SubTrait<DataVector, double> {
-  using Type = DataVector;
-};
-
-template <>
-struct SubTrait<double, DataVector> {
-  using Type = DataVector;
-};
-
-template <>
-struct MultTrait<DataVector, DataVector> {
-  using Type = DataVector;
-};
-
-template <>
-struct MultTrait<DataVector, double> {
-  using Type = DataVector;
-};
-
-template <>
-struct MultTrait<double, DataVector> {
-  using Type = DataVector;
-};
-
-template <>
-struct DivTrait<DataVector, DataVector> {
-  using Type = DataVector;
-};
-
-template <>
-struct DivTrait<DataVector, double> {
-  using Type = DataVector;
-};
-
-template <typename Operator>
-struct UnaryMapTrait<DataVector, Operator> {
-  using Type = DataVector;
-};
-
-template <typename Operator>
-struct BinaryMapTrait<DataVector, DataVector, Operator> {
-  using Type = DataVector;
-};
-}  // namespace blaze
+// Specialize the Blaze {Unary,Binary}Map traits to correctly handle DataVector
+MAKE_EXPRESSION_VECMATH_SPECIALIZE_BLAZE_MAP_TRAITS(DataVector)
 
 SPECTRE_ALWAYS_INLINE decltype(auto) fabs(const DataVector& t) noexcept {
   return abs(~t);
 }
 
-template <typename T, size_t Dim>
-std::array<DataVector, Dim> operator+(
-    const std::array<T, Dim>& lhs,
-    const std::array<DataVector, Dim>& rhs) noexcept {
-  std::array<DataVector, Dim> result;
-  for (size_t i = 0; i < Dim; i++) {
-    gsl::at(result, i) = gsl::at(lhs, i) + gsl::at(rhs, i);
-  }
-  return result;
-}
-template <typename U, size_t Dim>
-std::array<DataVector, Dim> operator+(const std::array<DataVector, Dim>& lhs,
-                                      const std::array<U, Dim>& rhs) noexcept {
-  return rhs + lhs;
-}
-template <size_t Dim>
-std::array<DataVector, Dim> operator+(
-    const std::array<DataVector, Dim>& lhs,
-    const std::array<DataVector, Dim>& rhs) noexcept {
-  std::array<DataVector, Dim> result;
-  for (size_t i = 0; i < Dim; i++) {
-    gsl::at(result, i) = gsl::at(lhs, i) + gsl::at(rhs, i);
-  }
-  return result;
-}
-template <size_t Dim>
-std::array<DataVector, Dim>& operator+=(
-    std::array<DataVector, Dim>& lhs,
-    const std::array<DataVector, Dim>& rhs) noexcept {
-  for (size_t i = 0; i < Dim; i++) {
-    gsl::at(lhs, i) += gsl::at(rhs, i);
-  }
-  return lhs;
-}
-template <typename T, size_t Dim>
-std::array<DataVector, Dim> operator-(
-    const std::array<T, Dim>& lhs,
-    const std::array<DataVector, Dim>& rhs) noexcept {
-  std::array<DataVector, Dim> result;
-  for (size_t i = 0; i < Dim; i++) {
-    gsl::at(result, i) = gsl::at(lhs, i) - gsl::at(rhs, i);
-  }
-  return result;
-}
-template <typename U, size_t Dim>
-std::array<DataVector, Dim> operator-(const std::array<DataVector, Dim>& lhs,
-                                      const std::array<U, Dim>& rhs) noexcept {
-  std::array<DataVector, Dim> result;
-  for (size_t i = 0; i < Dim; i++) {
-    gsl::at(result, i) = gsl::at(lhs, i) - gsl::at(rhs, i);
-  }
-  return result;
-}
-template <size_t Dim>
-std::array<DataVector, Dim> operator-(
-    const std::array<DataVector, Dim>& lhs,
-    const std::array<DataVector, Dim>& rhs) noexcept {
-  std::array<DataVector, Dim> result;
-  for (size_t i = 0; i < Dim; i++) {
-    gsl::at(result, i) = gsl::at(lhs, i) - gsl::at(rhs, i);
-  }
-  return result;
-}
-template <size_t Dim>
-std::array<DataVector, Dim>& operator-=(
-    std::array<DataVector, Dim>& lhs,
-    const std::array<DataVector, Dim>& rhs) noexcept {
-  for (size_t i = 0; i < Dim; i++) {
-    gsl::at(lhs, i) -= gsl::at(rhs, i);
-  }
-  return lhs;
-}
+/// Define +, +=, -, -= operations between std::array's of DataVectors
+MAKE_EXPRESSION_VECMATH_OP_ADD_ARRAYS_OF_VEC(DataVector)
+MAKE_EXPRESSION_VECMATH_OP_SUB_ARRAYS_OF_VEC(DataVector)
 
 /// \cond HIDDEN_SYMBOLS
-template <typename VT, bool VF>
-DataVector::DataVector(const blaze::DenseVector<VT, VF>& expression) noexcept
-    : owned_data_((~expression).size()) {
-  static_assert(cpp17::is_same_v<typename VT::ResultType, DataVector>,
-                "You are attempting to assign the result of an expression that "
-                "is not a DataVector to a DataVector.");
-  reset_pointer_vector();
-  ~*this = expression;
-}
-
-template <typename VT, bool VF>
-DataVector& DataVector::operator=(
-    const blaze::DenseVector<VT, VF>& expression) noexcept {
-  static_assert(cpp17::is_same_v<typename VT::ResultType, DataVector>,
-                "You are attempting to assign the result of an expression that "
-                "is not a DataVector to a DataVector.");
-  if (owning_ and (~expression).size() != size()) {
-    owned_data_.resize((~expression).size());
-    reset_pointer_vector();
-  } else if (not owning_) {
-    ASSERT((~expression).size() == size(), "Must copy into same size, not "
-                                               << (~expression).size()
-                                               << " into " << size());
-  }
-  ~*this = expression;
-  return *this;
-}
+/// Forbid assignment of blaze::DenseVector<VT,VF>'s to DataVector, if its
+/// result type VT::ResultType is not DataVector
+MAKE_EXPRESSION_VEC_OP_ASSIGNMENT_RESTRICT_TYPE(DataVector)
 /// \endcond
 
-namespace MakeWithValueImpls {
-/// \brief Returns a DataVector the same size as `input`, with each element
-/// equal to `value`.
-template <>
-SPECTRE_ALWAYS_INLINE DataVector
-MakeWithValueImpl<DataVector, DataVector>::apply(const DataVector& input,
-                                                 const double value) {
-  return DataVector(input.size(), value);
-}
-}  // namespace MakeWithValueImpls
+/// Construct a DataVector with value(s)
+MAKE_EXPRESSION_VEC_OP_MAKE_WITH_VALUE(DataVector)
 
 namespace ConstantExpressions_detail {
 template <>

--- a/src/DataStructures/ModalVector.cpp
+++ b/src/DataStructures/ModalVector.cpp
@@ -1,0 +1,132 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/ModalVector.hpp"
+
+#include <algorithm>
+#include <pup.h>
+#include <pup_stl.h>
+
+#include "Utilities/StdHelpers.hpp"
+
+ModalVector::ModalVector(const size_t size, const double value)
+    : size_(size),
+      owned_data_(size_, value),
+      data_(owned_data_.data(), size_) {}
+
+template <class T, Requires<cpp17::is_same_v<T, double>>>
+ModalVector::ModalVector(std::initializer_list<T> list)
+    : size_(list.size()),
+      owned_data_(std::move(list)),
+      data_(owned_data_.data(), size_) {}
+
+ModalVector::ModalVector(double* start, size_t size)
+    : size_(size), owned_data_(0), data_(start, size_), owning_(false) {}
+
+/// \cond HIDDEN_SYMBOLS
+ModalVector::ModalVector(const ModalVector& rhs) {
+  size_ = rhs.size();
+  if (rhs.is_owning()) {
+    owned_data_ = rhs.owned_data_;
+  } else {
+    owned_data_ = InternalStorage_t(rhs.begin(), rhs.end());
+  }
+  data_ = decltype(data_){owned_data_.data(), size_};
+}
+
+ModalVector& ModalVector::operator=(const ModalVector& rhs) {
+  if (this == &rhs) {
+    return *this;
+  }
+  if (owning_) {
+    size_ = rhs.size();
+    if (rhs.is_owning()) {
+      owned_data_ = rhs.owned_data_;
+    } else {
+      owned_data_ = InternalStorage_t(rhs.begin(), rhs.end());
+    }
+    data_ = decltype(data_){owned_data_.data(), size_};
+  } else {
+    ASSERT(rhs.size() == size(), "Must copy into same size, not "
+                                     << rhs.size() << " into " << size());
+    std::copy(rhs.begin(), rhs.end(), begin());
+  }
+  return *this;
+}
+
+ModalVector::ModalVector(ModalVector&& rhs) noexcept {
+  size_ = rhs.size_;
+  owned_data_ = std::move(rhs.owned_data_);
+  // clang-tidy: move trivially copyable type, future proof in case impl
+  // changes
+  data_ = std::move(rhs.data_);  // NOLINT
+  owning_ = rhs.owning_;
+
+  rhs.owning_ = true;
+  rhs.size_ = 0;
+  rhs.data_ = decltype(rhs.data_){};
+}
+
+ModalVector&
+ModalVector::operator=(ModalVector&& rhs) noexcept {
+  if (this == &rhs) {
+    return *this;
+  }
+  if (owning_) {
+    size_ = rhs.size_;
+    owned_data_ = std::move(rhs.owned_data_);
+    // clang-tidy: move trivially copyable type, future proof in case impl
+    // changes
+    data_ = std::move(rhs.data_);  // NOLINT
+    owning_ = rhs.owning_;
+  } else {
+    ASSERT(rhs.size() == size(), "Must copy into same size, not "
+                                     << rhs.size() << " into " << size());
+    std::copy(rhs.begin(), rhs.end(), begin());
+  }
+  rhs.owning_ = true;
+  rhs.size_ = 0;
+  rhs.data_ = decltype(rhs.data_){};
+  return *this;
+}
+/// \endcond
+
+void ModalVector::pup(PUP::er& p) noexcept {  // NOLINT
+  p | size_;
+  if (p.isUnpacking()) {
+    owning_ = true;
+    p | owned_data_;
+    data_ = decltype(data_){owned_data_.data(), size_};
+  } else {
+    if (not owning_) {
+      owned_data_ =
+          InternalStorage_t(data_.data(), data_.data() + size_);  // NOLINT
+      p | owned_data_;
+      owned_data_.clear();
+    } else {
+      p | owned_data_;
+    }
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, const ModalVector& d) {
+  // This function is inside the detail namespace StdHelpers.hpp
+  StdHelpers_detail::print_helper(os, d.begin(), d.end());
+  return os;
+}
+
+/// Equivalence operator for ModalVector
+bool operator==(const ModalVector& lhs, const ModalVector& rhs) {
+  return lhs.size() == rhs.size() and
+         std::equal(lhs.begin(), lhs.end(), rhs.begin());
+}
+
+/// Inequivalence operator for ModalVector
+bool operator!=(const ModalVector& lhs, const ModalVector& rhs) {
+  return not(lhs == rhs);
+}
+
+/// \cond
+template
+ModalVector::ModalVector(std::initializer_list<double> list);
+/// \endcond

--- a/src/DataStructures/ModalVector.cpp
+++ b/src/DataStructures/ModalVector.cpp
@@ -3,112 +3,27 @@
 
 #include "DataStructures/ModalVector.hpp"
 
-#include <algorithm>
-#include <pup.h>
+#include <algorithm>                  // IWYU pragma: keep
+#include <pup.h>                      // IWYU pragma: keep
 
-#include "Utilities/StdHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"   // IWYU pragma: keep
 
-ModalVector::ModalVector(const size_t size, const double value)
-    : owned_data_(size, value) {
-  reset_pointer_vector();
-}
-
-ModalVector::ModalVector(double* start, size_t size) noexcept
-    : BaseType(start, size), owned_data_(0), owning_(false) {}
-
-template <class T, Requires<cpp17::is_same_v<T, double>>>
-ModalVector::ModalVector(std::initializer_list<T> list)
-    : owned_data_(std::move(list)) {
-  reset_pointer_vector();
-}
+/// Construct a ModalVector with value(s)
+MAKE_EXPRESSION_VEC_DEF_CONSTRUCT_WITH_VALUE(ModalVector)
 
 /// \cond HIDDEN_SYMBOLS
+/// Construct / Assign ModalVector with / to ModalVector reference or rvalue
 // clang-tidy: calling a base constructor other than the copy constructor.
 //             We reset the base class in reset_pointer_vector after calling its
 //             default constructor
-ModalVector::ModalVector(const ModalVector& rhs) : BaseType{} {  // NOLINT
-  if (rhs.is_owning()) {
-    owned_data_ = rhs.owned_data_;
-  } else {
-    owned_data_.assign(rhs.begin(), rhs.end());
-  }
-  reset_pointer_vector();
-}
-
-ModalVector& ModalVector::operator=(const ModalVector& rhs) {
-  if (this != &rhs) {
-    if (owning_) {
-      if (rhs.is_owning()) {
-        owned_data_ = rhs.owned_data_;
-      } else {
-        owned_data_.assign(rhs.begin(), rhs.end());
-      }
-      reset_pointer_vector();
-    } else {
-      ASSERT(rhs.size() == size(), "Must copy into same size, not "
-                                       << rhs.size() << " into " << size());
-      std::copy(rhs.begin(), rhs.end(), begin());
-    }
-  }
-  return *this;
-}
-
-ModalVector::ModalVector(ModalVector&& rhs) noexcept {
-  owned_data_ = std::move(rhs.owned_data_);
-  ~*this = ~rhs;  // PointerVector is trivially copyable
-  owning_ = rhs.owning_;
-
-  rhs.owning_ = true;
-  rhs.reset();
-}
-
-ModalVector& ModalVector::operator=(ModalVector&& rhs) noexcept {
-  if (this != &rhs) {
-    if (owning_) {
-      owned_data_ = std::move(rhs.owned_data_);
-      ~*this = ~rhs;  // PointerVector is trivially copyable
-      owning_ = rhs.owning_;
-    } else {
-      ASSERT(rhs.size() == size(), "Must copy into same size, not "
-                                       << rhs.size() << " into " << size());
-      std::copy(rhs.begin(), rhs.end(), begin());
-    }
-    rhs.owning_ = true;
-    rhs.reset();
-  }
-  return *this;
-}
+MAKE_EXPRESSION_VEC_DEF_CONSTRUCT_WITH_VEC(ModalVector)
 /// \endcond
 
-void ModalVector::pup(PUP::er& p) noexcept {  // NOLINT
-  auto my_size = size();
-  p | my_size;
-  if (my_size > 0) {
-    if (p.isUnpacking()) {
-      owning_ = true;
-      owned_data_.resize(my_size);
-      reset_pointer_vector();
-    }
-    PUParray(p, data(), size());
-  }
-}
+/// Define shift and (in)equivalence operators for ModalVector with itself
+MAKE_EXPRESSION_VECMATH_OP_DEF_COMP_SELF(ModalVector)
 
-std::ostream& operator<<(std::ostream& os, const ModalVector& d) {
-  // This function is inside the detail namespace StdHelpers.hpp
-  StdHelpers_detail::print_helper(os, d.begin(), d.end());
-  return os;
-}
-
-/// Equivalence operator for ModalVector
-bool operator==(const ModalVector& lhs, const ModalVector& rhs) noexcept {
-  return lhs.size() == rhs.size() and
-         std::equal(lhs.begin(), lhs.end(), rhs.begin());
-}
-
-/// Inequivalence operator for ModalVector
-bool operator!=(const ModalVector& lhs, const ModalVector& rhs) noexcept {
-  return not(lhs == rhs);
-}
+/// Charm++ object packing / unpacking
+MAKE_EXPRESSION_VEC_OP_PUP_CHARM(ModalVector)
 
 /// \cond
 template ModalVector::ModalVector(std::initializer_list<double> list);

--- a/src/DataStructures/ModalVector.hpp
+++ b/src/DataStructures/ModalVector.hpp
@@ -90,7 +90,8 @@ using std::abs;  // NOLINT
  *
  */
 /// ModalVector class
-MAKE_EXPRESSION_DATA_MODAL_VECTOR_CLASSES(ModalVector)
+MAKE_EXPRESSION_DATA_MODAL_VECTOR_CLASSES(ModalVector, double,
+    MAKE_EXPRESSION_MATH_ASSIGN_ADD_SUB(ModalVector))
 
 /// Declare shift and (in)equivalence operators for ModalVector with itself
 MAKE_EXPRESSION_VECMATH_OP_COMP_SELF(ModalVector)
@@ -102,7 +103,7 @@ MAKE_EXPRESSION_VECMATH_OP_COMP_DV(ModalVector)
 /// \endcond
 
 // Specialize Blaze type traits to correctly handle ModalVector
-MAKE_EXPRESSION_VECMATH_SPECIALIZE_BLAZE_ARITHMETIC_TRAITS(ModalVector)
+MAKE_EXPRESSION_VECMATH_SPECIALIZE_BLAZE_ARITHMETIC_TRAITS_0(ModalVector)
 
 // Specialize the Blaze {Unary,Binary}Map traits to correctly handle ModalVector
 namespace blaze {

--- a/src/DataStructures/ModalVector.hpp
+++ b/src/DataStructures/ModalVector.hpp
@@ -1,0 +1,485 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines class Data.
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <initializer_list>
+#include <limits>
+#include <ostream>
+#include <type_traits>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+//~ #include "Utilities/PointerVector.hpp" // IWYU complains on double includes
+#include "Utilities/Requires.hpp"
+
+/// \cond HIDDEN_SYMBOLS
+namespace PUP {
+class er;
+}  // namespace PUP
+
+// clang-tidy: no using declarations in header files
+//             We want the std::abs to be used
+using std::abs;  // NOLINT
+/// \endcond
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief A class for storing spectral coefficients on a mesh.
+ *
+ * A ModalVector holds an array of spectral coefficients, and can be
+ * either owning (the array is deleted when the Data goes out of scope) or
+ * non-owning, meaning it just has a pointer to an array.
+ *
+ * Only basic mathematical operations are supported with ModalVectors. In
+ * addition to the addition, subtraction, multiplication, division, etc. there
+ * are the following element-wise operations:
+ *
+ * - abs
+ * - max
+ * - min
+ */
+class ModalVector {
+  /// \cond HIDDEN_SYMBOLS
+  static constexpr int private_asserts() {
+    static_assert(std::is_nothrow_move_constructible<ModalVector>::value,
+                  "Missing move semantics");
+    return 0;
+  }
+  /// \endcond
+ public:
+  using value_type = double;
+  using allocator_type = std::allocator<value_type>;
+  using size_type = size_t;
+  using difference_type = std::ptrdiff_t;
+
+  // The type alias ElementType is needed because blaze::IsInvertible<T> is not
+  // SFINAE friendly to an ElementType type alias
+  using ElementType = double;
+
+ private:
+  /// The type of the "pointer" used internally
+  using InternalModalVector_t = PointerVector<double>;
+  /// The type used to store the data in
+  using InternalStorage_t = std::vector<double, allocator_type>;
+
+ public:
+  /// Create with the given size and value.
+  ///
+  /// \param size number of values
+  /// \param value the value to initialize each element.
+  explicit ModalVector(
+  size_t size, double value = std::numeric_limits<double>::signaling_NaN());
+
+  /// Create a non-owning ModalVector that points to `start`
+  ModalVector(double* start, size_t size);
+
+  /// Create from an initializer list of doubles. All elements in the
+  /// `std::initializer_list` must have decimal points
+  // cppcheck-suppress syntaxError
+  template <class T, Requires<cpp17::is_same_v<T, double>> = nullptr>
+  ModalVector(std::initializer_list<T> list);
+
+  /// Empty ModalVector
+  ModalVector() = default;
+  /// \cond HIDDEN_SYMBOLS
+  ~ModalVector() = default;
+
+  ModalVector(const ModalVector& rhs);
+  ModalVector(ModalVector&& rhs) noexcept;
+  ModalVector& operator=(const ModalVector& rhs);
+  ModalVector& operator=(ModalVector&& rhs) noexcept;
+
+  // This is a converting constructor. clang-tidy complains that it's not
+  // explicit, but we want it to allow conversion.
+  // clang-tidy: mark as explicit (we want conversion to ModalVector)
+  template <typename VT, bool VF>
+  ModalVector(const blaze::Vector<VT, VF>& expression);  // NOLINT
+
+  template <typename VT, bool VF>
+  ModalVector& operator=(const blaze::Vector<VT, VF>& expression);
+  /// \endcond
+
+  /// Number of values stored
+  size_t size() const noexcept { return size_; }
+
+  // @{
+  /// Set the ModalVector to be a reference to another ModalVector
+  /// object
+  void set_data_ref(gsl::not_null<ModalVector*> rhs) noexcept {
+    set_data_ref(rhs->data(), rhs->size_);
+  }
+  void set_data_ref(double* start, size_t size) noexcept {
+    size_ = size;
+    owned_data_ = decltype(owned_data_){};
+    data_ = decltype(data_){start, size_};
+    owning_ = false;
+  }
+  // @}
+
+  /// Returns true if the class owns the data
+  bool is_owning() const noexcept { return owning_; }
+
+  // @{
+  /// Access ith element
+  double& operator[](const size_type i) noexcept {
+    ASSERT(i < size_, "i = " << i << ", size = " << size_);
+    // clang-tidy: do not use pointer arithmetic
+    return data_[i];  // NOLINT
+  }
+  const double& operator[](const size_type i) const noexcept {
+    ASSERT(i < size_, "i = " << i << ", size = " << size_);
+    // clang-tidy: do not use pointer arithmetic
+    return data_[i];  // NOLINT
+  }
+  // @}
+
+  // @{
+  /// Access to the pointer
+  double* data() noexcept { return data_.data(); }
+  const double* data() const noexcept { return data_.data(); }
+  // @}
+
+  // @{
+  /// Returns iterator to beginning of data
+  decltype(auto) begin() noexcept { return data_.begin(); }
+  decltype(auto) begin() const noexcept { return data_.begin(); }
+  // @}
+  // @{
+  /// Returns iterator to end of data
+  decltype(auto) end() noexcept { return data_.end(); }
+  decltype(auto) end() const noexcept { return data_.end(); }
+  // @}
+
+  /// Serialization for Charm++
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  // @{
+  /// See the Blaze library documentation for details on these functions since
+  /// they merely forward to Blaze.
+  /// https://bitbucket.org/blaze-lib/blaze/overview
+  ModalVector& operator=(const double& rhs) noexcept {
+    data_ = rhs;
+    return *this;
+  }
+
+  ModalVector& operator+=(const ModalVector& rhs) noexcept {
+    data_ += rhs.data_;
+    return *this;
+  }
+  template <typename VT, bool VF>
+  ModalVector& operator+=(const blaze::Vector<VT, VF>& rhs) noexcept {
+    data_ += rhs;
+    return *this;
+  }
+  ModalVector& operator+=(const double& rhs) noexcept {
+    data_ += rhs;
+    return *this;
+  }
+
+  ModalVector& operator-=(const ModalVector& rhs) noexcept {
+    data_ -= rhs.data_;
+    return *this;
+  }
+  template <typename VT, bool VF>
+  ModalVector& operator-=(const blaze::Vector<VT, VF>& rhs) noexcept {
+    data_ -= rhs;
+    return *this;
+  }
+  ModalVector& operator-=(const double& rhs) noexcept {
+    data_ -= rhs;
+    return *this;
+  }
+
+  template <typename VT, bool VF>
+  ModalVector& operator*=(const blaze::Vector<VT, VF>& rhs) noexcept {
+    data_ *= rhs;
+    return *this;
+  }
+  ModalVector& operator*=(const double& rhs) noexcept {
+    data_ *= rhs;
+    return *this;
+  }
+  ModalVector& operator*=(const ModalVector& rhs) noexcept {
+    data_ *= rhs.data_;
+    return *this;
+  }
+  // FIXME PK: Can we avoid the instantiation of new DV object in this function
+  ModalVector& operator*=(const DataVector& rhs) noexcept {
+    const blaze::DynamicVector<double> _rhs_local(rhs.size(), rhs.data());
+    data_ *= _rhs_local;
+    return *this;
+  }
+
+  template <typename VT, bool VF>
+  ModalVector& operator/=(const blaze::Vector<VT, VF>& rhs) noexcept {
+    data_ /= rhs;
+    return *this;
+  }
+  ModalVector& operator/=(const double& rhs) noexcept {
+    data_ /= rhs;
+    return *this;
+  }
+  // FIXME PK: Can we avoid the instantiation of new DV object in this function
+  ModalVector& operator/=(const DataVector& rhs) noexcept {
+    const blaze::DynamicVector<double> _rhs_local(rhs.size(), rhs.data());
+    data_ /= _rhs_local;
+    return *this;
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator+(
+      const ModalVector& lhs, const ModalVector& rhs) noexcept {
+    return lhs.data_ + rhs.data_;
+  }
+  template <typename VT, bool VF>
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator+(
+      const blaze::Vector<VT, VF>& lhs, const ModalVector& rhs) noexcept {
+    return ~lhs + rhs.data_;
+  }
+  template <typename VT, bool VF>
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator+(
+      const ModalVector& lhs, const blaze::Vector<VT, VF>& rhs) noexcept {
+    return lhs.data_ + ~rhs;
+  }
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator+(
+      const ModalVector& lhs, const double& rhs) noexcept {
+    return lhs.data_ + rhs;
+  }
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator+(
+      const double& lhs, const ModalVector& rhs) noexcept {
+    return lhs + rhs.data_;
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator-(
+      const ModalVector& lhs, const ModalVector& rhs) noexcept {
+    return lhs.data_ - rhs.data_;
+  }
+  template <typename VT, bool VF>
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator-(
+      const blaze::Vector<VT, VF>& lhs, const ModalVector& rhs) noexcept {
+    return ~lhs - rhs.data_;
+  }
+  template <typename VT, bool VF>
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator-(
+      const ModalVector& lhs, const blaze::Vector<VT, VF>& rhs) noexcept {
+    return lhs.data_ - ~rhs;
+  }
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator-(
+      const ModalVector& lhs, const double& rhs) noexcept {
+    return lhs.data_ - rhs;
+  }
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator-(
+      const double& lhs, const ModalVector& rhs) noexcept {
+    return lhs - rhs.data_;
+  }
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator-(
+      const ModalVector& rhs) noexcept {
+    return -rhs.data_;
+  };
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator*(
+      const ModalVector& lhs, const double& rhs) noexcept {
+    return lhs.data_ * rhs;
+  }
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator*(
+      const double& lhs, const ModalVector& rhs) noexcept {
+    return lhs * rhs.data_;
+  }
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator*(
+      const ModalVector& lhs, const ModalVector& rhs) noexcept {
+    return lhs.data_ * rhs.data_;
+  }
+  template <typename VT, bool VF>
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator*(
+      const blaze::Vector<VT, VF>& lhs, const ModalVector& rhs) noexcept {
+    return ~lhs * rhs.data_;
+  }
+  template <typename VT, bool VF>
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator*(
+      const ModalVector& lhs, const blaze::Vector<VT, VF>& rhs) noexcept {
+    return lhs.data_ * ~rhs;
+  }
+  // FIXME PK: Can we avoid the instantiation of new DV objects in the
+  // next 2 functions?
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator*(
+      const ModalVector& lhs, const DataVector& rhs) noexcept {
+    blaze::DynamicVector<double> _rhs_local(rhs.size(), rhs.data());
+    return lhs * _rhs_local;
+  }
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator*(
+      const DataVector& lhs, const ModalVector& rhs) noexcept {
+    blaze::DynamicVector<double> _lhs_local(lhs.size(), lhs.data());
+    return rhs * _lhs_local;
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator/(
+      const ModalVector& lhs, const double& rhs) noexcept {
+    return lhs.data_ / rhs;
+  }
+  template <typename VT, bool VF>
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator/(
+      const ModalVector& lhs, const blaze::Vector<VT, VF>& rhs) noexcept {
+    return lhs.data_ / ~rhs;
+  }
+  // FIXME PK: Can we avoid the instantiation of new DV object in this function
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) operator/(
+      const ModalVector& lhs, const DataVector& rhs) noexcept {
+    const blaze::DynamicVector<double> _rhs_local(rhs.size(), rhs.data());
+    return lhs / _rhs_local;
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) min(
+      const ModalVector& t) noexcept {
+    return min(t.data_);
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) max(
+      const ModalVector& t) noexcept {
+    return max(t.data_);
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) abs(
+      const ModalVector& t) noexcept {
+    return abs(t.data_);
+  }
+
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) fabs(
+      const ModalVector& t) noexcept {
+    return abs(t.data_);
+  }
+  // @}
+
+  /// If less than zero returns zero, otherwise returns one
+  SPECTRE_ALWAYS_INLINE friend decltype(auto) step_function(
+      const ModalVector& t) noexcept {
+    return step_function(t.data_);
+  }
+
+ private:
+  /// \cond HIDDEN_SYMBOLS
+  size_t size_ = 0;
+  InternalStorage_t owned_data_;
+  InternalModalVector_t data_;
+  bool owning_{true};
+  /// \endcond
+};
+
+/// Output operator for ModalVector
+std::ostream& operator<<(std::ostream& os, const ModalVector& d);
+
+/// Equivalence operator for ModalVector
+bool operator==(const ModalVector& lhs, const ModalVector& rhs);
+
+/// Inequivalence operator for ModalVector
+bool operator!=(const ModalVector& lhs, const ModalVector& rhs);
+
+template <typename T, size_t Dim>
+std::array<ModalVector, Dim> operator+(
+    const std::array<T, Dim>& lhs,
+    const std::array<ModalVector, Dim>& rhs) noexcept {
+  std::array<ModalVector, Dim> result;
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = gsl::at(lhs, i) + gsl::at(rhs, i);
+  }
+  return result;
+}
+template <typename U, size_t Dim>
+std::array<ModalVector, Dim> operator+(
+    const std::array<ModalVector, Dim>& lhs,
+    const std::array<U, Dim>& rhs) noexcept {
+  return rhs + lhs;
+}
+template <size_t Dim>
+std::array<ModalVector, Dim> operator+(
+    const std::array<ModalVector, Dim>& lhs,
+    const std::array<ModalVector, Dim>& rhs) noexcept {
+  std::array<ModalVector, Dim> result;
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = gsl::at(lhs, i) + gsl::at(rhs, i);
+  }
+  return result;
+}
+template <size_t Dim>
+std::array<ModalVector, Dim>& operator+=(
+    std::array<ModalVector, Dim>& lhs,
+    const std::array<ModalVector, Dim>& rhs) noexcept {
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(lhs, i) += gsl::at(rhs, i);
+  }
+  return lhs;
+}
+
+template <typename T, size_t Dim>
+std::array<ModalVector, Dim> operator-(
+    const std::array<T, Dim>& lhs,
+    const std::array<ModalVector, Dim>& rhs) noexcept {
+  std::array<ModalVector, Dim> result;
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = gsl::at(lhs, i) - gsl::at(rhs, i);
+  }
+  return result;
+}
+template <typename U, size_t Dim>
+std::array<ModalVector, Dim> operator-(
+    const std::array<ModalVector, Dim>& lhs,
+    const std::array<U, Dim>& rhs) noexcept {
+  std::array<ModalVector, Dim> result;
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = gsl::at(lhs, i) - gsl::at(rhs, i);
+  }
+  return result;
+}
+template <size_t Dim>
+std::array<ModalVector, Dim> operator-(
+    const std::array<ModalVector, Dim>& lhs,
+    const std::array<ModalVector, Dim>& rhs) noexcept {
+  std::array<ModalVector, Dim> result;
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(result, i) = gsl::at(lhs, i) - gsl::at(rhs, i);
+  }
+  return result;
+}
+template <size_t Dim>
+std::array<ModalVector, Dim>& operator-=(
+    std::array<ModalVector, Dim>& lhs,
+    const std::array<ModalVector, Dim>& rhs) noexcept {
+  for (size_t i = 0; i < Dim; i++) {
+    gsl::at(lhs, i) -= gsl::at(rhs, i);
+  }
+  return lhs;
+}
+
+// FIXME PK: What is the purpose of next 2 functions copied from DataVector?
+/// \cond HIDDEN_SYMBOLS
+template <typename VT, bool VF>
+ModalVector::ModalVector(const blaze::Vector<VT, VF>& expression)
+    : size_((~expression).size()),
+      owned_data_((~expression).size()),
+      data_(owned_data_.data(), (~expression).size()) {
+  data_ = expression;
+}
+
+template <typename VT, bool VF>
+ModalVector& ModalVector::operator=(
+    const blaze::Vector<VT, VF>& expression) {
+  if (owning_ and (~expression).size() != size()) {
+    size_ = (~expression).size();
+    owned_data_ = InternalStorage_t(size_);
+    data_ = decltype(data_){owned_data_.data(), size_};
+  } else if (not owning_) {
+    ASSERT((~expression).size() == size(), "Must copy into same size");
+  }
+  data_ = expression;
+  return *this;
+}
+/// \endcond

--- a/src/DataStructures/ModalVector.hpp
+++ b/src/DataStructures/ModalVector.hpp
@@ -59,6 +59,7 @@ using std::abs;  // NOLINT
 // IWYU pragma: no_include <blaze/math/traits/BinaryMapTrait.h>
 // IWYU pragma: no_include <blaze/math/traits/UnaryMapTrait.h>
 // IWYU pragma: no_include <blaze/math/typetraits/TransposeFlag.h>
+// IWYU pragma: no_include "DataStructures/DataVector.hpp"
 
 // IWYU pragma: no_forward_declare blaze::DenseVector
 // IWYU pragma: no_forward_declare blaze::UnaryMapTrait

--- a/src/DataStructures/VectorMacros.hpp
+++ b/src/DataStructures/VectorMacros.hpp
@@ -1,0 +1,534 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Common code for classes DataVector and ModalVector
+
+#pragma once
+
+
+/**
+ * \ingroup DataStructuresGroup
+ * \brief Here be code common to container classes DataVector and ModalVector.
+ *
+ * \details DataVector is intended to contain function values on the
+ * computational domain. It holds an array of contiguous data and supports a
+ * variety of mathematical operations that are applicable to nodal coefficients.
+ * ModalVector, on the other hand, is intended to contain values of spectral
+ * coefficients for any quantity expanded in its respective bases. It also
+ * holds an array of contiguous data, but allows only limited math operations,
+ * i.e. only those that are applicable to spectral coefficients, such as
+ * elementwise addition, subtraction, multiplication, division and a few more.
+ *
+ * Therefore, both classes have significantly common structure and properties.
+ * This file contains code (in the form of macros) that is used to build both
+ * {Data,Modal}Vector classes.
+ *
+ * A VECTYPE class (below) holds an array of contiguous data. VECTYPE can be
+ * owning, meaning the array is deleted when the VECTYPE goes out of scope, or
+ * non-owning, meaning it just has a pointer to an array.
+ */
+#define MAKE_EXPRESSION_DATA_MODAL_VECTOR_CLASSES(VECTYPE)                     \
+class VECTYPE /* NOLINT */                                                     \
+    : public PointerVector<double, blaze::unaligned, blaze::unpadded,          \
+                           blaze::defaultTransposeFlag, VECTYPE> { /* NOLINT */\
+  /** \cond HIDDEN_SYMBOLS */                                                  \
+  static constexpr void private_asserts() noexcept { /* NOLINTNEXTLINE */      \
+    static_assert(std::is_nothrow_move_constructible<VECTYPE>::value,          \
+                  "Missing move semantics");                                   \
+  }                                                                            \
+  /** \endcond */                                                              \
+ public:                                                                       \
+  using value_type = double;                                                   \
+  using allocator_type = std::allocator<value_type>;                           \
+  using size_type = size_t;                                                    \
+  using difference_type = std::ptrdiff_t;                                      \
+  using BaseType = PointerVector<double, blaze::unaligned, blaze::unpadded,    \
+                                 blaze::defaultTransposeFlag,                  \
+                                 VECTYPE>; /* NOLINT */                        \
+  static constexpr bool transpose_flag = blaze::defaultTransposeFlag;          \
+                                                                               \
+  using BaseType::ElementType;                                                 \
+  using TransposeType = VECTYPE; /* NOLINT */                                  \
+  using CompositeType = const VECTYPE&; /* NOLINT */                           \
+                                                                               \
+  using BaseType::operator[];                                                  \
+  using BaseType::begin;                                                       \
+  using BaseType::cbegin;                                                      \
+  using BaseType::cend;                                                        \
+  using BaseType::data;                                                        \
+  using BaseType::end;                                                         \
+  using BaseType::size;                                                        \
+                                                                               \
+  /** @{ */                                                                    \
+  /* Upcast to `BaseType` */                                                   \
+  const BaseType& operator~() const noexcept {                                 \
+    return static_cast<const BaseType&>(*this);                                \
+  }                                                                            \
+  BaseType& operator~() noexcept { return static_cast<BaseType&>(*this); }     \
+  /** @} */                                                                    \
+                                                                               \
+  /** Create with the given size and value. */                                 \
+  /** */                                                                       \
+  /** \param size number of values */                                          \
+  /** \param value the value to initialize each element. */                    \
+  explicit VECTYPE( /* NOLINT */                                               \
+      size_t size,                                                             \
+      double value = std::numeric_limits<double>::signaling_NaN()) noexcept;   \
+                                                                               \
+  /** Create a non-owning VECTYPE that points to `start` */                    \
+  VECTYPE(double* start, size_t size) noexcept; /* NOLINT */                   \
+                                                                               \
+  /** Create from an initializer list of doubles. All elements in the */       \
+  /** `std::initializer_list` must have decimal points */                      \
+  template <class T, Requires<cpp17::is_same_v<T, double>> = nullptr>          \
+  VECTYPE(std::initializer_list<T> list) noexcept; /* NOLINT */                \
+                                                                               \
+  /** Empty VECTYPE */                                                         \
+  VECTYPE() noexcept = default; /* NOLINT */                                   \
+  /** \cond HIDDEN_SYMBOLS */                                                  \
+  ~VECTYPE() = default; /* NOLINT */                                           \
+                                                                               \
+  VECTYPE(const VECTYPE& rhs); /* NOLINT */                                    \
+  VECTYPE(VECTYPE&& rhs) noexcept; /* NOLINT */                                \
+  VECTYPE& operator=(const VECTYPE& rhs); /* NOLINT */                         \
+  VECTYPE& operator=(VECTYPE&& rhs) noexcept; /* NOLINT */                     \
+                                                                               \
+  /* This is a converting constructor. clang-tidy complains that it's not */   \
+  /* explicit, but we want it to allow conversion.                        */   \
+  /* clang-tidy: mark as explicit (we want conversion to VECTYPE)      */      \
+  template <typename VT, bool VF>                                              \
+  VECTYPE(const blaze::DenseVector<VT, VF>& expression) noexcept; /* NOLINT */ \
+                                                                               \
+  template <typename VT, bool VF>  /* NOLINTNEXTLINE */                        \
+  VECTYPE& operator=(const blaze::DenseVector<VT, VF>& expression) noexcept;   \
+  /** \endcond */                                                              \
+                                                                               \
+  MAKE_EXPRESSION_MATH_ASSIGN_PV(+=, VECTYPE) /* NOLINT */                     \
+  MAKE_EXPRESSION_MATH_ASSIGN_PV(-=, VECTYPE) /* NOLINT */                     \
+  MAKE_EXPRESSION_MATH_ASSIGN_PV(*=, VECTYPE) /* NOLINT */                     \
+  MAKE_EXPRESSION_MATH_ASSIGN_PV(/=, VECTYPE) /* NOLINT */                     \
+                                                                               \
+  VECTYPE& operator=(const double& rhs) noexcept { /* NOLINT */                \
+    ~*this = rhs;                                                              \
+    return *this;                                                              \
+  }                                                                            \
+                                                                               \
+  /** @{ */                                                                    \
+  /** Set the VECTYPE to be a reference to another VECTYPE object */           \
+  void set_data_ref(gsl::not_null<VECTYPE*> rhs) noexcept { /* NOLINT */       \
+    set_data_ref(rhs->data(), rhs->size());                                    \
+  }                                                                            \
+  void set_data_ref(double* start, size_t size) noexcept {                     \
+    owned_data_ = decltype(owned_data_){};                                     \
+    (~*this).reset(start, size);                                               \
+    owning_ = false;                                                           \
+  }                                                                            \
+  /** @} */                                                                    \
+                                                                               \
+  /** Returns true if the class owns the data */                               \
+  bool is_owning() const noexcept { return owning_; }                          \
+                                                                               \
+  /** Serialization for Charm++ */                                             \
+  /* clang-tidy: google-runtime-references */                                  \
+  void pup(PUP::er& p) noexcept; /* NOLINT */                                  \
+                                                                               \
+ private:                                                                      \
+  SPECTRE_ALWAYS_INLINE void reset_pointer_vector() noexcept {                 \
+    reset(owned_data_.data(), owned_data_.size());                             \
+  }                                                                            \
+                                                                               \
+  /** \cond HIDDEN_SYMBOLS */                                                  \
+  std::vector<double, allocator_type> owned_data_;                             \
+  bool owning_{true};                                                          \
+  /** \endcond */                                                              \
+};
+
+
+/**
+ * Declare left-shift, equivalence, and inequivalence operations for VECTYPE
+ * with itself
+ */
+#define MAKE_EXPRESSION_VECMATH_OP_COMP_SELF(VECTYPE)                          \
+/**Output operator for VECTYPE */                                              \
+std::ostream& operator<<(std::ostream& os, const VECTYPE& d); /* NOLINT */     \
+                                                                               \
+/** Equivalence operator for VECTYPE */                                        \
+bool operator==(const VECTYPE& lhs, const VECTYPE& rhs) noexcept; /* NOLINT */ \
+                                                                               \
+/** Inequivalence operator for VECTYPE */                                      \
+bool operator!=(const VECTYPE& lhs, const VECTYPE& rhs) noexcept; /* NOLINT */
+
+
+/**
+ * Define equivalence, and inequivalence operations for VECTYPE
+ * with blaze::DenseVector<VT, VF>
+ */
+/// \cond
+#define MAKE_EXPRESSION_VECMATH_OP_COMP_DV(VECTYPE)               \
+/* Used for comparing VECTYPE to an expression */                 \
+template <typename VT, bool VF>                                   \
+bool operator==(const VECTYPE& lhs, /* NOLINT */                  \
+                const blaze::DenseVector<VT, VF>& rhs) noexcept { \
+  return lhs == VECTYPE(rhs); /* NOLINT */                        \
+}                                                                 \
+                                                                  \
+template <typename VT, bool VF>                                   \
+bool operator!=(const VECTYPE& lhs, /* NOLINT */                  \
+                const blaze::DenseVector<VT, VF>& rhs) noexcept { \
+  return not(lhs == rhs);                                         \
+}                                                                 \
+                                                                  \
+template <typename VT, bool VF>                                   \
+bool operator==(const blaze::DenseVector<VT, VF>& lhs,            \
+                const VECTYPE& rhs) noexcept { /* NOLINT */       \
+  return VECTYPE(lhs) == rhs; /* NOLINT */                        \
+}                                                                 \
+                                                                  \
+template <typename VT, bool VF>                                   \
+bool operator!=(const blaze::DenseVector<VT, VF>& lhs,            \
+                const VECTYPE& rhs) noexcept { /* NOLINT */       \
+  return not(lhs == rhs);                                         \
+}
+/// \endcond
+
+/**
+ * Specialize the Blaze type traits (Add,Sub,Mult,Div) to handle VECTYPE
+ * correctly.
+ */
+#define MAKE_EXPRESSION_VECMATH_SPECIALIZE_BLAZE_ARITHMETIC_TRAITS(VECTYPE) \
+namespace blaze {                                                           \
+template <>                                                                 \
+struct IsVector<VECTYPE> : std::true_type {}; /* NOLINT */                  \
+                                                                            \
+template <>                                                                 \
+struct TransposeFlag<VECTYPE> : BoolConstant< /* NOLINT */                  \
+                VECTYPE::transpose_flag> {}; /* NOLINT */                   \
+                                                                            \
+template <>                                                                 \
+struct AddTrait<VECTYPE, VECTYPE> { /* NOLINT */                            \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+                                                                            \
+template <>                                                                 \
+struct AddTrait<VECTYPE, double> { /* NOLINT */                             \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+                                                                            \
+template <>                                                                 \
+struct AddTrait<double, VECTYPE> { /* NOLINT */                             \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+                                                                            \
+template <>                                                                 \
+struct SubTrait<VECTYPE, VECTYPE> { /* NOLINT */                            \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+                                                                            \
+template <>                                                                 \
+struct SubTrait<VECTYPE, double> { /* NOLINT */                             \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+                                                                            \
+template <>                                                                 \
+struct SubTrait<double, VECTYPE> { /* NOLINT */                             \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+                                                                            \
+template <>                                                                 \
+struct MultTrait<VECTYPE, VECTYPE> { /* NOLINT */                           \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+                                                                            \
+template <>                                                                 \
+struct MultTrait<VECTYPE, double> { /* NOLINT */                            \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+                                                                            \
+template <>                                                                 \
+struct MultTrait<double, VECTYPE> { /* NOLINT */                            \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+                                                                            \
+template <>                                                                 \
+struct DivTrait<VECTYPE, VECTYPE> { /* NOLINT */                            \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+                                                                            \
+template <>                                                                 \
+struct DivTrait<VECTYPE, double> { /* NOLINT */                             \
+  using Type = VECTYPE; /* NOLINT */                                        \
+};                                                                          \
+} /* namespace blaze*/
+
+
+/**
+ * Specialize the Blaze Map traits to correctly handle VECTYPE
+ */
+#define MAKE_EXPRESSION_VECMATH_SPECIALIZE_BLAZE_MAP_TRAITS(VECTYPE) \
+namespace blaze {                                                    \
+template <typename Operator>                                         \
+struct UnaryMapTrait<VECTYPE, Operator> { /* NOLINT */               \
+  using Type = VECTYPE; /* NOLINT */                                 \
+};                                                                   \
+                                                                     \
+template <typename Operator>                                         \
+struct BinaryMapTrait<VECTYPE, VECTYPE, Operator> { /* NOLINT */     \
+  using Type = VECTYPE; /* NOLINT */                                 \
+};                                                                   \
+}  /* namespace blaze */
+
+
+/**
+ * Define + and += operations for std::arrays of VECTYPE's
+ */
+#define MAKE_EXPRESSION_VECMATH_OP_ADD_ARRAYS_OF_VEC(VECTYPE)                \
+template <typename T, size_t Dim>                                            \
+std::array<VECTYPE, Dim> operator+( /* NOLINT */                             \
+    const std::array<T, Dim>& lhs,                                           \
+    const std::array<VECTYPE, Dim>& rhs) noexcept { /* NOLINT */             \
+  std::array<VECTYPE, Dim> result; /* NOLINT */                              \
+  for (size_t i = 0; i < Dim; i++) {                                         \
+    gsl::at(result, i) = gsl::at(lhs, i) + gsl::at(rhs, i);                  \
+  }                                                                          \
+  return result;                                                             \
+}                                                                            \
+template <typename U, size_t Dim>                                            \
+std::array<VECTYPE, Dim> operator+( /* NOLINT */                             \
+    const std::array<VECTYPE, Dim>& lhs, /* NOLINT */                        \
+    const std::array<U, Dim>& rhs) noexcept {                                \
+  return rhs + lhs;                                                          \
+}                                                                            \
+template <size_t Dim>                                                        \
+std::array<VECTYPE, Dim> operator+( /* NOLINT */                             \
+    const std::array<VECTYPE, Dim>& lhs, /* NOLINT */                        \
+    const std::array<VECTYPE, Dim>& rhs) noexcept { /* NOLINT */             \
+  std::array<VECTYPE, Dim> result; /* NOLINT */                              \
+  for (size_t i = 0; i < Dim; i++) {                                         \
+    gsl::at(result, i) = gsl::at(lhs, i) + gsl::at(rhs, i);                  \
+  }                                                                          \
+  return result;                                                             \
+}                                                                            \
+template <size_t Dim>                                                        \
+std::array<VECTYPE, Dim>& operator+=( /* NOLINT */                           \
+    std::array<VECTYPE, Dim>& lhs, /* NOLINT */                              \
+    const std::array<VECTYPE, Dim>& rhs) noexcept { /* NOLINT */             \
+  for (size_t i = 0; i < Dim; i++) {                                         \
+    gsl::at(lhs, i) += gsl::at(rhs, i);                                      \
+  }                                                                          \
+  return lhs;                                                                \
+}
+
+/**
+ * Define - and -= operations for std::arrays of VECTYPE's
+ */
+#define MAKE_EXPRESSION_VECMATH_OP_SUB_ARRAYS_OF_VEC(VECTYPE)                \
+template <typename T, size_t Dim>                                            \
+std::array<VECTYPE, Dim> operator-( /* NOLINT */                             \
+    const std::array<T, Dim>& lhs,                                           \
+    const std::array<VECTYPE, Dim>& rhs) noexcept { /* NOLINT */             \
+  std::array<VECTYPE, Dim> result; /* NOLINT */                              \
+  for (size_t i = 0; i < Dim; i++) {                                         \
+    gsl::at(result, i) = gsl::at(lhs, i) - gsl::at(rhs, i);                  \
+  }                                                                          \
+  return result;                                                             \
+}                                                                            \
+template <typename U, size_t Dim>                                            \
+std::array<VECTYPE, Dim> operator-( /* NOLINT */                             \
+    const std::array<VECTYPE, Dim>& lhs, /* NOLINT */                        \
+    const std::array<U, Dim>& rhs) noexcept {                                \
+  std::array<VECTYPE, Dim> result; /* NOLINT */                              \
+  for (size_t i = 0; i < Dim; i++) {                                         \
+    gsl::at(result, i) = gsl::at(lhs, i) - gsl::at(rhs, i);                  \
+  }                                                                          \
+  return result;                                                             \
+}                                                                            \
+template <size_t Dim>                                                        \
+std::array<VECTYPE, Dim> operator-( /* NOLINT */                             \
+    const std::array<VECTYPE, Dim>& lhs, /* NOLINT */                        \
+    const std::array<VECTYPE, Dim>& rhs) noexcept { /* NOLINT */             \
+  std::array<VECTYPE, Dim> result; /* NOLINT */                              \
+  for (size_t i = 0; i < Dim; i++) {                                         \
+    gsl::at(result, i) = gsl::at(lhs, i) - gsl::at(rhs, i);                  \
+  }                                                                          \
+  return result;                                                             \
+}                                                                            \
+template <size_t Dim>                                                        \
+std::array<VECTYPE, Dim>& operator-=( /* NOLINT */                           \
+    std::array<VECTYPE, Dim>& lhs, /* NOLINT */                              \
+    const std::array<VECTYPE, Dim>& rhs) noexcept { /* NOLINT */             \
+  for (size_t i = 0; i < Dim; i++) {                                         \
+    gsl::at(lhs, i) -= gsl::at(rhs, i);                                      \
+  }                                                                          \
+  return lhs;                                                                \
+}
+
+
+/**
+ * Forbid assignment of blaze::DenseVector<VT,VF>'s to VECTYPE, if the result
+ * type VT::ResultType is not VECTYPE
+ */
+#define MAKE_EXPRESSION_VEC_OP_ASSIGNMENT_RESTRICT_TYPE(VECTYPE)               \
+template <typename VT, bool VF> /* NOLINTNEXTLINE */                         \
+VECTYPE::VECTYPE(const blaze::DenseVector<VT, VF>& expression) noexcept        \
+    : owned_data_((~expression).size()) {                                      \
+  static_assert(cpp17::is_same_v<typename VT::ResultType,VECTYPE>, /* NOLINT */\
+              "You are attempting to assign the result of an expression that " \
+              "is not a " #VECTYPE " to a " #VECTYPE "."); /* NOLINT */        \
+  reset_pointer_vector();                                                      \
+  ~*this = expression;                                                         \
+}                                                                              \
+                                                                               \
+template <typename VT, bool VF>                                                \
+VECTYPE& VECTYPE::operator=( /* NOLINT */                                      \
+    const blaze::DenseVector<VT, VF>& expression) noexcept {                   \
+  static_assert(cpp17::is_same_v<typename VT::ResultType,VECTYPE>, /* NOLINT */\
+              "You are attempting to assign the result of an expression that " \
+              "is not a " #VECTYPE " to a " #VECTYPE "."); /* NOLINT */        \
+  if (owning_ and (~expression).size() != size()) {                            \
+    owned_data_.resize((~expression).size());                                  \
+    reset_pointer_vector();                                                    \
+  } else if (not owning_) {                                                    \
+    ASSERT((~expression).size() == size(), "Must copy into same size, not "    \
+                                               << (~expression).size()         \
+                                               << " into " << size());         \
+  }                                                                            \
+  ~*this = expression;                                                         \
+  return *this;                                                                \
+}
+
+
+#define MAKE_EXPRESSION_VEC_OP_MAKE_WITH_VALUE(VECTYPE)                     \
+namespace MakeWithValueImpls {                                              \
+/** \brief Returns a VECTYPE the same size as `input`, with each element */ \
+/** equal to `value`. */                                                    \
+template <>                                                                 \
+SPECTRE_ALWAYS_INLINE VECTYPE /* NOLINT */                                  \
+MakeWithValueImpl<VECTYPE,VECTYPE>::apply(const VECTYPE& input, /* NOLINT */\
+                                           const double value) {            \
+  return VECTYPE(input.size(), value); /* NOLINT */                         \
+}                                                                           \
+}  /* namespace MakeWithValueImpls*/
+
+
+
+/**                 Function definitions               */
+
+/**
+ * Construct VECTYPE with value(s)
+ */
+#define MAKE_EXPRESSION_VEC_DEF_CONSTRUCT_WITH_VALUE(VECTYPE)                \
+VECTYPE::VECTYPE(const size_t size, const double value) noexcept /* NOLINT */\
+    : owned_data_(size, value) {                                             \
+  reset_pointer_vector();                                                    \
+}                                                                            \
+                                                                             \
+VECTYPE::VECTYPE(double* start, size_t size) noexcept /* NOLINT */           \
+    : BaseType(start, size), owned_data_(0), owning_(false) {}               \
+                                                                             \
+template <class T, Requires<cpp17::is_same_v<T, double>>>                    \
+VECTYPE::VECTYPE(std::initializer_list<T> list) noexcept /* NOLINT */        \
+    : owned_data_(std::move(list)) {                                         \
+  reset_pointer_vector();                                                    \
+}
+
+/**
+ * Construct / Assign VECTYPE with / to VECTYPE reference or rvalue
+ */
+// clang-tidy: calling a base constructor other than the copy constructor.
+//             We reset the base class in reset_pointer_vector after calling its
+//             default constructor
+#define MAKE_EXPRESSION_VEC_DEF_CONSTRUCT_WITH_VEC(VECTYPE)                  \
+VECTYPE::VECTYPE(const VECTYPE& rhs) : BaseType{} { /* NOLINT */             \
+  if (rhs.is_owning()) {                                                     \
+    owned_data_ = rhs.owned_data_;                                           \
+  } else {                                                                   \
+    owned_data_.assign(rhs.begin(), rhs.end());                              \
+  }                                                                          \
+  reset_pointer_vector();                                                    \
+}                                                                            \
+                                                                             \
+VECTYPE& VECTYPE::operator=(const VECTYPE& rhs) { /* NOLINT */               \
+  if (this != &rhs) {                                                        \
+    if (owning_) {                                                           \
+      if (rhs.is_owning()) {                                                 \
+        owned_data_ = rhs.owned_data_;                                       \
+      } else {                                                               \
+        owned_data_.assign(rhs.begin(), rhs.end());                          \
+      }                                                                      \
+      reset_pointer_vector();                                                \
+    } else {                                                                 \
+      ASSERT(rhs.size() == size(), "Must copy into same size, not "          \
+                                       << rhs.size() << " into " << size()); \
+      std::copy(rhs.begin(), rhs.end(), begin());                            \
+    }                                                                        \
+  }                                                                          \
+  return *this;                                                              \
+}                                                                            \
+                                                                             \
+VECTYPE::VECTYPE(VECTYPE&& rhs) noexcept { /* NOLINT */                      \
+  owned_data_ = std::move(rhs.owned_data_);                                  \
+  ~*this = ~rhs;  /* PointerVector is trivially copyable */                  \
+  owning_ = rhs.owning_;                                                     \
+                                                                             \
+  rhs.owning_ = true;                                                        \
+  rhs.reset();                                                               \
+}                                                                            \
+                                                                             \
+VECTYPE& VECTYPE::operator=(VECTYPE&& rhs) noexcept { /* NOLINT */           \
+  if (this != &rhs) {                                                        \
+    if (owning_) {                                                           \
+      owned_data_ = std::move(rhs.owned_data_);                              \
+      ~*this = ~rhs;  /* PointerVector is trivially copyable */              \
+      owning_ = rhs.owning_;                                                 \
+    } else {                                                                 \
+      ASSERT(rhs.size() == size(), "Must copy into same size, not "          \
+                                       << rhs.size() << " into " << size()); \
+      std::copy(rhs.begin(), rhs.end(), begin());                            \
+    }                                                                        \
+    rhs.owning_ = true;                                                      \
+    rhs.reset();                                                             \
+  }                                                                          \
+  return *this;                                                              \
+}
+
+
+/**
+ * Charm++ packing / unpacking of object
+ */
+#define MAKE_EXPRESSION_VEC_OP_PUP_CHARM(VECTYPE)       \
+void VECTYPE::pup(PUP::er& p) noexcept { /* NOLINT */   \
+  auto my_size = size();                                \
+  p | my_size;                                          \
+  if (my_size > 0) {                                    \
+    if (p.isUnpacking()) {                              \
+      owning_ = true;                                   \
+      owned_data_.resize(my_size);                      \
+      reset_pointer_vector();                           \
+    }                                                   \
+    PUParray(p, data(), size());                        \
+  }                                                     \
+}
+
+
+/**
+ * Define left-shift, equivalence, and inequivalence operations for VECTYPE
+ * with itself
+ */
+#define MAKE_EXPRESSION_VECMATH_OP_DEF_COMP_SELF(VECTYPE)                      \
+/** Left-shift operator for VECTYPE */                                         \
+std::ostream& operator<<(std::ostream& os, const VECTYPE& d) { /* NOLINT */    \
+  sequence_print_helper(os, d.begin(), d.end());                     \
+  return os;                                                                   \
+}                                                                              \
+                                                                               \
+/** Equivalence operator for VECTYPE */                                        \
+bool operator==(const VECTYPE& lhs, const VECTYPE& rhs) noexcept { /* NOLINT */\
+  return lhs.size() == rhs.size() and                                          \
+         std::equal(lhs.begin(), lhs.end(), rhs.begin());                      \
+}                                                                              \
+                                                                               \
+/** Inequivalence operator for VECTYPE */                                      \
+bool operator!=(const VECTYPE& lhs, const VECTYPE& rhs) noexcept { /* NOLINT */\
+  return not(lhs == rhs);                                                      \
+}

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_Index.cpp
   Test_IndexIterator.cpp
   Test_LeviCivitaIterator.cpp
+  Test_ModalVector.cpp
   Test_OrientVariablesOnSlice.cpp
   Test_SliceIterator.cpp
   Test_StripeIterator.cpp

--- a/tests/Unit/DataStructures/Test_ModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ModalVector.cpp
@@ -1,0 +1,469 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <numeric>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector",
+                  "[DataStructures][Unit]") {
+  ModalVector a{2};
+  CHECK(a.size() == 2);
+  ModalVector b{2, 10.0};
+  CHECK(b.size() == 2);
+  for (size_t i = 0; i < b.size(); ++i) {
+    INFO(i);
+    CHECK(b[i] == 10.0);
+  }
+
+  ModalVector t(5, 10.0);
+  CHECK(t.size() == 5);
+  for (size_t i = 0; i < t.size(); ++i) {
+    INFO(i);
+    CHECK(t[i] == 10.0);
+  }
+  for (const auto& p : t) {
+    CHECK(p == 10.0);
+  }
+  for (auto& p : t) {
+    CHECK(p == 10.0);
+  }
+  ModalVector t2{1.43, 2.83, 3.94, 7.85};
+  CHECK(t2.size() == 4);
+  CHECK(t2.is_owning());
+  CHECK(t2[0] == 1.43);
+  CHECK(t2[1] == 2.83);
+  CHECK(t2[2] == 3.94);
+  CHECK(t2[3] == 7.85);
+  test_copy_semantics(t);
+  auto t_copy = t;
+  CHECK(t_copy.is_owning());
+  test_move_semantics(std::move(t), t_copy);
+  ModalVector t_move_assignment = std::move(t_copy);
+  CHECK(t_move_assignment.is_owning());
+  ModalVector t_move_constructor = std::move(t_move_assignment);
+  CHECK(t_move_constructor.is_owning());
+}
+
+SPECTRE_TEST_CASE("Unit.Serialization.ModalVector",
+                  "[DataStructures][Unit][Serialization]") {
+  const size_t npts = 10;
+  ModalVector t(npts), tgood(npts);
+  std::iota(t.begin(), t.end(), 1.2);
+  std::iota(tgood.begin(), tgood.end(), 1.2);
+  CHECK(tgood == t);
+  CHECK(t.is_owning());
+  CHECK(tgood.is_owning());
+  const ModalVector serialized = serialize_and_deserialize(t);
+  CHECK(tgood == t);
+  CHECK(serialized == tgood);
+  CHECK(serialized.is_owning());
+  CHECK(serialized.data() != t.data());
+  CHECK(t.is_owning());
+}
+
+SPECTRE_TEST_CASE("Unit.Serialization.ModalVector_Ref",
+                  "[DataStructures][Unit][Serialization]") {
+  const size_t npts = 10;
+  ModalVector t(npts);
+  std::iota(t.begin(), t.end(), 4.3);
+  ModalVector t2;
+  t2.set_data_ref(&t);
+  CHECK(t.is_owning());
+  CHECK_FALSE(t2.is_owning());
+  CHECK(t2 == t);
+  const ModalVector serialized = serialize_and_deserialize(t);
+  CHECK(t2 == t);
+  CHECK(serialized == t2);
+  CHECK(serialized.is_owning());
+  CHECK(serialized.data() != t.data());
+  CHECK(t.is_owning());
+  const ModalVector serialized2 = serialize_and_deserialize(t2);
+  CHECK(t2 == t);
+  CHECK(serialized2 == t2);
+  CHECK(serialized2.is_owning());
+  CHECK(serialized2.data() != t2.data());
+  CHECK_FALSE(t2.is_owning());
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector_Ref",
+                  "[DataStructures][Unit]") {
+  ModalVector data{1.43, 2.83, 3.94, 7.85};
+  ModalVector t;
+  t.set_data_ref(&data);
+  CHECK(not t.is_owning());
+  CHECK(data.is_owning());
+  CHECK(t.data() == data.data());
+  CHECK(t.size() == 4);
+  CHECK(t[0] == 1.43);
+  CHECK(t[1] == 2.83);
+  CHECK(t[2] == 3.94);
+  CHECK(t[3] == 7.85);
+  test_copy_semantics(t);
+  ModalVector t_copy;
+  t_copy.set_data_ref(&t);
+  test_move_semantics(std::move(t), t_copy);
+  ModalVector t_move_assignment = std::move(t_copy);
+  CHECK(not t_move_assignment.is_owning());
+  ModalVector t_move_constructor = std::move(t_move_assignment);
+  CHECK(not t_move_constructor.is_owning());
+  {
+    ModalVector data_2{1.43, 2.83, 3.94, 7.85};
+    ModalVector data_2_ref;
+    data_2_ref.set_data_ref(&data_2);
+    ModalVector data_3{2.43, 3.83, 4.94, 8.85};
+    data_2_ref = std::move(data_3);
+    CHECK(data_2[0] == 2.43);
+    CHECK(data_2[1] == 3.83);
+    CHECK(data_2[2] == 4.94);
+    CHECK(data_2[3] == 8.85);
+// Intentionally testing self-move
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+#endif  // defined(__clang__)
+    data_2_ref = std::move(data_2_ref);
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif  // defined(__clang__)
+    CHECK(data_2[0] == 2.43);
+    CHECK(data_2[1] == 3.83);
+    CHECK(data_2[2] == 4.94);
+    CHECK(data_2[3] == 8.85);
+    ModalVector owned_data;
+    // clang-tidy: false positive, used after it was moved
+    owned_data = data_2_ref;  // NOLINT
+    CHECK(owned_data[0] == 2.43);
+    CHECK(owned_data[1] == 3.83);
+    CHECK(owned_data[2] == 4.94);
+    CHECK(owned_data[3] == 8.85);
+    // Test operator!=
+    CHECK_FALSE(owned_data != data_2_ref);
+  }
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+                "Unit.DataStructures.ModalVector.ref_diff_size",
+                "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  ModalVector data{1.43, 2.83, 3.94, 7.85};
+  ModalVector data_ref;
+  data_ref.set_data_ref(&data);
+  ModalVector data2{1.43, 2.83, 3.94};
+  data_ref = data2;
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.ModalVector.move_ref_diff_size",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  ModalVector data{1.43, 2.83, 3.94, 7.85};
+  ModalVector data_ref;
+  data_ref.set_data_ref(&data);
+  ModalVector data2{1.43, 2.83, 3.94};
+  data_ref = std::move(data2);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+namespace {
+template <typename T1, typename T2>
+void check_vectors(const T1& t1, const T2& t2) {
+  CHECK_ITERABLE_APPROX(t1, t2);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.MathAfterMove",
+                  "[Unit][DataStructures]") {
+  ModalVector m0(10, 3.0), m1(10, 9.0);
+  {
+    ModalVector a(10, 2.0);
+    ModalVector b{};
+    b = std::move(a);
+    b = m0 + m1;
+    check_vectors(b, ModalVector(10, 12.0));
+    // clang-tidy: use after move (intentional here)
+    CHECK(a.size() == 0);  // NOLINT
+    CHECK(a.is_owning());
+    a = m0 * m1;
+    check_vectors(a, ModalVector(10, 27.0));
+    check_vectors(b, ModalVector(10, 12.0));
+  }
+
+  {
+    ModalVector a(10, 2.0);
+    ModalVector b{};
+    b = std::move(a);
+    a = m0 + m1;
+    check_vectors(b, ModalVector(10, 2.0));
+    check_vectors(a, ModalVector(10, 12.0));
+  }
+
+  {
+    ModalVector a(10, 2.0);
+    ModalVector b{std::move(a)};
+    b = m0 + m1;
+    CHECK(b.size() == 10);
+    check_vectors(b, ModalVector(10, 12.0));
+    // clang-tidy: use after move (intentional here)
+    CHECK(a.size() == 0);  // NOLINT
+    CHECK(a.is_owning());
+    a = m0 * m1;
+    check_vectors(a, ModalVector(10, 27.0));
+    check_vectors(b, ModalVector(10, 12.0));
+  }
+
+  {
+    ModalVector a(10, 2.0);
+    ModalVector b{std::move(a)};
+    a = m0 + m1;
+    check_vectors(b, ModalVector(10, 2.0));
+    check_vectors(a, ModalVector(10, 12.0));
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.Math",
+                  "[Unit][DataStructures]") {
+  const size_t num_pts = 19;
+  ModalVector val{1., -2., 3., -4., 8., 12., -14.};
+  ModalVector nine(num_pts, 9.0);
+  ModalVector one(num_pts, 1.0);
+
+  // Test unary minus
+  check_vectors(-nine, ModalVector(num_pts, -9.0));
+
+  check_vectors(nine + 2.0, ModalVector(num_pts, 11.0));
+  check_vectors(2.0 + nine, ModalVector(num_pts, 11.0));
+  check_vectors(nine - 2.0, ModalVector(num_pts, 7.0));
+  check_vectors(2.0 - nine, ModalVector(num_pts, -7.0));
+  check_vectors(nine + nine, ModalVector(num_pts, 18.0));
+  check_vectors(nine + (one * nine), ModalVector(num_pts, 18.0));
+  check_vectors((one * nine) + nine, ModalVector(num_pts, 18.0));
+  check_vectors(nine - ModalVector(num_pts, 8.0), one);
+  check_vectors(nine - (one * nine), ModalVector(num_pts, 0.0));
+  check_vectors((one * nine) - nine, ModalVector(num_pts, 0.0));
+
+  //~ check_vectors(ModalVector(num_pts, -1.0 / 9.0), -one / nine);
+  //~ check_vectors(ModalVector(num_pts,-8.0 / 9.0),-(nine - one) / nine);
+  check_vectors(ModalVector(num_pts, 18.0), (one / 0.5) * nine);
+  //~ check_vectors(ModalVector(num_pts, 1.0), 9.0 / nine);
+  //~ check_vectors(ModalVector(num_pts, 1.0), (one * 9.0) / nine);
+
+  CHECK(-14 == min(val));
+  CHECK(12 == max(val));
+  check_vectors(ModalVector{1., 2., 3., 4., 8., 12., 14.}, abs(val));
+  check_vectors(ModalVector{1., 2., 3., 4., 8., 12., 14.}, fabs(val));
+
+  check_vectors(step_function(
+                ModalVector{-12.3, 2.0, -4.0, 0.0, 7.0, -8.0}),
+                ModalVector{0.0, 1.0, 0.0, 1.0, 1.0, 0.0});
+
+  check_vectors(ModalVector(num_pts, 81.0), nine * nine);
+  check_vectors(ModalVector(num_pts, 81.0), nine * (nine * one));
+  check_vectors(ModalVector(num_pts, 81.0), (nine * nine) * one);
+  check_vectors(ModalVector(num_pts, 81.0), 9.0 * nine);
+  check_vectors(ModalVector(num_pts, 81.0), nine * 9.0);
+  check_vectors(ModalVector(num_pts, 1.0), nine / 9.0);
+  //~ check_vectors(ModalVector(num_pts, 1.0), nine / (one * 9.0));
+  //~ check_vectors(ModalVector(num_pts, 9.0), (one * nine) / one);
+
+  ModalVector dummy(nine * nine * 1.0);
+  check_vectors(ModalVector(num_pts, 81.0), dummy);
+
+  // Test assignment
+  ModalVector test_81(num_pts, -1.0);
+  test_81 = nine * nine;
+  check_vectors(ModalVector(num_pts, 81.0), test_81);
+  CHECK(test_81.is_owning());
+  ModalVector test_81_ref(test_81.data(), test_81.size());
+  test_81_ref = 0.0;
+  test_81 = 0.0;
+  test_81_ref = nine * nine;
+  check_vectors(ModalVector(num_pts, 81.0), test_81);
+  CHECK(test_81.is_owning());
+  check_vectors(ModalVector(num_pts, 81.0), test_81_ref);
+  CHECK_FALSE(test_81_ref.is_owning());
+  ModalVector second_81(num_pts);
+  second_81 = test_81;
+  check_vectors(ModalVector(num_pts, 81.0), second_81);
+  CHECK(second_81.is_owning());
+  test_81_ref = 0.0;
+  check_vectors(ModalVector(num_pts, 0.0), test_81_ref);
+  test_81_ref = second_81;
+  check_vectors(ModalVector(num_pts, 81.0), test_81_ref);
+  second_81 = 0.0;
+  test_81_ref.set_data_ref(&test_81);
+  second_81 = std::move(test_81_ref);
+  check_vectors(ModalVector(num_pts, 81.0), second_81);
+  CHECK_FALSE(second_81.is_owning());
+  second_81 = 0.0;
+  check_vectors(ModalVector(num_pts, 0.0), second_81);
+  test_81 = 81.0;
+  check_vectors(ModalVector(num_pts, 81.0), second_81);
+  CHECK_FALSE(second_81.is_owning());
+
+  test_81 = 81.0;
+  ModalVector test_081;
+  test_081.set_data_ref(&test_81);
+  check_vectors(ModalVector(num_pts, 81.0), test_081);
+  CHECK_FALSE(test_081.is_owning());
+
+  ModalVector test_assignment(num_pts, 7.0);
+  test_assignment += nine;
+  check_vectors(ModalVector(num_pts, 16.0), test_assignment);
+  test_assignment += 3.0;
+  check_vectors(ModalVector(num_pts, 19.0), test_assignment);
+  test_assignment += (nine * nine);
+  check_vectors(ModalVector(num_pts, 100.0), test_assignment);
+
+  test_assignment = 7.0;
+  test_assignment -= nine;
+  check_vectors(ModalVector(num_pts, -2.0), test_assignment);
+  test_assignment -= 3.0;
+  check_vectors(ModalVector(num_pts, -5.0), test_assignment);
+  test_assignment -= nine * nine;
+  check_vectors(ModalVector(num_pts, -86.0), test_assignment);
+
+  test_assignment = 2.0;
+  test_assignment *= 3.0;
+  check_vectors(ModalVector(num_pts, 6.0), test_assignment);
+  test_assignment *= nine;
+  check_vectors(ModalVector(num_pts, 54.0), test_assignment);
+  test_assignment = 1.0;
+  test_assignment *= nine * nine;
+  check_vectors(ModalVector(num_pts, 81.0), test_assignment);
+
+  test_assignment = 2.0;
+  test_assignment /= 2.0;
+  check_vectors(ModalVector(num_pts, 1.0), test_assignment);
+  //~ test_assignment /= ModalVector(num_pts, 0.5);
+  //~ check_vectors(ModalVector(num_pts, 2.0), test_assignment);
+  //~ test_assignment /=
+  //~       (ModalVector(num_pts, 2.0) * ModalVector(num_pts, 3.0));
+  //~ check_vectors(ModalVector(num_pts, 1.0 / 3.0), test_assignment);
+
+  // Test assignment where the RHS is an expression that contains the LHS
+  ModalVector x(num_pts, 4.);
+  x *= x;
+  check_vectors(ModalVector(num_pts, 16.0), x);
+  //~ x /= x;
+  //~ check_vectors(ModalVector(num_pts, 1.0), x);
+
+  // Test addition of arrays of ModalVectors to arrays of doubles.
+  const ModalVector t1{0.0, 1.0, 2.0, 3.0};
+  const ModalVector t2{-0.1, -0.2, -0.3, -0.4};
+  const ModalVector t3{5.0, 4.0, 3.0, 2.0};
+  const ModalVector e1{10.0, 11.0, 12.0, 13.0};
+  const ModalVector e2{19.9, 19.8, 19.7, 19.6};
+  const ModalVector e3{35.0, 34.0, 33.0, 32.0};
+  const ModalVector e4{-10.0, -9.0, -8.0, -7.0};
+  const ModalVector e5{-20.1, -20.2, -20.3, -20.4};
+  const ModalVector e6{-25.0, -26.0, -27.0, -28.0};
+  const ModalVector e7{10.0, 12.0, 14.0, 16.0};
+  const ModalVector e8{19.8, 19.6, 19.4, 19.2};
+  const ModalVector e9{40.0, 38.0, 36.0, 34.0};
+  const ModalVector e10{-10.0, -10.0, -10.0, -10.0};
+  const ModalVector e11{-20.0, -20.0, -20.0, -20.0};
+  const ModalVector e12{-30.0, -30.0, -30.0, -30.0};
+
+  const std::array<double, 3> point{{10.0, 20.0, 30.0}};
+  std::array<ModalVector, 3> points{{t1, t2, t3}};
+  const std::array<ModalVector, 3> expected{{e1, e2, e3}};
+  const std::array<ModalVector, 3> expected2{{e4, e5, e6}};
+  std::array<ModalVector, 3> dvectors1{{t1, t2, t3}};
+  const std::array<ModalVector, 3> dvectors2{{e1, e2, e3}};
+  const std::array<ModalVector, 3> expected3{{e7, e8, e9}};
+  const std::array<ModalVector, 3> expected4{{e10, e11, e12}};
+  CHECK(points + point == expected);
+  CHECK(point + points == expected);
+  CHECK(points - point == expected2);
+  CHECK(point - points == -expected2);
+
+  points += point;
+  CHECK(points == expected);
+  points -= point;
+  points -= point;
+  CHECK(points == expected2);
+
+  CHECK_ITERABLE_APPROX(dvectors1 + dvectors2, expected3);
+  CHECK_ITERABLE_APPROX(dvectors1 - dvectors2, expected4);
+
+  dvectors1 += dvectors2;
+  CHECK_ITERABLE_APPROX(dvectors1, expected3);
+  dvectors1 -= dvectors2;
+  dvectors1 -= dvectors2;
+  CHECK_ITERABLE_APPROX(dvectors1, expected4);
+
+  // Test calculation of magnitude of ModalVector
+  const std::array<ModalVector, 1> d1{{ModalVector{-2.5, 3.4}}};
+  const ModalVector expected_d1{2.5, 3.4};
+  const auto magnitude_d1 = magnitude(d1);
+  CHECK_ITERABLE_APPROX(expected_d1, magnitude_d1);
+  const std::array<ModalVector, 2> d2{{ModalVector(2, 3.),
+                                             ModalVector(2, 4.)}};
+  const ModalVector expected_d2(2, 5.);
+  const auto magnitude_d2 = magnitude(d2);
+  CHECK_ITERABLE_APPROX(expected_d2, magnitude_d2);
+  const std::array<ModalVector, 3> d3{
+      {ModalVector(2, 3.), ModalVector(2, -4.),
+       ModalVector(2, 12.)}};
+  const ModalVector expected_d3(2, 13.);
+  const auto magnitude_d3 = magnitude(d3);
+  CHECK_ITERABLE_APPROX(expected_d3, magnitude_d3);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.MathWithDataVector",
+                  "[Unit][DataStructures]") {
+  const size_t num_pts = 23;
+  ModalVector nine(num_pts, 9.0);
+  CHECK(nine.is_owning());
+  DataVector eight(num_pts, 8.0);
+
+  // Test math with DataVector
+  ModalVector test_72(num_pts, -1.0);
+  test_72 = nine * eight;
+  check_vectors(ModalVector(num_pts, 72.0), test_72);
+  CHECK(test_72.is_owning());
+  test_72 = eight * nine;
+  check_vectors(ModalVector(num_pts, 72.0), test_72);
+  CHECK(test_72.is_owning());
+  test_72 = nine;
+  test_72 *= eight;
+  check_vectors(ModalVector(num_pts, 72.0), test_72);
+  CHECK(test_72.is_owning());
+  test_72 /= eight;
+  check_vectors(ModalVector(num_pts, 9.0), test_72);
+  CHECK(test_72.is_owning());
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.ModalVector.ExpressionAssignError",
+    "[Unit][DataStructures]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  ModalVector one(10, 1.0);
+  ModalVector one_ref(one.data(), one.size());
+  ModalVector one_b(2, 1.0);
+  one_ref = (one_b * one_b);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}

--- a/tests/Unit/DataStructures/Test_ModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ModalVector.cpp
@@ -214,8 +214,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.MathAfterMove",
     // clang-tidy: use after move (intentional here)
     CHECK(a.size() == 0);  // NOLINT
     CHECK(a.is_owning());
-    a = m0 * m1;
-    check_vectors(a, ModalVector(10, 27.0));
+    a = m0 - m1;
+    check_vectors(a, ModalVector(10, -6.0));
     check_vectors(b, ModalVector(10, 12.0));
   }
 
@@ -237,8 +237,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.MathAfterMove",
     // clang-tidy: use after move (intentional here)
     CHECK(a.size() == 0);  // NOLINT
     CHECK(a.is_owning());
-    a = m0 * m1;
-    check_vectors(a, ModalVector(10, 27.0));
+    a = m0 - m1;
+    check_vectors(a, ModalVector(10, -6.0));
     check_vectors(b, ModalVector(10, 12.0));
   }
 
@@ -291,47 +291,23 @@ void test_ModalVector_math() noexcept {
   check_vectors(wrap<WrapLeftOp>(nine) + wrap<WrapRightOp>(nine),
                 ModalVector(num_pts, 18.0));
   check_vectors(wrap<WrapLeftOp>(nine) +
-                    (wrap<WrapLeftOp>(one) * wrap<WrapRightOp>(nine)),
-                ModalVector(num_pts, 18.0));
-  check_vectors((wrap<WrapLeftOp>(one) * wrap<WrapLeftOp>(nine)) +
+                    (wrap<WrapLeftOp>(one) + wrap<WrapRightOp>(nine)),
+                ModalVector(num_pts, 19.0));
+  check_vectors((wrap<WrapLeftOp>(one) + wrap<WrapLeftOp>(nine)) +
                     wrap<WrapRightOp>(nine),
-                ModalVector(num_pts, 18.0));
+                ModalVector(num_pts, 19.0));
   check_vectors(wrap<WrapLeftOp>(nine) - ModalVector(num_pts, 8.0),
                 ModalVector(num_pts, 1.0));
   check_vectors(wrap<WrapLeftOp>(nine) -
-                    (wrap<WrapRightOp>(one) * wrap<WrapLeftOp>(nine)),
-                ModalVector(num_pts, 0.0));
-  check_vectors((wrap<WrapLeftOp>(one) * wrap<WrapLeftOp>(nine)) -
+                    (wrap<WrapRightOp>(one) + wrap<WrapLeftOp>(nine)),
+                ModalVector(num_pts, -1.0));
+  check_vectors((wrap<WrapLeftOp>(one) + wrap<WrapLeftOp>(nine)) -
                     wrap<WrapRightOp>(nine),
-                ModalVector(num_pts, 0.0));
+                ModalVector(num_pts, 1.0));
 
-  check_vectors(ModalVector(num_pts, -1.0 / 9.0),
-                -one / wrap<WrapRightOp>(nine));
-  //~ check_vectors(ModalVector(num_pts, -8.0 / 9.0),
-                //~ -(wrap<WrapLeftOp>(nine) - wrap<WrapRightOp>(one)) /
-                    //~ wrap<WrapLeftOp>(nine));
-  check_vectors(ModalVector(num_pts, 18.0),
-                (wrap<WrapLeftOp>(one) / 0.5) * wrap<WrapRightOp>(nine));
-  //~ check_vectors(ModalVector(num_pts, 1.0), 9.0 / wrap<WrapRightOp>(nine));
-  //~ check_vectors(ModalVector(num_pts, 1.0),
-                //~ (wrap<WrapLeftOp>(one) * 9.0) / wrap<WrapRightOp>(nine));
-
-  check_vectors(ModalVector(num_pts, 81.0),
-                wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(nine));
-  check_vectors(ModalVector(num_pts, 81.0),
-                wrap<WrapLeftOp>(nine) *
-                    (wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(one)));
-  check_vectors(ModalVector(num_pts, 81.0),
-                (wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(nine)) *
-                    wrap<WrapLeftOp>(one));
   check_vectors(ModalVector(num_pts, 81.0), 9.0 * wrap<WrapLeftOp>(nine));
   check_vectors(ModalVector(num_pts, 81.0), wrap<WrapLeftOp>(nine) * 9.0);
   check_vectors(ModalVector(num_pts, 1.0), wrap<WrapLeftOp>(nine) / 9.0);
-  check_vectors(ModalVector(num_pts, 1.0),
-                wrap<WrapLeftOp>(nine) / (wrap<WrapRightOp>(one) * 9.0));
-  //~ check_vectors(ModalVector(num_pts, 9.0),
-                //~ (wrap<WrapLeftOp>(one) * wrap<WrapLeftOp>(nine)) /
-                    //~ wrap<WrapRightOp>(one));
 
   CHECK(-14 == min(wrap<WrapLeftOp>(val)));
   CHECK(12 == max(wrap<WrapLeftOp>(val)));
@@ -340,19 +316,14 @@ void test_ModalVector_math() noexcept {
   check_vectors(ModalVector{1., 2., 3., 4., 8., 12., 14.},
                 fabs(wrap<WrapLeftOp>(val)));
 
-  ModalVector dummy(wrap<WrapLeftOp>(nine) * wrap<WrapLeftOp>(nine) * 1.0);
-  check_vectors(ModalVector(num_pts, 81.0), dummy);
-
   // Test assignment
-  ModalVector test_81(num_pts, -1.0);
-  // cannot assign to a reference_wrapper using an expr :(
-  test_81 = wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(nine);
+  ModalVector test_81(num_pts, 81.0);
   check_vectors(ModalVector(num_pts, 81.0), test_81);
   CHECK(test_81.is_owning());
   ModalVector test_81_ref(test_81.data(), test_81.size());
   test_81_ref = 0.0;
   test_81 = 0.0;
-  test_81_ref = wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(nine);
+  test_81_ref = wrap<WrapLeftOp>(nine) * 9.0;
   check_vectors(ModalVector(num_pts, 81.0), test_81);
   CHECK(test_81.is_owning());
   check_vectors(ModalVector(num_pts, 81.0), test_81_ref);
@@ -387,7 +358,7 @@ void test_ModalVector_math() noexcept {
   check_vectors(ModalVector(num_pts, 16.0), test_assignment);
   test_assignment += 3.0;
   check_vectors(ModalVector(num_pts, 19.0), test_assignment);
-  test_assignment += (wrap<WrapLeftOp>(nine) * wrap<WrapLeftOp>(nine));
+  test_assignment += wrap<WrapLeftOp>(test_81);
   check_vectors(ModalVector(num_pts, 100.0), test_assignment);
 
   test_assignment = 7.0;
@@ -395,42 +366,37 @@ void test_ModalVector_math() noexcept {
   check_vectors(ModalVector(num_pts, -2.0), test_assignment);
   test_assignment -= 3.0;
   check_vectors(ModalVector(num_pts, -5.0), test_assignment);
-  test_assignment -= wrap<WrapLeftOp>(nine) * wrap<WrapLeftOp>(nine);
-  check_vectors(ModalVector(num_pts, -86.0), test_assignment);
+  test_assignment -= (wrap<WrapLeftOp>(nine) + wrap<WrapLeftOp>(nine));
+  check_vectors(ModalVector(num_pts, -23.0), test_assignment);
 
   test_assignment = 2.0;
   test_assignment *= 3.0;
   check_vectors(ModalVector(num_pts, 6.0), test_assignment);
-  test_assignment *= wrap<WrapLeftOp>(nine);
+  test_assignment *= 9.0;
   check_vectors(ModalVector(num_pts, 54.0), test_assignment);
   test_assignment = 1.0;
-  test_assignment *= wrap<WrapLeftOp>(nine) * wrap<WrapLeftOp>(nine);
+  test_assignment *= 81.0;
   check_vectors(ModalVector(num_pts, 81.0), test_assignment);
 
   test_assignment = 2.0;
   test_assignment /= 2.0;
   check_vectors(ModalVector(num_pts, 1.0), test_assignment);
-  test_assignment /= ModalVector(num_pts, 0.5);
+  test_assignment /= 0.5;
   check_vectors(ModalVector(num_pts, 2.0), test_assignment);
-  test_assignment /= (ModalVector(num_pts, 2.0) * ModalVector(num_pts, 3.0));
+  test_assignment /= 6.0;
   check_vectors(ModalVector(num_pts, 1.0 / 3.0), test_assignment);
 
   // Test assignment where the RHS is an expression that contains the LHS
   ModalVector x(num_pts, -2.);
   x = abs(wrap<WrapLeftOp>(x));
   check_vectors(ModalVector(num_pts, 2.0), x);
-  x *= wrap<WrapLeftOp>(x);
-  check_vectors(ModalVector(num_pts, 4.0), x);
-  x /= wrap<WrapLeftOp>(x);
-  check_vectors(ModalVector(num_pts, 1.0), x);
 
   // Test composition of constant expressions with ModalVector math member
   // functions
   x = ModalVector(num_pts, -2.);
-  check_vectors(ModalVector(num_pts, 2.),
-                abs(wrap<WrapLeftOp>(x)));
+  check_vectors(ModalVector(num_pts, 2.), abs(wrap<WrapLeftOp>(x)));
   check_vectors(ModalVector(num_pts, 4.),
-                fabs(wrap<WrapLeftOp>(x) * wrap<WrapRightOp>(x)));
+                fabs(wrap<WrapLeftOp>(x) + wrap<WrapRightOp>(x)));
 }
 
 void test_ModalVector_array_math() noexcept {
@@ -511,7 +477,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.Math",
   ModalVector one(10, 1.0);
   ModalVector one_ref(one.data(), one.size());
   ModalVector one_b(2, 1.0);
-  one_ref = (one_b * one_b);
+  one_ref = (one_b + one_b);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }

--- a/tests/Unit/DataStructures/Test_ModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ModalVector.cpp
@@ -261,20 +261,12 @@ SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.Math",
   check_vectors(nine - (one * nine), ModalVector(num_pts, 0.0));
   check_vectors((one * nine) - nine, ModalVector(num_pts, 0.0));
 
-  //~ check_vectors(ModalVector(num_pts, -1.0 / 9.0), -one / nine);
-  //~ check_vectors(ModalVector(num_pts,-8.0 / 9.0),-(nine - one) / nine);
   check_vectors(ModalVector(num_pts, 18.0), (one / 0.5) * nine);
-  //~ check_vectors(ModalVector(num_pts, 1.0), 9.0 / nine);
-  //~ check_vectors(ModalVector(num_pts, 1.0), (one * 9.0) / nine);
 
   CHECK(-14 == min(val));
   CHECK(12 == max(val));
   check_vectors(ModalVector{1., 2., 3., 4., 8., 12., 14.}, abs(val));
   check_vectors(ModalVector{1., 2., 3., 4., 8., 12., 14.}, fabs(val));
-
-  check_vectors(step_function(
-                ModalVector{-12.3, 2.0, -4.0, 0.0, 7.0, -8.0}),
-                ModalVector{0.0, 1.0, 0.0, 1.0, 1.0, 0.0});
 
   check_vectors(ModalVector(num_pts, 81.0), nine * nine);
   check_vectors(ModalVector(num_pts, 81.0), nine * (nine * one));
@@ -282,8 +274,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.Math",
   check_vectors(ModalVector(num_pts, 81.0), 9.0 * nine);
   check_vectors(ModalVector(num_pts, 81.0), nine * 9.0);
   check_vectors(ModalVector(num_pts, 1.0), nine / 9.0);
-  //~ check_vectors(ModalVector(num_pts, 1.0), nine / (one * 9.0));
-  //~ check_vectors(ModalVector(num_pts, 9.0), (one * nine) / one);
 
   ModalVector dummy(nine * nine * 1.0);
   check_vectors(ModalVector(num_pts, 81.0), dummy);
@@ -354,18 +344,11 @@ SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.Math",
   test_assignment = 2.0;
   test_assignment /= 2.0;
   check_vectors(ModalVector(num_pts, 1.0), test_assignment);
-  //~ test_assignment /= ModalVector(num_pts, 0.5);
-  //~ check_vectors(ModalVector(num_pts, 2.0), test_assignment);
-  //~ test_assignment /=
-  //~       (ModalVector(num_pts, 2.0) * ModalVector(num_pts, 3.0));
-  //~ check_vectors(ModalVector(num_pts, 1.0 / 3.0), test_assignment);
 
   // Test assignment where the RHS is an expression that contains the LHS
   ModalVector x(num_pts, 4.);
   x *= x;
   check_vectors(ModalVector(num_pts, 16.0), x);
-  //~ x /= x;
-  //~ check_vectors(ModalVector(num_pts, 1.0), x);
 
   // Test addition of arrays of ModalVectors to arrays of doubles.
   const ModalVector t1{0.0, 1.0, 2.0, 3.0};
@@ -445,6 +428,8 @@ SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector.MathWithDataVector",
   test_72 = eight * nine;
   check_vectors(ModalVector(num_pts, 72.0), test_72);
   CHECK(test_72.is_owning());
+  test_72 = test_72 / eight;
+  check_vectors(ModalVector(num_pts, 9.0), test_72);
   test_72 = nine;
   test_72 *= eight;
   check_vectors(ModalVector(num_pts, 72.0), test_72);

--- a/tests/Unit/DataStructures/Test_ModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ModalVector.cpp
@@ -5,7 +5,7 @@
 
 #include <algorithm>                         // for move
 #include <array>                             // for array, operator==
-#include <cmath>                             // for abs
+//~ #include <cmath>                             // for abs
 #include <cstddef>                           // for size_t
 #include <functional>                        // for std::reference_wrapper
 #include <numeric>                           // for iota
@@ -307,14 +307,14 @@ void test_ModalVector_math() noexcept {
 
   check_vectors(ModalVector(num_pts, -1.0 / 9.0),
                 -one / wrap<WrapRightOp>(nine));
-  check_vectors(ModalVector(num_pts, -8.0 / 9.0),
-                -(wrap<WrapLeftOp>(nine) - wrap<WrapRightOp>(one)) /
-                    wrap<WrapLeftOp>(nine));
+  //~ check_vectors(ModalVector(num_pts, -8.0 / 9.0),
+                //~ -(wrap<WrapLeftOp>(nine) - wrap<WrapRightOp>(one)) /
+                    //~ wrap<WrapLeftOp>(nine));
   check_vectors(ModalVector(num_pts, 18.0),
                 (wrap<WrapLeftOp>(one) / 0.5) * wrap<WrapRightOp>(nine));
-  check_vectors(ModalVector(num_pts, 1.0), 9.0 / wrap<WrapRightOp>(nine));
-  check_vectors(ModalVector(num_pts, 1.0),
-                (wrap<WrapLeftOp>(one) * 9.0) / wrap<WrapRightOp>(nine));
+  //~ check_vectors(ModalVector(num_pts, 1.0), 9.0 / wrap<WrapRightOp>(nine));
+  //~ check_vectors(ModalVector(num_pts, 1.0),
+                //~ (wrap<WrapLeftOp>(one) * 9.0) / wrap<WrapRightOp>(nine));
 
   check_vectors(ModalVector(num_pts, 81.0),
                 wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(nine));
@@ -329,9 +329,9 @@ void test_ModalVector_math() noexcept {
   check_vectors(ModalVector(num_pts, 1.0), wrap<WrapLeftOp>(nine) / 9.0);
   check_vectors(ModalVector(num_pts, 1.0),
                 wrap<WrapLeftOp>(nine) / (wrap<WrapRightOp>(one) * 9.0));
-  check_vectors(ModalVector(num_pts, 9.0),
-                (wrap<WrapLeftOp>(one) * wrap<WrapLeftOp>(nine)) /
-                    wrap<WrapRightOp>(one));
+  //~ check_vectors(ModalVector(num_pts, 9.0),
+                //~ (wrap<WrapLeftOp>(one) * wrap<WrapLeftOp>(nine)) /
+                    //~ wrap<WrapRightOp>(one));
 
   CHECK(-14 == min(wrap<WrapLeftOp>(val)));
   CHECK(12 == max(wrap<WrapLeftOp>(val)));
@@ -339,8 +339,6 @@ void test_ModalVector_math() noexcept {
                 abs(wrap<WrapLeftOp>(val)));
   check_vectors(ModalVector{1., 2., 3., 4., 8., 12., 14.},
                 fabs(wrap<WrapLeftOp>(val)));
-
-  check_vectors(sqrt(wrap<WrapLeftOp>(nine)), ModalVector(num_pts, 3.0));
 
   ModalVector dummy(wrap<WrapLeftOp>(nine) * wrap<WrapLeftOp>(nine) * 1.0);
   check_vectors(ModalVector(num_pts, 81.0), dummy);
@@ -418,12 +416,8 @@ void test_ModalVector_math() noexcept {
   check_vectors(ModalVector(num_pts, 1.0 / 3.0), test_assignment);
 
   // Test assignment where the RHS is an expression that contains the LHS
-  ModalVector x(num_pts, 4.);
-  x += sqrt(wrap<WrapLeftOp>(x));
-  check_vectors(ModalVector(num_pts, 6.0), x);
-  x -= sqrt(wrap<WrapLeftOp>(x) - 2.0);
-  check_vectors(ModalVector(num_pts, 4.0), x);
-  x = sqrt(wrap<WrapLeftOp>(x));
+  ModalVector x(num_pts, -2.);
+  x = abs(wrap<WrapLeftOp>(x));
   check_vectors(ModalVector(num_pts, 2.0), x);
   x *= wrap<WrapLeftOp>(x);
   check_vectors(ModalVector(num_pts, 4.0), x);
@@ -432,11 +426,11 @@ void test_ModalVector_math() noexcept {
 
   // Test composition of constant expressions with ModalVector math member
   // functions
-  x = ModalVector(num_pts, 2.);
-  check_vectors(ModalVector(num_pts, 1.4142135623730951),
-                sqrt(abs(wrap<WrapLeftOp>(x))));
+  x = ModalVector(num_pts, -2.);
   check_vectors(ModalVector(num_pts, 2.),
-                sqrt(wrap<WrapLeftOp>(x) * wrap<WrapRightOp>(x)));
+                abs(wrap<WrapLeftOp>(x)));
+  check_vectors(ModalVector(num_pts, 4.),
+                fabs(wrap<WrapLeftOp>(x) * wrap<WrapRightOp>(x)));
 }
 
 void test_ModalVector_array_math() noexcept {
@@ -490,15 +484,6 @@ void test_ModalVector_array_math() noexcept {
   const ModalVector expected_d1{2.5, 3.4};
   const auto magnitude_d1 = magnitude(d1);
   CHECK_ITERABLE_APPROX(expected_d1, magnitude_d1);
-  const std::array<ModalVector, 2> d2{{ModalVector(2, 3.), ModalVector(2, 4.)}};
-  const ModalVector expected_d2(2, 5.);
-  const auto magnitude_d2 = magnitude(d2);
-  CHECK_ITERABLE_APPROX(expected_d2, magnitude_d2);
-  const std::array<ModalVector, 3> d3{
-      {ModalVector(2, 3.), ModalVector(2, -4.), ModalVector(2, 12.)}};
-  const ModalVector expected_d3(2, 13.);
-  const auto magnitude_d3 = magnitude(d3);
-  CHECK_ITERABLE_APPROX(expected_d3, magnitude_d3);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

In response to #378 (over-writing #704), this PR adds the `ModalVector` class that has a design similar to `DataVector`, but is intentionally a functional subset of `DataVector`. A `ModalVector` is intended to exclusively hold coefficients of spectral expansion for objects on the computational mesh. Unlike `DataVector`, only **basic** math operations are overloaded for `ModalVector` objects (scalar multiplication, addition, abs, sqrt) to ensure code safety.


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments


