### PR TITLE
Additions for RotatedBricks 4

### DIFF
--- a/docs/Tutorials/Orientation.md
+++ b/docs/Tutorials/Orientation.md
@@ -183,8 +183,8 @@ Block2: 4-0=4  => +zeta
 It is also possible to identify faces of a Block using the subset CNS. For
 example, to identify the lower zeta face with the upper zeta face of a Block
 where the corners are labeled `{3,0,4,1,9,6,10,7}`, one may supply the lists
-`{3,0,4,1}` and `{9,6,10,7}` to the `set_periodic_boundaries` function.
-\note The `set_periodic_boundaries` function is sensitive to the order of the
+`{3,0,4,1}` and `{9,6,10,7}` to the `set_identified_boundaries` function.
+\note The `set_identified_boundaries` function is sensitive to the order of the
 corners in the lists supplied as arguments. This is because the function
 identifies corners and edges with each other as opposed to simply faces. This
 allows the user to specify more peculiar boundary conditions. For example,

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -37,8 +37,8 @@ Domain<VolumeDim, TargetFrame>::Domain(
       neighbors_of_all_blocks;
   set_internal_boundaries<VolumeDim>(corners_of_all_blocks,
                                      &neighbors_of_all_blocks);
-  set_periodic_boundaries<VolumeDim>(identifications, corners_of_all_blocks,
-                                     &neighbors_of_all_blocks);
+  set_identified_boundaries<VolumeDim>(identifications, corners_of_all_blocks,
+                                       &neighbors_of_all_blocks);
   for (size_t i = 0; i < corners_of_all_blocks.size(); i++) {
     blocks_.emplace_back(std::move(maps[i]), i,
                          std::move(neighbors_of_all_blocks[i]));

--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -40,6 +40,9 @@ template <>
 void register_with_charm<1>() {
   PUPable_reg(
       SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine>));
+  PUPable_reg(
+      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                 CoordinateMaps::DiscreteRotation<1>, Affine>));
 }
 
 template <>

--- a/src/Domain/DomainCreators/RotatedIntervals.cpp
+++ b/src/Domain/DomainCreators/RotatedIntervals.cpp
@@ -2,20 +2,19 @@
 // See LICENSE.txt for details.
 
 #include "Domain/DomainCreators/RotatedIntervals.hpp"
-
+#include "DataStructures/Index.hpp"
 #include "Domain/Block.hpp"          // IWYU pragma: keep
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
-#include "Domain/CoordinateMaps/Affine.hpp"
-#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Direction.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/DomainHelpers.hpp"
+#include "Domain/OrientationMap.hpp"
 
 /// \cond
 namespace Frame {
 struct Grid;
 struct Inertial;
-struct Logical;
 }  // namespace Frame
 /// \endcond
 
@@ -41,13 +40,11 @@ RotatedIntervals<TargetFrame>::RotatedIntervals(
 template <typename TargetFrame>
 Domain<1, TargetFrame> RotatedIntervals<TargetFrame>::create_domain() const
     noexcept {
-  return Domain<1, TargetFrame>{
-      make_vector_coordinate_map_base<Frame::Logical, TargetFrame>(
-          CoordinateMaps::Affine{-1.0, 1.0, lower_x_[0], midpoint_x_[0]},
-          CoordinateMaps::Affine{-1.0, 1.0, upper_x_[0], midpoint_x_[0]}),
-      std::vector<std::array<size_t, 2>>{{{1, 2}}, {{3, 2}}},
-      is_periodic_in_[0] ? std::vector<PairOfFaces>{{{1}, {3}}}
-                         : std::vector<PairOfFaces>{}};
+  return rectilinear_domain<1, TargetFrame>(
+      Index<1>{2}, {{{lower_x_[0], midpoint_x_[0], upper_x_[0]}}}, {},
+      {OrientationMap<1>{}, OrientationMap<1>{std::array<Direction<1>, 1>{
+                                {Direction<1>::lower_xi()}}}},
+      is_periodic_in_);
 }
 
 template <typename TargetFrame>

--- a/src/Domain/DomainCreators/RotatedRectangles.cpp
+++ b/src/Domain/DomainCreators/RotatedRectangles.cpp
@@ -21,6 +21,7 @@ RotatedRectangles<TargetFrame>::RotatedRectangles(
     const typename LowerBound::type lower_xy,
     const typename Midpoint::type midpoint_xy,
     const typename UpperBound::type upper_xy,
+    const typename IsPeriodicIn::type is_periodic_in,
     const typename InitialRefinement::type initial_refinement_level_xy,
     const typename InitialGridPoints::type
         initial_number_of_grid_points_in_xy) noexcept
@@ -28,6 +29,7 @@ RotatedRectangles<TargetFrame>::RotatedRectangles(
     : lower_xy_(std::move(lower_xy)),                         // NOLINT
       midpoint_xy_(std::move(midpoint_xy)),                   // NOLINT
       upper_xy_(std::move(upper_xy)),                         // NOLINT
+      is_periodic_in_(std::move(is_periodic_in)),             // NOLINT
       initial_refinement_level_xy_(                           // NOLINT
           std::move(initial_refinement_level_xy)),            // NOLINT
       initial_number_of_grid_points_in_xy_(                   // NOLINT
@@ -49,7 +51,8 @@ Domain<2, TargetFrame> RotatedRectangles<TargetFrame>::create_domain() const
           OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
           OrientationMap<2>{std::array<Direction<2>, 2>{
-              {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}});
+              {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}},
+      is_periodic_in_);
 }
 
 template <typename TargetFrame>

