### PR TITLE
Block vector

### DIFF
--- a/src/DataStructures/IdPair.hpp
+++ b/src/DataStructures/IdPair.hpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+#include <type_traits>
+#include <utility>
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief A data structure that contains an ID and data associated with that ID.
+ */
+template <typename IdType, typename DataType>
+struct IdPair {
+  IdType id;
+  DataType data;
+};
+
+template <typename IdType, typename DataType>
+IdPair<std::decay_t<IdType>, std::decay_t<DataType>> make_id_pair(
+    IdType&& id, DataType&& data) noexcept {
+  return {std::forward<IdType>(id), std::forward<DataType>(data)};
+}
+
+/// \cond
+// We write the pup function as a free function to keep IdPair a POD
+// clang-tidy: no non-const references
+template <typename IdType, typename DataType>
+void pup(PUP::er& p, IdPair<IdType, DataType>& t) noexcept {  // NOLINT
+  p | t.id;
+  p | t.data;
+}
+
+// clang-tidy: no non-const references
+template <typename IdType, typename DataType>
+void operator|(PUP::er& p, IdPair<IdType, DataType>& t) noexcept {  // NOLINT
+  pup(p, t);
+}
+
+template <typename IdType, typename DataType>
+bool operator==(const IdPair<IdType, DataType>& lhs,
+                const IdPair<IdType, DataType>& rhs) noexcept {
+  return lhs.id == rhs.id and lhs.data == rhs.data;
+}
+
+template <typename IdType, typename DataType>
+bool operator!=(const IdPair<IdType, DataType>& lhs,
+                const IdPair<IdType, DataType>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+/// \endcond

--- a/src/Domain/BlockId.hpp
+++ b/src/Domain/BlockId.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <ostream>
+#include <pup.h>
+
+namespace PUP {
+class er;
+}  // namespace PUP
+
+namespace domain {
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief Index a block of the computational domain.
+ */
+class BlockId {
+ public:
+  BlockId() = default;
+  explicit BlockId(size_t id) noexcept : id_(id) {}
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept { p | id_; }
+
+  size_t get_index() const noexcept { return id_; }
+
+  BlockId& operator++() noexcept {
+    ++id_;
+    return *this;
+  }
+
+  BlockId& operator--() noexcept {
+    --id_;
+    return *this;
+  }
+
+  // NOLINTNEXTLINE(cert-dcl21-cpp) returned object doesn't need to be const
+  BlockId operator++(int) noexcept {
+    id_++;
+    return *this;
+  }
+
+  // NOLINTNEXTLINE(cert-dcl21-cpp) returned object doesn't need to be const
+  BlockId operator--(int) noexcept {
+    id_--;
+    return *this;
+  }
+
+ private:
+  friend bool operator==(const BlockId& lhs, const BlockId& rhs) noexcept;
+  friend std::ostream& operator<<(std::ostream& os, const BlockId& block_id);
+
+  size_t id_{0};
+};
+
+inline bool operator==(const BlockId& lhs, const BlockId& rhs) noexcept {
+  return lhs.id_ == rhs.id_;
+}
+
+inline bool operator!=(const BlockId& lhs, const BlockId& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const BlockId& block_id) {
+  return os << '[' << block_id.id_ << ']';
+}
+
+}  // namespace domain

--- a/src/Domain/BlockVector.hpp
+++ b/src/Domain/BlockVector.hpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <ostream>
+#include <vector>
+
+#include "Domain/BlockId.hpp"
+
+namespace domain {
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief A vector that is indexed by `BlockId`.
+ */
+template <class T, class Allocator = std::allocator<T>>
+class BlockVector : private std::vector<T, Allocator> {
+ public:
+  // Member types
+  using value_type = typename std::vector<T, Allocator>::value_type;
+  using allocator_type = typename std::vector<T, Allocator>::allocator_type;
+  using size_type = typename std::vector<T, Allocator>::size_type;
+  using difference_type = typename std::vector<T, Allocator>::difference_type;
+  using reference = typename std::vector<T, Allocator>::reference;
+  using const_reference = typename std::vector<T, Allocator>::const_reference;
+  using pointer = typename std::vector<T, Allocator>::pointer;
+  using const_pointer = typename std::vector<T, Allocator>::const_pointer;
+  using iterator = typename std::vector<T, Allocator>::iterator;
+  using const_iterator = typename std::vector<T, Allocator>::const_iterator;
+  using reverse_iterator = typename std::vector<T, Allocator>::reverse_iterator;
+  using const_reverse_iterator =
+      typename std::vector<T, Allocator>::const_reverse_iterator;
+
+  // Member functions
+  using std::vector<T, Allocator>::vector;
+  using std::vector<T, Allocator>::operator=;
+  using std::vector<T, Allocator>::assign;
+  using std::vector<T, Allocator>::get_allocator;
+
+  // Element access
+  reference at(const BlockId& pos) noexcept {
+    return static_cast<std::vector<T, Allocator>&>(*this).at(pos.get_index());
+  }
+  const_reference at(const BlockId& pos) const noexcept {
+    return static_cast<const std::vector<T, Allocator>&>(*this).at(
+        pos.get_index());
+  }
+  reference operator[](const BlockId& pos) noexcept {
+    return static_cast<std::vector<T, Allocator>&>(*this)[pos.get_index()];
+  }
+  const_reference operator[](const BlockId& pos) const noexcept {
+    return static_cast<const std::vector<T, Allocator>&>(
+        *this)[pos.get_index()];
+  }
+  using std::vector<T, Allocator>::front;
+  using std::vector<T, Allocator>::back;
+  using std::vector<T, Allocator>::data;
+
+  // Iterators
+  using std::vector<T, Allocator>::begin;
+  using std::vector<T, Allocator>::cbegin;
+  using std::vector<T, Allocator>::end;
+  using std::vector<T, Allocator>::cend;
+
+  // Capacity
+  using std::vector<T, Allocator>::empty;
+  using std::vector<T, Allocator>::size;
+  using std::vector<T, Allocator>::max_size;
+  using std::vector<T, Allocator>::reserve;
+  using std::vector<T, Allocator>::capacity;
+  using std::vector<T, Allocator>::shrink_to_fit;
+
+  // Modifiers
+  using std::vector<T, Allocator>::clear;
+  using std::vector<T, Allocator>::push_back;
+  using std::vector<T, Allocator>::emplace_back;
+  using std::vector<T, Allocator>::pop_back;
+  using std::vector<T, Allocator>::resize;
+  using std::vector<T, Allocator>::swap;
+
+  // Charm++ serialization
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept {
+    p | static_cast<std::vector<T, Allocator>&>(*this);
+  }
+
+#define GENERATE_OP(OP)                                                        \
+  template <class S, class SAllocator = std::allocator<S>>                     \
+  friend bool operator OP(                                                     \
+      const domain::BlockVector<S, SAllocator>& lhs,                           \
+      const domain::BlockVector<S, SAllocator>& rhs) noexcept {                \
+    return static_cast<const std::vector<S, SAllocator>&>(lhs) OP /* NOLINT */ \
+        static_cast<const std::vector<S, SAllocator>&>(rhs);                   \
+  }
+  GENERATE_OP(==)
+  GENERATE_OP(!=)
+  GENERATE_OP(<)
+  GENERATE_OP(<=)
+  GENERATE_OP(>)
+  GENERATE_OP(>=)
+#undef GENERATE_OP
+
+  template <class S, class SAllocator = std::allocator<T>>
+  friend std::ostream& operator<<(
+      std::ostream& os, const BlockVector<S, SAllocator>& block_vector) {
+    // We intentionally don't use the std::vector stream operator since
+    // including that would suck in almost the entire STL.
+    const auto& base =
+        static_cast<const std::vector<S, SAllocator>&>(block_vector);
+    os << '(';
+    for (size_t i = 0; i < base.size(); ++i) {
+      os << (i > 0 ? "," : "") << base[i];
+    }
+    return os << ')';
+  }
+};
+}  // namespace domain

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_DenseMatrix.cpp
   Test_DenseVector.cpp
   Test_GeneralIndexIterator.cpp
+  Test_IdPair.cpp
   Test_Index.cpp
   Test_IndexIterator.cpp
   Test_OrientVariablesOnSlice.cpp

--- a/tests/Unit/DataStructures/Test_IdPair.cpp
+++ b/tests/Unit/DataStructures/Test_IdPair.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <vector>
+
+#include "DataStructures/IdPair.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.IdPair",
+                  "[Unit][DataStructures]") {
+  auto id_pair = make_id_pair(5, std::vector<double>{1.2, 7.8});
+  static_assert(cpp17::is_same_v<decltype(id_pair.id), int>,
+                "Failed checking type decay in make_id_pair");
+  static_assert(cpp17::is_same_v<decltype(id_pair.data), std::vector<double>>,
+                "Failed checking type decay in make_id_pair");
+  CHECK(id_pair.id == 5);
+  CHECK(id_pair.data == std::vector<double>{1.2, 7.8});
+  CHECK(id_pair == make_id_pair(5, std::vector<double>{1.2, 7.8}));
+  CHECK(id_pair != make_id_pair(6, std::vector<double>{1.2, 7.8}));
+  CHECK(id_pair != make_id_pair(5, std::vector<double>{1.3, 7.8}));
+  CHECK(id_pair != make_id_pair(7, std::vector<double>{1.3, 7.8}));
+
+  // Test PUP
+  test_serialization(id_pair);
+}

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_Block.cpp
   Test_BlockId.cpp
   Test_BlockNeighbor.cpp
