### PR TITLE
Documentation visibility

### DIFF
--- a/src/DataStructures/Tensor/IndexType.hpp
+++ b/src/DataStructures/Tensor/IndexType.hpp
@@ -110,7 +110,6 @@ inline std::ostream& operator<<(std::ostream& os, const IndexType& index_type) {
 }
 /// \endcond
 
-namespace Tensor_detail {
 /// \ingroup TensorGroup
 /// A ::TensorIndexType holds information about what type of index an index of a
 /// Tensor is. It holds the information about the number of spatial dimensions,
@@ -126,9 +125,10 @@ struct TensorIndexType {
                 "Cannot have a spatial dimensionality less than 1 (one) in a "
                 "TensorIndexType");
   using value_type = decltype(SpatialDim);
+  /// Dimensionality of the index, i.e., SpatialDim for spatial
+  /// indices or SpatialDim + 1 for spacetime indices.
   static constexpr value_type dim =
-      Index == IndexType::Spatial ? SpatialDim
-                                  : SpatialDim + static_cast<value_type>(1);
+      Index == IndexType::Spatial ? SpatialDim : SpatialDim + 1;
   // value is here just so that some generic metafunctions can retrieve the dim
   // easily
   static constexpr value_type value = dim;
@@ -136,7 +136,6 @@ struct TensorIndexType {
   using Frame = Fr;
   static constexpr IndexType index_type = Index;
 };
-}  // namespace Tensor_detail
 
 /// \ingroup TensorGroup
 /// A SpatialIndex holds information about the number of spatial
