### PR TITLE
Add function to compute primitive variables from conservatives

### DIFF
--- a/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   ConservativeFromPrimitive.cpp
   Equations.cpp
   Fluxes.cpp
+  PrimitiveFromConservative.cpp
   )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
@@ -1,0 +1,181 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp"
+
+#include <cmath>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/RootFinding/TOMS748.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Overloader.hpp"
+
+// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+
+/// \cond
+namespace RelativisticEuler {
+namespace Valencia {
+
+namespace {
+
+template <typename DataType, size_t ThermodynamicDim>
+class FunctionOfZ {
+ public:
+  FunctionOfZ(const Scalar<DataType>& tilde_d,
+              const Scalar<DataType>& tilde_tau,
+              const Scalar<DataType>& tilde_s_magnitude,
+              const Scalar<DataType>& sqrt_det_spatial_metric,
+              const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+                  equation_of_state) noexcept
+      : tilde_d_(tilde_d),
+        tilde_tau_(tilde_tau),
+        tilde_s_magnitude_(tilde_s_magnitude),
+        sqrt_det_spatial_metric_(sqrt_det_spatial_metric),
+        equation_of_state_(equation_of_state) {}
+
+  double operator()(const double z, const size_t i = 0) const noexcept {
+    const double r =
+        get_element(get(tilde_s_magnitude_), i) / get_element(get(tilde_d_), i);
+    const double q =
+        get_element(get(tilde_tau_), i) / get_element(get(tilde_d_), i);
+    const double W = sqrt(1.0 + square(z));
+    const double rho = get_element(get(tilde_d_), i) /
+                       (W * get_element(get(sqrt_det_spatial_metric_), i));
+    // Note z^2/(1+W) is numerically more accurate than W-1 for small
+    // velocities.
+    const double epsilon = W * q - z * r + square(z) / (1.0 + W);
+    const double e = rho * (1.0 + epsilon);
+
+    const double pressure =
+        make_overloader(
+            [&rho](const EquationsOfState::EquationOfState<true, 1>&
+                       equation_of_state) noexcept {
+              return equation_of_state.pressure_from_density(
+                  Scalar<double>(rho));
+            },
+            [&rho, &epsilon ](const EquationsOfState::EquationOfState<true, 2>&
+                                  equation_of_state) noexcept {
+              return equation_of_state.pressure_from_density(
+                  Scalar<double>(rho), Scalar<double>(epsilon));
+            })(equation_of_state_)
+            .get();
+
+    const double a = pressure / e;
+    const double h = (1.0 + epsilon) * (1.0 + a);
+    return z - r / h;
+  }
+
+ private:
+  const Scalar<DataType>& tilde_d_;
+  const Scalar<DataType>& tilde_tau_;
+  const Scalar<DataType>& tilde_s_magnitude_;
+  const Scalar<DataType>& sqrt_det_spatial_metric_;
+  const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+      equation_of_state_;
+};
+}  // namespace
+
+template <size_t ThermodynamicDim, typename DataType, size_t Dim>
+void primitive_from_conservative(
+    const gsl::not_null<Scalar<DataType>*> rest_mass_density,
+    const gsl::not_null<Scalar<DataType>*> specific_internal_energy,
+    const gsl::not_null<Scalar<DataType>*> lorentz_factor,
+    const gsl::not_null<Scalar<DataType>*> specific_enthalpy,
+    const gsl::not_null<Scalar<DataType>*> pressure,
+    const gsl::not_null<tnsr::I<DataType, Dim, Frame::Inertial>*>
+        spatial_velocity,
+    const Scalar<DataType>& tilde_d, const Scalar<DataType>& tilde_tau,
+    const tnsr::i<DataType, Dim, Frame::Inertial>& tilde_s,
+    const tnsr::II<DataType, Dim, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) noexcept {
+  const auto tilde_s_M = raise_or_lower_index(tilde_s, inv_spatial_metric);
+  const Scalar<DataType> tilde_s_magnitude{
+      sqrt(get(dot_product(tilde_s, tilde_s_M)))};
+
+  // find z via root find
+  // k not const to save allocation later
+  DataType k = get(tilde_s_magnitude) / (get(tilde_tau) + get(tilde_d));
+  const DataType lower_bound = 0.5 * k / sqrt(1.0 - 0.25 * square(k));
+  const DataType upper_bound = k / sqrt(1.0 - square(k));
+  const auto f_of_z = FunctionOfZ<DataType, ThermodynamicDim>{
+      tilde_d, tilde_tau, tilde_s_magnitude, sqrt_det_spatial_metric,
+      equation_of_state};
+
+  const auto z =
+      // NOLINTNEXTLINE(clang-analyzer-core)
+      RootFinder::toms748(f_of_z, lower_bound, upper_bound,
+                          10.0 * std::numeric_limits<double>::epsilon(),
+                          10.0 * std::numeric_limits<double>::epsilon(), 100);
+  get(*lorentz_factor) = sqrt(1.0 + square(z));
+  get(*rest_mass_density) =
+      get(tilde_d) / (get(*lorentz_factor) * get(sqrt_det_spatial_metric));
+  get(*specific_internal_energy) =
+      (get(*lorentz_factor) * get(tilde_tau) - z * get(tilde_s_magnitude)) /
+          get(tilde_d) +
+      square(z) / (1.0 + get(*lorentz_factor));
+
+  *pressure = make_overloader(
+      [&rest_mass_density](const EquationsOfState::EquationOfState<true, 1>&
+                               the_equation_of_state) noexcept {
+        return the_equation_of_state.pressure_from_density(*rest_mass_density);
+      },
+      [&rest_mass_density, &specific_internal_energy ](
+          const EquationsOfState::EquationOfState<true, 2>&
+              the_equation_of_state) noexcept {
+        return the_equation_of_state.pressure_from_density(
+            *rest_mass_density, *specific_internal_energy);
+      })(equation_of_state);
+
+  get(*specific_enthalpy) = 1.0 + get(*specific_internal_energy) +
+                            get(*pressure) / get(*rest_mass_density);
+
+  // reuse k as a temporary
+  DataType denominator = std::move(k);
+  denominator = get(tilde_d) * get(*lorentz_factor) * get(*specific_enthalpy);
+  for (size_t d = 0; d < Dim; ++d) {
+    spatial_velocity->get(d) = tilde_s_M.get(d) / denominator;
+  }
+}
+
+}  // namespace Valencia
+}  // namespace RelativisticEuler
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define THERMODIM(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATION(_, data)                                               \
+  template void                                                              \
+  RelativisticEuler::Valencia::primitive_from_conservative<THERMODIM(data)>( \
+      const gsl::not_null<Scalar<DTYPE(data)>*> rest_mass_density,           \
+      const gsl::not_null<Scalar<DTYPE(data)>*> specific_internal_energy,    \
+      const gsl::not_null<Scalar<DTYPE(data)>*> lorentz_factor,              \
+      const gsl::not_null<Scalar<DTYPE(data)>*> specific_enthalpy,           \
+      const gsl::not_null<Scalar<DTYPE(data)>*> pressure,                    \
+      const gsl::not_null<tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>*> \
+          spatial_velocity,                                                  \
+      const Scalar<DTYPE(data)>& tilde_d,                                    \
+      const Scalar<DTYPE(data)>& tilde_tau,                                  \
+      const tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>& tilde_s,       \
+      const tnsr::II<DTYPE(data), DIM(data), Frame::Inertial>&               \
+          inv_spatial_metric,                                                \
+      const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                    \
+      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&        \
+          equation_of_state) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (double, DataVector), (1, 2, 3), (1, 2))
+
+#undef INSTANTIATION
+#undef THERMODIM
+#undef DIM
+#undef DTYPE
+/// \endcond

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/EquationsOfState/EquationOfState.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+
+namespace RelativisticEuler {
+namespace Valencia {
+
+/*!
+ * \brief Compute the primitive variables from the conservative variables
+ *
+ * For the Valencia formulation of the Relativistic Euler system, the conversion
+ * of the evolved conserved variables to the primitive variables cannot
+ * be expressed in closed analytic form and requires a root find.  We use
+ * the method from [Appendix C of Galeazzi \em et \em al, PRD 88, 064009 (2013)]
+ * (https://journals.aps.org/prd/abstract/10.1103/PhysRevD.88.064009).  The
+ * method finds the root of \f[ f(z) = z - \frac{r}{h(z)} \f] where
+ * \f{align*}
+ * r = & \frac{\sqrt{\gamma^{mn} {\tilde S}_m {\tilde S}_n}}{\tilde D} \\
+ * h(z) = & [1+ \epsilon(z)][1 + a(z)] \\
+ * \epsilon(z) = & W(z) q - z r + \frac{z^2}{1 + W(z)} \\
+ * W(z) = & \sqrt{1 + z^2} \\
+ * q = & \frac{\tilde \tau}{\tilde D} \\
+ * a(z) = & \frac{p}{\rho(z) [1 + \epsilon(z)]} \\
+ * \rho(z) = & \frac{\tilde D}{\sqrt{\gamma} W(z)}
+ * \f}
+ * and where the conserved variables \f${\tilde D}\f$, \f${\tilde S}_i\f$, and
+ * \f${\tilde \tau}\f$ are a generalized mass-energy density, momentum density,
+ * and specific internal energy density as measured by an Eulerian observer,
+ * \f$\gamma\f$ and \f$\gamma^{mn}\f$ are the determinant and inverse of the
+ * spatial metric \f$\gamma_{mn}\f$, \f$\rho\f$ is the rest mass density, \f$W =
+ * 1/\sqrt{1 - \gamma_{mn} v^m v^n}\f$ is the Lorentz factor, \f$h = 1 +
+ * \epsilon + \frac{p}{\rho}\f$ is the specific enthalpy, \f$v^i\f$ is the
+ * spatial velocity, \f$\epsilon\f$ is the specific internal energy, and \f$p\f$
+ * is the pressure.  The pressure is determined from the equation of state.
+ * Finally, once \f$z\f$ is found, the spatial velocity is given by \f[ v^i =
+ * \frac{{\tilde S}^i}{{\tilde D} W(z) h(z)} \f]
+ *
+ * \todo The method also will make corrections if physical bounds are violated,
+ * see the paper for details.
+ */
+template <size_t ThermodynamicDim, typename DataType, size_t Dim>
+void primitive_from_conservative(
+    gsl::not_null<Scalar<DataType>*> rest_mass_density,
+    gsl::not_null<Scalar<DataType>*> specific_internal_energy,
+    gsl::not_null<Scalar<DataType>*> lorentz_factor,
+    gsl::not_null<Scalar<DataType>*> specific_enthalpy,
+    gsl::not_null<Scalar<DataType>*> pressure,
+    gsl::not_null<tnsr::I<DataType, Dim, Frame::Inertial>*> spatial_velocity,
+    const Scalar<DataType>& tilde_d, const Scalar<DataType>& tilde_tau,
+    const tnsr::i<DataType, Dim, Frame::Inertial>& tilde_s,
+    const tnsr::II<DataType, Dim, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) noexcept;
+}  // namespace Valencia
+}  // namespace RelativisticEuler

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,3 +2,4 @@
 # See LICENSE.txt for details.
 
 add_subdirectory(Unit)
