### PR TITLE
Boundary items

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -132,6 +132,18 @@ struct InternalDirections : db::ComputeTag {
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
+/// The set of directions which correspond to external boundaries
+template <size_t VolumeDim>
+struct BoundaryDirections : db::ComputeTag {
+  static std::string name() noexcept { return "BoundaryDirections"; }
+  using argument_tags = tmpl::list<Element<VolumeDim>>;
+  static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
+    return element.external_boundaries();
+  }
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
 /// Base type for the Interface tag.  Exposed so that specializations
 /// can reuse the implementation.
 /// \tparam DirectionsTag the item of directions

--- a/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
@@ -87,6 +87,9 @@ struct InitializeElement {
   template <typename Tag>
   using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
 
+  template <typename Tag>
+  using boundary_tag = Tags::Interface<Tags::BoundaryDirections<Dim>, Tag>;
+
   template <class Metavariables>
   using return_tag_list = tmpl::list<
       // Simple items
@@ -118,7 +121,14 @@ struct InitializeElement {
       // System::normal_dot_fluxes::argument_tags, but it is not clear
       // how to get that.  System::variables_tag should generally be a
       // superset.
-      interface_tag<typename Metavariables::system::variables_tag>>;
+      interface_tag<typename Metavariables::system::variables_tag>,
+      Tags::BoundaryDirections<Dim>, boundary_tag<Tags::Direction<Dim>>,
+      boundary_tag<Tags::Extents<Dim - 1>>,
+      boundary_tag<Tags::UnnormalizedFaceNormal<Dim>>,
+      boundary_tag<typename Metavariables::system::template magnitude_tag<
+          Tags::UnnormalizedFaceNormal<Dim>>>,
+      boundary_tag<Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>,
+      boundary_tag<typename Metavariables::system::variables_tag>>;
 
   template <typename... InboxTags, typename Metavariables, typename ActionList,
             typename ParallelComponent>

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -107,6 +107,9 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
   using boundary_directions = Tags::BoundaryDirections<dim>;
   using templated_directions = TestTags::TemplatedDirections<int>;
 
+  CHECK(internal_directions::name() == "InternalDirections");
+  CHECK(boundary_directions::name() == "BoundaryDirections");
+
   Element<dim> element{ElementId<3>(0),
                        {{Direction<dim>::lower_xi(), {}},
                         {Direction<dim>::upper_xi(), {}},

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -226,6 +226,15 @@ void test_initialize_element(const ElementId<Dim>& element_id,
       Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>(box);
   (void)db::get<Tags::Interface<Tags::InternalDirections<Dim>,
                                 typename System<Dim>::variables_tag>>(box);
+  (void)db::get<Tags::Interface<Tags::BoundaryDirections<Dim>,
+                                Tags::UnnormalizedFaceNormal<Dim>>>(box);
+  (void)db::get<Tags::Interface<Tags::BoundaryDirections<Dim>, magnitude_tag>>(
+      box);
+  (void)db::get<Tags::Interface<
+      Tags::BoundaryDirections<Dim>,
+      Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>(box);
+  (void)db::get<Tags::Interface<Tags::BoundaryDirections<Dim>,
+                                typename System<Dim>::variables_tag>>(box);
 }
 }  // namespace
 


### PR DESCRIPTION
## Proposed changes

Adds `BoundaryDirections` Tag so that interface items works on external boundaries of Elements. 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
