### PR TITLE
Additions for BBH Domain creation 3

### DIFF
--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -131,12 +131,19 @@ auto wedge_coordinate_maps(double inner_radius, double outer_radius,
 
 /// \ingroup ComputationalDomainGroup
 /// These are the ten Frustums used in the DomainCreators for binary compact
-/// objects. The cubes enveloping the two Shells each have a side length of
-/// `length_inner_cube`. The ten frustums also make up a cube of their own,
-/// of side length `length_outer_cube`.
+/// objects. The Frustums partition the volume defined by two bounding
+/// surfaces: The inner surface is the surface of the two joined inner cubes
+/// enveloping the two compact objects, while the outer is the surface of the
+/// outer cube. The cubes enveloping the two Shells each have a side length of
+/// `length_inner_cube`. The outer cube has a side length of
+/// `length_outer_cube`. `origin_preimage` is a parameter
+/// that moves the center of the two joined inner cubes away from the origin
+/// and to `-origin_preimage`.
 template <typename TargetFrame>
-auto frustum_coordinate_maps(double length_inner_cube, double length_outer_cube,
-                             bool use_equiangular_map) noexcept
+auto frustum_coordinate_maps(
+    double length_inner_cube, double length_outer_cube,
+    bool use_equiangular_map,
+    const std::array<double, 3>& origin_preimage = {{0.0, 0.0, 0.0}}) noexcept
     -> std::vector<std::unique_ptr<
         domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
 

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -496,111 +496,170 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.AllFrustumDirections",
   const double lower = 1.7;
   // half of the length of the outer cube in the binary compact object domain:
   const double top = 5.2;
+  const std::array<double, 3> origin_preimage{{0.2, 0.3, -0.1}};
+  const auto displacement1 =
+      discrete_rotation(OrientationMap<3>{}, origin_preimage);
+  const auto displacement2 =
+      discrete_rotation(OrientationMap<3>{}, origin_preimage);
+  const auto displacement3 = discrete_rotation(
+      OrientationMap<3>{std::array<Direction<3>, 3>{
+          {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+           Direction<3>::lower_zeta()}}},
+      origin_preimage);
+  const auto displacement4 = discrete_rotation(
+      OrientationMap<3>{std::array<Direction<3>, 3>{
+          {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+           Direction<3>::lower_zeta()}}},
+      origin_preimage);
+  const auto displacement5 = discrete_rotation(
+      OrientationMap<3>{std::array<Direction<3>, 3>{
+          {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+           Direction<3>::lower_eta()}}},
+      origin_preimage);
+  const auto displacement6 = discrete_rotation(
+      OrientationMap<3>{std::array<Direction<3>, 3>{
+          {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+           Direction<3>::lower_eta()}}},
+      origin_preimage);
+  const auto displacement7 = discrete_rotation(
+      OrientationMap<3>{std::array<Direction<3>, 3>{
+          {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+           Direction<3>::upper_eta()}}},
+      origin_preimage);
+  const auto displacement8 = discrete_rotation(
+      OrientationMap<3>{std::array<Direction<3>, 3>{
+          {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+           Direction<3>::upper_eta()}}},
+      origin_preimage);
+  const auto displacement9 = discrete_rotation(
+      OrientationMap<3>{std::array<Direction<3>, 3>{
+          {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+           Direction<3>::upper_eta()}}},
+      origin_preimage);
+  const auto displacement10 = discrete_rotation(
+      OrientationMap<3>{std::array<Direction<3>, 3>{
+          {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+           Direction<3>::upper_eta()}}},
+      origin_preimage);
+
   for (const bool use_equiangular_map : {true, false}) {
-    const auto expected_coord_maps = make_vector_coordinate_map_base<
-        Frame::Logical, Frame::Inertial>(
-        FrustumMap{{{{{-2.0 * lower, -lower}},
-                     {{0.0, lower}},
-                     {{-top, -top}},
-                     {{0.0, top}}}},
-                   lower,
-                   top,
-                   OrientationMap<3>{},
-                   use_equiangular_map},
-        FrustumMap{{{{{0.0, -lower}},
-                     {{2.0 * lower, lower}},
-                     {{0.0, -top}},
-                     {{top, top}}}},
-                   lower,
-                   top,
-                   OrientationMap<3>{},
-                   use_equiangular_map},
-        FrustumMap{{{{{-2.0 * lower, -lower}},
-                     {{0.0, lower}},
-                     {{-top, -top}},
-                     {{0.0, top}}}},
-                   lower,
-                   top,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                        Direction<3>::lower_zeta()}}},
-                   use_equiangular_map},
-        FrustumMap{{{{{0.0, -lower}},
-                     {{2.0 * lower, lower}},
-                     {{0.0, -top}},
-                     {{top, top}}}},
-                   lower,
-                   top,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                        Direction<3>::lower_zeta()}}},
-                   use_equiangular_map},
-        FrustumMap{{{{{-2.0 * lower, -lower}},
-                     {{0.0, lower}},
-                     {{-top, -top}},
-                     {{0.0, top}}}},
-                   lower,
-                   top,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                        Direction<3>::lower_eta()}}},
-                   use_equiangular_map},
-        FrustumMap{{{{{0.0, -lower}},
-                     {{2.0 * lower, lower}},
-                     {{0.0, -top}},
-                     {{top, top}}}},
-                   lower,
-                   top,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                        Direction<3>::lower_eta()}}},
-                   use_equiangular_map},
-        FrustumMap{{{{{-2.0 * lower, -lower}},
-                     {{0.0, lower}},
-                     {{-top, -top}},
-                     {{0.0, top}}}},
-                   lower,
-                   top,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                        Direction<3>::upper_eta()}}},
-                   use_equiangular_map},
-        FrustumMap{{{{{0.0, -lower}},
-                     {{2.0 * lower, lower}},
-                     {{0.0, -top}},
-                     {{top, top}}}},
-                   lower,
-                   top,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                        Direction<3>::upper_eta()}}},
-                   use_equiangular_map},
-        // Frustum on right half in the +x direction
-        FrustumMap{{{{{-lower, -lower}},
-                     {{lower, lower}},
-                     {{-top, -top}},
-                     {{top, top}}}},
-                   2.0 * lower,
-                   top,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
-                        Direction<3>::upper_eta()}}},
-                   use_equiangular_map},
-        // Frustum on left half in the -x direction
-        FrustumMap{{{{{-lower, -lower}},
-                     {{lower, lower}},
-                     {{-top, -top}},
-                     {{top, top}}}},
-                   2.0 * lower,
-                   top,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
-                        Direction<3>::upper_eta()}}},
-                   use_equiangular_map});
+    const auto expected_coord_maps =
+        make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            FrustumMap{{{{{-2.0 * lower + displacement1[0],
+                           -lower + displacement1[1]}},
+                         {{displacement1[0], lower + displacement1[1]}},
+                         {{-top, -top}},
+                         {{0.0, top}}}},
+                       lower + displacement1[2],
+                       top,
+                       OrientationMap<3>{},
+                       use_equiangular_map},
+            FrustumMap{
+                {{{{displacement2[0], -lower + displacement2[1]}},
+                  {{2.0 * lower + displacement2[0], lower + displacement2[1]}},
+                  {{0.0, -top}},
+                  {{top, top}}}},
+                lower + displacement2[2],
+                top,
+                OrientationMap<3>{},
+                use_equiangular_map},
+            FrustumMap{{{{{-2.0 * lower + displacement3[0],
+                           -lower + displacement3[1]}},
+                         {{displacement3[0], lower + displacement3[1]}},
+                         {{-top, -top}},
+                         {{0.0, top}}}},
+                       lower + displacement3[2],
+                       top,
+                       OrientationMap<3>{std::array<Direction<3>, 3>{
+                           {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                            Direction<3>::lower_zeta()}}},
+                       use_equiangular_map},
+            FrustumMap{
+                {{{{displacement4[0], -lower + displacement4[1]}},
+                  {{2.0 * lower + displacement4[0], lower + displacement4[1]}},
+                  {{0.0, -top}},
+                  {{top, top}}}},
+                lower + displacement4[2],
+                top,
+                OrientationMap<3>{std::array<Direction<3>, 3>{
+                    {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                     Direction<3>::lower_zeta()}}},
+                use_equiangular_map},
+            FrustumMap{
+                {{{{-2.0 * lower + displacement5[0],
+                    -lower + displacement5[1]}},
+                  {{displacement5[0], lower + displacement5[1]}},
+                  {{-top, -top}},
+                  {{0.0, top}}}},
+                lower + displacement5[2],
+                top,
+                OrientationMap<3>{std::array<Direction<3>, 3>{
+                    {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                     Direction<3>::lower_eta()}}},
+                use_equiangular_map},
+            FrustumMap{
+                {{{{displacement6[0], -lower + displacement6[1]}},
+                  {{2.0 * lower + displacement6[0], lower + displacement6[1]}},
+                  {{0.0, -top}},
+                  {{top, top}}}},
+                lower + displacement6[2],
+                top,
+                OrientationMap<3>{std::array<Direction<3>, 3>{
+                    {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                     Direction<3>::lower_eta()}}},
+                use_equiangular_map},
+            FrustumMap{
+                {{{{-2.0 * lower + displacement7[0],
+                    -lower + displacement7[1]}},
+                  {{displacement7[0], lower + displacement7[1]}},
+                  {{-top, -top}},
+                  {{0.0, top}}}},
+                lower + displacement7[2],
+                top,
+                OrientationMap<3>{std::array<Direction<3>, 3>{
+                    {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                     Direction<3>::upper_eta()}}},
+                use_equiangular_map},
+            FrustumMap{
+                {{{{displacement8[0], -lower + displacement8[1]}},
+                  {{2.0 * lower + displacement8[0], lower + displacement8[1]}},
+                  {{0.0, -top}},
+                  {{top, top}}}},
+                lower + displacement8[2],
+                top,
+                OrientationMap<3>{std::array<Direction<3>, 3>{
+                    {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                     Direction<3>::upper_eta()}}},
+                use_equiangular_map},
+            // Frustum on right half in the +x direction
+            FrustumMap{
+                {{{{-lower + displacement9[0], -lower + displacement9[1]}},
+                  {{lower + displacement9[0], lower + displacement9[1]}},
+                  {{-top, -top}},
+                  {{top, top}}}},
+                2.0 * lower + displacement9[2],
+                top,
+                OrientationMap<3>{std::array<Direction<3>, 3>{
+                    {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                     Direction<3>::upper_eta()}}},
+                use_equiangular_map},
+            // Frustum on left half in the -x direction
+            FrustumMap{
+                {{{{-lower + displacement10[0], -lower + displacement10[1]}},
+                  {{lower + displacement10[0], lower + displacement10[1]}},
+                  {{-top, -top}},
+                  {{top, top}}}},
+                2.0 * lower + displacement10[2],
+                top,
+                OrientationMap<3>{std::array<Direction<3>, 3>{
+                    {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                     Direction<3>::upper_eta()}}},
+                use_equiangular_map});
 
     const auto maps = frustum_coordinate_maps<Frame::Inertial>(
-        2.0 * lower, 2.0 * top, use_equiangular_map);
+        2.0 * lower, 2.0 * top, use_equiangular_map, origin_preimage);
     for (size_t i = 0; i < maps.size(); i++) {
+      INFO(i);
       CHECK(*expected_coord_maps[i] == *maps[i]);
     }
   }


### PR DESCRIPTION
## Proposed changes

Currently, in #709, the two central cubes are frozen in place and cannot be moved,
the Frustums are corresponding built around this geometry.

This PR allows for the two central cubes to be moved around and the corresponding Frustums
are constructed. As a result, frustum_coordinate_maps in DomainHelpers needs some updating.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
