### PR TITLE
Fix compilation with AppleClang 9.1.0.9020039

### DIFF
--- a/tests/Unit/PointwiseFunctions/EquationsOfState/TestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/EquationsOfState/TestHelpers.hpp
@@ -38,7 +38,7 @@ struct CreateMemberFunctionPointer<ThermodynamicDim,
 template <class T, typename EoS>
 using Function = Scalar<T> (EoS::*)(const Scalar<T>&, const Scalar<T>&) const;
 
-template <bool IsRelativistic, size_t ThermodynamicDim, class... MemberArgs,
+template <size_t ThermodynamicDim, bool IsRelativistic, class... MemberArgs,
           class T, size_t... Is>
 void check_impl(const std::unique_ptr<::EquationsOfState::EquationOfState<
                     IsRelativistic, ThermodynamicDim>>& in_eos,
@@ -182,23 +182,25 @@ template <class EosType, class T, class... MemberArgs>
 void check(std::unique_ptr<EosType> in_eos,
            const std::string& python_function_prefix, const T& used_for_size,
            const MemberArgs&... member_args) noexcept {
-  detail::check_impl(std::unique_ptr<::EquationsOfState::EquationOfState<
-                         EosType::is_relativistic, EosType::thermodynamic_dim>>(
-                         std::move(in_eos)),
-                     python_function_prefix, used_for_size,
-                     std::make_index_sequence<EosType::thermodynamic_dim - 1>{},
-                     member_args...);
+  detail::check_impl<EosType::thermodynamic_dim>(
+      std::unique_ptr<::EquationsOfState::EquationOfState<
+          EosType::is_relativistic, EosType::thermodynamic_dim>>(
+          std::move(in_eos)),
+      python_function_prefix, used_for_size,
+      std::make_index_sequence<EosType::thermodynamic_dim - 1>{},
+      member_args...);
 }
 
 template <class EosType, class T, class... MemberArgs>
 void check(EosType in_eos, const std::string& python_function_prefix,
            const T& used_for_size, const MemberArgs&... member_args) noexcept {
-  detail::check_impl(std::unique_ptr<::EquationsOfState::EquationOfState<
-                         EosType::is_relativistic, EosType::thermodynamic_dim>>(
-                         std::make_unique<EosType>(std::move(in_eos))),
-                     python_function_prefix, used_for_size,
-                     std::make_index_sequence<EosType::thermodynamic_dim - 1>{},
-                     member_args...);
+  detail::check_impl<EosType::thermodynamic_dim>(
+      std::unique_ptr<::EquationsOfState::EquationOfState<
+          EosType::is_relativistic, EosType::thermodynamic_dim>>(
+          std::make_unique<EosType>(std::move(in_eos))),
+      python_function_prefix, used_for_size,
+      std::make_index_sequence<EosType::thermodynamic_dim - 1>{},
+      member_args...);
 }
 // @}
 }  // namespace EquationsOfState


### PR DESCRIPTION
Need to explicitly specify template parameter for ThermodynamicDim.
Otherwise, check_impl template is ignored with:
could not match '__make_integer_seq' against 'integer_sequence'
for the first argument of check_impl

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
