### PR TITLE
Standardize Tags::div interface

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -7,98 +7,88 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
 #include <string>
-#include <tuple>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/Tensor/Metafunctions.hpp"
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits.hpp"
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
 
 /// \cond
+class DataVector;
 template <size_t Dim>
 class Index;
-template <typename DataType, typename Symm, typename IndexList>
-class Tensor;
 template <typename TagsList>
 class Variables;
 
 namespace Tags {
 template <size_t Dim>
 struct Extents;
-template <class TagList>
-struct Variables;
-
-namespace Tags_detail {
-template <typename T, typename S, typename = std::nullptr_t>
-struct div_impl;
-}  // namespace Tags_detail
 /// \endcond
 
 /// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating the divergence
 ///
-/// There are two variants of this tag that change how the derivatives are
-/// computed depending on which is chosen. The simplest is the non-compute
-/// item versions for a Tensor tag. This takes two template parameters:
-/// 1. The tag to wrap
-/// 2. The frame in which the divergence was taken
+/// Prefix indicating the divergence of a Tensor or that a Variables
+/// contains divergences of Tensors.
 ///
-/// The second variant of the divergence tag is a compute item that computes
-/// the divergence in a Frame that is not the logical frame. This compute
-/// item is used by specifying the the list of flux tags to be differentiated,
-/// and the Tag for the inverse Jacobian between the logical frame and the frame
-/// in which the divergence is taken.
-template <typename T, typename S>
-struct div : Tags_detail::div_impl<T, S> {};
+/// \snippet Test_Divergence.cpp divergence_name
+///
+/// \see Tags::ComputeDiv
+template <typename Tag, typename = std::nullptr_t>
+struct div;
+
+/// \cond
+template <typename Tag>
+struct div<Tag, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
+    : db::PrefixTag, db::SimpleTag {
+  static std::string name() noexcept { return "div(" + Tag::name() + ")"; }
+  using tag = Tag;
+  using type = TensorMetafunctions::remove_first_index<db::item_type<Tag>>;
+};
+
+template <typename Tag>
+struct div<Tag, Requires<tt::is_a_v<::Variables, db::item_type<Tag>>>>
+    : db::PrefixTag, db::SimpleTag {
+  static std::string name() noexcept { return "div(" + Tag::name() + ")"; }
+  using tag = Tag;
+  using type = db::item_type<Tag>;
+};
+/// \endcond
 }  // namespace Tags
 
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the (Euclidean) divergence of fluxes
-///
-/// \return a `Variables` with the same structure as `F` and each tag in
-/// `FluxTags` wrapped with a `Tags::div`.
 template <typename FluxTags, size_t Dim, typename DerivativeFrame>
-Variables<db::wrap_tags_in<Tags::div, FluxTags, DerivativeFrame>> divergence(
+Variables<db::wrap_tags_in<Tags::div, FluxTags>> divergence(
     const Variables<FluxTags>& F, const Index<Dim>& extents,
     const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept;
 
 namespace Tags {
-namespace Tags_detail {
-template <typename Tag, typename Frame>
-struct div_impl<Tag, Frame, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::PrefixTag, db::SimpleTag {
-  static_assert(
-      cpp17::is_same_v<Frame,
-                       std::tuple_element_t<
-                           0, decltype(db::item_type<Tag>::index_frames())>>,
-      "the first index is not in the specified Frame");
-  using type = TensorMetafunctions::remove_first_index<db::item_type<Tag>>;
-  using tag = Tag;
-  static std::string name() noexcept { return "div"; }
-};
-
-template <typename... FluxTags, typename InverseJacobianTag>
-struct div_impl<tmpl::list<FluxTags...>, InverseJacobianTag,
-                Requires<tt::is_a_v<Tensor, db::item_type<InverseJacobianTag>>>>
-    : db::ComputeTag {
+/// \ingroup DataBoxTagsGroup
+/// \brief Compute the divergence of a Variables
+///
+/// Computes the divergence of the Tensors in the Variables
+/// represented by `Tag` in the frame mapped to by
+/// `InverseJacobianTag`.  The map must map from the logical frame.
+///
+/// This tag inherits from `db::add_prefix_tag<Tags::div, Tag>`.
+template <typename Tag, typename InverseJacobianTag>
+struct ComputeDiv : db::add_tag_prefix<div, Tag>, db::ComputeTag {
  private:
-  using derivative_frame_index =
-      tmpl::back<typename db::item_type<InverseJacobianTag>::index_list>;
-  using flux_tags = tmpl::list<FluxTags...>;
+  using inv_jac_indices =
+      typename db::item_type<InverseJacobianTag>::index_list;
+  static constexpr auto dim = tmpl::back<inv_jac_indices>::dim;
+  static_assert(cpp17::is_same_v<typename tmpl::front<inv_jac_indices>::Frame,
+                                 Frame::Logical>,
+                "Must map from the logical frame.");
 
  public:
-  static std::string name() noexcept { return "div"; }
   static constexpr auto function =
-      divergence<flux_tags, derivative_frame_index::dim,
-                 typename derivative_frame_index::Frame>;
-  using argument_tags = tmpl::list<Tags::Variables<flux_tags>,
-                                   Tags::Extents<derivative_frame_index::dim>,
-                                   InverseJacobianTag>;
+      divergence<typename db::item_type<Tag>::tags_list, dim,
+                 typename tmpl::back<inv_jac_indices>::Frame>;
+  using argument_tags = tmpl::list<Tag, Tags::Extents<dim>, InverseJacobianTag>;
 };
-}  // namespace Tags_detail
 }  // namespace Tags


### PR DESCRIPTION
This makes the Variables and Tensor versions' interfaces match so that
they can be used with the standard prefixing infrastructure.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
