### PR TITLE
Simplify compositions over multiple maps

### DIFF
--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -626,6 +626,27 @@ make_vector_coordinate_map_base(Arg0&& arg_0,
   return return_vector;
 }
 
+/// \ingroup ComputationalDomainGroup
+/// \brief Creates a `std::vector<std::unique_ptr<CoordinateMapBase>>`
+/// containing the result of `make_coordinate_map_base` applied to each
+/// element of the vector of maps composed with the rest of the arguments
+/// passed in.
+template <typename SourceFrame, typename TargetFrame, size_t Dim, typename Map,
+          typename... Maps>
+std::vector<std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, Dim>>>
+make_vector_coordinate_map_base(std::vector<Map> maps,
+                                const Maps&... remaining_maps) noexcept {
+  std::vector<std::unique_ptr<CoordinateMapBase<SourceFrame, TargetFrame, Dim>>>
+      return_vector;
+  return_vector.reserve(sizeof...(Maps) + 1);
+  for (auto& map : maps) {
+    return_vector.emplace_back(
+        make_coordinate_map_base<SourceFrame, TargetFrame>(std::move(map),
+                                                           remaining_maps...));
+  }
+  return return_vector;
+}
+
 /// \cond
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 PUP::able::PUP_ID

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -548,6 +548,7 @@ void test_coordinate_map_with_rotation_wedge() {
 
 void test_make_vector_coordinate_map_base() {
   using Affine = CoordinateMaps::Affine;
+  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
 
   const auto affine1d = make_coordinate_map<Frame::Logical, Frame::Grid>(
       Affine{-1.0, 1.0, 2.0, 8.0});
@@ -564,6 +565,38 @@ void test_make_vector_coordinate_map_base() {
   CHECK(*(vector_of_affine1d[0]) == affine1d);
 
   using Wedge2DMap = CoordinateMaps::Wedge2D;
+  const auto upper_xi_wedge =
+      Wedge2DMap{1.0,
+                 2.0,
+                 0.0,
+                 1.0,
+                 OrientationMap<2>{std::array<Direction<2>, 2>{
+                     {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
+                 true};
+  const auto upper_eta_wedge =
+      Wedge2DMap{1.0,
+                 2.0,
+                 0.0,
+                 1.0,
+                 OrientationMap<2>{std::array<Direction<2>, 2>{
+                     {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
+                 true};
+  const auto lower_xi_wedge =
+      Wedge2DMap{1.0,
+                 2.0,
+                 0.0,
+                 1.0,
+                 OrientationMap<2>{std::array<Direction<2>, 2>{
+                     {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
+                 true};
+  const auto lower_eta_wedge =
+      Wedge2DMap{1.0,
+                 2.0,
+                 0.0,
+                 1.0,
+                 OrientationMap<2>{std::array<Direction<2>, 2>{
+                     {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
+                 true};
   const auto vector_of_wedges =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Wedge2DMap{
@@ -586,34 +619,125 @@ void test_make_vector_coordinate_map_base() {
               OrientationMap<2>{std::array<Direction<2>, 2>{
                   {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
               true});
-  const auto upper_xi_wedge =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Wedge2DMap{
-          1.0, 2.0, 0.0, 1.0,
-          OrientationMap<2>{std::array<Direction<2>, 2>{
-              {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
-          true});
-  const auto upper_eta_wedge =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Wedge2DMap{
-          1.0, 2.0, 0.0, 1.0,
-          OrientationMap<2>{std::array<Direction<2>, 2>{
-              {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
-          true});
-  const auto lower_xi_wedge =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Wedge2DMap{
-          1.0, 2.0, 0.0, 1.0,
-          OrientationMap<2>{std::array<Direction<2>, 2>{
-              {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
-          true});
-  const auto lower_eta_wedge =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Wedge2DMap{
-          1.0, 2.0, 0.0, 1.0,
-          OrientationMap<2>{std::array<Direction<2>, 2>{
-              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
-          true});
-  CHECK(upper_xi_wedge == *(vector_of_wedges[0]));
-  CHECK(upper_eta_wedge == *(vector_of_wedges[1]));
-  CHECK(lower_xi_wedge == *(vector_of_wedges[2]));
-  CHECK(lower_eta_wedge == *(vector_of_wedges[3]));
+
+  CHECK(make_coordinate_map<Frame::Logical, Frame::Inertial>(upper_xi_wedge) ==
+        *(vector_of_wedges[0]));
+  CHECK(make_coordinate_map<Frame::Logical, Frame::Inertial>(upper_eta_wedge) ==
+        *(vector_of_wedges[1]));
+  CHECK(make_coordinate_map<Frame::Logical, Frame::Inertial>(lower_xi_wedge) ==
+        *(vector_of_wedges[2]));
+  CHECK(make_coordinate_map<Frame::Logical, Frame::Inertial>(lower_eta_wedge) ==
+        *(vector_of_wedges[3]));
+  CHECK(*make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            upper_xi_wedge) == *(vector_of_wedges[0]));
+  CHECK(*make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            upper_eta_wedge) == *(vector_of_wedges[1]));
+  CHECK(*make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            lower_xi_wedge) == *(vector_of_wedges[2]));
+  CHECK(*make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            lower_eta_wedge) == *(vector_of_wedges[3]));
+
+  const auto wedges = std::vector<Wedge2DMap>{upper_xi_wedge, upper_eta_wedge,
+                                              lower_xi_wedge, lower_eta_wedge};
+  const auto vector_of_wedges2 =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial, 2>(
+          wedges);
+  CHECK(make_coordinate_map<Frame::Logical, Frame::Inertial>(upper_xi_wedge) ==
+        *(vector_of_wedges2[0]));
+  CHECK(make_coordinate_map<Frame::Logical, Frame::Inertial>(upper_eta_wedge) ==
+        *(vector_of_wedges2[1]));
+  CHECK(make_coordinate_map<Frame::Logical, Frame::Inertial>(lower_xi_wedge) ==
+        *(vector_of_wedges2[2]));
+  CHECK(make_coordinate_map<Frame::Logical, Frame::Inertial>(lower_eta_wedge) ==
+        *(vector_of_wedges2[3]));
+  CHECK(*make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            upper_xi_wedge) == *(vector_of_wedges2[0]));
+  CHECK(*make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            upper_eta_wedge) == *(vector_of_wedges2[1]));
+  CHECK(*make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            lower_xi_wedge) == *(vector_of_wedges2[2]));
+  CHECK(*make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            lower_eta_wedge) == *(vector_of_wedges2[3]));
+
+  const auto translation =
+      Affine2D{Affine{-1.0, 1.0, -1.0, 1.0}, Affine{-1.0, 1.0, 0.0, 2.0}};
+  const auto vector_of_translated_wedges =
+      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial, 2>(
+          wedges, translation);
+
+  const auto translated_upper_xi_wedge =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{
+              1.0, 2.0, 0.0, 1.0,
+              OrientationMap<2>{std::array<Direction<2>, 2>{
+                  {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
+              true},
+          translation);
+  const auto translated_upper_eta_wedge =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{
+              1.0, 2.0, 0.0, 1.0,
+              OrientationMap<2>{std::array<Direction<2>, 2>{
+                  {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
+              true},
+          translation);
+  const auto translated_lower_xi_wedge =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{
+              1.0, 2.0, 0.0, 1.0,
+              OrientationMap<2>{std::array<Direction<2>, 2>{
+                  {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
+              true},
+          translation);
+  const auto translated_lower_eta_wedge =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{
+              1.0, 2.0, 0.0, 1.0,
+              OrientationMap<2>{std::array<Direction<2>, 2>{
+                  {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
+              true},
+          translation);
+  const auto translated_upper_xi_wedge_base =
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{
+              1.0, 2.0, 0.0, 1.0,
+              OrientationMap<2>{std::array<Direction<2>, 2>{
+                  {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
+              true},
+          translation);
+  const auto translated_upper_eta_wedge_base =
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{
+              1.0, 2.0, 0.0, 1.0,
+              OrientationMap<2>{std::array<Direction<2>, 2>{
+                  {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
+              true},
+          translation);
+  const auto translated_lower_xi_wedge_base =
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{
+              1.0, 2.0, 0.0, 1.0,
+              OrientationMap<2>{std::array<Direction<2>, 2>{
+                  {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}},
+              true},
+          translation);
+  const auto translated_lower_eta_wedge_base =
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge2DMap{
+              1.0, 2.0, 0.0, 1.0,
+              OrientationMap<2>{std::array<Direction<2>, 2>{
+                  {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
+              true},
+          translation);
+
+  CHECK(translated_upper_xi_wedge == *(vector_of_translated_wedges[0]));
+  CHECK(translated_upper_eta_wedge == *(vector_of_translated_wedges[1]));
+  CHECK(translated_lower_xi_wedge == *(vector_of_translated_wedges[2]));
+  CHECK(translated_lower_eta_wedge == *(vector_of_translated_wedges[3]));
+  CHECK(*translated_upper_xi_wedge_base == *(vector_of_translated_wedges[0]));
+  CHECK(*translated_upper_eta_wedge_base == *(vector_of_translated_wedges[1]));
+  CHECK(*translated_lower_xi_wedge_base == *(vector_of_translated_wedges[2]));
+  CHECK(*translated_lower_eta_wedge_base == *(vector_of_translated_wedges[3]));
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -239,7 +239,8 @@ void test_wedge_map_generation_against_domain_helpers(
   const auto maps = wedge_coordinate_maps<Frame::Inertial>(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges);
-  for (size_t i = 0; i < maps.size(); i++) {
+  CHECK(maps.size() == expected_coord_maps.size());
+  for (size_t i = 0; i < expected_coord_maps.size(); i++) {
     CHECK(*expected_coord_maps[i] == *maps[i]);
   }
 }


### PR DESCRIPTION
## Proposed changes

Makes it easier to compose a vector of maps (say, the six wedges in Shell) with a translation or rotation.
To be used in extending Shell to allow for EquatorialCompression #750 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
