### PR TITLE
Add Mesh::slices()

### DIFF
--- a/src/Domain/Mesh.cpp
+++ b/src/Domain/Mesh.cpp
@@ -52,6 +52,15 @@ Mesh<SliceDim> Mesh<Dim>::slice_through(
                         std::move(slice_quadratures));
 }
 
+template <size_t Dim>
+std::array<Mesh<1>, Dim> Mesh<Dim>::slices() const noexcept {
+  std::array<Mesh<1>, Dim> result{};
+  for (size_t d = 0; d < Dim; ++d) {
+    gsl::at(result, d) = Mesh<1>(extents(d), basis(d), quadrature(d));
+  }
+  return result;
+}
+
 /// \cond HIDDEN_SYMBOLS
 template <size_t Dim>
 void Mesh<Dim>::pup(PUP::er& p) noexcept {

--- a/src/Domain/Mesh.hpp
+++ b/src/Domain/Mesh.hpp
@@ -187,6 +187,15 @@ class Mesh {
   Mesh<SliceDim> slice_through(const std::array<size_t, SliceDim>& dims) const
       noexcept;
 
+  /*!
+   * \brief Returns the Meshes representing 1D slices of this Mesh.
+   *
+   * The is the same as the array filled with `slice_through(d)` for
+   * `d` from `0` to `Dim - 1` except in dimension 0 where
+   * `slice_through(d)` is not defined.
+   */
+  std::array<Mesh<1>, Dim> slices() const noexcept;
+
   // clang-tidy: runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 

--- a/tests/Unit/Domain/Test_Mesh.cpp
+++ b/tests/Unit/Domain/Test_Mesh.cpp
@@ -33,6 +33,7 @@ void test_extents_basis_and_quadrature(
     CHECK(mesh.extents(d) == gsl::at(extents, d));
     CHECK(mesh.basis(d) == gsl::at(basis, d));
     CHECK(mesh.quadrature(d) == gsl::at(quadrature, d));
+    CHECK(gsl::at(mesh.slices(), d) == mesh.slice_through(d));
   }
 }
 }  // namespace


### PR DESCRIPTION
Using Mesh::slice_through(d) to iterate over dimensions has turned out
to be unpleasant due to the need for compile-time special casing for
Dim=0 to avoid instantiating a slice through a Mesh<0>.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
