### PR TITLE
Add function to compute conservative variables for GRMHD

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -2,3 +2,15 @@
 # See LICENSE.txt for details.
 
 set(LIBRARY ValenciaDivClean)
+
+set(LIBRARY_SOURCES
+  ConservativeFromPrimitive.cpp
+  )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  )

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/Gsl.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_include <array>
+
+/// \cond
+namespace grmhd {
+namespace ValenciaDivClean {
+
+void conservative_from_primitive(
+    const gsl::not_null<Scalar<DataVector>*> tilde_d,
+    const gsl::not_null<Scalar<DataVector>*> tilde_tau,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
+    const gsl::not_null<Scalar<DataVector>*> tilde_phi,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_enthalpy,
+    const Scalar<DataVector>& pressure,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const Scalar<DataVector>& divergence_cleaning_field) noexcept {
+  const auto spatial_velocity_one_form =
+      raise_or_lower_index(spatial_velocity, spatial_metric);
+  const auto magnetic_field_one_form =
+      raise_or_lower_index(magnetic_field, spatial_metric);
+  const auto magnetic_field_dot_spatial_velocity =
+      dot_product(magnetic_field, spatial_velocity_one_form);
+  const auto spatial_velocity_squared =
+      dot_product(spatial_velocity, spatial_velocity_one_form);
+  // not const to save an allocation later
+  auto magnetic_field_squared =
+      dot_product(magnetic_field, magnetic_field_one_form);
+
+  get(*tilde_d) = get(sqrt_det_spatial_metric) * get(rest_mass_density) *
+                  get(lorentz_factor);
+
+  get(*tilde_tau) =
+      get(*tilde_d) * (get(lorentz_factor) * get(specific_enthalpy) - 1.0) +
+      get(sqrt_det_spatial_metric) *
+          (0.5 * get(magnetic_field_squared) *
+               (1.0 + get(spatial_velocity_squared)) -
+           0.5 * get(magnetic_field_dot_spatial_velocity) - get(pressure));
+
+  Scalar<DataVector> common_factor = std::move(magnetic_field_squared);
+  get(common_factor) *= get(sqrt_det_spatial_metric);
+  get(common_factor) +=
+      get(*tilde_d) * get(lorentz_factor) * get(specific_enthalpy);
+  for (size_t i = 0; i < 3; ++i) {
+    tilde_s->get(i) = get(common_factor) * spatial_velocity_one_form.get(i) -
+                      get(magnetic_field_dot_spatial_velocity) *
+                          get(sqrt_det_spatial_metric) *
+                          magnetic_field_one_form.get(i);
+  }
+  for (size_t i = 0; i < 3; ++i) {
+    tilde_b->get(i) = get(sqrt_det_spatial_metric) * magnetic_field.get(i);
+  }
+  get(*tilde_phi) =
+      get(sqrt_det_spatial_metric) * get(divergence_cleaning_field);
+}
+
+}  // namespace ValenciaDivClean
+}  // namespace grmhd
+/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+class DataVector;
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace grmhd {
+namespace ValenciaDivClean {
+
+/*!
+ * \brief Compute the conservative variables from primitive variables
+ *
+ * \f{align*}
+ * {\tilde D} = & \sqrt{\gamma} \rho W \\
+ * {\tilde S}_i = & \sqrt{\gamma} \left( \rho h W^2 v_i + B^m B_m v_i - B^m v_m
+ * B_i \right) \\
+ * {\tilde \tau} = & \sqrt{\gamma} \left[ \rho h W^2 - p - \rho W - \frac{1}{2}
+ * B^m v_m + \frac{1}{2} B^m B_m \left( 1 + v^m v_m \right) \right] \\
+ * {\tilde B}^i = & \sqrt{\gamma} B^i \\
+ * {\tilde \Phi} = & \sqrt{\gamma} \Phi
+ * \f}
+ *
+ * where the conserved variables \f${\tilde D}\f$, \f${\tilde S}_i\f$,
+ * \f${\tilde \tau}\f$, \f${\tilde B}^i\f$, and \f${\tilde \Phi}\f$ are a
+ * generalized mass-energy density, momentum density, specific internal energy
+ * density, magnetic field, and divergence cleaning field.  Furthermore
+ * \f$\gamma\f$ is the determinant of the spatial metric, \f$\rho\f$ is the rest
+ * mass density, \f$W = 1/\sqrt{1-v_i v^i}\f$ is the Lorentz factor, \f$h = 1 +
+ * \epsilon + \frac{p}{\rho}\f$ is the specific enthalpy, \f$v^i\f$ is the
+ * spatial velocity, \f$\epsilon\f$ is the specific internal energy, \f$p\f$ is
+ * the pressure, \f$B^i\f$ is the spatial magnetic field measured by an Eulerian
+ * observer, and \f$\Phi\f$ is a divergence cleaning field.
+ */
+void conservative_from_primitive(
+    gsl::not_null<Scalar<DataVector>*> tilde_d,
+    gsl::not_null<Scalar<DataVector>*> tilde_tau,
+    gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
+    gsl::not_null<Scalar<DataVector>*> tilde_phi,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_enthalpy,
+    const Scalar<DataVector>& pressure,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const Scalar<DataVector>& divergence_cleaning_field) noexcept;
+}  // namespace ValenciaDivClean
+}  // namespace grmhd

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ValenciaDivClean")
 
 set(LIBRARY_SOURCES
+  Test_ConservativeFromPrimitive.cpp
   Test_ValenciaDivClean.cpp
   )
 
