### PR TITLE
Add BlockLogicalCoordinates and ElementLogicalCoordinates.

### DIFF
--- a/src/DataStructures/IdPair.hpp
+++ b/src/DataStructures/IdPair.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <ostream>
 #include <pup.h>
 #include <type_traits>
 #include <utility>
@@ -48,5 +49,11 @@ template <typename IdType, typename DataType>
 bool operator!=(const IdPair<IdType, DataType>& lhs,
                 const IdPair<IdType, DataType>& rhs) noexcept {
   return not(lhs == rhs);
+}
+
+template <typename IdType, typename DataType>
+std::ostream& operator<<(std::ostream& os,
+                         const IdPair<IdType, DataType>& t) noexcept {
+  return os << '(' << t.id << ',' << t.data << ')';
 }
 /// \endcond

--- a/src/DataStructures/IdPair.hpp
+++ b/src/DataStructures/IdPair.hpp
@@ -13,8 +13,8 @@
  */
 template <typename IdType, typename DataType>
 struct IdPair {
-  IdType id;
-  DataType data;
+  IdType id{};
+  DataType data{};
 };
 
 template <typename IdType, typename DataType>

--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "BlockLogicalCoordinates.hpp"
+
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/IdPair.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/BlockId.hpp"
+#include "Domain/Domain.hpp"  // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace {
+// Define this alias so we don't need to keep typing this monster.
+template <size_t Dim>
+using block_logical_coord_holder =
+    IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>;
+}  // namespace
+
+template <size_t Dim, typename Frame>
+std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
+    const Domain<Dim, Frame>& domain,
+    const tnsr::I<DataVector, Dim, Frame>& x) noexcept {
+  const size_t num_pts = get<0>(x).size();
+  std::vector<block_logical_coord_holder<Dim>> block_coord_holders(num_pts);
+  std::vector<tnsr::I<double, Dim, Frame>> points_with_no_block;
+  for (size_t s = 0; s < num_pts; ++s) {
+    tnsr::I<double, Dim, Frame> x_frame(0.0);
+    for (size_t d = 0; d < Dim; ++d) {
+      x_frame.get(d) = x.get(d)[s];
+    }
+    auto& x_logical = block_coord_holders[s].data;
+    // Check which block this point is in. Each point will be in one
+    // and only one block, unless it is on a shared boundary.  In that
+    // case, choose the first matching block (and this block will have
+    // the smallest block_id).
+    bool found_block = false;
+    for (const auto& block : domain.blocks()) {
+      x_logical = block.coordinate_map().inverse(x_frame);
+      bool is_contained = true;
+      for (size_t d = 0; d < Dim; ++d) {
+        // Assumes that logical coordinates go from -1 to +1 in each
+        // dimension.
+        is_contained = is_contained and x_logical.get(d) >= -1.0 and
+                       x_logical.get(d) <= 1.0;
+      }
+      if (is_contained) {
+        // Point is in this block.  Don't bother checking subsequent
+        // blocks.
+        block_coord_holders[s].id = domain::BlockId(block.id());
+        found_block = true;
+        break;
+      }
+    }
+    if (not found_block) {
+      points_with_no_block.emplace_back(std::move(x_frame));
+    }
+  }
+  if (not points_with_no_block.empty()) {
+    ERROR("Found points that are not in any block\n: x_frame = "
+          << points_with_no_block);
+  }
+  return block_coord_holders;
+}
+
+// Explicit instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                  \
+  template std::vector<block_logical_coord_holder<DIM(data)>> \
+  block_logical_coordinates(                                  \
+      const Domain<DIM(data), FRAME(data)>& domain,           \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& x) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
+                        (Frame::Distorted, Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE
+/// \endcond

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -1,0 +1,39 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace domain {
+class BlockId;
+}  // namespace domain
+class DataVector;
+template <size_t VolumeDim, typename TargetFrame>
+class Domain;
+template <typename IdType, typename DataType>
+class IdPair;
+/// \endcond
+
+/// \ingroup ComputationalDomainGroup
+///
+/// Computes the block logical coordinates and the containing `BlockId`
+/// of a set of points, given coordinates in the `Frame` frame.
+///
+/// \details Returns a std::vector<IdPair<BlockId,coords>>, where the
+/// vector runs over the points and is indexed in the same order as
+/// the input coordinates `x`. For each point, the `IdPair` holds the
+/// block logical coords of that point and the `BlockId` of the `Block` that
+/// contains that point.
+/// If a point is on a shared boundary of two or more `Block`s, it is
+/// returned only once, and is considered to belong to the `Block`
+/// with the smaller `BlockId`.
+template <size_t Dim, typename Frame>
+std::vector<
+    IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>>
+block_logical_coordinates(const Domain<Dim, Frame>& domain,
+                          const tnsr::I<DataVector, Dim, Frame>& x) noexcept;

--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY Domain)
 
 set(LIBRARY_SOURCES
     Block.cpp
+    BlockLogicalCoordinates.cpp
     BlockNeighbor.cpp
     CreateInitialElement.cpp
     Domain.cpp
@@ -17,6 +18,7 @@ set(LIBRARY_SOURCES
     Element.cpp
     ElementId.cpp
     ElementIndex.cpp
+    ElementLogicalCoordinates.cpp
     ElementMap.cpp
     FaceNormal.cpp
     InitialElementIds.cpp

--- a/src/Domain/ElementLogicalCoordinates.cpp
+++ b/src/Domain/ElementLogicalCoordinates.cpp
@@ -1,0 +1,116 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ElementLogicalCoordinates.hpp"
+
+#include <array>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/IdPair.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/BlockId.hpp"    // IWYU pragma: keep
+#include "Domain/ElementId.hpp"  // IWYU pragma: keep
+#include "Domain/Side.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+namespace {
+// Define this alias so we don't need to keep typing this monster.
+template <size_t Dim>
+using block_logical_coord_holder =
+    IdPair<domain::BlockId, tnsr::I<double, Dim, typename ::Frame::Logical>>;
+}  // namespace
+
+template <size_t Dim>
+std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>>
+element_logical_coordinates(const std::vector<ElementId<Dim>>& element_ids,
+                            const std::vector<block_logical_coord_holder<Dim>>&
+                                block_coord_holders) noexcept {
+  // Temporarily put results here in data structures that allow
+  // push_back, because we don't know the sizes of the output
+  // DataVectors ahead of time.
+  std::vector<std::array<std::vector<double>, Dim>> x_element_logical(
+      element_ids.size());
+  std::vector<std::vector<size_t>> offsets(element_ids.size());
+
+  // Loop over points
+  for (size_t offset = 0; offset < block_coord_holders.size(); ++offset) {
+    const auto& block_id = block_coord_holders[offset].id;
+    const auto& x_block_logical = block_coord_holders[offset].data;
+    // Need to loop over elements, because the block doesn't know
+    // things like the refinement_level of each element.
+    for (size_t index = 0; index < element_ids.size(); ++index) {
+      const auto& element_id = element_ids[index];
+      if (element_id.block_id() == block_id.get_index()) {
+        // This element is in this block; now check if the point is in
+        // this element.
+        bool is_contained = true;
+        auto x_elem = make_array<Dim>(0.0);
+        for (size_t d = 0; d < Dim; ++d) {
+          const double up =
+              gsl::at(element_id.segment_ids(), d).endpoint(Side::Upper);
+          const double lo =
+              gsl::at(element_id.segment_ids(), d).endpoint(Side::Lower);
+          const double x_block_log = x_block_logical.get(d);
+          if (x_block_log < lo or x_block_log > up) {
+            is_contained = false;
+            break;
+          }
+          // Map to element coords
+          gsl::at(x_elem, d) = (2.0 * x_block_log - up - lo) / (up - lo);
+        }
+        if (is_contained) {
+          for (size_t d = 0; d < Dim; ++d) {
+            gsl::at(x_element_logical[index], d).push_back(gsl::at(x_elem, d));
+          }
+          offsets[index].push_back(offset);
+          // Found a matching element, so we don't need to check other
+          // elements.
+          break;
+        }
+      }
+    }
+  }
+
+  // Now we know how many points are in each element, so we can
+  // put the intermediate results into the final data structure.
+  std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>> result;
+  for (size_t index = 0; index < element_ids.size(); ++index) {
+    const size_t num_grid_pts = x_element_logical[index][0].size();
+    if (num_grid_pts > 0) {
+      tnsr::I<DataVector, Dim, Frame::Logical> tmp(num_grid_pts);
+      std::vector<size_t> off(num_grid_pts);
+      for (size_t s = 0; s < num_grid_pts; ++s) {
+        for (size_t d = 0; d < Dim; ++d) {
+          tmp.get(d)[s] = gsl::at(x_element_logical[index], d)[s];
+        }
+        off[s] = offsets[index][s];
+      }
+      result.emplace(element_ids[index], ElementLogicalCoordHolder<Dim>{
+                                             std::move(tmp), std::move(off)});
+    }
+  }
+  return result;
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                        \
+  template std::unordered_map<ElementId<DIM(data)>,                 \
+                              ElementLogicalCoordHolder<DIM(data)>> \
+  element_logical_coordinates(                                      \
+      const std::vector<ElementId<DIM(data)>>& element_ids,         \
+      const std::vector<block_logical_coord_holder<DIM(data)>>&     \
+          block_coord_holders) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond

--- a/src/Domain/ElementLogicalCoordinates.hpp
+++ b/src/Domain/ElementLogicalCoordinates.hpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace domain {
+class BlockId;
+}  // namespace domain
+class DataVector;
+template <size_t VolumeDim>
+class ElementId;
+template <typename IdType, typename DataType>
+class IdPair;
+/// \endcond
+
+/// \ingroup ComputationalDomainGroup
+///
+/// Holds element logical coordinates of an arbitrary set of points on
+/// a single `Element`.  The arbitrary set of points is assumed to be
+/// a subset of a larger set of points spanning multiple `Element`s,
+/// and this class holds `offsets` that index into that larger set of
+/// points.
+///
+/// \details `offsets.size()` is the same as the size of the `DataVector`
+/// inside `element_logical_coords`.
+///
+/// This is used during the process of interpolating volume quantities
+/// on the `Elements` (e.g. the spatial metric) onto an arbitrary set
+/// of points (e.g. the points on an apparent horizon or a
+/// wave-extraction surface) expressed in some frame.  Here is an
+/// outline of how this interpolation proceeds, and where
+/// `element_logical_coordinates` and `block_logical_coordinates` fit
+/// into the picture:
+///
+/// Assume some component (e.g. HorizonA) has a `Tensor<DataVector>`
+/// of target coordinate points in some coordinate frame.  The goal is
+/// to determine the `Element` and logical coordinates of each point,
+/// have each `Element` interpolate volume data onto the points
+/// contained inside that `Element`, and send the interpolated data
+/// back to the component.  The first step of this process is to
+/// determine the block_id and block_logical_coordinates of each
+/// point; this is done by the component (e.g. HorizonA), which calls
+/// the function `block_logical_coordinates` on its full set of target
+/// points.  The result of `block_logical_coordinates` is then
+/// communicated to the members of a NodeGroup component
+/// (e.g. HorizonManager).  Each node of the NodeGroup then calls
+/// `element_logical_coordinates`, which returns a map of `ElementId`
+/// to `ElementLogicalCoordHolder` for all the `Element`s on that node
+/// that contain one or more of the target points. The NodeGroup
+/// (which already has received the volume data from the `Elements` on
+/// that node), interpolates the volume data to the element logical
+/// coordinates for all of these `ElementId`s.  The `offsets` in the
+/// `ElementLogicalCoordHolder` are the indices into the `DataVectors`
+/// of the original target coordinates and will be used to assemble
+/// the interpolated data into `Tensor<DataVector>`s that have the
+/// same ordering as the original target coordinates. The NodeGroups
+/// perform a reduction to get the data back to the original
+/// component.
+template <size_t Dim>
+struct ElementLogicalCoordHolder {
+  tnsr::I<DataVector, Dim, Frame::Logical> element_logical_coords;
+  std::vector<size_t> offsets;
+};
+
+/// \ingroup ComputationalDomainGroup
+///
+/// Given a set of points in block logical coordinates and their
+/// `BlockIds`, as returned from the function
+/// `block_logical_coordinates`, determines which `Element`s in a list
+/// of `ElementId`s contains each point, and determines the element
+/// logical coordinates of each point.
+///
+/// \details Returns a std::unordered_map from `ElementId`s to
+/// `ElementLogicalCoordHolder`s.
+/// It is expected that only a subset of the points will be found
+/// in the given `Element`s.
+/// If a point is on a shared boundary of two or more `Element`s, it
+/// will be returned only once, and will be considered to belong to
+/// the first `Element` in the list of `ElementId`s.
+template <size_t Dim>
+std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>>
+element_logical_coordinates(
+    const std::vector<ElementId<Dim>>& element_ids,
+    const std::vector<
+        IdPair<domain::BlockId, tnsr::I<double, Dim, typename Frame::Logical>>>&
+        block_coord_holders) noexcept;

--- a/tests/Unit/DataStructures/Test_IdPair.cpp
+++ b/tests/Unit/DataStructures/Test_IdPair.cpp
@@ -3,14 +3,16 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <string>
 #include <vector>
 
 #include "DataStructures/IdPair.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.DataStructures.IdPair",
-                  "[Unit][DataStructures]") {
+SPECTRE_TEST_CASE("Unit.DataStructures.IdPair", "[Unit][DataStructures]") {
   auto id_pair = make_id_pair(5, std::vector<double>{1.2, 7.8});
   static_assert(cpp17::is_same_v<decltype(id_pair.id), int>,
                 "Failed checking type decay in make_id_pair");
@@ -22,6 +24,9 @@ SPECTRE_TEST_CASE("Unit.DataStructures.IdPair",
   CHECK(id_pair != make_id_pair(6, std::vector<double>{1.2, 7.8}));
   CHECK(id_pair != make_id_pair(5, std::vector<double>{1.3, 7.8}));
   CHECK(id_pair != make_id_pair(7, std::vector<double>{1.3, 7.8}));
+
+  // Test stream operator
+  CHECK(get_output(id_pair) == "(5,(1.2,7.8))");
 
   // Test PUP
   test_serialization(id_pair);

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Domain")
 set(LIBRARY_SOURCES
   DomainTestHelpers.cpp
   Test_Block.cpp
+  Test_BlockAndElementLogicalCoordinates.cpp
   Test_BlockId.cpp
   Test_BlockNeighbor.cpp
   Test_CoordinatesTag.cpp

--- a/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_BlockAndElementLogicalCoordinates.cpp
@@ -1,0 +1,522 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <limits>
+#include <random>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/IdPair.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockId.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Domain/DomainCreators/Shell.hpp"
+#include "Domain/DomainHelpers.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/InitialElementIds.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+template <size_t Dim, typename TargetFrame>
+void fuzzy_test_block_and_element_logical_coordinates(
+    const Domain<Dim, TargetFrame>& domain,
+    const std::vector<std::array<size_t, Dim>>& refinement_levels,
+    const size_t n_pts) noexcept {
+  const auto all_element_ids = initial_element_ids<Dim>(refinement_levels);
+
+  // Random element_id for each point.
+  const auto element_ids = [&all_element_ids, &n_pts ]() noexcept {
+    std::uniform_int_distribution<size_t> ran(0, all_element_ids.size()-1);
+    std::mt19937 gen;
+    std::vector<ElementId<Dim>> ids(n_pts);
+    for (size_t s = 0; s < n_pts; ++s) {
+      ids[s] = all_element_ids[ran(gen)];
+    }
+    return ids;
+  }
+  ();
+  CAPTURE_PRECISE(element_ids);
+
+  // Random element logical coords for each point
+  const auto element_coords = [&n_pts]() noexcept {
+    // Assumes logical coords go from -1 to 1.
+    std::uniform_real_distribution<double> ran(-1.0, 1.0);
+    std::mt19937 gen;
+    std::vector<tnsr::I<double, Dim, Frame::Logical>> coords(n_pts);
+    for (size_t s = 0; s < n_pts; ++s) {
+      for (size_t d = 0; d < Dim; ++d) {
+        coords[s].get(d) = ran(gen);
+      }
+    }
+    return coords;
+  }
+  ();
+  CAPTURE_PRECISE(element_coords);
+
+  // Compute expected map of element_ids to ElementLogicalCoordHolders.
+  // This is just re-organizing and re-bookkeeping element_ids and
+  // element_coords into the same structure that will be returned by
+  // the function we are testing.
+  const auto expected_coord_holders =
+      [&element_ids, &element_coords, &n_pts ]() noexcept {
+    // This is complicated because we don't know ahead of time
+    // how many points are in each element.  So we do a first pass
+    // filling a structure that you can easily push_back to.
+    struct coords_plus_offset {
+      std::vector<std::array<double, Dim>> coords;
+      std::vector<size_t> offsets;
+    };
+    std::unordered_map<ElementId<Dim>, coords_plus_offset> coords_plus_offsets;
+    for (size_t s = 0; s < n_pts; ++s) {
+      auto new_coords = make_array<Dim>(0.0);
+      for (size_t d = 0; d < Dim; ++d) {
+        gsl::at(new_coords, d) = element_coords[s].get(d);
+      }
+      auto pos = coords_plus_offsets.find(element_ids[s]);
+      if (pos == coords_plus_offsets.end()) {
+        coords_plus_offsets.emplace(element_ids[s],
+                                    coords_plus_offset{{new_coords}, {{s}}});
+      } else {
+        pos->second.coords.push_back(new_coords);
+        pos->second.offsets.push_back(s);
+      }
+    }
+
+    // The second pass fills the desired structure.
+    std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>> holders;
+    for (const auto& coord_holder : coords_plus_offsets) {
+      const size_t num_grid_pts = coord_holder.second.offsets.size();
+      tnsr::I<DataVector, Dim, Frame::Logical> coords(num_grid_pts);
+      for (size_t s = 0; s < num_grid_pts; ++s) {
+        for (size_t d = 0; d < Dim; ++d) {
+          coords.get(d)[s] = gsl::at(coord_holder.second.coords[s], d);
+        }
+      }
+      holders.emplace(
+          coord_holder.first,
+          ElementLogicalCoordHolder<Dim>{coords, coord_holder.second.offsets});
+    }
+    return holders;
+  }
+  ();
+
+  // Transform element_coords to frame coords
+  const auto frame_coords =
+      [&n_pts, &domain, &element_ids, &element_coords ]() noexcept {
+    tnsr::I<DataVector, Dim, TargetFrame> coords(n_pts);
+    for (size_t s = 0; s < n_pts; ++s) {
+      const auto& my_block = domain.blocks()[element_ids[s].block_id()];
+      ElementMap<Dim, TargetFrame> map{element_ids[s],
+                                       my_block.coordinate_map().get_clone()};
+      const auto coord_one_point = map(element_coords[s]);
+      for (size_t d = 0; d < Dim; ++d) {
+        coords.get(d)[s] = coord_one_point.get(d);
+      }
+    }
+    return coords;
+  }
+  ();
+
+  const auto block_logical_result =
+      block_logical_coordinates(domain, frame_coords);
+  test_serialization(block_logical_result);
+
+  for (size_t s = 0; s < n_pts; ++s) {
+    CHECK(block_logical_result[s].id.get_index() == element_ids[s].block_id());
+    // We don't know block logical coordinates here, so we can't
+    // test them.
+  }
+
+  // Test versus all the element_ids.
+  const auto element_logical_result =
+      element_logical_coordinates(all_element_ids, block_logical_result);
+
+  for (const auto& expected_holder_pair : expected_coord_holders) {
+    const auto pos = element_logical_result.find(expected_holder_pair.first);
+    CHECK(pos != element_logical_result.end());
+    if (pos != element_logical_result.end()) {
+      const auto& holder = pos->second;
+      CHECK(holder.offsets == expected_holder_pair.second.offsets);
+      CHECK_ITERABLE_APPROX(holder.element_logical_coords,
+                            expected_holder_pair.second.element_logical_coords);
+    }
+  }
+
+  // Make sure every element in element_logical_result is also
+  // in expected_coord_holders.
+  for (const auto& holder_pair : element_logical_result) {
+    const auto pos = expected_coord_holders.find(holder_pair.first);
+    CHECK(pos != expected_coord_holders.end());
+  }
+}
+
+template <size_t Dim, typename TargetFrame>
+void fuzzy_test_block_and_element_logical_coordinates_unrefined(
+    const Domain<Dim, TargetFrame>& domain, const size_t n_pts) noexcept {
+  const size_t n_blocks = domain.blocks().size();
+
+  // Random block_id for each point.
+  const auto block_ids = [&n_pts, &n_blocks ]() noexcept {
+    std::uniform_int_distribution<size_t> ran(0, n_blocks-1);
+    std::mt19937 gen;
+    std::vector<size_t> ids(n_pts);
+    for (size_t s = 0; s < n_pts; ++s) {
+      ids[s] = ran(gen);
+    }
+    return ids;
+  }
+  ();
+  CAPTURE_PRECISE(block_ids);
+
+  // Random block logical coords for each point
+  // (block logical coords == element logical coords)
+  const auto block_coords = [&n_pts]() noexcept {
+    // Assumes logical coords go from -1 to 1.
+    std::uniform_real_distribution<double> ran(-1.0, 1.0);
+    std::mt19937 gen;
+    std::vector<tnsr::I<double, Dim, Frame::Logical>> coords(n_pts);
+    for (size_t s = 0; s < n_pts; ++s) {
+      for (size_t d = 0; d < Dim; ++d) {
+        coords[s].get(d) = ran(gen);
+      }
+    }
+    return coords;
+  }
+  ();
+  CAPTURE_PRECISE(block_coords);
+
+  // Map to frame coords
+  const auto frame_coords =
+      [&n_pts, &domain, &block_ids, &block_coords ]() noexcept {
+    tnsr::I<DataVector, Dim, TargetFrame> coords(n_pts);
+    for (size_t s = 0; s < n_pts; ++s) {
+      const auto coord_one_point =
+          domain.blocks()[block_ids[s]].coordinate_map()(block_coords[s]);
+      for (size_t d = 0; d < Dim; ++d) {
+        coords.get(d)[s] = coord_one_point.get(d);
+      }
+    }
+    return coords;
+  }
+  ();
+
+  const auto block_logical_result =
+      block_logical_coordinates(domain, frame_coords);
+  test_serialization(block_logical_result);
+
+  for (size_t s = 0; s < n_pts; ++s) {
+    CHECK(block_logical_result[s].id.get_index() == block_ids[s]);
+    CHECK_ITERABLE_APPROX(block_logical_result[s].data, block_coords[s]);
+  }
+}
+
+template <typename TargetFrame>
+void fuzzy_test_block_and_element_logical_coordinates_shell(
+    const size_t n_pts) noexcept {
+  const auto shell =
+      DomainCreators::Shell<TargetFrame>(1.5, 2.5, 2, {{1, 1}}, true, 1.0);
+  const auto domain = shell.create_domain();
+  fuzzy_test_block_and_element_logical_coordinates_unrefined(domain, n_pts);
+  fuzzy_test_block_and_element_logical_coordinates(
+      domain, shell.initial_refinement_levels(), n_pts);
+}
+
+template <typename TargetFrame>
+void fuzzy_test_block_and_element_logical_coordinates3(
+    const size_t n_pts) noexcept {
+  Domain<3, TargetFrame> domain(
+      maps_for_rectilinear_domains<TargetFrame>(
+          Index<3>{2, 2, 2},
+          std::array<std::vector<double>, 3>{
+              {{0.0, 0.5, 1.0}, {0.0, 0.5, 1.0}, {0.0, 0.5, 1.0}}},
+          {Index<3>{}}),
+      corners_for_rectilinear_domains(Index<3>{2, 2, 2}));
+  fuzzy_test_block_and_element_logical_coordinates_unrefined(domain, n_pts);
+  fuzzy_test_block_and_element_logical_coordinates(domain,
+                                                   {{{0, 1, 2}},
+                                                    {{2, 2, 2}},
+                                                    {{2, 1, 1}},
+                                                    {{0, 2, 1}},
+                                                    {{2, 2, 2}},
+                                                    {{2, 2, 2}},
+                                                    {{1, 2, 0}},
+                                                    {{2, 0, 1}}},
+                                                   n_pts);
+}
+
+template <typename TargetFrame>
+void fuzzy_test_block_and_element_logical_coordinates2(
+    const size_t n_pts) noexcept {
+  Domain<2, TargetFrame> domain(
+      maps_for_rectilinear_domains<TargetFrame>(
+          Index<2>{2, 3},
+          std::array<std::vector<double>, 2>{
+              {{0.0, 0.5, 1.0}, {0.0, 0.33, 0.66, 1.0}}},
+          {Index<2>{}}),
+      corners_for_rectilinear_domains(Index<2>{2, 3}));
+  fuzzy_test_block_and_element_logical_coordinates_unrefined(domain, n_pts);
+  fuzzy_test_block_and_element_logical_coordinates(
+      domain, {{{0, 1}}, {{2, 1}}, {{2, 2}}, {{3, 2}}, {{0, 0}}, {{2, 0}}},
+      n_pts);
+}
+
+template <typename TargetFrame>
+void fuzzy_test_block_and_element_logical_coordinates1(
+    const size_t n_pts) noexcept {
+  Domain<1, TargetFrame> domain(
+      maps_for_rectilinear_domains<TargetFrame>(
+          Index<1>{2}, std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.0}}},
+          {Index<1>{}}),
+      corners_for_rectilinear_domains(Index<1>{2}));
+  fuzzy_test_block_and_element_logical_coordinates_unrefined(domain, n_pts);
+  fuzzy_test_block_and_element_logical_coordinates(domain, {{{0}}, {{3}}},
+                                                   n_pts);
+}
+
+template <size_t Dim, typename TargetFrame>
+void test_block_and_element_logical_coordinates(
+    const Domain<Dim, TargetFrame>& domain,
+    const std::vector<std::array<double, Dim>>& x_frame,
+    const std::vector<size_t>& expected_block_ids,
+    const std::vector<std::array<double, Dim>>& expected_block_logical,
+    const std::vector<ElementId<Dim>>& element_ids,
+    const std::vector<size_t>& expected_element_id_indices,
+    const std::vector<std::vector<size_t>>& expected_offset,
+    const std::vector<std::vector<std::array<double, Dim>>>&
+        expected_element_logical) noexcept {
+  tnsr::I<DataVector, Dim, TargetFrame> frame_coords(x_frame.size());
+  std::vector<tnsr::I<double, Dim, Frame::Logical>> expected_logical_coords(
+      x_frame.size());
+  for (size_t s = 0; s < x_frame.size(); ++s) {
+    for (size_t d = 0; d < Dim; ++d) {
+      frame_coords.get(d)[s] = gsl::at(x_frame[s], d);
+      expected_logical_coords[s].get(d) = gsl::at(expected_block_logical[s], d);
+    }
+  }
+
+  const auto block_logical_result =
+      block_logical_coordinates(domain, frame_coords);
+  for (size_t s = 0; s < x_frame.size(); ++s) {
+    CHECK(block_logical_result[s].id.get_index() == expected_block_ids[s]);
+    CHECK_ITERABLE_APPROX(block_logical_result[s].data,
+                          expected_logical_coords[s]);
+  }
+
+  test_serialization(block_logical_result);
+
+  const auto element_logical_result =
+      element_logical_coordinates(element_ids, block_logical_result);
+
+  std::vector<tnsr::I<DataVector, Dim, Frame::Logical>> expected_elem_logical;
+  for (const auto& coord : expected_element_logical) {
+    tnsr::I<DataVector, Dim, Frame::Logical> dum(coord.size());
+    for (size_t s = 0; s < coord.size(); ++s) {
+      for (size_t d = 0; d < Dim; ++d) {
+        dum.get(d)[s] = gsl::at(coord[s], d);
+      }
+    }
+    expected_elem_logical.emplace_back(std::move(dum));
+  }
+
+  std::vector<ElementId<Dim>> expected_ids;
+  expected_ids.reserve(expected_element_id_indices.size());
+  for (const auto& index : expected_element_id_indices) {
+    expected_ids.push_back(element_ids[index]);
+  }
+
+  for (size_t s = 0; s < expected_ids.size(); ++s) {
+    const auto pos = element_logical_result.find(expected_ids[s]);
+    CHECK(pos != element_logical_result.end());
+    if (pos != element_logical_result.end()) {
+      const auto& holder = pos->second;
+      CHECK(holder.offsets == expected_offset[s]);
+      CHECK_ITERABLE_APPROX(holder.element_logical_coords,
+                            expected_elem_logical[s]);
+    }
+  }
+  // Make sure we got all the elements
+  for (const auto& holder_pair : element_logical_result) {
+    const auto pos =
+        std::find(expected_ids.begin(), expected_ids.end(), holder_pair.first);
+    CHECK(pos != expected_ids.end());
+  }
+}
+
+template <typename TargetFrame>
+void test_block_and_element_logical_coordinates1() noexcept {
+  Domain<1, TargetFrame> domain(
+      maps_for_rectilinear_domains<TargetFrame>(
+          Index<1>{2}, std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.0}}},
+          {Index<1>{}}),
+      corners_for_rectilinear_domains(Index<1>{2}));
+
+  std::vector<std::array<double, 1>> x_frame{
+      {{0.1}},
+      {{0.8}},
+      {{0.5 + 1000.0 * std::numeric_limits<double>::epsilon()}},
+      {{0.5}}};
+  std::vector<size_t> expected_block_ids{0, 1, 1, 0};
+  std::vector<std::array<double, 1>> expected_x_logical{
+      {{-0.6}},
+      {{0.2}},
+      {{4000.0 * std::numeric_limits<double>::epsilon() - 1.0}},
+      {{1.0}}
+      // The last result is 1.0 because it checks the lower block_id first.
+  };
+
+  // Create some Elements.  I (Mark) did this by hand.
+  auto element_ids = initial_element_ids<1>({{{2}}, {{3}}});
+
+  // I (Mark) computed these expected quantities by hand, given the
+  // points above and the choices of elements.
+  std::vector<size_t> expected_id_indices{{0, 8, 4, 3}};
+  std::vector<std::vector<size_t>> expected_offset{
+      std::vector<size_t>{0}, std::vector<size_t>{1}, std::vector<size_t>{2},
+      std::vector<size_t>{3}};
+  std::vector<std::vector<std::array<double, 1>>> expected_elem_log{
+      std::vector<std::array<double, 1>>{{{0.6}}},
+      std::vector<std::array<double, 1>>{{{0.6}}},
+      std::vector<std::array<double, 1>>{
+          {{32000.0 * std::numeric_limits<double>::epsilon() - 1.0}}},
+      std::vector<std::array<double, 1>>{{{1.0}}}};
+
+  test_block_and_element_logical_coordinates(
+      domain, x_frame, expected_block_ids, expected_x_logical, element_ids,
+      expected_id_indices, expected_offset, expected_elem_log);
+}
+
+template <typename TargetFrame>
+void test_block_logical_coordinates1fail() noexcept {
+  Domain<1, TargetFrame> domain(
+      maps_for_rectilinear_domains<TargetFrame>(
+          Index<1>{2}, std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.0}}},
+          {Index<1>{}}),
+      corners_for_rectilinear_domains(Index<1>{2}));
+
+  std::vector<std::array<double, 1>> x_frame{
+      {{0.1}}, {{1.1}}, {{-0.2}}, {{0.5}}};
+  tnsr::I<DataVector, 1, TargetFrame> frame_coords(x_frame.size());
+  for (size_t s = 0; s < x_frame.size(); ++s) {
+    for (size_t d = 0; d < 1; ++d) {
+      frame_coords.get(d)[s] = gsl::at(x_frame[s], d);
+    }
+  }
+  const auto block_logical_result =
+      block_logical_coordinates(domain, frame_coords);
+}
+
+template <typename TargetFrame>
+void test_block_and_element_logical_coordinates3() noexcept {
+  Domain<3, TargetFrame> domain(
+      maps_for_rectilinear_domains<TargetFrame>(
+          Index<3>{2, 2, 2},
+          std::array<std::vector<double>, 3>{
+              {{0.0, 0.5, 1.0}, {0.0, 0.5, 1.0}, {0.0, 0.5, 1.0}}},
+          {Index<3>{}}),
+      corners_for_rectilinear_domains(Index<3>{2, 2, 2}));
+
+  std::vector<std::array<double, 3>> x_frame{
+      {{0.1, 0.1, 0.1}},   {{0.05, 0.05, 0.05}}, {{0.24, 0.24, 0.24}},
+      {{0.9, 0.24, 0.24}}, {{0.24, 0.8, 0.24}},  {{0.9, 0.8, 0.24}},
+      {{0.1, 0.1, 0.7}},   {{0.1, 0.8, 0.7}},    {{0.7, 0.2, 0.7}},
+      {{0.9, 0.9, 0.9}},   {{0.5, 0.75, 1.0}}};
+  // The last point above lies on the boundary of a block and of an
+  // element.  block_logical_coordinates should pick the smallest
+  // block_id that it lies on.
+  std::vector<size_t> expected_block_ids{{0, 0, 0, 1, 2, 3, 4, 6, 5, 7, 6}};
+  std::vector<std::array<double, 3>> expected_x_logical{
+      {{-0.6, -0.6, -0.6}},  {{-0.8, -0.8, -0.8}},  {{-0.04, -0.04, -0.04}},
+      {{0.6, -0.04, -0.04}}, {{-0.04, 0.2, -0.04}}, {{0.6, 0.2, -0.04}},
+      {{-0.6, -0.6, -0.2}},  {{-0.6, 0.2, -0.2}},   {{-0.2, -0.2, -0.2}},
+      {{0.6, 0.6, 0.6}},     {{1.0, 0.0, 1.0}}};
+
+  // Create some Elements.  I (Mark) did this by hand.
+  auto element_ids = initial_element_ids<3>(4, {{0, 1, 2}});
+  auto element_ids_0 = initial_element_ids<3>(0, {{2, 2, 2}});
+  auto element_ids_1 = initial_element_ids<3>(1, {{2, 1, 1}});
+  auto element_ids_2 = initial_element_ids<3>(2, {{0, 2, 1}});
+  auto element_ids_3 = initial_element_ids<3>(3, {{2, 2, 2}});
+  auto element_ids_6 = initial_element_ids<3>(6, {{2, 2, 2}});
+  auto element_ids_5 = initial_element_ids<3>(5, {{1, 2, 0}});
+  auto element_ids_7 = initial_element_ids<3>(7, {{2, 0, 1}});
+  std::copy(element_ids_0.begin(), element_ids_0.end(),
+            std::back_inserter(element_ids));
+  std::copy(element_ids_1.begin(), element_ids_1.end(),
+            std::back_inserter(element_ids));
+  std::copy(element_ids_2.begin(), element_ids_2.end(),
+            std::back_inserter(element_ids));
+  std::copy(element_ids_3.begin(), element_ids_3.end(),
+            std::back_inserter(element_ids));
+  std::copy(element_ids_6.begin(), element_ids_6.end(),
+            std::back_inserter(element_ids));
+  std::copy(element_ids_5.begin(), element_ids_5.end(),
+            std::back_inserter(element_ids));
+  std::copy(element_ids_7.begin(), element_ids_7.end(),
+            std::back_inserter(element_ids));
+
+  // I (Mark) computed these expected quantities by hand, given the
+  // points above and the choices of elements.
+  std::vector<size_t> expected_id_indices{
+      {1, 8, 29, 84, 92, 153, 169, 225, 239, 215}};
+  // The last point above is on an element boundary;
+  // element_logical_coordinates should choose the first element in
+  // the list of elements it is passed.
+  std::vector<std::vector<size_t>> expected_offset{
+      std::vector<size_t>{6}, std::vector<size_t>{0, 1}, std::vector<size_t>{2},
+      std::vector<size_t>{3}, std::vector<size_t>{4},    std::vector<size_t>{5},
+      std::vector<size_t>{7}, std::vector<size_t>{8},    std::vector<size_t>{9},
+      std::vector<size_t>{10}};
+  std::vector<std::vector<std::array<double, 3>>> expected_elem_log{
+      std::vector<std::array<double, 3>>{{{-0.6, -0.2, 0.2}}},
+      std::vector<std::array<double, 3>>{{{0.6, 0.6, 0.6}},
+                                         {{-0.2, -0.2, -0.2}}},
+      std::vector<std::array<double, 3>>{{{0.84, 0.84, 0.84}}},
+      std::vector<std::array<double, 3>>{{{-0.6, 0.92, 0.92}}},
+      std::vector<std::array<double, 3>>{{{-0.04, -0.2, 0.92}}},
+      std::vector<std::array<double, 3>>{{{-0.6, -0.2, 0.84}}},
+      std::vector<std::array<double, 3>>{{{0.6, -0.2, 0.2}}},
+      std::vector<std::array<double, 3>>{{{0.6, 0.2, -0.2}}},
+      std::vector<std::array<double, 3>>{{{-0.6, 0.6, 0.2}}},
+      std::vector<std::array<double, 3>>{{{1.0, 1.0, 1.0}}}};
+
+  test_block_and_element_logical_coordinates(
+      domain, x_frame, expected_block_ids, expected_x_logical, element_ids,
+      expected_id_indices, expected_offset, expected_elem_log);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.BlockAndElementLogicalCoords",
+                  "[Domain][Unit]") {
+  test_block_and_element_logical_coordinates1<Frame::Grid>();
+  test_block_and_element_logical_coordinates3<Frame::Grid>();
+  fuzzy_test_block_and_element_logical_coordinates3<Frame::Grid>(20);
+  fuzzy_test_block_and_element_logical_coordinates2<Frame::Grid>(20);
+  fuzzy_test_block_and_element_logical_coordinates1<Frame::Grid>(20);
+  fuzzy_test_block_and_element_logical_coordinates1<Frame::Grid>(0);
+  fuzzy_test_block_and_element_logical_coordinates_shell<Frame::Grid>(20);
+}
+
+// [[OutputRegex, Found points that are not in any block.:
+// x_frame = \(T\(0\)=1\.1,T\(0\)=-0\.2\)]]
+SPECTRE_TEST_CASE("Unit.Domain.BlockLogicalCoords.Fail", "[Domain][Unit]") {
+  ERROR_TEST();
+  test_block_logical_coordinates1fail<Frame::Grid>();
+}


### PR DESCRIPTION
These compute the block/element logical coordinates of arbitrary
points.

## Proposed changes
Adds functions for computing block logical coordinates and element logical coordinates of an arbitrary list of points.  Will be useful for interpolation onto horizons and onto extraction spheres.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
