### PR TITLE
Conservative actions

### DIFF
--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -59,6 +59,17 @@ struct Flux<Tag, VolumeDim, Fr,
 /// \endcond
 
 /// \ingroup DataBoxTagsGroup
+/// \brief Prefix indicating a source term
+///
+/// \snippet Test_DataBoxPrefixes.cpp source_name
+template <typename Tag>
+struct Source : db::PrefixTag, db::SimpleTag {
+  using type = db::item_type<Tag>;
+  using tag = Tag;
+  static std::string name() noexcept { return "Source(" + Tag::name() + ")"; }
+};
+
+/// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a boundary unit normal vector dotted into
 /// the flux
 template <typename Tag>

--- a/src/Evolution/Actions/ComputeVolumeFluxes.hpp
+++ b/src/Evolution/Actions/ComputeVolumeFluxes.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \brief Compute the volume fluxes of the evolved variables
+///
+/// Uses:
+/// - DataBox: Items in system::volume_fluxes::argument_tags
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   db::add_tag_prefix<Tags::Flux, variables_tag,
+///                      tmpl::size_t<system::volume_dim>, Frame::Inertial>
+struct ComputeVolumeFluxes {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::size<DbTagsList>::value != 0> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using system = typename Metavariables::system;
+    using variables_tag = typename system::variables_tag;
+    db::mutate_apply<db::split_tag<db::add_tag_prefix<
+                         Tags::Flux, variables_tag,
+                         tmpl::size_t<system::volume_dim>, Frame::Inertial>>,
+                     typename system::volume_fluxes::argument_tags>(
+        typename system::volume_fluxes{}, make_not_null(&box));
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions

--- a/src/Evolution/Actions/ComputeVolumeSources.hpp
+++ b/src/Evolution/Actions/ComputeVolumeSources.hpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \brief Compute the volume sources of the evolved variables
+///
+/// Uses:
+/// - DataBox: Items in system::volume_sources::argument_tags
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies: db::wrap_tags_in<Tags::Source, sourced_variables>
+struct ComputeVolumeSources {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::size<DbTagsList>::value != 0> = nullptr>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using system = typename Metavariables::system;
+    db::mutate_apply<
+        db::wrap_tags_in<Tags::Source, typename system::sourced_variables>,
+        typename system::volume_sources::argument_tags>(
+        typename system::volume_sources{}, make_not_null(&box));
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_DataStructures")
 set(LIBRARY_SOURCES
   Test_BaseTags.cpp
   Test_DataBox.cpp
+  Test_DataBoxPrefixes.cpp
   Test_DataBoxTag.cpp
   Test_DataVector.cpp
   Test_Deferred.cpp

--- a/tests/Unit/DataStructures/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/Test_DataBoxPrefixes.cpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+
+namespace {
+struct Tag : db::SimpleTag {
+  static std::string name() noexcept { return "Tag"; }
+  using type = double;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
+                  "[Unit][DataStructures]") {
+  /// [source_name]
+  CHECK(Tags::Source<Tag>::name() == "Source(" + Tag::name() + ")");
+  /// [source_name]
+}

--- a/tests/Unit/Evolution/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Actions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_EvolutionActions")
 
 set(LIBRARY_SOURCES
   Test_ComputeVolumeDuDt.cpp
+  Test_ComputeVolumeFluxes.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Actions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Actions/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_EvolutionActions")
 set(LIBRARY_SOURCES
   Test_ComputeVolumeDuDt.cpp
   Test_ComputeVolumeFluxes.cpp
+  Test_ComputeVolumeSources.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
@@ -1,0 +1,82 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Evolution/Actions/ComputeVolumeFluxes.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+constexpr size_t dim = 2;
+
+struct Var1 : db::SimpleTag {
+  static std::string name() noexcept { return "Var1"; }
+  using type = Scalar<double>;
+};
+
+struct Var2 : db::SimpleTag {
+  static std::string name() noexcept { return "Var2"; }
+  using type = tnsr::I<double, dim, Frame::Inertial>;
+};
+
+struct ComputeFluxes {
+  using argument_tags = tmpl::list<Var2, Var1>;
+  static void apply(
+      const gsl::not_null<tnsr::I<double, dim, Frame::Inertial>*> flux1,
+      const tnsr::I<double, dim, Frame::Inertial>& var2,
+      const Scalar<double>& var1) noexcept {
+    get<0>(*flux1) = get(var1) * (get<0>(var2) - get<1>(var2));
+    get<1>(*flux1) = get(var1) * (get<0>(var2) + get<1>(var2));
+  }
+};
+
+struct System {
+  static constexpr size_t volume_dim = dim;
+  using variables_tag = Var1;
+  using volume_fluxes = ComputeFluxes;
+};
+
+using ElementIndexType = ElementIndex<dim>;
+
+struct Metavariables;
+using component =
+    ActionTesting::MockArrayComponent<Metavariables, ElementIndexType,
+                                      tmpl::list<>,
+                                      tmpl::list<Actions::ComputeVolumeFluxes>>;
+
+struct Metavariables {
+  using component_list = tmpl::list<component>;
+  using system = System;
+  using const_global_cache_tag_list = tmpl::list<>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeFluxes",
+                  "[Unit][Evolution][Actions]") {
+  ActionTesting::ActionRunner<Metavariables> runner{{}};
+  const ElementId<dim> self(1);
+
+  using flux_tag = Tags::Flux<Var1, tmpl::size_t<dim>, Frame::Inertial>;
+  auto start_box = db::create<db::AddSimpleTags<Var1, Var2, flux_tag>>(
+      db::item_type<Var1>{{{3.}}}, db::item_type<Var2>{{{7., 12.}}},
+      db::item_type<flux_tag>{{{-100.}}});
+
+  const auto box = get<0>(
+      runner.apply<component, Actions::ComputeVolumeFluxes>(start_box, self));
+  CHECK(get<0>(db::get<flux_tag>(box)) == -15.);
+  CHECK(get<1>(db::get<flux_tag>(box)) == 57.);
+}

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Evolution/Actions/ComputeVolumeSources.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+constexpr size_t dim = 2;
+
+struct Var1 : db::SimpleTag {
+  static std::string name() noexcept { return "Var1"; }
+  using type = Scalar<DataVector>;
+};
+
+struct Var2 : db::SimpleTag {
+  static std::string name() noexcept { return "Var2"; }
+  using type = tnsr::I<DataVector, dim, Frame::Inertial>;
+};
+
+struct Var3 : db::SimpleTag {
+  static std::string name() noexcept { return "Var3"; }
+  using type = Scalar<DataVector>;
+};
+
+struct ComputeSources {
+  using argument_tags = tmpl::list<Var1, Var3>;
+  static void apply(
+      const gsl::not_null<tnsr::I<DataVector, dim, Frame::Inertial>*> source2,
+      const Scalar<DataVector>& var1, const Scalar<DataVector>& var3) noexcept {
+    get<0>(*source2) = get(var1);
+    get<1>(*source2) = get(var3);
+  }
+};
+
+struct System {
+  static constexpr size_t volume_dim = dim;
+  using variables_tag = Tags::Variables<tmpl::list<Var1, Var2>>;
+  using sourced_variables = tmpl::list<Var2>;
+  using volume_sources = ComputeSources;
+};
+
+using ElementIndexType = ElementIndex<dim>;
+
+struct Metavariables;
+using component = ActionTesting::MockArrayComponent<
+    Metavariables, ElementIndexType, tmpl::list<>,
+    tmpl::list<Actions::ComputeVolumeSources>>;
+
+struct Metavariables {
+  using component_list = tmpl::list<component>;
+  using system = System;
+  using const_global_cache_tag_list = tmpl::list<>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeSources",
+                  "[Unit][Evolution][Actions]") {
+  ActionTesting::ActionRunner<Metavariables> runner{{}};
+  const ElementId<dim> self(1);
+
+  const Scalar<DataVector> var1{{{{3., 4.}}}};
+  const Scalar<DataVector> var3{{{{5., 6.}}}};
+
+  db::item_type<System::variables_tag> vars(2);
+  get<Var1>(vars) = var1;
+
+  using source_tag =
+      Tags::Source<Tags::Variables<tmpl::list<Tags::Source<Var2>>>>;
+
+  auto start_box =
+      db::create<db::AddSimpleTags<System::variables_tag, Var3, source_tag>>(
+          std::move(vars), var3, db::item_type<source_tag>(2));
+
+  const auto box = get<0>(
+      runner.apply<component, Actions::ComputeVolumeSources>(start_box, self));
+  CHECK(get<0>(db::get<Tags::Source<Var2>>(box)) == get(var1));
+  CHECK(get<1>(db::get<Tags::Source<Var2>>(box)) == get(var3));
+}


### PR DESCRIPTION
A particular thing to consider here is the handling of source terms.  I currently have the system specifying which variables have sources and then only passing those to the source calculation functions (and in a later PR to the RHS).

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
