### PR TITLE
Fix and update RotatedRectangles

### DIFF
--- a/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/DomainCreators/RegisterDerivedWithCharm.cpp
@@ -46,9 +46,9 @@ template <>
 void register_with_charm<2>() {
   PUPable_reg(
       SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D>));
-  PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D,
-                                 CoordinateMaps::DiscreteRotation<2>>));
+  PUPable_reg(SINGLE_ARG(
+      ::CoordinateMap<Frame::Logical, Frame::Inertial,
+                      CoordinateMaps::DiscreteRotation<2>, Affine2D>));
   PUPable_reg(SINGLE_ARG(
       ::CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular2D>));
   PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,

--- a/src/Domain/DomainCreators/RotatedRectangles.hpp
+++ b/src/Domain/DomainCreators/RotatedRectangles.hpp
@@ -6,11 +6,8 @@
 #include <array>
 #include <cstddef>
 #include <limits>
-#include <memory>
-#include <pup.h>
 #include <vector>
 
-#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
@@ -22,12 +19,15 @@ namespace DomainCreators {
 /// Create a 2D Domain consisting of four rotated Blocks.
 /// - The lower left block has its logical \f$\xi\f$-axis aligned with
 /// the grid x-axis.
-/// - The upper left block has its logical \f$\xi\f$-axis opposite to
-/// the grid x-axis.
-/// - The lower right block has its logical \f$\xi\f$-axis aligned with
-/// the grid y-axis.
-/// - The upper right block has its logical \f$\xi\f$-axis opposite to
-/// the grid y-axis.
+///
+/// - The lower right block is rotated a half-turn (180 degrees) relative to the
+/// lower left block.
+///
+/// - The upper left block is rotated a quarter-turn counterclockwise
+/// (+90 degrees) relative to the lower left block.
+//
+/// - The upper right block is rotated a quarter-turn clockwise
+/// (-90 degrees) relative to the lower left block.
 ///
 /// This DomainCreator is useful for testing code that deals with
 /// unaligned blocks.

--- a/tests/Unit/Domain/DomainCreators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_RotatedRectangles.cpp
@@ -62,20 +62,19 @@ void test_rotated_rectangles_construction(
           Affine2D(lower_x_map, lower_y_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          Affine2D(lower_x_map, upper_y_map),
           DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
-              {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}}}));
+              {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}}},
+          Affine2D(upper_x_map, lower_y_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          Affine2D(upper_x_map, lower_y_map),
           DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
-              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}}));
+              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}},
+          Affine2D(lower_x_map, upper_y_map)));
   coord_maps.emplace_back(
       make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          Affine2D(upper_x_map, upper_y_map),
           DiscreteRotation2D{OrientationMap<2>{std::array<Direction<2>, 2>{
-              {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}}));
-
+              {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}}},
+          Affine2D(upper_x_map, upper_y_map)));
   test_domain_construction(domain, expected_block_neighbors,
                            expected_external_boundaries, coord_maps);
   test_initial_domain(domain, rotated_rectangles.initial_refinement_levels());
@@ -85,11 +84,11 @@ void test_rotated_rectangles_construction(
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles",
                   "[Domain][Unit]") {
   const std::vector<std::array<size_t, 2>> grid_points{
-      {{4, 2}}, {{4, 3}}, {{2, 1}}, {{3, 1}}},
+      {{4, 2}}, {{1, 2}}, {{3, 4}}, {{3, 1}}},
       refinement_level{{{0, 1}}, {{0, 1}}, {{1, 0}}, {{1, 0}}};
   const std::array<double, 2> lower_bound{{-1.2, -2.0}}, midpoint{{-0.6, 0.2}},
       upper_bound{{0.8, 3.0}};