+add_subdirectory(Utilities)

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_ConservativeFromPrimitive.cpp
   Test_Equations.cpp
   Test_Fluxes.cpp
+  Test_PrimitiveFromConservative.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
@@ -1,0 +1,235 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.hpp"
+#include "PointwiseFunctions/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Overloader.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+#include "tests/Utilities/RandomUnitNormal.hpp"
+
+// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+
+namespace {
+
+template <typename DataType>
+Scalar<DataType> random_density(const gsl::not_null<std::mt19937*> generator,
+                                const DataType& used_for_size) noexcept {
+  // 1 g/cm^3 = 1.62e-18 in geometric units
+  constexpr double minimum_density = 1.0e-5;
+  constexpr double maximum_density = 1.0e-3;
+  std::uniform_real_distribution<> distribution(log(minimum_density),
+                                                log(maximum_density));
+  return Scalar<DataType>{exp(make_with_random_values<DataType>(
+      generator, make_not_null(&distribution), used_for_size))};
+}
+
+template <typename DataType>
+Scalar<DataType> random_lorentz_factor(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-10.0, 3.0);
+  return Scalar<DataType>{
+      1.0 + exp(make_with_random_values<DataType>(
+                generator, make_not_null(&distribution), used_for_size))};
+}
+
+template <typename DataType, size_t Dim>
+tnsr::I<DataType, Dim> random_velocity(
+    const gsl::not_null<std::mt19937*> generator,
+    const Scalar<DataType>& lorentz_factor,
+    const tnsr::ii<DataType, Dim>& spatial_metric) noexcept {
+  tnsr::I<DataType, Dim> spatial_velocity =
+      random_unit_normal(generator, spatial_metric);
+  const DataType v = sqrt(1.0 - 1.0 / square(get(lorentz_factor)));
+  for (size_t d = 0; d < Dim; ++d) {
+    spatial_velocity.get(d) *= v;
+  }
+  return spatial_velocity;
+}
+
+// temperature in MeV
+template <typename DataType>
+Scalar<DataType> random_temperature(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  constexpr double minimum_temperature = 1.0;
+  constexpr double maximum_temperature = 50.0;
+  std::uniform_real_distribution<> distribution(log(minimum_temperature),
+                                                log(maximum_temperature));
+  return Scalar<DataType>{exp(make_with_random_values<DataType>(
+      generator, make_not_null(&distribution), used_for_size))};
+}
+
+template <typename DataType>
+Scalar<DataType> random_specific_internal_energy(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  // assumes Ideal gas with gamma = 4/3
+  // For ideal fluid T = (m/k_b)(gamma - 1) epsilon
+  // where m = atomic mass unit, k_b = Boltzmann constant
+  return Scalar<DataType>{3.21e-3 *
+                          get(random_temperature(generator, used_for_size))};
+}
+
+template <typename DataType>
+Scalar<DataType> specific_enthalpy(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const Scalar<DataType>& pressure) noexcept {
+  return Scalar<DataType>{1.0 + get(specific_internal_energy) +
+                          get(pressure) / get(rest_mass_density)};
+}
+
+template <typename DataType, size_t Dim>
+tnsr::ii<DataType, Dim> random_spatial_metric(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-0.05, 0.05);
+  auto spatial_metric = make_with_random_values<tnsr::ii<DataType, Dim>>(
+      generator, make_not_null(&distribution), used_for_size);
+  for (size_t d = 0; d < Dim; ++d) {
+    spatial_metric.get(d, d) += 1.0;
+  }
+  return spatial_metric;
+}
+
+template <size_t Dim, size_t ThermodynamicDim, typename DataType>
+void test_primitive_from_conservative(
+    const gsl::not_null<std::mt19937*> generator,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state,
+    const DataType& used_for_size) noexcept {
+  const auto expected_rest_mass_density =
+      random_density(generator, used_for_size);
+  const auto expected_lorentz_factor =
+      random_lorentz_factor(generator, used_for_size);
+  const auto spatial_metric =
+      random_spatial_metric<DataType, Dim>(generator, used_for_size);
+  const auto expected_spatial_velocity =
+      random_velocity(generator, expected_lorentz_factor, spatial_metric);
+  const auto expected_specific_internal_energy = make_overloader(
+      [&expected_rest_mass_density](
+          const EquationsOfState::EquationOfState<true, 1>&
+              the_equation_of_state) noexcept {
+        return the_equation_of_state.specific_internal_energy_from_density(
+            expected_rest_mass_density);
+      },
+      [&generator,
+       &used_for_size ](const EquationsOfState::EquationOfState<true, 2>&
+                        /*the_equation_of_state*/) noexcept {
+        // note this call assumes an ideal fluid
+        return random_specific_internal_energy(generator, used_for_size);
+      })(equation_of_state);
+  const auto expected_pressure = make_overloader(
+      [&expected_rest_mass_density](
+          const EquationsOfState::EquationOfState<true, 1>&
+              the_equation_of_state) noexcept {
+        return the_equation_of_state.pressure_from_density(
+            expected_rest_mass_density);
+      },
+      [&expected_rest_mass_density, &expected_specific_internal_energy ](
+          const EquationsOfState::EquationOfState<true, 2>&
+              the_equation_of_state) noexcept {
+        return the_equation_of_state.pressure_from_density(
+            expected_rest_mass_density, expected_specific_internal_energy);
+      })(equation_of_state);
+
+  const auto expected_specific_enthalpy =
+      specific_enthalpy(expected_rest_mass_density,
+                        expected_specific_internal_energy, expected_pressure);
+
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& inv_spatial_metric = det_and_inv.second;
+  const Scalar<DataType> sqrt_det_spatial_metric =
+      Scalar<DataType>{sqrt(get(det_and_inv.first))};
+  const auto spatial_velocity_oneform =
+      raise_or_lower_index(expected_spatial_velocity, spatial_metric);
+  const auto spatial_velocity_squared =
+      dot_product(spatial_velocity_oneform, expected_spatial_velocity);
+
+  auto tilde_d = make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+  auto tilde_tau = make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+  auto tilde_s = make_with_value<tnsr::i<DataType, Dim>>(used_for_size, 0.0);
+
+  RelativisticEuler::Valencia::conservative_from_primitive(
+      make_not_null(&tilde_d), make_not_null(&tilde_tau),
+      make_not_null(&tilde_s), expected_rest_mass_density,
+      expected_specific_internal_energy, spatial_velocity_oneform,
+      spatial_velocity_squared, expected_lorentz_factor,
+      expected_specific_enthalpy, expected_pressure, sqrt_det_spatial_metric);
+
+  auto rest_mass_density =
+      make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+  auto specific_internal_energy =
+      make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+  auto lorentz_factor = make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+  auto specific_enthalpy =
+      make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+  auto pressure = make_with_value<Scalar<DataType>>(used_for_size, 0.0);
+  auto spatial_velocity =
+      make_with_value<tnsr::I<DataType, Dim>>(used_for_size, 0.0);
+
+  RelativisticEuler::Valencia::primitive_from_conservative<ThermodynamicDim>(
+      make_not_null(&rest_mass_density),
+      make_not_null(&specific_internal_energy), make_not_null(&lorentz_factor),
+      make_not_null(&specific_enthalpy), make_not_null(&pressure),
+      make_not_null(&spatial_velocity), tilde_d, tilde_tau, tilde_s,
+      inv_spatial_metric, sqrt_det_spatial_metric, equation_of_state);
+
+  Approx larger_approx =
+      Approx::custom().epsilon(std::numeric_limits<double>::epsilon() * 1.e6);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_rest_mass_density, rest_mass_density,
+                               larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_specific_internal_energy,
+                               specific_internal_energy, larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_lorentz_factor, lorentz_factor,
+                               larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_specific_enthalpy, specific_enthalpy,
+                               larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_pressure, pressure, larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_spatial_velocity, spatial_velocity,
+                               larger_approx);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.RelativisticEuler.Valencia.PrimitiveFromConservative",
+                  "[Unit][RelativisticEuler]") {
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed = " << seed);
+
+  EquationsOfState::PolytropicFluid<true> polytropic_fluid(100.0, 2.0);
+  EquationsOfState::IdealFluid<true> ideal_fluid(4.0 / 3.0);
+  const double d = std::numeric_limits<double>::signaling_NaN();
+  test_primitive_from_conservative<1, 1>(&generator, polytropic_fluid, d);
+  test_primitive_from_conservative<2, 1>(&generator, polytropic_fluid, d);
+  test_primitive_from_conservative<3, 1>(&generator, polytropic_fluid, d);
+  test_primitive_from_conservative<1, 2>(&generator, ideal_fluid, d);
+  test_primitive_from_conservative<2, 2>(&generator, ideal_fluid, d);
+  test_primitive_from_conservative<3, 2>(&generator, ideal_fluid, d);
+
+  const DataVector dv(5);
+  test_primitive_from_conservative<1, 1>(&generator, polytropic_fluid, dv);
+  test_primitive_from_conservative<2, 1>(&generator, polytropic_fluid, dv);
+  test_primitive_from_conservative<3, 1>(&generator, polytropic_fluid, dv);
+  test_primitive_from_conservative<1, 2>(&generator, ideal_fluid, dv);
+  test_primitive_from_conservative<2, 2>(&generator, ideal_fluid, dv);
+  test_primitive_from_conservative<3, 2>(&generator, ideal_fluid, dv);
+}

