### PR TITLE
Block

### DIFF
--- a/src/DataStructures/IdPair.hpp
+++ b/src/DataStructures/IdPair.hpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+#include <type_traits>
+#include <utility>
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief A data structure that contains an ID and data associated with that ID.
+ */
+template <typename IdType, typename DataType>
+struct IdPair {
+  IdType id;
+  DataType data;
+};
+
+template <typename IdType, typename DataType>
+IdPair<std::decay_t<IdType>, std::decay_t<DataType>> make_id_pair(
+    IdType&& id, DataType&& data) noexcept {
+  return {std::forward<IdType>(id), std::forward<DataType>(data)};
+}
+
+/// \cond
+// We write the pup function as a free function to keep IdPair a POD
+// clang-tidy: no non-const references
+template <typename IdType, typename DataType>
+void pup(PUP::er& p, IdPair<IdType, DataType>& t) noexcept {  // NOLINT
+  p | t.id;
+  p | t.data;
+}
+
+// clang-tidy: no non-const references
+template <typename IdType, typename DataType>
+void operator|(PUP::er& p, IdPair<IdType, DataType>& t) noexcept {  // NOLINT
+  pup(p, t);
+}
+
+template <typename IdType, typename DataType>
+bool operator==(const IdPair<IdType, DataType>& lhs,
+                const IdPair<IdType, DataType>& rhs) noexcept {
+  return lhs.id == rhs.id and lhs.data == rhs.data;
+}
+
+template <typename IdType, typename DataType>
+bool operator!=(const IdPair<IdType, DataType>& lhs,
+                const IdPair<IdType, DataType>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+/// \endcond

--- a/src/Domain/BlockId.hpp
+++ b/src/Domain/BlockId.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <ostream>
+#include <pup.h>
+
+namespace PUP {
+class er;
+}  // namespace PUP
+
+namespace domain {
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief Index a block of the computational domain.
+ */
+class BlockId {
+ public:
+  BlockId() = default;
+  explicit BlockId(size_t id) noexcept : id_(id) {}
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept { p | id_; }
+
+  size_t get_index() const noexcept { return id_; }
+
+  BlockId& operator++() noexcept {
+    ++id_;
+    return *this;
+  }
+
+  BlockId& operator--() noexcept {
+    --id_;
+    return *this;
+  }
+
+  // NOLINTNEXTLINE(cert-dcl21-cpp) returned object doesn't need to be const
+  BlockId operator++(int) noexcept {
+    BlockId temp = *this;
+    id_++;
+    return temp;
+  }
+
+  // NOLINTNEXTLINE(cert-dcl21-cpp) returned object doesn't need to be const
+  BlockId operator--(int) noexcept {
+    BlockId temp = *this;
+    id_--;
+    return temp;
+  }
+
+ private:
+
+  size_t id_{0};
+};
+
+inline bool operator==(const BlockId& lhs, const BlockId& rhs) noexcept {
+  return lhs.get_index() == rhs.get_index();
+}
+
+inline bool operator!=(const BlockId& lhs, const BlockId& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const BlockId& block_id) {
+  return os << '[' << block_id.get_index() << ']';
+}
+
+}  // namespace domain

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_DenseMatrix.cpp
   Test_DenseVector.cpp
   Test_GeneralIndexIterator.cpp
+  Test_IdPair.cpp
   Test_Index.cpp
   Test_IndexIterator.cpp
   Test_OrientVariablesOnSlice.cpp

--- a/tests/Unit/DataStructures/Test_IdPair.cpp
+++ b/tests/Unit/DataStructures/Test_IdPair.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <vector>
+
+#include "DataStructures/IdPair.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.IdPair",
+                  "[Unit][DataStructures]") {
+  auto id_pair = make_id_pair(5, std::vector<double>{1.2, 7.8});
+  static_assert(cpp17::is_same_v<decltype(id_pair.id), int>,
+                "Failed checking type decay in make_id_pair");
+  static_assert(cpp17::is_same_v<decltype(id_pair.data), std::vector<double>>,
+                "Failed checking type decay in make_id_pair");
+  CHECK(id_pair.id == 5);
+  CHECK(id_pair.data == std::vector<double>{1.2, 7.8});
+  CHECK(id_pair == make_id_pair(5, std::vector<double>{1.2, 7.8}));
+  CHECK(id_pair != make_id_pair(6, std::vector<double>{1.2, 7.8}));
+  CHECK(id_pair != make_id_pair(5, std::vector<double>{1.3, 7.8}));
+  CHECK(id_pair != make_id_pair(7, std::vector<double>{1.3, 7.8}));
+
+  // Test PUP
+  test_serialization(id_pair);
+}

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Domain")
 set(LIBRARY_SOURCES
   DomainTestHelpers.cpp
   Test_Block.cpp
+  Test_BlockId.cpp
   Test_BlockNeighbor.cpp
   Test_CoordinatesTag.cpp
   Test_CreateInitialElement.cpp

--- a/tests/Unit/Domain/Test_BlockId.cpp
+++ b/tests/Unit/Domain/Test_BlockId.cpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "Domain/BlockId.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.BlockId", "[Domain][Unit]") {
+  domain::BlockId id{10};
+  CHECK(id.get_index() == 10);
+  CHECK(id == domain::BlockId{10});
+  CHECK(id != domain::BlockId{7});
+  CHECK(get_output(id) == "[10]");
+  CHECK(id++ == domain::BlockId{10});
+  CHECK(id == domain::BlockId{11});
+  CHECK(id-- == domain::BlockId{11});
+  CHECK(id == domain::BlockId{10});
+  CHECK(&id == &(++id));
+  CHECK(id == domain::BlockId{11});
+  CHECK(&id == &(--id));
+  CHECK(id == domain::BlockId{10});
+
+  // Test PUP
+  test_serialization(id);
+}


### PR DESCRIPTION
## Proposed changes

- Add `BlockId` class to index Blocks. @gsb76 could you tell me what other operations you need for these? I expect `operator<`, etc. What else? I'd like to eventually be able to get rid of the `get_index` method.
- Add `IdPair` which is a POD that should be used when a pair between an ID and some data is necessary. The access is easier to understand because it is `id_pair.id` and `id_pair.data`.
- ~Add `BlockVector` that is a vector indexed by a `BlockId`.~

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
