### PR TITLE
Add Chebyshev basis

### DIFF
--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY Spectral)
 
 set(LIBRARY_SOURCES
+    Chebyshev.cpp
     Legendre.cpp
     Projection.cpp
     Spectral.cpp

--- a/src/NumericalAlgorithms/Spectral/Chebyshev.cpp
+++ b/src/NumericalAlgorithms/Spectral/Chebyshev.cpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+#include <cmath>
+#include <cstddef>
+// IWYU pragma: no_include <type_traits>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace Spectral {
+
+// Algorithms to compute Chebyshev basis functions
+// These functions specialize the templates declared in `Spectral.cpp`.
+
+/// \cond
+template <Basis>
+DataVector compute_basis_function_values(size_t, const DataVector&) noexcept;
+template <>
+DataVector compute_basis_function_values<Basis::Chebyshev>(
+    const size_t k, const DataVector& x) noexcept {
+  // Algorithm 21 in Kopriva, p. 60
+  switch (k) {
+    case 0:
+      return DataVector(x.size(), 1.);
+    case 1:
+      return x;
+    default:
+      // These values can be computed either through recursion
+      // (implemented here), or analytically as `cos(k * acos(x))`.
+      // Since the trigonometric form is expensive to compute it is useful only
+      // for large k. See Kopriva, section 3.1 (p. 59) and Fig. 3.1 (p. 61) for
+      // a discussion.
+      DataVector T_k_minus_2(x.size(), 1.);
+      DataVector T_k_minus_1 = x;
+      DataVector T_k(x.size());
+      for (size_t j = 2; j <= k; j++) {
+        T_k = 2 * x * T_k_minus_1 - T_k_minus_2;
+        T_k_minus_2 = T_k_minus_1;
+        T_k_minus_1 = T_k;
+      }
+      return T_k;
+  }
+}
+
+template <Basis>
+DataVector compute_inverse_weight_function_values(const DataVector&) noexcept;
+template <>
+DataVector compute_inverse_weight_function_values<Basis::Chebyshev>(
+    const DataVector& x) noexcept {
+  return sqrt(1. - square(x));
+}
+
+template <Basis>
+double compute_basis_function_normalization_square(size_t) noexcept;
+template <>
+double compute_basis_function_normalization_square<Basis::Chebyshev>(
+    const size_t k) noexcept {
+  if (k == 0) {
+    return M_PI;
+  } else {
+    return M_PI_2;
+  }
+}
+
+template <Basis, Quadrature>
+std::pair<DataVector, DataVector> compute_collocation_points_and_weights(
+    size_t) noexcept;
+/// \endcond
+
+// Algorithm to compute Chebyshev-Gauss quadrature
+
+/// \cond
+template <>
+std::pair<DataVector, DataVector>
+compute_collocation_points_and_weights<Basis::Chebyshev, Quadrature::Gauss>(
+    const size_t num_points) noexcept {
+  // Algorithm 26 in Kopriva, p. 67
+  ASSERT(num_points >= 1,
+         "Chebyshev-Gauss quadrature requires at least one collocation point.");
+  const size_t poly_degree = num_points - 1;
+  DataVector x(num_points);
+  DataVector w(num_points, M_PI / num_points);
+  for (size_t j = 0; j < num_points; j++) {
+    x[j] = -cos(M_PI_2 * (2 * j + 1) / (poly_degree + 1));
+  }
+  return std::make_pair(std::move(x), std::move(w));
+}
+/// \endcond
+
+// Algorithm to compute Chebyshev-Gauss-Lobatto quadrature
+
+/// \cond
+template <>
+std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
+    Basis::Chebyshev, Quadrature::GaussLobatto>(
+    const size_t num_points) noexcept {
+  // Algorithm 27 in Kopriva, p. 68
+  ASSERT(num_points >= 2,
+         "Chebyshev-Gauss-Lobatto quadrature requires at least two collocation "
+         "points.");
+  const size_t poly_degree = num_points - 1;
+  DataVector x(num_points);
+  DataVector w(num_points, M_PI / poly_degree);
+  for (size_t j = 0; j < num_points; j++) {
+    x[j] = -cos(M_PI * j / poly_degree);
+  }
+  w[0] *= 0.5;
+  w[num_points - 1] *= 0.5;
+  return std::make_pair(std::move(x), std::move(w));
+}
+/// \endcond
+
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/Chebyshev.cpp
+++ b/src/NumericalAlgorithms/Spectral/Chebyshev.cpp
@@ -15,11 +15,9 @@
 namespace Spectral {
 
 // Algorithms to compute Chebyshev basis functions
-// These functions specialize the templates declared in `Spectral.cpp`.
+// These functions specialize the templates declared in `Spectral.hpp`.
 
 /// \cond
-template <Basis>
-DataVector compute_basis_function_values(size_t, const DataVector&) noexcept;
 template <>
 DataVector compute_basis_function_values<Basis::Chebyshev>(
     const size_t k, const DataVector& x) noexcept {
@@ -47,16 +45,12 @@ DataVector compute_basis_function_values<Basis::Chebyshev>(
   }
 }
 
-template <Basis>
-DataVector compute_inverse_weight_function_values(const DataVector&) noexcept;
 template <>
 DataVector compute_inverse_weight_function_values<Basis::Chebyshev>(
     const DataVector& x) noexcept {
   return sqrt(1. - square(x));
 }
 
-template <Basis>
-double compute_basis_function_normalization_square(size_t) noexcept;
 template <>
 double compute_basis_function_normalization_square<Basis::Chebyshev>(
     const size_t k) noexcept {
@@ -66,10 +60,6 @@ double compute_basis_function_normalization_square<Basis::Chebyshev>(
     return M_PI_2;
   }
 }
-
-template <Basis, Quadrature>
-std::pair<DataVector, DataVector> compute_collocation_points_and_weights(
-    size_t) noexcept;
 /// \endcond
 
 // Algorithm to compute Chebyshev-Gauss quadrature

--- a/src/NumericalAlgorithms/Spectral/Legendre.cpp
+++ b/src/NumericalAlgorithms/Spectral/Legendre.cpp
@@ -21,20 +21,20 @@ namespace Spectral {
 
 /// \cond
 template <Basis>
-double compute_basis_function_value(size_t, double) noexcept;
+DataVector compute_basis_function_values(size_t, const DataVector&) noexcept;
 template <>
-double compute_basis_function_value<Basis::Legendre>(const size_t k,
-                                                     const double x) noexcept {
-  // Algorithm 20 from Kopriva's book, p. 60
+DataVector compute_basis_function_values<Basis::Legendre>(
+    const size_t k, const DataVector& x) noexcept {
+  // Algorithm 20 in Kopriva, p. 60
   switch (k) {
     case 0:
-      return 1.;
+      return DataVector(x.size(), 1.);
     case 1:
       return x;
     default:
-      double L_k_minus_2 = 1.;
-      double L_k_minus_1 = x;
-      double L_k = std::numeric_limits<double>::signaling_NaN();
+      DataVector L_k_minus_2(x.size(), 1.);
+      DataVector L_k_minus_1 = x;
+      DataVector L_k(x.size());
       for (size_t j = 2; j <= k; j++) {
         L_k = ((2. * j - 1.) * x * L_k_minus_1 - (j - 1.) * L_k_minus_2) / j;
         L_k_minus_2 = L_k_minus_1;
@@ -42,6 +42,14 @@ double compute_basis_function_value<Basis::Legendre>(const size_t k,
       }
       return L_k;
   }
+}
+
+template <Basis>
+DataVector compute_inverse_weight_function_values(const DataVector&) noexcept;
+template <>
+DataVector compute_inverse_weight_function_values<Basis::Legendre>(
+    const DataVector& x) noexcept {
+  return DataVector(x.size(), 1.);
 }
 
 template <Basis>
@@ -60,7 +68,6 @@ std::pair<DataVector, DataVector> compute_collocation_points_and_weights(
 // Algorithms to compute Legendre-Gauss quadrature
 
 namespace {
-
 struct LegendrePolynomialAndDerivative {
   LegendrePolynomialAndDerivative(size_t poly_degree, double x) noexcept;
   double L;
@@ -69,7 +76,7 @@ struct LegendrePolynomialAndDerivative {
 
 LegendrePolynomialAndDerivative::LegendrePolynomialAndDerivative(
     const size_t poly_degree, const double x) noexcept {
-  // Algorithm 22 from Kopriva's book, p. 63
+  // Algorithm 22 in Kopriva, p. 63
   // The cases where `poly_degree` is `0` or `1` are omitted because they are
   // never used.
   double L_N_minus_2 = 1.;
@@ -97,7 +104,7 @@ template <>
 std::pair<DataVector, DataVector>
 compute_collocation_points_and_weights<Basis::Legendre, Quadrature::Gauss>(
     const size_t num_points) noexcept {
-  // Algorithm 23 from Kopriva's book, p.64
+  // Algorithm 23 in Kopriva, p.64
   ASSERT(num_points >= 1,
          "Legendre-Gauss quadrature requires at least one collocation point.");
   const size_t poly_degree = num_points - 1;
@@ -147,7 +154,6 @@ compute_collocation_points_and_weights<Basis::Legendre, Quadrature::Gauss>(
 // Algorithms to compute Legendre-Gauss-Lobatto quadrature
 
 namespace {
-
 struct EvaluateQandL {
   EvaluateQandL(size_t poly_degree, double x) noexcept;
   double q;
@@ -157,7 +163,7 @@ struct EvaluateQandL {
 
 EvaluateQandL::EvaluateQandL(const size_t poly_degree,
                              const double x) noexcept {
-  // Algorithm 24 from Kopriva's book, p. 65
+  // Algorithm 24 in Kopriva, p. 65
   // Note: Book has errors in last 4 lines, corrected in errata on website
   // https://www.math.fsu.edu/~kopriva/publications/errata.pdf
   ASSERT(poly_degree >= 2, "Polynomial degree must be at least two.");
@@ -189,7 +195,7 @@ template <>
 std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
     Basis::Legendre, Quadrature::GaussLobatto>(
     const size_t num_points) noexcept {
-  // Algorithm 25 from Kopriva's book, p. 66
+  // Algorithm 25 in Kopriva, p. 66
   ASSERT(num_points >= 2,
          "Legendre-Gauss-Lobatto quadrature requires at least two collocation "
          "points.");

--- a/src/NumericalAlgorithms/Spectral/Legendre.cpp
+++ b/src/NumericalAlgorithms/Spectral/Legendre.cpp
@@ -17,11 +17,9 @@
 namespace Spectral {
 
 // Algorithms to compute Legendre basis functions
-// These functions specialize the templates declared in `Spectral.cpp`.
+// These functions specialize the templates declared in `Spectral.hpp`.
 
 /// \cond
-template <Basis>
-DataVector compute_basis_function_values(size_t, const DataVector&) noexcept;
 template <>
 DataVector compute_basis_function_values<Basis::Legendre>(
     const size_t k, const DataVector& x) noexcept {
@@ -44,25 +42,17 @@ DataVector compute_basis_function_values<Basis::Legendre>(
   }
 }
 
-template <Basis>
-DataVector compute_inverse_weight_function_values(const DataVector&) noexcept;
 template <>
 DataVector compute_inverse_weight_function_values<Basis::Legendre>(
     const DataVector& x) noexcept {
   return DataVector(x.size(), 1.);
 }
 
-template <Basis>
-double compute_basis_function_normalization_square(size_t) noexcept;
 template <>
 double compute_basis_function_normalization_square<Basis::Legendre>(
     const size_t k) noexcept {
   return 2. / (2. * k + 1.);
 }
-
-template <Basis, Quadrature>
-std::pair<DataVector, DataVector> compute_collocation_points_and_weights(
-    size_t) noexcept;
 /// \endcond
 
 // Algorithms to compute Legendre-Gauss quadrature

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -39,46 +39,6 @@ std::ostream& operator<<(std::ostream& os,
   }
 }
 
-// Forward declarations with basis-specific implementations
-
-/// \cond
-/*!
- * \brief Computes the function values of the basis function \f$\Phi_k(x)\f$
- * (zero-indexed).
- */
-template <Basis BasisType>
-DataVector compute_basis_function_values(size_t k,
-                                         const DataVector& x) noexcept;
-
-/*!
- * \brief Computes the inverse of the weight function \f$w(x)\f$ w.r.t. which
- * the basis functions are orthogonal. See the description of
- * quadrature_weights(size_t) for details.
- */
-template <Basis>
-DataVector compute_inverse_weight_function_values(const DataVector&) noexcept;
-
-/*!
- * \brief Computes the normalization square of the basis function \f$\Phi_k\f$
- * (zero-indexed), i.e. the weighted definite integral over its square.
- */
-template <Basis BasisType>
-double compute_basis_function_normalization_square(size_t k) noexcept;
-
-/*!
- * \brief Computes the collocation points and weights associated to the
- * basis and quadrature.
- *
- * \details This function is expected to return the tuple
- * \f$(\xi_k,w_k)\f$ where the \f$\xi_k\f$ are the collocation
- * points and the \f$w_k\f$ are defined in the description of
- * quadrature_weights(size_t).
- */
-template <Basis BasisType, Quadrature QuadratureType>
-std::pair<DataVector, DataVector> compute_collocation_points_and_weights(
-    size_t num_points) noexcept;
-/// \endcond
-
 namespace {
 
 // Caching mechanism

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -460,7 +460,8 @@ template Matrix Spectral::interpolation_matrix(const Mesh<1>&,
 template Matrix Spectral::interpolation_matrix(
     const Mesh<1>&, const std::vector<double>&) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (Spectral::Basis::Legendre),
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (Spectral::Basis::Chebyshev, Spectral::Basis::Legendre),
                         (Spectral::Quadrature::Gauss,
                          Spectral::Quadrature::GaussLobatto))
 

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <iosfwd>
 #include <limits>
+#include <utility>
 
 /// \cond
 class Matrix;
@@ -90,6 +91,42 @@ constexpr size_t minimum_number_of_points<BasisType, Quadrature::GaussLobatto> =
  */
 template <Basis>
 constexpr size_t maximum_number_of_points = 12;
+
+/*!
+ * \brief Compute the function values of the basis function \f$\Phi_k(x)\f$
+ * (zero-indexed).
+ */
+template <Basis BasisType>
+DataVector compute_basis_function_values(size_t k,
+                                         const DataVector& x) noexcept;
+
+/*!
+ * \brief Compute the inverse of the weight function \f$w(x)\f$ w.r.t. which
+ * the basis functions are orthogonal. See the description of
+ * `quadrature_weights(size_t)` for details.
+ */
+template <Basis>
+DataVector compute_inverse_weight_function_values(const DataVector&) noexcept;
+
+/*!
+ * \brief Compute the normalization square of the basis function \f$\Phi_k\f$
+ * (zero-indexed), i.e. the weighted definite integral over its square.
+ */
+template <Basis BasisType>
+double compute_basis_function_normalization_square(size_t k) noexcept;
+
+/*!
+ * \brief Compute the collocation points and weights associated to the
+ * basis and quadrature.
+ *
+ * \details This function is expected to return the tuple
+ * \f$(\xi_k,w_k)\f$ where the \f$\xi_k\f$ are the collocation
+ * points and the \f$w_k\f$ are defined in the description of
+ * `quadrature_weights(size_t)`.
+ */
+template <Basis BasisType, Quadrature QuadratureType>
+std::pair<DataVector, DataVector> compute_collocation_points_and_weights(
+    size_t num_points) noexcept;
 
 /*!
  * \brief Collocation points

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -42,8 +42,11 @@ namespace Spectral {
  * \ingroup SpectralGroup
  * \brief The choice of basis functions for computing collocation points and
  * weights.
+ *
+ * \details Choose `Legendre` for a general-purpose DG mesh, unless you have a
+ * particular reason for choosing another basis.
  */
-enum class Basis { Legendre };
+enum class Basis { Chebyshev, Legendre };
 
 /// \cond HIDDEN_SYMBOLS
 std::ostream& operator<<(std::ostream& os, const Basis& basis) noexcept;

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -103,7 +103,23 @@ const DataVector& collocation_points(size_t num_points) noexcept;
 const DataVector& collocation_points(const Mesh<1>& mesh) noexcept;
 
 /*!
- * \brief Quadrature weights
+ * \brief Weights to compute definite integrals.
+ *
+ * \details These are the coefficients to contract with the nodal
+ * function values \f$f_k\f$ to approximate the definite integral \f$I[f]=\int
+ * f(x)\mathrm{d}x\f$.
+ *
+ * Note that the term _quadrature_ also often refers to the quantity
+ * \f$Q[f]=\int f(x)w(x)\mathrm{d}x\approx \sum_k f_k w_k\f$. Here, \f$w(x)\f$
+ * denotes the basis-specific weight function w.r.t. to which the basis
+ * functions \f$\Phi_k\f$ are orthogonal, i.e \f$\int\Phi_i(x)\Phi_j(x)w(x)=0\f$
+ * for \f$i\neq j\f$. The weights \f$w_k\f$ approximate this inner product. To
+ * approximate the definite integral \f$I[f]\f$ we must employ the
+ * coefficients \f$\frac{w_k}{w(\xi_k)}\f$ instead, where the \f$\xi_k\f$ are
+ * the collocation points. These are the coefficients this function returns.
+ * Only for a unit weight function \f$w(x)=1\f$, i.e. a Legendre basis, is
+ * \f$I[f]=Q[f]\f$ so this function returns the \f$w_k\f$ identically.
+ *
  * \param num_points The number of collocation points
  */
 template <Basis BasisType, Quadrature QuadratureType>
@@ -122,8 +138,8 @@ const DataVector& quadrature_weights(const Mesh<1>& mesh) noexcept;
  * \details For a function represented by the nodal coefficients \f$u_j\f$ a
  * matrix multiplication with the differentiation matrix \f$D_{ij}\f$ gives the
  * coefficients of the function's derivative. Since \f$u(x)\f$ is expanded in
- * Lagrange polynomials \f$u(x)=u_j l_j(x)\f$ the differentiation matrix is
- * computed as \f$D_{ij}=l_j^\prime(\xi_i)\f$ where the \f$\xi_i\f$ are the
+ * Lagrange polynomials \f$u(x)=\sum_j u_j l_j(x)\f$ the differentiation matrix
+ * is computed as \f$D_{ij}=l_j^\prime(\xi_i)\f$ where the \f$\xi_i\f$ are the
  * collocation points.
  *
  * \param num_points The number of collocation points
@@ -168,11 +184,11 @@ Matrix interpolation_matrix(const Mesh<1>& mesh,
  * \details The Vandermonde matrix is computed as
  * \f$\mathcal{V}_{ij}=\Phi_j(\xi_i)\f$ where the \f$\Phi_j(x)\f$ are the
  * spectral basis functions used in the modal expansion
- * \f$u(x)=\widetilde{u}_j\Phi_j(x)\f$, e.g. normalized Legendre polynomials,
- * and the \f$\xi_i\f$ are the collocation points used to construct the
- * interpolating Lagrange polynomials in the nodal expansion
- * \f$u(x)=u_j l_j(x)\f$. Then the Vandermonde matrix arises as
- * \f$u(\xi_i)=u_i=\widetilde{u}_j\Phi_j(\xi_i)=
+ * \f$u(x)=\sum_j \widetilde{u}_j\Phi_j(x)\f$, e.g. normalized Legendre
+ * polynomials, and the \f$\xi_i\f$ are the collocation points used to construct
+ * the interpolating Lagrange polynomials in the nodal expansion
+ * \f$u(x)=\sum_j u_j l_j(x)\f$. Then the Vandermonde matrix arises as
+ * \f$u(\xi_i)=u_i=\sum_j \widetilde{u}_j\Phi_j(\xi_i)=\sum_j
  * \mathcal{V}_{ij}\widetilde{u}_j\f$.
  *
  * \param num_points The number of collocation points
@@ -198,7 +214,8 @@ const Matrix& spectral_to_grid_points_matrix(const Mesh<1>& mesh) noexcept;
  * \details This is the inverse to the Vandermonde matrix \f$\mathcal{V}\f$
  * computed in spectral_to_grid_points_matrix(size_t). It can be computed
  * analytically for Gauss quadrature by evaluating
- * \f$\mathcal{V}^{-1}_{ij}u_j=\widetilde{u}_i=\frac{(u,\Phi_i)}{\gamma_i}\f$
+ * \f$\sum_j\mathcal{V}^{-1}_{ij}u_j=\widetilde{u}_i=
+ * \frac{(u,\Phi_i)}{\gamma_i}\f$
  * for a Lagrange basis function \f$u(x)=l_k(x)\f$ to find
  * \f$\mathcal{V}^{-1}_{ij}=\mathcal{V}_{ji}\frac{w_j}{\gamma_i}\f$ where the
  * \f$w_j\f$ are the Gauss quadrature weights and \f$\gamma_i\f$ is the norm

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -4,6 +4,8 @@
 set(LIBRARY "Test_Spectral")
 
 set(LIBRARY_SOURCES
+  Test_ChebyshevGauss.cpp
+  Test_ChebyshevGaussLobatto.cpp
   Test_LegendreGauss.cpp
   Test_LegendreGaussLobatto.cpp
   Test_Projection.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ChebyshevGauss.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ChebyshevGauss.cpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+namespace {
+
+void test_points_and_weights(const size_t num_points,
+                             const DataVector expected_points,
+                             const DataVector expected_weights) {
+  const auto& points =
+      Spectral::collocation_points<Spectral::Basis::Chebyshev,
+                                   Spectral::Quadrature::Gauss>(num_points);
+  CHECK_ITERABLE_APPROX(expected_points, points);
+  // We test the \f$w_k\f$ here directly. Test_Spectral.cpp and
+  // Test_DefiniteIntegral.cpp take care of testing the
+  // `Spectral::quadrature_weights`.
+  const auto weights =
+      Spectral::compute_collocation_points_and_weights<
+          Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss>(num_points)
+          .second;
+  CHECK_ITERABLE_APPROX(expected_weights, weights);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ChebyshevGauss.PointsAndWeights",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  // Compare Chebyshev-Gauss points and weights to the analytic expressions
+  // \f$\x_j=-\cos{\frac{2j+1}{2p+2}\pi}\f$ and \f$w_k=\frac{\pi}{N}\f$, where
+  // \f$p=N-1\f$ is the polynomial degree, \f$N\f$ the number of collocation
+  // points and \f$0\leq j \leq p\f$ (Kopriva, eqn. (1.128)).
+
+  SECTION("Check 1 point") {
+    test_points_and_weights(1, DataVector{0.}, DataVector{3.141592653589793});
+  }
+
+  SECTION("Check 2 points") {
+    test_points_and_weights(2,
+                            DataVector{-0.707106781186548, 0.7071067811865475},
+                            DataVector(size_t{2}, 1.570796326794897));
+  }
+  SECTION("Check 3 points") {
+    test_points_and_weights(
+        3, DataVector{-0.866025403784439, 0., 0.866025403784439},
+        DataVector(size_t{3}, 1.047197551196598));
+  }
+  SECTION("Check 4 points") {
+    test_points_and_weights(4,
+                            DataVector{-0.923879532511287, -0.382683432365090,
+                                       0.3826834323650898, 0.9238795325112868},
+                            DataVector(size_t{4}, 0.785398163397448));
+  }
+  SECTION("Check 5 points") {
+    test_points_and_weights(
+        5,
+        DataVector{-0.951056516295154, -0.587785252292473, 0.,
+                   0.5877852522924731, 0.9510565162951536},
+        DataVector(size_t{5}, 0.628318530717959));
+  }
+  SECTION("Check 6 points") {
+    test_points_and_weights(
+        6,
+        DataVector{-0.965925826289068, -0.707106781186548, -0.258819045102521,
+                   0.258819045102521, 0.7071067811865475, 0.965925826289068},
+        DataVector(size_t{6}, 0.523598775598299));
+  }
+}

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ChebyshevGaussLobatto.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ChebyshevGaussLobatto.cpp
@@ -1,0 +1,72 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+
+namespace {
+
+void test_points_and_weights(const size_t num_points,
+                             const DataVector expected_points,
+                             const DataVector expected_weights) {
+  const auto& points =
+      Spectral::collocation_points<Spectral::Basis::Chebyshev,
+                                   Spectral::Quadrature::GaussLobatto>(
+          num_points);
+  CHECK_ITERABLE_APPROX(expected_points, points);
+  // We test the \f$w_k\f$ here directly. Test_Spectral.cpp and
+  // Test_DefiniteIntegral.cpp take care of testing the
+  // Spectral::quadrature_weights.
+  const auto weights =
+      Spectral::compute_collocation_points_and_weights<
+          Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>(
+          num_points)
+          .second;
+  CHECK_ITERABLE_APPROX(expected_weights, weights);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Numerical.Spectral.ChebyshevGaussLobatto.PointsAndWeights",
+    "[NumericalAlgorithms][Spectral][Unit]") {
+  // Compare Chebyshev-Gauss-Lobatto points and weights to the analytic
+  // expressions \f$\x_j=-\cos{\frac{j\pi}{p}}\f$ and \f$w_k=\frac{\pi}{p}\f$
+  // except for \f$w_{0,p}=\frac{\pi}{2p}\f$, where \f$p=N-1\f$ is the
+  // polynomial degree, \f$N\f$ the number of collocation points and \f$0\leq j
+  // \leq p\f$ (Kopriva, eqn. (1.130)).
+
+  SECTION("Check 2 points") {
+    test_points_and_weights(2, DataVector{-1., 1.},
+                            DataVector(size_t{2}, 1.570796326794897));
+  }
+  SECTION("Check 3 points") {
+    test_points_and_weights(
+        3, DataVector{-1., 0., 1.},
+        DataVector{0.785398163397448, 1.570796326794897, 0.785398163397448});
+  }
+  SECTION("Check 4 points") {
+    test_points_and_weights(4, DataVector{-1., -0.5, 0.5, 1.},
+                            DataVector{0.523598775598299, 1.047197551196598,
+                                       1.047197551196598, 0.523598775598299});
+  }
+  SECTION("Check 5 points") {
+    test_points_and_weights(
+        5, DataVector{-1., -0.707106781186548, 0., 0.7071067811865475, 1.},
+        DataVector{0.3926990816987242, 0.785398163397448, 0.785398163397448,
+                   0.785398163397448, 0.3926990816987242});
+  }
+  SECTION("Check 6 points") {
+    test_points_and_weights(
+        6,
+        DataVector{-1., -0.809016994374947, -0.309016994374947,
+                   0.3090169943749474, 0.809016994374947, 1.},
+        DataVector{0.3141592653589793, 0.628318530717959, 0.628318530717959,
+                   0.628318530717959, 0.628318530717959, 0.3141592653589793});
+  }
+}

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <cstddef>
 #include <string>
+#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
@@ -16,6 +17,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/Math.hpp"
 
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.streaming",
                   "[NumericalAlgorithms][Spectral][Unit]") {
@@ -27,25 +29,45 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.streaming",
 
 namespace {
 
+DataVector unit_polynomial(const size_t deg, const DataVector& x) {
+  // Simply choose all polynomial coefficients to one
+  const std::vector<double> coeffs(deg + 1, 1.);
+  return evaluate_polynomial(coeffs, x);
+};
+double unit_polynomial_integral(const size_t deg) {
+  std::vector<double> coeffs(deg + 2);
+  coeffs[0] = 0.;
+  for (size_t p = 1; p < coeffs.size(); p++) {
+    coeffs[p] = 1. / p;
+  }
+  const auto integrals = evaluate_polynomial(coeffs, DataVector{-1., 1.});
+  return integrals[1] - integrals[0];
+};
+
+}  // namespace
+
+namespace {
+
 template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
-void test_linear_filter(const size_t num_points) {
-  const Matrix& filter_matrix =
-      Spectral::linear_filter_matrix<BasisType, QuadratureType>(num_points);
-  const Matrix& grid_points_to_spectral_matrix =
-      Spectral::grid_points_to_spectral_matrix<BasisType, QuadratureType>(
-          num_points);
-  const DataVector& collocation_pts =
-      Spectral::collocation_points<BasisType, QuadratureType>(num_points);
-  const DataVector u = exp(collocation_pts);
-  DataVector u_filtered(num_points);
-  dgemv_('N', num_points, num_points, 1.0, filter_matrix.data(), num_points,
-         u.data(), 1, 0.0, u_filtered.data(), 1);
-  DataVector u_filtered_spectral(num_points);
-  dgemv_('N', num_points, num_points, 1.0,
-         grid_points_to_spectral_matrix.data(), num_points, u_filtered.data(),
-         1, 0.0, u_filtered_spectral.data(), 1);
-  for (size_t s = 2; s < num_points; ++s) {
-    CHECK(0.0 == approx(u_filtered_spectral[s]));
+void test_linear_filter() {
+  for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+       n <= Spectral::maximum_number_of_points<BasisType>; n++) {
+    const auto& filter_matrix =
+        Spectral::linear_filter_matrix<BasisType, QuadratureType>(n);
+    const auto& grid_points_to_spectral_matrix =
+        Spectral::grid_points_to_spectral_matrix<BasisType, QuadratureType>(n);
+    const auto& collocation_pts =
+        Spectral::collocation_points<BasisType, QuadratureType>(n);
+    const DataVector u = exp(collocation_pts);
+    DataVector u_filtered(n);
+    dgemv_('N', n, n, 1.0, filter_matrix.data(), n, u.data(), 1, 0.0,
+           u_filtered.data(), 1);
+    DataVector u_filtered_spectral(n);
+    dgemv_('N', n, n, 1.0, grid_points_to_spectral_matrix.data(), n,
+           u_filtered.data(), 1, 0.0, u_filtered_spectral.data(), 1);
+    for (size_t s = 2; s < n; ++s) {
+      CHECK(0.0 == approx(u_filtered_spectral[s]));
+    }
   }
 }
 
@@ -54,49 +76,37 @@ void test_linear_filter(const size_t num_points) {
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LinearFilter",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   SECTION("Legendre-Gauss") {
-    for (size_t n =
-             Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
-                                                Spectral::Quadrature::Gauss>;
-         n <= Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
-         ++n) {
-      test_linear_filter<Spectral::Basis::Legendre,
-                         Spectral::Quadrature::Gauss>(n);
-    }
+    test_linear_filter<Spectral::Basis::Legendre,
+                       Spectral::Quadrature::Gauss>();
   }
   SECTION("Legendre-Gauss-Lobatto") {
-    for (size_t n = Spectral::minimum_number_of_points<
-             Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
-         n <= Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
-         ++n) {
-      test_linear_filter<Spectral::Basis::Legendre,
-                         Spectral::Quadrature::GaussLobatto>(n);
-    }
+    test_linear_filter<Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto>();
   }
 }
 
 namespace {
 
-template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
-void test_exact_interpolation(size_t num_pts, int poly_deg) {
-  const DataVector& collocation_pts =
-      Spectral::collocation_points<BasisType, QuadratureType>(num_pts);
-  auto polynomial = [poly_deg](const DataVector& x) {
-    auto func_value = DataVector(x.size(), 1.);
-    for (int p = 1; p <= poly_deg; p++) {
-      func_value += pow(x, p);
+template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType,
+          typename Function>
+void test_exact_interpolation(const Function& max_poly_deg) {
+  for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+       n <= Spectral::maximum_number_of_points<BasisType>; n++) {
+    for (size_t p = 0; p <= max_poly_deg(n); p++) {
+      const auto& collocation_pts =
+          Spectral::collocation_points<BasisType, QuadratureType>(n);
+      const DataVector u = unit_polynomial(p, collocation_pts);
+      const DataVector target_points{-0.5, -0.4837, 0.5, 0.9378, 1.};
+      DataVector interpolated_u(target_points.size(), 0.);
+      const auto interp_matrix =
+          Spectral::interpolation_matrix<BasisType, QuadratureType>(
+              n, target_points);
+      dgemv_('n', target_points.size(), n, 1.0, interp_matrix.data(),
+             target_points.size(), u.data(), 1, 0.0, interpolated_u.data(), 1);
+      CHECK(interpolated_u.size() == target_points.size());
+      CHECK_ITERABLE_APPROX(unit_polynomial(p, target_points), interpolated_u);
     }
-    return func_value;
-  };
-  const DataVector u = polynomial(collocation_pts);
-  const DataVector new_points{-0.5, -0.4837, 0.5, 0.9378, 1.0};
-  DataVector interpolated_u(new_points.size(), 0.0);
-  const Matrix interp_matrix =
-      Spectral::interpolation_matrix<BasisType, QuadratureType>(num_pts,
-                                                                new_points);
-  dgemv_('n', new_points.size(), num_pts, 1.0, interp_matrix.data(),
-         new_points.size(), u.data(), 1, 0.0, interpolated_u.data(), 1);
-  CHECK(interpolated_u.size() == new_points.size());
-  CHECK_ITERABLE_APPROX(polynomial(new_points), interpolated_u);
+  }
 }
 
 }  // namespace
@@ -106,60 +116,38 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactInterpolation",
   SECTION(
       "Legendre-Gauss interpolation is exact to polynomial order "
       "num_points-1") {
-    for (size_t n =
-             Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
-                                                Spectral::Quadrature::Gauss>;
-         n <= Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
-         n++) {
-      for (size_t p = 0; p <= n - 1; p++) {
-        test_exact_interpolation<Spectral::Basis::Legendre,
-                                 Spectral::Quadrature::Gauss>(n, p);
-      }
-    }
+    test_exact_interpolation<Spectral::Basis::Legendre,
+                             Spectral::Quadrature::Gauss>(
+        [](const size_t n) { return n - 1; });
   }
   SECTION(
       "Legendre-Gauss-Lobatto interpolation is exact to polynomial "
       "order num_points-1") {
-    for (size_t n = Spectral::minimum_number_of_points<
-             Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
-         n <= Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
-         n++) {
-      for (size_t p = 0; p <= n - 1; p++) {
-        test_exact_interpolation<Spectral::Basis::Legendre,
-                                 Spectral::Quadrature::GaussLobatto>(n, p);
-      }
-    }
+    test_exact_interpolation<Spectral::Basis::Legendre,
+                             Spectral::Quadrature::GaussLobatto>(
+        [](const size_t n) { return n - 1; });
   }
 }
 
 namespace {
 
-template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
-void test_exact_quadrature(size_t num_pts, int poly_deg) {
-  const DataVector& collocation_pts =
-      Spectral::collocation_points<BasisType, QuadratureType>(num_pts);
-  const DataVector& weights =
-      Spectral::quadrature_weights<BasisType, QuadratureType>(num_pts);
-  auto polynomial = [poly_deg](const DataVector& x) {
-    auto func_value = DataVector(x.size(), 1.);
-    for (int p = 1; p <= poly_deg; p++) {
-      func_value += pow(x, p);
+template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType,
+          typename Function>
+void test_exact_quadrature(const Function& max_poly_deg) {
+  for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+       n <= Spectral::maximum_number_of_points<BasisType>; n++) {
+    for (size_t p = 0; p <= max_poly_deg(n); p++) {
+      const double analytic_quadrature = unit_polynomial_integral(p);
+      const auto& collocation_pts =
+          Spectral::collocation_points<BasisType, QuadratureType>(n);
+      const auto& weights =
+          Spectral::quadrature_weights<BasisType, QuadratureType>(n);
+      const DataVector u = unit_polynomial(p, collocation_pts);
+      const double numeric_quadrature =
+          ddot_(n, u.data(), 1, weights.data(), 1);
+      CHECK_ITERABLE_APPROX(analytic_quadrature, numeric_quadrature);
     }
-    return func_value;
-  };
-  auto polynomial_integral = [poly_deg](const double x) {
-    double func_value = 0.;
-    for (int p = 1; p <= poly_deg + 1; p++) {
-      func_value += pow(x, p) / double(p);
-    }
-    return func_value;
-  };
-  const DataVector u = polynomial(collocation_pts);
-  const double numeric_integral =
-      ddot_(num_pts, u.data(), 1, weights.data(), 1);
-  const double analytic_integral =
-      polynomial_integral(1.) - polynomial_integral(-1.);
-  CHECK_ITERABLE_APPROX(analytic_integral, numeric_integral);
+  }
 }
 
 }  // namespace
@@ -168,29 +156,16 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactQuadrature",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   SECTION(
       "Legendre-Gauss quadrature is exact to polynomial order 2*num_points-1") {
-    for (size_t n =
-             Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
-                                                Spectral::Quadrature::Gauss>;
-         n <= Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
-         n++) {
-      for (size_t p = 0; p <= 2 * n - 1; p++) {
-        test_exact_quadrature<Spectral::Basis::Legendre,
-                              Spectral::Quadrature::Gauss>(n, p);
-      }
-    }
+    test_exact_quadrature<Spectral::Basis::Legendre,
+                          Spectral::Quadrature::Gauss>(
+        [](const size_t n) { return 2 * n - 1; });
   }
   SECTION(
       "Legendre-Gauss-Lobatto quadrature is exact to polynomial order "
       "2*num_points-3") {
-    for (size_t n = Spectral::minimum_number_of_points<
-             Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
-         n <= Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
-         n++) {
-      for (size_t p = 0; p <= 2 * n - 3; p++) {
-        test_exact_quadrature<Spectral::Basis::Legendre,
-                              Spectral::Quadrature::GaussLobatto>(n, p);
-      }
-    }
+    test_exact_quadrature<Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto>(
+        [](const size_t n) { return 2 * n - 3; });
   }
 }
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -19,16 +19,6 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Math.hpp"
 
-namespace Spectral {
-// For exact-quadrature test where we need the \f$w_k\f$. We don't provide a
-// public accessor since we only ever need them in Spectral.cpp.
-template <Basis, Quadrature>
-std::pair<DataVector, DataVector> compute_collocation_points_and_weights(
-    size_t) noexcept;
-template <Basis>
-DataVector compute_inverse_weight_function_values(const DataVector&) noexcept;
-}  // namespace Spectral
-
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.streaming",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   CHECK(get_output(Spectral::Basis::Legendre) == "Legendre");

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -40,7 +40,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.streaming",
 namespace {
 
 DataVector unit_polynomial(const size_t deg, const DataVector& x) {
-  // Simply choose all polynomial coefficients to one
+  // Choose all polynomial coefficients to be one
   const std::vector<double> coeffs(deg + 1, 1.);
   return evaluate_polynomial(coeffs, x);
 }
@@ -100,6 +100,20 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactDifferentiation",
                                Spectral::Quadrature::GaussLobatto>(
         [](const size_t n) { return n - 1; });
   }
+  SECTION(
+      "Chebyshev-Gauss differentiation is exact to polynomial order "
+      "num_points - 1") {
+    test_exact_differentiation<Spectral::Basis::Chebyshev,
+                               Spectral::Quadrature::Gauss>(
+        [](const size_t n) { return n - 1; });
+  }
+  SECTION(
+      "Chebyshev-Gauss-Lobatto differentiation is exact to polynomial order "
+      "num_points - 1") {
+    test_exact_differentiation<Spectral::Basis::Chebyshev,
+                               Spectral::Quadrature::GaussLobatto>(
+        [](const size_t n) { return n - 1; });
+  }
 }
 
 namespace {
@@ -137,6 +151,14 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.LinearFilter",
   }
   SECTION("Legendre-Gauss-Lobatto") {
     test_linear_filter<Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto>();
+  }
+  SECTION("Chebyshev-Gauss") {
+    test_linear_filter<Spectral::Basis::Chebyshev,
+                       Spectral::Quadrature::Gauss>();
+  }
+  SECTION("Chebyshev-Gauss-Lobatto") {
+    test_linear_filter<Spectral::Basis::Chebyshev,
                        Spectral::Quadrature::GaussLobatto>();
   }
 }
@@ -180,6 +202,20 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactInterpolation",
       "Legendre-Gauss-Lobatto interpolation is exact to polynomial "
       "order num_points-1") {
     test_exact_interpolation<Spectral::Basis::Legendre,
+                             Spectral::Quadrature::GaussLobatto>(
+        [](const size_t n) { return n - 1; });
+  }
+  SECTION(
+      "Chebyshev-Gauss interpolation is exact to polynomial "
+      "order num_points-1") {
+    test_exact_interpolation<Spectral::Basis::Chebyshev,
+                             Spectral::Quadrature::Gauss>(
+        [](const size_t n) { return n - 1; });
+  }
+  SECTION(
+      "Chebyshev-Gauss-Lobatto interpolation is exact to polynomial "
+      "order num_points-1") {
+    test_exact_interpolation<Spectral::Basis::Chebyshev,
                              Spectral::Quadrature::GaussLobatto>(
         [](const size_t n) { return n - 1; });
   }
@@ -233,6 +269,46 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExactQuadrature",
                                       Spectral::Quadrature::GaussLobatto>(
         [](const size_t n) { return 2 * n - 3; });
   }
+  // For a function \f$f(x)\f$ the exact quadrature is
+  // \f$\int_{-1}^{1}f(x)w(x)\mathrm{d}x\f$ where \f$w(x)=1/sqrt(1-x^2)\f$ is
+  // the Chebyshev weight. We test this here for polynomials with unit
+  // coefficients \f$f(x)=1+x+x^2+\ldots\f$.
+  SECTION(
+      "Chebyshev-Gauss quadrature is exact to polynomial order "
+      "2*num_points-1") {
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::Gauss>(1, 1, M_PI);
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::Gauss>(2, 3, 3. * M_PI / 2.);
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::Gauss>(3, 5, 15. * M_PI / 8.);
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::Gauss>(4, 7, 35. * M_PI / 16.);
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::Gauss>(5, 9,
+                                                       315. * M_PI / 128.);
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::Gauss>(6, 11,
+                                                       693. * M_PI / 256.);
+  }
+  SECTION(
+      "Chebyshev-Gauss-Lobatto quadrature is exact to polynomial order "
+      "2*num_points-3") {
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::GaussLobatto>(2, 1, M_PI);
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::GaussLobatto>(3, 3,
+                                                              3. * M_PI / 2.);
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::GaussLobatto>(4, 5,
+                                                              15. * M_PI / 8.);
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::GaussLobatto>(5, 7,
+                                                              35. * M_PI / 16.);
+    test_exact_quadrature<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::GaussLobatto>(
+        6, 9, 315. * M_PI / 128.);
+  }
 }
 
 namespace {
@@ -265,6 +341,10 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.QuadratureWeights",
   test_quadrature_weights<Spectral::Basis::Legendre,
                           Spectral::Quadrature::Gauss>();
   test_quadrature_weights<Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto>();
+  test_quadrature_weights<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::Gauss>();
+  test_quadrature_weights<Spectral::Basis::Chebyshev,
                           Spectral::Quadrature::GaussLobatto>();
 }
 


### PR DESCRIPTION
## Proposed changes

This PR adds Chebyshev polynomials as a choice for `Spectral::Basis`. This is mostly for testing that our `Spectral` interface works as expected also for a basis that is not `Spectral::Basis::Legendre`.

Indeed the interface needs a few additions to accommodate for basis functions with a non-unity weight function, i.e. the function w.r.t. which the basis functions are orthogonal. In particular, quadrature and integration is not identical in that case, so this PR makes explicit that `Spectral::quadrature_weights` returns the coefficients for computing the **definite integral** of a function (as opposed to the coefficients for computing the quadrature, i.e. the definite integral of a function times the weight function).

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