--- a/tests/Unit/TestUtilities/CMakeLists.txt
+++ b/tests/Unit/TestUtilities/CMakeLists.txt
@@ -5,11 +5,12 @@ set(LIBRARY "Test_TestUtilities")
 
 set(LIBRARY_SOURCES
   Test_MakeWithRandomValues.cpp
+  Test_RandomUnitNormal.cpp
   )
 
 add_test_library(
   ${LIBRARY}
   "TestUtilities"
   "${LIBRARY_SOURCES}"
-  "DataStructures"
+  "DataStructures;TestUtilities"
   )

--- a/tests/Unit/TestUtilities/Test_RandomUnitNormal.cpp
+++ b/tests/Unit/TestUtilities/Test_RandomUnitNormal.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+#include "tests/Utilities/RandomUnitNormal.hpp"
+
+namespace {
+
+template <typename DataType, size_t Dim>
+tnsr::ii<DataType, Dim> random_spatial_metric(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataType& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-0.05, 0.05);
+  auto spatial_metric = make_with_random_values<tnsr::ii<DataType, Dim>>(
+      generator, make_not_null(&distribution), used_for_size);
+  for (size_t d = 0; d < Dim; ++d) {
+    spatial_metric.get(d, d) += 1.0;
+  }
+  return spatial_metric;
+}
+
+template <size_t Dim, typename DataType>
+void test_random_unit_normal(const gsl::not_null<std::mt19937*> generator,
+                             const DataType& used_for_size) noexcept {
+  const auto spatial_metric =
+      random_spatial_metric<DataType, Dim>(generator, used_for_size);
+  const auto unit_normal = random_unit_normal(generator, spatial_metric);
+  const auto expected_magnitude =
+      make_with_value<Scalar<DataType>>(used_for_size, 1.0);
+  const auto magnitude_of_unit_normal = magnitude(unit_normal, spatial_metric);
+  CHECK_ITERABLE_APPROX(expected_magnitude, magnitude_of_unit_normal);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Test.TestHelpers.RandomUnitNormal", "[Unit]") {
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed = " << seed);
+
+  const double d = std::numeric_limits<double>::signaling_NaN();
+  test_random_unit_normal<1>(&generator, d);
+  test_random_unit_normal<2>(&generator, d);
+  test_random_unit_normal<3>(&generator, d);
+
+  const DataVector dv(5);
+  test_random_unit_normal<1>(&generator, dv);
+  test_random_unit_normal<2>(&generator, dv);
+  test_random_unit_normal<3>(&generator, dv);
+}

