### PR TITLE
DirectionMap

### DIFF
--- a/src/DataStructures/DataVector.cpp
+++ b/src/DataStructures/DataVector.cpp
@@ -6,8 +6,9 @@
 #include <algorithm>
 #include <pup.h>
 #include <pup_stl.h>
+#include <utility>
 
-#include "Utilities/StdHelpers.hpp"
+#include "Utilities/PrintHelpers.hpp"
 
 DataVector::DataVector(const size_t size, const double value)
     : size_(size),

--- a/src/DataStructures/DataVector.cpp
+++ b/src/DataStructures/DataVector.cpp
@@ -109,8 +109,7 @@ void DataVector::pup(PUP::er& p) noexcept {  // NOLINT
 }
 
 std::ostream& operator<<(std::ostream& os, const DataVector& d) {
-  // This function is inside the detail namespace StdHelpers.hpp
-  StdHelpers_detail::print_helper(os, d.begin(), d.end());
+  sequence_print_helper(os, d.begin(), d.end());
   return os;
 }
 

--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -18,8 +18,7 @@ Block<VolumeDim, TargetFrame>::Block(
     std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>&&
         map,
     const size_t id,
-    std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>
-        neighbors)
+    DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors)
     : map_(std::move(map)), id_(id), neighbors_(std::move(neighbors)) {
   // Loop over Directions to search which Directions were not set to neighbors_,
   // set these Directions to external_boundaries_.

--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -42,11 +42,7 @@ template <size_t VolumeDim, typename TargetFrame>
 std::ostream& operator<<(std::ostream& os,
                          const Block<VolumeDim, TargetFrame>& block) {
   os << "Block " << block.id() << ":\n";
-  os << "Neighbors:\n";
-  for (const auto& direction_to_neighbors : block.neighbors()) {
-    os << direction_to_neighbors.first << ": " << direction_to_neighbors.second
-       << "\n";
-  }
+  os << "Neighbors: " << block.neighbors() << "\n";
   os << "External boundaries: " << block.external_boundaries() << "\n";
   return os;
 }

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -9,12 +9,12 @@
 #include <cstddef>
 #include <memory>
 #include <ostream>
-#include <unordered_map>
 #include <unordered_set>
 
 #include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"  // IWYU pragma: keep
+#include "Domain/DirectionMap.hpp"
 
 /// \cond
 namespace Frame {
@@ -47,9 +47,7 @@ class Block {
   /// boundary with this Block.
   Block(std::unique_ptr<
             CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>&& map,
-        size_t id,
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>
-            neighbors);
+        size_t id, DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors);
 
   Block() = default;
   ~Block() = default;
@@ -69,8 +67,8 @@ class Block {
   size_t id() const noexcept { return id_; }
 
   /// Information about the neighboring Blocks.
-  const std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>&
-  neighbors() const noexcept {
+  const DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>& neighbors() const
+      noexcept {
     return neighbors_;
   }
 
@@ -87,7 +85,7 @@ class Block {
   std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>
       map_;
   size_t id_{0};
-  std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>> neighbors_;
+  DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors_;
   std::unordered_set<Direction<VolumeDim>> external_boundaries_;
 };
 

--- a/src/Domain/DirectionMap.hpp
+++ b/src/Domain/DirectionMap.hpp
@@ -1,0 +1,373 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+// What incorrect header IWYU wants to pull ptrdiff_t from seems to be
+// very sensitive to the other includes.  I've left pragmas for all
+// the ones it has requested during development to defend against
+// problems from changes to the include list, even though not all of
+// them are requested with the current include list.
+#include <algorithm>
+// For ptrdiff_t (actually in cstddef)
+// IWYU pragma: no_include <alloca.h>
+#include <array>
+#include <boost/none.hpp>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <initializer_list>
+#include <iterator>
+#include <ostream>
+#include <stdexcept>
+// For ptrdiff_t (actually in cstddef)
+// IWYU pragma: no_include <stdlib.h>
+// For ptrdiff_t (actually in cstddef)
+// IWYU pragma: no_include <sys/types.h>
+#include <utility>
+
+#include "Domain/Direction.hpp"
+#include "Domain/Side.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
+#include "Utilities/BoostHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/// \cond
+template <typename ValueType>
+class DirectionMapIterator;
+/// \endcond
+
+/// \ingroup DataStructuresGroup
+/// \ingroup ComputationalDomainGroup
+/// An optimized map with Direction keys
+template <size_t Dim, typename T>
+class DirectionMap {
+ public:
+  using key_type = Direction<Dim>;
+  using mapped_type = T;
+  using value_type = std::pair<const key_type, mapped_type>;
+  using size_type = size_t;
+  using difference_type = ptrdiff_t;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using iterator = DirectionMapIterator<value_type>;
+  using const_iterator = DirectionMapIterator<const value_type>;
+
+  DirectionMap() = default;
+  DirectionMap(const DirectionMap&) = default;
+  DirectionMap(DirectionMap&&) = default;
+  ~DirectionMap() = default;
+
+  DirectionMap& operator=(const DirectionMap& other) noexcept;
+  DirectionMap& operator=(DirectionMap&& other) noexcept;
+
+  DirectionMap(std::initializer_list<value_type> init) noexcept;
+
+  iterator begin() noexcept { return unconst(cbegin()); }
+  const_iterator begin() const noexcept {
+    return const_iterator(data_.begin(), data_.end());
+  }
+  const_iterator cbegin() const noexcept { return begin(); }
+
+  iterator end() noexcept { return unconst(cend()); }
+  const_iterator end() const noexcept {
+    return const_iterator(data_.end(), data_.end());
+  }
+  const_iterator cend() const noexcept { return end(); }
+
+  bool empty() const noexcept {
+    return std::none_of(data_.begin(), data_.end(), is_set);
+  }
+  size_t size() const noexcept {
+    return static_cast<size_t>(
+        std::count_if(data_.begin(), data_.end(), is_set));
+  }
+
+  void clear() noexcept;
+  std::pair<iterator, bool> insert(const value_type& value) noexcept {
+    return insert(value_type(value));
+  }
+  std::pair<iterator, bool> insert(value_type&& value) noexcept;
+  template <typename... Args>
+  std::pair<iterator, bool> emplace(Args&&... args) noexcept {
+    return insert(value_type(std::forward<Args>(args)...));
+  }
+  iterator erase(const const_iterator& pos) noexcept;
+  size_t erase(const Direction<Dim>& key) noexcept;
+
+  T& at(const Direction<Dim>& key);
+  const T& at(const Direction<Dim>& key) const;
+  T& operator[](const Direction<Dim>& key) noexcept;
+
+  size_t count(const Direction<Dim>& key) const noexcept {
+    return data_entry(key) ? 1 : 0;
+  }
+  iterator find(const Direction<Dim>& key) noexcept {
+    return unconst(cpp17::as_const(*this).find(key));
+  }
+  const_iterator find(const Direction<Dim>& key) const noexcept {
+    return data_entry(key) ? const_iterator(&data_entry(key), data_.end())
+                           : end();
+  }
+
+  void pup(PUP::er& p) noexcept {  // NOLINT(google-runtime-references)
+    p | data_;
+  }
+
+ private:
+  boost::optional<value_type>& data_entry(const Direction<Dim>& key) noexcept {
+    return gsl::at(data_,
+                   2 * key.dimension() + (key.side() == Side::Upper ? 1 : 0));
+  }
+  const boost::optional<value_type>& data_entry(const Direction<Dim>& key) const
+      noexcept {
+    return gsl::at(data_,
+                   2 * key.dimension() + (key.side() == Side::Upper ? 1 : 0));
+  }
+
+  iterator unconst(const const_iterator& it) noexcept {
+    return iterator(&it.get_optional() - data_.begin() + data_.begin(),
+                    data_.end());
+  }
+
+  static bool is_set(const boost::optional<value_type>& opt) noexcept {
+    return static_cast<bool>(opt);
+  }
+
+  template <size_t FDim, typename FT>
+  // NOLINTNEXTLINE(readability-redundant-declaration) false positive
+  friend bool operator==(const DirectionMap<FDim, FT>& a,
+                         const DirectionMap<FDim, FT>& b) noexcept;
+
+  std::array<boost::optional<value_type>, 2 * Dim> data_;
+};
+
+/// \cond HIDDEN_SYMBOLS
+template <typename ValueType>
+class DirectionMapIterator {
+ public:
+  using difference_type = ptrdiff_t;
+  using value_type = std::remove_const_t<ValueType>;
+  using pointer = ValueType*;
+  using reference = ValueType&;
+  using iterator_category = std::forward_iterator_tag;
+
+  DirectionMapIterator() = default;
+
+  /// Implicit conversion from mutable to const iterator.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  operator DirectionMapIterator<const ValueType>() const noexcept {
+    return {entry_, end_};
+  }
+
+  reference operator*() const noexcept { return **entry_; }
+  pointer operator->() const noexcept { return entry_->get_ptr(); }
+
+  DirectionMapIterator& operator++() noexcept;
+  // clang-tidy wants this to return a const object.  Returning const
+  // objects is very strange, and as of June 2018 clang-tidy's
+  // explanation for the lint is a dead link.
+  DirectionMapIterator operator++(int) noexcept;  // NOLINT(cert-dcl21-cpp)
+
+ private:
+  friend class DirectionMap<value_type::first_type::volume_dim,
+                            typename value_type::second_type>;
+  friend class DirectionMapIterator<value_type>;
+
+  friend bool operator==(const DirectionMapIterator& a,
+                         const DirectionMapIterator& b) noexcept {
+    return a.entry_ == b.entry_;
+  }
+  friend bool operator<(const DirectionMapIterator& a,
+                        const DirectionMapIterator& b) noexcept {
+    return a.entry_ < b.entry_;
+  }
+
+  // The rest of the comparison operators don't need access to the
+  // class internals, but they need to be instantiated for each
+  // instantiation of the class.
+  friend bool operator!=(const DirectionMapIterator& a,
+                         const DirectionMapIterator& b) noexcept {
+    return not(a == b);
+  }
+  friend bool operator>(const DirectionMapIterator& a,
+                        const DirectionMapIterator& b) noexcept {
+    return b < a;
+  }
+  friend bool operator<=(const DirectionMapIterator& a,
+                         const DirectionMapIterator& b) noexcept {
+    return not(b < a);
+  }
+  friend bool operator>=(const DirectionMapIterator& a,
+                         const DirectionMapIterator& b) noexcept {
+    return not(a < b);
+  }
+
+  using map_optional_type = boost::optional<std::remove_const_t<ValueType>>;
+  using optional_type =
+      tmpl::conditional_t<std::is_const<ValueType>::value,
+                          const map_optional_type, map_optional_type>;
+
+  DirectionMapIterator(optional_type* const entry,
+                       optional_type* const end) noexcept
+      : entry_(entry), end_(end) {
+    if (entry_ != end_ and not *entry_) {
+      operator++();
+    }
+  }
+
+  optional_type& get_optional() const { return *entry_; }
+
+  optional_type* entry_{nullptr};
+  optional_type* end_{nullptr};
+};
+
+template <typename ValueType>
+DirectionMapIterator<ValueType>& DirectionMapIterator<ValueType>::
+operator++() noexcept {
+  ASSERT(entry_ != end_, "Tried to increment an end iterator");
+  do {
+    ++entry_;  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  } while (entry_ < end_ and not *entry_);
+  return *this;
+}
+
+template <typename ValueType>
+// NOLINTNEXTLINE(cert-dcl21-cpp) see declaration
+DirectionMapIterator<ValueType> DirectionMapIterator<ValueType>::operator++(
+    int) noexcept {
+  const auto ret = *this;
+  operator++();
+  return ret;
+}
+/// \endcond
+
+template <size_t Dim, typename T>
+DirectionMap<Dim, T>& DirectionMap<Dim, T>::operator=(
+    const DirectionMap<Dim, T>& other) noexcept {
+  clear();
+  for (size_t i = 0; i < data_.size(); ++i) {
+    const auto& other_optional = gsl::at(other.data_, i);
+    if (other_optional) {
+      gsl::at(data_, i).emplace(*other_optional);
+    }
+  }
+  return *this;
+}
+
+template <size_t Dim, typename T>
+DirectionMap<Dim, T>& DirectionMap<Dim, T>::operator=(
+    DirectionMap<Dim, T>&& other) noexcept {
+  clear();
+  for (size_t i = 0; i < data_.size(); ++i) {
+    auto& other_optional = gsl::at(other.data_, i);
+    if (other_optional) {
+      gsl::at(data_, i).emplace(std::move(*other_optional));
+    }
+  }
+  return *this;
+}
+
+template <size_t Dim, typename T>
+DirectionMap<Dim, T>::DirectionMap(
+    const std::initializer_list<value_type> init) noexcept {
+  for (const auto& entry : init) {
+    insert(entry);
+  }
+}
+
+template <size_t Dim, typename T>
+void DirectionMap<Dim, T>::clear() noexcept {
+  for (auto& entry : data_) {
+    entry = boost::none;
+  }
+}
+
+template <size_t Dim, typename T>
+std::pair<typename DirectionMap<Dim, T>::iterator, bool>
+DirectionMap<Dim, T>::insert(value_type&& value) noexcept {
+  const Direction<Dim> key = value.first;
+  const bool is_new_entry = not data_entry(key);
+  if (is_new_entry) {
+    data_entry(key).emplace(key, std::move(value.second));
+  }
+  return std::make_pair(find(key), is_new_entry);
+}
+
+template <size_t Dim, typename T>
+typename DirectionMap<Dim, T>::iterator DirectionMap<Dim, T>::erase(
+    const const_iterator& pos) noexcept {
+  unconst(pos).get_optional() = boost::none;
+  // pos is now invalid.  The unconst operation will adjust it to the
+  // next valid value.
+  return unconst(pos);
+}
+
+template <size_t Dim, typename T>
+size_t DirectionMap<Dim, T>::erase(const Direction<Dim>& key) noexcept {
+  if (not data_entry(key)) {
+    return 0;
+  }
+  data_entry(key) = boost::none;
+  return 1;
+}
+
+template <size_t Dim, typename T>
+T& DirectionMap<Dim, T>::at(const Direction<Dim>& key) {
+  if (not data_entry(key)) {
+    throw std::out_of_range(get_output(key) + " not in map");
+  }
+  return data_entry(key)->second;
+}
+
+template <size_t Dim, typename T>
+const T& DirectionMap<Dim, T>::at(const Direction<Dim>& key) const {
+  if (not data_entry(key)) {
+    throw std::out_of_range(get_output(key) + " not in map");
+  }
+  return data_entry(key)->second;
+}
+
+template <size_t Dim, typename T>
+T& DirectionMap<Dim, T>::operator[](const Direction<Dim>& key) noexcept {
+  if (not data_entry(key)) {
+    data_entry(key).emplace(key, T{});
+  }
+  return data_entry(key)->second;
+}
+
+template <size_t Dim, typename T>
+bool operator==(const DirectionMap<Dim, T>& a,
+                const DirectionMap<Dim, T>& b) noexcept {
+  return a.data_ == b.data_;
+}
+
+template <size_t Dim, typename T>
+bool operator!=(const DirectionMap<Dim, T>& a,
+                const DirectionMap<Dim, T>& b) noexcept {
+  return not(a == b);
+}
+
+template <size_t Dim, typename T>
+inline std::ostream& operator<<(std::ostream& os,
+                                const DirectionMap<Dim, T>& m) {
+  unordered_print_helper(
+      os, std::begin(m), std::end(m),
+      [](std::ostream& out, typename DirectionMap<Dim, T>::const_iterator it) {
+        out << "[" << it->first << "," << it->second << "]";
+      });
+  return os;
+}

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -5,11 +5,10 @@
 
 #include <ostream>
 #include <pup.h>  // IWYU pragma: keep
-#include <unordered_map>
 
 #include "Domain/BlockNeighbor.hpp"                 // IWYU pragma: keep
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"  // IWYU pragma: keep
-#include "Domain/Direction.hpp"                     // IWYU pragma: keep
+#include "Domain/DirectionMap.hpp"                  // IWYU pragma: keep
 #include "Domain/DomainHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
@@ -32,8 +31,7 @@ Domain<VolumeDim, TargetFrame>::Domain(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
     const std::vector<PairOfFaces>& identifications) {
-  std::vector<
-      std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>
+  std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>
       neighbors_of_all_blocks;
   set_internal_boundaries<VolumeDim>(corners_of_all_blocks,
                                      &neighbors_of_all_blocks);

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -11,7 +11,6 @@
 
 #include "DataStructures/IndexIterator.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
@@ -254,12 +253,12 @@ template <size_t VolumeDim>
 void set_internal_boundaries(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    gsl::not_null<std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
+    gsl::not_null<
+        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks) {
   for (size_t block1_index = 0; block1_index < corners_of_all_blocks.size();
        block1_index++) {
-    std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>> neighbor;
+    DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbor;
     for (size_t block2_index = 0; block2_index < corners_of_all_blocks.size();
          block2_index++) {
       if (block1_index != block2_index and
@@ -286,8 +285,8 @@ void set_periodic_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    gsl::not_null<std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
+    gsl::not_null<
+        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks) {
   for (const auto& pair : identifications) {
     const auto& face1 = pair.first;
@@ -777,37 +776,31 @@ std::array<size_t, two_to_the(VolumeDim)> discrete_rotation(
 
 template void set_internal_boundaries(
     const std::vector<std::array<size_t, 2>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>*>
+    gsl::not_null<std::vector<DirectionMap<1, BlockNeighbor<1>>>*>
         neighbors_of_all_blocks);
 template void set_internal_boundaries(
     const std::vector<std::array<size_t, 4>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>*>
+    gsl::not_null<std::vector<DirectionMap<2, BlockNeighbor<2>>>*>
         neighbors_of_all_blocks);
 template void set_internal_boundaries(
     const std::vector<std::array<size_t, 8>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>*>
+    gsl::not_null<std::vector<DirectionMap<3, BlockNeighbor<3>>>*>
         neighbors_of_all_blocks);
 
 template void set_periodic_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 2>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>*>
+    gsl::not_null<std::vector<DirectionMap<1, BlockNeighbor<1>>>*>
         neighbors_of_all_blocks);
 template void set_periodic_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 4>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>*>
+    gsl::not_null<std::vector<DirectionMap<2, BlockNeighbor<2>>>*>
         neighbors_of_all_blocks);
 template void set_periodic_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 8>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>*>
+    gsl::not_null<std::vector<DirectionMap<3, BlockNeighbor<3>>>*>
         neighbors_of_all_blocks);
 template std::vector<std::array<size_t, 2>> corners_for_rectilinear_domains(
     const Index<1>& domain_extents,

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -10,19 +10,20 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 #include "DataStructures/Index.hpp"
+// Can be forward declaration in C++17
+#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"
+// Can be forward declaration in C++17
+#include "Domain/DirectionMap.hpp"  // IWYU pragma: keep
 #include "Domain/Side.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
 /// \cond
-template <size_t VolumeDim>
-class BlockNeighbor;
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
 template <size_t VolumeDim>
@@ -50,8 +51,8 @@ template <size_t VolumeDim>
 void set_internal_boundaries(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    gsl::not_null<std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
+    gsl::not_null<
+        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks);
 
 /// \ingroup ComputationalDomainGroup
@@ -63,8 +64,8 @@ void set_periodic_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    gsl::not_null<std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
+    gsl::not_null<
+        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks);
 
 /// \ingroup ComputationalDomainGroup

--- a/src/Domain/Element.hpp
+++ b/src/Domain/Element.hpp
@@ -8,10 +8,10 @@
 
 #include <cstddef>
 #include <iosfwd>
-#include <unordered_map>
 #include <unordered_set>
 
 #include "Domain/Direction.hpp"  // IWYU pragma: keep
+#include "Domain/DirectionMap.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/Neighbors.hpp"  // IWYU pragma: keep
 
@@ -28,8 +28,7 @@ class er;
 template <size_t VolumeDim>
 class Element {
  public:
-  using Neighbors_t =
-      std::unordered_map<Direction<VolumeDim>, Neighbors<VolumeDim>>;
+  using Neighbors_t = DirectionMap<VolumeDim, Neighbors<VolumeDim>>;
 
   /// Constructor
   ///

--- a/src/Options/OptionsDetails.hpp
+++ b/src/Options/OptionsDetails.hpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "ErrorHandling/Assert.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -130,9 +131,7 @@ struct print {
   }
   template <typename T, Requires<has_lower_bound<T>::value> = nullptr>
   static std::string print_lower_bound() noexcept {
-    std::ostringstream ss;
-    ss << "min=" << T::lower_bound();
-    return ss.str();
+    return "min=" + get_output(T::lower_bound());
   }
   template <typename T, Requires<not has_lower_bound<T>::value> = nullptr>
   static std::string print_lower_bound() noexcept {
@@ -140,9 +139,7 @@ struct print {
   }
   template <typename T, Requires<has_upper_bound<T>::value> = nullptr>
   static std::string print_upper_bound() noexcept {
-    std::ostringstream ss;
-    ss << "max=" << T::upper_bound();
-    return ss.str();
+    return "max=" + get_output(T::upper_bound());
   }
   template <typename T, Requires<not has_upper_bound<T>::value> = nullptr>
   static std::string print_upper_bound() noexcept {
@@ -150,9 +147,7 @@ struct print {
   }
   template <typename T, Requires<has_lower_bound_on_size<T>::value> = nullptr>
   static std::string print_lower_bound_on_size() noexcept {
-    std::ostringstream ss;
-    ss << "min size=" << T::lower_bound_on_size();
-    return ss.str();
+    return "min size=" + get_output(T::lower_bound_on_size());
   }
   template <typename T,
             Requires<not has_lower_bound_on_size<T>::value> = nullptr>
@@ -161,9 +156,7 @@ struct print {
   }
   template <typename T, Requires<has_upper_bound_on_size<T>::value> = nullptr>
   static std::string print_upper_bound_on_size() noexcept {
-    std::ostringstream ss;
-    ss << "max size=" << T::upper_bound_on_size();
-    return ss.str();
+    return "max size=" + get_output(T::upper_bound_on_size());
   }
   template <typename T,
             Requires<not has_upper_bound_on_size<T>::value> = nullptr>

--- a/src/Utilities/GetOutput.hpp
+++ b/src/Utilities/GetOutput.hpp
@@ -11,7 +11,7 @@
  * \brief Get the streamed output of `t` as a `std::string`
  */
 template <typename T>
-std::string get_output(const T& t) {
+std::string get_output(const T& t) noexcept {
   std::ostringstream os;
   os << t;
   return os.str();

--- a/src/Utilities/GetOutput.hpp
+++ b/src/Utilities/GetOutput.hpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <sstream>
+#include <string>
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Get the streamed output of `t` as a `std::string`
+ */
+template <typename T>
+std::string get_output(const T& t) {
+  std::ostringstream os;
+  os << t;
+  return os.str();
+}

--- a/src/Utilities/PrintHelpers.hpp
+++ b/src/Utilities/PrintHelpers.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Applies the function f(out, it) to each item from begin to
+ * end, separated by commas and surrounded by parens.
+ */
+template <typename ForwardIt, typename Func>
+inline void sequence_print_helper(std::ostream& out, ForwardIt&& begin,
+                                  ForwardIt&& end, Func f) {
+  out << "(";
+  if (begin != end) {
+    while (true) {
+      f(out, begin++);
+      if (begin == end) {
+        break;
+      }
+      out << ",";
+    }
+  }
+  out << ")";
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Prints all the items as a comma separated list surrounded by parens.
+ */
+template <typename ForwardIt>
+inline void sequence_print_helper(std::ostream& out, ForwardIt&& begin,
+                                  ForwardIt&& end) {
+  sequence_print_helper(
+      out, std::forward<ForwardIt>(begin), std::forward<ForwardIt>(end),
+      [](std::ostream& os, const ForwardIt& it) { os << *it; });
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * Like sequence_print_helper, but sorts the string representations.
+ */
+//@{
+template <typename ForwardIt, typename Func>
+inline void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
+                                   ForwardIt&& end, Func f) {
+  std::vector<std::string> entries;
+  while (begin != end) {
+    std::ostringstream ss;
+    f(ss, begin++);
+    entries.push_back(ss.str());
+  }
+  std::sort(entries.begin(), entries.end());
+  sequence_print_helper(out, entries.begin(), entries.end());
+}
+
+template <typename ForwardIt>
+inline void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
+                                   ForwardIt&& end) {
+  unordered_print_helper(
+      out, std::forward<ForwardIt>(begin), std::forward<ForwardIt>(end),
+      [](std::ostream& os, const ForwardIt& it) { os << *it; });
+}
+//@}

--- a/src/Utilities/StdHelpers.hpp
+++ b/src/Utilities/StdHelpers.hpp
@@ -30,12 +30,14 @@
 #include "Utilities/StlStreamDeclarations.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-namespace StdHelpers_detail {
-// applies the function f(out, it) to each item from begin to end, separated
-// by commas and surrounded by parens
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Applies the function f(out, it) to each item from begin to
+ * end, separated by commas and surrounded by parens.
+ */
 template <typename ForwardIt, typename Func>
-inline void print_helper(std::ostream& out, ForwardIt&& begin, ForwardIt&& end,
-                         Func f) {
+inline void sequence_print_helper(std::ostream& out, ForwardIt&& begin,
+                                  ForwardIt&& end, Func f) {
   out << "(";
   if (begin != end) {
     while (true) {
@@ -49,16 +51,23 @@ inline void print_helper(std::ostream& out, ForwardIt&& begin, ForwardIt&& end,
   out << ")";
 }
 
-// prints all the items as a comma separated list surrounded by parens
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Prints all the items as a comma separated list surrounded by parens.
+ */
 template <typename ForwardIt>
-inline void print_helper(std::ostream& out, ForwardIt&& begin,
-                         ForwardIt&& end) {
-  print_helper(out, std::forward<ForwardIt>(begin),
-               std::forward<ForwardIt>(end),
-               [](std::ostream& os, const ForwardIt& it) { os << *it; });
+inline void sequence_print_helper(std::ostream& out, ForwardIt&& begin,
+                                  ForwardIt&& end) {
+  sequence_print_helper(
+      out, std::forward<ForwardIt>(begin), std::forward<ForwardIt>(end),
+      [](std::ostream& os, const ForwardIt& it) { os << *it; });
 }
 
-// Like print_helper, but sorts the string representations
+/*!
+ * \ingroup UtilitiesGroup
+ * Like sequence_print_helper, but sorts the string representations.
+ */
+//@{
 template <typename ForwardIt, typename Func>
 inline void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
                                    ForwardIt&& end, Func f) {
@@ -69,7 +78,7 @@ inline void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
     entries.push_back(ss.str());
   }
   std::sort(entries.begin(), entries.end());
-  print_helper(out, entries.begin(), entries.end());
+  sequence_print_helper(out, entries.begin(), entries.end());
 }
 
 template <typename ForwardIt>
@@ -79,7 +88,9 @@ inline void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
       out, std::forward<ForwardIt>(begin), std::forward<ForwardIt>(end),
       [](std::ostream& os, const ForwardIt& it) { os << *it; });
 }
+//@}
 
+namespace StdHelpers_detail {
 // Helper classes for operator<< for tuples
 template <size_t N>
 struct TuplePrinter {
@@ -116,7 +127,7 @@ struct TuplePrinter<0> {
  */
 template <typename T>
 inline std::ostream& operator<<(std::ostream& os, const std::list<T>& v) {
-  StdHelpers_detail::print_helper(os, std::begin(v), std::end(v));
+  sequence_print_helper(os, std::begin(v), std::end(v));
   return os;
 }
 
@@ -126,7 +137,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::list<T>& v) {
  */
 template <typename T>
 inline std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
-  StdHelpers_detail::print_helper(os, std::begin(v), std::end(v));
+  sequence_print_helper(os, std::begin(v), std::end(v));
   return os;
 }
 
@@ -136,7 +147,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
  */
 template <typename T>
 inline std::ostream& operator<<(std::ostream& os, const std::deque<T>& v) {
-  StdHelpers_detail::print_helper(os, std::begin(v), std::end(v));
+  sequence_print_helper(os, std::begin(v), std::end(v));
   return os;
 }
 
@@ -146,7 +157,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::deque<T>& v) {
  */
 template <typename T, size_t N>
 inline std::ostream& operator<<(std::ostream& os, const std::array<T, N>& a) {
-  StdHelpers_detail::print_helper(os, begin(a), end(a));
+  sequence_print_helper(os, begin(a), end(a));
   return os;
 }
 
@@ -170,7 +181,7 @@ inline std::ostream& operator<<(std::ostream& os,
 template <typename K, typename V, typename H>
 inline std::ostream& operator<<(std::ostream& os,
                                 const std::unordered_map<K, V, H>& m) {
-  StdHelpers_detail::unordered_print_helper(
+  unordered_print_helper(
       os, begin(m), end(m),
       [](std::ostream& out,
          typename std::unordered_map<K, V, H>::const_iterator it) {
@@ -185,7 +196,7 @@ inline std::ostream& operator<<(std::ostream& os,
  */
 template <typename K, typename V, typename C>
 inline std::ostream& operator<<(std::ostream& os, const std::map<K, V, C>& m) {
-  StdHelpers_detail::print_helper(
+  sequence_print_helper(
       os, begin(m), end(m),
       [](std::ostream& out, typename std::map<K, V, C>::const_iterator it) {
         out << "[" << it->first << "," << it->second << "]";
@@ -200,7 +211,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::map<K, V, C>& m) {
 template <typename T>
 inline std::ostream& operator<<(std::ostream& os,
                                 const std::unordered_set<T>& v) {
-  StdHelpers_detail::unordered_print_helper(os, std::begin(v), std::end(v));
+  unordered_print_helper(os, std::begin(v), std::end(v));
   return os;
 }
 
@@ -210,7 +221,7 @@ inline std::ostream& operator<<(std::ostream& os,
  */
 template <typename T, typename C>
 inline std::ostream& operator<<(std::ostream& os, const std::set<T, C>& v) {
-  StdHelpers_detail::print_helper(os, std::begin(v), std::end(v));
+  sequence_print_helper(os, std::begin(v), std::end(v));
   return os;
 }
 
@@ -248,7 +259,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::pair<T, U>& t) {
 template <typename K, typename V, typename H>
 inline std::string keys_of(const std::unordered_map<K, V, H>& m) {
   std::ostringstream os;
-  StdHelpers_detail::unordered_print_helper(
+  unordered_print_helper(
       os, begin(m), end(m),
       [](std::ostream& out,
          typename std::unordered_map<K, V, H>::const_iterator it) {
@@ -264,7 +275,7 @@ inline std::string keys_of(const std::unordered_map<K, V, H>& m) {
 template <typename K, typename V, typename C>
 inline std::string keys_of(const std::map<K, V, C>& m) {
   std::ostringstream os;
-  StdHelpers_detail::print_helper(
+  sequence_print_helper(
       os, begin(m), end(m),
       [](std::ostream& out, typename std::map<K, V, C>::const_iterator it) {
         out << it->first;

--- a/src/Utilities/StdHelpers.hpp
+++ b/src/Utilities/StdHelpers.hpp
@@ -6,89 +6,27 @@
 
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <chrono>
+#include <cstdio>
 #include <ctime>
 #include <deque>
-#include <iterator>
 #include <list>
 #include <map>
 #include <memory>
-#include <numeric>
 #include <set>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
-#include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/PrintHelpers.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/StlStreamDeclarations.hpp"
 #include "Utilities/TypeTraits.hpp"
-
-/*!
- * \ingroup UtilitiesGroup
- * \brief Applies the function f(out, it) to each item from begin to
- * end, separated by commas and surrounded by parens.
- */
-template <typename ForwardIt, typename Func>
-inline void sequence_print_helper(std::ostream& out, ForwardIt&& begin,
-                                  ForwardIt&& end, Func f) {
-  out << "(";
-  if (begin != end) {
-    while (true) {
-      f(out, begin++);
-      if (begin == end) {
-        break;
-      }
-      out << ",";
-    }
-  }
-  out << ")";
-}
-
-/*!
- * \ingroup UtilitiesGroup
- * \brief Prints all the items as a comma separated list surrounded by parens.
- */
-template <typename ForwardIt>
-inline void sequence_print_helper(std::ostream& out, ForwardIt&& begin,
-                                  ForwardIt&& end) {
-  sequence_print_helper(
-      out, std::forward<ForwardIt>(begin), std::forward<ForwardIt>(end),
-      [](std::ostream& os, const ForwardIt& it) { os << *it; });
-}
-
-/*!
- * \ingroup UtilitiesGroup
- * Like sequence_print_helper, but sorts the string representations.
- */
-//@{
-template <typename ForwardIt, typename Func>
-inline void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
-                                   ForwardIt&& end, Func f) {
-  std::vector<std::string> entries;
-  while (begin != end) {
-    std::ostringstream ss;
-    f(ss, begin++);
-    entries.push_back(ss.str());
-  }
-  std::sort(entries.begin(), entries.end());
-  sequence_print_helper(out, entries.begin(), entries.end());
-}
-
-template <typename ForwardIt>
-inline void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
-                                   ForwardIt&& end) {
-  unordered_print_helper(
-      out, std::forward<ForwardIt>(begin), std::forward<ForwardIt>(end),
-      [](std::ostream& os, const ForwardIt& it) { os << *it; });
-}
-//@}
 
 namespace StdHelpers_detail {
 // Helper classes for operator<< for tuples

--- a/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
+++ b/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
@@ -27,6 +27,7 @@
 #include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"

--- a/tests/Unit/ApparentHorizons/Test_SpherepackIterator.cpp
+++ b/tests/Unit/ApparentHorizons/Test_SpherepackIterator.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "ApparentHorizons/SpherepackIterator.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Literals.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 

--- a/tests/Unit/DataStructures/Test_Index.cpp
+++ b/tests/Unit/DataStructures/Test_Index.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
 #include "ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Literals.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 

--- a/tests/Unit/DataStructures/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Test_Tensor.cpp
@@ -16,6 +16,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdHelpers.hpp"

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -20,6 +20,7 @@
 #include "DataStructures/VariablesHelpers.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/StdHelpers.hpp"

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_CoordinatesTag.cpp
   Test_CreateInitialElement.cpp
   Test_Direction.cpp
+  Test_DirectionMap.cpp
   Test_Domain.cpp
   Test_DomainHelpers.cpp
   Test_DomainTestHelpers.cpp

--- a/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
@@ -7,17 +7,16 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Block.hpp"          // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Brick.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
@@ -39,7 +38,7 @@ void test_brick_construction(
     const std::array<double, 3>& upper_bound,
     const std::vector<std::array<size_t, 3>>& expected_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>&
+    const std::vector<DirectionMap<3, BlockNeighbor<3>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<3>>>&
         expected_external_boundaries) {
@@ -70,23 +69,23 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   const DomainCreators::Brick<Frame::Inertial> brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, false, false}},
       refinement_level[0], grid_points[0]};
-  test_brick_construction(
-      brick, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{{}},
-      std::vector<std::unordered_set<Direction<3>>>{
-          {{Direction<3>::lower_xi()},
-           {Direction<3>::upper_xi()},
-           {Direction<3>::lower_eta()},
-           {Direction<3>::upper_eta()},
-           {Direction<3>::lower_zeta()},
-           {Direction<3>::upper_zeta()}}});
+  test_brick_construction(brick, lower_bound, upper_bound, grid_points,
+                          refinement_level,
+                          std::vector<DirectionMap<3, BlockNeighbor<3>>>{{}},
+                          std::vector<std::unordered_set<Direction<3>>>{
+                              {{Direction<3>::lower_xi()},
+                               {Direction<3>::upper_xi()},
+                               {Direction<3>::lower_eta()},
+                               {Direction<3>::upper_eta()},
+                               {Direction<3>::lower_zeta()},
+                               {Direction<3>::upper_zeta()}}});
 
   const DomainCreators::Brick<Frame::Inertial> periodic_x_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, false, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
       periodic_x_brick, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
            {Direction<3>::upper_xi(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<3>>>{
@@ -100,7 +99,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
       refinement_level[0], grid_points[0]};
   test_brick_construction(
       periodic_y_brick, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_eta(), {0, aligned_orientation}},
            {Direction<3>::upper_eta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<3>>>{
@@ -114,7 +113,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
       refinement_level[0], grid_points[0]};
   test_brick_construction(
       periodic_z_brick, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_zeta(), {0, aligned_orientation}},
            {Direction<3>::upper_zeta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<3>>>{
@@ -129,7 +128,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   test_brick_construction(
       periodic_xy_brick, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
            {Direction<3>::upper_xi(), {0, aligned_orientation}},
            {Direction<3>::lower_eta(), {0, aligned_orientation}},
@@ -143,7 +142,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   test_brick_construction(
       periodic_yz_brick, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_eta(), {0, aligned_orientation}},
            {Direction<3>::upper_eta(), {0, aligned_orientation}},
            {Direction<3>::lower_zeta(), {0, aligned_orientation}},
@@ -159,7 +158,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   test_brick_construction(
       periodic_xz_brick, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
            {Direction<3>::upper_xi(), {0, aligned_orientation}},
            {Direction<3>::lower_zeta(), {0, aligned_orientation}},
@@ -173,7 +172,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   test_brick_construction(
       periodic_xyz_brick, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
            {Direction<3>::upper_xi(), {0, aligned_orientation}},
            {Direction<3>::lower_eta(), {0, aligned_orientation}},
@@ -213,7 +212,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick.Factory",
   test_brick_construction(
       *brick_creator, {{0., 0., 0.}}, {{1., 2., 3.}}, {{{3, 4, 3}}},
       {{{2, 3, 2}}},
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, {}}},
            {Direction<3>::upper_xi(), {0, {}}},
            {Direction<3>::lower_zeta(), {0, {}}},

--- a/tests/Unit/Domain/DomainCreators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Cylinder.cpp
@@ -8,19 +8,18 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Block.hpp"          // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Cylinder.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
@@ -49,28 +48,26 @@ void test_cylinder_construction(
   const OrientationMap<3> quarter_turn_cw(std::array<Direction<3>, 3>{
       {Direction<3>::upper_eta(), Direction<3>::lower_xi(),
        Direction<3>::upper_zeta()}});
-  std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{};
+  std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{};
   std::vector<std::unordered_set<Direction<3>>> expected_external_boundaries{};
   if (not is_periodic_in_z) {
-    expected_block_neighbors =
-        std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
-            {{Direction<3>::lower_eta(), {3, aligned_orientation}},
-             {Direction<3>::upper_eta(), {1, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, aligned_orientation}}},
-            {{Direction<3>::lower_eta(), {0, aligned_orientation}},
-             {Direction<3>::upper_eta(), {2, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, quarter_turn_cw}}},
-            {{Direction<3>::lower_eta(), {1, aligned_orientation}},
-             {Direction<3>::upper_eta(), {3, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, half_turn}}},
-            {{Direction<3>::lower_eta(), {2, aligned_orientation}},
-             {Direction<3>::upper_eta(), {0, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, quarter_turn_ccw}}},
-            {{Direction<3>::upper_xi(), {0, aligned_orientation}},
-             {Direction<3>::upper_eta(), {1, quarter_turn_ccw}},
-             {Direction<3>::lower_xi(), {2, half_turn}},
-             {Direction<3>::lower_eta(), {3, quarter_turn_cw}}}};
+    expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        {{Direction<3>::lower_eta(), {3, aligned_orientation}},
+         {Direction<3>::upper_eta(), {1, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, aligned_orientation}}},
+        {{Direction<3>::lower_eta(), {0, aligned_orientation}},
+         {Direction<3>::upper_eta(), {2, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, quarter_turn_cw}}},
+        {{Direction<3>::lower_eta(), {1, aligned_orientation}},
+         {Direction<3>::upper_eta(), {3, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, half_turn}}},
+        {{Direction<3>::lower_eta(), {2, aligned_orientation}},
+         {Direction<3>::upper_eta(), {0, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, quarter_turn_ccw}}},
+        {{Direction<3>::upper_xi(), {0, aligned_orientation}},
+         {Direction<3>::upper_eta(), {1, quarter_turn_ccw}},
+         {Direction<3>::lower_xi(), {2, half_turn}},
+         {Direction<3>::lower_eta(), {3, quarter_turn_cw}}}};
     expected_external_boundaries =
         std::vector<std::unordered_set<Direction<3>>>{
             {{Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
@@ -83,34 +80,33 @@ void test_cylinder_construction(
               Direction<3>::lower_zeta()}},
             {Direction<3>::upper_zeta(), Direction<3>::lower_zeta()}};
   } else {
-    expected_block_neighbors =
-        std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
-            {{Direction<3>::lower_eta(), {3, aligned_orientation}},
-             {Direction<3>::upper_eta(), {1, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, aligned_orientation}},
-             {Direction<3>::upper_zeta(), {0, aligned_orientation}},
-             {Direction<3>::lower_zeta(), {0, aligned_orientation}}},
-            {{Direction<3>::lower_eta(), {0, aligned_orientation}},
-             {Direction<3>::upper_eta(), {2, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, quarter_turn_cw}},
-             {Direction<3>::upper_zeta(), {1, aligned_orientation}},
-             {Direction<3>::lower_zeta(), {1, aligned_orientation}}},
-            {{Direction<3>::lower_eta(), {1, aligned_orientation}},
-             {Direction<3>::upper_eta(), {3, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, half_turn}},
-             {Direction<3>::upper_zeta(), {2, aligned_orientation}},
-             {Direction<3>::lower_zeta(), {2, aligned_orientation}}},
-            {{Direction<3>::lower_eta(), {2, aligned_orientation}},
-             {Direction<3>::upper_eta(), {0, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, quarter_turn_ccw}},
-             {Direction<3>::upper_zeta(), {3, aligned_orientation}},
-             {Direction<3>::lower_zeta(), {3, aligned_orientation}}},
-            {{Direction<3>::upper_xi(), {0, aligned_orientation}},
-             {Direction<3>::upper_eta(), {1, quarter_turn_ccw}},
-             {Direction<3>::lower_xi(), {2, half_turn}},
-             {Direction<3>::lower_eta(), {3, quarter_turn_cw}},
-             {Direction<3>::upper_zeta(), {4, aligned_orientation}},
-             {Direction<3>::lower_zeta(), {4, aligned_orientation}}}};
+    expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        {{Direction<3>::lower_eta(), {3, aligned_orientation}},
+         {Direction<3>::upper_eta(), {1, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, aligned_orientation}},
+         {Direction<3>::upper_zeta(), {0, aligned_orientation}},
+         {Direction<3>::lower_zeta(), {0, aligned_orientation}}},
+        {{Direction<3>::lower_eta(), {0, aligned_orientation}},
+         {Direction<3>::upper_eta(), {2, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, quarter_turn_cw}},
+         {Direction<3>::upper_zeta(), {1, aligned_orientation}},
+         {Direction<3>::lower_zeta(), {1, aligned_orientation}}},
+        {{Direction<3>::lower_eta(), {1, aligned_orientation}},
+         {Direction<3>::upper_eta(), {3, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, half_turn}},
+         {Direction<3>::upper_zeta(), {2, aligned_orientation}},
+         {Direction<3>::lower_zeta(), {2, aligned_orientation}}},
+        {{Direction<3>::lower_eta(), {2, aligned_orientation}},
+         {Direction<3>::upper_eta(), {0, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, quarter_turn_ccw}},
+         {Direction<3>::upper_zeta(), {3, aligned_orientation}},
+         {Direction<3>::lower_zeta(), {3, aligned_orientation}}},
+        {{Direction<3>::upper_xi(), {0, aligned_orientation}},
+         {Direction<3>::upper_eta(), {1, quarter_turn_ccw}},
+         {Direction<3>::lower_xi(), {2, half_turn}},
+         {Direction<3>::lower_eta(), {3, quarter_turn_cw}},
+         {Direction<3>::upper_zeta(), {4, aligned_orientation}},
+         {Direction<3>::lower_zeta(), {4, aligned_orientation}}}};
 
     expected_external_boundaries =
         std::vector<std::unordered_set<Direction<3>>>{

--- a/tests/Unit/Domain/DomainCreators/Test_Disk.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Disk.cpp
@@ -8,19 +8,18 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Block.hpp"          // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Disk.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
@@ -44,7 +43,7 @@ void test_disk_construction(
       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}});
   const OrientationMap<2> quarter_turn_cw(std::array<Direction<2>, 2>{
       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}});
-  const std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>
+  const std::vector<DirectionMap<2, BlockNeighbor<2>>>
       expected_block_neighbors{
           {{Direction<2>::lower_eta(), {3, aligned_orientation}},
            {Direction<2>::upper_eta(), {1, aligned_orientation}},

--- a/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
@@ -7,16 +7,15 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Block.hpp"          // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/Interval.hpp"
@@ -35,7 +34,7 @@ void test_interval_construction(
     const std::array<double, 1>& upper_bound,
     const std::vector<std::array<size_t, 1>>& expected_extents,
     const std::vector<std::array<size_t, 1>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>&
+    const std::vector<DirectionMap<1, BlockNeighbor<1>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<1>>>&
         expected_external_boundaries) noexcept {
@@ -64,7 +63,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval", "[Domain][Unit]") {
       refinement_level[0], grid_points[0]};
   test_interval_construction(
       interval, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{{}},
+      std::vector<DirectionMap<1, BlockNeighbor<1>>>{{}},
       std::vector<std::unordered_set<Direction<1>>>{
           {{Direction<1>::lower_xi()}, {Direction<1>::upper_xi()}}});
 
@@ -74,7 +73,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval", "[Domain][Unit]") {
   test_interval_construction(
       periodic_interval, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+      std::vector<DirectionMap<1, BlockNeighbor<1>>>{
           {{Direction<1>::lower_xi(), {0, aligned_orientation}},
            {Direction<1>::upper_xi(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<1>>>{{}});
@@ -107,10 +106,10 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval.Factory",
   const auto* interval_creator =
       dynamic_cast<const DomainCreators::Interval<Frame::Inertial>*>(
           domain_creator.get());
-  test_interval_construction(
-      *interval_creator, {{0.}}, {{1.}}, {{{3}}}, {{{2}}},
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
-          {{Direction<1>::lower_xi(), {0, {}}},
-           {Direction<1>::upper_xi(), {0, {}}}}},
-      std::vector<std::unordered_set<Direction<1>>>{{}});
+  test_interval_construction(*interval_creator, {{0.}}, {{1.}}, {{{3}}},
+                             {{{2}}},
+                             std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+                                 {{Direction<1>::lower_xi(), {0, {}}},
+                                  {Direction<1>::upper_xi(), {0, {}}}}},
+                             std::vector<std::unordered_set<Direction<1>>>{{}});
 }

--- a/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
@@ -7,17 +7,16 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Block.hpp"          // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/Rectangle.hpp"
@@ -38,7 +37,7 @@ void test_rectangle_construction(
     const std::array<double, 2>& upper_bound,
     const std::vector<std::array<size_t, 2>>& expected_extents,
     const std::vector<std::array<size_t, 2>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>&
+    const std::vector<DirectionMap<2, BlockNeighbor<2>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<2>>>&
         expected_external_boundaries) {
@@ -68,7 +67,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
       rectangle, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{{}},
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{{}},
       std::vector<std::unordered_set<Direction<2>>>{
           {{Direction<2>::lower_xi()},
            {Direction<2>::upper_xi()},
@@ -81,7 +80,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
   test_rectangle_construction(
       periodic_x_rectangle, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::lower_xi(), {0, aligned_orientation}},
            {Direction<2>::upper_xi(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<2>>>{
@@ -93,7 +92,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
   test_rectangle_construction(
       periodic_y_rectangle, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::lower_eta(), {0, aligned_orientation}},
            {Direction<2>::upper_eta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<2>>>{
@@ -105,7 +104,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
   test_rectangle_construction(
       periodic_xy_rectangle, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::lower_xi(), {0, aligned_orientation}},
            {Direction<2>::upper_xi(), {0, aligned_orientation}},
            {Direction<2>::lower_eta(), {0, aligned_orientation}},
@@ -144,7 +143,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle.Factory",
           domain_creator.get());
   test_rectangle_construction(
       *rectangle_creator, {{0., 0.}}, {{1., 2.}}, {{{3, 4}}}, {{{2, 3}}},
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::lower_xi(), {0, {}}},
            {Direction<2>::upper_xi(), {0, {}}}}},
       std::vector<std::unordered_set<Direction<2>>>{

--- a/tests/Unit/Domain/DomainCreators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_RotatedIntervals.cpp
@@ -6,15 +6,14 @@
 #include <array>
 #include <cstddef>
 #include <memory>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
-#include "Domain/Block.hpp"          // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/RotatedIntervals.hpp"
@@ -37,7 +36,7 @@ void test_rotated_intervals_construction(
     const std::array<double, 1>& upper_bound,
     const std::vector<std::array<size_t, 1>>& expected_extents,
     const std::vector<std::array<size_t, 1>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>&
+    const std::vector<DirectionMap<1, BlockNeighbor<1>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<1>>>&
         expected_external_boundaries) noexcept {
@@ -75,7 +74,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedIntervals",
   test_rotated_intervals_construction(
       rotated_intervals, lower_bound, midpoint, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+      std::vector<DirectionMap<1, BlockNeighbor<1>>>{
           {{Direction<1>::upper_xi(), {1, flipped}}},
           {{Direction<1>::upper_xi(), {0, flipped}}}},
       std::vector<std::unordered_set<Direction<1>>>{
@@ -89,7 +88,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedIntervals",
   test_rotated_intervals_construction(
       periodic_rotated_intervals, lower_bound, midpoint, upper_bound,
       grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+      std::vector<DirectionMap<1, BlockNeighbor<1>>>{
           {{Direction<1>::lower_xi(), {1, flipped}},
            {Direction<1>::upper_xi(), {1, flipped}}},
           {{Direction<1>::lower_xi(), {0, flipped}},
@@ -116,7 +115,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedIntervals.Factory",
   test_rotated_intervals_construction(
       *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
       {{{2}}, {{2}}},
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+      std::vector<DirectionMap<1, BlockNeighbor<1>>>{
           {{Direction<1>::lower_xi(), {1, flipped}},
            {Direction<1>::upper_xi(), {1, flipped}}},
           {{Direction<1>::lower_xi(), {0, flipped}},

--- a/tests/Unit/Domain/DomainCreators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_RotatedRectangles.cpp
@@ -7,17 +7,17 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/RotatedRectangles.hpp"
@@ -34,7 +34,7 @@ void test_rotated_rectangles_construction(
     const std::array<double, 2>& upper_bound,
     const std::vector<std::array<size_t, 2>>& expected_extents,
     const std::vector<std::array<size_t, 2>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>&
+    const std::vector<DirectionMap<2, BlockNeighbor<2>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<2>>>&
         expected_external_boundaries) noexcept {
@@ -106,7 +106,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles",
   test_rotated_rectangles_construction(
       rotated_rectangles, lower_bound, midpoint, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::upper_xi(), {2, quarter_turn_ccw}},
            {Direction<2>::upper_eta(), {1, flipped}}},
           {{Direction<2>::lower_xi(), {3, quarter_turn_ccw}},
@@ -146,7 +146,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles.Factory",
       *rotated_rectangles_creator, {{0.1, -0.4}}, {{2.6, 3.2}}, {{5.1, 6.2}},
       {{{3, 1}}, {{3, 4}}, {{1, 2}}, {{4, 2}}},
       {{{2, 1}}, {{2, 1}}, {{1, 2}}, {{1, 2}}},
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::upper_xi(), {2, quarter_turn_ccw}},
            {Direction<2>::upper_eta(), {1, flipped}}},
           {{Direction<2>::lower_xi(), {3, quarter_turn_ccw}},

--- a/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
@@ -6,15 +6,14 @@
 #include <array>
 #include <cstddef>
 #include <memory>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
-#include "Domain/Block.hpp"          // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/Shell.hpp"
@@ -50,32 +49,31 @@ void test_shell_construction(
       std::array<Direction<3>, 3>{{Direction<3>::upper_eta(),
                                    Direction<3>::lower_xi(),
                                    Direction<3>::upper_zeta()}});
-  const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{
-          {{Direction<3>::upper_xi(), {4, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::upper_eta(), {2, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, quarter_turn_cw_about_zeta}},
-           {Direction<3>::lower_eta(), {3, aligned_orientation}}},
-          {{Direction<3>::upper_xi(), {4, quarter_turn_cw_about_zeta}},
-           {Direction<3>::upper_eta(), {3, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::lower_eta(), {2, aligned_orientation}}},
-          {{Direction<3>::upper_xi(), {4, half_turn_about_zeta}},
-           {Direction<3>::upper_eta(), {1, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, half_turn_about_zeta}},
-           {Direction<3>::lower_eta(), {0, aligned_orientation}}},
-          {{Direction<3>::upper_xi(), {4, aligned_orientation}},
-           {Direction<3>::upper_eta(), {0, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, aligned_orientation}},
-           {Direction<3>::lower_eta(), {1, aligned_orientation}}},
-          {{Direction<3>::upper_xi(), {2, half_turn_about_zeta}},
-           {Direction<3>::upper_eta(), {0, quarter_turn_cw_about_zeta}},
-           {Direction<3>::lower_xi(), {3, aligned_orientation}},
-           {Direction<3>::lower_eta(), {1, quarter_turn_ccw_about_zeta}}},
-          {{Direction<3>::upper_xi(), {3, aligned_orientation}},
-           {Direction<3>::upper_eta(), {0, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::lower_xi(), {2, half_turn_about_zeta}},
-           {Direction<3>::lower_eta(), {1, quarter_turn_cw_about_zeta}}}};
+  const std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
+      {{Direction<3>::upper_xi(), {4, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::upper_eta(), {2, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, quarter_turn_cw_about_zeta}},
+       {Direction<3>::lower_eta(), {3, aligned_orientation}}},
+      {{Direction<3>::upper_xi(), {4, quarter_turn_cw_about_zeta}},
+       {Direction<3>::upper_eta(), {3, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::lower_eta(), {2, aligned_orientation}}},
+      {{Direction<3>::upper_xi(), {4, half_turn_about_zeta}},
+       {Direction<3>::upper_eta(), {1, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, half_turn_about_zeta}},
+       {Direction<3>::lower_eta(), {0, aligned_orientation}}},
+      {{Direction<3>::upper_xi(), {4, aligned_orientation}},
+       {Direction<3>::upper_eta(), {0, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, aligned_orientation}},
+       {Direction<3>::lower_eta(), {1, aligned_orientation}}},
+      {{Direction<3>::upper_xi(), {2, half_turn_about_zeta}},
+       {Direction<3>::upper_eta(), {0, quarter_turn_cw_about_zeta}},
+       {Direction<3>::lower_xi(), {3, aligned_orientation}},
+       {Direction<3>::lower_eta(), {1, quarter_turn_ccw_about_zeta}}},
+      {{Direction<3>::upper_xi(), {3, aligned_orientation}},
+       {Direction<3>::upper_eta(), {0, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::lower_xi(), {2, half_turn_about_zeta}},
+       {Direction<3>::lower_eta(), {1, quarter_turn_cw_about_zeta}}}};
   const std::vector<std::unordered_set<Direction<3>>>
       expected_external_boundaries{
           {{Direction<3>::upper_zeta()}, {Direction<3>::lower_zeta()}},

--- a/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
@@ -8,19 +8,18 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/Block.hpp"          // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/Sphere.hpp"
@@ -68,49 +67,48 @@ void test_sphere_construction(
                                    Direction<3>::upper_zeta(),
                                    Direction<3>::lower_xi()}});
 
-  const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{
-          {{Direction<3>::upper_xi(), {4, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::upper_eta(), {2, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, quarter_turn_cw_about_zeta}},
-           {Direction<3>::lower_eta(), {3, aligned_orientation}},
-           {Direction<3>::lower_zeta(), {6, aligned_orientation}}},
-          {{Direction<3>::upper_xi(), {4, quarter_turn_cw_about_zeta}},
-           {Direction<3>::upper_eta(), {3, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::lower_eta(), {2, aligned_orientation}},
-           {Direction<3>::lower_zeta(), {6, center_relative_to_minus_z}}},
-          {{Direction<3>::upper_xi(), {4, half_turn_about_zeta}},
-           {Direction<3>::upper_eta(), {1, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, half_turn_about_zeta}},
-           {Direction<3>::lower_eta(), {0, aligned_orientation}},
-           {Direction<3>::lower_zeta(), {6, center_relative_to_plus_y}}},
-          {{Direction<3>::upper_xi(), {4, aligned_orientation}},
-           {Direction<3>::upper_eta(), {0, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, aligned_orientation}},
-           {Direction<3>::lower_eta(), {1, aligned_orientation}},
-           {Direction<3>::lower_zeta(), {6, center_relative_to_minus_y}}},
-          {{Direction<3>::upper_xi(), {2, half_turn_about_zeta}},
-           {Direction<3>::upper_eta(), {0, quarter_turn_cw_about_zeta}},
-           {Direction<3>::lower_xi(), {3, aligned_orientation}},
-           {Direction<3>::lower_eta(), {1, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::lower_zeta(), {6, center_relative_to_plus_x}}},
-          {{Direction<3>::upper_xi(), {3, aligned_orientation}},
-           {Direction<3>::upper_eta(), {0, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::lower_xi(), {2, half_turn_about_zeta}},
-           {Direction<3>::lower_eta(), {1, quarter_turn_cw_about_zeta}},
-           {Direction<3>::lower_zeta(), {6, center_relative_to_minus_x}}},
-          {{Direction<3>::upper_zeta(), {0, aligned_orientation}},
-           {Direction<3>::lower_zeta(),
-            {1, center_relative_to_minus_z.inverse_map()}},
-           {Direction<3>::upper_eta(),
-            {2, center_relative_to_plus_y.inverse_map()}},
-           {Direction<3>::lower_eta(),
-            {3, center_relative_to_minus_y.inverse_map()}},
-           {Direction<3>::upper_xi(),
-            {4, center_relative_to_plus_x.inverse_map()}},
-           {Direction<3>::lower_xi(),
-            {5, center_relative_to_minus_x.inverse_map()}}}};
+  const std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
+      {{Direction<3>::upper_xi(), {4, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::upper_eta(), {2, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, quarter_turn_cw_about_zeta}},
+       {Direction<3>::lower_eta(), {3, aligned_orientation}},
+       {Direction<3>::lower_zeta(), {6, aligned_orientation}}},
+      {{Direction<3>::upper_xi(), {4, quarter_turn_cw_about_zeta}},
+       {Direction<3>::upper_eta(), {3, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::lower_eta(), {2, aligned_orientation}},
+       {Direction<3>::lower_zeta(), {6, center_relative_to_minus_z}}},
+      {{Direction<3>::upper_xi(), {4, half_turn_about_zeta}},
+       {Direction<3>::upper_eta(), {1, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, half_turn_about_zeta}},
+       {Direction<3>::lower_eta(), {0, aligned_orientation}},
+       {Direction<3>::lower_zeta(), {6, center_relative_to_plus_y}}},
+      {{Direction<3>::upper_xi(), {4, aligned_orientation}},
+       {Direction<3>::upper_eta(), {0, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, aligned_orientation}},
+       {Direction<3>::lower_eta(), {1, aligned_orientation}},
+       {Direction<3>::lower_zeta(), {6, center_relative_to_minus_y}}},
+      {{Direction<3>::upper_xi(), {2, half_turn_about_zeta}},
+       {Direction<3>::upper_eta(), {0, quarter_turn_cw_about_zeta}},
+       {Direction<3>::lower_xi(), {3, aligned_orientation}},
+       {Direction<3>::lower_eta(), {1, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::lower_zeta(), {6, center_relative_to_plus_x}}},
+      {{Direction<3>::upper_xi(), {3, aligned_orientation}},
+       {Direction<3>::upper_eta(), {0, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::lower_xi(), {2, half_turn_about_zeta}},
+       {Direction<3>::lower_eta(), {1, quarter_turn_cw_about_zeta}},
+       {Direction<3>::lower_zeta(), {6, center_relative_to_minus_x}}},
+      {{Direction<3>::upper_zeta(), {0, aligned_orientation}},
+       {Direction<3>::lower_zeta(),
+        {1, center_relative_to_minus_z.inverse_map()}},
+       {Direction<3>::upper_eta(),
+        {2, center_relative_to_plus_y.inverse_map()}},
+       {Direction<3>::lower_eta(),
+        {3, center_relative_to_minus_y.inverse_map()}},
+       {Direction<3>::upper_xi(),
+        {4, center_relative_to_plus_x.inverse_map()}},
+       {Direction<3>::lower_xi(),
+        {5, center_relative_to_minus_x.inverse_map()}}}};
 
   const std::vector<std::unordered_set<Direction<3>>>
       expected_external_boundaries{{{Direction<3>::upper_zeta()}},

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -7,22 +7,23 @@
 
 #include <algorithm>
 #include <typeinfo>
+#include <unordered_map>
 
 #include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "Domain/Block.hpp"                  // IWYU pragma: keep
-#include "Domain/BlockNeighbor.hpp"          // IWYU pragma: keep
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Domain.hpp"  // IWYU pragma: keep
 #include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
 #include "Domain/InitialElementIds.hpp"
-#include "Domain/Neighbors.hpp"  // IWYU pragma: keep
 #include "Domain/OrientationMap.hpp"
+#include "Domain/Side.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -330,8 +331,7 @@ double physical_separation(
 template <size_t VolumeDim>
 void test_domain_construction(
     const Domain<VolumeDim, Frame::Inertial>& domain,
-    const std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>&
+    const std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
@@ -418,8 +418,7 @@ tnsr::i<DataVector, SpatialDim, SpatialFrame> euclidean_basis_vector(
 #define INSTANTIATE1(_, data)                                                  \
   template void test_domain_construction<DIM(data)>(                           \
       const Domain<DIM(data), Frame::Inertial>& domain,                        \
-      const std::vector<                                                       \
-          std::unordered_map<Direction<DIM(data)>, BlockNeighbor<DIM(data)>>>& \
+      const std::vector<DirectionMap<DIM(data), BlockNeighbor<DIM(data)>>>&    \
           expected_block_neighbors,                                            \
       const std::vector<std::unordered_set<Direction<DIM(data)>>>&             \
           expected_external_boundaries,                                        \

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -7,21 +7,18 @@
 #include <boost/rational.hpp>
 #include <cstddef>
 #include <memory>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Domain/Side.hpp"
-#include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeArray.hpp"
+// Can be forward declaration in C++17
+#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+// Can be forward declaration in C++17
+#include "Domain/DirectionMap.hpp"  // IWYU pragma: keep
 
 /// \cond
 template <size_t VolumeDim, typename TargetFrame>
 class Block;
-template <size_t VolumeDim>
-class BlockNeighbor;
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
 class DataVector;
@@ -37,8 +34,7 @@ class ElementId;
 template <size_t VolumeDim>
 void test_domain_construction(
     const Domain<VolumeDim, Frame::Inertial>& domain,
-    const std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>&
+    const std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -3,15 +3,14 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <algorithm>
 #include <array>
 #include <cstddef>
-#include <functional>
+// IWYU pragma: no_include <initializer_list>
 #include <memory>
 #include <pup.h>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Block.hpp"
@@ -19,6 +18,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -63,7 +63,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Block.Identity", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Block.Neighbors", "[Domain][Unit]") {
-  // Create std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>
+  // Create DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>
 
   // Each BlockNeighbor is an id and an OrientationMap:
   const BlockNeighbor<2> block_neighbor1(
@@ -72,7 +72,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Block.Neighbors", "[Domain][Unit]") {
   const BlockNeighbor<2> block_neighbor2(
       2, OrientationMap<2>(std::array<Direction<2>, 2>{
              {Direction<2>::lower_xi(), Direction<2>::upper_eta()}}));
-  std::unordered_map<Direction<2>, BlockNeighbor<2>> neighbors = {
+  DirectionMap<2, BlockNeighbor<2>> neighbors = {
       {Direction<2>::upper_xi(), block_neighbor1},
       {Direction<2>::lower_eta(), block_neighbor2}};
   using coordinate_map =

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -93,9 +93,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Block.Neighbors", "[Domain][Unit]") {
   // Test output:
   CHECK(get_output(block) ==
         "Block 3:\n"
-        "Neighbors:\n"
-        "-1: Id = 2; orientation = (-0, +1)\n"
-        "+0: Id = 1; orientation = (+0, +1)\n"
+        "Neighbors: "
+        "([+0,Id = 1; orientation = (+0, +1)],"
+        "[-1,Id = 2; orientation = (-0, +1)])\n"
         "External boundaries: (+1,-0)\n");
 
   // Test comparison:

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -20,6 +20,7 @@
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 template <size_t Dim>

--- a/tests/Unit/Domain/Test_BlockNeighbor.cpp
+++ b/tests/Unit/Domain/Test_BlockNeighbor.cpp
@@ -11,6 +11,7 @@
 #include "Domain/Direction.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Domain/SegmentId.hpp"  // IWYU pragma: keep
+#include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.BlockNeighbor", "[Domain][Unit]") {

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -4,9 +4,9 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <functional>
+// IWYU pragma: no_include <initializer_list>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Block.hpp"
@@ -15,6 +15,7 @@
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/Neighbors.hpp"
@@ -25,8 +26,7 @@
 namespace {
 void test_create_initial_element(
     const ElementId<2>& element_id, const Block<2, Frame::Inertial>& block,
-    const std::unordered_map<Direction<2>, Neighbors<2>>&
-        expected_neighbors) noexcept {
+    const DirectionMap<2, Neighbors<2>>& expected_neighbors) noexcept {
   const auto created_element = create_initial_element(element_id, block);
   const Element<2> expected_element{element_id, expected_neighbors};
   CHECK(created_element == expected_element);

--- a/tests/Unit/Domain/Test_Direction.cpp
+++ b/tests/Unit/Domain/Test_Direction.cpp
@@ -11,6 +11,7 @@
 #include "Domain/Direction.hpp"
 #include "Domain/Side.hpp"
 #include "ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 

--- a/tests/Unit/Domain/Test_DirectionMap.cpp
+++ b/tests/Unit/Domain/Test_DirectionMap.cpp
@@ -1,0 +1,239 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+// IWYU pragma: no_include <array>
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+template <size_t Dim>
+void check_single_element_map(const Direction<Dim>& direction) noexcept {
+  DirectionMap<Dim, std::pair<double, NonCopyable>> map;
+  map.emplace(direction, std::make_pair(1.5, NonCopyable{}));
+  const typename decltype(map)::value_type entry(
+      cpp17::as_const(direction), std::make_pair(1.5, NonCopyable{}));
+
+  const auto& const_map = map;
+
+  test_iterators(map);
+  check_cmp(const_map.begin(), const_map.end());
+  check_cmp(map.begin(), map.end());
+  check_cmp(map.cbegin(), map.end());
+  check_cmp(map.begin(), map.cend());
+
+  CHECK(not const_map.empty());
+  CHECK(const_map.size() == 1);
+
+  CHECK(const_map.count(direction) == 1);
+  CHECK(const_map.count(direction.opposite()) == 0);
+
+  CHECK(const_map.find(direction) == const_map.begin());
+  CHECK(const_map.find(direction.opposite()) == const_map.end());
+
+  CHECK(*const_map.begin() == entry);
+  CHECK(&const_map.at(direction) == &const_map.begin()->second);
+
+  auto it = map.begin();
+  CHECK(*it == entry);
+  CHECK(it.operator->() == &*it);
+  auto it2 = it;
+  CHECK(*it++ == entry);
+  CHECK(it != it2);
+  CHECK(*it2 == entry);
+  CHECK(it == map.end());
+  CHECK(++it2 == map.end());
+  CHECK(it2 == map.end());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.DirectionMap", "[Domain][Unit]") {
+  for (const auto& direction : Direction<2>::all_directions()) {
+    check_single_element_map(direction);
+  }
+
+  DirectionMap<2, double> map;
+
+  CHECK(map.empty());
+  CHECK(map.size() == 0);  // NOLINT(readability-container-size-empty)
+
+  CHECK(map.begin() == cpp17::as_const(map).begin());
+  CHECK(map.begin() == cpp17::as_const(map).cbegin());
+  CHECK(map.end() == cpp17::as_const(map).end());
+  CHECK(map.end() == cpp17::as_const(map).cend());
+  CHECK(map.begin() == map.end());
+
+  const auto dir1 = Direction<2>::lower_eta();
+  const auto dir2 = Direction<2>::upper_xi();
+  const auto dir3 = Direction<2>::lower_xi();
+  {
+    CHECK(map.count(dir1) == 0);
+    const auto result = map.emplace(dir1, 1.);
+    CHECK(result.second);
+    CHECK(result.first == map.find(dir1));
+    CHECK(map.count(dir1) == 1);
+  }
+  CHECK(not map.empty());
+  CHECK(map.size() == 1);
+  {
+    CHECK(map.count(dir2) == 0);
+    const auto result = map.insert(std::make_pair(dir2, 2.));
+    CHECK(result.second);
+    CHECK(result.first == map.find(dir2));
+    CHECK(map.count(dir2) == 1);
+  }
+  CHECK(not map.empty());
+  CHECK(map.size() == 2);
+  {
+    const auto result = map.insert(std::make_pair(dir2, 3.));
+    CHECK(not result.second);
+    CHECK(result.first == map.find(dir2));
+    CHECK(map.count(dir2) == 1);
+  }
+  CHECK(map.size() == 2);
+  {
+    const auto result = map.emplace(dir1, 4.);
+    CHECK(not result.second);
+    CHECK(result.first == map.find(dir1));
+    CHECK(map.count(dir1) == 1);
+  }
+  CHECK(map.size() == 2);
+  CHECK(cpp17::as_const(map).at(dir1) == 1.);
+  CHECK(cpp17::as_const(map).at(dir2) == 2.);
+  map.at(dir2) = 5.;
+  CHECK(cpp17::as_const(map).at(dir2) == 5.);
+  CHECK(map.size() == 2);
+  CHECK(&cpp17::as_const(map).find(dir1)->second ==
+        &cpp17::as_const(map).at(dir1));
+  CHECK(&cpp17::as_const(map).find(dir2)->second ==
+        &cpp17::as_const(map).at(dir2));
+  CHECK(cpp17::as_const(map).find(dir3) == map.end());
+
+  const auto check_exception = [&dir3](auto& passed_map) noexcept {
+    try {
+      passed_map.at(dir3);
+      CHECK(false);
+    } catch (const std::out_of_range& e) {
+      CHECK(e.what() == get_output(dir3) + " not in map");
+    } catch (...) {
+      CHECK(false);
+    }
+  };
+  check_exception(map);
+  check_exception(cpp17::as_const(map));
+
+  map[dir3] = 6.;
+  CHECK(map.size() == 3);
+  CHECK(cpp17::as_const(map).at(dir3) == 6.);
+
+  test_iterators(map);
+
+  {
+    // The map doesn't guarantee an iteration order, so this block
+    // would put the map into a difficult-to-describe state.  We use a
+    // copy to not have to deal with that.
+    auto map2 = map;
+    const auto second = std::next(map2.begin());
+    const auto third = std::next(map2.begin(), 2);
+    // Checks iterator mutability correctness for erase
+    const auto next = map2.erase(cpp17::as_const(map2).find(second->first));
+    CHECK(map2.size() == 2);
+    CHECK(next == third);
+    next->second = -1.;
+    CHECK(std::next(map2.begin())->second == -1.);
+  }
+
+  CHECK(map == map);
+  CHECK_FALSE(map != map);
+  {
+    // Test copy and move
+    const auto check_equal = [](const auto& a, const auto& b) noexcept {
+      CHECK(a == b);
+      CHECK(b == a);
+      CHECK_FALSE(a != b);
+      CHECK_FALSE(b != a);
+    };
+    auto map2 = map;
+    check_equal(map, map2);
+    auto map3 = std::move(map2);
+    check_equal(map, map3);
+    decltype(map) map4;
+    map4 = std::move(map3);
+    check_equal(map, map4);
+    decltype(map) map5;
+    map5 = map4;
+    check_equal(map, map5);
+
+    // Test moving non-copyable entries
+    DirectionMap<2, NonCopyable> nc_map;
+    nc_map.emplace(Direction<2>::upper_xi(), NonCopyable{});
+    DirectionMap<2, NonCopyable> nc_map2;
+    nc_map2.emplace(Direction<2>::upper_xi(), NonCopyable{});
+
+    check_equal(nc_map, nc_map2);
+    auto nc_map3 = std::move(nc_map2);
+    check_equal(nc_map, nc_map3);
+    DirectionMap<2, NonCopyable> nc_map4;
+    nc_map4 = std::move(nc_map3);
+    check_equal(nc_map, nc_map4);
+  }
+  {
+    auto map2 = map;
+    map2.erase(dir1);
+    CHECK_FALSE(map == map2);
+    CHECK_FALSE(map2 == map);
+    CHECK(map != map2);
+    CHECK(map2 != map);
+  }
+  {
+    auto map2 = map;
+    map2.at(dir1) = -1.;
+    CHECK_FALSE(map == map2);
+    CHECK_FALSE(map2 == map);
+    CHECK(map != map2);
+    CHECK(map2 != map);
+  }
+  {
+    // Check initializer list constructor
+    CHECK(decltype(map)(std::initializer_list<decltype(map)::value_type>{})
+              .empty());
+    CHECK(map == decltype(map){{dir1, map.at(dir1)},
+                               {dir2, map.at(dir2)},
+                               {dir3, map.at(dir3)}});
+    CHECK(map == decltype(map){{dir2, map.at(dir2)},
+                               {dir3, map.at(dir3)},
+                               {dir1, map.at(dir1)}});
+  }
+
+  test_serialization(map);
+
+  CHECK(get_output(map) == get_output(std::unordered_map<Direction<2>, double>(
+                               map.begin(), map.end())));
+
+  CHECK(map.erase(dir1) == 1);
+  CHECK(map.size() == 2);
+  CHECK(map.find(dir1) == map.end());
+  CHECK(map.erase(dir1) == 0);
+  CHECK(map.size() == 2);
+  CHECK(map.find(dir1) == map.end());
+
+  map.clear();
+  CHECK(map.empty());
+  CHECK(map.size() == 0);  // NOLINT(readability-container-size-empty)
+  test_iterators(map);
+}

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -94,16 +94,9 @@ void test_1d_domains() {
         Domain<1, Frame::Inertial>{std::move(vector_of_blocks)},
         expected_neighbors, expected_boundaries, expected_maps);
 
-    CHECK(get_output(domain) ==
-          "Domain with 2 blocks:\n"
-          "Block 0:\n"
-          "Neighbors:\n"
-          "+0: Id = 1; orientation = (-0)\n"
-          "External boundaries: (-0)\n\n"
-          "Block 1:\n"
-          "Neighbors:\n"
-          "+0: Id = 0; orientation = (-0)\n"
-          "External boundaries: (-0)\n\n");
+    CHECK(get_output(domain) == "Domain with 2 blocks:\n" +
+                                    get_output(domain.blocks()[0]) + "\n" +
+                                    get_output(domain.blocks()[1]) + "\n");
   }
 
   {

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -3,15 +3,13 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <algorithm>
 #include <array>
 #include <cstddef>
-#include <functional>
 #include <memory>
 #include <pup.h>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -20,6 +18,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
@@ -51,11 +50,11 @@ void test_1d_domains() {
     const OrientationMap<1> unaligned_orientation{{{Direction<1>::lower_xi()}},
                                                   {{Direction<1>::upper_xi()}}};
 
-    const std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>
-        expected_neighbors{{{Direction<1>::upper_xi(),
-                             BlockNeighbor<1>{1, unaligned_orientation}}},
-                           {{Direction<1>::upper_xi(),
-                             BlockNeighbor<1>{0, unaligned_orientation}}}};
+    const std::vector<DirectionMap<1, BlockNeighbor<1>>> expected_neighbors{
+        {{Direction<1>::upper_xi(),
+          BlockNeighbor<1>{1, unaligned_orientation}}},
+        {{Direction<1>::upper_xi(),
+          BlockNeighbor<1>{0, unaligned_orientation}}}};
 
     const std::vector<std::unordered_set<Direction<1>>> expected_boundaries{
         {Direction<1>::lower_xi()}, {Direction<1>::lower_xi()}};
@@ -118,7 +117,7 @@ void test_1d_domains() {
     const auto expected_neighbors = []() {
       OrientationMap<1> orientation{{{Direction<1>::lower_xi()}},
                                     {{Direction<1>::lower_xi()}}};
-      return std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+      return std::vector<DirectionMap<1, BlockNeighbor<1>>>{
           {{Direction<1>::lower_xi(), BlockNeighbor<1>{0, orientation}},
            {Direction<1>::upper_xi(), BlockNeighbor<1>{0, orientation}}}};
     }();

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -23,6 +23,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -5,9 +5,9 @@
 
 #include <array>
 #include <cstddef>
+// IWYU pragma: no_include <initializer_list>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <vector>
 
 #include "DataStructures/Index.hpp"
@@ -21,6 +21,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Domain/Side.hpp"
@@ -33,8 +34,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.SameBlock",
                   "[Domain][Unit]") {
   const std::vector<std::array<size_t, 8>> corners_of_all_blocks{
       {{0, 1, 2, 3, 4, 5, 6, 7}}, {{8, 9, 10, 11, 0, 1, 2, 3}}};
-  std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      neighbors_of_all_blocks;
+  std::vector<DirectionMap<3, BlockNeighbor<3>>> neighbors_of_all_blocks;
   set_internal_boundaries<3>(corners_of_all_blocks, &neighbors_of_all_blocks);
 
   const OrientationMap<3> aligned{};
@@ -49,11 +49,11 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.SameBlock",
   CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
         aligned);
 
-  const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{{{Direction<3>::upper_xi(), {0, aligned}},
-                                {Direction<3>::lower_xi(), {0, aligned}},
-                                {Direction<3>::lower_zeta(), {1, aligned}}},
-                               {{Direction<3>::upper_zeta(), {0, aligned}}}};
+  const std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
+      {{Direction<3>::upper_xi(), {0, aligned}},
+       {Direction<3>::lower_xi(), {0, aligned}},
+       {Direction<3>::lower_zeta(), {1, aligned}}},
+      {{Direction<3>::upper_zeta(), {0, aligned}}}};
 
   CHECK(neighbors_of_all_blocks == expected_block_neighbors);
 }
@@ -62,8 +62,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.DifferentBlocks",
                   "[Domain][Unit]") {
   const std::vector<std::array<size_t, 8>> corners_of_all_blocks{
       {{0, 1, 2, 3, 4, 5, 6, 7}}, {{8, 9, 10, 11, 0, 1, 2, 3}}};
-  std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      neighbors_of_all_blocks;
+  std::vector<DirectionMap<3, BlockNeighbor<3>>> neighbors_of_all_blocks;
   set_internal_boundaries<3>(corners_of_all_blocks, &neighbors_of_all_blocks);
 
   const OrientationMap<3> aligned{};
@@ -77,11 +76,11 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.DifferentBlocks",
                              &neighbors_of_all_blocks);
   CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
         aligned);
-  const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{{{Direction<3>::upper_xi(), {1, aligned}},
-                                {Direction<3>::lower_zeta(), {1, aligned}}},
-                               {{Direction<3>::lower_xi(), {0, aligned}},
-                                {Direction<3>::upper_zeta(), {0, aligned}}}};
+  const std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
+      {{Direction<3>::upper_xi(), {1, aligned}},
+       {Direction<3>::lower_zeta(), {1, aligned}}},
+      {{Direction<3>::lower_xi(), {0, aligned}},
+       {Direction<3>::upper_zeta(), {0, aligned}}}};
 
   CHECK(neighbors_of_all_blocks == expected_block_neighbors);
 }

--- a/tests/Unit/Domain/Test_Element.cpp
+++ b/tests/Unit/Domain/Test_Element.cpp
@@ -11,6 +11,7 @@
 #include "Domain/ElementId.hpp"
 #include "Domain/Neighbors.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 #include "tests/Unit/TestHelpers.hpp"
 

--- a/tests/Unit/Domain/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Test_ElementId.cpp
@@ -12,6 +12,7 @@
 #include "Domain/ElementIndex.hpp"
 #include "Domain/SegmentId.hpp"
 #include "Domain/Side.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep

--- a/tests/Unit/Domain/Test_ElementIndex.cpp
+++ b/tests/Unit/Domain/Test_ElementIndex.cpp
@@ -12,7 +12,7 @@
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementIndex.hpp"
 #include "Domain/SegmentId.hpp"  // IWYU pragma: keep
-#include "tests/Unit/TestHelpers.hpp"
+#include "Utilities/GetOutput.hpp"
 
 namespace {
 template <size_t VolumeDim>

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -10,7 +10,6 @@
 #include <memory>
 #include <pup.h>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -23,6 +22,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/FaceNormal.hpp"
@@ -144,7 +144,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ComputeItem", "[Unit][Domain]") {
           make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
               CoordinateMaps::Rotation<2>(atan2(4., 3.)))));
 
-  std::unordered_map<Direction<2>, tnsr::i<DataVector, 2>> expected;
+  DirectionMap<2, tnsr::i<DataVector, 2>> expected;
   expected[Direction<2>::upper_xi()] =
       tnsr::i<DataVector, 2>{{{{0.6, 0.6}, {0.8, 0.8}}}};
   expected[Direction<2>::lower_eta()] =

--- a/tests/Unit/Domain/Test_Neighbors.cpp
+++ b/tests/Unit/Domain/Test_Neighbors.cpp
@@ -14,6 +14,7 @@
 #include "Domain/Neighbors.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Domain/SegmentId.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.Neighbors.1d", "[Domain][Unit]") {

--- a/tests/Unit/Domain/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Test_OrientationMap.cpp
@@ -16,6 +16,7 @@
 #include "Domain/SegmentId.hpp"
 #include "Domain/Side.hpp"
 #include "ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"

--- a/tests/Unit/Domain/Test_SegmentId.cpp
+++ b/tests/Unit/Domain/Test_SegmentId.cpp
@@ -10,6 +10,7 @@
 #include "Domain/SegmentId.hpp"
 #include "Domain/Side.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.SegmentId", "[Domain][Unit]") {

--- a/tests/Unit/Domain/Test_Side.cpp
+++ b/tests/Unit/Domain/Test_Side.cpp
@@ -6,7 +6,7 @@
 #include <string>
 
 #include "Domain/Side.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "Utilities/GetOutput.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.Side", "[Domain][Unit]") {
   Side side_lower = Side::Lower;

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -31,7 +31,7 @@
 #include "IO/VolumeDataFile.hpp"
 #include "Informer/InfoFromBuild.hpp"
 #include "Utilities/FileSystem.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "Utilities/GetOutput.hpp"
 
 SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
   const std::string h5_file_name("Unit.IO.H5.File.h5");

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -36,6 +36,7 @@
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"
 #include "Utilities/Gsl.hpp"
+// IWYU pragms: no_include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -8,6 +8,7 @@
 // IWYU pragma: no_include <boost/functional/hash/extensions.hpp>
 #include <cstddef>
 #include <functional>
+// IWYU pragma: no_include <initializer_list>
 #include <memory>
 #include <pup.h>
 #include <string>
@@ -28,6 +29,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementIndex.hpp"
@@ -197,10 +199,10 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
                                     Direction<2>::upper_xi(),
                                     Direction<2>::upper_eta()};
   const struct {
-    std::unordered_map<Direction<2>, Scalar<DataVector>> fluxes;
-    std::unordered_map<Direction<2>, Scalar<DataVector>> other_data;
-    std::unordered_map<Direction<2>, Scalar<DataVector>> remote_fluxes;
-    std::unordered_map<Direction<2>, Scalar<DataVector>> remote_other_data;
+    DirectionMap<2, Scalar<DataVector>> fluxes;
+    DirectionMap<2, Scalar<DataVector>> other_data;
+    DirectionMap<2, Scalar<DataVector>> remote_fluxes;
+    DirectionMap<2, Scalar<DataVector>> remote_other_data;
   } data{
       {{Direction<2>::lower_xi(), Scalar<DataVector>{{{{1., 2., 3.}}}}},
        {Direction<2>::upper_xi(), Scalar<DataVector>{{{{4., 5., 6.}}}}},

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -16,8 +16,8 @@
 #include "ErrorHandling/Error.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Options.Empty.success", "[Unit][Options]") {
   Options<tmpl::list<>> opts("");

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -8,9 +8,13 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
+#include <cstddef>
 #include <iterator>
 #include <memory>
+#include <ostream>
+#include <string>
 
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/Error.hpp"
@@ -19,7 +23,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/Requires.hpp"
-#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/StdArrayHelpers.hpp"  // IWYU pragma: keep
 #include "Utilities/TypeTraits.hpp"
 
 /*!
@@ -275,6 +279,17 @@ struct NonCopyable {
   NonCopyable& operator=(NonCopyable&&) = default;
   ~NonCopyable() = default;
 };
+inline bool operator==(const NonCopyable& /*a*/,
+                       const NonCopyable& /*b*/) noexcept {
+  return true;
+}
+inline bool operator!=(const NonCopyable& a, const NonCopyable& b) noexcept {
+  return not(a == b);
+}
+inline std::ostream& operator<<(std::ostream& os,
+                                const NonCopyable& /*v*/) noexcept {
+  return os << "NC";
+}
 
 class DoesNotThrow {
  public:

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -187,8 +187,8 @@ void test_reverse_iterators(Container& c) {
  * \brief Function to test comparison operators.  Pass values with
  * less < greater.
  */
-template <typename T>
-void check_cmp(const T& less, const T& greater) {
+template <typename T, typename U>
+void check_cmp(const T& less, const U& greater) {
   CHECK(less == less);
   CHECK_FALSE(less == greater);
   CHECK(less != greater);

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -14,7 +14,6 @@
 #include <iterator>
 #include <memory>
 #include <ostream>
-#include <string>
 
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/Error.hpp"
@@ -221,17 +220,6 @@ void check_cmp(const T& less, const U& greater) {
     CHECK((f op## = b_) == c_); \
     CHECK(f == c_);             \
   } while (false)
-
-/*!
- * \ingroup TestingFrameworkGroup
- * \brief Get the streamed output `c` as a `std::string`
- */
-template <typename Container>
-std::string get_output(const Container& c) {
-  std::ostringstream os;
-  os << c;
-  return os.str();
-}
 
 /*!
  * \ingroup TestingFrameworkGroup

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -3,18 +3,18 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <algorithm>
 #include <boost/iterator/transform_iterator.hpp>
 #include <cstddef>
 #include <deque>
 #include <string>
-#include <sys/types.h>
+#include <utility>
 #include <vector>
 
 #include "Time/BoundaryHistory.hpp"
 #include "Time/History.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 

--- a/tests/Unit/Time/Test_Slab.cpp
+++ b/tests/Unit/Time/Test_Slab.cpp
@@ -9,6 +9,7 @@
 #include "ErrorHandling/Error.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.Slab", "[Unit][Time]") {

--- a/tests/Unit/Time/Test_Time.cpp
+++ b/tests/Unit/Time/Test_Time.cpp
@@ -10,6 +10,7 @@
 #include "ErrorHandling/Error.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
+#include "Utilities/GetOutput.hpp"
 // IWYU pragma: no_include "Utilities/Rational.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 

--- a/tests/Unit/Time/Test_TimeId.cpp
+++ b/tests/Unit/Time/Test_TimeId.cpp
@@ -10,6 +10,7 @@
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.TimeId", "[Unit][Time]") {

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_SOURCES
   Test_FakeVirtual.cpp
   Test_FileSystem.cpp
   Test_FractionUtilities.cpp
+  Test_GetOutput.cpp
   Test_Gsl.cpp
   Test_MakeArray.cpp
   Test_MakeVector.cpp

--- a/tests/Unit/Utilities/Test_Array.cpp
+++ b/tests/Unit/Utilities/Test_Array.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "Utilities/Array.hpp"  // IWYU pragma: associated
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 

--- a/tests/Unit/Utilities/Test_GetOutput.cpp
+++ b/tests/Unit/Utilities/Test_GetOutput.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.GetOutput", "[Utilities][Unit]") {
+  CHECK(get_output(3) == "3");
+  CHECK(get_output(std::string("abc")) == "abc");
+}

--- a/tests/Unit/Utilities/Test_GetOutput.cpp
+++ b/tests/Unit/Utilities/Test_GetOutput.cpp
@@ -6,8 +6,10 @@
 #include <string>
 
 #include "Utilities/GetOutput.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.GetOutput", "[Utilities][Unit]") {
   CHECK(get_output(3) == "3");
   CHECK(get_output(std::string("abc")) == "abc");
+  CHECK(get_output(NonCopyable{}) == "NC");
 }

--- a/tests/Unit/Utilities/Test_Rational.cpp
+++ b/tests/Unit/Utilities/Test_Rational.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Rational.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 

--- a/tests/Unit/Utilities/Test_StdHelpers.cpp
+++ b/tests/Unit/Utilities/Test_StdHelpers.cpp
@@ -18,8 +18,8 @@
 #include <utility>
 #include <vector>
 
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/StdHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
 
 // IWYU pragma: no_forward_declare boost::hash
 

--- a/tools/Iwyu/stl.imp
+++ b/tools/Iwyu/stl.imp
@@ -4,6 +4,7 @@
 [
   { symbol: ["size_t", private, "<cstddef>", public]},
   { symbol: ["ssize_t", private, "<cstddef>", public]},
+  { symbol: ["ptrdiff_t", private, "<cstddef>", public]},
   { symbol: ["std::abs", private, "<cmath>", public]},
   { symbol: ["abs", private, "<cmath>", public]},
   { symbol: ["std::hash", private, "<functional>", public]},


### PR DESCRIPTION
## Proposed changes

Adds an optimized, stack-allocated map with Directions as keys.

We use these maps a lot, and the interface items create and destroy them fairly frequently.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
