### PR TITLE
Add RunSingleTest executable

### DIFF
--- a/docs/DevGuide/WritingTests.md
+++ b/docs/DevGuide/WritingTests.md
@@ -194,3 +194,20 @@ the `ifdef SPECTRE_DEBUG` block, they can just call have the code that triggers
 an `ERROR`. For example,
 
 \snippet Test_AbortWithErrorMessage.cpp error_test_example
+
+### Building and Running A Single Test File
+
+In cases where low-level header files are frequently being altered and the
+changes need to be tested, building `RunTests` becomes extremely time
+consuming. The `RunSingleTest` executable in `tests/Unit/RunSingleTest` allows
+one to compile only a select few of the test source files and only link in the
+necessary libraries. To set which test file and libraries are linked into
+`RunSingleTest` edit the `tests/Unit/RunSingleTest/CMakeLists.txt`
+file. However, do not commit your changes to that file since it is meant to
+serve as an example. To compile `RunSingleTest` use `make RunSingleTest`, and to
+run it use `BUILD_DIR/bin/RunSingleTest Unit.Test.Name`.
+
+\warning
+`Parallel::abort` does not work correctly in the `RunSingleTest` executable
+because a segfault occurs inside Charm++ code after the abort message is
+printed.

--- a/src/ErrorHandling/AbortWithErrorMessage.cpp
+++ b/src/ErrorHandling/AbortWithErrorMessage.cpp
@@ -7,6 +7,7 @@
 
 #include "Parallel/Abort.hpp"
 #include "Parallel/Info.hpp"
+#include "Parallel/Printf.hpp"
 
 void abort_with_error_message(const char* expression, const char* file,
                               const int line, const char* pretty_function,
@@ -22,7 +23,11 @@ void abort_with_error_message(const char* expression, const char* file,
      << message << "\n"
      << "############ ASSERT FAILED ############\n"
      << "\n";
-  Parallel::abort(os.str());
+  // We use printf instead of abort to print the error message because in the
+  // case of an executable not using Charm++'s main function the call to abort
+  // will segfault before anything is printed.
+  Parallel::printf(os.str());
+  Parallel::abort("");
 }
 
 void abort_with_error_message(const char* file, const int line,
@@ -38,5 +43,9 @@ void abort_with_error_message(const char* file, const int line,
      << message << "\n"
      << "############ ERROR ############\n"
      << "\n";
-  Parallel::abort(os.str());
+  // We use printf instead of abort to print the error message because in the
+  // case of an executable not using Charm++'s main function the call to abort
+  // will segfault before anything is printed.
+  Parallel::printf(os.str());
+  Parallel::abort("");
 }

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -105,3 +105,5 @@ set_target_properties(
   )
 
 add_compilation_tests(${EXECUTABLE})
+
+add_subdirectory(RunSingleTest)

--- a/tests/Unit/RunSingleTest/CMakeLists.txt
+++ b/tests/Unit/RunSingleTest/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(EXECUTABLE "RunSingleTest")
+
+add_executable(
+  ${EXECUTABLE}
+  EXCLUDE_FROM_ALL
+  ${EXECUTABLE}.cpp
+  # The following lines list the source files with tests in them to be
+  # compiled into the executable.
+  ../DataStructures/Test_DataVector.cpp
+  )
+
+target_link_libraries(
+  ${EXECUTABLE}
+  DataStructures
+  )
+
+set_target_properties(
+  ${EXECUTABLE}
+  PROPERTIES
+  LINK_FLAGS "-nomain -nomain-module"
+  )

--- a/tests/Unit/RunSingleTest/RunSingleTest.cpp
+++ b/tests/Unit/RunSingleTest/RunSingleTest.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#define CATCH_CONFIG_RUNNER
+
+#include "tests/Unit/TestingFramework.hpp"
+
+void CkRegisterMainModule() {}
+
+int main(int argc, char* argv[]) {
+  // clang-tidy: internal warning in Catch
+  return Catch::Session{}.run(argc, argv);  // NOLINT
+}


### PR DESCRIPTION
## Proposed changes

RunSingleTest allows one to compile only one of the many test files and SpECTRE
libraries, and run the tests within the file. This reduces turn around time when
editing low-level headers such as some of the ones found in `Utilities` that are
compiled into the pre-compiled header. The reason is that when the PCH changes
all libraries need to be recompiled, which is very time consuming and not
necessary if only editing something that affects `DataVector`, for example.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
