### PR TITLE
Fix line wraps in GitHub PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,19 +3,18 @@
 ### Expected behavior:
 
 <!--
-describe the expected behavior
+Describe the expected behavior.
 -->
 
 ### Current behavior:
 
 <!--
-describe the current behavior and how to reproduce
+Describe the current behavior and how to reproduce the issue.
 -->
 
 ### Environment:
 
-Add as an attachment `$SPECTRE_BUILD_DIR/LibraryVersions.txt` or
-add its contents here.
+Add as an attachment `$SPECTRE_BUILD_DIR/LibraryVersions.txt` or add its contents here.
 
 # Feature request:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,19 +18,12 @@ At a high level, describe what this PR does.
 
 ### Code review checklist
 
-- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
-  instructions on how to perform the CI checks locally refer to the [Dev guide
-  on the Travis CI](https://spectre-code.org/travis_guide.html).
-- [ ] The code is documented and the documentation renders correctly. Run `make doc`
-  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
-  `index.html`.
-- [ ] The code follows the stylistic and code quality guidelines listed in the
-  [code review guide](https://spectre-code.org/code_review_guide.html).
+- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For instructions on how to perform the CI checks locally refer to the [Dev guide on the Travis CI](https://spectre-code.org/travis_guide.html).
+- [ ] The code is documented and the documentation renders correctly. Run `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`. Then open `index.html`.
+- [ ] The code follows the stylistic and code quality guidelines listed in the [code review guide](https://spectre-code.org/code_review_guide.html).
 
 ### Further comments
 
 <!--
-If this is a relatively large or complex change, kick off the discussion by
-explaining why you chose the solution you did and what alternatives you
-considered, etc...
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
 -->


### PR DESCRIPTION
## Proposed changes

Removes the 80 char line wraps in the `.github/` templates to render them better on GitHub.
