### PR TITLE
Decouple flux communication from Metavariables

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
@@ -91,6 +91,10 @@ struct InitializeElement {
   template <typename Tag>
   using boundary_tag = Tags::Interface<Tags::BoundaryDirections<Dim>, Tag>;
 
+  template <typename Metavariables>
+  using flux_comm_types = dg::FluxCommunicationTypes<
+      Dim, Tags::TimeId, typename Metavariables::normal_dot_numerical_flux>;
+
   template <class Metavariables>
   using return_tag_list = tmpl::list<
       // Simple items
@@ -103,7 +107,7 @@ struct InitializeElement {
                              typename Metavariables::system::variables_tag>>,
       db::add_tag_prefix<Tags::dt,
                          typename Metavariables::system::variables_tag>,
-      typename dg::FluxCommunicationTypes<
+      typename flux_comm_types<
           Metavariables>::global_time_stepping_mortar_data_tag,
       Tags::Mortars<Tags::Next<Tags::TimeId>, Dim>,
       // Compute items
@@ -204,7 +208,7 @@ struct InitializeElement {
     }
 
     // Set up boundary information
-    db::item_type<typename dg::FluxCommunicationTypes<
+    db::item_type<typename flux_comm_types<
         Metavariables>::global_time_stepping_mortar_data_tag>
         boundary_data{};
     typename Tags::Mortars<Tags::Next<Tags::TimeId>, Dim>::type

--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -71,7 +71,6 @@ void UpwindFlux<Dim>::package_data(
     const gsl::not_null<Variables<package_tags>*> packaged_data,
     const Scalar<DataVector>& normal_dot_flux_pi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_dot_flux_phi,
-    const Scalar<DataVector>& /*normal_dot_flux_psi*/,
     const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
     const noexcept {

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -86,6 +86,7 @@ struct ComputeDuDt {
 template <size_t Dim>
 struct ComputeNormalDotFluxes {
   using argument_tags = tmpl::list<Pi, Phi<Dim>>;
+  using target_fields = tmpl::list<Pi, Phi<Dim>, Psi>;
   static void apply(gsl::not_null<Scalar<DataVector>*> pi_normal_dot_flux,
                     gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
                         phi_normal_dot_flux,
@@ -130,25 +131,41 @@ struct UpwindFlux {
   // clang-tidy: non-const reference
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 
+  // The fields for which the fluxes are computed. There must be a `Variables`
+  // with precisely these fields in the databox.
+  using target_fields = tmpl::list<Pi, Phi<Dim>, Psi>;
+
+  // This is the data needed to compute the numerical flux.
+  // `dg::SendBoundaryFluxes` calls `package_data` to store these tags in a
+  // Variables. Local and remote values of this data are then combined in the
+  // `()` operator.
   using package_tags =
       tmpl::list<Tags::NormalDotFlux<Pi>, Tags::NormalDotFlux<Phi<Dim>>, Pi,
                  NormalTimesFluxPi>;
 
-  using slice_tags = tmpl::list<Pi>;
+  // These tags on the interface of the element are passed to
+  // `package_data` to provide the data needed to compute the numerical fluxes.
+  using argument_tags =
+      tmpl::list<Tags::NormalDotFlux<Pi>, Tags::NormalDotFlux<Phi<Dim>>, Pi>;
 
   // pseudo-interface: used internally by Algorithm infrastructure, not
   // user-level code
+  // Following the not-null pointer to packaged_data, this function expects as
+  // arguments the databox types of the `argument_tags`.
   void package_data(
       gsl::not_null<Variables<package_tags>*> packaged_data,
       const Scalar<DataVector>& normal_dot_flux_pi,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_dot_flux_phi,
-      const Scalar<DataVector>& /*normal_dot_flux_psi*/,
       const Scalar<DataVector>& pi,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
       const noexcept;
 
   // pseudo-interface: used internally by Algorithm infrastructure, not
   // user-level code
+  // The arguments are first the target_fields wrapped in
+  // Tags::NormalDotNumericalFLux as not-null pointers to write the results
+  // into, then the package_tags on the interior side of the mortar followed by
+  // the package_tags on the exterior side.
   void operator()(
       gsl::not_null<Scalar<DataVector>*> pi_normal_dot_numerical_flux,
       gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -33,10 +33,10 @@ struct System {
   using gradients_tags = tmpl::list<Pi, Phi<Dim>>;
 
   using du_dt = ComputeDuDt<Dim>;
-  using normal_dot_fluxes = ComputeNormalDotFluxes<Dim>;
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed;
 
+  // This is only used in InitializeElement
   template <typename Tag>
   using magnitude_tag = Tags::EuclideanMagnitude<Tag>;
 };

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
@@ -34,26 +34,27 @@ namespace Actions {
 ///   Tags::Interface<
 ///       Tags::InternalDirections<volume_dim>,
 ///       Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>,
-///   interface items as required by Metavariables::system::normal_dot_fluxes
+///   interface items as required by Flux::argument_tags
 ///
 /// DataBox changes:
 /// - Adds:
 ///   Tags::Interface<
 ///       Tags::InternalDirections<volume_dim>,
-///       db::add_tag_prefix<Tags::NormalDotFlux, variables_tag>>
+///       db::add_tag_prefix<
+///           Tags::NormalDotFlux,
+///           Tags::Variables<typename Flux::target_fields>>
 /// - Removes: nothing
 /// - Modifies: nothing
+template <size_t Dim, typename Flux>
 struct ComputeNonconservativeBoundaryFluxes {
  private:
-  template <typename Metavariables, typename... NormalDotFluxTags, size_t Dim,
-            typename Frame, typename... Args>
+  template <typename... NormalDotFluxTags, typename Frame, typename... Args>
   static void apply_flux(
       gsl::not_null<Variables<tmpl::list<NormalDotFluxTags...>>*> boundary_flux,
       const tnsr::i<DataVector, Dim, Frame>& unit_face_normal,
       const Args&... boundary_variables) noexcept {
-    Metavariables::system::normal_dot_fluxes::apply(
-        make_not_null(&get<NormalDotFluxTags>(*boundary_flux))...,
-        boundary_variables..., unit_face_normal);
+    Flux::apply(make_not_null(&get<NormalDotFluxTags>(*boundary_flux))...,
+                boundary_variables..., unit_face_normal);
   }
 
  public:
@@ -66,23 +67,20 @@ struct ComputeNonconservativeBoundaryFluxes {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using system = typename Metavariables::system;
-    using variables_tag = typename system::variables_tag;
+    using internal_directions_tag = Tags::InternalDirections<Dim>;
 
-    using internal_directions_tag =
-        Tags::InternalDirections<system::volume_dim>;
-
-    using normal_tag = Tags::UnnormalizedFaceNormal<system::volume_dim>;
-
+    using normal_tag = Tags::UnnormalizedFaceNormal<Dim>;
     using unit_normal_tag =
         Tags::Interface<internal_directions_tag, Tags::Normalized<normal_tag>>;
+
     using interface_normal_dot_fluxes_tag =
-        Tags::Interface<internal_directions_tag,
-                        db::add_tag_prefix<Tags::NormalDotFlux, variables_tag>>;
+    Tags::Interface<internal_directions_tag,
+                    db::add_tag_prefix<Tags::NormalDotFlux,
+                           Tags::Variables<typename Flux::target_fields>>>;
 
     auto boundary_fluxes_result = db::apply<tmpl::push_front<
         tmpl::transform<
-            typename Metavariables::system::normal_dot_fluxes::argument_tags,
+            typename Flux::argument_tags,
             tmpl::bind<Tags::Interface, internal_directions_tag, tmpl::_1>>,
         internal_directions_tag, unit_normal_tag>>(
         [](const db::item_type<internal_directions_tag>& internal_directions,
@@ -95,9 +93,9 @@ struct ComputeNonconservativeBoundaryFluxes {
             auto& side_boundary_flux = boundary_fluxes[direction];
             side_boundary_flux = std::decay_t<decltype(side_boundary_flux)>(
                 side_unit_face_normal.begin()->size(), 0.0);
-            apply_flux<Metavariables>(make_not_null(&side_boundary_flux),
-                                      side_unit_face_normal,
-                                      tensors.at(direction)...);
+            apply_flux(make_not_null(&side_boundary_flux),
+                       side_unit_face_normal,
+                       tensors.at(direction)...);
           }
           return boundary_fluxes;
         },

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp
@@ -22,22 +22,50 @@
 #include "Utilities/TMPL.hpp"
 
 namespace dg {
-/// \ingroup DiscontinuousGalerkinGroup
-/// \brief Types related to flux communication.
-template <typename Metavariables>
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief Types related to flux communication.
+ *
+ * \tparam Dim The spatial dimensions of the system.
+ * \tparam TemporalIdTag The databox tag of the type that identifies a step in
+ * the algorithm, e.g. Tags::TimeId.
+ * \tparam NumericalFluxTag The cache tag for the type responsible for computing
+ * the numerical fluxes. The latter must expose the following types:
+ * - `target_fields`: A `tmpl::list` of databox tags for which the fluxes are
+ * computed. This is needed to apply the computed and lifted fluxes to the
+ * fields in the databox. There must be a `Variables` with precisely these tags
+ * in the databox.
+ * - `argument_tags`: A `tmpl::list` of tags of which interface tags
+ * must exist in the databox. When sending fluxes, the values of these interface
+ * tags are passed to the `package_data` function to provide the necessary data.
+ * - `package_tags`: A `tmpl::list` of databox tags that the `package_data`
+ * function computes. This data is communicated and made available to the
+ * numerical flux computer on both sides of the boundary. It is passed to the
+ * `()` operator when fluxes are applied, e.g. in
+ * `dg::ApplyBoundaryFluxesGlobalTimestepping`.
+ */
+template <size_t Dim, typename TemporalIdTag, typename NumericalFluxTag>
 struct FluxCommunicationTypes {
- private:
-  using system = typename Metavariables::system;
-  static constexpr size_t volume_dim = system::volume_dim;
-
  public:
-  /// The type of the Variables sent to neighboring elements.
-  using PackagedData = Variables<
-      typename Metavariables::normal_dot_numerical_flux::type::package_tags>;
+  /// The type that computes numerical fluxes
+  using numerical_flux = typename NumericalFluxTag::type;
 
-  /// The DataBox tag for the normal fluxes of the evolved variables.
-  using normal_dot_fluxes_tag =
-      db::add_tag_prefix<Tags::NormalDotFlux, typename system::variables_tag>;
+  /// The type of the Variables sent to neighboring elements.
+  using PackagedData = Variables<typename numerical_flux::package_tags>;
+
+  /// The Variables tag that stores the normal numerical fluxes. Computed by the
+  /// numerical flux computer and used e.g. by lift_flux.
+  using normal_dot_numerical_fluxes_tag = db::add_tag_prefix<
+      Tags::NormalDotNumericalFlux,
+      Tags::Variables<typename numerical_flux::target_fields>>;
+
+  // The Variables tag that stores the normal fluxes, also used e.g. by
+  // lift_flux to compute the strong DG flux contribution on an interface. These
+  // have to be computed on the interfaces and stored in the databox before
+  // SendDataForFluxes is called.
+  using normal_dot_fluxes_tag = db::add_tag_prefix<
+      Tags::NormalDotFlux,
+      Tags::Variables<typename numerical_flux::target_fields>>;
 
   /// Variables tag for storing the magnitude of the face normal in
   /// the LocalData.
@@ -45,7 +73,7 @@ struct FluxCommunicationTypes {
     using type = Scalar<DataVector>;
   };
 
-  /// The type of the Variables needed for the local part of the flux
+  /// The type of the Variables needed for the local part of the
   /// numerical flux computations.  Contains the PackagedData, the
   /// normal fluxes, and MagnitudeOfFaceNormal.
   using LocalData = Variables<tmpl::remove_duplicates<tmpl::append<
@@ -61,21 +89,19 @@ struct FluxCommunicationTypes {
   /// time stepping.
   using global_time_stepping_mortar_data_tag =
       BasedMortars<Tags::VariablesBoundaryData,
-                   Tags::SimpleBoundaryData<
-                       db::item_type<typename Metavariables::temporal_id>,
-                       LocalData, PackagedData>,
-                   volume_dim>;
+                   Tags::SimpleBoundaryData<db::item_type<TemporalIdTag>,
+                                            LocalData, PackagedData>,
+                   Dim>;
 
   /// The inbox tag for flux communication.
   struct FluxesTag {
-    using temporal_id = db::item_type<typename Metavariables::temporal_id>;
-    using type = std::map<
-        temporal_id,
-        std::unordered_map<
-            std::pair<Direction<volume_dim>, ElementId<volume_dim>>,
-            std::pair<temporal_id, PackagedData>,
-            boost::hash<
-                std::pair<Direction<volume_dim>, ElementId<volume_dim>>>>>;
+    using temporal_id = typename db::item_type<TemporalIdTag>;
+    using type =
+        std::map<temporal_id,
+                 std::unordered_map<
+                     std::pair<Direction<Dim>, ElementId<Dim>>,
+                     std::pair<temporal_id, PackagedData>,
+                     boost::hash<std::pair<Direction<Dim>, ElementId<Dim>>>>>;
   };
 };
 }  // namespace dg

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -95,7 +95,10 @@ struct System {
 };
 
 struct NormalDotNumericalFluxTag {
-  using type = struct { using package_tags = tmpl::list<Var>; };
+  using type = struct {
+    using target_fields = tmpl::list<Var>;
+    using package_tags = tmpl::list<Var>;
+  };
 };
 
 template <size_t Dim>
@@ -112,7 +115,6 @@ template <size_t Dim>
 struct Metavariables {
   using component_list = tmpl::list<component<Dim>>;
   using system = System<Dim>;
-  using temporal_id = Tags::TimeId;
   using normal_dot_numerical_flux = NormalDotNumericalFluxTag;
   using const_global_cache_tag_list = tmpl::list<>;
 };
@@ -222,7 +224,8 @@ void test_initialize_element(const ElementId<Dim>& element_id,
         Variables<tmpl::list<Tags::dt<Var>>>(extents.product(), 0.0));
 
   CHECK(db::get<typename dg::FluxCommunicationTypes<
-            Metavariables<Dim>>::global_time_stepping_mortar_data_tag>(box)
+          Dim, Tags::TimeId,
+          NormalDotNumericalFluxTag>::global_time_stepping_mortar_data_tag>(box)
             .size() == element.number_of_neighbors());
   CHECK(db::get<Tags::Mortars<Tags::Next<Tags::TimeId>, Dim>>(box).size() ==
         element.number_of_neighbors());

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -199,11 +199,11 @@ void check_upwind_flux(const size_t npts, const double t) {
   ScalarWave::UpwindFlux<Dim> flux_computer{};
   flux_computer.package_data(
       make_not_null(&packaged_data_int), solution.dpsi_dt(x, t + 1.0),
-      solution.dpsi_dx(x, t + 2.0), solution.psi(x, t + 3.0),
+      solution.dpsi_dx(x, t + 2.0),
       solution.psi(x, t + 4.0), unit_normal);
   flux_computer.package_data(
       make_not_null(&packaged_data_ext), solution.dpsi_dt(x, 2.0 * t + 10.0),
-      solution.dpsi_dx(x, 2.0 * t + 9.0), solution.psi(x, 2.0 * t + 8.0),
+      solution.dpsi_dx(x, 2.0 * t + 9.0),
       solution.psi(x, 2.0 * t + 7.0), unit_normal);
 
   Scalar<DataVector> normal_dot_numerical_flux_pi(pow<Dim>(npts), 0.0);


### PR DESCRIPTION
## Proposed changes

This PR decouples the actions that send, receive and apply fluxes from `Metavariables`, and instead templates them only on the information they need (generally this is the `TemporalIdTag` and the type that computes the flux). Aside from making the code less dependent on global information in `Metavariables` or `Metavariables::system` (which I think we should generally strive for, see #797), this allows us to use the infrastructure to communicate multiple fluxes and/or fluxes for a subset of variables, e.g. to compute an auxiliary field and the corresponding physical field in two separate steps with different fluxes.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For instructions on how to perform the CI checks locally refer to the [Dev guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`. Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the [code review guide](https://spectre-code.org/code_review_guide.html).
