### PR TITLE
Add apply_matrices_to_variables

### DIFF
--- a/src/DataStructures/IndexIterator.hpp
+++ b/src/DataStructures/IndexIterator.hpp
@@ -42,7 +42,8 @@ class IndexIterator {
   /// Advance to next Index.
   IndexIterator<Dim>& operator++();
 
-  decltype(auto) operator*() const noexcept { return index_; }
+  const Index<Dim>& operator*() const noexcept { return index_; }
+  const Index<Dim>* operator->() const noexcept { return &index_; }
 
   /// Returns an index representing the (i, j, ...)th values that the iterator
   /// currently represents

--- a/src/NumericalAlgorithms/LinearOperators/ApplyMatrices.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/ApplyMatrices.cpp
@@ -1,0 +1,371 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/LinearOperators/ApplyMatrices.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "NumericalAlgorithms/LinearOperators/Transpose.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace {
+void multiply_in_first_dimension(const gsl::not_null<double*> result,
+                                 const gsl::not_null<size_t*> data_size,
+                                 const Matrix& matrix,
+                                 const double* data) noexcept {
+  *data_size /= matrix.columns();
+  dgemm_<true>('N', 'N',
+               matrix.rows(),     // rows of matrix and result
+               *data_size,        // columns of result and u
+               matrix.columns(),  // columns of matrix and rows of u
+               1.0,               // overall multiplier
+               matrix.data(),     // matrix
+               matrix.rows(),     // rows of matrix
+               data,              // u
+               matrix.columns(),  // rows of u
+               0.0,               // multiplier for unused term
+               result.get(),      // result
+               matrix.rows());    // rows of result
+  *data_size *= matrix.rows();
+}
+
+void do_transpose(const gsl::not_null<double*> result, const double* const data,
+                  const size_t data_size, const size_t chunk_size) noexcept {
+  raw_transpose(result, data, chunk_size, data_size / chunk_size);
+}
+
+struct Scratch {
+  std::vector<double> buffer;
+  double* a;
+  double* b;
+};
+
+// This does not take into account the order that the matrices are
+// applied in and gives the largest amount of space that could be
+// required for any application order.
+template <typename MatrixType, size_t Dim>
+Scratch get_scratch(const std::array<MatrixType, Dim>& matrices,
+                    const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+  size_t size = number_of_independent_components;
+  for (size_t i = 0; i < Dim; ++i) {
+    const auto& matrix = gsl::at(matrices, i);
+    if (matrix == Matrix{}) {
+      size *= extents[i];
+    } else {
+      size *= std::max(dereference_wrapper(matrix).rows(),
+                       dereference_wrapper(matrix).columns());
+    }
+  }
+  Scratch result{};
+  result.buffer.resize(2 * size);
+  result.a = &result.buffer[0];
+  result.b = &result.buffer[size];
+  return result;
+}
+
+// Produce the array of the number of rows in each matrix.  Empty
+// matrices are processed as if they were identity matrices.
+template <size_t Dim, typename MatrixType>
+std::array<size_t, Dim> matrix_rows(const std::array<MatrixType, Dim>& matrices,
+                                    const Index<Dim>& extents) noexcept {
+  std::array<size_t, Dim> result{};
+  for (size_t i = 0; i < Dim; ++i) {
+    if (gsl::at(matrices, i) == Matrix{}) {
+      gsl::at(result, i) = extents[i];
+    } else {
+      gsl::at(result, i) = dereference_wrapper(gsl::at(matrices, i)).rows();
+    }
+  }
+  return result;
+}
+}  // namespace
+
+namespace apply_matrices_detail {
+template <size_t Dim, bool... DimensionIsIdentity>
+template <typename MatrixType>
+void Impl<Dim, DimensionIsIdentity...>::apply(
+    const gsl::not_null<double*> result,
+    const std::array<MatrixType, Dim>& matrices, const double* const data,
+    const Index<Dim>& extents,
+    const size_t number_of_independent_components) noexcept {
+  if (matrices[sizeof...(DimensionIsIdentity)] == Matrix{}) {
+    Impl<Dim, DimensionIsIdentity..., true>::apply(
+        result, matrices, data, extents, number_of_independent_components);
+  } else {
+    Impl<Dim, DimensionIsIdentity..., false>::apply(
+        result, matrices, data, extents, number_of_independent_components);
+  }
+}
+
+template <>
+struct Impl<1, false> {
+  static constexpr const size_t Dim = 1;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    size_t data_size = number_of_independent_components * extents.product();
+    multiply_in_first_dimension(result, &data_size, matrices[0], data);
+  }
+};
+
+template <>
+struct Impl<1, true> {
+  static constexpr const size_t Dim = 1;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& /*matrices*/,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    std::copy(data, data + number_of_independent_components * extents.product(),
+              result.get());
+  }
+};
+
+template <>
+struct Impl<2, false, false> {
+  static constexpr size_t Dim = 2;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    const auto rows = matrix_rows(matrices, extents);
+    auto scratch =
+        get_scratch(matrices, extents, number_of_independent_components);
+
+    size_t data_size = number_of_independent_components * extents.product();
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[0], data);
+    do_transpose(scratch.b, scratch.a, data_size, rows[0]);
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[1], scratch.b);
+    do_transpose(result, scratch.a, data_size,
+                 number_of_independent_components * rows[1]);
+  }
+};
+
+template <>
+struct Impl<2, false, true> {
+  static constexpr size_t Dim = 2;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    size_t data_size = number_of_independent_components * extents.product();
+    multiply_in_first_dimension(result, &data_size, matrices[0], data);
+  }
+};
+
+template <>
+struct Impl<2, true, false> {
+  static constexpr size_t Dim = 2;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    const auto rows = matrix_rows(matrices, extents);
+    auto scratch =
+        get_scratch(matrices, extents, number_of_independent_components);
+
+    size_t data_size = number_of_independent_components * extents.product();
+    do_transpose(scratch.b, data, data_size, rows[0]);
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[1], scratch.b);
+    do_transpose(result, scratch.a, data_size,
+                 number_of_independent_components * rows[1]);
+  }
+};
+
+template <>
+struct Impl<2, true, true> {
+  static constexpr size_t Dim = 2;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& /*matrices*/,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    std::copy(data, data + number_of_independent_components * extents.product(),
+              result.get());
+  }
+};
+
+template <>
+struct Impl<3, false, false, false> {
+  static constexpr size_t Dim = 3;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    const auto rows = matrix_rows(matrices, extents);
+    auto scratch =
+        get_scratch(matrices, extents, number_of_independent_components);
+
+    size_t data_size = number_of_independent_components * extents.product();
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[0], data);
+    do_transpose(scratch.b, scratch.a, data_size, rows[0]);
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[1], scratch.b);
+    do_transpose(scratch.b, scratch.a, data_size, rows[1]);
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[2], scratch.b);
+    do_transpose(result, scratch.a, data_size,
+                 number_of_independent_components * rows[2]);
+  }
+};
+
+template <>
+struct Impl<3, false, false, true> {
+  static constexpr size_t Dim = 3;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    const auto rows = matrix_rows(matrices, extents);
+    auto scratch =
+        get_scratch(matrices, extents, number_of_independent_components);
+
+    size_t data_size = number_of_independent_components * extents.product();
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[0], data);
+    do_transpose(scratch.b, scratch.a, data_size, rows[0]);
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[1], scratch.b);
+    do_transpose(result, scratch.a, data_size,
+                 number_of_independent_components * rows[1] * rows[2]);
+  }
+};
+
+template <>
+struct Impl<3, false, true, false> {
+  static constexpr size_t Dim = 3;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    const auto rows = matrix_rows(matrices, extents);
+    auto scratch =
+        get_scratch(matrices, extents, number_of_independent_components);
+
+    size_t data_size = number_of_independent_components * extents.product();
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[0], data);
+    do_transpose(scratch.b, scratch.a, data_size, rows[0] * rows[1]);
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[2], scratch.b);
+    do_transpose(result, scratch.a, data_size,
+                 number_of_independent_components * rows[2]);
+  }
+};
+
+template <>
+struct Impl<3, false, true, true> {
+  static constexpr size_t Dim = 3;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    size_t data_size = number_of_independent_components * extents.product();
+    multiply_in_first_dimension(result, &data_size, matrices[0], data);
+  }
+};
+
+template <>
+struct Impl<3, true, false, false> {
+  static constexpr size_t Dim = 3;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    const auto rows = matrix_rows(matrices, extents);
+    auto scratch =
+        get_scratch(matrices, extents, number_of_independent_components);
+
+    size_t data_size = number_of_independent_components * extents.product();
+    do_transpose(scratch.b, data, data_size, rows[0]);
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[1], scratch.b);
+    do_transpose(scratch.b, scratch.a, data_size, rows[1]);
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[2], scratch.b);
+    do_transpose(result, scratch.a, data_size,
+                 number_of_independent_components * rows[2]);
+  }
+};
+
+template <>
+struct Impl<3, true, false, true> {
+  static constexpr size_t Dim = 3;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    const auto rows = matrix_rows(matrices, extents);
+    auto scratch =
+        get_scratch(matrices, extents, number_of_independent_components);
+
+    size_t data_size = number_of_independent_components * extents.product();
+    do_transpose(scratch.b, data, data_size, rows[0]);
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[1], scratch.b);
+    do_transpose(result, scratch.a, data_size,
+                 number_of_independent_components * rows[1] * rows[2]);
+  }
+};
+
+template <>
+struct Impl<3, true, true, false> {
+  static constexpr size_t Dim = 3;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    const auto rows = matrix_rows(matrices, extents);
+    auto scratch =
+        get_scratch(matrices, extents, number_of_independent_components);
+
+    size_t data_size = number_of_independent_components * extents.product();
+    do_transpose(scratch.b, data, data_size, rows[0] * rows[1]);
+    multiply_in_first_dimension(scratch.a, &data_size, matrices[2], scratch.b);
+    do_transpose(result, scratch.a, data_size,
+                 number_of_independent_components * rows[2]);
+  }
+};
+
+template <>
+struct Impl<3, true, true, true> {
+  static constexpr size_t Dim = 3;
+  template <typename MatrixType>
+  static auto apply(const gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& /*matrices*/,
+                    const double* const data, const Index<Dim>& extents,
+                    const size_t number_of_independent_components) noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    std::copy(data, data + number_of_independent_components * extents.product(),
+              result.get());
+  }
+};
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define MATRIX(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATE(_, data)                                           \
+  template void Impl<DIM(data)>::apply(                                \
+      const gsl::not_null<double*>,                                    \
+      const std::array<MATRIX(data), DIM(data)>&, const double* const, \
+      const Index<DIM(data)>&, const size_t) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (Matrix, std::reference_wrapper<const Matrix>))
+
+#undef DIM
+#undef MATRIX
+#undef INSTANTIATE
+}  // namespace apply_matrices_detail