-  const OrientationMap<2> flipped{std::array<Direction<2>, 2>{
+  const OrientationMap<2> half_turn{std::array<Direction<2>, 2>{
       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}};
   const OrientationMap<2> quarter_turn_cw{std::array<Direction<2>, 2>{
       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}};
@@ -101,30 +100,31 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles",
       midpoint,
       upper_bound,
       {{refinement_level[0][0], refinement_level[0][1]}},
-      {{{{grid_points[0][0], grid_points[2][1]}},
-        {{grid_points[0][1], grid_points[1][1]}}}}};
+      {{{{grid_points[0][0], grid_points[1][0]}},
+        {{grid_points[0][1], grid_points[2][0]}}}}};
   test_rotated_rectangles_construction(
       rotated_rectangles, lower_bound, midpoint, upper_bound, grid_points,
       refinement_level,
       std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
-          {{Direction<2>::upper_xi(), {2, quarter_turn_ccw}},
-           {Direction<2>::upper_eta(), {1, flipped}}},
-          {{Direction<2>::lower_xi(), {3, quarter_turn_ccw}},
-           {Direction<2>::upper_eta(), {0, flipped}}},
-          {{Direction<2>::upper_xi(), {3, flipped}},
-           {Direction<2>::upper_eta(), {0, quarter_turn_cw}}},
-          {{Direction<2>::upper_xi(), {2, flipped}},
-           {Direction<2>::lower_eta(), {1, quarter_turn_cw}}}},
+          {{Direction<2>::upper_xi(), {1, half_turn}},
+           {Direction<2>::upper_eta(), {2, quarter_turn_ccw}}},
+          {{Direction<2>::upper_xi(), {0, half_turn}},
+           {Direction<2>::lower_eta(), {3, quarter_turn_ccw}}},
+          {{Direction<2>::lower_xi(), {0, quarter_turn_cw}},
+           {Direction<2>::lower_eta(), {3, half_turn}}},
+          {{Direction<2>::upper_xi(), {1, quarter_turn_cw}},
+           {Direction<2>::lower_eta(), {2, half_turn}}}},
       std::vector<std::unordered_set<Direction<2>>>{
           {Direction<2>::lower_xi(), Direction<2>::lower_eta()},
-          {Direction<2>::upper_xi(), Direction<2>::lower_eta()},
-          {Direction<2>::lower_xi(), Direction<2>::lower_eta()},
+          {Direction<2>::lower_xi(), Direction<2>::upper_eta()},
+          {Direction<2>::upper_xi(), Direction<2>::upper_eta()},
           {Direction<2>::lower_xi(), Direction<2>::upper_eta()}});
+  test_physical_separation(rotated_rectangles.create_domain().blocks());
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles.Factory",
                   "[Domain][Unit]") {
-  const OrientationMap<2> flipped{std::array<Direction<2>, 2>{
+  const OrientationMap<2> half_turn{std::array<Direction<2>, 2>{
       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}};
   const OrientationMap<2> quarter_turn_cw{std::array<Direction<2>, 2>{
       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}};
@@ -144,20 +144,20 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles.Factory",
           domain_creator.get());
   test_rotated_rectangles_construction(
       *rotated_rectangles_creator, {{0.1, -0.4}}, {{2.6, 3.2}}, {{5.1, 6.2}},
-      {{{3, 1}}, {{3, 4}}, {{1, 2}}, {{4, 2}}},
+      {{{3, 1}}, {{2, 1}}, {{4, 3}}, {{4, 2}}},
       {{{2, 1}}, {{2, 1}}, {{1, 2}}, {{1, 2}}},
       std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
-          {{Direction<2>::upper_xi(), {2, quarter_turn_ccw}},
-           {Direction<2>::upper_eta(), {1, flipped}}},
-          {{Direction<2>::lower_xi(), {3, quarter_turn_ccw}},
-           {Direction<2>::upper_eta(), {0, flipped}}},
-          {{Direction<2>::upper_xi(), {3, flipped}},
-           {Direction<2>::upper_eta(), {0, quarter_turn_cw}}},
-          {{Direction<2>::upper_xi(), {2, flipped}},
-           {Direction<2>::lower_eta(), {1, quarter_turn_cw}}}},
+          {{Direction<2>::upper_xi(), {1, half_turn}},
+           {Direction<2>::upper_eta(), {2, quarter_turn_ccw}}},
+          {{Direction<2>::upper_xi(), {0, half_turn}},
+           {Direction<2>::lower_eta(), {3, quarter_turn_ccw}}},
+          {{Direction<2>::lower_xi(), {0, quarter_turn_cw}},
+           {Direction<2>::lower_eta(), {3, half_turn}}},
+          {{Direction<2>::upper_xi(), {1, quarter_turn_cw}},
+           {Direction<2>::lower_eta(), {2, half_turn}}}},
       std::vector<std::unordered_set<Direction<2>>>{
           {Direction<2>::lower_xi(), Direction<2>::lower_eta()},
-          {Direction<2>::upper_xi(), Direction<2>::lower_eta()},
-          {Direction<2>::lower_xi(), Direction<2>::lower_eta()},
+          {Direction<2>::lower_xi(), Direction<2>::upper_eta()},
+          {Direction<2>::upper_xi(), Direction<2>::upper_eta()},
           {Direction<2>::lower_xi(), Direction<2>::upper_eta()}});
 }


### PR DESCRIPTION
Add test_physical_separation to Test_RotatedRectangles
to ensure elements are non-overlapping.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
