### PR TITLE
Add mass operator

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
     ApplyMatrices.cpp
     DefiniteIntegral.cpp
     Linearize.cpp
+    Mass.cpp
     MeanValue.cpp
     )
 

--- a/src/NumericalAlgorithms/LinearOperators/Mass.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/Mass.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/LinearOperators/Mass.hpp"
+
+#include <ostream>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/IndexIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "NumericalAlgorithms/Spectral/LegendreGaussLobatto.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+template <size_t Dim>
+DataVector mass(
+    const DataVector& data,
+    const Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>& jacobian,
+    const Index<Dim>& mesh) noexcept {
+  ASSERT(data.size() == mesh.product(),
+         "size = " << data.size() << ", num_grid_points = " << mesh.product());
+  // This can be vectorized when we have implemented functionality to apply
+  // diagonal matrices to DataVectors.
+  auto massive_data = data;
+  for (IndexIterator<Dim> index(mesh); index; ++index) {
+    for (size_t d = 0; d < Dim; d++) {
+      massive_data[index.collapsed_index()] *=
+          Basis::lgl::quadrature_weights(mesh[d])[index()[d]] *
+          jacobian.get(d, d)[index.collapsed_index()];
+    }
+  }
+  return massive_data;
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(_, data)                                                 \
+  template DataVector mass<DIM(data)>(                                         \
+      const DataVector&,                                                       \
+      const Jacobian<DataVector, DIM(data), Frame::Logical, Frame::Inertial>&, \
+      const Index<DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+/// \endcond

--- a/src/NumericalAlgorithms/LinearOperators/Mass.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Mass.hpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines function mass.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+class DataVector;
+template <size_t>
+class Index;
+/// \endcond
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Applies the mass matrix.
+ *
+ * \details We use a diagonal mass matrix approximation. Please refer to
+ * dg::lift_flux() for details.
+ */
+template <size_t Dim>
+DataVector mass(
+    const DataVector& data,
+    const Jacobian<DataVector, Dim, Frame::Logical, Frame::Inertial>& jacobian,
+    const Index<Dim>& mesh) noexcept;


### PR DESCRIPTION
## Proposed changes

This PR adds a linear operator that applies the mass matrix to a `DataVector` in the diagonal mass matrix approximation. This is needed to make the operator in elliptic equations symmetric, which helps with their iterative solution. If there are alternatives to this approach, please let me know.

I'll also add tests.

This is in preparation for the elliptic solver components added in future PRs.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
