### PR TITLE
Add function to compute fluxes for GRMHD

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY ValenciaDivClean)
 
 set(LIBRARY_SOURCES
   ConservativeFromPrimitive.cpp
+  Fluxes.cpp
   )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.cpp
@@ -1,0 +1,95 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_include <array>
+
+/// \cond
+namespace grmhd {
+namespace ValenciaDivClean {
+
+void fluxes(
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        tilde_tau_flux,
+    const gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+    const gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        tilde_phi_flux,
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_phi, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& pressure,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field) noexcept {
+  // not const to save an allocation below
+  auto spatial_velocity_one_form =
+      raise_or_lower_index(spatial_velocity, spatial_metric);
+  const auto magnetic_field_one_form =
+      raise_or_lower_index(magnetic_field, spatial_metric);
+  const auto magnetic_field_dot_spatial_velocity =
+      dot_product(magnetic_field, spatial_velocity_one_form);
+  const auto magnetic_field_squared =
+      dot_product(magnetic_field, magnetic_field_one_form);
+
+  const DataVector one_over_w_squared = 1.0 / square(get(lorentz_factor));
+  // p_star = p + p_m = p + b^2/2 = p + ((B^m v_m)^2 + (B^m B_m)/W^2)/2
+  const DataVector p_star_alpha_sqrt_det_g =
+      get(sqrt_det_spatial_metric) * get(lapse) *
+      (get(pressure) + 0.5 * square(get(magnetic_field_dot_spatial_velocity)) +
+       0.5 * get(magnetic_field_squared) * one_over_w_squared);
+
+  // lapse b_i / W = lapse (B_i / W^2 + v_i (B^m v_m)
+  tnsr::i<DataVector, 3, Frame::Inertial> lapse_b_over_w =
+      std::move(spatial_velocity_one_form);
+  for (size_t i = 0; i < 3; ++i) {
+    lapse_b_over_w.get(i) *= get(magnetic_field_dot_spatial_velocity);
+    lapse_b_over_w.get(i) +=
+        one_over_w_squared * magnetic_field_one_form.get(i);
+    lapse_b_over_w.get(i) *= get(lapse);
+  }
+
+  // Outside the loop to save allocations
+  DataVector transport_velocity_I(p_star_alpha_sqrt_det_g.size());
+
+  for (size_t i = 0; i < 3; ++i) {
+    transport_velocity_I = get(lapse) * spatial_velocity.get(i) - shift.get(i);
+    tilde_d_flux->get(i) = get(tilde_d) * transport_velocity_I;
+    tilde_tau_flux->get(i) =
+        get(tilde_tau) * transport_velocity_I +
+        p_star_alpha_sqrt_det_g * spatial_velocity.get(i) -
+        get(lapse) * get(magnetic_field_dot_spatial_velocity) * tilde_b.get(i);
+    tilde_phi_flux->get(i) =
+        get(lapse) * tilde_b.get(i) - get(tilde_phi) * shift.get(i);
+    for (size_t j = 0; j < 3; ++j) {
+      tilde_s_flux->get(i, j) = tilde_s.get(j) * transport_velocity_I -
+                                lapse_b_over_w.get(j) * tilde_b.get(i);
+      tilde_b_flux->get(i, j) =
+          tilde_b.get(j) * transport_velocity_I +
+          get(lapse) * (get(tilde_phi) * inv_spatial_metric.get(i, j) -
+                        spatial_velocity.get(j) * tilde_b.get(i));
+    }
+    tilde_s_flux->get(i, i) += p_star_alpha_sqrt_det_g;
+  }
+}
+}  // namespace ValenciaDivClean
+}  // namespace grmhd
+/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+class DataVector;
+/// \endcond
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace grmhd {
+namespace ValenciaDivClean {
+
+/*!
+ * \brief The fluxes of the conservative variables
+ *
+ * \f{align*}
+ * F^i({\tilde D}) = &~ {\tilde D} v^i_{tr} \\
+ * F^i({\tilde S}_j) = &~  {\tilde S}_j v^i_{tr} + \sqrt{\gamma} \alpha \left( p
+ * + p_m \right) \delta^i_j - \frac{B_j {\tilde B}^i}{W^2} - v_j {\tilde B}^i
+ * B^m v_m\\
+ * F^i({\tilde \tau}) = &~  {\tilde \tau} v^i_{tr} + \sqrt{\gamma} \alpha \left(
+ * p + p_m \right) v^i - \alpha {\tilde B}^i B^m v_m \\
+ * F^i({\tilde B}^j) = &~  {\tilde B}^j v^i_{tr} - \alpha v^j {\tilde B}^i +
+ * \alpha \gamma^{ij} {\tilde \Phi} \\
+ * F^i({\tilde \Phi}) = &~ \alpha {\tilde B^i} - \beta^i {\tilde \Phi}
+ * \f}
+ *
+ * where the conserved variables \f${\tilde D}\f$, \f${\tilde S}_i\f$,
+ * \f${\tilde \tau}\f$, \f${\tilde B}^i\f$, and \f${\tilde \Phi}\f$ are a
+ * generalized mass-energy density, momentum density, specific internal energy
+ * density, magnetic field, and divergence cleaning field.  Furthermore,
+ * \f$v^i_{tr} = \alpha v^i - \beta^i\f$ is the transport velocity, \f$\alpha\f$
+ * is the lapse, \f$\beta^i\f$ is the shift, \f$\gamma\f$ is the determinant of
+ * the spatial metric \f$\gamma_{ij}\f$,  \f$v^i\f$ is the spatial velocity,
+ * \f$B^i\f$ is the spatial magnetic field measured by an Eulerian observer,
+ * \f$p\f$ is the fluid pressure, and \f$p_m = \frac{1}{2} \left[ \left( B^n v_n
+ * \right)^2 + B^n B_n / W^2 \right]\f$ is the magnetic pressure.
+ */
+void fluxes(
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_tau_flux,
+    gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+    gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_phi_flux,
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_phi, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& pressure,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field) noexcept;
+}  // namespace ValenciaDivClean
+}  // namespace grmhd

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ValenciaDivClean")
 
 set(LIBRARY_SOURCES
   Test_ConservativeFromPrimitive.cpp
+  Test_Fluxes.cpp
   Test_ValenciaDivClean.cpp
   )
 

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
@@ -4,6 +4,33 @@
 import numpy as np
 
 
