### PR TITLE
Disable libxsmm in DEBUG mode

### DIFF
--- a/src/Utilities/Blas.hpp
+++ b/src/Utilities/Blas.hpp
@@ -9,7 +9,9 @@
 
 #pragma once
 
+#ifndef SPECTRE_DEBUG
 #include <libxsmm.h>
+#endif  // ifndef SPECTRE_DEBUG
 
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
@@ -103,6 +105,9 @@ inline void dgemm_(const char& TRANSA, const char& TRANSB, const size_t& M,
       gsl::narrow_cast<int>(LDB), BETA, C, gsl::narrow_cast<int>(LDC));
 }
 
+// libxsmm is disabled in DEBUG builds because backtraces (from, for
+// example, FPEs) do not work when the error occurs in libxsmm code.
+#ifndef SPECTRE_DEBUG
 template <>
 inline void dgemm_<true>(const char& TRANSA, const char& TRANSB,
                          const size_t& M, const size_t& N, const size_t& K,
@@ -123,6 +128,7 @@ inline void dgemm_<true>(const char& TRANSA, const char& TRANSB,
   libxsmm_dgemm(&TRANSA, &TRANSB, &m, &n, &k, &ALPHA, A, &lda, B, &ldb, &BETA,
                 C, &ldc);
 }
+#endif  // ifndef SPECTRE_DEBUG
 // @}
 
 // @{


### PR DESCRIPTION
Errors triggered within libxsmm (such as FPEs from passing NaNs in the
input arrays) produce no backtrace, even when run in a debugger.  This
is probably related to its use of JIT compilation.

Since libxsmm is just a performance optimization over BLAS, disabling
it in unoptimized builds should not cause any problems.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
