### PR TITLE
Add example and dox of an executable not using Charm++

### DIFF
--- a/docs/DevGuide/CreatingExecutables.md
+++ b/docs/DevGuide/CreatingExecutables.md
@@ -1,0 +1,96 @@
+\cond NEVER
+Distributed under the MIT License.
+See LICENSE.txt for details.
+\endcond
+# Creating Executables {#dev_guide_creating_executables}
+
+There are several different types of executables that can be built:
+- An executable that uses Charm++ to run in parallel,
+  e.g. `Executables/ParallelInfo`
+- An executable that does not use Charm++, does not run in parallel, and
+  supplies its own `main`, e.g. `Executables/Benchmark`
+- An executable that uses Charm++ to run in parallel but supplies its own `main`
+- An executable that uses custom compilation or linking flags,
+  e.g. `DebugPreprocessor`
+- Executables used for evolutions or elliptic solves
+
+### Executable Using Charm++ for Parallelization
+
+Pull request #751 will add documentation here.
+
+### Executable Using Charm++ with Custom main()
+
+While this is technically possible, it has not been tested. We recommend using
+the Charm++ supplied main chare mechanism for the time being.
+
+### Executable Not Using Charm++
+
+An example of an executable that does not use Charm++ for parallelization but
+still can use all other infrastructure in SpECTRE is in
+`src/Executables/HelloWorldNoCharm`. Adding a non-Charm++ executable to SpECTRE
+mostly follows the standard way of adding an executable using CMake. The only
+deviation is that the `CMakeLists.txt` file must tell Charm++ not to add a
+`main()` by passing the link flags `-nomain-module -nomain`. This is done using
+CMake's `set_target_properties`:
+
+```
+set_target_properties(
+  ${EXECUTABLE}
+  PROPERTIES LINK_FLAGS "-nomain-module -nomain"
+  )
+```
+
+To add the executable as a target you must use CMake's `add_executable` function
+directly, not any of the SpECTRE-provided wrappers that add Charm++ parallelized
+executables. For example,
+
+```
+add_executable(
+  ${EXECUTABLE}
+  EXCLUDE_FROM_ALL # Exclude from calls to `make` without a specified target
+  HelloWorld.cpp
+  )
+```
+
+You can link in any of the SpECTRE libraries by adding them to the
+`target_link_libraries`, for example:
+
+```
+target_link_libraries(
+  ${EXECUTABLE}
+  DataStructures
+  )
+```
+
+We recommend that you add a test that the executable properly runs by adding an
+input file to `tests/InputFiles` in an appropriate subdirectory. See
+[`tests/InputFiles/ExampleExecutables/HelloWorldNoCharm.yaml`]
+(https://github.com/sxs-collaboration/spectre/tree/develop/tests/InputFiles/
+ExampleExecutables/HelloWorldNoCharm.yaml)
+for an example.
+The input file is passed to the executable using `--input-file
+path/to/Input.yaml`. In the case of the executable not taking any input file
+this is just used to generate a test that runs the executable.
+
+For these types of executables `main` can take the usual `(int argc, char
+*argv[])` and parse command line options. Executables not using Charm++ are just
+standard executables that can link in any of the libraries in SpECTRE.
+
+\warning
+Currently calling `Parallel::abort` results in a segfault deep inside Charm++
+code. However, the error messages from `ASSERT` and `ERROR` are still printed.
+
+### Executable With Custom Compilation or Linking Flags
+
+Use the CMake function `set_target_properties` to add flags to an executable. To
+call a completely custom compiler invocation you should use the
+`add_custom_target` CMake function. The need for the `custom_target` level of
+control is rare and should generally be avoided since it adds quite a bit of
+technical debt to the code base. Thus, it is not explained here. If you are
+certain you need it you can see the `DebugPreprocessor` executable's
+`CMakeLists.txt` file for an example.
+
+### Executable Used for Evolution or Elliptic Solve
+
+Once they are written, see the tutorials specific to evolution and elliptic
+solves.

