### PR TITLE
Checked inverse

### DIFF
--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -40,7 +40,12 @@ std::vector<block_logical_coord_holder<Dim>> block_logical_coordinates(
     // the smallest block_id).
     bool found_block = false;
     for (const auto& block : domain.blocks()) {
-      x_logical = block.coordinate_map().inverse(x_frame);
+      const auto inv = block.coordinate_map().inverse(x_frame);
+      if(inv) {
+        x_logical = inv.get();
+      } else {
+        continue; // Not in this block
+      }
       bool is_contained = true;
       for (size_t d = 0; d < Dim; ++d) {
         // Assumes that logical coordinates go from -1 to +1 in each

--- a/src/Domain/CoordinateMaps/Affine.cpp
+++ b/src/Domain/CoordinateMaps/Affine.cpp
@@ -30,11 +30,10 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Affine::operator()(
            length_of_domain_}};
 }
 
-template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, 1> Affine::inverse(
-    const std::array<T, 1>& target_coords) const noexcept {
-  return {{(length_of_domain_ * target_coords[0] - a_ * B_ + b_ * A_) /
-           length_of_range_}};
+boost::optional<std::array<double, 1>> Affine::inverse(
+    const std::array<double, 1>& target_coords) const noexcept {
+  return {{{(length_of_domain_ * target_coords[0] - a_ * B_ + b_ * A_) /
+            length_of_range_}}};
 }
 
 template <typename T>
@@ -80,9 +79,6 @@ bool operator==(const CoordinateMaps::Affine& lhs,
 #define INSTANTIATE(_, data)                                                  \
   template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1> Affine::       \
   operator()(const std::array<DTYPE(data), 1>& source_coords) const noexcept; \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                \
-  Affine::inverse(const std::array<DTYPE(data), 1>& target_coords)            \
-      const noexcept;                                                         \
   template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>  \
   Affine::jacobian(const std::array<DTYPE(data), 1>& source_coords)           \
       const noexcept;                                                         \
@@ -93,7 +89,6 @@ bool operator==(const CoordinateMaps::Affine& lhs,
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
                                       std::reference_wrapper<const double>,
                                       std::reference_wrapper<const DataVector>))
-
 #undef DTYPE
 #undef INSTANTIATE
 /// \endcond

--- a/src/Domain/CoordinateMaps/Affine.hpp
+++ b/src/Domain/CoordinateMaps/Affine.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -47,9 +48,8 @@ class Affine {
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 1> inverse(
-      const std::array<T, 1>& target_coords) const noexcept;
+  boost::optional<std::array<double, 1>> inverse(
+      const std::array<double, 1>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(

--- a/src/Domain/CoordinateMaps/BulgedCube.hpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -473,9 +474,8 @@ class BulgedCube {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 3> inverse(
-      const std::array<T, 3>& target_coords) const noexcept;
+  boost::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(

--- a/src/Domain/CoordinateMaps/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/CubicScale.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
 #include <string>
@@ -43,8 +44,9 @@ class CubicScale {
       const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
       noexcept;
 
+  /// Returns boost::none if the point is outside the range of the map.
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 1> inverse(
+  boost::optional<std::array<tt::remove_cvref_wrap_t<T>, 1>> inverse(
       const std::array<T, 1>& target_coords, double time,
       const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
       noexcept;

--- a/src/Domain/CoordinateMaps/DiscreteRotation.cpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.cpp
@@ -26,10 +26,9 @@ operator()(const std::array<T, VolumeDim>& source_coords) const noexcept {
 }
 
 template <size_t VolumeDim>
-template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, VolumeDim>
+boost::optional<std::array<double, VolumeDim>>
 DiscreteRotation<VolumeDim>::inverse(
-    const std::array<T, VolumeDim>& target_coords) const noexcept {
+    const std::array<double, VolumeDim>& target_coords) const noexcept {
   return discrete_rotation(orientation_.inverse_map(), target_coords);
 }
 
@@ -85,9 +84,6 @@ template class DiscreteRotation<3>;
   template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
   DiscreteRotation<DIM(data)>::operator()(                                     \
       const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept; \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
-  DiscreteRotation<DIM(data)>::inverse(                                        \
-      const std::array<DTYPE(data), DIM(data)>& target_coords) const noexcept; \
   template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
                     Frame::NoFrame>                                            \
   DiscreteRotation<DIM(data)>::jacobian(                                       \

--- a/src/Domain/CoordinateMaps/DiscreteRotation.hpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -43,9 +44,8 @@ class DiscreteRotation {
   std::array<tt::remove_cvref_wrap_t<T>, VolumeDim> operator()(
       const std::array<T, VolumeDim>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, VolumeDim> inverse(
-      const std::array<T, VolumeDim>& target_coords) const noexcept;
+  boost::optional<std::array<double, VolumeDim>> inverse(
+      const std::array<double, VolumeDim>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, VolumeDim, Frame::NoFrame> jacobian(

--- a/src/Domain/CoordinateMaps/EquatorialCompression.hpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
 
@@ -64,9 +65,8 @@ class EquatorialCompression {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 3> inverse(
-      const std::array<T, 3>& target_coords) const noexcept;
+  boost::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
@@ -82,8 +82,7 @@ class EquatorialCompression {
  private:
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 3> angular_distortion(
-      const std::array<T, 3>& coords, double inverse_alpha) const
-      noexcept;
+      const std::array<T, 3>& coords, double inverse_alpha) const noexcept;
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
   angular_distortion_jacobian(const std::array<T, 3>& coords,

--- a/src/Domain/CoordinateMaps/Equiangular.cpp
+++ b/src/Domain/CoordinateMaps/Equiangular.cpp
@@ -39,13 +39,12 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Equiangular::operator()(
                                      (-B_ - A_ + 2.0 * source_coords[0])))}};
 }
 
-template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, 1> Equiangular::inverse(
-    const std::array<T, 1>& target_coords) const noexcept {
-  return {{0.5 * (A_ + B_ +
-                  length_of_domain_over_m_pi_4_ *
-                      atan(one_over_length_of_range_ *
-                           (-a_ - b_ + 2.0 * target_coords[0])))}};
+boost::optional<std::array<double, 1>> Equiangular::inverse(
+    const std::array<double, 1>& target_coords) const noexcept {
+  return {{{0.5 * (A_ + B_ +
+                   length_of_domain_over_m_pi_4_ *
+                       atan(one_over_length_of_range_ *
+                            (-a_ - b_ + 2.0 * target_coords[0])))}}};
 }
 
 template <typename T>
@@ -111,9 +110,6 @@ bool operator==(const CoordinateMaps::Equiangular& lhs,
 #define INSTANTIATE(_, data)                                                  \
   template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1> Equiangular::  \
   operator()(const std::array<DTYPE(data), 1>& source_coords) const noexcept; \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                \
-  Equiangular::inverse(const std::array<DTYPE(data), 1>& target_coords)       \
-      const noexcept;                                                         \
   template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame>  \
   Equiangular::jacobian(const std::array<DTYPE(data), 1>& source_coords)      \
       const noexcept;                                                         \

--- a/src/Domain/CoordinateMaps/Equiangular.hpp
+++ b/src/Domain/CoordinateMaps/Equiangular.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cmath>
 #include <cstddef>
 
@@ -63,9 +64,8 @@ class Equiangular {
   std::array<tt::remove_cvref_wrap_t<T>, 1> operator()(
       const std::array<T, 1>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 1> inverse(
-      const std::array<T, 1>& target_coords) const noexcept;
+  boost::optional<std::array<double, 1>> inverse(
+      const std::array<double, 1>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 1, Frame::NoFrame> jacobian(
@@ -87,7 +87,7 @@ class Equiangular {
   double a_{-1.0};
   double b_{1.0};
   double length_of_domain_over_m_pi_4_{(B_ - A_) / M_PI_4};  // 4(B-A)/\pi
-  double length_of_range_{2.0};                             // b-a
+  double length_of_range_{2.0};                              // b-a
   double m_pi_4_over_length_of_domain_{M_PI_4 / (B_ - A_)};
   double one_over_length_of_range_{0.5};
   // The jacobian for the affine map with the same parameters.

--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
 
@@ -51,9 +52,12 @@ class Frustum {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 3> inverse(
-      const std::array<T, 3>& target_coords) const noexcept;
+  /// Returns boost::none if \f$z\f$ is at or beyond the \f$z\f$-coordinate of
+  /// the apex of the pyramid, tetrahedron, or triangular prism that is
+  /// formed by extending the `Frustum` (for a
+  /// \f$z\f$-oriented `Frustum`).
+  boost::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(

--- a/src/Domain/CoordinateMaps/Identity.cpp
+++ b/src/Domain/CoordinateMaps/Identity.cpp
@@ -42,9 +42,7 @@ Identity<Dim>::inv_jacobian(const std::array<T, Dim>& source_coords) const
 
 template class Identity<1>;
 template class Identity<2>;
-// Identity should only be used in ProductMaps if a particular dimension is
-// unaffected.  So if the largest dim we do is 3, then you should never use
-// Identity<3>
+template class Identity<3>;
 
 // Explicit instantiations
 /// \cond

--- a/src/Domain/CoordinateMaps/Identity.cpp
+++ b/src/Domain/CoordinateMaps/Identity.cpp
@@ -18,10 +18,9 @@ std::array<tt::remove_cvref_wrap_t<T>, Dim> Identity<Dim>::operator()(
 }
 
 template <size_t Dim>
-template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, Dim> Identity<Dim>::inverse(
-    const std::array<T, Dim>& target_coords) const noexcept {
-  return make_array<tt::remove_cvref_wrap_t<T>, Dim>(target_coords);
+boost::optional<std::array<double, Dim>> Identity<Dim>::inverse(
+    const std::array<double, Dim>& target_coords) const noexcept {
+  return make_array<double, Dim>(target_coords);
 }
 
 template <size_t Dim>
@@ -53,9 +52,6 @@ template class Identity<3>;
   template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
   Identity<DIM(data)>::operator()(                                             \
       const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept; \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
-  Identity<DIM(data)>::inverse(                                                \
-      const std::array<DTYPE(data), DIM(data)>& target_coords) const noexcept; \
   template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
                     Frame::NoFrame>                                            \
   Identity<DIM(data)>::jacobian(                                               \

--- a/src/Domain/CoordinateMaps/Identity.hpp
+++ b/src/Domain/CoordinateMaps/Identity.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -36,9 +37,8 @@ class Identity {
   std::array<tt::remove_cvref_wrap_t<T>, Dim> operator()(
       const std::array<T, Dim>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, Dim> inverse(
-      const std::array<T, Dim>& target_coords) const noexcept;
+  boost::optional<std::array<double, Dim>> inverse(
+      const std::array<double, Dim>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, Dim, Frame::NoFrame> jacobian(

--- a/src/Domain/CoordinateMaps/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/Rotation.cpp
@@ -32,13 +32,12 @@ std::array<tt::remove_cvref_wrap_t<T>, 2> Rotation<2>::operator()(
                source_coords[1] * get<1, 1>(rotation_matrix_)}};
 }
 
-template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, 2> Rotation<2>::inverse(
-    const std::array<T, 2>& target_coords) const noexcept {
-  return {{target_coords[0] * get<0, 0>(rotation_matrix_) +
-               target_coords[1] * get<1, 0>(rotation_matrix_),
-           target_coords[0] * get<0, 1>(rotation_matrix_) +
-               target_coords[1] * get<1, 1>(rotation_matrix_)}};
+boost::optional<std::array<double, 2>> Rotation<2>::inverse(
+    const std::array<double, 2>& target_coords) const noexcept {
+  return {{{target_coords[0] * get<0, 0>(rotation_matrix_) +
+                target_coords[1] * get<1, 0>(rotation_matrix_),
+            target_coords[0] * get<0, 1>(rotation_matrix_) +
+                target_coords[1] * get<1, 1>(rotation_matrix_)}}};
 }
 
 template <typename T>
@@ -123,19 +122,18 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> Rotation<3>::operator()(
                source_coords[2] * get<2, 2>(rotation_matrix_)}};
 }
 
-template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, 3> Rotation<3>::inverse(
-    const std::array<T, 3>& target_coords) const noexcept {
+boost::optional<std::array<double, 3>> Rotation<3>::inverse(
+    const std::array<double, 3>& target_coords) const noexcept {
   // Inverse rotation matrix is the same as the transpose.
-  return {{target_coords[0] * get<0, 0>(rotation_matrix_) +
-               target_coords[1] * get<1, 0>(rotation_matrix_) +
-               target_coords[2] * get<2, 0>(rotation_matrix_),
-           target_coords[0] * get<0, 1>(rotation_matrix_) +
-               target_coords[1] * get<1, 1>(rotation_matrix_) +
-               target_coords[2] * get<2, 1>(rotation_matrix_),
-           target_coords[0] * get<0, 2>(rotation_matrix_) +
-               target_coords[1] * get<1, 2>(rotation_matrix_) +
-               target_coords[2] * get<2, 2>(rotation_matrix_)}};
+  return {{{target_coords[0] * get<0, 0>(rotation_matrix_) +
+                target_coords[1] * get<1, 0>(rotation_matrix_) +
+                target_coords[2] * get<2, 0>(rotation_matrix_),
+            target_coords[0] * get<0, 1>(rotation_matrix_) +
+                target_coords[1] * get<1, 1>(rotation_matrix_) +
+                target_coords[2] * get<2, 1>(rotation_matrix_),
+            target_coords[0] * get<0, 2>(rotation_matrix_) +
+                target_coords[1] * get<1, 2>(rotation_matrix_) +
+                target_coords[2] * get<2, 2>(rotation_matrix_)}}};
 }
 
 template <typename T>
@@ -200,9 +198,6 @@ bool operator!=(const Rotation<3>& lhs, const Rotation<3>& rhs) noexcept {
   template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
   Rotation<DIM(data)>::operator()(                                             \
       const std::array<DTYPE(data), DIM(data)>& source_coords) const noexcept; \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data)>         \
-  Rotation<DIM(data)>::inverse(                                                \
-      const std::array<DTYPE(data), DIM(data)>& target_coords) const noexcept; \
   template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, DIM(data),           \
                     Frame::NoFrame>                                            \
   Rotation<DIM(data)>::jacobian(                                               \
@@ -216,7 +211,6 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
                         (double, DataVector,
                          std::reference_wrapper<const double>,
                          std::reference_wrapper<const DataVector>))
-
 #undef DIM
 #undef DTYPE
 #undef INSTANTIATE

--- a/src/Domain/CoordinateMaps/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/Rotation.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
 
@@ -59,9 +60,8 @@ class Rotation<2> {
   std::array<tt::remove_cvref_wrap_t<T>, 2> operator()(
       const std::array<T, 2>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 2> inverse(
-      const std::array<T, 2>& target_coords) const noexcept;
+  boost::optional<std::array<double, 2>> inverse(
+      const std::array<double, 2>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> jacobian(
@@ -131,9 +131,8 @@ class Rotation<3> {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 3> inverse(
-      const std::array<T, 3>& target_coords) const noexcept;
+  boost::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(

--- a/src/Domain/CoordinateMaps/SpecialMobius.hpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
 
@@ -44,6 +45,19 @@ namespace CoordinateMaps {
  * z(1-\mu^2)\\
  * \end{bmatrix}\f]
  *
+ * The inverse map is the same as the forward map with \f$\mu\f$
+ * replaced by \f$-\mu\f$.
+ *
+ * This map is intended to be used only inside the unit sphere.  A
+ * point inside the unit sphere maps to another point inside the unit
+ * sphere. The map can have undesirable behavior at certain points
+ * outside the unit sphere: The map is singular at
+ * \f$(x,y,z) = (1/\mu, 0, 0)\f$ (which is outside the unit sphere
+ * since \f$|\mu| < 1\f$). Moreover, a point on the \f$x\f$-axis
+ * arbitrarily close to the singularity maps to an arbitrarily large
+ * value on the \f$\pm x\f$-axis, where the sign depends on which side
+ * of the singularity the point is on.
+ *
  * A general Mobius transformation is a function on the complex plane, and
  * takes the form \f$ f(z) = \frac{az+b}{cz+d}\f$, where
  * \f$z, a, b, c, d \in \mathbb{C}\f$, and \f$ad-bc\neq 0\f$.
@@ -81,9 +95,9 @@ class SpecialMobius {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 3> inverse(
-      const std::array<T, 3>& target_coords) const noexcept;
+  /// Returns boost::none for target_coords outside the unit sphere.
+  boost::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(

--- a/src/Domain/CoordinateMaps/Translation.cpp
+++ b/src/Domain/CoordinateMaps/Translation.cpp
@@ -23,12 +23,11 @@ std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::operator()(
   return {{source_coords[0] + map_list.at(f_of_t_name_).func(time)[0][0]}};
 }
 
-template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, 1> Translation::inverse(
-    const std::array<T, 1>& target_coords, const double time,
+boost::optional<std::array<double, 1>> Translation::inverse(
+    const std::array<double, 1>& target_coords, const double time,
     const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
     noexcept {
-  return {{target_coords[0] - map_list.at(f_of_t_name_).func(time)[0][0]}};
+  return {{{target_coords[0] - map_list.at(f_of_t_name_).func(time)[0][0]}}};
 }
 
 template <typename T>
@@ -70,11 +69,6 @@ bool operator==(const CoordMapsTimeDependent::Translation& lhs,
   operator()(const std::array<DTYPE(data), 1>& source_coords,                  \
              const double time,                                                \
              const std::unordered_map<std::string, FunctionOfTime&>& map_list) \
-      const noexcept;                                                          \
-  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
-  Translation::inverse(                                                        \
-      const std::array<DTYPE(data), 1>& target_coords, const double time,      \
-      const std::unordered_map<std::string, FunctionOfTime&>& map_list)        \
       const noexcept;                                                          \
   template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 1>                 \
   Translation::frame_velocity(                                                 \

--- a/src/Domain/CoordinateMaps/Translation.hpp
+++ b/src/Domain/CoordinateMaps/Translation.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <string>
 #include <unordered_map>
@@ -36,9 +37,8 @@ class Translation {
       const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
       noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 1> inverse(
-      const std::array<T, 1>& target_coords, double time,
+  boost::optional<std::array<double, 1>> inverse(
+      const std::array<double, 1>& target_coords, double time,
       const std::unordered_map<std::string, FunctionOfTime&>& map_list) const
       noexcept;
 

--- a/src/Domain/CoordinateMaps/Wedge2D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
 
@@ -134,9 +135,9 @@ class Wedge2D {
   std::array<tt::remove_cvref_wrap_t<T>, 2> operator()(
       const std::array<T, 2>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 2> inverse(
-      const std::array<T, 2>& target_coords) const noexcept;
+  /// Returns invalid if \f$x<=0\f$ (for a \f$+x\f$-oriented `Wedge2D`).
+  boost::optional<std::array<double, 2>> inverse(
+      const std::array<double, 2>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 2, Frame::NoFrame> jacobian(

--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <limits>
 
@@ -237,9 +238,16 @@ class Wedge3D {
   std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
       const std::array<T, 3>& source_coords) const noexcept;
 
-  template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 3> inverse(
-      const std::array<T, 3>& target_coords) const noexcept;
+  /// For a \f$+z\f$-oriented `Wedge3D`, returns invalid if \f$z<=0\f$
+  /// or if \f$(x,y,z)\f$ is on or outside the cone defined
+  /// by \f$(x^2/z^2 + y^2/z^2+1)^{1/2} = -S/F\f$, where
+  /// \f$S = \frac{1}{2}(s_1 r_1 - s_0 r_0)\f$ and
+  /// \f$F = \frac{1}{2\sqrt{3}}((1-s_1) r_1 - (1-s_0) r_0)\f$.
+  /// Here \f$s_0,s_1\f$ and \f$r_0,r_1\f$ are the specified sphericities
+  /// and radii of the inner and outer \f$z\f$ surfaces.  The map is singular on
+  /// the cone and on the xy plane.
+  boost::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const noexcept;
 
   template <typename T>
   tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(

--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -65,7 +65,8 @@ class ElementMap {
   template <typename T>
   tnsr::I<T, Dim, Frame::Logical> inverse(
       tnsr::I<T, Dim, TargetFrame> target_point) const noexcept {
-    auto source_point{block_map_->inverse(std::move(target_point))};
+    auto source_point{
+        block_map_->inverse(std::move(target_point)).get()};
     // Apply the affine map to the points
     for (size_t d = 0; d < Dim; ++d) {
       source_point.get(d) =

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -294,6 +294,8 @@ void test_inverse_map(const Map& map,
  * \ingroup TestingFrameworkGroup
  * \brief Given a Map `map`, tests the map functions, including map inverse,
  * jacobian, and inverse jacobian, for a series of points.
+ * These points are chosen in a dim-dimensonal cube of side 2 centered at
+ * the origin.  The map is expected to be valid on the boundaries of the cube.
  */
 template <typename Map>
 void test_suite_for_map_on_unit_cube(const Map& map) {
@@ -329,6 +331,89 @@ void test_suite_for_map_on_unit_cube(const Map& map) {
     test_jacobian(map_to_test, random_point);
     test_inv_jacobian(map_to_test, random_point);
     test_inverse_map(map_to_test, random_point);
+  };
+  test_helper(map);
+  const auto map2 = serialize_and_deserialize(map);
+  check_if_maps_are_equal(
+      make_coordinate_map<Frame::Logical, Frame::Grid>(map),
+      make_coordinate_map<Frame::Logical, Frame::Grid>(map2));
+  test_helper(map2);
+}
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Given a Map `map`, tests the map functions, including map inverse,
+ * jacobian, and inverse jacobian, for a series of points.
+ * These points are chosen in a sphere of radius `radius_of_sphere`, and the
+ * map is expected to be valid on the boundary of that sphere as well as
+ * in its interior.  The flag `include_origin` indicates whether to test the
+ * map at the origin.
+ * This test works only in 3 dimensions.
+ */
+template <typename Map>
+void test_suite_for_map_on_sphere(const Map& map,
+                                  const bool include_origin = true,
+                                  const double radius_of_sphere = 1.0) {
+  static_assert(Map::dim == 3, "Works only for a 3d map");
+
+  // Set up random number generator
+  const auto seed = std::random_device{}();
+  std::mt19937 gen(seed);
+  INFO("seed = " << seed);
+
+  // If we don't include the origin, we want to use some finite inner
+  // boundary so that random points stay away from the origin.
+  // test_jacobian has a dx of 1.e-4 for finite-differencing, so here
+  // we pick a value larger than that.
+  const double inner_bdry = include_origin ? 0.0 : 5.e-3;
+
+  std::uniform_real_distribution<> radius_dis(inner_bdry, radius_of_sphere);
+  std::uniform_real_distribution<> theta_dis(0, M_PI);
+  std::uniform_real_distribution<> phi_dis(0, 2.0 * M_PI);
+
+  const double theta = theta_dis(gen);
+  CAPTURE_PRECISE(theta);
+  const double phi = phi_dis(gen);
+  CAPTURE_PRECISE(phi);
+  const double radius = radius_dis(gen);
+  CAPTURE_PRECISE(radius);
+
+  const std::array<double, 3> random_point{{radius * sin(theta) * cos(phi),
+                                            radius * sin(theta) * sin(phi),
+                                            radius * cos(theta)}};
+
+  const std::array<double, 3> random_bdry_point{
+      {radius_of_sphere * sin(theta) * cos(phi),
+       radius_of_sphere * sin(theta) * sin(phi),
+       radius_of_sphere * cos(theta)}};
+
+  // This point is either the origin or (if include_origin is false)
+  // it is some random point on the inner boundary.
+  const std::array<double, 3> random_inner_bdry_point_or_origin{
+      {inner_bdry * sin(theta) * cos(phi),
+       inner_bdry * sin(theta) * sin(phi),
+       inner_bdry * cos(theta)}};
+
+  const auto test_helper =
+    [&random_bdry_point, &random_inner_bdry_point_or_origin,
+       &random_point ](const auto& map_to_test) noexcept {
+    test_serialization(map_to_test);
+    CHECK_FALSE(map_to_test != map_to_test);
+
+    test_coordinate_map_argument_types(map_to_test,
+                                       random_inner_bdry_point_or_origin);
+    test_jacobian(map_to_test, random_inner_bdry_point_or_origin);
+    test_inv_jacobian(map_to_test, random_inner_bdry_point_or_origin);
+    test_inverse_map(map_to_test, random_inner_bdry_point_or_origin);
+
+    test_coordinate_map_argument_types(map_to_test, random_point);
+    test_jacobian(map_to_test, random_point);
+    test_inv_jacobian(map_to_test, random_point);
+    test_inverse_map(map_to_test, random_point);
+
+    test_jacobian(map_to_test, random_bdry_point);
+    test_inv_jacobian(map_to_test, random_bdry_point);
+    test_inverse_map(map_to_test, random_bdry_point);
   };
   test_helper(map);
   const auto map2 = serialize_and_deserialize(map);

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -296,7 +296,7 @@ void test_inverse_map(const Map& map,
  * jacobian, and inverse jacobian, for a series of points.
  */
 template <typename Map>
-void test_suite_for_map(const Map& map) {
+void test_suite_for_map_on_unit_cube(const Map& map) {
   // Set up random number generator
   const auto seed = std::random_device{}();
   std::mt19937 gen(seed);

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -172,8 +172,8 @@ void test_coordinate_map_argument_types(
     const Args&... args) {
   const auto make_array_data_vector = [](const auto& double_array) noexcept {
     std::array<DataVector, Map::dim> result;
-    std::transform(double_array.begin(), double_array.end(), result.begin(),
-                   [](const double x) noexcept {
+    std::transform(double_array.begin(), double_array.end(),
+                   result.begin(), [](const double x) noexcept {
                      return DataVector{x, x};
                    });
     return result;
@@ -193,17 +193,6 @@ void test_coordinate_map_argument_types(
     CHECK_ITERABLE_APPROX(
         map(add_reference_wrapper(make_array_data_vector(test_point)), args...),
         make_array_data_vector(mapped_point));
-
-    const auto expected = map.inverse(mapped_point, args...);
-    CHECK_ITERABLE_APPROX(
-        map.inverse(add_reference_wrapper(mapped_point), args...), expected);
-    CHECK_ITERABLE_APPROX(
-        map.inverse(make_array_data_vector(mapped_point), args...),
-        make_array_data_vector(expected));
-    CHECK_ITERABLE_APPROX(
-        map.inverse(add_reference_wrapper(make_array_data_vector(mapped_point)),
-                    args...),
-        make_array_data_vector(expected));
   }
 
   // Here, time_args is a const auto& not const Args& because time_args
@@ -287,7 +276,7 @@ void test_coordinate_map_argument_types(
 template <typename Map, typename T>
 void test_inverse_map(const Map& map,
                       const std::array<T, Map::dim>& test_point) {
-  CHECK_ITERABLE_APPROX(test_point, map.inverse(map(test_point)));
+  CHECK_ITERABLE_APPROX(test_point, map.inverse(map(test_point)).get());
 }
 
 /*!

--- a/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <boost/optional.hpp>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
@@ -32,9 +33,9 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Affine", "[Domain][Unit]") {
   CHECK(affine_map(point_B) == point_b);
   CHECK(affine_map(point_xi) == point_x);
 
-  CHECK(affine_map.inverse(point_a) == point_A);
-  CHECK(affine_map.inverse(point_b) == point_B);
-  CHECK(affine_map.inverse(point_x) == point_xi);
+  CHECK(affine_map.inverse(point_a).get() == point_A);
+  CHECK(affine_map.inverse(point_b).get() == point_B);
+  CHECK(affine_map.inverse(point_x).get() == point_xi);
 
   const double inv_jacobian_00 = (xB - xA) / (xb - xa);
 

--- a/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cmath>
 #include <memory>
 #include <pup.h>
@@ -15,7 +16,6 @@
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
-
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Identity",
                   "[Domain][Unit]") {
@@ -46,6 +46,35 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Identity",
   CHECK_FALSE(serialize_and_deserialize(map) != map);
 
   test_coordinate_map_argument_types(map, test_point1);
+}
+
+void test_bulged_cube_fail() {
+  const CoordinateMaps::BulgedCube map(2.0 * sqrt(3.0), 0.5, false);
+
+  // The corners of the mapped cube have coordinates +/- 2 in each
+  // dimension.  If we inverse-map points that are sufficiently
+  // outside of the mapped cube, then the inverse map will fail.
+  const std::array<double, 3> test_mapped_point1{{3.0, 3.0, 3.0}};
+  const std::array<double, 3> test_mapped_point2{{2.0, 2.0, 2.01}};
+  const std::array<double, 3> test_mapped_point3{{4.0, 0.0, 0.0}};
+
+  // These points are outside the mapped BulgedCube. So inverse should either
+  // return the correct inverse (which happens to be computable for
+  // these points) or it should return boost::none.
+  const std::array<double, 3> test_mapped_point4{{2.0, 2.0, 2.0}};
+  const std::array<double, 3> test_mapped_point5{{3.0, 0.0, 0.0}};
+
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point1)));
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point2)));
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point3)));
+  if(map.inverse(test_mapped_point4)) {
+    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point4).get()),
+                          test_mapped_point4);
+  }
+  if(map.inverse(test_mapped_point5)) {
+    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point5).get()),
+                          test_mapped_point5);
+  }
 }
 
 void test_bulged_cube(bool with_equiangular_map) {
@@ -95,8 +124,6 @@ void test_bulged_cube(bool with_equiangular_map) {
   test_inverse_map(map, test_point2);
   test_inverse_map(map, test_point3);
   test_inverse_map(map, test_point4);
-  test_inverse_map(map, test_points);
-  test_inverse_map(map, test_points2);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Bulged.Equiangular",
@@ -107,4 +134,9 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Bulged.Equiangular",
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Bulged.Equidistant",
                   "[Domain][Unit]") {
   test_bulged_cube(false);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Bulged.Fail",
+                  "[Domain][Unit]") {
+  test_bulged_cube_fail();
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cmath>
 #include <cstddef>
 #include <memory>
@@ -87,15 +88,16 @@ void test_single_coordinate_map() {
     CHECK((make_array<double, 1>((*affine1d_base)(
               tnsr::I<double, 1, Frame::Logical>{{{coord[0]}}}))) ==
           first_affine1d(coord));
-    CHECK((make_array<double, 1>(affine1d_base->inverse(
-              tnsr::I<double, 1, Frame::Grid>{{{coord[0]}}}))) ==
-          first_affine1d.inverse(coord));
+    CHECK((make_array<double, 1>(
+              affine1d_base
+                  ->inverse(tnsr::I<double, 1, Frame::Grid>{{{coord[0]}}})
+                  .get())) == first_affine1d.inverse(coord).get());
 
     CHECK((make_array<double, 1>(affine1d(tnsr::I<double, 1, Frame::Logical>{
               {{coord[0]}}}))) == first_affine1d(coord));
-    CHECK((make_array<double, 1>(affine1d.inverse(
-              tnsr::I<double, 1, Frame::Grid>{{{coord[0]}}}))) ==
-          first_affine1d.inverse(coord));
+    CHECK((make_array<double, 1>(
+              affine1d.inverse(tnsr::I<double, 1, Frame::Grid>{{{coord[0]}}})
+                  .get())) == first_affine1d.inverse(coord).get());
 
     const auto jac =
         affine1d.jacobian(tnsr::I<double, 1, Frame::Logical>{{{coord[0]}}});
@@ -132,15 +134,19 @@ void test_single_coordinate_map() {
     CHECK((make_array<double, 2>((*rotated2d_base)(
               tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}}))) ==
           first_rotated2d(coord));
-    CHECK((make_array<double, 2>(rotated2d_base->inverse(
-              tnsr::I<double, 2, Frame::Grid>{{{coord[0], coord[1]}}}))) ==
-          first_rotated2d.inverse(coord));
+    CHECK((make_array<double, 2>(rotated2d_base
+                                     ->inverse(tnsr::I<double, 2, Frame::Grid>{
+                                         {{coord[0], coord[1]}}})
+                                     .get())) ==
+          first_rotated2d.inverse(coord).get());
 
     CHECK((make_array<double, 2>(rotated2d(tnsr::I<double, 2, Frame::Logical>{
               {{coord[0], coord[1]}}}))) == first_rotated2d(coord));
-    CHECK((make_array<double, 2>(rotated2d.inverse(
-              tnsr::I<double, 2, Frame::Grid>{{{coord[0], coord[1]}}}))) ==
-          first_rotated2d.inverse(coord));
+    CHECK((make_array<double, 2>(rotated2d
+                                     .inverse(tnsr::I<double, 2, Frame::Grid>{
+                                         {{coord[0], coord[1]}}})
+                                     .get())) ==
+          first_rotated2d.inverse(coord).get());
 
     const auto jac = rotated2d.jacobian(
         tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}});
@@ -187,17 +193,19 @@ void test_single_coordinate_map() {
     CHECK((make_array<double, 3>((
               *rotated3d_base)(tnsr::I<double, 3, Frame::Logical>{
               {{coord[0], coord[1], coord[2]}}}))) == first_rotated3d(coord));
-    CHECK((make_array<double, 3>(
-              rotated3d_base->inverse(tnsr::I<double, 3, Frame::Grid>{
-                  {{coord[0], coord[1], coord[2]}}}))) ==
-          first_rotated3d.inverse(coord));
+    CHECK((make_array<double, 3>(rotated3d_base
+                                     ->inverse(tnsr::I<double, 3, Frame::Grid>{
+                                         {{coord[0], coord[1], coord[2]}}})
+                                     .get())) ==
+          first_rotated3d.inverse(coord).get());
 
     CHECK((make_array<double, 3>(rotated3d(tnsr::I<double, 3, Frame::Logical>{
               {{coord[0], coord[1], coord[2]}}}))) == first_rotated3d(coord));
-    CHECK((make_array<double, 3>(
-              rotated3d.inverse(tnsr::I<double, 3, Frame::Grid>{
-                  {{coord[0], coord[1], coord[2]}}}))) ==
-          first_rotated3d.inverse(coord));
+    CHECK((make_array<double, 3>(rotated3d
+                                     .inverse(tnsr::I<double, 3, Frame::Grid>{
+                                         {{coord[0], coord[1], coord[2]}}})
+                                     .get())) ==
+          first_rotated3d.inverse(coord).get());
 
     const auto jac = rotated3d.jacobian(
         tnsr::I<double, 3, Frame::Logical>{{{coord[0], coord[1], coord[2]}}});
@@ -240,8 +248,8 @@ void test_coordinate_map_with_affine_map() {
     CHECK((tnsr::I<double, 1, Frame::Grid>(1.0 / i + -0.5))[0] ==
           approx(map(tnsr::I<double, 1, Frame::Logical>{2.0 / i + -1.0})[0]));
     CHECK((tnsr::I<double, 1, Frame::Logical>(2.0 / i + -1.0))[0] ==
-          approx(
-              map.inverse(tnsr::I<double, 1, Frame::Grid>{1.0 / i + -0.5})[0]));
+          approx(map.inverse(tnsr::I<double, 1, Frame::Grid>{1.0 / i + -0.5})
+                     .get()[0]));
 
     CHECK(approx(map.inv_jacobian(
                         tnsr::I<double, 1, Frame::Logical>{2.0 / i + -1.0})
@@ -265,8 +273,10 @@ void test_coordinate_map_with_affine_map() {
     CHECK(get<0>(expected_mapped_point) == approx(get<0>(mapped_point)));
     CHECK(get<1>(expected_mapped_point) == approx(get<1>(mapped_point)));
 
-    const auto inv_mapped_point = prod_map2d.inverse(
-        tnsr::I<double, 2, Frame::Grid>{{{4.0 / i + 2.0, 8.0 / i + 0.0}}});
+    const auto inv_mapped_point = prod_map2d
+                                      .inverse(tnsr::I<double, 2, Frame::Grid>{
+                                          {{4.0 / i + 2.0, 8.0 / i + 0.0}}})
+                                      .get();
     const auto expected_inv_mapped_point =
         tnsr::I<double, 2, Frame::Grid>{{{-1.0 + 2.0 / i, 0.0 + 2.0 / i}}};
     CHECK(get<0>(expected_inv_mapped_point) ==
@@ -308,8 +318,10 @@ void test_coordinate_map_with_affine_map() {
     CHECK(get<2>(expected_mapped_point) == approx(get<2>(mapped_point)));
 
     const auto inv_mapped_point =
-        prod_map3d.inverse(tnsr::I<double, 3, Frame::Grid>{
-            {{4.0 / i + 2.0, 8.0 / i + 0.0, 3.0 + 20.0 / i}}});
+        prod_map3d
+            .inverse(tnsr::I<double, 3, Frame::Grid>{
+                {{4.0 / i + 2.0, 8.0 / i + 0.0, 3.0 + 20.0 / i}}})
+            .get();
     const auto expected_inv_mapped_point = tnsr::I<double, 3, Frame::Grid>{
         {{-1.0 + 2.0 / i, 0.0 + 2.0 / i, 5.0 + 2.0 / i}}};
     CHECK(get<0>(expected_inv_mapped_point) ==
@@ -368,9 +380,11 @@ void test_coordinate_map_with_rotation_map() {
     CHECK((make_array<double, 2>(double_rotated2d(
               tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}}))) ==
           second_rotated2d(first_rotated2d(coord)));
-    CHECK((make_array<double, 2>(double_rotated2d.inverse(
-              tnsr::I<double, 2, Frame::Grid>{{{coord[0], coord[1]}}}))) ==
-          first_rotated2d.inverse(second_rotated2d.inverse(coord)));
+    CHECK((make_array<double, 2>(double_rotated2d
+                                     .inverse(tnsr::I<double, 2, Frame::Grid>{
+                                         {{coord[0], coord[1]}}})
+                                     .get())) ==
+          first_rotated2d.inverse(second_rotated2d.inverse(coord).get()).get());
 
     const auto jac = double_rotated2d.jacobian(
         tnsr::I<double, 2, Frame::Logical>{{{coord[0], coord[1]}}});
@@ -404,10 +418,11 @@ void test_coordinate_map_with_rotation_map() {
               double_rotated3d(tnsr::I<double, 3, Frame::Logical>{
                   {{coord[0], coord[1], coord[2]}}}))) ==
           second_rotated3d(first_rotated3d(coord)));
-    CHECK((make_array<double, 3>(
-              double_rotated3d.inverse(tnsr::I<double, 3, Frame::Grid>{
-                  {{coord[0], coord[1], coord[2]}}}))) ==
-          first_rotated3d.inverse(second_rotated3d.inverse(coord)));
+    CHECK((make_array<double, 3>(double_rotated3d
+                                     .inverse(tnsr::I<double, 3, Frame::Grid>{
+                                         {{coord[0], coord[1], coord[2]}}})
+                                     .get())) ==
+          first_rotated3d.inverse(second_rotated3d.inverse(coord).get()).get());
 
     const auto jac = double_rotated3d.jacobian(
         tnsr::I<double, 3, Frame::Logical>{{{coord[0], coord[1], coord[2]}}});
@@ -449,9 +464,6 @@ void test_coordinate_map_with_rotation_map_datavector() {
 
     CHECK((make_array<DataVector, 2>(double_rotated2d(coords2d))) ==
           second_rotated2d(first_rotated2d(coords2d_array)));
-    CHECK(
-        (make_array<DataVector, 2>(double_rotated2d.inverse(coords2d_grid))) ==
-        first_rotated2d.inverse(second_rotated2d.inverse(coords2d_array)));
 
     const auto jac = double_rotated2d.jacobian(coords2d);
     const auto expected_jac =
@@ -494,9 +506,6 @@ void test_coordinate_map_with_rotation_map_datavector() {
 
     CHECK((make_array<DataVector, 3>(double_rotated3d(coords3d))) ==
           second_rotated3d(first_rotated3d(coords3d_array)));
-    CHECK(
-        (make_array<DataVector, 3>(double_rotated3d.inverse(coords3d_grid))) ==
-        first_rotated3d.inverse(second_rotated3d.inverse(coords3d_array)));
 
     const auto jac = double_rotated3d.jacobian(coords3d);
     const auto expected_jac =

--- a/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
@@ -92,10 +92,10 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation",
                   "[Domain][Unit]") {
   for (OrientationMapIterator<2> map_i{}; map_i; ++map_i) {
     const CoordinateMaps::DiscreteRotation<2> coord_map{map_i()};
-    test_suite_for_map(coord_map);
+    test_suite_for_map_on_unit_cube(coord_map);
   }
   for (OrientationMapIterator<3> map_i{}; map_i; ++map_i) {
     const CoordinateMaps::DiscreteRotation<3> coord_map{map_i()};
-    test_suite_for_map(coord_map);
+    test_suite_for_map_on_unit_cube(coord_map);
   }
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
@@ -24,7 +24,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.EquatorialCompression",
   CAPTURE_PRECISE(aspect_ratio);
   const CoordinateMaps::EquatorialCompression angular_compression_map(
       aspect_ratio);
-  test_suite_for_map(angular_compression_map);
+  test_suite_for_map_on_unit_cube(angular_compression_map);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.EquatorialCompression.Radius",

--- a/tests/Unit/Domain/CoordinateMaps/Test_Equiangular.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Equiangular.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cmath>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -42,12 +43,12 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Equiangular", "[Domain][Unit]") {
   CHECK(equiangular_map(point_r2)[0] ==
         approx(-0.5 + 2.5 * tan(M_PI_4 * (2.0 * r2 - 1.0) / 3.0)));
 
-  CHECK(equiangular_map.inverse(point_a)[0] == approx(point_A[0]));
-  CHECK(equiangular_map.inverse(point_b)[0] == approx(point_B[0]));
-  CHECK(equiangular_map.inverse(point_x)[0] == approx(point_xi[0]));
-  CHECK(equiangular_map.inverse(point_r1)[0] ==
+  CHECK(equiangular_map.inverse(point_a).get()[0] == approx(point_A[0]));
+  CHECK(equiangular_map.inverse(point_b).get()[0] == approx(point_B[0]));
+  CHECK(equiangular_map.inverse(point_x).get()[0] == approx(point_xi[0]));
+  CHECK(equiangular_map.inverse(point_r1).get()[0] ==
         approx(0.5 + 3.0 * atan(0.4 * r1 + 0.2) / M_PI_2));
-  CHECK(equiangular_map.inverse(point_r2)[0] ==
+  CHECK(equiangular_map.inverse(point_r2).get()[0] ==
         approx(0.5 + 3.0 * atan(0.4 * r2 + 0.2) / M_PI_2));
 
   CHECK((get<0, 0>(equiangular_map.inv_jacobian(point_A))) *

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <boost/optional.hpp>
 #include <random>
 
 #include "Domain/CoordinateMaps/Frustum.hpp"
@@ -48,7 +49,37 @@ void test_suite_for_frustum(const bool with_equiangular_map) {
     test_suite_for_map_on_unit_cube(frustum_map);
   }
 }
+
+void test_frustum_fail() noexcept {
+  const std::array<std::array<double, 2>, 4> face_vertices{
+      {{{-2.0, -2.0}}, {{2.0, 2.0}}, {{-4.0, -4.0}}, {{4.0, 4.0}}}};
+  const CoordinateMaps::Frustum map(face_vertices, 2.0, 5.0,
+                                    OrientationMap<3>{});
+
+  // For the choice of params above, any point with z<=-1 should fail.
+  const std::array<double, 3> test_mapped_point1{{3.0, 3.0, -1.0}};
+  const std::array<double, 3> test_mapped_point2{{6.0, -7.0, -1.0}};
+  const std::array<double, 3> test_mapped_point3{{6.0, -7.0, -3.0}};
+
+  // This is outside the mapped frustum, so inverse should either
+  // return the correct inverse (which happens to be computable for
+  // this point) or it should return boost::none.
+  const std::array<double, 3> test_mapped_point4{{0.0, 0.0, 9.0}};
+
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point1)));
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point2)));
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point3)));
+  if(map.inverse(test_mapped_point4)) {
+    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point4).get()),
+                          test_mapped_point4);
+  }
+}
+
 }  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Fail", "[Domain][Unit]") {
+  test_frustum_fail();
+}
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Equidistant",
                   "[Domain][Unit]") {

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -45,7 +45,7 @@ void test_suite_for_frustum(const bool with_equiangular_map) {
          {{upper_x_upper_base, upper_y_upper_base}}}};
     const CoordinateMaps::Frustum frustum_map(face_vertices, -1.0, 2.0, map_i(),
                                               with_equiangular_map);
-    test_suite_for_map(frustum_map);
+    test_suite_for_map_on_unit_cube(frustum_map);
   }
 }
 }  // namespace

--- a/tests/Unit/Domain/CoordinateMaps/Test_Identity.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Identity.cpp
@@ -6,8 +6,8 @@
 #include <array>
 #include <cstddef>
 
-#include "Utilities/MakeArray.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
@@ -17,7 +17,7 @@ void test_identity() {
   const auto xi = make_array<Dim>(1.0);
   const auto x = make_array<Dim>(1.0);
   CHECK(identity_map(xi) == x);
-  CHECK(identity_map.inverse(x) == xi);
+  CHECK(identity_map.inverse(x).get() == xi);
   const auto inv_jac = identity_map.inv_jacobian(xi);
   const auto jac = identity_map.jacobian(xi);
   for (size_t i = 0; i < Dim; ++i) {

--- a/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cmath>
 #include <cstddef>
 
@@ -26,8 +27,8 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Rotation<2>", "[Domain][Unit]") {
   CHECK(half_pi_rotation_map(xi0)[0] == approx(x0[0]));
   CHECK(half_pi_rotation_map(xi0)[1] == approx(x0[1]));
 
-  CHECK(half_pi_rotation_map.inverse(x0)[0] == approx(xi0[0]));
-  CHECK(half_pi_rotation_map.inverse(x0)[1] == approx(xi0[1]));
+  CHECK(half_pi_rotation_map.inverse(x0).get()[0] == approx(xi0[0]));
+  CHECK(half_pi_rotation_map.inverse(x0).get()[1] == approx(xi0[1]));
 
   const std::array<double, 2> xi1{{1.0, 0.0}};
   const std::array<double, 2> x1{{0.0, 1.0}};
@@ -35,8 +36,8 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Rotation<2>", "[Domain][Unit]") {
   CHECK(half_pi_rotation_map(xi1)[0] == approx(x1[0]));
   CHECK(half_pi_rotation_map(xi1)[1] == approx(x1[1]));
 
-  CHECK(half_pi_rotation_map.inverse(x1)[0] == approx(xi1[0]));
-  CHECK(half_pi_rotation_map.inverse(x1)[1] == approx(xi1[1]));
+  CHECK(half_pi_rotation_map.inverse(x1).get()[0] == approx(xi1[0]));
+  CHECK(half_pi_rotation_map.inverse(x1).get()[1] == approx(xi1[1]));
 
   const std::array<double, 2> xi2{{0.0, 1.0}};
   const std::array<double, 2> x2{{-1.0, 0.0}};
@@ -44,8 +45,8 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Rotation<2>", "[Domain][Unit]") {
   CHECK(half_pi_rotation_map(xi2)[0] == approx(x2[0]));
   CHECK(half_pi_rotation_map(xi2)[1] == approx(x2[1]));
 
-  CHECK(half_pi_rotation_map.inverse(x2)[0] == approx(xi2[0]));
-  CHECK(half_pi_rotation_map.inverse(x2)[1] == approx(xi2[1]));
+  CHECK(half_pi_rotation_map.inverse(x2).get()[0] == approx(xi2[0]));
+  CHECK(half_pi_rotation_map.inverse(x2).get()[1] == approx(xi2[1]));
 
   const auto inv_jac = half_pi_rotation_map.inv_jacobian(xi2);
   CHECK((get<0, 0>(inv_jac)) == approx(0.0));
@@ -87,13 +88,13 @@ void test_rotation_3(const CoordinateMaps::Rotation<3>& three_dim_rotation_map,
           approx(gsl::at(eta_hat, i)));
     CHECK(gsl::at(three_dim_rotation_map(zeta), i) ==
           approx(gsl::at(zeta_hat, i)));
-    CHECK(gsl::at(three_dim_rotation_map.inverse(zero_grid), i) ==
+    CHECK(gsl::at(three_dim_rotation_map.inverse(zero_grid).get(), i) ==
           approx(gsl::at(zero_logical, i)));
-    CHECK(gsl::at(three_dim_rotation_map.inverse(xi_hat), i) ==
+    CHECK(gsl::at(three_dim_rotation_map.inverse(xi_hat).get(), i) ==
           approx(gsl::at(xi, i)));
-    CHECK(gsl::at(three_dim_rotation_map.inverse(eta_hat), i) ==
+    CHECK(gsl::at(three_dim_rotation_map.inverse(eta_hat).get(), i) ==
           approx(gsl::at(eta, i)));
-    CHECK(gsl::at(three_dim_rotation_map.inverse(zeta_hat), i) ==
+    CHECK(gsl::at(three_dim_rotation_map.inverse(zeta_hat).get(), i) ==
           approx(gsl::at(zeta, i)));
     CHECK(inv_jac.get(0, i) == approx(gsl::at(xi_hat, i)));
     CHECK(inv_jac.get(1, i) == approx(gsl::at(eta_hat, i)));

--- a/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
@@ -26,7 +26,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius.Suite",
   const double mu = mu_dis(gen);
   CAPTURE_PRECISE(mu);
   const CoordinateMaps::SpecialMobius special_mobius_map(mu);
-  test_suite_for_map(special_mobius_map);
+  test_suite_for_map_on_unit_cube(special_mobius_map);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius.Map",

--- a/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cstddef>
 #include <string>
 #include <unordered_map>
@@ -47,15 +48,16 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.Translation",
 
     CHECK_ITERABLE_APPROX(trans_map(point_xi, t, f_of_t_list),
                           point_xi + trans_x);
-    CHECK_ITERABLE_APPROX(trans_map.inverse(point_xi + trans_x, t, f_of_t_list),
-                          point_xi);
+    CHECK_ITERABLE_APPROX(
+        trans_map.inverse(point_xi + trans_x, t, f_of_t_list).get(), point_xi);
     CHECK_ITERABLE_APPROX(trans_map.frame_velocity(point_xi, t, f_of_t_list),
                           frame_vel);
 
     CHECK_ITERABLE_APPROX(trans_map_deserialized(point_xi, t, f_of_t_list),
                           point_xi + trans_x);
     CHECK_ITERABLE_APPROX(
-        trans_map_deserialized.inverse(point_xi + trans_x, t, f_of_t_list),
+        trans_map_deserialized.inverse(point_xi + trans_x, t, f_of_t_list)
+            .get(),
         point_xi);
     CHECK_ITERABLE_APPROX(trans_map_deserialized.frame_velocity(
                               point_xi + trans_x, t, f_of_t_list),

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -118,7 +118,7 @@ void test_wedge2d_all_orientations(const bool with_equiangular_map) {
   CAPTURE_PRECISE(outer_circularity);
 
   for (OrientationMapIterator<2> map_i{}; map_i; ++map_i) {
-    test_suite_for_map(CoordinateMaps::Wedge2D{
+    test_suite_for_map_on_unit_cube(CoordinateMaps::Wedge2D{
         inner_radius, outer_radius, inner_circularity, outer_circularity,
         map_i(), with_equiangular_map});
   }

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -40,7 +40,7 @@ void test_wedge3d_all_directions(const bool with_equiangular_map) {
       const CoordinateMaps::Wedge3D wedge_map(
           inner_radius, outer_radius, direction, inner_sphericity,
           outer_sphericity, with_equiangular_map, halves);
-      test_suite_for_map(wedge_map);
+      test_suite_for_map_on_unit_cube(wedge_map);
     }
   }
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <boost/optional.hpp>
 #include <cmath>
 #include <random>
 
@@ -233,7 +234,46 @@ void test_wedge3d_random_radii(const bool with_equiangular_map) {
   CHECK(magnitude(map_upper_zeta(random_outer_face)) ==
         approx(random_outer_radius_upper_zeta));
 }
+
+void test_wedge3d_fail() noexcept {
+  const CoordinateMaps::Wedge3D map(0.2, 4.0, OrientationMap<3>{}, 0.0, 1.0,
+                                    true);
+  // Any point with z=0 should fail the inverse map.
+  const std::array<double, 3> test_mapped_point1{{3.0, 3.0, 0.0}};
+  const std::array<double, 3> test_mapped_point2{{-3.0, 3.0, 0.0}};
+
+  // Any point with (x^2+y^2)/z^2 >= 1199 should fail the inverse map.
+  const std::array<double, 3> test_mapped_point3{{sqrt(1198.0), 1.0, 1.0}};
+  const std::array<double, 3> test_mapped_point4{{30.0, sqrt(299.0), 1.0}};
+  const std::array<double, 3> test_mapped_point5{{30.0, sqrt(300.0), 1.0}};
+
+  // These points are outside the mapped wedge. So inverse should either
+  // return the correct inverse (which happens to be computable for
+  // these points) or it should return boost::none.
+  const std::array<double, 3> test_mapped_point6{{30.0, sqrt(298.0), 1.0}};
+  const std::array<double, 3> test_mapped_point7{{2.0, 4.0, 6.0}};
+
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point1)));
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point2)));
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point3)));
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point4)));
+  CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point5)));
+  if(map.inverse(test_mapped_point6)) {
+    Approx my_approx = Approx::custom().epsilon(1.e-10).scale(1.0);
+    CHECK_ITERABLE_CUSTOM_APPROX(map(map.inverse(test_mapped_point6).get()),
+                                 test_mapped_point6, my_approx);
+  }
+  if(map.inverse(test_mapped_point7)) {
+    CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point7).get()),
+                          test_mapped_point7);
+  }
+}
+
 }  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Fail", "[Domain][Unit]") {
+  test_wedge3d_fail();
+}
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map.Equiangular",
                   "[Domain][Unit]") {

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -47,7 +47,7 @@ void test_block() {
   const tnsr::I<double, Dim, Frame::Logical> xi(1.0);
   const tnsr::I<double, Dim, Frame::Grid> x(1.0);
   CHECK(map(xi) == x);
-  CHECK(map.inverse(x) == xi);
+  CHECK(map.inverse(x).get() == xi);
 
   // Test PUP
   test_serialization(block);

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -61,14 +61,10 @@ void test_element_impl(
       composed_map(logical_point_dv);
 
   if (test_inverse) {
-    CHECK(element_map.inverse(inertial_point_dv) ==
-          composed_map.inverse(inertial_point_dv));
     CHECK(element_map.inverse(inertial_point_double) ==
-          composed_map.inverse(inertial_point_double));
-    CHECK(element_map_deserialized.inverse(inertial_point_dv) ==
-          composed_map.inverse(inertial_point_dv));
+          composed_map.inverse(inertial_point_double).get());
     CHECK(element_map_deserialized.inverse(inertial_point_double) ==
-          composed_map.inverse(inertial_point_double));
+          composed_map.inverse(inertial_point_double).get());
   }
 
   CHECK(element_map.inv_jacobian(logical_point_dv) ==


### PR DESCRIPTION
## Proposed changes

The `inverse` function of all CoordinateMaps now returns `boost::optional<...>`, which holds an invalid value if one tries to inverse-map a point that is sufficiently outside the range of the map, especially a point for which the map is singular or not one-to-one.

Instantiations of inverse for DataVectors have been removed, since we don't see a use case (outside of tests) for inverse acting on a DataVector.  Similarly, ElementMap::inverse is no longer used/tested for DataVectors.

This is a breaking change for any code that uses inverse maps.

This is a large PR because it needs to touch all the maps, all the tests for them, and any place that the inverse map is used (the latter is not many).

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