@@ -148,8 +147,7 @@ struct TensorIndexType {
 /// \tparam Fr the ::Frame the \ref SpatialIndex "TensorIndexType"
 /// is in
 template <size_t SpatialDim, UpLo Ul, typename Fr>
-using SpatialIndex =
-    Tensor_detail::TensorIndexType<SpatialDim, Ul, Fr, IndexType::Spatial>;
+using SpatialIndex = TensorIndexType<SpatialDim, Ul, Fr, IndexType::Spatial>;
 
 /// \ingroup TensorGroup
 /// A SpacetimeIndex holds information about the number of spatial
@@ -163,7 +161,7 @@ using SpatialIndex =
 /// is in
 template <size_t SpatialDim, UpLo Ul, typename Fr>
 using SpacetimeIndex =
-    Tensor_detail::TensorIndexType<SpatialDim, Ul, Fr, IndexType::Spacetime>;
+    TensorIndexType<SpatialDim, Ul, Fr, IndexType::Spacetime>;
 
 namespace tt {
 // @{
@@ -175,8 +173,7 @@ template <typename T>
 struct is_tensor_index_type : std::false_type {};
 /// \cond HIDDEN_SYMBOLS
 template <size_t SpatialDim, UpLo Ul, typename Fr, IndexType Index>
-struct is_tensor_index_type<
-    Tensor_detail::TensorIndexType<SpatialDim, Ul, Fr, Index>>
+struct is_tensor_index_type<TensorIndexType<SpatialDim, Ul, Fr, Index>>
     : std::true_type {};
 /// \endcond
 /// \see is_tensor_index_type
@@ -194,10 +191,11 @@ using is_tensor_index_type_t = typename is_tensor_index_type<T>::type;
 ///
 /// \tparam Index the \ref SpacetimeIndex "TensorIndexType" to change
 template <typename Index>
-using change_index_up_lo = Tensor_detail::TensorIndexType<
-    Index::index_type == IndexType::Spatial ? Index::value : Index::value - 1,
-    Index::ul == UpLo::Up ? UpLo::Lo : UpLo::Up, typename Index::Frame,
-    Index::index_type>;
+using change_index_up_lo =
+    TensorIndexType<Index::index_type == IndexType::Spatial ? Index::value
+                                                            : Index::value - 1,
+                    Index::ul == UpLo::Up ? UpLo::Lo : UpLo::Up,
+                    typename Index::Frame, Index::index_type>;
 
 template <typename... Ts>
 using index_list = tmpl::list<Ts...>;

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -33,13 +33,11 @@ namespace tnsr {
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
 using a = Tensor<DataType, tmpl::integral_list<std::int32_t, 1>,
-                 index_list<Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo,
-                                                           Fr, Index>>>;
+                 index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
 using A = Tensor<DataType, tmpl::integral_list<std::int32_t, 1>,
-                 index_list<Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up,
-                                                           Fr, Index>>>;
+                 index_list<TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using i = Tensor<DataType, tmpl::integral_list<std::int32_t, 1>,
                  index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>>>;
@@ -50,32 +48,24 @@ using I = Tensor<DataType, tmpl::integral_list<std::int32_t, 1>,
 // Rank 2
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using ab = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using ab = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+                  index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                             TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using Ab = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using Ab = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+                  index_list<TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                             TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using aB = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
+using aB = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+                  index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                             TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using AB = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
+using AB = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
+                  index_list<TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                             TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using ij = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
                   index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
@@ -94,23 +84,19 @@ using IJ = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
                              SpatialIndex<SpatialDim, UpLo::Up, Fr>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using ia = Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1>,
-index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
-           SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
+                  index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
+                             SpacetimeIndex<SpatialDim, UpLo::Lo, Fr>>>;
 
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using aa = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 1, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using aa = Tensor<DataType, tmpl::integral_list<std::int32_t, 1, 1>,
+                  index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                             TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using AA = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 1, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
+using AA = Tensor<DataType, tmpl::integral_list<std::int32_t, 1, 1>,
+                  index_list<TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                             TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
 using ii = Tensor<DataType, tmpl::integral_list<std::int32_t, 1, 1>,
                   index_list<SpatialIndex<SpatialDim, UpLo::Lo, Fr>,
@@ -123,100 +109,88 @@ using II = Tensor<DataType, tmpl::integral_list<std::int32_t, 1, 1>,
 // Rank 3 - spacetime
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using abc = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using abc =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using abC = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
+using abC =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using aBc = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using aBc =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using Abc = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using Abc =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using aBC = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
+using aBC =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using AbC = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
+using AbC =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using ABc = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using ABc =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using ABC = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
+using ABC =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using abb = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using abb =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using Abb = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using Abb =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using aBB = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
+using aBB =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using ABB = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
+using ABB =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 2, 1, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>>>;
 
 // Rank 3 - spatial
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>
@@ -343,22 +317,20 @@ using ijaa = Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
 // Rank 4 - generic (default spacetime)
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using abcc = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using abcc =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using aBcc = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using aBcc =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 3, 2, 1, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Up, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 
 // Rank 4 - spatial
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial>

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -348,6 +348,7 @@ constexpr CoordinateMap<SourceFrame, TargetFrame, Maps...>::CoordinateMap(
     Maps... maps)
     : maps_(std::move(maps)...) {}
 
+/// \cond
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 template <typename T, size_t... Is>
 constexpr SPECTRE_ALWAYS_INLINE tnsr::I<
@@ -573,6 +574,7 @@ CoordinateMap<SourceFrame, TargetFrame, Maps...>::jacobian_impl(
       maps_);
   return jac;
 }
+/// \endcond
 
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 bool operator!=(

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -83,12 +83,11 @@ static_assert(
         tnsr::ab<double, 3, Frame::Grid>,
         TensorMetafunctions::remove_first_index<Tensor<
             double, tmpl::integral_list<std::int32_t, 2, 2, 1>,
-            index_list<Tensor_detail::TensorIndexType<3, UpLo::Lo, Frame::Grid,
-                                                      IndexType::Spacetime>,
-                       Tensor_detail::TensorIndexType<3, UpLo::Lo, Frame::Grid,
-                                                      IndexType::Spacetime>,
-                       Tensor_detail::TensorIndexType<3, UpLo::Lo, Frame::Grid,
-                                                      IndexType::Spacetime>>>>>,
+            index_list<
+                TensorIndexType<3, UpLo::Lo, Frame::Grid, IndexType::Spacetime>,
+                TensorIndexType<3, UpLo::Lo, Frame::Grid, IndexType::Spacetime>,
+                TensorIndexType<3, UpLo::Lo, Frame::Grid,
+                                IndexType::Spacetime>>>>>,
     "Failed testing remove_first_index");
 static_assert(cpp17::is_same_v<tnsr::aa<double, 3, Frame::Grid>,
                                TensorMetafunctions::remove_first_index<
@@ -198,13 +197,12 @@ static_assert(
 namespace {
 template <typename DataType, size_t SpatialDim, typename Fr = Frame::Inertial,
           IndexType Index = IndexType::Spacetime>
-using abcd = Tensor<
-    DataType, tmpl::integral_list<std::int32_t, 4, 3, 2, 1>,
-    index_list<
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
-        Tensor_detail::TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
+using abcd =
+    Tensor<DataType, tmpl::integral_list<std::int32_t, 4, 3, 2, 1>,
+           index_list<TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>,
+                      TensorIndexType<SpatialDim, UpLo::Lo, Fr, Index>>>;
 
 // Test construction of high-rank, high-dim tensors
 constexpr abcd<double, 7> check_construction{};


### PR DESCRIPTION
## Proposed changes

Hides documentation of internal function, makes a public class show up by not hiding it in a detail namespace.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
