### PR TITLE
Extend DomainTestHelpers to generic Frames

### DIFF
--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -399,13 +399,12 @@ void test_initial_domain(const Domain<VolumeDim, Frame>& domain,
   test_refinement_levels_of_neighbors<0>(elements);
 }
 
-template <size_t SpatialDim, typename SpatialFrame>
-tnsr::i<DataVector, SpatialDim, SpatialFrame> euclidean_basis_vector(
+template <size_t SpatialDim, typename Fr>
+tnsr::i<DataVector, SpatialDim, Fr> euclidean_basis_vector(
     const Direction<SpatialDim>& direction,
     const DataVector& used_for_size) noexcept {
   auto basis_vector =
-      make_with_value<tnsr::i<DataVector, SpatialDim, SpatialFrame>>(
-          used_for_size, 0.0);
+      make_with_value<tnsr::i<DataVector, SpatialDim, Fr>>(used_for_size, 0.0);
 
   basis_vector.get(direction.axis()) =
       make_with_value<DataVector>(used_for_size, direction.sign());

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -19,10 +19,12 @@
 #include "Domain/InitialElementIds.hpp"
 #include "Domain/Neighbors.hpp"  // IWYU pragma: keep
 #include "Domain/OrientationMap.hpp"
+#include "Domain/Side.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -60,9 +62,9 @@ bool is_a_neighbor_of_my_neighbor_me(
   return 1 == number_of_matches;
 }
 
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename Fr>
 void test_domain_connectivity(
-    const Domain<VolumeDim, Frame::Inertial>& domain,
+    const Domain<VolumeDim, Fr>& domain,
     const std::unordered_map<ElementId<VolumeDim>, Element<VolumeDim>>&
         elements_in_domain) noexcept {
   boost::rational<size_t> volume_of_elements{0};
@@ -327,16 +329,16 @@ double physical_separation(
 }
 }  // namespace
 
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename Fr>
 void test_domain_construction(
-    const Domain<VolumeDim, Frame::Inertial>& domain,
+    const Domain<VolumeDim, Fr>& domain,
     const std::vector<
         std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
-    const std::vector<std::unique_ptr<
-        CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>&
+    const std::vector<
+        std::unique_ptr<CoordinateMapBase<Frame::Logical, Fr, VolumeDim>>>&
         expected_maps) noexcept {
   const auto& blocks = domain.blocks();
   CHECK(blocks.size() == expected_external_boundaries.size());
@@ -380,8 +382,8 @@ boost::rational<size_t> fraction_of_block_volume(
   return {1, two_to_the(sum_of_refinement_levels)};
 }
 
-template <size_t VolumeDim>
-void test_initial_domain(const Domain<VolumeDim, Frame::Inertial>& domain,
+template <size_t VolumeDim, typename Frame>
+void test_initial_domain(const Domain<VolumeDim, Frame>& domain,
                          const std::vector<std::array<size_t, VolumeDim>>&
                              initial_refinement_levels) noexcept {
   const auto element_ids = initial_element_ids(initial_refinement_levels);
@@ -415,25 +417,25 @@ tnsr::i<DataVector, SpatialDim, SpatialFrame> euclidean_basis_vector(
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATE1(_, data)                                                  \
+#define INSTANTIATE1(_, data)                                \
+  template boost::rational<size_t> fraction_of_block_volume( \
+      const ElementId<DIM(data)>& element_id) noexcept;
+
+#define INSTANTIATE2(_, data)                                                  \
   template void test_domain_construction<DIM(data)>(                           \
-      const Domain<DIM(data), Frame::Inertial>& domain,                        \
+      const Domain<DIM(data), FRAME(data)>& domain,                            \
       const std::vector<                                                       \
           std::unordered_map<Direction<DIM(data)>, BlockNeighbor<DIM(data)>>>& \
           expected_block_neighbors,                                            \
       const std::vector<std::unordered_set<Direction<DIM(data)>>>&             \
           expected_external_boundaries,                                        \
       const std::vector<std::unique_ptr<                                       \
-          CoordinateMapBase<Frame::Logical, Frame::Inertial, DIM(data)>>>&     \
+          CoordinateMapBase<Frame::Logical, FRAME(data), DIM(data)>>>&         \
           expected_maps) noexcept;                                             \
-  template boost::rational<size_t> fraction_of_block_volume(                   \
-      const ElementId<DIM(data)>& element_id) noexcept;                        \
   template void test_initial_domain(                                           \
-      const Domain<DIM(data), Frame::Inertial>& domain,                        \
+      const Domain<DIM(data), FRAME(data)>& domain,                            \
       const std::vector<std::array<size_t, DIM(data)>>&                        \
-          initial_refinement_levels) noexcept;
-
-#define INSTANTIATE2(_, data)                                                  \
+          initial_refinement_levels) noexcept;                                 \
   template void test_physical_separation(                                      \
       const std::vector<Block<DIM(data), FRAME(data)>>& blocks) noexcept;      \
   template tnsr::i<DataVector, DIM(data), FRAME(data)> euclidean_basis_vector( \

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -12,10 +12,6 @@
 #include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Domain/Side.hpp"
-#include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeArray.hpp"
 
 /// \cond
 template <size_t VolumeDim, typename TargetFrame>
@@ -34,22 +30,22 @@ class ElementId;
 /// \endcond
 
 // Test that the Blocks in the Domain are constructed correctly.
-template <size_t VolumeDim>
+template <size_t VolumeDim, typename Fr = Frame::Inertial>
 void test_domain_construction(
-    const Domain<VolumeDim, Frame::Inertial>& domain,
+    const Domain<VolumeDim, Fr>& domain,
     const std::vector<
         std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
-    const std::vector<std::unique_ptr<
-        CoordinateMapBase<Frame::Logical, Frame::Inertial, VolumeDim>>>&
+    const std::vector<
+        std::unique_ptr<CoordinateMapBase<Frame::Logical, Fr, VolumeDim>>>&
         expected_maps) noexcept;
 
 // Test that two neighboring Blocks abut each other.
-template <size_t VolumeDim, typename TargetFrame>
+template <size_t VolumeDim, typename Fr = Frame::Inertial>
 void test_physical_separation(
-    const std::vector<Block<VolumeDim, TargetFrame>>& blocks) noexcept;
+    const std::vector<Block<VolumeDim, Fr>>& blocks) noexcept;
 
 // Fraction of the logical volume of a block covered by an element
 // The sum of this over all the elements of a block should be one
@@ -60,8 +56,8 @@ boost::rational<size_t> fraction_of_block_volume(
 // Test that the Elements of the initial domain are connected and cover the
 // computational domain, as well as that neighboring Elements  are at the same
 // refinement level.
-template <size_t VolumeDim>
-void test_initial_domain(const Domain<VolumeDim, Frame::Inertial>& domain,
+template <size_t VolumeDim, typename Fr = Frame::Inertial>
+void test_initial_domain(const Domain<VolumeDim, Fr>& domain,
                          const std::vector<std::array<size_t, VolumeDim>>&
                              initial_refinement_levels) noexcept;
 

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -62,7 +62,7 @@ void test_initial_domain(const Domain<VolumeDim, Fr>& domain,
                              initial_refinement_levels) noexcept;
 
 // Euclidean basis vector along the given `Direction` and in the given `Frame`.
-template <size_t SpatialDim, typename SpatialFrame = Frame::Inertial>
-tnsr::i<DataVector, SpatialDim, SpatialFrame> euclidean_basis_vector(
+template <size_t SpatialDim, typename Fr = Frame::Inertial>
+tnsr::i<DataVector, SpatialDim, Fr> euclidean_basis_vector(
     const Direction<SpatialDim>& direction,
     const DataVector& used_for_size) noexcept;


### PR DESCRIPTION
## Proposed changes

DomainTestHelpers currently hard-codes Frame::Inertial into its tests.
As BinaryCompactObject will have Frame::Grid we need to extend DomainTestHelpers.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
