### PR TITLE
Additions for RotatedBricks 3

### DIFF
--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -738,7 +738,9 @@ std::array<size_t, two_to_the(VolumeDim)> discrete_rotation(
       std::array<Direction<VolumeDim>, VolumeDim> directions_of_mapped_corner{};
       for (size_t i = 0; i < VolumeDim; i++) {
         gsl::at(directions_of_mapped_corner, i) =
-            orientation(gsl::at(directions_of_logical_corner, i));
+            // The inverse_map is used here to match the sense of rotation
+            // used in OrientationMap's discrete_rotation.
+            orientation.inverse_map()(gsl::at(directions_of_logical_corner, i));
       }
       size_t mapped_corner = 0;
       for (size_t i = 0; i < VolumeDim; i++) {

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -151,9 +151,10 @@ std::vector<std::array<size_t, 8>> corners_for_biradially_layered_domains(
 /// \ingroup ComputationalDomainGroup
 /// \brief Permutes the corner numbers of an n-cube.
 ///
-/// Returns the correct ordering of global corner numbers for a block
-/// having this orientation relative to an aligned edifice of blocks,
-/// given the corner numbering the block would have if it were aligned.
+/// Returns the correct ordering of global corner numbers for a rotated block
+/// in an otherwise aligned edifice of blocks, given the OrientationMap a
+/// block aligned with the edifice has relative to this one, and given the
+/// corner numbering the rotated block would have if it were aligned.
 /// This is useful in creating domains for testing purposes, e.g.
 /// RotatedIntervals, RotatedRectangles, and RotatedBricks.
 template <size_t VolumeDim>

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -25,6 +25,8 @@ template <size_t VolumeDim>
 class BlockNeighbor;
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
+template <size_t VolumeDim, typename TargetFrame>
+class Domain;
 template <size_t VolumeDim>
 class OrientationMap;
 namespace Frame {
@@ -176,6 +178,35 @@ maps_for_rectilinear_domains(
     const std::vector<Index<VolumeDim>>& block_indices_to_exclude = {},
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks =
         {},
+    bool use_equiangular_map = false) noexcept;
+
+/// \ingroup ComputationalDomainGroup
+/// \brief Create a rectilinear Domain of multicubes.
+///
+/// \details Useful for constructing domains for testing non-trivially
+/// connected rectilinear domains made up of cubes. We refer to a domain of
+/// this type as an edifice. The `domain_extents` provides the size (in the
+/// number of blocks) of the initial aligned edifice to construct. The
+/// `block_indices_to_exclude` parameter is used in refining the shape of
+/// the edifice from a cube to sometime more non-trivial, such as an L-shape
+/// or the net of a tesseract. The `block_demarcations` and
+/// `use_equiangular_map` parameters determine the CoordinateMaps to be used.
+/// `orientations_of_all_blocks` contains the OrientationMap of the edifice
+/// relative to each block.
+///
+/// The `identifications` parameter is used when identifying the faces of
+/// blocks in an edifice. This is used to identify the 1D boundaries in the 2D
+/// net for a 3D cube to construct a domain with topology S2. Note: If the user
+/// wishes to rotate the blocks as well as manually identify their faces, the
+/// user must provide the PairOfFaces corresponding to the rotated corners.
+template <size_t VolumeDim, typename TargetFrame>
+Domain<VolumeDim, TargetFrame> rectilinear_domain(
+    const Index<VolumeDim>& domain_extents,
+    const std::array<std::vector<double>, VolumeDim>& block_demarcations,
+    const std::vector<Index<VolumeDim>>& block_indices_to_exclude = {},
+    const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks =
+        {},
+    const std::vector<PairOfFaces>& identifications = {},
     bool use_equiangular_map = false) noexcept;
 
 /// \ingroup ComputationalDomainGroup

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -173,8 +173,10 @@ std::vector<
 maps_for_rectilinear_domains(
     const Index<VolumeDim>& domain_extents,
     const std::array<std::vector<double>, VolumeDim>& block_demarcations,
-    const std::vector<Index<VolumeDim>>& block_indices_to_exclude,
-    bool use_equiangular_map) noexcept;
+    const std::vector<Index<VolumeDim>>& block_indices_to_exclude = {},
+    const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks =
+        {},
+    bool use_equiangular_map = false) noexcept;
 
 /// \ingroup ComputationalDomainGroup
 /// Iterates over the corners of a VolumeDim-dimensional cube.

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -19,10 +19,12 @@
 #include "Domain/InitialElementIds.hpp"
 #include "Domain/Neighbors.hpp"  // IWYU pragma: keep
 #include "Domain/OrientationMap.hpp"
+#include "Domain/Side.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -12,10 +12,6 @@
 #include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Domain/Side.hpp"
-#include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeArray.hpp"
 
 /// \cond
 template <size_t VolumeDim, typename TargetFrame>

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -946,12 +946,12 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.DiscreteRotation.CornerNumbers",
   CHECK(std::array<size_t, 4>{{1, 4, 0, 3}} ==
         discrete_rotation(
             OrientationMap<2>(std::array<Direction<2>, 2>{
-                {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}),
+                {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}),
             std::array<size_t, 4>{{0, 1, 3, 4}}));
   CHECK(std::array<size_t, 4>{{4, 0, 5, 1}} ==
         discrete_rotation(
             OrientationMap<2>(std::array<Direction<2>, 2>{
-                {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}),
+                {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}),
             std::array<size_t, 4>{{0, 1, 4, 5}}));
   CHECK(std::array<size_t, 4>{{3, 1, 2, 0}} ==
         discrete_rotation(
@@ -962,20 +962,20 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.DiscreteRotation.CornerNumbers",
   CHECK(std::array<size_t, 8>{{9, 0, 12, 3, 10, 1, 13, 4}} ==
         discrete_rotation(
             OrientationMap<3>(std::array<Direction<3>, 3>{
-                {Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
-                 Direction<3>::upper_xi()}}),
+                {Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                 Direction<3>::lower_xi()}}),
             std::array<size_t, 8>{{0, 1, 3, 4, 9, 10, 12, 13}}));
   CHECK(std::array<size_t, 8>{{10, 13, 9, 12, 1, 4, 0, 3}} ==
         discrete_rotation(
             OrientationMap<3>(std::array<Direction<3>, 3>{
-                {Direction<3>::upper_eta(), Direction<3>::lower_xi(),
+                {Direction<3>::lower_eta(), Direction<3>::upper_xi(),
                  Direction<3>::lower_zeta()}}),
             std::array<size_t, 8>{{0, 1, 3, 4, 9, 10, 12, 13}}));
   CHECK(std::array<size_t, 8>{{12, 3, 13, 4, 9, 0, 10, 1}} ==
         discrete_rotation(
             OrientationMap<3>(std::array<Direction<3>, 3>{
-                {Direction<3>::lower_zeta(), Direction<3>::upper_xi(),
-                 Direction<3>::lower_eta()}}),
+                {Direction<3>::upper_eta(), Direction<3>::lower_zeta(),
+                 Direction<3>::lower_xi()}}),
             std::array<size_t, 8>{{0, 1, 3, 4, 9, 10, 12, 13}}));
 }
 

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -995,7 +995,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.MapsForRectilinearDomains",
       affine_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<1>{3},
           std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.7, 2.0}}},
