### PR TITLE
Allow finding Charm without CHARM_ROOT being set

### DIFF
--- a/cmake/FindCharm.cmake
+++ b/cmake/FindCharm.cmake
@@ -5,23 +5,11 @@ if (DEFINED ENV{CHARM_ROOT} AND "${CHARM_ROOT}" STREQUAL "")
   set(CHARM_ROOT "$ENV{CHARM_ROOT}")
 endif()
 
-if (NOT EXISTS "${CHARM_ROOT}")
-  if ("${CHARM_ROOT}" STREQUAL "")
-    message(
-        FATAL_ERROR "CHARM_ROOT was not set. Pass it as a command-line arg: "
-        "cmake -D CHARM_ROOT=/path/to/charm++/build-dir")
-  endif()
-  message(
-      FATAL_ERROR "CHARM_ROOT=${CHARM_ROOT} does not exist. "
-      "Please pass it as a command-line definition to cmake, i.e. "
-      "cmake -D CHARM_ROOT=/path/to/charm++/build-dir"
-  )
-endif ()
-
 find_path(
     CHARM_INCLUDE_DIRS charm.h
     PATH_SUFFIXES include
     HINTS ${CHARM_ROOT}
+    DOC "Charm include directory. Used CHARM_ROOT to set a search dir."
 )
 
 if (EXISTS "${CHARM_INCLUDE_DIRS}/VERSION")


### PR DESCRIPTION
## Proposed changes

This PR suggests removing the requirement that `cmake` is passed a `-D CHARM_ROOT` argument, or that an environment variable of the same name exists. Indeed, with the changes of this PR (just removing the `FATAL_ERROR`s) cmake runs fine e.g. on Minerva with no `-D` flags required (#809). The changes of this PR do not affect the situation where `CHARM_ROOT` is defined, so it doesn't break any existing setups.

If, however, the `CHARM_ROOT` requirement has been kept around on purpose, please let me know why it's still necessary.

### Component:

- [x] Build system