### PR TITLE
 Add a script to render docs from a PR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,15 @@ site_name(HOSTNAME)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+option(
+  DOCS_ONLY
+  "Skip all initialization not required for rendering documentation"
+)
+if (DOCS_ONLY)
+  include(SetupDoxygen)
+  return()
+endif (DOCS_ONLY)
+
 include(CheckCompilerVersion)
 include(ProhibitInSourceBuild)
 include(SetupNinjaColors)

--- a/docs/DevGuide/Travis.md
+++ b/docs/DevGuide/Travis.md
@@ -98,6 +98,12 @@ useful to perform at least the following tests locally:
   create a separate build directory and append `-D USE_PCH=OFF` to the usual
   `cmake` call. Note that it is very easy to incorrectly install IWYU (if not
   using the Docker container) and generate nonsense errors.
+- **Documentation:** To render the documentation for the current state
+  of the source tree the command `make doc` (or `make doc-check` to
+  highlight warnings) can be used, placing its result in the `docs`
+  directory in the build tree.  Once code has been made into a pull
+  request to GitHub, the documentation can be rendered locally using
+  the `tools/pr-docs` script.
 
 ## Travis setup
 

--- a/tools/pr-docs
+++ b/tools/pr-docs
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+usage() {
+    cat <<EOF
+Usage: $0 pr-number output/location
+
+Render documentation from a pull request and write the result to the
+specified location.  This script must be run from within a SpECTRE repo.
+EOF
+}
+
+if [ "$1" = -h ] ; then
+    usage
+    exit 0
+fi
+
+if [ "$#" -ne 2 ] ; then
+    usage >&2
+    exit 1
+fi
+
+pr=$1
+outdir=$2
+
+# Linux || OSX
+tmpdir=$(mktemp -d --tmpdir 2>/dev/null || mkdir -d -t spectre-doc)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+spectre=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "Must run from a SpECTRE git working tree" >&2
+    exit 1
+}
+
+pushd "${tmpdir}" >/dev/null
+# Clone from the local SpECTRE repo to avoid having to redownload
+# everything.
+git clone --shared --quiet --no-checkout -- "${spectre}" source
+pushd source >/dev/null
+git fetch https://github.com/sxs-collaboration/spectre pull/"${pr}"/head
+git checkout --quiet FETCH_HEAD
+popd >/dev/null
+cmake -D DOCS_ONLY=TRUE source
+# Ignore doxygen failures.  We want them to be displayed, but we still
+# usually get usable documentation.
+make doc-check || :
+rm -rf "${outdir}"
+popd >/dev/null
+mv "${tmpdir}/docs/html" "${outdir}"


### PR DESCRIPTION
This will only work on PRs that have the CMakeLists.txt changes included here applied.  At the moment that is just this PR.

There is OSX-specific code in the rendering script that I cannot test.  I will need someone else to do that for me.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
