### PR TITLE
Add comment on matching newline in OutputRegex.

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -1084,6 +1084,8 @@ then typically look as follows:
  * just that the test failed. Since the string passed is a regular
  * expression you must escape any regex tokens. For example, to match
  * `some (word) and` you must specify the string `some \(word\) and`.
+ * If your error message contains a newline, you can match it using the
+ * dot operator `.`, which matches any character.
  * </td>
  * </tr>
  * </table>


### PR DESCRIPTION
## Proposed changes

Add a short comment in the doxygen about matching newlines when using OutputRegex.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