--- a/tests/Utilities/CMakeLists.txt
+++ b/tests/Utilities/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "TestUtilities")
+
+set(LIBRARY_SOURCES
+  RandomUnitNormal.cpp
+  )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/tests/Utilities/RandomUnitNormal.cpp
+++ b/tests/Utilities/RandomUnitNormal.cpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Utilities/RandomUnitNormal.hpp"
+
+#include <cmath>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+/// \cond
+template <typename DataType>
+tnsr::I<DataType, 1> random_unit_normal(
+    const gsl::not_null<std::mt19937*> generator,
+    const tnsr::ii<DataType, 1>& spatial_metric) noexcept {
+  std::uniform_int_distribution<> distribution(0, 1);
+  auto unit_normal = make_with_value<tnsr::I<DataType, 1>>(
+      spatial_metric, 1.0 - 2.0 * distribution(*generator));
+  get<0>(unit_normal) /= get(magnitude(unit_normal, spatial_metric));
+  return unit_normal;
+}
+
+template <typename DataType>
+tnsr::I<DataType, 2> random_unit_normal(
+    const gsl::not_null<std::mt19937*> generator,
+    const tnsr::ii<DataType, 2>& spatial_metric) noexcept {
+  std::uniform_real_distribution<> distribution(-M_PI, M_PI);
+  // non-const to reuse allocation
+  auto phi = make_with_random_values<DataType>(
+      generator, make_not_null(&distribution), spatial_metric);
+  auto unit_normal = make_with_value<tnsr::I<DataType, 2>>(spatial_metric, 1.0);
+  get<0>(unit_normal) *= cos(phi);
+  get<1>(unit_normal) *= sin(phi);
+  DataType one_over_magnitude = std::move(phi);
+  one_over_magnitude = 1.0 / get(magnitude(unit_normal, spatial_metric));
+  get<0>(unit_normal) *= one_over_magnitude;
+  get<1>(unit_normal) *= one_over_magnitude;
+  return unit_normal;
+}
+
+template <typename DataType>
+tnsr::I<DataType, 3> random_unit_normal(
+    const gsl::not_null<std::mt19937*> generator,
+    const tnsr::ii<DataType, 3>& spatial_metric) noexcept {
+  std::uniform_real_distribution<> nz_distribution(-1.0, 1.0);
+  // non-const to reuse allocation
+  auto nz = make_with_random_values<DataType>(
+      generator, make_not_null(&nz_distribution), spatial_metric);
+  const DataType rho = sqrt(1.0 - square(nz));
+  std::uniform_real_distribution<> phi_distribution(-M_PI, M_PI);
+  const auto phi = make_with_random_values<DataType>(
+      generator, make_not_null(&phi_distribution), spatial_metric);
+  auto unit_normal = make_with_value<tnsr::I<DataType, 3>>(spatial_metric, 0.0);
+  get<0>(unit_normal) = rho * cos(phi);
+  get<1>(unit_normal) = rho * sin(phi);
+  get<2>(unit_normal) = nz;
+  DataType one_over_magnitude = std::move(nz);
+  one_over_magnitude = 1.0 / get(magnitude(unit_normal, spatial_metric));
+  get<0>(unit_normal) *= one_over_magnitude;
+  get<1>(unit_normal) *= one_over_magnitude;
+  get<2>(unit_normal) *= one_over_magnitude;
+  return unit_normal;
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(_, data)                                 \
+  template tnsr::I<DTYPE(data), DIM(data)> random_unit_normal( \
+      const gsl::not_null<std::mt19937*> generator,            \
+      const tnsr::ii<DTYPE(data), DIM(data)>& spatial_metric) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (double, DataVector), (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+#undef DTYPE
+/// \endcond

--- a/tests/Utilities/RandomUnitNormal.cpp
+++ b/tests/Utilities/RandomUnitNormal.cpp
@@ -4,11 +4,11 @@
 #include "tests/Utilities/RandomUnitNormal.hpp"
 
 #include <cmath>
-#include <utility>
 
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
-#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"

--- a/tests/Utilities/RandomUnitNormal.hpp
+++ b/tests/Utilities/RandomUnitNormal.hpp
@@ -18,15 +18,15 @@ class not_null;
 /// \brief Make a random unit normal vector at each element of `DataType`.
 template <typename DataType>
 tnsr::I<DataType, 1> random_unit_normal(
-    const gsl::not_null<std::mt19937*> generator,
+    gsl::not_null<std::mt19937*> generator,
     const tnsr::ii<DataType, 1>& spatial_metric) noexcept;
 
 template <typename DataType>
 tnsr::I<DataType, 2> random_unit_normal(
-    const gsl::not_null<std::mt19937*> generator,
+    gsl::not_null<std::mt19937*> generator,
     const tnsr::ii<DataType, 2>& spatial_metric) noexcept;
 
 template <typename DataType>
 tnsr::I<DataType, 3> random_unit_normal(
-    const gsl::not_null<std::mt19937*> generator,
+    gsl::not_null<std::mt19937*> generator,
     const tnsr::ii<DataType, 3>& spatial_metric) noexcept;

--- a/tests/Utilities/RandomUnitNormal.hpp
+++ b/tests/Utilities/RandomUnitNormal.hpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <random>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Make a random unit normal vector at each element of `DataType`.
+template <typename DataType>
+tnsr::I<DataType, 1> random_unit_normal(
+    const gsl::not_null<std::mt19937*> generator,
+    const tnsr::ii<DataType, 1>& spatial_metric) noexcept;
+
+template <typename DataType>
+tnsr::I<DataType, 2> random_unit_normal(
+    const gsl::not_null<std::mt19937*> generator,
+    const tnsr::ii<DataType, 2>& spatial_metric) noexcept;
+
+template <typename DataType>
+tnsr::I<DataType, 3> random_unit_normal(
+    const gsl::not_null<std::mt19937*> generator,
+    const tnsr::ii<DataType, 3>& spatial_metric) noexcept;


### PR DESCRIPTION
## Proposed changes

This adds the function to compute primitive variables from the conservative variables of the Valencia formulation.  It only does the actual inversion, it does not include fixing unphysical variables.  Variable fixing will be added in a subsequent pull request.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