+  Test_BlockVector.cpp
   Test_CoordinatesTag.cpp
   Test_CreateInitialElement.cpp
   Test_Direction.cpp

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Domain")
 set(LIBRARY_SOURCES
   DomainTestHelpers.cpp
   Test_Block.cpp
+  Test_BlockId.cpp
   Test_BlockNeighbor.cpp
   Test_CoordinatesTag.cpp
   Test_CreateInitialElement.cpp

--- a/tests/Unit/Domain/Test_BlockId.cpp
+++ b/tests/Unit/Domain/Test_BlockId.cpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "Domain/BlockId.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.BlockId", "[Domain][Unit]") {
+  domain::BlockId id{10};
+  CHECK(id.get_index() == 10);
+  CHECK(id == domain::BlockId{10});
+  CHECK(id != domain::BlockId{7});
+  CHECK(get_output(id) == "[10]");
+  id++;
+  CHECK(id == domain::BlockId{11});
+  id--;
+  CHECK(id == domain::BlockId{10});
+  ++id;
+  CHECK(id == domain::BlockId{11});
+  --id;
+  CHECK(id == domain::BlockId{10});
+
+  // Test PUP
+  test_serialization(id);
+}

--- a/tests/Unit/Domain/Test_BlockVector.cpp
+++ b/tests/Unit/Domain/Test_BlockVector.cpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "Domain/BlockId.hpp"
+#include "Domain/BlockVector.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.BlockVector", "[Domain][Unit]") {
+  using domain::BlockId;
+  domain::BlockVector<double> block_vector{1.3, 4.8, 7.8};
+  CHECK(block_vector[BlockId{0}] == 1.3);
+  CHECK(block_vector[BlockId{1}] == 4.8);
+  CHECK(block_vector[BlockId{2}] == 7.8);
+  CHECK(block_vector == domain::BlockVector<double>{1.3, 4.8, 7.8});
+  CHECK(get_output(block_vector) == "(1.3,4.8,7.8)");
+
+  domain::BlockVector<double> block_vector2{8.3, 2.8, -7.8};
+  using std::swap;
+  swap(block_vector, block_vector2);
+  CHECK(block_vector == domain::BlockVector<double>{8.3, 2.8, -7.8});
+  CHECK(block_vector2 == domain::BlockVector<double>{1.3, 4.8, 7.8});
+
+  check_cmp(block_vector2, block_vector);
+
+  // Test PUP
+  test_serialization(block_vector);
+}


### PR DESCRIPTION
## Proposed changes

*note:* Based on #784, only adds BlockVector commit

- Add `BlockVector` that is a vector indexed by a `BlockId`.

There are a few functions I'm not sure we want in this because as @wthrowe said, it should behave more like an associative container.
- `push_back`
- `emplace_back`
- `pop_back`
- `front`
- `back`
- `data`

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