--- a/src/NumericalAlgorithms/LinearOperators/ApplyMatrices.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/ApplyMatrices.hpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <ostream>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Variables.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+template <size_t Dim>
+class Index;
+// IWYU pragma: no_forward_declare Variables
+/// \endcond
+
+namespace apply_matrices_detail {
+template <size_t Dim, bool... DimensionIsIdentity>
+struct Impl {
+  template <typename MatrixType>
+  static void apply(gsl::not_null<double*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const double* data, const Index<Dim>& extents,
+                    size_t number_of_independent_components) noexcept;
+};
+
+template <typename MatrixType, size_t Dim>
+size_t result_size(const std::array<MatrixType, Dim>& matrices,
+                   const Index<Dim>& extents) noexcept {
+  size_t num_points_result = 1;
+  for (size_t d = 0; d < Dim; ++d) {
+    const size_t cols = dereference_wrapper(gsl::at(matrices, d)).columns();
+    if (cols == 0) {
+      // An empty matrix is treated as the identity.
+      num_points_result *= extents[d];
+    } else {
+      ASSERT(cols == extents[d],
+             "Matrix " << d << " has wrong number of columns: "
+             << cols << " (expected " << extents[d] << ")");
+      num_points_result *= dereference_wrapper(gsl::at(matrices, d)).rows();
+    }
+  }
+  return num_points_result;
+}
+}  // namespace apply_matrices_detail
+
+/// \ingroup NumericalAlgorithmsGroup
+/// \brief Multiply by matrices in each dimension
+///
+/// Multiplies each stripe in the first dimension of `u` by
+/// `matrices[0]`, each stripe in the second dimension of `u` by
+/// `matrices[1]`, and so on.  If any of the matrices are empty they
+/// will be treated as the identity, but the matrix multiplications
+/// will be skipped for increased efficiency.
+//@{
+template <typename VariableTags, typename MatrixType, size_t Dim>
+void apply_matrices(const gsl::not_null<Variables<VariableTags>*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const Variables<VariableTags>& u,
+                    const Index<Dim>& extents) noexcept {
+  ASSERT(u.number_of_grid_points() == extents.product(),
+         "Mismatch between extents (" << extents.product()
+         << ") and variables (" << u.number_of_grid_points() << ").");
+  ASSERT(result->number_of_grid_points() ==
+         apply_matrices_detail::result_size(matrices, extents),
+         "result has wrong size.  Expected "
+         << apply_matrices_detail::result_size(matrices, extents)
+         << ", received " << result->number_of_grid_points());
+  apply_matrices_detail::Impl<Dim>::apply(result->data(), matrices, u.data(),
+                                          extents,
+                                          u.number_of_independent_components);
+}
+
+template <typename VariableTags, typename MatrixType, size_t Dim>
+Variables<VariableTags> apply_matrices(
+    const std::array<MatrixType, Dim>& matrices,
+    const Variables<VariableTags>& u, const Index<Dim>& extents) noexcept {
+  Variables<VariableTags> result(
+      apply_matrices_detail::result_size(matrices, extents));
+  apply_matrices(make_not_null(&result), matrices, u, extents);
+  return result;
+}
+
+template <typename MatrixType, size_t Dim>
+void apply_matrices(const gsl::not_null<DataVector*> result,
+                    const std::array<MatrixType, Dim>& matrices,
+                    const DataVector& u, const Index<Dim>& extents) noexcept {
+  ASSERT(u.size() == extents.product(),
+         "Mismatch between extents (" << extents.product() << ") and size ("
+         << u.size() << ").");
+  ASSERT(result->size() ==
+         apply_matrices_detail::result_size(matrices, extents),
+         "result has wrong size.  Expected "
+         << apply_matrices_detail::result_size(matrices, extents)
+         << ", received " << result->size());
+  apply_matrices_detail::Impl<Dim>::apply(result->data(), matrices, u.data(),
+                                          extents, 1);
+}
+
+template <typename MatrixType, size_t Dim>
+DataVector apply_matrices(const std::array<MatrixType, Dim>& matrices,
+                          const DataVector& u,
+                          const Index<Dim>& extents) noexcept {
+  DataVector result(apply_matrices_detail::result_size(matrices, extents));
+  apply_matrices(make_not_null(&result), matrices, u, extents);
+  return result;
+}
+//@}

