### PR TITLE
Make flux argument_tags explicit

### DIFF
--- a/src/Evolution/Systems/Burgers/Equations.cpp
+++ b/src/Evolution/Systems/Burgers/Equations.cpp
@@ -21,8 +21,7 @@ namespace Burgers {
 void LocalLaxFriedrichsFlux::package_data(
     gsl::not_null<Variables<package_tags>*> packaged_data,
     const Scalar<DataVector>& normal_dot_flux_u,
-    const Scalar<DataVector>& u,
-    const tnsr::i<DataVector, 1>& /*interface_unit_normal*/) const noexcept {
+    const Scalar<DataVector>& u) const noexcept {
   get<Tags::U>(*packaged_data) = u;
   get<::Tags::NormalDotFlux<Tags::U>>(*packaged_data) = normal_dot_flux_u;
 }

--- a/src/Evolution/Systems/Burgers/Equations.hpp
+++ b/src/Evolution/Systems/Burgers/Equations.hpp
@@ -38,13 +38,12 @@ struct LocalLaxFriedrichsFlux {
 
   using package_tags = tmpl::list<::Tags::NormalDotFlux<Tags::U>, Tags::U>;
 
-  using slice_tags = tmpl::list<Tags::U>;
+  using argument_tags = tmpl::list<::Tags::NormalDotFlux<Tags::U>, Tags::U>;
 
   void package_data(
       gsl::not_null<Variables<package_tags>*> packaged_data,
       const Scalar<DataVector>& normal_dot_flux_u,
-      const Scalar<DataVector>& u,
-      const tnsr::i<DataVector, 1>& /*interface_unit_normal*/) const noexcept;
+      const Scalar<DataVector>& u) const noexcept;
 
   void operator()(
       gsl::not_null<Scalar<DataVector>*> normal_dot_numerical_flux_u,

--- a/src/Evolution/Systems/ScalarWave/Equations.cpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.cpp
@@ -70,7 +70,6 @@ void UpwindFlux<Dim>::package_data(
     const gsl::not_null<Variables<package_tags>*> packaged_data,
     const Scalar<DataVector>& normal_dot_flux_pi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_dot_flux_phi,
-    const Scalar<DataVector>& /*normal_dot_flux_psi*/,
     const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
     const noexcept {

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp
@@ -31,9 +31,6 @@ namespace Actions {
 /// - ConstGlobalCache: nothing
 /// - DataBox:
 ///   Tags::InternalDirections<volume_dim>,
-///   Tags::Interface<
-///       Tags::InternalDirections<volume_dim>,
-///       Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>,
 ///   interface items as required by Metavariables::system::normal_dot_fluxes
 ///
 /// DataBox changes:
@@ -45,15 +42,14 @@ namespace Actions {
 ///       db::add_tag_prefix<Tags::NormalDotFlux, variables_tag>>
 struct ComputeNonconservativeBoundaryFluxes {
  private:
-  template <typename Metavariables, typename... NormalDotFluxTags, size_t Dim,
-            typename Frame, typename... Args>
+  template <typename Metavariables, typename... NormalDotFluxTags,
+            typename... Args>
   static void apply_flux(
       gsl::not_null<Variables<tmpl::list<NormalDotFluxTags...>>*> boundary_flux,
-      const tnsr::i<DataVector, Dim, Frame>& unit_face_normal,
       const Args&... boundary_variables) noexcept {
     Metavariables::system::normal_dot_fluxes::apply(
         make_not_null(&get<NormalDotFluxTags>(*boundary_flux))...,
-        boundary_variables..., unit_face_normal);
+        boundary_variables...);
   }
 
  public:
@@ -72,10 +68,6 @@ struct ComputeNonconservativeBoundaryFluxes {
     using internal_directions_tag =
         Tags::InternalDirections<system::volume_dim>;
 
-    using normal_tag = Tags::UnnormalizedFaceNormal<system::volume_dim>;
-
-    using unit_normal_tag =
-        Tags::Interface<internal_directions_tag, Tags::Normalized<normal_tag>>;
     using interface_normal_dot_fluxes_tag =
         Tags::Interface<internal_directions_tag,
                         db::add_tag_prefix<Tags::NormalDotFlux, variables_tag>>;
@@ -87,16 +79,15 @@ struct ComputeNonconservativeBoundaryFluxes {
                 typename Metavariables::system::normal_dot_fluxes::
                     argument_tags,
                 tmpl::bind<Tags::Interface, internal_directions_tag, tmpl::_1>>,
-            internal_directions_tag, unit_normal_tag>>(
+            internal_directions_tag>>(
         [](const gsl::not_null<db::item_type<interface_normal_dot_fluxes_tag>*>
                boundary_fluxes,
            const db::item_type<internal_directions_tag>& internal_directions,
-           const db::item_type<unit_normal_tag>& unit_face_normals,
            const auto&... tensors) noexcept {
           for (const auto& direction : internal_directions) {
             apply_flux<Metavariables>(
                 make_not_null(&boundary_fluxes->at(direction)),
-                unit_face_normals.at(direction), tensors.at(direction)...);
+                tensors.at(direction)...);
           }
           return boundary_fluxes;
         },

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp
@@ -31,8 +31,6 @@ template <typename Tag>
 struct Magnitude;
 template <typename Tag>
 struct Next;
-template <typename Tag>
-struct Normalized;
 }  // namespace Tags
 // IWYU pragma: no_forward_declare db::DataBox
 /// \endcond
@@ -181,10 +179,8 @@ struct ReceiveDataForFluxes {
 /// - DataBox:
 ///   - Tags::Element<volume_dim>
 ///   - Interface<Tags listed in
-///               Metavariables::normal_dot_numerical_flux::type::slice_tags>
-///   - Interface<FluxCommunicationTypes<Metavariables>::normal_dot_fluxes_tag>
+///               Metavariables::normal_dot_numerical_flux::type::argument_tags>
 ///   - Interface<Tags::Mesh<volume_dim - 1>>
-///   - Interface<Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>
 ///   - Interface<Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>,
 ///   - Metavariables::temporal_id
 ///   - Tags::Next<Metavariables::temporal_id>
@@ -251,12 +247,8 @@ struct SendDataForFluxes {
       // from this side of the mortar now, then package it into a Variables.
       // We store one copy of the Variables and send another, since we need
       // the data on both sides of the mortar.
-      using package_arguments = tmpl::append<
-          typename db::item_type<
-              typename flux_comm_types::normal_dot_fluxes_tag>::tags_list,
-          typename Metavariables::normal_dot_numerical_flux::type::slice_tags,
-          tmpl::list<
-              Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>>;
+      using package_arguments = typename Metavariables::
+          normal_dot_numerical_flux::type::argument_tags;
       const auto packaged_data = db::apply<tmpl::transform<
           package_arguments,
           tmpl::bind<Tags::Interface, Tags::InternalDirections<volume_dim>,

--- a/tests/Unit/Evolution/Systems/Burgers/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_Equations.cpp
@@ -3,7 +3,6 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <limits>
 #include <random>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -26,20 +25,16 @@ DataVector apply_numerical_flux(const DataVector& ndotf_interior,
                                 const DataVector& u_exterior) noexcept {
   using flux = Burgers::LocalLaxFriedrichsFlux;
 
-  // Scalar fluxes should not depend on the normal.
-  const auto normal = make_with_value<tnsr::i<DataVector, 1>>(
-      u_interior, std::numeric_limits<double>::signaling_NaN());
-
   auto package_data_interior =
       make_with_value<Variables<typename flux::package_tags>>(u_interior, 0.);
   flux{}.package_data(&package_data_interior,
                       Scalar<DataVector>(ndotf_interior),
-                      Scalar<DataVector>(u_interior), normal);
+                      Scalar<DataVector>(u_interior));
   auto package_data_exterior =
       make_with_value<Variables<typename flux::package_tags>>(u_interior, 0.);
   flux{}.package_data(&package_data_exterior,
                       Scalar<DataVector>(ndotf_exterior),
-                      Scalar<DataVector>(u_exterior), normal);
+                      Scalar<DataVector>(u_exterior));
 
   auto result = make_with_value<Scalar<DataVector>>(u_interior, 0.);
   flux{}(&result,

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_Equations.cpp
@@ -203,11 +203,11 @@ void check_upwind_flux(const size_t npts, const double t) {
   ScalarWave::UpwindFlux<Dim> flux_computer{};
   flux_computer.package_data(
       make_not_null(&packaged_data_int), solution.dpsi_dt(x, t + 1.0),
-      solution.dpsi_dx(x, t + 2.0), solution.psi(x, t + 3.0),
+      solution.dpsi_dx(x, t + 2.0),
       solution.psi(x, t + 4.0), unit_normal);
   flux_computer.package_data(
       make_not_null(&packaged_data_ext), solution.dpsi_dt(x, 2.0 * t + 10.0),
-      solution.dpsi_dx(x, 2.0 * t + 9.0), solution.psi(x, 2.0 * t + 8.0),
+      solution.dpsi_dx(x, 2.0 * t + 9.0),
       solution.psi(x, 2.0 * t + 7.0), unit_normal);
 
   Scalar<DataVector> normal_dot_numerical_flux_pi(pow<Dim>(npts), 0.0);

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -68,12 +68,13 @@ struct System {
   using magnitude_tag = Tags::EuclideanMagnitude<Tag>;
 
   struct normal_dot_fluxes {
-    using argument_tags = tmpl::list<Var, OtherArg, Var2>;
+    using argument_tags =
+        tmpl::list<Var, OtherArg, Var2,
+                   Tags::Normalized<Tags::UnnormalizedFaceNormal<2>>>;
     static void apply(
         const gsl::not_null<Scalar<DataVector>*> var_normal_dot_flux,
         const gsl::not_null<tnsr::ii<DataVector, 2>*> var2_normal_dot_flux,
-        const Scalar<DataVector>& var,
-        const double other_arg,
+        const Scalar<DataVector>& var, const double other_arg,
         const tnsr::ii<DataVector, 2>& var2,
         const tnsr::i<DataVector, 2>& unit_face_normal) noexcept {
       get(*var_normal_dot_flux) =

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -82,14 +82,14 @@ class NumericalFlux {
   // This is a silly set of things to request, but it tests not
   // requesting the evolved variables and requesting multiple other
   // things.
-  using slice_tags = tmpl::list<Tags::NormalDotFlux<Var>, OtherData>;
+  using argument_tags =
+      tmpl::list<Tags::NormalDotFlux<Var>, OtherData,
+                 Tags::Normalized<Tags::UnnormalizedFaceNormal<2>>>;
   void package_data(const gsl::not_null<Variables<package_tags>*> packaged_data,
                     const Scalar<DataVector>& var_flux,
-                    const Scalar<DataVector>& var_flux2,
                     const Scalar<DataVector>& other_data,
                     const tnsr::i<DataVector, 2, Frame::Inertial>&
                         interface_unit_normal) const noexcept {
-    CHECK(var_flux == var_flux2);
     get(get<Var>(*packaged_data)) = 10. * get(var_flux);
     get<0>(get<ExtraData>(*packaged_data)) =
         get(other_data) + 2. * get<0>(interface_unit_normal) +
@@ -373,7 +373,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
         x /= get(get<MagnitudeOfFaceNormal>(local_data));
       }
       PackagedData local_packaged(3);
-      NumericalFlux{}.package_data(&local_packaged, local_flux, local_flux,
+      NumericalFlux{}.package_data(&local_packaged, local_flux,
                                    local_other, normalized_local_normal);
       local_data.assign_subset(local_packaged);
 
@@ -383,7 +383,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
         x /= get(magnitude_remote_normal);
       }
       PackagedData remote_packaged(3);
-      NumericalFlux{}.package_data(&remote_packaged, remote_flux, remote_flux,
+      NumericalFlux{}.package_data(&remote_packaged, remote_flux,
                                    remote_other, normalized_remote_normal);
       // Cannot be inlined because of CHECK implementation.
       const auto expected =


### PR DESCRIPTION
## Proposed changes

This PR removes the implicit arguments to fluxes and numerical fluxes and instead requires them to be specified in their `argument_tags`, as discussed in #767. For fluxes this is the unit normal, and for numerical fluxes the unit normal and the n.fluxes.

**What breaks:**

- Numerical flux computers need their `slice_tags` renamed to `argument_tags` and the arguments of their `package_data` function adjusted. Add the `Tags::NormalDotFluxed` and the `Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>` to the `argument_tags` as needed.
- Flux computers should also add the unit normal to their `argument_tags` as needed.

### Component:

- [x] Code

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