-          {Index<1>{0}}, false);
+          {Index<1>{0}}, {}, false);
   const auto expected_affine_maps_1d =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Affine{-1., 1., 0.5, 1.7}, Affine{-1., 1., 1.7, 2.0});
@@ -1008,7 +1008,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.MapsForRectilinearDomains",
       equiangular_maps_1d = maps_for_rectilinear_domains<Frame::Inertial>(
           Index<1>{3},
           std::array<std::vector<double>, 1>{{{0.0, 0.5, 1.7, 2.0}}},
-          {Index<1>{1}}, true);
+          {Index<1>{1}}, {}, true);
   const auto expected_equiangular_maps_1d =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Equiangular{-1., 1., 0.0, 0.5}, Equiangular{-1., 1., 1.7, 2.0});
@@ -1022,7 +1022,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.MapsForRectilinearDomains",
           Index<2>{3, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 0.5, 1.7, 2.0}, {0.0, 1.0, 2.0}}},
-          {Index<2>{}}, false);
+          {Index<2>{}}, {}, false);
   const auto expected_affine_maps_2d =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Affine2D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 0.0, 1.0}},
@@ -1041,7 +1041,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.MapsForRectilinearDomains",
           Index<2>{3, 2},
           std::array<std::vector<double>, 2>{
               {{0.0, 0.5, 1.7, 2.0}, {0.0, 1.0, 2.0}}},
-          {Index<2>{2, 1}}, true);
+          {Index<2>{2, 1}}, {}, true);
   const auto expected_equiangular_maps_2d =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Equiangular2D{Equiangular{-1., 1., 0.0, 0.5},
@@ -1064,7 +1064,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.MapsForRectilinearDomains",
           Index<3>{2, 2, 1},
           std::array<std::vector<double>, 3>{
               {{0.0, 0.5, 2.0}, {0.0, 1.0, 2.0}, {-0.4, 0.3}}},
-          {Index<3>{}}, false);
+          {Index<3>{}}, {}, false);
   const auto expected_affine_maps_3d =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Affine3D{Affine{-1., 1., 0.0, 0.5}, Affine{-1., 1., 0.0, 1.0},
@@ -1085,7 +1085,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.MapsForRectilinearDomains",
           Index<3>{2, 2, 1},
           std::array<std::vector<double>, 3>{
               {{0.0, 0.5, 2.0}, {0.0, 1.0, 2.0}, {-0.4, 0.3}}},
-          {Index<3>{0, 0, 0}}, true);
+          {Index<3>{0, 0, 0}}, {}, true);
   const auto expected_equiangular_maps_3d =
       make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
           Equiangular3D{Equiangular{-1., 1., 0.5, 2.0},


### PR DESCRIPTION
## Proposed changes

Additions for RotatedBricks 1 : corners for rectilinear domains
Additions for RotatedBricks 2: maps for rectilinear domains, corners for rotated rectilinear domains
Additions for RotatedBricks 3: maps for rotated rectilinear domains, new domain constructor
Additions for RotatedBricks 4: allows for periodic/identified boundary conditions

This PR allows the user to create arbitrarily rotated rectilinear domains. It also introduces a new
constructor for Domain that internally calls the functions introduced in the previous two PRs.

This PR also factors out the parts of the old Additions for RotatedBricks 3, #729 , now Additions for RotatedBricks 4, that were already reviewed, so hopefully these commits can be merged in quickly.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
