### PR TITLE
Bary interp

### DIFF
--- a/src/NumericalAlgorithms/CMakeLists.txt
+++ b/src/NumericalAlgorithms/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Interpolation)
 add_subdirectory(LinearAlgebra)
 add_subdirectory(LinearOperators)
 add_subdirectory(RootFinding)

--- a/src/NumericalAlgorithms/Interpolation/BarycentricRational.cpp
+++ b/src/NumericalAlgorithms/Interpolation/BarycentricRational.cpp
@@ -1,0 +1,89 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/BarycentricRational.hpp"
+
+#include <algorithm>
+#include <ostream>
+#include <pup.h>
+#include <pup_stl.h>
+
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace intrp {
+BarycentricRational::BarycentricRational(std::vector<double> x_values,
+                                         std::vector<double> y_values,
+                                         const size_t order) noexcept
+    : x_values_(std::move(x_values)),
+      y_values_(std::move(y_values)),
+      weights_(x_values_.size(), 0.0),
+      order_(static_cast<ssize_t>(order)) {
+  ASSERT(x_values_.size() == y_values_.size(),
+         "The x-value and y-value vectors must be of the same length, but "
+         "receives x-value of size: "
+             << x_values_.size()
+             << " and y-value of size: " << y_values_.size());
+  ASSERT(x_values_.size() >= order,
+         " The size of the x-value and y-value vectors must be at least the "
+         "requested order of interpolation. The requested order is: "
+             << order_
+             << " while the size of the vectors is: " << x_values_.size());
+  // Use ssize_t because we do signed arithmetic
+  const auto size = static_cast<ssize_t>(x_values_.size());
+  // for each weights[k]...
+  for (ssize_t k = 0; k < size; ++k) {
+    const ssize_t i_lower_bound = std::max(k - order_, ssize_t{0});
+    const ssize_t i_upper_bound = std::min(size - order_ - 1, k);
+    // perform sum w_k = \sum_{i=k-order, 0 \le i < N - order}^{k} (-1)^i where
+    // N is the size of the input vectors, order the interpolation order, k is
+    // the index of the weights (which is in [0, order_]).
+    for (ssize_t i = i_lower_bound; i <= i_upper_bound; ++i) {
+      const ssize_t j_max = std::min(i + order_, size - 1);
+      double inv_product = 1.0;
+      // perform product: \prod_{j=i, j!=k}^{i+order} 1 / (x_k - x_j)
+      for (ssize_t j = i; j <= j_max; ++j) {
+        if (UNLIKELY(j == k)) {
+          continue;
+        }
+        inv_product *= (x_values_[static_cast<size_t>(k)] -
+                        x_values_[static_cast<size_t>(j)]);
+      }
+      if ((i & static_cast<ssize_t>(1)) == 1) {
+        // if i is odd subtract
+        weights_[static_cast<size_t>(k)] -= 1.0 / inv_product;
+      } else {
+        // if i is even add
+        weights_[static_cast<size_t>(k)] += 1.0 / inv_product;
+      }
+    }
+  }
+}
+
+double BarycentricRational::operator()(const double x_to_interp_to) const
+    noexcept {
+  double numerator = 0.0;
+  double denominator = 0.0;
+  const size_t size = x_values_.size();
+  for (size_t i = 0; i < size; ++i) {
+    if (x_to_interp_to == x_values_[i]) {
+      return y_values_[i];
+    }
+    const double temp = weights_[i] / (x_to_interp_to - x_values_[i]);
+    numerator += temp * y_values_[i];
+    denominator += temp;
+  }
+  return numerator / denominator;
+}
+
+size_t BarycentricRational::order() const noexcept {
+  return static_cast<size_t>(order_);
+}
+
+void BarycentricRational::pup(PUP::er& p) noexcept {
+  p | x_values_;
+  p | y_values_;
+  p | weights_;
+  p | order_;
+}
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/BarycentricRational.hpp
+++ b/src/NumericalAlgorithms/Interpolation/BarycentricRational.hpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <unistd.h>  // IWYU pragma: keep
+#include <vector>
+
+namespace PUP {
+class er;
+}  // namespace PUP
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Contains classes and functions for interpolation
+ */
+namespace intrp {
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief A barycentric rational interpolation class
+ *
+ * The class builds a barycentric rational interpolant of a specified order
+ * using the `x_values` and `y_values` passed into the constructor.
+ * Barycentric interpolation requires \f$3N\f$ storage, and costs
+ * \f$\mathcal{O}(Nd)\f$ to construct, where \f$N\f$ is the size of the x- and
+ * y-value vectors and \f$d\f$ is the order of the interpolant. The evaluation
+ * cost is \f$\mathcal{O}(N)\f$ compared to \f$\mathcal{O}(d)\f$ of a spline
+ * method, but constructing the barycentric interpolant does not require any
+ * derivatives of the function to be known.
+ *
+ * The interpolation function is
+ *
+ * \f[
+ *   \mathcal{I}(x)=\frac{\sum_{i=0}^{N-1}w_i y_i /
+ *   (x-x_i)}{\sum_{i=0}^{N-1}w_i/(x-x_i)}
+ * \f]
+ *
+ * where \f$w_i\f$ are the weights. The weights are computed using
+ *
+ * \f[
+ *   w_k=\sum_{i=k-d\\0\le i < N-d}^{k}(-1)^{i}
+ *       \prod_{j=i\\j\ne k}^{i+d}\frac{1}{x_k-x_j} \f]
+ *
+ * \requires `x_values.size() == y_values.size()` and
+ * `x_values_.size() >= order`
+ */
+class BarycentricRational {
+ public:
+  BarycentricRational() noexcept = default;
+  BarycentricRational(std::vector<double> x_values,
+                      std::vector<double> y_values, size_t order) noexcept;
+
+  double operator()(double x_to_interp_to) const noexcept;
+
+  size_t order() const noexcept;
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  std::vector<double> x_values_;
+  std::vector<double> y_values_;
+  std::vector<double> weights_;
+  ssize_t order_{0};
+};
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY Interpolation)
+
+set(LIBRARY_SOURCES
+  BarycentricRational.cpp
+  )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  )

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -61,10 +61,11 @@ struct div<Tag, Requires<tt::is_a_v<::Variables, db::item_type<Tag>>>>
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the (Euclidean) divergence of fluxes
 template <typename FluxTags, size_t Dim, typename DerivativeFrame>
