### PR TITLE
Generalize pointer vector to be result type-safe

### DIFF
--- a/src/DataStructures/DataVector.cpp
+++ b/src/DataStructures/DataVector.cpp
@@ -5,106 +5,91 @@
 
 #include <algorithm>
 #include <pup.h>
-#include <pup_stl.h>
 
 #include "Utilities/StdHelpers.hpp"
 
-DataVector::DataVector(const size_t size, const double value)
-    : size_(size),
-      owned_data_(size_, value),
-      data_(owned_data_.data(), size_) {}
+DataVector::DataVector(const size_t size, const double value) noexcept
+    : owned_data_(size, value) {
+  reset_pointer_vector();
+}
+
+DataVector::DataVector(double* start, size_t size) noexcept
+    : BaseType(start, size), owned_data_(0), owning_(false) {}
 
 template <class T, Requires<cpp17::is_same_v<T, double>>>
-DataVector::DataVector(std::initializer_list<T> list)
-    : size_(list.size()),
-      owned_data_(std::move(list)),
-      data_(owned_data_.data(), size_) {}
-
-DataVector::DataVector(double* start, size_t size)
-    : size_(size), owned_data_(0), data_(start, size_), owning_(false) {}
+DataVector::DataVector(std::initializer_list<T> list) noexcept
+    : owned_data_(std::move(list)) {
+  reset_pointer_vector();
+}
 
 /// \cond HIDDEN_SYMBOLS
