### PR TITLE
Allow Parallel::printf to print an enum class.

### DIFF
--- a/src/Parallel/Printf.hpp
+++ b/src/Parallel/Printf.hpp
@@ -37,7 +37,9 @@ inline constexpr T stream_object_to_string(T&& t) {
  * We need a 2-phase call so that the std::string doesn't go out of scope before
  * the C-style string is passed to printf.
  */
-template <typename T, Requires<std::is_class<std::decay_t<T>>::value> = nullptr>
+template <typename T,
+          Requires<std::is_class<std::decay_t<T>>::value or
+                   std::is_enum<std::decay_t<T>>::value> = nullptr>
 inline std::string stream_object_to_string(T&& t) {
   static_assert(tt::is_streamable<std::stringstream, T>::value,
                 "Cannot stream type and therefore it cannot be printed. Please "

--- a/tests/Unit/Parallel/Test_Parallel.cpp
+++ b/tests/Unit/Parallel/Test_Parallel.cpp
@@ -24,10 +24,24 @@ std::ostream& operator<<(std::ostream& os, const TestStream& t) {
   os << t.b[t.b.size() - 1] << ")";
   return os;
 }
+
+enum class TestEnum { Value1, Value2 };
+
+std::ostream& operator<<(std::ostream& os, const TestEnum& t) noexcept {
+  switch (t) {
+    case TestEnum::Value1:
+      return os << "Value 1";
+    case TestEnum::Value2:
+      return os << "Value 2";
+    default:
+      return os;
+  }
+}
+
 }  // namespace
 
 // [[OutputRegex, -100 3000000000 1.0000000000000000000e\+00 \(0,4,8,-7\) test 1
-// 2 3 abf a o e u]]
+// 2 3 abf a o e u Value 2]]
 SPECTRE_TEST_CASE("Unit.Parallel.printf", "[Unit][Parallel]") {
   const char c_string0[40] = {"test 1 2 3"};
   auto* c_string1 = new char[80];
@@ -37,8 +51,8 @@ SPECTRE_TEST_CASE("Unit.Parallel.printf", "[Unit][Parallel]") {
   c_string1[2] = 'f';   // NOLINT
   c_string1[3] = '\0';  // NOLINT
   constexpr const char* const c_string2 = {"a o e u"};
-  Parallel::printf("%d %lld %s %s %s %s\n", -100, 3000000000, TestStream{},
-                   c_string0, c_string1, c_string2);
+  Parallel::printf("%d %lld %s %s %s %s %s\n", -100, 3000000000, TestStream{},
+                   c_string0, c_string1, c_string2, TestEnum::Value2);
   delete[] c_string1;
   // Catch requires us to have at least one CHECK in each test
   // The Unit.Parallel.printf does not need to check anything


### PR DESCRIPTION
## Proposed changes

If you have an enum class with a stream operator, Parallel::printf can now print it.

Previously it wouldn't compile because of conditions that excluded an enum class.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
