### PR TITLE
Adding circular test and fixing polytropic eos

### DIFF
--- a/src/PointwiseFunctions/EquationsOfState/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/EquationsOfState/PolytropicFluid.cpp
@@ -59,18 +59,20 @@ template <>
 template <class DataType>
 Scalar<DataType> PolytropicFluid<true>::rest_mass_density_from_enthalpy_impl(
     const Scalar<DataType>& specific_enthalpy) const noexcept {
-  return Scalar<DataType>{
-      pow((1.0 - 1.0 / polytropic_exponent_) * (get(specific_enthalpy) - 1.0),
-          1.0 / (polytropic_exponent_ - 1.0))};
+  return Scalar<DataType>{pow(((polytropic_exponent_ - 1.0) /
+                               (polytropic_constant_ * polytropic_exponent_)) *
+                                  (get(specific_enthalpy) - 1.0),
+                              1.0 / (polytropic_exponent_ - 1.0))};
 }
 
 template <>
 template <class DataType>
 Scalar<DataType> PolytropicFluid<false>::rest_mass_density_from_enthalpy_impl(
     const Scalar<DataType>& specific_enthalpy) const noexcept {
-  return Scalar<DataType>{
-      pow((1.0 - 1.0 / polytropic_exponent_) * get(specific_enthalpy),
-          1.0 / (polytropic_exponent_ - 1.0))};
+  return Scalar<DataType>{pow(((polytropic_exponent_ - 1.0) /
+                               (polytropic_constant_ * polytropic_exponent_)) *
+                                  get(specific_enthalpy),
+                              1.0 / (polytropic_exponent_ - 1.0))};
 }
 
 template <>
@@ -78,9 +80,10 @@ template <class DataType>
 Scalar<DataType> PolytropicFluid<true>::specific_enthalpy_from_density_impl(
     const Scalar<DataType>& rest_mass_density) const noexcept {
   return Scalar<DataType>{
-      1.0 + polytropic_exponent_ / (polytropic_exponent_ - 1.0) *
-                polytropic_constant_ *
-                pow(get(rest_mass_density), polytropic_exponent_ - 1.0)};
+      1.0 +
+      polytropic_exponent_ / (polytropic_exponent_ - 1.0) *
+          polytropic_constant_ *
+          pow(get(rest_mass_density), polytropic_exponent_ - 1.0)};
 }
 
 template <>

--- a/tests/Unit/PointwiseFunctions/EquationsOfState/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/EquationsOfState/TestFunctions.py
@@ -76,13 +76,13 @@ def polytropic_pressure_from_density(rest_mass_density, polytropic_constant,
 
 def polytropic_rel_rest_mass_density_from_enthalpy(
         specific_enthalpy, polytropic_constant, polytropic_exponent):
-    return ((polytropic_exponent - 1.0) / polytropic_exponent *
+    return ((polytropic_exponent - 1.0) / (polytropic_constant*polytropic_exponent) *
             (specific_enthalpy - 1.0))**(1.0 / (polytropic_exponent - 1.0))
 
 
 def polytropic_newt_rest_mass_density_from_enthalpy(
         specific_enthalpy, polytropic_constant, polytropic_exponent):
-    return ((polytropic_exponent - 1.0) / polytropic_exponent *
+    return ((polytropic_exponent - 1.0) / (polytropic_constant*polytropic_exponent) *
             (specific_enthalpy))**(1.0 / (polytropic_exponent - 1.0))
 
 


### PR DESCRIPTION
## Proposed changes

Fixes mistake in formula for rest mass density from enthalpy in polytropic fluid.
Adds a test for a circular computation, testing that rest mass density from enthalpy and enthalpy from rest mass density are inverses of each other.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