--- a/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY LinearOperators)
 
 set(LIBRARY_SOURCES
+    ApplyMatrices.cpp
     DefiniteIntegral.cpp
     Linearize.cpp
     MeanValue.cpp

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -117,8 +117,8 @@ struct LogicalImpl<2, VariableTags, DerivativeTags> {
                  extents[1], 1.0, differentiation_matrix_eta.data(), extents[1],
                  u_eta_fastest.data(), extents[1], 0.0,
                  partial_u_wrt_eta.data(), extents[1]);
-    transpose(partial_u_wrt_eta, num_components_times_xi_slices, extents[0],
-              make_not_null(&logical_partial_derivatives_of_u[1]));
+    transpose(make_not_null(&logical_partial_derivatives_of_u[1]),
+              partial_u_wrt_eta, num_components_times_xi_slices, extents[0]);
 
     return logical_partial_derivatives_of_u;
   }
@@ -153,14 +153,15 @@ struct LogicalImpl<3, VariableTags, DerivativeTags> {
                  extents[1], 1.0, differentiation_matrix_eta.data(), extents[1],
                  u_eta_or_zeta_fastest.data(), extents[1], 0.0,
                  partial_u_wrt_eta_or_zeta.data(), extents[1]);
-    transpose(partial_u_wrt_eta_or_zeta, num_components_times_xi_slices,
-              extents[0], make_not_null(&logical_partial_derivatives_of_u[1]));
+    transpose(make_not_null(&logical_partial_derivatives_of_u[1]),
+              partial_u_wrt_eta_or_zeta, num_components_times_xi_slices,
+              extents[0]);
 
     const size_t chunk_size = extents[0] * extents[1];
     const size_t number_of_chunks =
         logical_partial_derivatives_of_u[1].size() / chunk_size;
