### PR TITLE
Add conjugate gradient linear solver

### DIFF
--- a/cmake/SetupClangTidy.cmake
+++ b/cmake/SetupClangTidy.cmake
@@ -34,6 +34,7 @@ elseif(CMAKE_CXX_CLANG_TIDY)
 endif()
 
 if (CLANG_TIDY_BIN)
+  message(STATUS "clang-tidy: ${CLANG_TIDY_BIN}")
   set(MODULES_TO_DEPEND_ON
     module_RunTests
     module_ConstGlobalCache
@@ -92,4 +93,6 @@ if (CLANG_TIDY_BIN)
     clang-tidy-hash
     ${MODULES_TO_DEPEND_ON}
   )
+else()
+  message(STATUS "clang-tidy: Not using clang or couldn't find clang-tidy.")
 endif()

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -391,7 +391,14 @@
 
 /*!
  * \defgroup EllipticSystemsGroup Elliptic Systems
- * \brief Contains the namespaces of all the available elliptic systems.
+ * \brief All available elliptic systems and information on how to implement
+ * elliptic systems
+ *
+ * \details Actions and parallel components may require an elliptic system to
+ * expose the following types:
+ *
+ * - `fields_tag`: A \ref DataBoxGroup tag that represents the fields being
+ * solved for.
  */
 
 /*!

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp"
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp"
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace LinearSolver {
+
+/*!
+ * \ingroup LinearSolverGroup
+ * \brief A conjugate gradient solver for linear systems of equations \f$Ax=b\f$
+ * where the operator \f$A\f$ is symmetric.
+ *
+ * \details The only operation we need to supply to the algorithm is the
+ * result of the operation \f$A(p)\f$ (see \ref LinearSolverGroup) that in the
+ * case of the conjugate gradient algorithm must be symmetric. Each invocation
+ * of the `perform_step` action expects that \f$A(p)\f$ has been computed in a
+ * preceding action and stored in the DataBox as
+ * %db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
+ * db::add_tag_prefix<LinearSolver::Tags::Operand, typename
+ * Metavariables::system::fields_tag>>.
+ *
+ * Note that the operand \f$p\f$ for which \f$A(p)\f$ needs to be computed is
+ * not the field \f$x\f$ we are solving for but
+ * `db::add_tag_prefix<LinearSolver::Tags::Operand, typename
+ * Metavariables::system::fields_tag>`. This field is initially set to the
+ * residual \f$r = b - A(x_0)\f$ where \f$x_0\f$ is the initial value of the
+ * `Metavariables::system::fields_tag`.
+ *
+ * When the `perform_step` action is invoked after the operator action
+ * \f$A(p)\f$ has been computed and stored in the DataBox, the conjugate
+ * gradient algorithm implemented here will converge the field \f$x\f$ towards
+ * the solution and update the operand \f$p\f$ in the process. This requires
+ * two reductions over all elements that are received by a `ResidualMonitor`
+ * singleton parallel component, processed, and then broadcast back to all
+ * elements. The actions are implemented in the `cg_detail` namespace and
+ * constitute the full algorithm in the following order:
+ * 1. `PerformStep` (on elements): Compute the inner product \f$\langle p,
+ * A(p)\rangle\f$ and reduce.
+ * 2. `ComputeAlpha` (on `ResidualMonitor`): Compute
+ * \f$\alpha=\frac{r^2}{\langle p, A(p)\rangle}\f$ and broadcast.
+ * 3. `UpdateFieldValues` (on elements): Update \f$x\f$ and \f$r\f$, then
+ * compute the inner product \f$\langle r, r\rangle\f$ and reduce to find the
+ * new \f$r^2\f$.
+ * 4. `UpdateResidual` (on `ResidualMonitor`): Store the new \f$r^2\f$ and
+ * broadcast the ratio of the new and old \f$r^2\f$, as well as a termination
+ * flag if the residual vanishes to a precision determined by
+ * `equal_within_roundoff`.
+ * 5. `UpdateOperand` (on elements): Update \f$p\f$. Stop if termination flag
+ * was received.
+ */
+template <typename Metavariables>
+struct ConjugateGradient {
+  /*!
+   * \brief The parallel components used by the conjugate gradient linear solver
+   *
+   * Uses:
+   * - System:
+   *   * `fields_tag`
+   */
+  using component_list = tmpl::list<cg_detail::ResidualMonitor<Metavariables>>;
+
+  /*!
+   * \brief Initialize the tags used by the conjugate gradient linear solver
+   *
+   * Uses:
+   * - System:
+   *   * `fields_tag`
+   * - ConstGlobalCache: nothing
+   *
+   * With:
+   * - `operand_tag` =
+   * `db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>`
+   * - `operator_tag` =
+   * `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>`
+   * - `residual_tag` =
+   * `db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>`
+   *
+   * DataBox changes:
+   * - Adds:
+   *   * `LinearSolver::Tags::IterationId`
+   *   * `Tags::Next<LinearSolver::Tags::IterationId>`
+   *   * `operand_tag`
+   *   * `operator_tag`
+   *   * `residual_tag`
+   * - Removes: nothing
+   * - Modifies: nothing
+   */
+  using tags = cg_detail::InitializeElement<Metavariables>;
+
+  /*!
+   * \brief Perform an iteration of the conjugate gradient linear solver
+   *
+   * Uses:
+   * - System:
+   *   * `fields_tag`
+   * - ConstGlobalCache: nothing
+   *
+   * With:
+   * - `operand_tag` =
+   * `db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>`
+   * - `residual_tag` =
+   * `db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>`
+   *
+   * DataBox changes:
+   * - Adds: nothing
+   * - Removes: nothing
+   * - Modifies:
+   *   * `LinearSolver::Tags::IterationId`
+   *   * `Tags::Next<LinearSolver::Tags::IterationId>`
+   *   * `fields_tag`
+   *   * `residual_tag`
+   *   * `operand_tag`
+   */
+  using perform_step = cg_detail::PerformStep;
+};
+
+}  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp
@@ -1,0 +1,171 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp"
+#include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+
+/// \cond
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+namespace LinearSolver {
+namespace cg_detail {
+template <typename>
+struct ResidualMonitor;
+}  // namespace cg_detail
+}  // namespace LinearSolver
+/// \endcond
+
+namespace LinearSolver {
+namespace cg_detail {
+
+struct PerformStep {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index, const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using fields_tag = typename Metavariables::system::fields_tag;
+    using operand_tag =
+        db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+    using operator_tag =
+        db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>;
+
+    // At this point Ap must have been computed in a previous action
+    // We compute the inner product <p,p> w.r.t A. This requires a global
+    // reduction.
+    const double local_conj_grad_inner_product =
+        inner_product(get<operand_tag>(box), get<operator_tag>(box));
+
+    Parallel::contribute_to_reduction<ComputeAlpha<ParallelComponent>>(
+        Parallel::ReductionData<
+            Parallel::ReductionDatum<double, funcl::Plus<>>>{
+            local_conj_grad_inner_product},
+        Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
+        Parallel::get_parallel_component<ResidualMonitor<Metavariables>>(
+            cache));
+
+    // Terminate algorithm for now. The reduction will be broadcasted to the
+    // next action which is responsible for restarting the algorithm.
+    return std::tuple<db::DataBox<DbTagsList>&&, bool>(std::move(box), true);
+  }
+};
+
+struct UpdateFieldValues {
+  template <
+      typename... DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<tmpl2::flat_any_v<cpp17::is_same_v<
+          typename Metavariables::system::fields_tag, DbTags>...>> = nullptr>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index, const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const double alpha) noexcept {
+    using fields_tag = typename Metavariables::system::fields_tag;
+    using operand_tag =
+        db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+    using operator_tag =
+        db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>;
+    using residual_tag =
+        db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
+
+    // Received global reduction result, proceed with conjugate gradient.
+    db::mutate<residual_tag, fields_tag>(
+        make_not_null(&box),
+        [alpha](const gsl::not_null<db::item_type<residual_tag>*> r,
+                const gsl::not_null<db::item_type<fields_tag>*> x,
+                const db::item_type<operand_tag>& p,
+                const db::item_type<operator_tag>& Ap) noexcept {
+          *x += alpha * p;
+          *r -= alpha * Ap;
+        },
+        get<operand_tag>(box), get<operator_tag>(box));
+
+    // Compute new residual norm in a second global reduction
+    const auto& r = get<residual_tag>(box);
+    const double local_residual_magnitude_square = inner_product(r, r);
+
+    Parallel::contribute_to_reduction<UpdateResidual<ParallelComponent>>(
+        Parallel::ReductionData<
+            Parallel::ReductionDatum<double, funcl::Plus<>>>{
+            local_residual_magnitude_square},
+        Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
+        Parallel::get_parallel_component<ResidualMonitor<Metavariables>>(
+            cache));
+  }
+};
+
+struct UpdateOperand {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl2::flat_any_v<cpp17::is_same_v<
+                db::add_tag_prefix<LinearSolver::Tags::Operand,
+                                   typename Metavariables::system::fields_tag>,
+                DbTags>...>> = nullptr>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index, const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const double res_ratio, const bool terminate) noexcept {
+    using fields_tag = typename Metavariables::system::fields_tag;
+    using operand_tag =
+        db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+    using residual_tag =
+        db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
+
+    // Prepare conjugate gradient for next iteration
+    db::mutate<operand_tag>(
+        make_not_null(&box),
+        [res_ratio](const gsl::not_null<db::item_type<operand_tag>*> p,
+                    const db::item_type<residual_tag>& r) noexcept {
+          *p = r + res_ratio * *p;
+        },
+        get<residual_tag>(box));
+
+    // Increment iteration id
+    db::mutate<LinearSolver::Tags::IterationId,
+               ::Tags::Next<LinearSolver::Tags::IterationId>>(
+        make_not_null(&box), [](const gsl::not_null<IterationId*> iteration_id,
+                                const gsl::not_null<IterationId*>
+                                    next_iteration_id) noexcept {
+          iteration_id->step_number++;
+          next_iteration_id->step_number = iteration_id->step_number + 1;
+        });
+
+    // Terminate when the residual vanishes to machine precision
+    // We use `ckLocal()` here since this is essentially retrieving "self",
+    // which is guaranteed to be on the local processor. This ensures the calls
+    // are evaluated in order.
+    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
+        .ckLocal()
+        ->set_terminate(terminate);
+    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
+        .perform_algorithm();
+  }
+};
+
+}  // namespace cg_detail
+}  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/// \cond
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+namespace LinearSolver {
+namespace cg_detail {
+template <typename>
+struct ResidualMonitor;
+struct InitializeResidual;
+}  // namespace cg_detail
+}  // namespace LinearSolver
+/// \endcond
+
+namespace LinearSolver {
+namespace cg_detail {
+
+template <typename Metavariables>
+struct InitializeElement {
+ private:
+  using fields_tag = typename Metavariables::system::fields_tag;
+  using operand_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
+  using operator_tag =
+      db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>;
+  using residual_tag =
+      db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
+
+ public:
+  using simple_tags =
+      db::AddSimpleTags<LinearSolver::Tags::IterationId,
+                        ::Tags::Next<LinearSolver::Tags::IterationId>,
+                        operand_tag, operator_tag, residual_tag>;
+  using compute_tags = db::AddComputeTags<>;
+
+  template <typename TagsList, typename ArrayIndex, typename ParallelComponent>
+  static auto initialize(
+      db::DataBox<TagsList>&& box,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ParallelComponent* const /*meta*/,
+      const db::item_type<db::add_tag_prefix<::Tags::Source, fields_tag>>& b,
+      const db::item_type<db::add_tag_prefix<
+          LinearSolver::Tags::OperatorAppliedTo, fields_tag>>& Ax) noexcept {
+    LinearSolver::IterationId iteration_id{0};
+    LinearSolver::IterationId next_iteration_id{1};
+
+    db::item_type<operand_tag> p = b - Ax;
+    auto r = db::item_type<residual_tag>(p);
+    auto Ap = make_with_value<db::item_type<operator_tag>>(
+        b, std::numeric_limits<double>::signaling_NaN());
+
+    // Perform global reduction to compute initial residual magnitude square for
+    // residual monitor
+    Parallel::contribute_to_reduction<cg_detail::InitializeResidual>(
+        Parallel::ReductionData<
+            Parallel::ReductionDatum<double, funcl::Plus<>>>{
+            inner_product(r, r)},
+        Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
+        Parallel::get_parallel_component<ResidualMonitor<Metavariables>>(
+            cache));
+
+    return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+        std::move(box), iteration_id, next_iteration_id, std::move(p),
+        std::move(Ap), std::move(r));
+  }
+};
+
+}  // namespace cg_detail
+}  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "AlgorithmSingleton.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Informer/Tags.hpp"
+#include "Informer/Verbosity.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+
+/// \cond
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+namespace LinearSolver {
+namespace cg_detail {
+template <typename>
+struct InitializeResidualMonitor;
+}  // namespace cg_detail
+}  // namespace LinearSolver
+/// \endcond
+
+namespace LinearSolver {
+namespace cg_detail {
+
+template <typename Metavariables>
+struct ResidualMonitor {
+  struct Verbosity {
+    using type = ::Verbosity;
+    static constexpr OptionString help = {"Verbosity"};
+    static type default_value() { return ::Verbosity::Quiet; }
+  };
+
+  using chare_type = Parallel::Algorithms::Singleton;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using options = tmpl::list<Verbosity>;
+  using metavariables = Metavariables;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<tmpl::append<
+      typename InitializeResidualMonitor<Metavariables>::simple_tags,
+      typename InitializeResidualMonitor<Metavariables>::compute_tags>>;
+
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+      ::Verbosity verbosity) noexcept {
+    Parallel::simple_action<InitializeResidualMonitor<Metavariables>>(
+        Parallel::get_parallel_component<ResidualMonitor>(
+            *(global_cache.ckLocalBranch())),
+        verbosity);
+  }
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase /*next_phase*/,
+      const Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*global_cache*/) noexcept {}
+};
+
+template <typename Metavariables>
+struct InitializeResidualMonitor {
+ private:
+  using fields_tag = typename Metavariables::system::fields_tag;
+  using residual_square_tag =
+      db::add_tag_prefix<LinearSolver::Tags::ResidualMagnitudeSquare,
+                         fields_tag>;
+
+ public:
+  using simple_tags =
+      db::AddSimpleTags<::Tags::Verbosity, ::LinearSolver::Tags::IterationId,
+                        residual_square_tag>;
+  using compute_tags = db::AddComputeTags<>;
+
+  template <typename... InboxTags, typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    ::Verbosity verbosity) noexcept {
+    auto box = db::create<simple_tags, compute_tags>(
+        verbosity, LinearSolver::IterationId{0},
+        std::numeric_limits<double>::signaling_NaN());
+    return std::make_tuple(std::move(box));
+  }
+};
+
+}  // namespace cg_detail
+}  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "Informer/Tags.hpp"
+#include "Informer/Verbosity.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/Requires.hpp"
+
+/// \cond
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+namespace LinearSolver {
+namespace cg_detail {
+struct UpdateFieldValues;
+struct UpdateOperand;
+}  // namespace cg_detail
+}  // namespace LinearSolver
+/// \endcond
+
+namespace LinearSolver {
+namespace cg_detail {
+
+struct InitializeResidual {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl2::flat_any_v<cpp17::is_same_v<
+                db::add_tag_prefix<LinearSolver::Tags::ResidualMagnitudeSquare,
+                                   typename Metavariables::system::fields_tag>,
+                DbTags>...>> = nullptr>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const double res_new) noexcept {
+    using fields_tag = typename Metavariables::system::fields_tag;
+    using residual_square_tag =
+        db::add_tag_prefix<LinearSolver::Tags::ResidualMagnitudeSquare,
+                           fields_tag>;
+
+    db::mutate<residual_square_tag>(
+        make_not_null(&box), [res_new](const gsl::not_null<double*>
+                                           res_old) noexcept {
+          *res_old = res_new;
+        });
+  }
+};
+
+template <typename BroadcastTarget>
+struct ComputeAlpha {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl2::flat_any_v<cpp17::is_same_v<
+                db::add_tag_prefix<LinearSolver::Tags::ResidualMagnitudeSquare,
+                                   typename Metavariables::system::fields_tag>,
+                DbTags>...>> = nullptr>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const double conj_grad_inner_product) noexcept {
+    using fields_tag = typename Metavariables::system::fields_tag;
+    using residual_square_tag =
+        db::add_tag_prefix<LinearSolver::Tags::ResidualMagnitudeSquare,
+                           fields_tag>;
+
+    Parallel::simple_action<UpdateFieldValues>(
+        Parallel::get_parallel_component<BroadcastTarget>(cache),
+        get<residual_square_tag>(box) / conj_grad_inner_product);
+  }
+};
+
+template <typename BroadcastTarget>
+struct UpdateResidual {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl2::flat_any_v<cpp17::is_same_v<
+                db::add_tag_prefix<LinearSolver::Tags::ResidualMagnitudeSquare,
+                                   typename Metavariables::system::fields_tag>,
+                DbTags>...>> = nullptr>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const double res_new) noexcept {
+    using fields_tag = typename Metavariables::system::fields_tag;
+    using residual_square_tag =
+        db::add_tag_prefix<LinearSolver::Tags::ResidualMagnitudeSquare,
+                           fields_tag>;
+
+    const double residual = sqrt(res_new);
+    const double res_ratio = res_new / get<residual_square_tag>(box);
+
+    if (static_cast<int>(get<::Tags::Verbosity>(box)) >=
+        static_cast<int>(::Verbosity::Verbose)) {
+      Parallel::printf(
+          "Linear solver iteration %d done. Remaining residual: %e\n",
+          get<LinearSolver::Tags::IterationId>(box).step_number + 1, residual);
+    }
+
+    db::mutate<residual_square_tag, LinearSolver::Tags::IterationId>(
+        make_not_null(&box), [res_new](const gsl::not_null<double*> res_old,
+                                       const gsl::not_null<IterationId*>
+                                           iteration_id) noexcept {
+          *res_old = res_new;
+          iteration_id->step_number++;
+        });
+
+    Parallel::simple_action<UpdateOperand>(
+        Parallel::get_parallel_component<BroadcastTarget>(cache), res_ratio,
+        equal_within_roundoff(residual, 0.));
+  }
+};
+
+}  // namespace cg_detail
+}  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Tags.hpp
@@ -16,10 +16,14 @@
  * \brief Functionality for solving linear systems of equations
  */
 namespace LinearSolver {
-namespace Tags {
 
 /*!
  * \ingroup LinearSolverGroup
+ * \brief The \ref DataBoxGroup tags associated with the linear solver
+ */
+namespace Tags {
+
+/*!
  * \brief Holds an `IterationId` that identifies a step in the linear solver
  * algorithm
  */
@@ -29,7 +33,6 @@ struct IterationId : db::SimpleTag {
 };
 
 /*!
- * \ingroup LinearSolverGroup
  * \brief The operand that the local linear operator \f$A\f$ is applied to
  *
  * \details The result of the operation should be wrapped in
@@ -45,7 +48,6 @@ struct Operand : db::PrefixTag, db::SimpleTag {
 };
 
 /*!
- * \ingroup LinearSolverGroup
  * \brief The linear operator \f$A\f$ applied to the data in `Tag`
  */
 template <typename Tag>
@@ -58,7 +60,6 @@ struct OperatorAppliedTo : db::PrefixTag, db::SimpleTag {
 };
 
 /*!
- * \ingroup LinearSolverGroup
  * \brief The residual \f$r=b - Ax\f$
  */
 template <typename Tag>
@@ -71,7 +72,6 @@ struct Residual : db::PrefixTag, db::SimpleTag {
 };
 
 /*!
- * \ingroup LinearSolverGroup
  * \brief The magnitude square of the residual \f$\langle r,r\rangle\f$ w.r.t.
  * the `LinearSolver::inner_product`
  */

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -205,6 +205,10 @@ class MockDistributedObject {
   void set_terminate(bool t) { terminate_ = t; }
   bool get_terminate() { return terminate_; }
 
+  // Actions may call this, but since tests step through actions manually it has
+  // no effect.
+  void perform_algorithm() noexcept {}
+
   template <typename BoxType>
   BoxType& get_databox() noexcept {
     return boost::get<BoxType>(box_);
@@ -592,6 +596,12 @@ class MockArrayElementProxy {
   void threaded_action() noexcept {
     local_algorithm_.template threaded_action<Action>();
   }
+
+  void set_terminate(bool t) noexcept { local_algorithm_.set_terminate(t); }
+
+  // Actions may call this, but since tests step through actions manually it has
+  // no effect.
+  void perform_algorithm() noexcept {}
 
   MockDistributedObject<Component>* ckLocal() { return &local_algorithm_; }
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -9,6 +9,8 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
+add_subdirectory(ConjugateGradient)
+
 add_test_library(
   ${LIBRARY}
   "NumericalAlgorithms/LinearSolver/"

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
@@ -1,0 +1,60 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_ConjugateGradient")
+
+set(LIBRARY_SOURCES
+  Test_ElementActions.cpp
+  Test_ResidualMonitorActions.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "NumericalAlgorithms/LinearSolver/ConjugateGradient"
+  "${LIBRARY_SOURCES}"
+  "DataStructures;LinearSolver"
+  )
+
+# This code is adapted from Parallel/CMakeLists.txt
+
+function(add_algorithm_test TEST_NAME)
+  set(EXECUTABLE_NAME Test_${TEST_NAME})
+  set(TEST_IDENTIFIER Integration.LinearSolver.${TEST_NAME})
+
+  add_executable(
+    ${EXECUTABLE_NAME}
+    ${EXECUTABLE_NAME}.cpp
+    )
+
+  add_dependencies(
+    ${EXECUTABLE_NAME}
+    module_ConstGlobalCache
+    module_Main
+    )
+
+  target_link_libraries(
+    ${EXECUTABLE_NAME}
+    ErrorHandling
+    Informer
+    DataStructures
+    LinearSolver
+    ${SPECTRE_LIBRARIES}
+    )
+
+  add_dependencies(test-executables ${EXECUTABLE_NAME})
+
+  add_test(
+    NAME "\"${TEST_IDENTIFIER}\""
+    COMMAND ${CMAKE_BINARY_DIR}/bin/${EXECUTABLE_NAME} --input-file ${CMAKE_SOURCE_DIR}/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/${EXECUTABLE_NAME}.input
+    )
+
+  set_tests_properties(
+    "\"${TEST_IDENTIFIER}\""
+    PROPERTIES
+    TIMEOUT 30
+    LABELS "integration"
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+endfunction()
+
+add_algorithm_test("ConjugateGradientAlgorithm")
+add_algorithm_test("DistributedConjugateGradientAlgorithm")

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -1,0 +1,205 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#define CATCH_CONFIG_RUNNER
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "AlgorithmArray.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DenseMatrix.hpp"
+#include "DataStructures/DenseVector.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp"
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"  // IWYU pragma: keep
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Main.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+// IWYU pragma: no_forward_declare db::DataBox
+
+namespace {
+
+// The symbols in this test are chosen to coincide with the pseudocode notation
+// in the [Blaze documentation](https://bitbucket.org/blaze-lib/blaze/wiki/
+// Getting%20Started#!a-complex-example)
+const DenseMatrix<double> A{{4., 1.}, {1., 3.}};  // Must be symmetric.
+const DenseVector<double> b{1., 2.};
+const DenseVector<double> x0{2., 1.};
+const DenseVector<double> expected_result{1. / 11., 7. / 11.};
+
+// This is the vector we want to solve for. Corresponds to the symbol `x` in the
+// notation referenced above.
+struct VectorTag : db::SimpleTag {
+  using type = DenseVector<double>;
+  static std::string name() noexcept { return "VectorTag"; }
+};
+
+struct ComputeOperatorAction {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const int /*array_index*/, const ActionList /*meta*/,
+                    const ParallelComponent* const /*component*/) noexcept {
+    db::mutate<LinearSolver::Tags::OperatorAppliedTo<
+        LinearSolver::Tags::Operand<VectorTag>>>(
+        make_not_null(&box), [](auto Ap, auto p) noexcept { *Ap = A * p; },
+        get<LinearSolver::Tags::Operand<VectorTag>>(box));
+
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+
+// Checks for the correct solution after the algorithm has terminated.
+struct TestResult {
+  template <
+      typename... DbTags, typename... InboxTags, typename Metavariables,
+      typename ActionList, typename ParallelComponent,
+      Requires<tmpl2::flat_any_v<cpp17::is_same_v<VectorTag, DbTags>...>> =
+          nullptr>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const int /*array_index*/, const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const auto& result = get<VectorTag>(box);
+    for (size_t i = 0; i < expected_result.size(); i++) {
+      SPECTRE_PARALLEL_REQUIRE(result[i] == approx(expected_result[i]));
+    }
+  }
+};
+
+struct InitializeElement {
+  template <typename Metavariables>
+  using return_tag_list =
+      tmpl::append<tmpl::list<VectorTag>,
+                   typename Metavariables::linear_solver::tags::simple_tags,
+                   typename Metavariables::linear_solver::tags::compute_tags>;
+
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(
+      const db::DataBox<tmpl::list<>>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const int array_index, const ActionList /*meta*/,
+      const ParallelComponent* const parallel_component_meta) noexcept {
+    auto box = db::create<db::AddSimpleTags<tmpl::list<VectorTag>>>(x0);
+
+    auto linear_solver_box = Metavariables::linear_solver::tags::initialize(
+        std::move(box), cache, array_index, parallel_component_meta, b, A * x0);
+
+    return std::make_tuple(std::move(linear_solver_box));
+  }
+};  // namespace
+
+template <typename Metavariables>
+struct ArrayParallelComponent {
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  // In each step of the algorithm we must provide A(p). The linear solver then
+  // takes care of updating x and p, as well as the internal variables r, its
+  // magnitude and the iteration step number.
+  /// [action_list]
+  using action_list =
+      tmpl::list<ComputeOperatorAction,
+                 typename Metavariables::linear_solver::perform_step>;
+  /// [action_list]
+  using initial_databox = db::compute_databox_type<
+      typename InitializeElement::return_tag_list<Metavariables>>;
+  using options = tmpl::list<>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using array_index = int;
+
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto& array_proxy =
+        Parallel::get_parallel_component<ArrayParallelComponent>(
+            *(global_cache.ckLocalBranch()));
+    array_proxy[0].insert(global_cache, 0);
+    array_proxy.doneInserting();
+
+    Parallel::simple_action<InitializeElement>(array_proxy);
+  }
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto array_proxy = Parallel::get_parallel_component<ArrayParallelComponent>(
+        *(global_cache.ckLocalBranch()));
+    switch (next_phase) {
+      case Metavariables::Phase::PerformConjugateGradient:
+        array_proxy.perform_algorithm();
+        break;
+      case Metavariables::Phase::TestResult:
+        Parallel::simple_action<TestResult>(array_proxy);
+        break;
+      default:
+        break;
+    }
+  }
+};
+
+struct System {
+  using fields_tag = VectorTag;
+};
+
+struct Metavariables {
+  using system = System;
+
+  using linear_solver = LinearSolver::ConjugateGradient<Metavariables>;
+
+  using component_list =
+      tmpl::append<tmpl::list<ArrayParallelComponent<Metavariables>>,
+                   typename linear_solver::component_list>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  static constexpr const char* const help{
+      "Test conjugate gradient linear solver algorithm"};
+  static constexpr bool ignore_unrecognized_command_line_options = false;
+
+  enum class Phase {
+    Initialization,
+    PerformConjugateGradient,
+    TestResult,
+    Exit
+  };
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::PerformConjugateGradient;
+      case Phase::PerformConjugateGradient:
+        return Phase::TestResult;
+      default:
+        return Phase::Exit;
+    }
+  }
+};
+
+}  // namespace
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<Metavariables>;
+
+#include "Parallel/CharmMain.cpp"

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.input
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Verbosity: Verbose

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -1,0 +1,295 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#define CATCH_CONFIG_RUNNER
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "AlgorithmArray.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp"
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+// IWYU pragma: no_forward_declare db::DataBox
+
+namespace {
+
+// This is a sample problem where the operator matrix represents a primal DG
+// discretization of the 1D Poisson operator with an internal penalty flux. The
+// source and solution are sinusoids on the interval [0, Pi].
+constexpr size_t number_of_grid_points = 3;
+constexpr size_t number_of_elements = 2;
+const std::array<Matrix, number_of_elements> operator_matrices{
+    {Matrix{{5.305164769729844, 0.8488263631567751, -0.7427230677621782},
+            {0.8488263631567751, 3.395305452627100, -0.4244131815783875},
+            {-0.7427230677621782, -0.4244131815783875, 3.395305452627100},
+            {0.3183098861837906, -1.273239544735163, -1.909859317102744},
+            {0., 0., -1.273239544735163},
+            {0., 0., 0.3183098861837906}},
+     Matrix{{0.3183098861837906, 0., 0.},
+            {-1.273239544735163, 0., 0.},
+            {-1.909859317102744, -1.273239544735163, 0.3183098861837906},
+            {3.395305452627100, -0.4244131815783875, -0.7427230677621782},
+            {-0.4244131815783875, 3.395305452627100, 0.8488263631567751},
+            {-0.7427230677621782, 0.8488263631567751, 5.305164769729844}}}};
+const std::array<DataVector, number_of_elements> sources{
+    {DataVector{0., 0.740480489693061, 0.2617993877991494},
+     DataVector{0.2617993877991494, 0.740480489693061, 0.}}};
+const std::array<DataVector, number_of_elements> expected_results{
+    {DataVector{-0.03634825103978584, 0.7235793356729763, 0.9928055333486299},
+     DataVector{0.9928055333486298, 0.7235793356729763, -0.03634825103978584}}};
+constexpr double source_magnitude_square = 1.233700550136170;
+
+struct ScalarFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "ScalarField"; }
+};
+
+using VariablesTag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
+using VariablesType = db::item_type<VariablesTag>;
+
+// Here we compute A(p)=sum_elements(A_element(p_element)) in a global reduction
+// and then broadcast the global A(p) back to the elements so that they can
+// extract their A_element(p).
+
+struct CollectAp;
+
+struct ComputeOperatorAction {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const int array_index, const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const auto& A = gsl::at(operator_matrices, array_index);
+    const auto& p =
+        get<db::add_tag_prefix<LinearSolver::Tags::Operand, VariablesTag>>(box);
+
+    VariablesType Ap{number_of_grid_points * number_of_elements};
+    dgemv_('N', A.rows(), A.columns(), 1, A.data(), A.rows(), p.data(), 1, 0,
+           Ap.data(), 1);
+
+    Parallel::contribute_to_reduction<CollectAp>(
+        Parallel::ReductionData<
+            Parallel::ReductionDatum<VariablesType, funcl::Plus<>>>{Ap},
+        Parallel::get_parallel_component<ParallelComponent>(cache)[array_index],
+        Parallel::get_parallel_component<ParallelComponent>(cache));
+
+    // Terminate algorithm for now. The reduction will be broadcasted to the
+    // next action which is responsible for restarting the algorithm.
+    return std::tuple<db::DataBox<DbTagsList>&&, bool>(std::move(box), true);
+  }
+};
+
+struct CollectAp {
+  template <
+      typename... DbTags, typename... InboxTags, typename Metavariables,
+      typename ActionList, typename ParallelComponent,
+      Requires<tmpl2::flat_any_v<cpp17::is_same_v<VariablesTag, DbTags>...>> =
+          nullptr>
+  static auto apply(
+      db::DataBox<tmpl::list<DbTags...>>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const int array_index, const ActionList /*meta*/,
+      const ParallelComponent* const /*component*/,
+      const VariablesType& Ap_global_data) noexcept {
+    // This could be generalized to work on the Variables instead of the
+    // Scalar, but it's only for the purpose of this test.
+    const auto& Ap_global = get<ScalarFieldTag>(Ap_global_data).get();
+    DataVector Ap_local{number_of_grid_points};
+    std::copy(Ap_global.begin() +
+                  array_index * static_cast<int>(number_of_grid_points),
+              Ap_global.begin() +
+                  (array_index + 1) * static_cast<int>(number_of_grid_points),
+              Ap_local.begin());
+    db::mutate<db::add_tag_prefix<
+        LinearSolver::Tags::OperatorAppliedTo,
+        db::add_tag_prefix<LinearSolver::Tags::Operand, ScalarFieldTag>>>(
+        make_not_null(&box), [&Ap_local](auto Ap) noexcept {
+          *Ap = Scalar<DataVector>(Ap_local);
+        });
+    // Proceed with algorithm
+    // We use `ckLocal()` here since this is essentially retrieving "self",
+    // which is guaranteed to be on the local processor. This ensures the calls
+    // are evaluated in order.
+    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
+        .ckLocal()
+        ->set_terminate(false);
+    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
+        .perform_algorithm();
+  }
+};
+
+// Checks for the correct solution after the algorithm has terminated.
+struct TestResult {
+  template <
+      typename... DbTags, typename... InboxTags, typename Metavariables,
+      typename ActionList, typename ParallelComponent,
+      Requires<tmpl2::flat_any_v<cpp17::is_same_v<VariablesTag, DbTags>...>> =
+          nullptr>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const int array_index, const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const auto& result = get<ScalarFieldTag>(box).get();
+    for (size_t i = 0; i < number_of_grid_points; i++) {
+      SPECTRE_PARALLEL_REQUIRE(
+          result[i] == approx(gsl::at(expected_results, array_index)[i]));
+    }
+  }
+};
+
+struct InitializeElement {
+  template <typename Metavariables>
+  using return_tag_list =
+      tmpl::append<tmpl::list<VariablesTag>,
+                   typename Metavariables::linear_solver::tags::simple_tags,
+                   typename Metavariables::linear_solver::tags::compute_tags>;
+
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(
+      const db::DataBox<tmpl::list<>>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const int array_index, const ActionList /*meta*/,
+      const ParallelComponent* const parallel_component_meta) noexcept {
+    auto box = db::create<db::AddSimpleTags<tmpl::list<VariablesTag>>>(
+        VariablesType{number_of_grid_points, 0.});
+
+    auto linear_solver_box = Metavariables::linear_solver::tags::initialize(
+        std::move(box), cache, array_index, parallel_component_meta,
+        gsl::at(sources, array_index),
+        db::item_type<db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
+                                         VariablesTag>>{number_of_grid_points,
+                                                        0.});
+
+    return std::make_tuple(std::move(linear_solver_box));
+  }
+};
+
+template <typename Metavariables>
+struct ArrayParallelComponent {
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  using action_list =
+      tmpl::list<ComputeOperatorAction,
+                 typename Metavariables::linear_solver::perform_step>;
+  using initial_databox = db::compute_databox_type<
+      typename InitializeElement::return_tag_list<Metavariables>>;
+  using options = tmpl::list<>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using array_index = int;
+
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto& array_proxy =
+        Parallel::get_parallel_component<ArrayParallelComponent>(
+            *(global_cache.ckLocalBranch()));
+
+    for (int i = 0, which_proc = 0,
+             number_of_procs = Parallel::number_of_procs();
+         i < int(number_of_elements); i++) {
+      array_proxy[i].insert(global_cache, which_proc);
+      which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+    }
+    array_proxy.doneInserting();
+
+    Parallel::simple_action<InitializeElement>(array_proxy);
+  }
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto array_proxy = Parallel::get_parallel_component<ArrayParallelComponent>(
+        *(global_cache.ckLocalBranch()));
+    switch (next_phase) {
+      case Metavariables::Phase::PerformConjugateGradient:
+        array_proxy.perform_algorithm();
+        break;
+      case Metavariables::Phase::TestResult:
+        Parallel::simple_action<TestResult>(array_proxy);
+        break;
+      default:
+        break;
+    }
+  }
+};
+
+struct System {
+  using fields_tag = VariablesTag;
+};
+
+struct Metavariables {
+  using system = System;
+
+  using linear_solver = LinearSolver::ConjugateGradient<Metavariables>;
+
+  using component_list =
+      tmpl::append<tmpl::list<ArrayParallelComponent<Metavariables>>,
+                   typename linear_solver::component_list>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  static constexpr const char* const help{
+      "Test conjugate gradient linear solver algorithm on multiple elements"};
+  static constexpr bool ignore_unrecognized_command_line_options = false;
+
+  enum class Phase {
+    Initialization,
+    PerformConjugateGradient,
+    TestResult,
+    Exit
+  };
+
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*cache_proxy*/) noexcept {
+    switch (current_phase) {
+      case Phase::Initialization:
+        return Phase::PerformConjugateGradient;
+      case Phase::PerformConjugateGradient:
+        return Phase::TestResult;
+      default:
+        return Phase::Exit;
+    }
+  }
+};
+
+}  // namespace
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<Metavariables>;
+
+#include "Parallel/CharmMain.cpp"

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.input
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Verbosity: Verbose

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ElementActions.cpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DenseVector.hpp"
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ElementActions.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+// IWYU pragma: no_forward_declare db::DataBox
+
+namespace {
+
+struct VectorTag : db::SimpleTag {
+  using type = DenseVector<double>;
+  static std::string name() noexcept { return "VectorTag"; }
+};
+
+using simple_tags =
+    db::AddSimpleTags<VectorTag, LinearSolver::Tags::IterationId,
+                      ::Tags::Next<LinearSolver::Tags::IterationId>,
+                      LinearSolver::Tags::Operand<VectorTag>,
+                      LinearSolver::Tags::Residual<VectorTag>>;
+
+template <typename Metavariables>
+struct ArrayParallelComponent {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<simple_tags>;
+};
+
+struct System {
+  using fields_tag = VectorTag;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<ArrayParallelComponent<Metavariables>>;
+  using system = System;
+  using const_global_cache_tag_list = tmpl::list<>;
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Numerical.LinearSolver.ConjugateGradient.ElementActions",
+    "[Unit][NumericalAlgorithms][LinearSolver][Actions]") {
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<
+          ArrayParallelComponent<Metavariables>>;
+
+  const int self_id{0};
+
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
+      .emplace(self_id, db::create<simple_tags>(DenseVector<double>(3, 0.),
+                                                LinearSolver::IterationId{0},
+                                                LinearSolver::IterationId{0},
+                                                DenseVector<double>(3, 2.),
+                                                DenseVector<double>(3, 1.)));
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
+  const auto get_box = [&runner, &self_id]() -> decltype(auto) {
+    return runner.algorithms<ArrayParallelComponent<Metavariables>>()
+        .at(self_id)
+        .get_databox<db::compute_databox_type<simple_tags>>();
+  };
+  {
+    const auto& box = get_box();
+    CHECK(db::get<LinearSolver::Tags::IterationId>(box).step_number == 0);
+    CHECK(db::get<LinearSolver::Tags::Operand<VectorTag>>(box) ==
+          DenseVector<double>(3, 2.));
+  }
+
+  // Can't test the other element actions because reductions are not yet
+  // supported. The full algorithm is tested in
+  // `Test_ConjugateGradientAlgorithm.cpp` and
+  // `Test_DistributedConjugateGradientAlgorithm.cpp` though.
+
+  SECTION("UpdateOperand") {
+    runner.simple_action<ArrayParallelComponent<Metavariables>,
+                         LinearSolver::cg_detail::UpdateOperand>(self_id, 2.,
+                                                                 false);
+    const auto& box = get_box();
+    CHECK(db::get<LinearSolver::Tags::IterationId>(box).step_number == 1);
+    CHECK(db::get<LinearSolver::Tags::Operand<VectorTag>>(box) ==
+          DenseVector<double>(3, 5.));
+    CHECK_FALSE(runner.algorithms<ArrayParallelComponent<Metavariables>>()
+              .at(self_id)
+              .get_terminate());
+  }
+  SECTION("UpdateOperandAndTerminate") {
+    runner.simple_action<ArrayParallelComponent<Metavariables>,
+                         LinearSolver::cg_detail::UpdateOperand>(self_id, 2.,
+                                                                 true);
+    CHECK(runner.algorithms<ArrayParallelComponent<Metavariables>>()
+              .at(self_id)
+              .get_terminate());
+  }
+}

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -1,0 +1,249 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DenseVector.hpp"
+#include "Informer/Verbosity.hpp"
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp"
+#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+// IWYU pragma: no_forward_declare db::DataBox
+
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+namespace LinearSolver {
+namespace cg_detail {
+struct UpdateFieldValues;
+struct UpdateOperand;
+}  // namespace cg_detail
+}  // namespace LinearSolver
+
+namespace {
+
+struct VectorTag : db::SimpleTag {
+  using type = DenseVector<double>;
+  static std::string name() noexcept { return "VectorTag"; }
+};
+
+struct CheckValueTag : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "CheckValueTag"; }
+};
+
+struct CheckTerminateTag : db::SimpleTag {
+  using type = bool;
+  static std::string name() noexcept { return "CheckTerminateTag"; }
+};
+
+template <typename Metavariables>
+using residual_monitor_tags =
+    tmpl::append<typename LinearSolver::cg_detail::InitializeResidualMonitor<
+                     Metavariables>::simple_tags,
+                 typename LinearSolver::cg_detail::InitializeResidualMonitor<
+                     Metavariables>::compute_tags>;
+
+template <typename Metavariables>
+struct MockResidualMonitor {
+  using metavariables = Metavariables;
+  // We represent the singleton as an array with only one element for the action
+  // testing framework
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox =
+      db::compute_databox_type<residual_monitor_tags<Metavariables>>;
+};
+
+struct MockUpdateFieldValues {
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent, typename ArrayIndex>
+  static void apply(
+      db::DataBox<tmpl::list<CheckValueTag, CheckTerminateTag>>& box,  // NOLINT
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/, const double alpha) noexcept {
+    db::mutate<CheckValueTag>(
+        make_not_null(&box), [alpha](const gsl::not_null<double*>
+                                         value_box) noexcept {
+          *value_box = alpha;
+        });
+  }
+};
+
+struct MockUpdateOperand {
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent, typename ArrayIndex>
+  static void apply(
+      db::DataBox<tmpl::list<CheckValueTag, CheckTerminateTag>>& box,  // NOLINT
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/, const double res_ratio,
+      const bool terminate) noexcept {
+    db::mutate<CheckValueTag, CheckTerminateTag>(
+        make_not_null(&box),
+        [res_ratio, terminate](
+            const gsl::not_null<double*> value_box,
+            const gsl::not_null<bool*> terminate_box) noexcept {
+          *value_box = res_ratio;
+          *terminate_box = terminate;
+        });
+  }
+};
+
+// This is used to receive action calls from the residual monitor
+template <typename Metavariables>
+struct MockElementArray {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox =
+      db::compute_databox_type<tmpl::list<CheckValueTag, CheckTerminateTag>>;
+
+  using replace_these_simple_actions =
+      tmpl::list<LinearSolver::cg_detail::UpdateFieldValues,
+                 LinearSolver::cg_detail::UpdateOperand>;
+  using with_these_simple_actions =
+      tmpl::list<MockUpdateFieldValues, MockUpdateOperand>;
+};
+
+struct System {
+  using fields_tag = VectorTag;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<MockResidualMonitor<Metavariables>,
+                                    MockElementArray<Metavariables>>;
+  using system = System;
+  using const_global_cache_tag_list = tmpl::list<>;
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Numerical.LinearSolver.ConjugateGradient.ResidualMonitorActions",
+    "[Unit][NumericalAlgorithms][LinearSolver][Actions]") {
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+
+  // Setup mock residual monitor
+  using MockSingletonObjectsTag = MockRuntimeSystem::MockDistributedObjectsTag<
+      MockResidualMonitor<Metavariables>>;
+  const int singleton_id{0};
+  tuples::get<MockSingletonObjectsTag>(dist_objects)
+      .emplace(singleton_id,
+               db::create<residual_monitor_tags<Metavariables>>(
+                   Verbosity::Verbose, LinearSolver::IterationId{0},
+                   std::numeric_limits<double>::signaling_NaN()));
+
+  // Setup mock element array
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<
+          MockElementArray<Metavariables>>;
+  const int element_id{0};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
+      .emplace(element_id,
+               db::create<db::AddSimpleTags<CheckValueTag, CheckTerminateTag>>(
+                   std::numeric_limits<double>::signaling_NaN(), false));
+
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
+
+  // DataBox shortcuts
+  const auto get_box = [&runner, &singleton_id]() -> decltype(auto) {
+    return runner.algorithms<MockResidualMonitor<Metavariables>>()
+        .at(singleton_id)
+        .get_databox<
+            db::compute_databox_type<residual_monitor_tags<Metavariables>>>();
+  };
+  const auto get_mock_element_box = [&runner, &element_id]() -> decltype(auto) {
+    return runner.algorithms<MockElementArray<Metavariables>>()
+        .at(element_id)
+        .get_databox<db::compute_databox_type<
+            db::AddSimpleTags<CheckValueTag, CheckTerminateTag>>>();
+  };
+
+  using residual_square_tag =
+      LinearSolver::Tags::ResidualMagnitudeSquare<VectorTag>;
+
+  SECTION("InitializeResidual") {
+    runner.simple_action<MockResidualMonitor<Metavariables>,
+                         LinearSolver::cg_detail::InitializeResidual>(
+        singleton_id, 1.);
+    const auto& box = get_box();
+    CHECK(db::get<residual_square_tag>(box) == 1.);
+    CHECK(db::get<LinearSolver::Tags::IterationId>(box).step_number == 0);
+  }
+
+  SECTION("ComputeAlpha") {
+    runner.simple_action<MockResidualMonitor<Metavariables>,
+                         LinearSolver::cg_detail::InitializeResidual>(
+        singleton_id, 1.);
+    runner.simple_action<
+        MockResidualMonitor<Metavariables>,
+        LinearSolver::cg_detail::ComputeAlpha<MockElementArray<Metavariables>>>(
+        singleton_id, 2.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    const auto& box = get_box();
+    CHECK(db::get<residual_square_tag>(box) == 1.);
+    CHECK(db::get<LinearSolver::Tags::IterationId>(box).step_number == 0);
+    const auto& mock_element_box = get_mock_element_box();
+    CHECK(db::get<CheckValueTag>(mock_element_box) == 0.5);
+  }
+
+  SECTION("UpdateResidual") {
+    runner.simple_action<MockResidualMonitor<Metavariables>,
+                         LinearSolver::cg_detail::InitializeResidual>(
+        singleton_id, 1.);
+    runner.simple_action<MockResidualMonitor<Metavariables>,
+                         LinearSolver::cg_detail::UpdateResidual<
+                             MockElementArray<Metavariables>>>(singleton_id,
+                                                               10.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    const auto& box = get_box();
+    CHECK(db::get<residual_square_tag>(box) == 10.);
+    CHECK(db::get<LinearSolver::Tags::IterationId>(box).step_number == 1);
+    const auto& mock_element_box = get_mock_element_box();
+    CHECK(db::get<CheckValueTag>(mock_element_box) == 10.);
+    CHECK(db::get<CheckTerminateTag>(mock_element_box) == false);
+  }
+
+  SECTION("UpdateResidualAndTerminate") {
+    runner.simple_action<MockResidualMonitor<Metavariables>,
+                         LinearSolver::cg_detail::InitializeResidual>(
+        singleton_id, 1.);
+    runner.simple_action<MockResidualMonitor<Metavariables>,
+                         LinearSolver::cg_detail::UpdateResidual<
+                             MockElementArray<Metavariables>>>(singleton_id,
+                                                               0.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    const auto& box = get_box();
+    CHECK(db::get<residual_square_tag>(box) == 0.);
+    CHECK(db::get<LinearSolver::Tags::IterationId>(box).step_number == 1);
+    const auto& mock_element_box = get_mock_element_box();
+    CHECK(db::get<CheckValueTag>(mock_element_box) == 0.);
+    CHECK(db::get<CheckTerminateTag>(mock_element_box) == true);
+  }
+}


### PR DESCRIPTION
## Proposed changes

This PR adds a first simple linear solver based on our parallel infrastructure, to be used for elliptic systems. It implements the conjugate gradient algorithm with two global reductions per iteration.

Please see `Test_ConjugateGradientAlgorithm.cpp` for documentation. There is also a `Test_DistributedConjugateGradientAlgorithm.cpp` that works with a `Variables` and on multiple elements.

- [x] Depends on #696
- [x] Depends on #857, #854 and #867
- [x] Test individual actions (as far as the action testing framework currently supports it)
- [x] Refactor reductions (#994)
- [x] Use preliminary `Verbosity` functionality

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For instructions on how to perform the CI checks locally refer to the [Dev guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`. Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the [code review guide](https://spectre-code.org/code_review_guide.html).

## Further comments

For reference, this is the example Matlab code for the conjugate gradient algorithm [from Wikipedia](https://en.wikipedia.org/wiki/Conjugate_gradient_method):

```matlab
function [x] = conjgrad(A, b, x)
    r = b - A * x;
    p = r;
    rsold = r' * r;

    for i = 1:length(b)
        Ap = A * p;
        alpha = rsold / (p' * Ap);
        x = x + alpha * p;
        r = r - alpha * Ap;
        rsnew = r' * r;
        if sqrt(rsnew) < 1e-10
              break;
        end
        p = r + (rsnew / rsold) * p;
        rsold = rsnew;
    end
end
```