### PR TITLE
Extend Shell to allow for EquatorialCompression

### DIFF
--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -9,6 +9,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
@@ -27,6 +28,7 @@ using Equiangular3D =
     CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
 using Equiangular3DPrism =
     CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Affine>;
+using EquatorialCompression = CoordinateMaps::EquatorialCompression;
 using Wedge2D = CoordinateMaps::Wedge2D;
 using Wedge3D = CoordinateMaps::Wedge3D;
 using Wedge3DPrism = CoordinateMaps::ProductOf2Maps<Wedge2D, Affine>;
@@ -66,6 +68,8 @@ void register_with_charm<3>() {
                                          CoordinateMaps::Frustum>));
   PUPable_reg(
       SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3D>));
+  PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
+                                         Wedge3D, EquatorialCompression>));
   PUPable_reg(SINGLE_ARG(
       ::CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3DPrism>));
 }

--- a/src/Domain/DomainCreators/Shell.cpp
+++ b/src/Domain/DomainCreators/Shell.cpp
@@ -30,22 +30,25 @@ Shell<TargetFrame>::Shell(
     typename OuterRadius::type outer_radius,
     typename InitialRefinement::type initial_refinement,
     typename InitialGridPoints::type initial_number_of_grid_points,
-    typename UseEquiangularMap::type use_equiangular_map) noexcept
+    typename UseEquiangularMap::type use_equiangular_map,
+    typename AspectRatio::type aspect_ratio) noexcept
     // clang-tidy: trivially copyable
-    : inner_radius_(std::move(inner_radius)),                  // NOLINT
-      outer_radius_(std::move(outer_radius)),                  // NOLINT
-      initial_refinement_(                                     // NOLINT
-          std::move(initial_refinement)),                      // NOLINT
-      initial_number_of_grid_points_(                          // NOLINT
-          std::move(initial_number_of_grid_points)),           // NOLINT
-      use_equiangular_map_(std::move(use_equiangular_map)) {}  // NOLINT
+    : inner_radius_(std::move(inner_radius)),                // NOLINT
+      outer_radius_(std::move(outer_radius)),                // NOLINT
+      initial_refinement_(                                   // NOLINT
+          std::move(initial_refinement)),                    // NOLINT
+      initial_number_of_grid_points_(                        // NOLINT
+          std::move(initial_number_of_grid_points)),         // NOLINT
+      use_equiangular_map_(std::move(use_equiangular_map)),  // NOLINT
+      aspect_ratio_(std::move(aspect_ratio)) {}              // NOLINT
 
 template <typename TargetFrame>
 Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
   std::vector<
       std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
       coord_maps = wedge_coordinate_maps<TargetFrame>(
-          inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_);
+          inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_, 0.0,
+          false, aspect_ratio_);
   return Domain<3, TargetFrame>{std::move(coord_maps),
                                 corners_for_radially_layered_domains(1, false)};
 }

--- a/src/Domain/DomainCreators/Shell.hpp
+++ b/src/Domain/DomainCreators/Shell.hpp
@@ -56,23 +56,33 @@ class Shell : public DomainCreator<3, TargetFrame> {
     using type = bool;
     static constexpr OptionString help = {
         "Use equiangular instead of equidistant coordinates."};
-    static type default_value() { return true; }
+    static constexpr type default_value() noexcept { return true; }
   };
+
+  struct AspectRatio {
+    using type = double;
+    static constexpr OptionString help = {"The equatorial compression factor."};
+    static constexpr type default_value() noexcept { return 1.0; }
+  };
+
   using options = tmpl::list<InnerRadius, OuterRadius, InitialRefinement,
-                             InitialGridPoints, UseEquiangularMap>;
+                             InitialGridPoints, UseEquiangularMap, AspectRatio>;
 
   static constexpr OptionString help{
       "Creates a 3D spherical shell with 6 Blocks. `UseEquiangularMap` has\n"
       "a default value of `true` because there is no central Block in this\n"
       "domain. Equidistant coordinates are best suited to Blocks with\n"
       "Cartesian grids. However, the option is allowed for testing "
-      "purposes.\n"};
+      "purposes. The `aspect_ratio` moves grid points on the shell towards\n"
+      "the equator for values greater than 1.0, and towards the poles for\n"
+      "positive values less than 1.0."};
 
   Shell(typename InnerRadius::type inner_radius,
         typename OuterRadius::type outer_radius,
         typename InitialRefinement::type initial_refinement,
         typename InitialGridPoints::type initial_number_of_grid_points,
-        typename UseEquiangularMap::type use_equiangular_map) noexcept;
+        typename UseEquiangularMap::type use_equiangular_map,
+        typename AspectRatio::type aspect_ratio = 1.0) noexcept;
 
   Shell() = default;
   Shell(const Shell&) = delete;