--- a/docs/DevGuide/DevGuide.md
+++ b/docs/DevGuide/DevGuide.md
@@ -4,18 +4,19 @@ See LICENSE.txt for details.
 \endcond
 # Developer's Guide {#dev_guide}
 
-- \ref spectre_build_system "The build system" and how to add dependencies,
+- \ref spectre_build_system "Build system" and how to add dependencies,
   unit tests, and executables.
-- \ref writing_good_dox "Writing good documentation" is key for long term
-  maintainability of the project
-- \ref code_review_guide "Guidelines for code review." All code merged into
+- \ref code_review_guide "Code review guidelines." All code merged into
   master must follow these requirements.
 - \ref code_concepts "Concepts" used throughout the code are defined here
   for reference.
-- \ref template_metaprogramming "Template Metaprogramming"
+- \ref dev_guide_creating_executables "Executables and how to add them"
+- \ref dev_guide_option_parsing "Option parsing" to get options from input files
+- \ref ParallelGroup "Parallelization infrastructure" components and usage
 - \ref profiling_with_projections "Profiling With Charm++ Projections" and PAPI
   for optimizing performance
-- \ref writing_unit_tests "Writing Unit Tests"
+- \ref template_metaprogramming "Template Metaprogramming"
 - \ref travis_guide "Travis CI"
-- \ref ParallelGroup "Parallelization infrastructure" components and usage
-- \ref dev_guide_option_parsing "Option parsing" to get options from input files
+- \ref writing_good_dox "Writing good documentation" is key for long term
+  maintainability of the project
+- \ref writing_unit_tests "Writing Unit Tests"

--- a/src/Executables/CMakeLists.txt
+++ b/src/Executables/CMakeLists.txt
@@ -3,4 +3,5 @@
 
 add_subdirectory(Benchmark)
 add_subdirectory(DebugPreprocessor)
+add_subdirectory(Examples)
 add_subdirectory(ParallelInfo)

--- a/src/Executables/Examples/CMakeLists.txt
+++ b/src/Executables/Examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+add_subdirectory(HelloWorldNoCharm)

--- a/src/Executables/Examples/HelloWorldNoCharm/CMakeLists.txt
+++ b/src/Executables/Examples/HelloWorldNoCharm/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(EXECUTABLE HelloWorldNoCharm)
+
+add_executable(
+  ${EXECUTABLE}
+  EXCLUDE_FROM_ALL
+  HelloWorld.cpp
+  )
+
+target_link_libraries(
+  ${EXECUTABLE}
+  DataStructures
+  )
+
+set_target_properties(
+  ${EXECUTABLE}
+  PROPERTIES LINK_FLAGS "-nomain-module -nomain"
+  )

--- a/src/Executables/Examples/HelloWorldNoCharm/HelloWorld.cpp
+++ b/src/Executables/Examples/HelloWorldNoCharm/HelloWorld.cpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/DataVector.hpp"
+#include "Parallel/Printf.hpp"
+
+// Charm looks for this function but since we build without a main function or
+// main module we just have it be empty
+extern "C" void CkRegisterMainModule(void) {}
+
+int main() {
+  DataVector a{1.0, 2.3, 8.9};
+  Parallel::printf("%s\n", a);
+}

--- a/tests/InputFiles/ExampleExecutables/HelloWorldNoCharm.yaml
+++ b/tests/InputFiles/ExampleExecutables/HelloWorldNoCharm.yaml
@@ -1,0 +1,5 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Executable: HelloWorldNoCharm
+# Check: execute


### PR DESCRIPTION
## Proposed changes

Partly addresses #731 by adding documentation for how to add an executable that does not use Charm++ for parallelization.

The commit is marked as `fixup` because I want to ask @kidder if he could fill in the documentation for executables that use parallel components/Charm++ for parallelization. This could be done in #751 if that's alright with you, @kidder?

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