-    transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
-        u, chunk_size, number_of_chunks, make_not_null(&u_eta_or_zeta_fastest));
+    transpose(make_not_null(&u_eta_or_zeta_fastest), u, chunk_size,
+              number_of_chunks);
     const Matrix& differentiation_matrix_zeta =
         Basis::lgl::differentiation_matrix(extents[2]);
     const size_t num_components_times_zeta_slices =
@@ -169,8 +170,8 @@ struct LogicalImpl<3, VariableTags, DerivativeTags> {
                  extents[2], 1.0, differentiation_matrix_zeta.data(),
                  extents[2], u_eta_or_zeta_fastest.data(), extents[2], 0.0,
                  partial_u_wrt_eta_or_zeta.data(), extents[2]);
-    transpose(partial_u_wrt_eta_or_zeta, number_of_chunks, chunk_size,
-              make_not_null(&logical_partial_derivatives_of_u[2]));
+    transpose(make_not_null(&logical_partial_derivatives_of_u[2]),
+              partial_u_wrt_eta_or_zeta, number_of_chunks, chunk_size);
 
     return logical_partial_derivatives_of_u;
   }

--- a/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
@@ -46,9 +46,9 @@
 /// \tparam U the type of data to be transposed
 /// \tparam T the type of the transposed data
 template <typename U, typename T>