+def b_dot_v(magnetic_field, spatial_velocity, spatial_metric):
+    return np.einsum("ab, ab", spatial_metric,
+                     np.outer(magnetic_field, spatial_velocity))
+
+
+def bsq(magnetic_field, spatial_metric):
+    return np.einsum("ab, ab", spatial_metric,
+                     np.outer(magnetic_field, magnetic_field))
+
+
+def magnetic_field_one_form(magnetic_field, spatial_metric):
+    return np.einsum("a, ia", magnetic_field, spatial_metric)
+
+
+def p_star(pressure, b_dot_v, bsq, lorentz_factor):
+    return pressure + 0.5 * (b_dot_v**2 + bsq / lorentz_factor**2)
+
+
+def spatial_velocity_one_form(spatial_velocity, spatial_metric):
+    return np.einsum("a, ia", spatial_velocity, spatial_metric)
+
+
+def vsq(spatial_velocity, spatial_metric):
+    return np.einsum("ab, ab", spatial_metric,
+                     np.outer(spatial_velocity, spatial_velocity))
+
+
 # Functions for testing ConservativeFromPrimitive.cpp
 def tilde_d(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
             lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
@@ -14,31 +41,23 @@ def tilde_d(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
 def tilde_tau(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
               lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
               spatial_metric, divergence_cleaning_field):
-    bsq = np.einsum("ab, ab", spatial_metric,
-                    np.outer(magnetic_field, magnetic_field))
-    vsq = np.einsum("ab, ab", spatial_metric,
-                    np.outer(spatial_velocity, spatial_velocity))
-    b_dot_v = np.einsum("ab, ab", spatial_metric,
-                        np.outer(magnetic_field, spatial_velocity))
     return ((rest_mass_density * specific_enthalpy * lorentz_factor**2 -
-             pressure - rest_mass_density * lorentz_factor + 0.5 * bsq *
-             (1.0 + vsq) - 0.5 * b_dot_v) * sqrt_det_spatial_metric)
+             pressure - rest_mass_density * lorentz_factor +
+             0.5 * bsq(magnetic_field, spatial_metric) *
+             (1.0 + vsq(spatial_velocity, spatial_metric)) -
+             0.5 * b_dot_v(magnetic_field, spatial_velocity, spatial_metric)) *
+            sqrt_det_spatial_metric)
 
 
 def tilde_s(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
             lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
             spatial_metric, divergence_cleaning_field):
