### PR TITLE
Fix compute item missing-argument assertion

### DIFF
--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -166,6 +166,19 @@ using first_matching_tag = tmpl::front<list_of_matching_tags<TagList, Tag>>;
 template <typename TagList, typename Tag>
 constexpr auto number_of_matching_tags =
     tmpl::size<list_of_matching_tags<TagList, Tag>>::value;
+
+template <typename TagList, typename Tag>
+struct has_unique_matching_tag
+    : std::integral_constant<bool, number_of_matching_tags<TagList, Tag> == 1> {
+};
+
+template <typename TagList, typename Tag>
+using has_unique_matching_tag_t =
+    typename has_unique_matching_tag<TagList, Tag>::type;
+
+template <typename TagList, typename Tag>
+constexpr bool has_unique_matching_tag_v =
+    has_unique_matching_tag<TagList, Tag>::value;
 }  // namespace DataBox_detail
 
 /*!


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