--- a/src/Domain/DomainCreators/RotatedRectangles.hpp
+++ b/src/Domain/DomainCreators/RotatedRectangles.hpp
@@ -52,6 +52,13 @@ class RotatedRectangles : public DomainCreator<2, TargetFrame> {
         "Sequence of [x,y] for upper bounds in the target frame."};
   };
 
+  struct IsPeriodicIn {
+    using type = std::array<bool, 2>;
+    static constexpr OptionString help = {
+        "Sequence for [x], true if periodic."};
+    static type default_value() { return {{false, false}}; }
+  };
+
   struct InitialRefinement {
     using type = std::array<size_t, 2>;
     static constexpr OptionString help = {
@@ -64,7 +71,7 @@ class RotatedRectangles : public DomainCreator<2, TargetFrame> {
         "Initial number of grid points in [[x], [y]]."};
   };
 
-  using options = tmpl::list<LowerBound, Midpoint, UpperBound,
+  using options = tmpl::list<LowerBound, Midpoint, UpperBound, IsPeriodicIn,
                              InitialRefinement, InitialGridPoints>;
 
   static constexpr OptionString help = {
@@ -77,6 +84,7 @@ class RotatedRectangles : public DomainCreator<2, TargetFrame> {
   RotatedRectangles(
       typename LowerBound::type lower_xy, typename Midpoint::type midpoint_xy,
       typename UpperBound::type upper_xy,
+      typename IsPeriodicIn::type is_periodic_in,
       typename InitialRefinement::type initial_refinement_level_xy,
       typename InitialGridPoints::type
           initial_number_of_grid_points_in_xy) noexcept;
@@ -102,6 +110,7 @@ class RotatedRectangles : public DomainCreator<2, TargetFrame> {
       {std::numeric_limits<double>::signaling_NaN()}};
   typename UpperBound::type upper_xy_{
       {std::numeric_limits<double>::signaling_NaN()}};
+  typename IsPeriodicIn::type is_periodic_in_{{false, false}};
   typename InitialRefinement::type initial_refinement_level_xy_{
       {std::numeric_limits<size_t>::max()}};
   typename InitialGridPoints::type initial_number_of_grid_points_in_xy_{

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -285,7 +285,7 @@ void set_internal_boundaries(
 }
 
 template <size_t VolumeDim>
-void set_periodic_boundaries(
+void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
@@ -849,19 +849,19 @@ template void set_internal_boundaries(
         std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>*>
         neighbors_of_all_blocks);
 
-template void set_periodic_boundaries(
+template void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 2>>& corners_of_all_blocks,
     gsl::not_null<
         std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>*>
         neighbors_of_all_blocks);
-template void set_periodic_boundaries(
+template void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 4>>& corners_of_all_blocks,
     gsl::not_null<
         std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>*>
         neighbors_of_all_blocks);
-template void set_periodic_boundaries(
+template void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 8>>& corners_of_all_blocks,
     gsl::not_null<

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -30,9 +30,6 @@ template <size_t VolumeDim, typename TargetFrame>
 class Domain;
 template <size_t VolumeDim>
 class OrientationMap;
-namespace Frame {
-struct Logical;
-}  // namespace Frame
 /// \endcond
 
 /// \ingroup ComputationalDomainGroup
@@ -207,6 +204,8 @@ Domain<VolumeDim, TargetFrame> rectilinear_domain(
     const std::vector<Index<VolumeDim>>& block_indices_to_exclude = {},
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks =
         {},
+    const std::array<bool, VolumeDim>& dimension_is_periodic =
+        make_array<VolumeDim>(false),
     const std::vector<PairOfFaces>& identifications = {},
     bool use_equiangular_map = false) noexcept;
 

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -59,10 +59,10 @@ void set_internal_boundaries(
 
 /// \ingroup ComputationalDomainGroup
 /// Sets up additional BlockNeighbors corresponding to any
-/// periodic boundary condtions provided by the user. These are
-/// stored in identifications.
+/// identifications of faces provided by the user. Can be used
+/// for manually setting up periodic boundary conditions.
 template <size_t VolumeDim>
-void set_periodic_boundaries(
+void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -301,20 +301,20 @@ class FaceCornerIterator {
       corner_[i] = 2 * static_cast<int>(get_nth_bit(index_, i)) - 1;
     }
   }
-  explicit operator bool() noexcept {
+  explicit operator bool() const noexcept {
     return face_index_ < two_to_the(VolumeDim - 1);
   }
-  tnsr::I<double, VolumeDim, Frame::Logical> operator()() noexcept {
+  tnsr::I<double, VolumeDim, Frame::Logical> operator()() const noexcept {
     return corner_;
   }
-  tnsr::I<double, VolumeDim, Frame::Logical> operator*() noexcept {
+  tnsr::I<double, VolumeDim, Frame::Logical> operator*() const noexcept {
     return corner_;
   }
 
   // Returns the value used to construct the logical corner.
-  size_t volume_index() noexcept { return index_; }
+  size_t volume_index() const noexcept { return index_; }
   // Returns the number of times operator++ has been called.
-  size_t face_index() noexcept { return face_index_; }
+  size_t face_index() const noexcept { return face_index_; }
 
  private:
   const Direction<VolumeDim> direction_;

--- a/tests/Unit/Domain/DomainCreators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_RotatedRectangles.cpp
@@ -99,6 +99,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles",
       lower_bound,
       midpoint,
       upper_bound,
+      {{false, false}},
       {{refinement_level[0][0], refinement_level[0][1]}},
       {{{{grid_points[0][0], grid_points[1][0]}},
         {{grid_points[0][1], grid_points[2][0]}}}}};
@@ -120,6 +121,37 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles",
           {Direction<2>::upper_xi(), Direction<2>::upper_eta()},
           {Direction<2>::lower_xi(), Direction<2>::upper_eta()}});
   test_physical_separation(rotated_rectangles.create_domain().blocks());
+
+  const DomainCreators::RotatedRectangles<Frame::Inertial>
+      rotated_periodic_rectangles{
+          lower_bound,
+          midpoint,
+          upper_bound,
+          {{true, true}},
+          {{refinement_level[0][0], refinement_level[0][1]}},
+          {{{{grid_points[0][0], grid_points[1][0]}},
+            {{grid_points[0][1], grid_points[2][0]}}}}};
+  test_rotated_rectangles_construction(
+      rotated_periodic_rectangles, lower_bound, midpoint, upper_bound,
+      grid_points, refinement_level,
+      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+          {{Direction<2>::upper_xi(), {1, half_turn}},
+           {Direction<2>::upper_eta(), {2, quarter_turn_ccw}},
+           {Direction<2>::lower_xi(), {1, half_turn}},
+           {Direction<2>::lower_eta(), {2, quarter_turn_ccw}}},
+          {{Direction<2>::upper_xi(), {0, half_turn}},
+           {Direction<2>::lower_eta(), {3, quarter_turn_ccw}},
+           {Direction<2>::lower_xi(), {0, half_turn}},
+           {Direction<2>::upper_eta(), {3, quarter_turn_ccw}}},
+          {{Direction<2>::lower_xi(), {0, quarter_turn_cw}},
+           {Direction<2>::lower_eta(), {3, half_turn}},
+           {Direction<2>::upper_xi(), {0, quarter_turn_cw}},
+           {Direction<2>::upper_eta(), {3, half_turn}}},
+          {{Direction<2>::upper_xi(), {1, quarter_turn_cw}},
+           {Direction<2>::lower_eta(), {2, half_turn}},
+           {Direction<2>::lower_xi(), {1, quarter_turn_cw}},
+           {Direction<2>::upper_eta(), {2, half_turn}}}},
+      std::vector<std::unordered_set<Direction<2>>>{{}, {}, {}, {}});
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles.Factory",
@@ -137,6 +169,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles.Factory",
           "    LowerBound: [0.1, -0.4]\n"
           "    Midpoint:   [2.6, 3.2]\n"
           "    UpperBound: [5.1, 6.2]\n"
+          "    IsPeriodicIn: [false, false]\n"
           "    InitialGridPoints: [[3,2],[1,4]]\n"
           "    InitialRefinement: [2,1]\n");
   const auto* rotated_rectangles_creator =

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -16,6 +16,7 @@
 #include "Domain/Direction.hpp"
 #include "Domain/Domain.hpp"  // IWYU pragma: keep
 #include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
+#include "Domain/DomainHelpers.hpp"
 #include "Domain/InitialElementIds.hpp"
 #include "Domain/Neighbors.hpp"  // IWYU pragma: keep
 #include "Domain/OrientationMap.hpp"
@@ -165,56 +166,6 @@ void test_refinement_levels_of_neighbors(
         }
       }
     }
-  }
-}
-
-// Iterates over the 2^(VolumeDim-1) logical corners of the face of a
-// VolumeDim-dimensional cube in the given direction.
-template <size_t VolumeDim>
-class FaceCornerIterator {
- public:
-  explicit FaceCornerIterator(Direction<VolumeDim> direction) noexcept;
-  void operator++() noexcept {
-    face_index_++;
-    do {
-      index_++;
-    } while (get_nth_bit(index_, direction_.dimension()) ==
-             (direction_.side() == Side::Upper ? 0 : 1));
-    for (size_t i = 0; i < VolumeDim; ++i) {
-      corner_[i] = 2 * static_cast<int>(get_nth_bit(index_, i)) - 1;
-    }
-  }
-  explicit operator bool() noexcept {
-    return face_index_ < two_to_the(VolumeDim - 1);
-  }
-  tnsr::I<double, VolumeDim, Frame::Logical> operator()() noexcept {
-    return corner_;
-  }
-  tnsr::I<double, VolumeDim, Frame::Logical> operator*() noexcept {
-    return corner_;
-  }
-
-  // Returns the value used to construct the logical corner.
-  size_t volume_index() noexcept { return index_; }
-  // Returns the number of times operator++ has been called.
-  size_t face_index() noexcept { return face_index_; }
-
- private:
-  const Direction<VolumeDim> direction_;
-  size_t index_;
-  size_t face_index_ = 0;
-  tnsr::I<double, VolumeDim, Frame::Logical> corner_;
-};
-
-template <size_t VolumeDim>
-FaceCornerIterator<VolumeDim>::FaceCornerIterator(
-    Direction<VolumeDim> direction) noexcept
-    : direction_(std::move(direction)),
-      index_(direction.side() == Side::Upper
-                 ? two_to_the(direction_.dimension())
-                 : 0) {
-  for (size_t i = 0; i < VolumeDim; ++i) {
-    corner_[i] = 2 * static_cast<int>(get_nth_bit(index_, i)) - 1;
   }
 }
 

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -143,7 +143,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear1D1", "[Domain][Unit]") {
   SECTION("Aligned domain.") {
     const auto domain = rectilinear_domain<1, Frame::Inertial>(
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
-        {}, {}, {}, true);
+        {}, {}, {{false}}, {}, true);
     const OrientationMap<1> aligned{};
     std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>
         expected_block_neighbors{{{Direction<1>::upper_xi(), {1, aligned}}},
@@ -169,8 +169,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear1D1", "[Domain][Unit]") {
         std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
     const auto domain = rectilinear_domain<1, Frame::Inertial>(
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
-        {}, std::vector<OrientationMap<1>>{aligned, antialigned, aligned}, {},
-        true);
+        {}, std::vector<OrientationMap<1>>{aligned, antialigned, aligned},
+        {{false}}, {}, true);
     std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>
         expected_block_neighbors{
             {{Direction<1>::upper_xi(), {1, antialigned}}},

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -45,8 +45,8 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.SameBlock",
   const PairOfFaces x_faces{{1, 3, 5, 7}, {0, 2, 4, 6}};
 
   const std::vector<PairOfFaces> identifications{x_faces};
-  set_periodic_boundaries<3>(identifications, corners_of_all_blocks,
-                             &neighbors_of_all_blocks);
+  set_identified_boundaries<3>(identifications, corners_of_all_blocks,
+                               &neighbors_of_all_blocks);
   CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
         aligned);
 
@@ -74,8 +74,8 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.DifferentBlocks",
   const PairOfFaces x_faces_on_different_blocks{{1, 3, 5, 7}, {8, 10, 0, 2}};
 
   const std::vector<PairOfFaces> identifications{x_faces_on_different_blocks};
-  set_periodic_boundaries<3>(identifications, corners_of_all_blocks,
-                             &neighbors_of_all_blocks);
+  set_identified_boundaries<3>(identifications, corners_of_all_blocks,
+                               &neighbors_of_all_blocks);
   CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
         aligned);
   const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -862,6 +862,170 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.VolumeCornerIterator",
 #endif
 }
 
