### PR TITLE
Make DataBox non-copyable

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -445,17 +445,8 @@ class DataBox<tmpl::list<Tags...>>
     }
     return *this;
   }
-  DataBox(const DataBox& rhs) = default;
-  DataBox& operator=(const DataBox& rhs) noexcept(
-      tmpl2::flat_all_v<
-          cpp17::is_nothrow_copy_assignable_v<DataBox_detail::DataBoxLeaf<
-              Tags, db::item_type<Tags, tmpl::list<Tags...>>>>...>) {
-    if (&rhs != this) {
-      ::expand_pack(
-          (get_deferred<Tags>() = rhs.template get_deferred<Tags>())...);
-    }
-    return *this;
-  }
+  DataBox(const DataBox& rhs) = delete;
+  DataBox& operator=(const DataBox& rhs) = delete;
 #ifdef SPECTRE_DEBUG
   // Destructor is used for triggering assertions
   ~DataBox() noexcept {

--- a/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_BaseTags.cpp
@@ -102,14 +102,14 @@ void test_non_subitems() {
   /// [base_simple_and_compute_mutate]
 
   // - adding compute item that uses a base tag as its argument
-  const auto box2 =  // Add compute item that uses base tag as its argument
+  const auto& box2 =  // Add compute item that uses base tag as its argument
       db::create_from<db::RemoveTags<>, db::AddSimpleTags<>,
                       db::AddComputeTags<TestTags::ArrayComputeBase<1>>>(box);
   CHECK(db::get<TestTags::ArrayBase<1>>(box2) ==
         std::array<int, 3>{{2, 101, -8}});
   CHECK(db::get<TestTags::ArrayComputeBase<1>>(box2) ==
         std::array<int, 3>{{2, 101, -8}});
-  const auto box3 =
+  const auto& box3 =
       db::create_from<db::RemoveTags<TestTags::ArrayComputeBase<1>>>(box2);
   CHECK(db::get<TestTags::VectorBase<0>>(box3) ==
         std::vector<double>{101.8, 10.0});
@@ -128,7 +128,8 @@ void test_non_subitems() {
       db::RemoveTags<>,
       db::AddSimpleTags<TestTags::Vector<1>, TestTags::Vector<2>>,
       db::AddComputeTags<TestTags::ArrayComputeBase<1, 0, 1, 2>>>(
-      box, std::vector<double>{-7.1, 8.9}, std::vector<double>{103.1, -73.2});
+      std::move(box), std::vector<double>{-7.1, 8.9},
+      std::vector<double>{103.1, -73.2});
   CHECK(db::get<TestTags::ArrayBase<1>>(box4) ==
         std::array<int, 4>{{2, 101, -7, 103}});
   db::mutate<TestTags::VectorBase<2>>(
@@ -138,7 +139,7 @@ void test_non_subitems() {
 
   // - removing a compute item that uses a base tag as its argument
   // - removing a compute item by its base tag
-  const auto box5 =
+  const auto& box5 =
       db::create_from<db::RemoveTags<TestTags::ArrayBase<1>>>(box4);
   CHECK(db::get<TestTags::VectorBase<1>>(box5) ==
         std::vector<double>{-7.1, 8.9});
@@ -147,7 +148,7 @@ void test_non_subitems() {
 
   // - removing a compute item and its dependencies by the base tags
   /// [remove_using_base]
-  const auto box6 = db::create_from<
+  const auto& box6 = db::create_from<
       db::RemoveTags<TestTags::VectorBase<1>, TestTags::VectorBase<2>,
                      TestTags::ArrayBase<1>>>(box4);
   /// [remove_using_base]
@@ -329,7 +330,7 @@ void test_subitems_tags() {
 
   // - adding a compute item that uses subitems via base tags, one that's
   //   already in the box another that's being added
-  auto box2 =
+  const auto& box2 =
       db::create_from<db::RemoveTags<>, db::AddSimpleTags<>,
                       db::AddComputeTags<TestTags::ComputeMultiplyByTwo<0, 1>>>(
           box);
@@ -342,9 +343,10 @@ void test_subitems_tags() {
   auto box3 =
       db::create_from<db::RemoveTags<>, db::AddSimpleTags<TestTags::Parent<2>>,
                       db::AddComputeTags<TestTags::ComputeMultiplyByTwo<0, 2>>>(
-          box, std::make_pair(
-                   TestTags::Boxed<int>(std::make_shared<int>(8)),
-                   TestTags::Boxed<double>(std::make_shared<double>(9.5))));
+          std::move(box),
+          std::make_pair(
+              TestTags::Boxed<int>(std::make_shared<int>(8)),
+              TestTags::Boxed<double>(std::make_shared<double>(9.5))));
   CHECK(db::get<TestTags::MultiplyByTwo<0, 2>>(box3) == -3 * 9.5);
   db::mutate<TestTags::FirstBase<0>>(
       make_not_null(&box3), [](const gsl::not_null<TestTags::Boxed<int>*>

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -1719,8 +1719,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TaggedTuple",
     // Test that having a TaggedTuple inside a DataBox works properly
     auto box = db::create<db::AddSimpleTags<TestTags::TupleTag>>(
         tuples::TaggedTuple<TestTags::MyTag0, TestTags::MyTag1>{123, 2.3});
-    auto box2 = box;
-    box2 = std::move(box);
+    auto box2 = std::move(box);
     CHECK(tuples::get<TestTags::MyTag0>(db::get<TestTags::TupleTag>(box2)) ==
           123);
     CHECK(tuples::get<TestTags::MyTag1>(db::get<TestTags::TupleTag>(box2)) ==
@@ -1730,8 +1729,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.TaggedTuple",
     // Test that having a TaggedTuple inside a DataBox works properly
     auto box = db::create<db::AddSimpleTags<TestTags::TupleTag>>(
         tuples::TaggedTuple<TestTags::MyTag0, TestTags::MyTag1>{123, 2.3});
-    auto box2 = box;
-    box2 = box;
+    auto box2 = std::move(box);
     CHECK(tuples::get<TestTags::MyTag0>(db::get<TestTags::TupleTag>(box2)) ==
           123);
     CHECK(tuples::get<TestTags::MyTag1>(db::get<TestTags::TupleTag>(box2)) ==

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -403,7 +403,8 @@ struct add_int0_from_receive {
             .begin());
     tuples::get<IntReceiveTag>(inboxes).erase(db::get<TemporalId>(box));
     return std::make_tuple(
-        db::create_from<tmpl::list<>, tmpl::list<Int0>>(box, int0), ++a >= 5);
+        db::create_from<tmpl::list<>, tmpl::list<Int0>>(std::move(box), int0),
+        ++a >= 5);
   }
 
   /// [is_ready_example]

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -9,6 +9,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "AlgorithmArray.hpp"
@@ -77,7 +78,7 @@ namespace SingletonActions {
 struct Initialize {
   template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
             typename ActionList, typename ParallelComponent>
-  static auto apply(const db::DataBox<tmpl::list<>>& box,
+  static auto apply(db::DataBox<tmpl::list<>>& box,  // NOLINT
                     tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
@@ -88,7 +89,7 @@ struct Initialize {
                          SingletonParallelComponent<TestMetavariables>>,
         "The ParallelComponent is not deduced to be the right type");
     /// [return_forward_as_tuple]
-    return std::forward_as_tuple(box);
+    return std::forward_as_tuple(std::move(box));
     /// [return_forward_as_tuple]
   }
 };


### PR DESCRIPTION
Copying a DataBox just created aliases between all the members, which resulted in the surprising situation that mutating one DataBox would also change the other.  As a side-effect, this allowed const DataBoxes to be mutated by creating a non-const aliasing version.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