@@ -94,5 +104,6 @@ class Shell : public DomainCreator<3, TargetFrame> {
   typename InitialRefinement::type initial_refinement_{};
   typename InitialGridPoints::type initial_number_of_grid_points_{};
   typename UseEquiangularMap::type use_equiangular_map_ = true;
+  typename AspectRatio::type aspect_ratio_ = 1.0;
 };
 }  // namespace DomainCreators

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -14,6 +14,7 @@
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
@@ -368,7 +369,8 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const double outer_sphericity,
                       const bool use_equiangular_map,
                       const double x_coord_of_shell_center,
-                      const bool use_half_wedges) noexcept {
+                      const bool use_half_wedges,
+                      const double aspect_ratio) noexcept {
   const auto wedge_orientations = orientations_for_wrappings();
 
   using Wedge3DMap = CoordinateMaps::Wedge3D;
@@ -411,6 +413,15 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
     return make_vector_coordinate_map_base<Frame::Logical, TargetFrame, 3>(
         std::move(wedges), std::move(translation));  // NOLINT
   }
+
+  if (aspect_ratio != 1.0) {
+    const auto compression =
+        CoordinateMaps::EquatorialCompression{aspect_ratio};
+    // clang-tidy: trivially copyable
+    return make_vector_coordinate_map_base<Frame::Logical, TargetFrame, 3>(
+        std::move(wedges), std::move(compression));  // NOLINT
+  }
+
   // clang-tidy: trivially copyable
   return make_vector_coordinate_map_base<Frame::Logical, TargetFrame, 3>(
       std::move(wedges));  // NOLINT
@@ -808,7 +819,8 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const double outer_sphericity,
                       const bool use_equiangular_map,
                       const double x_coord_of_shell_center,
-                      const bool use_wedge_halves) noexcept;
+                      const bool use_wedge_halves,
+                      const double aspect_ratio) noexcept;
 template std::vector<
     std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
 wedge_coordinate_maps(const double inner_radius, const double outer_radius,
@@ -816,7 +828,8 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const double outer_sphericity,
                       const bool use_equiangular_map,
                       const double x_coord_of_shell_center,
-                      const bool use_wedge_halves) noexcept;
+                      const bool use_wedge_halves,
+                      const double aspect_ratio) noexcept;
 template std::vector<
     std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
 frustum_coordinate_maps(const double length_inner_cube,

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -91,13 +91,18 @@ corners_for_rectilinear_domains(const Index<VolumeDim>& domain_extents,
 /// When the argument `use_half_wedges` is set to `true`, the wedges in the
 /// +z,-z,+y,-y directions are cut in half along their xi-axes. The resulting
 /// ten CoordinateMaps are used for the outermost Blocks of the BBH Domain.
+/// The argument `aspect_ratio` sets the equatorial compression factor,
+/// used by the EquatorialCompression maps which get composed with the Wedges.
+/// This is done if `aspect_ratio` is set to something other than the default
+/// value of one.
 template <typename TargetFrame>
 std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
 wedge_coordinate_maps(double inner_radius, double outer_radius,
                       double inner_sphericity, double outer_sphericity,
                       bool use_equiangular_map,
                       double x_coord_of_shell_center = 0.0,
-                      bool use_half_wedges = false) noexcept;
+                      bool use_half_wedges = false,
+                      double aspect_ratio = 1.0) noexcept;
 
 /// \ingroup ComputationalDomainGroup
 /// These are the ten Frustums used in the DomainCreators for binary compact


### PR DESCRIPTION
## Proposed changes

Adds an additional option to the DomainCreator Shell, allowing the Wedge3Ds to be composed with EquatorialCompression maps.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