@@ -11,5 +12,5 @@ add_test_library(
   ${LIBRARY}
   "Evolution/Systems/GrMhd/ValenciaDivClean"
   "${LIBRARY_SOURCES}"
-  ""
+  "ValenciaDivClean"
   )

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
@@ -1,0 +1,56 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Functions for testing ConservativeFromPrimitive.cpp
+def tilde_d(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
+            lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
+            spatial_metric, divergence_cleaning_field):
+    return lorentz_factor * rest_mass_density * sqrt_det_spatial_metric
+
+
+def tilde_tau(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
+              lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
+              spatial_metric, divergence_cleaning_field):
+    bsq = np.einsum("ab, ab", spatial_metric,
+                    np.outer(magnetic_field, magnetic_field))
+    vsq = np.einsum("ab, ab", spatial_metric,
+                    np.outer(spatial_velocity, spatial_velocity))
+    b_dot_v = np.einsum("ab, ab", spatial_metric,
+                        np.outer(magnetic_field, spatial_velocity))
+    return ((rest_mass_density * specific_enthalpy * lorentz_factor**2 -
+             pressure - rest_mass_density * lorentz_factor + 0.5 * bsq *
+             (1.0 + vsq) - 0.5 * b_dot_v) * sqrt_det_spatial_metric)
+
+
+def tilde_s(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
+            lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
+            spatial_metric, divergence_cleaning_field):
+    spatial_velocity_one_form = np.einsum("a, ia", spatial_velocity,
+                                          spatial_metric)
+    magnetic_field_one_form = np.einsum("a, ia", magnetic_field,
+                                        spatial_metric)
+    bsq = np.einsum("ab, ab", spatial_metric,
+                    np.outer(magnetic_field, magnetic_field))
+    b_dot_v = np.einsum("ab, ab", spatial_metric,
+                        np.outer(magnetic_field, spatial_velocity))
+    return ((spatial_velocity_one_form *
+             (lorentz_factor**2 * specific_enthalpy * rest_mass_density + bsq)
+             - magnetic_field_one_form * b_dot_v) * sqrt_det_spatial_metric)
+
+
+def tilde_b(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
+            lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
+            spatial_metric, divergence_cleaning_field):
+    return sqrt_det_spatial_metric * magnetic_field
+
+
+def tilde_phi(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
+              lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
+              spatial_metric, divergence_cleaning_field):
+    return sqrt_det_spatial_metric * divergence_cleaning_field
+
+
+# End functions for testing ConservativeFromPrimitive.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_ConservativeFromPrimitive.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_ConservativeFromPrimitive.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_include "DataStructures/Tensor/Tensor.hpp"
+// IWYU pragma: no_include "Utilities/Gsl.hpp"
+// IWYU pragma: no_include <string>
+
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.ConservativeFromPrimitive",
+                  "[Unit][GrMhd]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GrMhd/ValenciaDivClean"};
+
+  pypp::check_with_random_values<1>(
+      &grmhd::ValenciaDivClean::conservative_from_primitive, "TestFunctions",
+      {"tilde_d", "tilde_tau", "tilde_s", "tilde_b", "tilde_phi"},
+      {{{0.0, 1.0}}}, DataVector{5});
+}


### PR DESCRIPTION
## Proposed changes

Add conservative_from_primitive for the Valencia formulation of GRMHD with divergence cleaning

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