-DataVector::DataVector(const DataVector& rhs) {
-  size_ = rhs.size();
+// clang-tidy: calling a base constructor other than the copy constructor.
+//             We reset the base class in reset_pointer_vector after calling its
+//             default constructor
+DataVector::DataVector(const DataVector& rhs) : BaseType{} {  // NOLINT
   if (rhs.is_owning()) {
     owned_data_ = rhs.owned_data_;
   } else {
-    owned_data_ = InternalStorage_t(rhs.begin(), rhs.end());
+    owned_data_.assign(rhs.begin(), rhs.end());
   }
-  data_ = decltype(data_){owned_data_.data(), size_};
+  reset_pointer_vector();
 }
 
 DataVector& DataVector::operator=(const DataVector& rhs) {
-  if (this == &rhs) {
-    return *this;
-  }
-  if (owning_) {
-    size_ = rhs.size();
-    if (rhs.is_owning()) {
-      owned_data_ = rhs.owned_data_;
+  if (this != &rhs) {
+    if (owning_) {
+      if (rhs.is_owning()) {
+        owned_data_ = rhs.owned_data_;
+      } else {
+        owned_data_.assign(rhs.begin(), rhs.end());
+      }
+      reset_pointer_vector();
     } else {
-      owned_data_ = InternalStorage_t(rhs.begin(), rhs.end());
+      ASSERT(rhs.size() == size(), "Must copy into same size, not "
+                                       << rhs.size() << " into " << size());
+      std::copy(rhs.begin(), rhs.end(), begin());
     }
-    data_ = decltype(data_){owned_data_.data(), size_};
-  } else {
-    ASSERT(rhs.size() == size(), "Must copy into same size, not "
-                                     << rhs.size() << " into " << size());
-    std::copy(rhs.begin(), rhs.end(), begin());
   }
   return *this;
 }
 
 DataVector::DataVector(DataVector&& rhs) noexcept {
-  size_ = rhs.size_;
   owned_data_ = std::move(rhs.owned_data_);
-  // clang-tidy: move trivially copyable type, future proof in case impl
-  // changes
-  data_ = std::move(rhs.data_);  // NOLINT
+  ~*this = ~rhs;  // PointerVector is trivially copyable
   owning_ = rhs.owning_;
 
   rhs.owning_ = true;
-  rhs.size_ = 0;
-  rhs.data_ = decltype(rhs.data_){};
+  rhs.reset();
 }
 
 DataVector& DataVector::operator=(DataVector&& rhs) noexcept {
-  if (this == &rhs) {
-    return *this;
+  if (this != &rhs) {
+    if (owning_) {
+      owned_data_ = std::move(rhs.owned_data_);
+      ~*this = ~rhs;  // PointerVector is trivially copyable
+      owning_ = rhs.owning_;
+    } else {
+      ASSERT(rhs.size() == size(), "Must copy into same size, not "
+                                       << rhs.size() << " into " << size());
+      std::copy(rhs.begin(), rhs.end(), begin());
+    }
+    rhs.owning_ = true;
+    rhs.reset();
   }
-  if (owning_) {
-    size_ = rhs.size_;
-    owned_data_ = std::move(rhs.owned_data_);
-    // clang-tidy: move trivially copyable type, future proof in case impl
-    // changes
-    data_ = std::move(rhs.data_);  // NOLINT
-    owning_ = rhs.owning_;
-  } else {
-    ASSERT(rhs.size() == size(), "Must copy into same size, not "
-                                     << rhs.size() << " into " << size());
-    std::copy(rhs.begin(), rhs.end(), begin());
-  }
-  rhs.owning_ = true;
-  rhs.size_ = 0;
-  rhs.data_ = decltype(rhs.data_){};
   return *this;
 }
 /// \endcond
 
 void DataVector::pup(PUP::er& p) noexcept {  // NOLINT
-  p | size_;
-  if (p.isUnpacking()) {
-    owning_ = true;
-    p | owned_data_;
-    data_ = decltype(data_){owned_data_.data(), size_};
-  } else {
-    if (not owning_) {
-      owned_data_ =
-          InternalStorage_t(data_.data(), data_.data() + size_);  // NOLINT
-      p | owned_data_;
-      owned_data_.clear();
-    } else {
-      p | owned_data_;
+  auto my_size = size();
+  p | my_size;
+  if (my_size > 0) {
+    if (p.isUnpacking()) {
+      owning_ = true;
+      owned_data_.resize(my_size);
+      reset_pointer_vector();
     }
+    PUParray(p, data(), size());
   }
 }
 
@@ -115,16 +100,16 @@ std::ostream& operator<<(std::ostream& os, const DataVector& d) {
 }
 
 /// Equivalence operator for DataVector
-bool operator==(const DataVector& lhs, const DataVector& rhs) {
+bool operator==(const DataVector& lhs, const DataVector& rhs) noexcept {
   return lhs.size() == rhs.size() and
          std::equal(lhs.begin(), lhs.end(), rhs.begin());
 }
 
 /// Inequivalence operator for DataVector
-bool operator!=(const DataVector& lhs, const DataVector& rhs) {
+bool operator!=(const DataVector& lhs, const DataVector& rhs) noexcept {
   return not(lhs == rhs);
 }
 
 /// \cond
-template DataVector::DataVector(std::initializer_list<double> list);
+template DataVector::DataVector(std::initializer_list<double> list) noexcept;
 /// \endcond

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -176,7 +176,7 @@ class Variables<tmpl::list<Tags...>> {
   /// Needed because of limitations and inconsistency between compiler
   /// implementations of friend function templates with auto return type of
   /// class templates
-  const PointerVector<double>& get_variable_data() const noexcept {
+  const auto& get_variable_data() const noexcept {
     return variable_data_;
   }
   /// \endcond
@@ -367,7 +367,10 @@ class Variables<tmpl::list<Tags...>> {
 
   std::vector<double, allocator_type> variable_data_impl_;
   // variable_data_ is only used to plug into the Blaze expression templates
-  PointerVector<double> variable_data_;
+  PointerVector<double, blaze::unaligned, blaze::unpadded,
+                blaze::defaultTransposeFlag,
+                blaze::DynamicVector<double, blaze::defaultTransposeFlag>>
+      variable_data_;
   size_t size_ = 0;
   size_t number_of_grid_points_ = 0;
   tuples::TaggedTuple<Tags...> reference_variable_data_;
@@ -377,9 +380,9 @@ template <typename... Tags>
 Variables<tmpl::list<Tags...>>::Variables() noexcept {
   // This makes an assertion trigger if one tries to assign to
   // components of a default-constructed Variables.
-  const auto set_refs = [this](auto& var) noexcept {
+  const auto set_refs = [](auto& var) noexcept {
     for (auto& dv : var) {
-      dv.set_data_ref(&variable_data_[0], 0);
+      dv.set_data_ref(nullptr, 0);
     }
     return 0;
   };

--- a/src/Utilities/DereferenceWrapper.hpp
+++ b/src/Utilities/DereferenceWrapper.hpp
@@ -9,6 +9,10 @@
 #include <functional>
 #include <utility>
 
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TypeTraits.hpp"
+
 /// \ingroup UtilitiesGroup
 /// \brief Returns the reference object held by a reference wrapper, if a
 /// non-reference_wrapper type is passed in then the object is returned
@@ -34,4 +38,118 @@ template <typename T>
 T&& dereference_wrapper(std::reference_wrapper<T>&& t) {
   return t.get();
 }
+/// \endcond
+
+/// \cond
+// Add overloads of math functions for reference_wrapper.
+// This is necessary because if a class, say DataVector, inherits from
+// PointerVector and does not specify the math operators specifically for
+// DataVector then the implicit cast from reference_wrapper<DataVector> to
+// DataVector does not result in finding the math operators.
+//
+// We use forwarding references to resolve ambiguity errors with
+// DVecScalarMultExpr and DVecScalarDivExpr, with a std::reference_wrapper
+// The forwarding references match everything perfectly and so the functions
+// here will (almost) always win in overload selection.
+#define UNARY_REF_WRAP_OP(OP)                        \
+  template <typename T>                              \
+  SPECTRE_ALWAYS_INLINE decltype(auto) OP(           \
+      const std::reference_wrapper<T>& t) noexcept { \
+    return OP(t.get());                              \
+  }
+#define BINARY_REF_WRAP_FUNCTION_OP(OP)                                    \
+  template <                                                               \
+      typename T0, typename T1,                                            \
+      Requires<not tt::is_a_v<std::reference_wrapper, std::decay_t<T1>>> = \
+          nullptr>                                                         \
+  SPECTRE_ALWAYS_INLINE decltype(auto) OP(                                 \
+      const std::reference_wrapper<T0>& t0, T1&& t1) noexcept {            \
+    return OP(t0.get(), t1);                                               \
+  }                                                                        \
+  template <                                                               \
+      typename T0, typename T1,                                            \
+      Requires<not tt::is_a_v<std::reference_wrapper, std::decay_t<T0>>> = \
+          nullptr>                                                         \
+  SPECTRE_ALWAYS_INLINE decltype(auto) OP(                                 \
+      T0&& t0, const std::reference_wrapper<T1>& t1) noexcept {            \
+    return OP(t0, t1.get());                                               \
+  }                                                                        \
+  template <typename T0, typename T1>                                      \
+  SPECTRE_ALWAYS_INLINE decltype(auto) OP(                                 \
+      const std::reference_wrapper<T0>& t0,                                \
+      const std::reference_wrapper<T1>& t1) noexcept {                     \
+    return OP(t0.get(), t1.get());                                         \
+  }
+
+#define BINARY_REF_WRAP_OP(OP)                                             \
+  template <                                                               \
+      typename T0, typename T1,                                            \
+      Requires<not tt::is_a_v<std::reference_wrapper, std::decay_t<T1>>> = \
+          nullptr>                                                         \
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator OP(                        \
+      const std::reference_wrapper<T0>& t0, T1&& t1) noexcept {            \
+    return t0.get() OP t1;                                                 \
+  }                                                                        \
+  template <                                                               \
+      typename T0, typename T1,                                            \
+      Requires<not tt::is_a_v<std::reference_wrapper, std::decay_t<T0>>> = \
+          nullptr>                                                         \
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator OP(                        \
+      T0&& t0, const std::reference_wrapper<T1>& t1) noexcept {            \
+    return t0 OP t1.get();                                                 \
+  }                                                                        \
+  template <typename T0, typename T1>                                      \
+  SPECTRE_ALWAYS_INLINE decltype(auto) operator OP(                        \
+      const std::reference_wrapper<T0>& t0,                                \
+      const std::reference_wrapper<T1>& t1) noexcept {                     \
+    return t0.get() OP t1.get();                                           \
+  }
+
+UNARY_REF_WRAP_OP(abs)
+UNARY_REF_WRAP_OP(acos)
+UNARY_REF_WRAP_OP(acosh)
+UNARY_REF_WRAP_OP(asin)
+UNARY_REF_WRAP_OP(asinh)
+UNARY_REF_WRAP_OP(atan)
+BINARY_REF_WRAP_FUNCTION_OP(atan2)
+UNARY_REF_WRAP_OP(atanh)
+UNARY_REF_WRAP_OP(cbrt)
+UNARY_REF_WRAP_OP(cos)
+UNARY_REF_WRAP_OP(cosh)
+UNARY_REF_WRAP_OP(erf)
+UNARY_REF_WRAP_OP(erfc)
+UNARY_REF_WRAP_OP(exp)
+UNARY_REF_WRAP_OP(exp2)
+UNARY_REF_WRAP_OP(exp10)
+UNARY_REF_WRAP_OP(fabs)
+BINARY_REF_WRAP_FUNCTION_OP(hypot)
+UNARY_REF_WRAP_OP(invcbrt)
+UNARY_REF_WRAP_OP(invsqrt)
+UNARY_REF_WRAP_OP(log)
+UNARY_REF_WRAP_OP(log2)
+UNARY_REF_WRAP_OP(log10)
+UNARY_REF_WRAP_OP(max)
+UNARY_REF_WRAP_OP(min)
+BINARY_REF_WRAP_FUNCTION_OP(pow)
+UNARY_REF_WRAP_OP(sin)
+UNARY_REF_WRAP_OP(sinh)
+UNARY_REF_WRAP_OP(sqrt)
+UNARY_REF_WRAP_OP(step_function)
+UNARY_REF_WRAP_OP(tan)
+UNARY_REF_WRAP_OP(tanh)
+
+BINARY_REF_WRAP_OP(+)
+BINARY_REF_WRAP_OP(-)
+BINARY_REF_WRAP_OP(*)
+BINARY_REF_WRAP_OP(/)
+
+template <typename T>
+SPECTRE_ALWAYS_INLINE decltype(auto) operator-(
+    const std::reference_wrapper<T>& t) noexcept {
+  return -t.get();
+}
+
+#undef UNARY_REF_WRAP_OP
+#undef BINARY_REF_WRAP_OP
+#undef BINARY_REF_WRAP_FUNCTION_OP
 /// \endcond

--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -448,8 +448,8 @@ struct PointerVector
     // clang-tidy: do not use pointer arithmetic
     return v_[i];  // NOLINT
   }
-  inline Reference at(size_t index);
-  inline ConstReference at(size_t index) const;
+  Reference at(size_t index);
+  ConstReference at(size_t index) const;
   Pointer data() noexcept { return v_; }
   ConstPointer data() const noexcept { return v_; }
   Iterator begin() noexcept { return Iterator(v_); }
@@ -468,33 +468,33 @@ struct PointerVector
 
   /*!\name Assignment operators */
   //@{
-  inline PointerVector& operator=(const Type& rhs);
-  inline PointerVector& operator=(std::initializer_list<Type> list);
+  PointerVector& operator=(const Type& rhs);
+  PointerVector& operator=(std::initializer_list<Type> list);
 
   template <typename Other, size_t N>
-  inline PointerVector& operator=(const Other (&array)[N]);
+  PointerVector& operator=(const Other (&array)[N]);
 
   template <typename VT>
-  inline PointerVector& operator=(const blaze::Vector<VT, TF>& rhs);
+  PointerVector& operator=(const blaze::Vector<VT, TF>& rhs);
   template <typename VT>
-  inline PointerVector& operator+=(const blaze::Vector<VT, TF>& rhs);
+  PointerVector& operator+=(const blaze::Vector<VT, TF>& rhs);
   template <typename VT>
-  inline PointerVector& operator-=(const blaze::Vector<VT, TF>& rhs);
+  PointerVector& operator-=(const blaze::Vector<VT, TF>& rhs);
   template <typename VT>
-  inline PointerVector& operator*=(const blaze::Vector<VT, TF>& rhs);
+  PointerVector& operator*=(const blaze::Vector<VT, TF>& rhs);
   template <typename VT>
-  inline PointerVector& operator/=(const blaze::Vector<VT, TF>& rhs);
+  PointerVector& operator/=(const blaze::Vector<VT, TF>& rhs);
   template <typename VT>
-  inline PointerVector& operator%=(const blaze::Vector<VT, TF>& rhs);
+  PointerVector& operator%=(const blaze::Vector<VT, TF>& rhs);
 
   template <typename Other>
-  inline std::enable_if_t<blaze::IsNumeric<Other>::value,
-                          PointerVector<Type, AF, PF, TF>>&
+  std::enable_if_t<blaze::IsNumeric<Other>::value,
+                   PointerVector<Type, AF, PF, TF>>&
   operator*=(Other rhs);
 
   template <typename Other>
-  inline std::enable_if_t<blaze::IsNumeric<Other>::value,
-                          PointerVector<Type, AF, PF, TF>>&
+  std::enable_if_t<blaze::IsNumeric<Other>::value,
+                   PointerVector<Type, AF, PF, TF>>&
   operator/=(Other rhs);
   //@}
 
@@ -514,7 +514,7 @@ struct PointerVector
   //@{
   void reset() { clear(); }
 
-  inline void reset(Type* ptr, size_t n) {
+  void reset(Type* ptr, size_t n) noexcept {
     v_ = ptr;
     size_ = n;
   }
@@ -557,12 +557,12 @@ struct PointerVector
   /*!\name Expression template evaluation functions */
   //@{
   template <typename Other>
-  inline bool canAlias(const Other* alias) const noexcept;
+  bool canAlias(const Other* alias) const noexcept;
   template <typename Other>
-  inline bool isAliased(const Other* alias) const noexcept;
+  bool isAliased(const Other* alias) const noexcept;
 
-  inline bool isAligned() const noexcept;
-  inline bool canSMPAssign() const noexcept;
+  bool isAligned() const noexcept;
+  bool canSMPAssign() const noexcept;
 
   BLAZE_ALWAYS_INLINE SIMDType load(size_t index) const noexcept;
   BLAZE_ALWAYS_INLINE SIMDType loada(size_t index) const noexcept;
@@ -574,57 +574,57 @@ struct PointerVector
   BLAZE_ALWAYS_INLINE void stream(size_t index, const SIMDType& value) noexcept;
 
   template <typename VT>
-  inline std::enable_if_t<not(
+  std::enable_if_t<not(
       PointerVector<Type, AF, PF, TF>::template VectorizedAssign<VT>::value)>
   assign(const blaze::DenseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline std::enable_if_t<(VectorizedAssign<VT>::value)> assign(
+  std::enable_if_t<(VectorizedAssign<VT>::value)> assign(
       const blaze::DenseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline std::enable_if_t<not(
+  std::enable_if_t<not(
       PointerVector<Type, AF, PF, TF>::template VectorizedAddAssign<VT>::value)>
   addAssign(const blaze::DenseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline std::enable_if_t<(VectorizedAddAssign<VT>::value)> addAssign(
+  std::enable_if_t<(VectorizedAddAssign<VT>::value)> addAssign(
       const blaze::DenseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline void addAssign(const blaze::SparseVector<VT, TF>& rhs);
+  void addAssign(const blaze::SparseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline std::enable_if_t<not(
+  std::enable_if_t<not(
       PointerVector<Type, AF, PF, TF>::template VectorizedSubAssign<VT>::value)>
   subAssign(const blaze::DenseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline std::enable_if_t<(VectorizedSubAssign<VT>::value)> subAssign(
+  std::enable_if_t<(VectorizedSubAssign<VT>::value)> subAssign(
       const blaze::DenseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline void subAssign(const blaze::SparseVector<VT, TF>& rhs);
+  void subAssign(const blaze::SparseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline std::enable_if_t<not(PointerVector<Type, AF, PF, TF>::
-                                  template VectorizedMultAssign<VT>::value)>
+  std::enable_if_t<not(PointerVector<Type, AF, PF, TF>::
+                           template VectorizedMultAssign<VT>::value)>
   multAssign(const blaze::DenseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline std::enable_if_t<(VectorizedMultAssign<VT>::value)> multAssign(
+  std::enable_if_t<(VectorizedMultAssign<VT>::value)> multAssign(
       const blaze::DenseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline void multAssign(const blaze::SparseVector<VT, TF>& rhs);
+  void multAssign(const blaze::SparseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline std::enable_if_t<not(
+  std::enable_if_t<not(
       PointerVector<Type, AF, PF, TF>::template VectorizedDivAssign<VT>::value)>
   divAssign(const blaze::DenseVector<VT, TF>& rhs);
 
   template <typename VT>
-  inline std::enable_if_t<(VectorizedDivAssign<VT>::value)> divAssign(
+  std::enable_if_t<(VectorizedDivAssign<VT>::value)> divAssign(
       const blaze::DenseVector<VT, TF>& rhs);
   //@}
 

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -6,13 +6,16 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
+#include <functional>
 #include <numeric>
-#include <stddef.h>
 
 #include "DataStructures/DataVector.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 #include "tests/Unit/TestHelpers.hpp"
@@ -238,124 +241,189 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.MathAfterMove",
   }
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
-                  "[Unit][DataStructures]") {
+namespace {
+enum class UseRefWrap { None, Cref, Ref };
+
+template <UseRefWrap Wrap, class T,
+          Requires<Wrap == UseRefWrap::Cref> = nullptr>
+decltype(auto) wrap(const T& t) noexcept {
+  return std::cref(t);
+}
+template <UseRefWrap Wrap, class T, Requires<Wrap == UseRefWrap::Ref> = nullptr>
+decltype(auto) wrap(T& t) noexcept {
+  return std::ref(t);
+}
+template <UseRefWrap Wrap, class T,
+          Requires<Wrap == UseRefWrap::None> = nullptr>
+decltype(auto) wrap(const T& t) noexcept {
+  return t;
+}
+
+// Wrap is used to wrap values in a std::reference_wrapper using std::cref and
+// std::ref, or to not wrap at all. This is done to verify that all math
+// operations work transparently with a `std::reference_wrapper` too.
+template <UseRefWrap WrapLeftOp, UseRefWrap WrapRightOp>
+void test_datavector_math() noexcept {
   constexpr size_t num_pts = 19;
   DataVector val{1., 2., 3., -4., 8., 12., -14.};
-  DataVector nine(num_pts, 9.0);
   DataVector one(num_pts, 1.0);
+  DataVector eight(num_pts, 8.0);
+  DataVector nine(num_pts, 9.0);
 
   // Test unary minus
-  check_vectors(-nine, DataVector(num_pts, -9.0));
+  check_vectors(-wrap<WrapLeftOp>(nine), DataVector(num_pts, -9.0));
 
-  check_vectors(nine + 2.0, DataVector(num_pts, 11.0));
-  check_vectors(2.0 + nine, DataVector(num_pts, 11.0));
-  check_vectors(nine - 2.0, DataVector(num_pts, 7.0));
-  check_vectors(2.0 - nine, DataVector(num_pts, -7.0));
-  check_vectors(nine + nine, DataVector(num_pts, 18.0));
-  check_vectors(nine + (one * nine), DataVector(num_pts, 18.0));
-  check_vectors((one * nine) + nine, DataVector(num_pts, 18.0));
-  check_vectors(nine - DataVector(num_pts, 8.0), DataVector(num_pts, 1.0));
-  check_vectors(nine - (one * nine), DataVector(num_pts, 0.0));
-  check_vectors((one * nine) - nine, DataVector(num_pts, 0.0));
+  check_vectors(wrap<WrapLeftOp>(nine) + 2.0, DataVector(num_pts, 11.0));
+  check_vectors(2.0 + wrap<WrapLeftOp>(nine), DataVector(num_pts, 11.0));
+  check_vectors(wrap<WrapLeftOp>(nine) - 2.0, DataVector(num_pts, 7.0));
+  check_vectors(2.0 - wrap<WrapLeftOp>(nine), DataVector(num_pts, -7.0));
+  check_vectors(wrap<WrapLeftOp>(nine) + wrap<WrapRightOp>(nine),
+                DataVector(num_pts, 18.0));
+  check_vectors(wrap<WrapLeftOp>(nine) +
+                    (wrap<WrapLeftOp>(one) * wrap<WrapRightOp>(nine)),
+                DataVector(num_pts, 18.0));
+  check_vectors((wrap<WrapLeftOp>(one) * wrap<WrapLeftOp>(nine)) +
+                    wrap<WrapRightOp>(nine),
+                DataVector(num_pts, 18.0));
+  check_vectors(wrap<WrapLeftOp>(nine) - DataVector(num_pts, 8.0),
+                DataVector(num_pts, 1.0));
+  check_vectors(wrap<WrapLeftOp>(nine) -
+                    (wrap<WrapRightOp>(one) * wrap<WrapLeftOp>(nine)),
+                DataVector(num_pts, 0.0));
+  check_vectors((wrap<WrapLeftOp>(one) * wrap<WrapLeftOp>(nine)) -
+                    wrap<WrapRightOp>(nine),
+                DataVector(num_pts, 0.0));
 
-  check_vectors(DataVector(num_pts, -1.0 / 9.0), -one / nine);
-  check_vectors(DataVector(num_pts, -8.0 / 9.0), -(nine - one) / nine);
-  check_vectors(DataVector(num_pts, 18.0), (one / 0.5) * nine);
-  check_vectors(DataVector(num_pts, 1.0), 9.0 / nine);
-  check_vectors(DataVector(num_pts, 1.0), (one * 9.0) / nine);
+  check_vectors(DataVector(num_pts, -1.0 / 9.0),
+                -one / wrap<WrapRightOp>(nine));
+  check_vectors(DataVector(num_pts, -8.0 / 9.0),
+                -(wrap<WrapLeftOp>(nine) - wrap<WrapRightOp>(one)) /
+                    wrap<WrapLeftOp>(nine));
+  check_vectors(DataVector(num_pts, 18.0),
+                (wrap<WrapLeftOp>(one) / 0.5) * wrap<WrapRightOp>(nine));
+  check_vectors(DataVector(num_pts, 1.0), 9.0 / wrap<WrapRightOp>(nine));
+  check_vectors(DataVector(num_pts, 1.0),
+                (wrap<WrapLeftOp>(one) * 9.0) / wrap<WrapRightOp>(nine));
 
-  CHECK(-14 == min(val));
-  CHECK(12 == max(val));
-  check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, abs(val));
-  check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.}, fabs(val));
+  check_vectors(DataVector(num_pts, 81.0),
+                wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(nine));
+  check_vectors(DataVector(num_pts, 81.0),
+                wrap<WrapLeftOp>(nine) *
+                    (wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(one)));
+  check_vectors(DataVector(num_pts, 81.0),
+                (wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(nine)) *
+                    wrap<WrapLeftOp>(one));
+  check_vectors(DataVector(num_pts, 81.0), 9.0 * wrap<WrapLeftOp>(nine));
+  check_vectors(DataVector(num_pts, 81.0), wrap<WrapLeftOp>(nine) * 9.0);
+  check_vectors(DataVector(num_pts, 1.0), wrap<WrapLeftOp>(nine) / 9.0);
+  check_vectors(DataVector(num_pts, 1.0),
+                wrap<WrapLeftOp>(nine) / (wrap<WrapRightOp>(one) * 9.0));
+  check_vectors(DataVector(num_pts, 9.0),
+                (wrap<WrapLeftOp>(one) * wrap<WrapLeftOp>(nine)) /
+                    wrap<WrapRightOp>(one));
 
-  check_vectors(step_function(DataVector{-12.3, 2.0, -4.0, 0.0, 7.0, -8.0}),
+  CHECK(-14 == min(wrap<WrapLeftOp>(val)));
+  CHECK(12 == max(wrap<WrapLeftOp>(val)));
+  check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.},
+                abs(wrap<WrapLeftOp>(val)));
+  check_vectors(DataVector{1., 2., 3., 4., 8., 12., 14.},
+                fabs(wrap<WrapLeftOp>(val)));
+
+  const DataVector step_function_data{-12.3, 2.0, -4.0, 0.0, 7.0, -8.0};
+  check_vectors(step_function(wrap<WrapLeftOp>(step_function_data)),
                 DataVector{0.0, 1.0, 0.0, 1.0, 1.0, 0.0});
 
-  check_vectors(DataVector(num_pts, 81.0), nine * nine);
-  check_vectors(DataVector(num_pts, 81.0), nine * (nine * one));
-  check_vectors(DataVector(num_pts, 81.0), (nine * nine) * one);
-  check_vectors(DataVector(num_pts, 81.0), 9.0 * nine);
-  check_vectors(DataVector(num_pts, 81.0), nine * 9.0);
-  check_vectors(DataVector(num_pts, 1.0), nine / 9.0);
-  check_vectors(DataVector(num_pts, 1.0), nine / (one * 9.0));
-  check_vectors(DataVector(num_pts, 9.0), (one * nine) / one);
+  check_vectors(sqrt(wrap<WrapLeftOp>(nine)), DataVector(num_pts, 3.0));
+  check_vectors(invsqrt(wrap<WrapLeftOp>(nine)),
+                DataVector(num_pts, 1.0 / 3.0));
+  check_vectors(cbrt(wrap<WrapLeftOp>(eight)), DataVector(num_pts, 2.0));
+  check_vectors(invcbrt(wrap<WrapLeftOp>(eight)), DataVector(num_pts, 0.5));
+  check_vectors(DataVector(num_pts, 81.0), pow(wrap<WrapLeftOp>(nine), 2));
 
-  check_vectors(sqrt(nine), DataVector(num_pts, 3.0));
-  check_vectors(invsqrt(nine), DataVector(num_pts, 1.0 / 3.0));
-  DataVector eight(num_pts, 8.0);
-  check_vectors(cbrt(eight), DataVector(num_pts, 2.0));
-  check_vectors(invcbrt(eight), DataVector(num_pts, 0.5));
-  check_vectors(DataVector(num_pts, 81.0), pow(nine, 2));
-
-  DataVector dummy(nine * nine * 1.0);
+  DataVector dummy(wrap<WrapLeftOp>(nine) * wrap<WrapLeftOp>(nine) * 1.0);
   check_vectors(DataVector(num_pts, 81.0), dummy);
-  check_vectors(DataVector(num_pts, 81.0), pow<2>(nine));
-  check_vectors(DataVector(num_pts, 81.0), pow<2>(nine * one));
+  check_vectors(DataVector(num_pts, 81.0), pow<2>(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, 81.0),
+                pow<2>(wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(one)));
   check_vectors(DataVector(num_pts, 1.0 / 81.0),
-                DataVector(num_pts, 1.0) / pow<2>(nine));
+                DataVector(num_pts, 1.0) / pow<2>(wrap<WrapLeftOp>(nine)));
 
-  check_vectors(DataVector(num_pts, exp(9.0)), exp(nine));
-  check_vectors(DataVector(num_pts, exp2(9.0)), exp2(nine));
-  check_vectors(DataVector(num_pts, pow<9>(10.0)), DataVector(exp10(nine)));
-  check_vectors(DataVector(num_pts, log(9.0)), log(nine));
-  check_vectors(DataVector(num_pts, log2(9.0)), log2(nine));
-  check_vectors(DataVector(num_pts, log10(9.0)), log10(nine));
+  check_vectors(DataVector(num_pts, exp(9.0)), exp(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, exp2(9.0)), exp2(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, pow<9>(10.0)),
+                DataVector(exp10(wrap<WrapLeftOp>(nine))));
+  check_vectors(DataVector(num_pts, log(9.0)), log(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, log2(9.0)), log2(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, log10(9.0)), log10(wrap<WrapLeftOp>(nine)));
 
   DataVector point_nine(num_pts, 0.9);
-  check_vectors(DataVector(num_pts, hypot(0.9, 9.0)), hypot(point_nine, nine));
   check_vectors(DataVector(num_pts, hypot(0.9, 9.0)),
-                hypot(point_nine, one * nine));
+                hypot(wrap<WrapLeftOp>(point_nine), wrap<WrapRightOp>(nine)));
   check_vectors(DataVector(num_pts, hypot(0.9, 9.0)),
-                hypot(one * point_nine, nine));
+                hypot(wrap<WrapLeftOp>(point_nine),
+                      wrap<WrapLeftOp>(one) * wrap<WrapRightOp>(nine)));
   check_vectors(DataVector(num_pts, hypot(0.9, 9.0)),
-                hypot(one * point_nine, one * nine));
+                hypot(wrap<WrapLeftOp>(one) * wrap<WrapRightOp>(point_nine),
+                      wrap<WrapRightOp>(nine)));
+  check_vectors(DataVector(num_pts, hypot(0.9, 9.0)),
+                hypot(wrap<WrapLeftOp>(one) * wrap<WrapRightOp>(point_nine),
+                      wrap<WrapLeftOp>(one) * wrap<WrapRightOp>(nine)));
 
-  check_vectors(DataVector(num_pts, sin(9.0)), sin(nine));
-  check_vectors(DataVector(num_pts, cos(9.0)), cos(nine));
-  check_vectors(DataVector(num_pts, tan(9.0)), tan(nine));
-  check_vectors(DataVector(num_pts, asin(0.9)), asin(point_nine));
-  check_vectors(DataVector(num_pts, acos(0.9)), acos(point_nine));
-  check_vectors(DataVector(num_pts, atan(0.9)), atan(point_nine));
-  check_vectors(DataVector(num_pts, atan2(0.9, 9.0)), atan2(point_nine, nine));
+  check_vectors(DataVector(num_pts, sin(9.0)), sin(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, cos(9.0)), cos(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, tan(9.0)), tan(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, asin(0.9)),
+                asin(wrap<WrapLeftOp>(point_nine)));
+  check_vectors(DataVector(num_pts, acos(0.9)),
+                acos(wrap<WrapLeftOp>(point_nine)));
+  check_vectors(DataVector(num_pts, atan(0.9)),
+                atan(wrap<WrapLeftOp>(point_nine)));
   check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
-                atan2(point_nine * one, nine));
+                atan2(wrap<WrapLeftOp>(point_nine), wrap<WrapRightOp>(nine)));
   check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
-                atan2(point_nine, nine * one));
+                atan2(wrap<WrapLeftOp>(point_nine) * wrap<WrapRightOp>(one),
+                      wrap<WrapRightOp>(nine)));
   check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
-                atan2(point_nine * one, nine * one));
+                atan2(wrap<WrapLeftOp>(point_nine),
+                      wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(one)));
+  check_vectors(DataVector(num_pts, atan2(0.9, 9.0)),
+                atan2(wrap<WrapLeftOp>(point_nine) * wrap<WrapRightOp>(one),
+                      wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(one)));
 
-  check_vectors(DataVector(num_pts, sinh(9.0)), sinh(nine));
-  check_vectors(DataVector(num_pts, cosh(9.0)), cosh(nine));
-  check_vectors(DataVector(num_pts, tanh(9.0)), tanh(nine));
-  check_vectors(DataVector(num_pts, asinh(9.0)), asinh(nine));
-  check_vectors(DataVector(num_pts, acosh(9.0)), acosh(nine));
-  check_vectors(DataVector(num_pts, atanh(0.9)), atanh(point_nine));
+  check_vectors(DataVector(num_pts, sinh(9.0)), sinh(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, cosh(9.0)), cosh(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, tanh(9.0)), tanh(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, asinh(9.0)), asinh(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, acosh(9.0)), acosh(wrap<WrapLeftOp>(nine)));
+  check_vectors(DataVector(num_pts, atanh(0.9)),
+                atanh(wrap<WrapLeftOp>(point_nine)));
 
-  check_vectors(DataVector(num_pts, erf(0.9)), erf(point_nine));
-  check_vectors(DataVector(num_pts, erfc(0.9)), erfc(point_nine));
+  check_vectors(DataVector(num_pts, erf(0.9)),
+                erf(wrap<WrapLeftOp>(point_nine)));
+  check_vectors(DataVector(num_pts, erfc(0.9)),
+                erfc(wrap<WrapLeftOp>(point_nine)));
 
   // Test assignment
   DataVector test_81(num_pts, -1.0);
-  test_81 = nine * nine;
+  // cannot assign to a reference_wrapper using an expr :(
+  test_81 = wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(nine);
   check_vectors(DataVector(num_pts, 81.0), test_81);
   CHECK(test_81.is_owning());
   DataVector test_81_ref(test_81.data(), test_81.size());
   test_81_ref = 0.0;
   test_81 = 0.0;
-  test_81_ref = nine * nine;
+  test_81_ref = wrap<WrapLeftOp>(nine) * wrap<WrapRightOp>(nine);
   check_vectors(DataVector(num_pts, 81.0), test_81);
   CHECK(test_81.is_owning());
   check_vectors(DataVector(num_pts, 81.0), test_81_ref);
   CHECK_FALSE(test_81_ref.is_owning());
   DataVector second_81(num_pts);
-  second_81 = test_81;
+  second_81 = wrap<WrapLeftOp>(test_81);
   check_vectors(DataVector(num_pts, 81.0), second_81);
   CHECK(second_81.is_owning());
   test_81_ref = 0.0;
   check_vectors(DataVector(num_pts, 0.0), test_81_ref);
-  test_81_ref = second_81;
+  test_81_ref = wrap<WrapLeftOp>(second_81);
   check_vectors(DataVector(num_pts, 81.0), test_81_ref);
   second_81 = 0.0;
   test_81_ref.set_data_ref(&test_81);
@@ -378,28 +446,28 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   CHECK_FALSE(test_081.is_owning());
 
   DataVector test_assignment(num_pts, 7.0);
-  test_assignment += nine;
+  test_assignment += wrap<WrapLeftOp>(nine);
   check_vectors(DataVector(num_pts, 16.0), test_assignment);
   test_assignment += 3.0;
   check_vectors(DataVector(num_pts, 19.0), test_assignment);
-  test_assignment += (nine * nine);
+  test_assignment += (wrap<WrapLeftOp>(nine) * wrap<WrapLeftOp>(nine));
   check_vectors(DataVector(num_pts, 100.0), test_assignment);
 
   test_assignment = 7.0;
-  test_assignment -= nine;
+  test_assignment -= wrap<WrapLeftOp>(nine);
   check_vectors(DataVector(num_pts, -2.0), test_assignment);
   test_assignment -= 3.0;
   check_vectors(DataVector(num_pts, -5.0), test_assignment);
-  test_assignment -= nine * nine;
+  test_assignment -= wrap<WrapLeftOp>(nine) * wrap<WrapLeftOp>(nine);
   check_vectors(DataVector(num_pts, -86.0), test_assignment);
 
   test_assignment = 2.0;
   test_assignment *= 3.0;
   check_vectors(DataVector(num_pts, 6.0), test_assignment);
-  test_assignment *= nine;
+  test_assignment *= wrap<WrapLeftOp>(nine);
   check_vectors(DataVector(num_pts, 54.0), test_assignment);
   test_assignment = 1.0;
-  test_assignment *= nine * nine;
+  test_assignment *= wrap<WrapLeftOp>(nine) * wrap<WrapLeftOp>(nine);
   check_vectors(DataVector(num_pts, 81.0), test_assignment);
 
   test_assignment = 2.0;
@@ -412,23 +480,27 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
 
   // Test assignment where the RHS is an expression that contains the LHS
   DataVector x(num_pts, 4.);
-  x += sqrt(x);
+  x += sqrt(wrap<WrapLeftOp>(x));
   check_vectors(DataVector(num_pts, 6.0), x);
-  x -= sqrt(x - 2.0);
+  x -= sqrt(wrap<WrapLeftOp>(x) - 2.0);
   check_vectors(DataVector(num_pts, 4.0), x);
-  x = sqrt(x);
+  x = sqrt(wrap<WrapLeftOp>(x));
   check_vectors(DataVector(num_pts, 2.0), x);
-  x *= x;
+  x *= wrap<WrapLeftOp>(x);
   check_vectors(DataVector(num_pts, 4.0), x);
-  x /= x;
+  x /= wrap<WrapLeftOp>(x);
   check_vectors(DataVector(num_pts, 1.0), x);
 
   // Test composition of constant expressions with DataVector math member
   // functions
   x = DataVector(num_pts, 2.);
-  check_vectors(DataVector(num_pts, 0.82682181043180603), square(sin(x)));
-  check_vectors(DataVector(num_pts, -0.072067555747765299), cube(cos(x)));
+  check_vectors(DataVector(num_pts, 0.82682181043180603),
+                square(sin(wrap<WrapLeftOp>(x))));
+  check_vectors(DataVector(num_pts, -0.072067555747765299),
+                cube(cos(wrap<WrapLeftOp>(x))));
+}
 
+void test_datavector_array_math() noexcept {
   // Test addition of arrays of DataVectors to arrays of doubles.
   const DataVector t1{0.0, 1.0, 2.0, 3.0};
   const DataVector t2{-0.1, -0.2, -0.3, -0.4};
@@ -488,6 +560,22 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
   const DataVector expected_d3(2, 13.);
   const auto magnitude_d3 = magnitude(d3);
   CHECK_ITERABLE_APPROX(expected_d3, magnitude_d3);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.Math",
+                  "[Unit][DataStructures]") {
+  test_datavector_math<UseRefWrap::Cref, UseRefWrap::Cref>();
+  test_datavector_math<UseRefWrap::Cref, UseRefWrap::Ref>();
+  test_datavector_math<UseRefWrap::Cref, UseRefWrap::None>();
+  test_datavector_math<UseRefWrap::Ref, UseRefWrap::Cref>();
+  test_datavector_math<UseRefWrap::Ref, UseRefWrap::Ref>();
+  test_datavector_math<UseRefWrap::Ref, UseRefWrap::None>();
+  test_datavector_math<UseRefWrap::None, UseRefWrap::Cref>();
+  test_datavector_math<UseRefWrap::None, UseRefWrap::Ref>();
+  test_datavector_math<UseRefWrap::None, UseRefWrap::None>();
+
+  test_datavector_array_math();
 }
 
 // [[OutputRegex, Must copy into same size]]

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
@@ -170,6 +170,7 @@ SPECTRE_TEST_CASE(
                                0., 0., 0.};
   // These factors are (see Kopriva 8.42)
   // -3[based on extents] * magnitude_of_normal
-  CHECK_ITERABLE_APPROX(get(db::get<Tags::dt<Var>>(out_box)),
-                        initial_dt - 6. * xi_flux - 9. * eta_flux);
+  CHECK_ITERABLE_APPROX(
+      get(db::get<Tags::dt<Var>>(out_box)),
+      get(get<Tags::dt<Var>>(initial_dt)) - 6. * xi_flux - 9. * eta_flux);
 }


### PR DESCRIPTION
## Proposed changes

Adds support to PointerVector to be able to track any result type instead of using Blaze's DynamicVector. Then uses this in DataVector to prohibit mixing DataVector expressions with any other type.

@wthrowe in a separate PR I'd like to do this for Variables, but for that it's not so clear which mixing should and shouldn't be allowed. For example, I could see `Variables + Variables<NormalDotNumericalFlux>` being considered "Okay". We could possibly get around this by providing a function/constructor that generates a light-weight wrapper to convert `Variables<NormalDotNumericalFlux>` into a `Variables` in an expression. It might even be possible to do this in such a way that the resulting type could never be assigned to an actual variable (not sure on that). You have the most experience with Variables math, so I'd love to know what you think is the right answer :)

Note: there is a `fixup` because I want feedback on the question in the commit message :)

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
