### PR TITLE
Make test for Ricci more robust

### DIFF
--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Ricci.cpp
@@ -20,7 +20,7 @@ template <size_t Dim, IndexType TypeOfIndex, typename DataType>
 void test_ricci(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
       &gr::ricci_tensor<Dim, Frame::Inertial, TypeOfIndex, DataType>, "GrTests",
-      "ricci_tensor", {{{-10., 10.}}}, used_for_size);
+      "ricci_tensor", {{{-1., 1.}}}, used_for_size);
 }
 }  // namespace
 


### PR DESCRIPTION
Test for Ricci fails on the travis builds often enough to be inconvenient. Chaning to O(1) random numbers seems to fix it.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
