### PR TITLE
Add module to eliminate warnings when running charm on orca

### DIFF
--- a/support/Environments/orca_gcc.sh
+++ b/support/Environments/orca_gcc.sh
@@ -24,6 +24,7 @@ module unload yaml-cpp-develop-gcc-7.3.0-wy6dpng
 module unload libxsmm/1.9
 module unload cmake-3.11.3-gcc-7.3.0-isxbgez
 module unload charm
+module unload zlib-1.2.11-gcc-7.3.0-qzvtd4j
 }
 
 spectre_load_modules() {
@@ -43,6 +44,7 @@ module load yaml-cpp-develop-gcc-7.3.0-wy6dpng
 module load libxsmm/1.9
 module load cmake-3.11.3-gcc-7.3.0-isxbgez
 module load charm
+module load zlib-1.2.11-gcc-7.3.0-qzvtd4j
 }
 
 spectre_run_cmake() {


### PR DESCRIPTION
## Proposed changes

I discovered that I can remove annoying warnings like this:

`orted: /lib64/libz.so.1: no version information available (required by `/share/apps/openmpi/3.1.0/lib/libopen-rte.so.40)"`

by adding zlib to the list of orca modules.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->