+namespace {
+void test_fci_1d() {
+  FaceCornerIterator<1> fci{Direction<1>::upper_xi()};
+  CHECK(fci);
+  CHECK(fci.volume_index() == 1);
+  CHECK(fci.face_index() == 0);
+  ++fci;
+  CHECK(not fci);
+
+  FaceCornerIterator<1> fci2{Direction<1>::lower_xi()};
+  CHECK(fci2);
+  CHECK(fci2.volume_index() == 0);
+  CHECK(fci2.face_index() == 0);
+  ++fci2;
+  CHECK(not fci2);
+}
+
+void test_fci_2d() {
+  FaceCornerIterator<2> fci{Direction<2>::upper_xi()};
+  CHECK(fci);
+  CHECK(fci.volume_index() == 1);
+  CHECK(fci.face_index() == 0);
+  ++fci;
+  CHECK(fci.volume_index() == 3);
+  CHECK(fci.face_index() == 1);
+  ++fci;
+  CHECK(not fci);
+
+  FaceCornerIterator<2> fci2{Direction<2>::lower_xi()};
+  CHECK(fci2);
+  CHECK(fci2.volume_index() == 0);
+  CHECK(fci2.face_index() == 0);
+  ++fci2;
+  CHECK(fci2.volume_index() == 2);
+  CHECK(fci2.face_index() == 1);
+  ++fci2;
+  CHECK(not fci2);
+
+  FaceCornerIterator<2> fci3{Direction<2>::upper_eta()};
+  CHECK(fci3);
+  CHECK(fci3.volume_index() == 2);
+  CHECK(fci3.face_index() == 0);
+  ++fci3;
+  CHECK(fci3.volume_index() == 3);
+  CHECK(fci3.face_index() == 1);
+  ++fci3;
+  CHECK(not fci3);
+
+  FaceCornerIterator<2> fci4{Direction<2>::lower_eta()};
+  CHECK(fci4);
+  CHECK(fci4.volume_index() == 0);
+  CHECK(fci4.face_index() == 0);
+  ++fci4;
+  CHECK(fci4.volume_index() == 1);
+  CHECK(fci4.face_index() == 1);
+  ++fci4;
+  CHECK(not fci4);
+}
+void test_fci_3d() {
+  FaceCornerIterator<3> fci{Direction<3>::upper_xi()};
+  CHECK(fci);
+  CHECK(fci.volume_index() == 1);
+  CHECK(fci.face_index() == 0);
+  ++fci;
+  CHECK(fci.volume_index() == 3);
+  CHECK(fci.face_index() == 1);
+  ++fci;
+  CHECK(fci.volume_index() == 5);
+  CHECK(fci.face_index() == 2);
+  ++fci;
+  CHECK(fci.volume_index() == 7);
+  CHECK(fci.face_index() == 3);
+  ++fci;
+  CHECK(not fci);
+
+  FaceCornerIterator<3> fci2{Direction<3>::lower_xi()};
+  CHECK(fci2);
+  CHECK(fci2.volume_index() == 0);
+  CHECK(fci2.face_index() == 0);
+  ++fci2;
+  CHECK(fci2.volume_index() == 2);
+  CHECK(fci2.face_index() == 1);
+  ++fci2;
+  CHECK(fci2.volume_index() == 4);
+  CHECK(fci2.face_index() == 2);
+  ++fci2;
+  CHECK(fci2.volume_index() == 6);
+  CHECK(fci2.face_index() == 3);
+  ++fci2;
+  CHECK(not fci2);
+
+  FaceCornerIterator<3> fci3{Direction<3>::upper_eta()};
+  CHECK(fci3);
+  CHECK(fci3.volume_index() == 2);
+  CHECK(fci3.face_index() == 0);
+  ++fci3;
+  CHECK(fci3.volume_index() == 3);
+  CHECK(fci3.face_index() == 1);
+  ++fci3;
+  CHECK(fci3.volume_index() == 6);
+  CHECK(fci3.face_index() == 2);
+  ++fci3;
+  CHECK(fci3.volume_index() == 7);
+  CHECK(fci3.face_index() == 3);
+  ++fci3;
+  CHECK(not fci3);
+
+  FaceCornerIterator<3> fci4{Direction<3>::lower_eta()};
+  CHECK(fci4);
+  CHECK(fci4.volume_index() == 0);
+  CHECK(fci4.face_index() == 0);
+  ++fci4;
+  CHECK(fci4.volume_index() == 1);
+  CHECK(fci4.face_index() == 1);
+  ++fci4;
+  CHECK(fci4.volume_index() == 4);
+  CHECK(fci4.face_index() == 2);
+  ++fci4;
+  CHECK(fci4.volume_index() == 5);
+  CHECK(fci4.face_index() == 3);
+  ++fci4;
+  CHECK(not fci4);
+
+  FaceCornerIterator<3> fci5{Direction<3>::upper_zeta()};
+  CHECK(fci5);
+  CHECK(fci5.volume_index() == 4);
+  CHECK(fci5.face_index() == 0);
+  ++fci5;
+  CHECK(fci5.volume_index() == 5);
+  CHECK(fci5.face_index() == 1);
+  ++fci5;
+  CHECK(fci5.volume_index() == 6);
+  CHECK(fci5.face_index() == 2);
+  ++fci5;
+  CHECK(fci5.volume_index() == 7);
+  CHECK(fci5.face_index() == 3);
+  ++fci5;
+  CHECK(not fci5);
+
+  FaceCornerIterator<3> fci6{Direction<3>::lower_zeta()};
+  CHECK(fci6);
+  CHECK(fci6.volume_index() == 0);
+  CHECK(fci6.face_index() == 0);
+  ++fci6;
+  CHECK(fci6.volume_index() == 1);
+  CHECK(fci6.face_index() == 1);
+  ++fci6;
+  CHECK(fci6.volume_index() == 2);
+  CHECK(fci6.face_index() == 2);
+  ++fci6;
+  CHECK(fci6.volume_index() == 3);
+  CHECK(fci6.face_index() == 3);
+  ++fci6;
+  CHECK(not fci6);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.FaceCornerIterator",
+                  "[Domain][Unit]") {
+  test_fci_1d();
+  test_fci_2d();
+  test_fci_3d();
+}
+
 SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.CornersForRectilinearDomains",
                   "[Domain][Unit]") {
   std::vector<std::array<size_t, 2>> corners_for_a_1d_road{


### PR DESCRIPTION
## Proposed changes

The final piece allowing for the general construction of rectilinear multicube domains
that have nontrivial orientations and identifications. Useful for testing purposes.

Corner numberings are now almost entirely an implementation detail for these domains
except in the cases where the user wants to set non-periodic identifications on the boundaries 
(e.g. identifying the edges of the cube net to obtain an S2 topology).

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