-    spatial_velocity_one_form = np.einsum("a, ia", spatial_velocity,
-                                          spatial_metric)
-    magnetic_field_one_form = np.einsum("a, ia", magnetic_field,
-                                        spatial_metric)
-    bsq = np.einsum("ab, ab", spatial_metric,
-                    np.outer(magnetic_field, magnetic_field))
-    b_dot_v = np.einsum("ab, ab", spatial_metric,
-                        np.outer(magnetic_field, spatial_velocity))
-    return ((spatial_velocity_one_form *
-             (lorentz_factor**2 * specific_enthalpy * rest_mass_density + bsq)
-             - magnetic_field_one_form * b_dot_v) * sqrt_det_spatial_metric)
+    return ((spatial_velocity_one_form(spatial_velocity, spatial_metric) *
+             (lorentz_factor**2 * specific_enthalpy * rest_mass_density + bsq(
+                 magnetic_field, spatial_metric)) -
+             magnetic_field_one_form(magnetic_field, spatial_metric) * b_dot_v(
+                 magnetic_field, spatial_velocity, spatial_metric)) *
+            sqrt_det_spatial_metric)
 
 
 def tilde_b(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
@@ -54,3 +73,55 @@ def tilde_phi(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
 
 
 # End functions for testing ConservativeFromPrimitive.cpp
+
+
+# Functions for testing Fluxes.cpp
+def tilde_d_flux(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, lapse, shift,
+                 sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
+                 pressure, spatial_velocity, lorentz_factor, magnetic_field):
+    return tilde_d * (lapse * spatial_velocity - shift)
+
+
+def tilde_tau_flux(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, lapse,
+                   shift, sqrt_det_spatial_metric, spatial_metric,
+                   inv_spatial_metric, pressure, spatial_velocity,
+                   lorentz_factor, magnetic_field):
+    b_dot_v_ = b_dot_v(magnetic_field, spatial_velocity, spatial_metric)
+    return (sqrt_det_spatial_metric * lapse * p_star(
+        pressure, b_dot_v_, bsq(magnetic_field, spatial_metric),
+        lorentz_factor) * spatial_velocity + tilde_tau *
+            (lapse * spatial_velocity - shift) - lapse * b_dot_v_ * tilde_b)
+
+
+def tilde_s_flux(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, lapse, shift,
+                 sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
+                 pressure, spatial_velocity, lorentz_factor, magnetic_field):
+    b_dot_v_ = b_dot_v(magnetic_field, spatial_velocity, spatial_metric)
+    b_i = (magnetic_field_one_form(magnetic_field, spatial_metric)
+           / lorentz_factor + spatial_velocity_one_form(
+               spatial_velocity, spatial_metric) * lorentz_factor * b_dot_v_)
+    result = np.outer(lapse * spatial_velocity - shift, tilde_s)
+    result -= lapse / lorentz_factor * np.outer(tilde_b, b_i)
+    result += (sqrt_det_spatial_metric * lapse * p_star(
+        pressure, b_dot_v_, bsq(magnetic_field, spatial_metric),
+        lorentz_factor) * np.identity(shift.size))
+    return result
+
+
+def tilde_b_flux(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, lapse, shift,
+                 sqrt_det_spatial_metric, spatial_metric, inv_spatial_metric,
+                 pressure, spatial_velocity, lorentz_factor, magnetic_field):
+    result = np.outer(lapse * spatial_velocity - shift, tilde_b)
+    result += lapse * inv_spatial_metric * tilde_phi
+    result -= lapse * np.outer(tilde_b, spatial_velocity)
+    return result
+
+
+def tilde_phi_flux(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, lapse,
+                   shift, sqrt_det_spatial_metric, spatial_metric,
+                   inv_spatial_metric, pressure, spatial_velocity,
+                   lorentz_factor, magnetic_field):
+    return lapse * tilde_b - tilde_phi * shift
+
+
+# End functions for testing Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Fluxes.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_include "DataStructures/Tensor/Tensor.hpp"
+// IWYU pragma: no_include "Utilities/Gsl.hpp"
+// IWYU pragma: no_include <string>
+
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Fluxes", "[Unit][GrMhd]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GrMhd/ValenciaDivClean"};
+
+  pypp::check_with_random_values<1>(
+      &grmhd::ValenciaDivClean::fluxes, "TestFunctions",
+      {"tilde_d_flux", "tilde_tau_flux", "tilde_s_flux", "tilde_b_flux",
+       "tilde_phi_flux"},
+      {{{0.0, 1.0}}}, DataVector{5});
+}


### PR DESCRIPTION
## Proposed changes

Add function to compute fluxes for Valencia formulation of GRMHD with divergence cleaning

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