-Variables<db::wrap_tags_in<Tags::div, FluxTags>> divergence(
+auto divergence(
     const Variables<FluxTags>& F, const Index<Dim>& extents,
     const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
-        inverse_jacobian) noexcept;
+        inverse_jacobian) noexcept
+    -> Variables<db::wrap_tags_in<Tags::div, FluxTags>>;
 
 namespace Tags {
 /// \ingroup DataBoxTagsGroup

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -73,8 +73,9 @@ struct deriv : Tags_detail::deriv_impl<T, S, U> {};
 /// \tparam DerivativeTags the subset of `VariableTags` for which derivatives
 /// are computed.
 template <typename DerivativeTags, typename VariableTags, size_t Dim>
-std::array<Variables<DerivativeTags>, Dim> logical_partial_derivatives(
-    const Variables<VariableTags>& u, const Index<Dim>& extents) noexcept;
+auto logical_partial_derivatives(const Variables<VariableTags>& u,
+                                 const Index<Dim>& extents) noexcept
+    -> std::array<Variables<DerivativeTags>, Dim>;
 
 /// \ingroup NumericalAlgorithmsGroup
 /// \brief Compute the partial derivatives of each variable with respect to
@@ -89,12 +90,12 @@ std::array<Variables<DerivativeTags>, Dim> logical_partial_derivatives(
 /// are computed.
 template <typename DerivativeTags, typename VariableTags, size_t Dim,
           typename DerivativeFrame>
-Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags, tmpl::size_t<Dim>,
-                           DerivativeFrame>>
-partial_derivatives(
+auto partial_derivatives(
     const Variables<VariableTags>& u, const Index<Dim>& extents,
     const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
-        inverse_jacobian) noexcept;
+        inverse_jacobian) noexcept
+    -> Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags,
+                                  tmpl::size_t<Dim>, DerivativeFrame>>;
 
 namespace Tags {
 namespace Tags_detail {

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_NumericalInterpolation")
 
 set(LIBRARY_SOURCES
+  Test_BarycentricRational.cpp
   Test_LagrangePolynomial.cpp
   )
 
@@ -11,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "NumericalAlgorithms/Interpolation/"
   "${LIBRARY_SOURCES}"
-  "" # Header-only, link dependencies included from testing lib
+  "Interpolation"
   )

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_BarycentricRational.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_BarycentricRational.cpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "NumericalAlgorithms/Interpolation/BarycentricRational.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <random>
+#include <vector>
+
+namespace {
+template <class F>
+void test_barycentric_rational(const F& function, const double lower_bound,
+                               const double upper_bound, const size_t size,
+                               const size_t order) noexcept {
+  std::vector<double> x_values(size), y_values(size);
+  const double delta_x = (upper_bound - lower_bound) / size;
+  std::random_device rd;
+  const auto seed = rd();
+  CAPTURE(seed);
+  std::mt19937 gen(seed);
+  std::uniform_real_distribution<> dis(0.0, delta_x);
+  for (size_t i = 0; i < size; ++i) {
+    x_values[i] = lower_bound + i * delta_x + dis(gen);
+    y_values[i] = function(x_values[i]);
+  }
+
+  intrp::BarycentricRational interpolant{x_values, y_values, order};
+
+  const auto deserialized_interpolant = serialize_and_deserialize(interpolant);
+  Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
+  for (size_t i = 0; i < 10 * size; ++i) {
+    const double x_value = lower_bound + i * delta_x * 0.1 + 0.1 * dis(gen);
+    CAPTURE(x_value);
+    CHECK_ITERABLE_CUSTOM_APPROX(function(x_value), interpolant(x_value),
+                                 custom_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        function(x_value), deserialized_interpolant(x_value), custom_approx);
+  }
+  CHECK(order == interpolant.order());
+  CHECK(order == deserialized_interpolant.order());
+}
+
+void single_call(const size_t number_of_points, const size_t order,
+                 const size_t expo) {
+  INFO("Polynomial degree := " << expo);
+  test_barycentric_rational(
+      [expo](const auto& x) noexcept {
+        auto result = x;
+        for (size_t j = 2; j < expo; ++j) {
+          result += pow(x, j);
+        }
+        return result;
+      },
+      -1.0, 2.3, number_of_points, order);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.BarycentricRational",
+                  "[Unit][NumericalAlgorithms]") {
+  for (size_t order = 3; order < 6; ++order) {
+    INFO("Order:= " << order);
+    {
+      const size_t number_of_points = 22 - 3 * order;
+      single_call(number_of_points, order, 1);
+      single_call(number_of_points, order, 2);
+    }
+    {
+      const size_t number_of_points = 22 - 2 * order;
+      single_call(number_of_points, order, 3);
+    }
+    if (order > 3) {
+      const size_t number_of_points = 22 - order;
+      single_call(number_of_points, order, 4);
+      single_call(number_of_points, order, 5);
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

Adds a barycentric rational interpolation class. Boost has one but only in recent versions, ~1.65.0 and newer, and the one from Boost also cannot be serialized.  This is necessary for #652 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