-void transpose(const U& u, const size_t chunk_size,
-               const size_t number_of_chunks,
-               const gsl::not_null<T*> transpose) {
+void transpose(const gsl::not_null<T*> transpose,
+               const U& u, const size_t chunk_size,
+               const size_t number_of_chunks) {
   ASSERT(chunk_size * number_of_chunks == transpose->size(),
          "chunk_size = " << chunk_size
                          << ", number_of_chunks = " << number_of_chunks
@@ -68,7 +68,7 @@ template <typename U, typename T = U>
 T transpose(const U& u, const size_t chunk_size,
             const size_t number_of_chunks) {
   T t = make_with_value<T>(u,0.0);
-  transpose(u, chunk_size, number_of_chunks, make_not_null(&t));
+  transpose(make_not_null(&t), u, chunk_size, number_of_chunks);
   return t;
 }
 // @}

--- a/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
@@ -59,6 +59,14 @@ void raw_transpose(const gsl::not_null<T*> result,
 /// filling `result` (or the returned object) with the transpose of that
 /// matrix.
 ///
+/// If `u` represents a block of data indexed by
+/// \f$(x, y, z, \ldots)\f$ with the first index varying fastest,
+/// transpose serves to rotate the indices.  If the extents are
+/// \f$(X, Y, Z, \ldots)\f$, with product \f$N\f$, `transpose(u, X,
+/// N/X)` reorders the data to be indexed \f$(y, z, \ldots, x)\f$,
+/// `transpose(u, X*Y, N/X/Y)` reorders the data to be indexed
+/// \f$(z, \ldots, x, y)\f$, etc.
+///
 /// \example
 /// \snippet Test_Transpose.cpp transpose_matrix
 /// \snippet Test_Transpose.cpp transpose_by_not_null_example

--- a/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
@@ -12,6 +12,28 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+/// \ingroup NumericalAlgorithmsGroup
+/// \brief Function to compute transposed data.
+///
+/// Transpose the data pointed to by `data`, writing the result to the
+/// location pointed to by `result`.  See the ::transpose function for
+/// a safer interface and for the meaning of the other arguments.
+// This is not an overload of transpose because overload resolution
+// would make non-intuitive choices of the return-by-pointer version
+// below over this function.
+template <typename T>
+void raw_transpose(const gsl::not_null<T*> result,
+                   const T* const data, const size_t chunk_size,
+                   const size_t number_of_chunks) noexcept {
+  for (size_t j = 0; j < number_of_chunks; ++j) {
+    for (size_t i = 0; i < chunk_size; ++i) {
+      // clang-tidy: pointer arithmetic
+      result.get()[j + number_of_chunks * i] =  // NOLINT
+          data[i + chunk_size * j];             // NOLINT
+    }
+  }
+}
+
 // @{
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Function to compute transposed data.
@@ -19,22 +41,22 @@
 /// The primary use of this function is to rearrange the memory layout so that
 /// another function can operate on contiguous chunks of memory.
 ///
-/// \requires `transpose.size()` to be the product of `number_of_chunks` and
-/// `chunk_size`, `u.size()` to be equal or greater than `transpose.size()`,
-/// and that both `transpose` and `u` have a `data()` member function.
+/// \requires `result.size()` to be the product of `number_of_chunks` and
+/// `chunk_size`, `u.size()` to be equal or greater than `result.size()`,
+/// and that both `result` and `u` have a `data()` member function.
 ///
 /// \details The container `u` holds a contiguous array of data,
 /// treated as a sequence of `number_of_chunks` contiguous sets of
-/// entries of size `chunk_size`.  The output `transpose` has its data
+/// entries of size `chunk_size`.  The output `result` has its data
 /// arranged such that the first `number_of_chunks` elements in
-/// `transpose` will be the first element of each chunk of `u`.  The
-/// last `number_of_chunks` elements in `transpose` will be the last
+/// `result` will be the first element of each chunk of `u`.  The
+/// last `number_of_chunks` elements in `result` will be the last
 /// (i.e.  `chunk_size`-th) element of each chunk of `u`.  If
-/// `u.size()` is greater than `transpose.size()` the extra elements
+/// `u.size()` is greater than `result.size()` the extra elements
 /// of `u` are ignored.
 ///
 /// \note This is equivalent to treating the first part of `u` as a matrix and
-/// filling `transpose` (or the returned object) with the transpose of that
+/// filling `result` (or the returned object) with the transpose of that
 /// matrix.
 ///
 /// \example
@@ -46,27 +68,22 @@
 /// \tparam U the type of data to be transposed
 /// \tparam T the type of the transposed data
 template <typename U, typename T>
-void transpose(const gsl::not_null<T*> transpose,
+void transpose(const gsl::not_null<T*> result,
                const U& u, const size_t chunk_size,
-               const size_t number_of_chunks) {
-  ASSERT(chunk_size * number_of_chunks == transpose->size(),
+               const size_t number_of_chunks) noexcept {
+  ASSERT(chunk_size * number_of_chunks == result->size(),
          "chunk_size = " << chunk_size
                          << ", number_of_chunks = " << number_of_chunks
-                         << ", size = " << transpose->size());
-  ASSERT(transpose->size() <= u.size(),
-         "transpose.size = " << transpose->size() << ", u.size = " << u.size());
-  for (size_t j = 0; j < number_of_chunks; ++j) {
-    for (size_t i = 0; i < chunk_size; ++i) {
-      // clang-tidy: pointer arithmetic
-      transpose->data()[j + number_of_chunks * i] =  // NOLINT
-          u.data()[i + chunk_size * j];              // NOLINT
-    }
-  }
+                         << ", size = " << result->size());
+  ASSERT(result->size() <= u.size(),
+         "result.size = " << result->size() << ", u.size = " << u.size());
+  raw_transpose(make_not_null(result->data()), u.data(), chunk_size,
+                number_of_chunks);
 }
 
 template <typename U, typename T = U>
 T transpose(const U& u, const size_t chunk_size,
-            const size_t number_of_chunks) {
+            const size_t number_of_chunks) noexcept {
   T t = make_with_value<T>(u,0.0);
   transpose(make_not_null(&t), u, chunk_size, number_of_chunks);
   return t;

--- a/src/Utilities/StdArrayHelpers.hpp
+++ b/src/Utilities/StdArrayHelpers.hpp
@@ -8,6 +8,8 @@
 
 #include <array>
 #include <cmath>
+#include <cstddef>
+#include <type_traits>
 #include <utility>
 
 #include "Utilities/Gsl.hpp"
@@ -148,3 +150,22 @@ inline T magnitude(const std::array<T, 3>& a) noexcept {
   return sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2]);
 }
 //@}
+
+namespace std_array_helpers_detail {
+template <typename T, size_t Dim, typename F, size_t... Indices>
+auto map_array_impl(const std::array<T, Dim>& array, const F& f,
+                    const std::index_sequence<Indices...> /*meta*/) noexcept {
+  return std::array<std::decay_t<decltype(f(std::declval<T>()))>, Dim>{
+      {f(array[Indices])...}};
+}
+}  // namespace std_array_helpers_detail
+
+/// \ingroup UtilitiesGroup
+/// Applies a function to each element of an array, producing a new
+/// array of the results.  The elements of the new array are
+/// constructed in place, so they need not be default constructible.
+template <typename T, size_t Dim, typename F>
+auto map_array(const std::array<T, Dim>& array, const F& f) noexcept {
+  return std_array_helpers_detail::map_array_impl(
+      array, f, std::make_index_sequence<Dim>{});
+}

--- a/tests/Unit/DataStructures/Test_IndexIterator.cpp
+++ b/tests/Unit/DataStructures/Test_IndexIterator.cpp
@@ -3,6 +3,9 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <array>
+#include <cstddef>
+
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
 
@@ -17,36 +20,22 @@ SPECTRE_TEST_CASE("Unit.DataStructures.IndexIterator",
   /// [index_iterator_example]
 
   IndexIterator<3> index_iterator(elements);
-  CHECK(index_iterator);
-  CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 0 and
-         index_iterator()[2] == 0));
-  CHECK(index_iterator.collapsed_index() == 0);
-  ++index_iterator;
-  CHECK(index_iterator);
-  CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 1 and
-         index_iterator()[2] == 0));
-  CHECK(index_iterator.collapsed_index() == 1);
-  ++index_iterator;
-  CHECK(index_iterator);
-  CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 0 and
-         index_iterator()[2] == 1));
-  CHECK(index_iterator.collapsed_index() == 2);
-  ++index_iterator;
-  CHECK(index_iterator);
-  CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 1 and
-         index_iterator()[2] == 1));
-  CHECK(index_iterator.collapsed_index() == 3);
-  ++index_iterator;
-  CHECK(index_iterator);
-  CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 0 and
-         index_iterator()[2] == 2));
-  CHECK(index_iterator.collapsed_index() == 4);
-  ++index_iterator;
-  CHECK(index_iterator);
-  CHECK((index_iterator()[0] == 0 and index_iterator()[1] == 1 and
-         index_iterator()[2] == 2));
-  CHECK(index_iterator.collapsed_index() == 5);
-  ++index_iterator;
+  auto check_next = [&index_iterator,
+                     call_num = 0](const Index<3>& expected) mutable noexcept {
+    CHECK(index_iterator);
+    CHECK(index_iterator() == expected);
+    CHECK(*index_iterator == expected);
+    CHECK(index_iterator->indices() == expected.indices());
+    CHECK(index_iterator.collapsed_index() == call_num);
+    ++index_iterator;
+    ++call_num;
+  };
+  check_next(Index<3>(0, 0, 0));
+  check_next(Index<3>(0, 1, 0));
+  check_next(Index<3>(0, 0, 1));
+  check_next(Index<3>(0, 1, 1));
+  check_next(Index<3>(0, 0, 2));
+  check_next(Index<3>(0, 1, 2));
   CHECK(not index_iterator);
 
   // Test 0D IndexIterator

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_LinearOperators")
 
 set(LIBRARY_SOURCES
+  Test_ApplyMatrices.cpp
   Test_DefiniteIntegral.cpp
   Test_Divergence.cpp
   Test_Linearize.cpp

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_ApplyMatrices.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_ApplyMatrices.cpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <functional>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/IndexIterator.hpp"
+#include "DataStructures/Matrix.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/LinearOperators/ApplyMatrices.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+constexpr Spectral::Basis basis = Spectral::Basis::Legendre;
+// Using Gauss points for this test would be nice, since that would
+// let us test the extent=1 cases, but that needs to wait for
+// everything to be updated to use Mesh.
+constexpr Spectral::Quadrature quadrature = Spectral::Quadrature::GaussLobatto;
+template <size_t Dim>
+constexpr size_t max_points = 4;
+template <>
+constexpr size_t max_points<3> = 3;
+
+using ScalarType = Scalar<DataVector>;
+using VectorType = tnsr::I<DataVector, 2>;
+
+struct ScalarTag {
+  using type = ScalarType;
+};
+
+struct VectorTag {
+  using type = VectorType;
+};
+
+template <size_t Dim>
+Variables<tmpl::list<ScalarTag, VectorTag>> polynomial_data(
+    const Index<Dim>& extents, const Index<Dim>& powers) noexcept {
+  const auto coords = logical_coordinates(extents);
+  Variables<tmpl::list<ScalarTag, VectorTag>> result(extents.product(), 1.);
+  for (size_t i = 0; i < Dim; ++i) {
+    get(get<ScalarTag>(result)) *= pow(coords.get(i), powers[i]);
+    get<0>(get<VectorTag>(result)) *= 2.0 * pow(coords.get(i), powers[i]);
+    get<1>(get<VectorTag>(result)) *= 3.0 * pow(coords.get(i), powers[i]);
+  }
+  return result;
+}
+
+template <size_t Dim, size_t FilledDim = 0>
+struct CheckApply {
+  static void apply(
+      const Index<Dim>& source_extents,
+      const Index<Dim>& dest_extents,
+      const Index<Dim>& powers,
+      std::array<Matrix, Dim> matrices = std::array<Matrix, Dim>{}) noexcept {
+    if (source_extents[FilledDim] == dest_extents[FilledDim]) {
+      // Check implicit identity
+      CheckApply<Dim, FilledDim + 1>::apply(source_extents, dest_extents,
+                                            powers, matrices);
+    }
+    matrices[FilledDim] = Spectral::interpolation_matrix<basis, quadrature>(
+        source_extents[FilledDim],
+        Spectral::collocation_points<basis, quadrature>(
+            dest_extents[FilledDim]));
+    CheckApply<Dim, FilledDim + 1>::apply(source_extents, dest_extents, powers,
+                                          matrices);
+  }
+};
+
+template <size_t Dim>
+struct CheckApply<Dim, Dim> {
+  static void apply(const Index<Dim>& source_extents,
+                    const Index<Dim>& dest_extents,
+                    const Index<Dim>& powers,
+                    const std::array<Matrix, Dim>& matrices = {}) noexcept {
+    const auto source_data = polynomial_data(source_extents, powers);
+    const auto result = apply_matrices(matrices, source_data, source_extents);
+    const auto expected = polynomial_data(dest_extents, powers);
+    // Using this over CHECK_ITERABLE_APPROX speeds the test up by a
+    // factor of 6 or so.
+    for (const auto& p : result - expected) {
+      CHECK(approx(p) == 0.);
+    }
+    const auto ref_matrices =
+        make_array<std::reference_wrapper<const Matrix>, Dim>(matrices);
+    CHECK(apply_matrices(ref_matrices, source_data, source_extents) == result);
+    CHECK(apply_matrices(matrices, get(get<ScalarTag>(source_data)),
+                         source_extents) == get(get<ScalarTag>(result)));
+    CHECK(apply_matrices(ref_matrices, get(get<ScalarTag>(source_data)),
+                         source_extents) == get(get<ScalarTag>(result)));
+  }
+};
+
+template <size_t Dim>
+void test_interpolation() noexcept {
+  const auto too_few_points = [](const size_t extent) noexcept {
+    return extent < Spectral::minimum_number_of_points<basis, quadrature>;
+  };
+
+  for (IndexIterator<Dim> source_extents(Index<Dim>(max_points<Dim> + 1));
+       source_extents;
+       ++source_extents) {
+    if (std::any_of(source_extents->begin(), source_extents->end(),
+                    too_few_points)) {
+      continue;
+    }
+    CAPTURE(*source_extents);
+    for (IndexIterator<Dim> dest_extents(Index<Dim>(max_points<Dim> + 1));
+         dest_extents;
+         ++dest_extents) {
+      if (std::any_of(dest_extents->begin(), dest_extents->end(),
+                      too_few_points)) {
+        continue;
+      }
+      CAPTURE(*dest_extents);
+      Index<Dim> max_powers;
+      for (size_t i = 0; i < Dim; ++i) {
+        max_powers[i] = std::min((*source_extents)[i], (*dest_extents)[i]);
+      }
+      for (IndexIterator<Dim> powers(max_powers); powers; ++powers) {
+        CAPTURE(*powers);
+        CheckApply<Dim>::apply(*source_extents, *dest_extents, *powers);
+      }
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.ApplyMatrices",
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+  test_interpolation<1>();
+  test_interpolation<2>();
+  test_interpolation<3>();
+}

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
@@ -93,8 +93,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Transpose",
   }
   const size_t number_of_chunks_vars = variables.size() / chunk_size_vars;
   auto transposed_vars = variables;
-  transpose(variables, chunk_size_vars, number_of_chunks_vars,
-            make_not_null(&transposed_vars));
+  transpose(make_not_null(&transposed_vars), variables, chunk_size_vars,
+            number_of_chunks_vars);
   for (size_t i = 0; i < chunk_size_vars; ++i) {
     for (size_t j = 0; j < number_of_chunks_vars; ++j) {
       // clang-tidy: pointer arithmetic
@@ -109,8 +109,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Transpose",
   get<Var1<2>>(partial_vars) = get<Var1<2>>(variables);
   Variables<one_var<2>> partial_transpose(n_grid_pts, 0.);
   const size_t partial_number_of_chunks = 2*number_of_chunks_vars / 3;
-  transpose(variables, chunk_size_vars, partial_number_of_chunks,
-            make_not_null(&partial_transpose));
+  transpose(make_not_null(&partial_transpose), variables, chunk_size_vars,
+            partial_number_of_chunks);
   for (size_t i = 0; i < chunk_size_vars; ++i) {
     for (size_t j = 0; j < partial_number_of_chunks; ++j) {
       // clang-tidy: pointer arithmetic

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Transpose.cpp
@@ -48,6 +48,11 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Transpose",
   /// [transpose_matrix]
   // clang-format on
 
+  DataVector transposed_matrix(12);
+  raw_transpose(make_not_null(transposed_matrix.data()), matrix.data(), 3, 4);
+  CHECK(transposed_matrix ==
+        DataVector{1., 4., 7., 10., 2., 5., 8., 11., 3., 6., 9., 12.});
+
   /// [return_transpose_example]
   const size_t chunk_size = 8;
   const size_t number_of_chunks = 2;

--- a/tests/Unit/Utilities/Test_StdArrayHelpers.cpp
+++ b/tests/Unit/Utilities/Test_StdArrayHelpers.cpp
@@ -125,3 +125,18 @@ SPECTRE_TEST_CASE("Unit.Utilities.StdArrayHelpers.Prepend",
   const auto p3 = prepend(a2, 5_st);
   CHECK(p3 == a3);
 }
+
+SPECTRE_TEST_CASE("Unit.Utilities.StdArrayHelpers.map_array",
+                  "[Utilities][Unit]") {
+  const auto func = [](const int x) noexcept { return 2. * x; };
+  CHECK(map_array(std::array<int, 3>{{4, 3, 2}}, func) ==
+        std::array<double, 3>{{8, 6, 4}});
+  CHECK(map_array(std::array<int, 1>{{4}}, func) == std::array<double, 1>{{8}});
+  CHECK(map_array(std::array<int, 0>{}, func) == std::array<double, 0>{});
+
+  // Check function returning a reference
+  CHECK(
+      map_array(std::array<int, 1>{{4}}, [](const int& x) noexcept->const int& {
+        return x;
+      }) == std::array<int, 1>{{4}});
+}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- Follows [code review guidelines](https://sxs-collaboration.github.io/spectre/code_review_guide.html)
- Code has documentation and unit tests
- Private member variables have a trailing underscore
- Do not use [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation), e.g. `double* pd_blah` is bad
- Header order:
  1. hpp corresponding to cpp (only in cpp files) or `tests/Unit/TestingFramework.hpp` (only in tests)
  2. Blank line (only in cpp files and tests)
  3. STL and externals (in alphabetical order)
  4. Blank line
  5. SpECTRE includes (in alphabetical order)
- File lists in CMake are alphabetical
- Correct `noexcept` specification for functions (if unsure, mark `noexcept`)
- Mark objects `const` whenever possible
- Almost always `auto`, except with expression templates, i.e. `DataVector`
- All commits for performance changes provide quantitative evidence and the tests used to obtain said evidence.
- Make sure error messages are helpful, e.g. "The number of grid points in the matrix 'F' is not the same as the number of grid points in the determinant."
- Prefix commits addressing PR requests with `fixup`. These commits are flagged
  by Travis so we do not accidentally merge them.
- Include what you use, prefer forward declarations in hpp files.
- Explicitly make numbers floating point, e.g. `2.` or `2.0` over `2`
- Use `Tensor`'s non-member get if the indices are constant expressions, e.g.
  `get<1>(tensor)`

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
