### PR TITLE
Add environment for zwicky (Fullerton)

### DIFF
--- a/docs/Installation/InstallationOnClusters.md
+++ b/docs/Installation/InstallationOnClusters.md
@@ -64,5 +64,16 @@ of `wheeler_gcc.sh`
 
 ## Orca at Fullerton
 
-Follow the general instructions, using `orca` for `SYSTEM_TO_RUN_ON`, 
-you do not need to install any dependencies, so you can skip steps 5 and 6. 
+Follow the general instructions, using `orca` for `SYSTEM_TO_RUN_ON`,
+you do not need to install any dependencies, so you can skip steps 5 and 6.
+
+## Zwicky at Fullerton
+
+Follow the general instructions using `zwicky` for `SYSTEM_TO_RUN_ON`, except
+you do not need to install any dependencies, so you can skip steps 5 and 6.
+Only gcc is supported (use `zwicky_gcc.sh`).
+
+Note that this is a very old machine, so you'll need to load many modules to
+do common things (e.g. load modules for openssh and git operations). Do
+`module avail` for a list of available modules, and look at
+`/home/geoffrey/.bash_profile` for an example list of modules to load.

--- a/support/Environments/zwicky_gcc.sh
+++ b/support/Environments/zwicky_gcc.sh
@@ -1,0 +1,72 @@
+#!/bin/env sh
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_setup_modules() {
+    echo "All modules on zwicky are provided by the system"
+}
+
+spectre_unload_modules() {
+module unload charm
+module unload catch-2.2.1-gcc-7.3.0-yaw3hxt
+module unload perl/5.26.2
+module unload python-2.7.15-gcc-7.3.0-qvsb5jh
+module unload py-numpy-1.14.3-gcc-7.3.0-fgkjppi
+module unload spack
+module unload gcc/7.3.0
+module unload openmpi/3.1.0
+module unload cmake/3.11.4
+module unload binutils-2.29.1-gcc-7.3.0-v6il5pu
+module unload blaze-3.2-gcc-7.3.0-m6qrjsx
+module unload boost-1.67.0-gcc-7.3.0-bpgr5si
+module unload brigand-master-gcc-7.3.0-7mqn34k
+module unload gsl-2.4-gcc-7.3.0-fkcmpxl
+module unload hdf5-1.10.2-gcc-7.3.0-2excv3j
+module unload jemalloc-4.5.0-gcc-7.3.0-adzurmv
+module unload libxsmm/master
+module unload curl-7.60.0-gcc-7.3.0-dbnl246
+module unload openssl-1.0.2n-gcc-7.3.0-mtsyoqu
+module unload openblas-0.3.0-gcc-7.3.0-vp5upid
+module unload yaml-cpp/develop
+module unload git-2.17.1-gcc-7.3.0-nmqkxud
+module unload openssh-7.6p1-gcc-7.3.0-gg6cb3b
+}
+
+spectre_load_modules() {
+module load charm
+module load catch-2.2.1-gcc-7.3.0-yaw3hxt
+module load perl/5.26.2
+module load python-2.7.15-gcc-7.3.0-qvsb5jh
+module load py-numpy-1.14.3-gcc-7.3.0-fgkjppi
+module load spack
+module load gcc/7.3.0
+module load openmpi/3.1.0
+module load cmake/3.11.4
+module load binutils-2.29.1-gcc-7.3.0-v6il5pu
+module load blaze-3.2-gcc-7.3.0-m6qrjsx
+module load boost-1.67.0-gcc-7.3.0-bpgr5si
+module load brigand-master-gcc-7.3.0-7mqn34k
+module load gsl-2.4-gcc-7.3.0-fkcmpxl
+module load hdf5-1.10.2-gcc-7.3.0-2excv3j
+module load jemalloc-4.5.0-gcc-7.3.0-adzurmv
+module load libxsmm/master
+module load curl-7.60.0-gcc-7.3.0-dbnl246
+module load openssl-1.0.2n-gcc-7.3.0-mtsyoqu
+module load openblas-0.3.0-gcc-7.3.0-vp5upid
+module load yaml-cpp/develop
+module load git-2.17.1-gcc-7.3.0-nmqkxud
+module load openssh-7.6p1-gcc-7.3.0-gg6cb3b
+}
+
+spectre_run_cmake() {
+    if [ -z ${SPECTRE_HOME} ]; then
+        echo "You must set SPECTRE_HOME to the cloned SpECTRE directory"
+        return 1
+    fi
+    spectre_load_modules
+    cmake -D CHARM_ROOT=$CHARM_ROOT \
+          -D CMAKE_BUILD_TYPE=Release \
+          -D CMAKE_Fortran_COMPILER=gfortran \
+          $SPECTRE_HOME
+}


### PR DESCRIPTION
## Proposed changes

Add an environment file to build spectre on zwicky.

Note that because zwicky is so old, I have to build with an old version of libxsmm (1.5.2, newest is 1.9).

All tests pass, except test 373 fails (some answers differ from the expected answers by roundoff).

Is the failing test a cause for concern? Are we sure the comparisons should always be exact, instead of differing by roundoff?

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
