### PR TITLE
Remove toms748 bound-tweaking

### DIFF
--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -78,11 +78,10 @@ DType scaling_factor(RootFunction<DType>&& rootfunction) noexcept {
   const DType& x_sq = rootfunction.get_x_sq();
   const DType& physical_r_squared = rootfunction.get_r_sq();
   try {
-    DType rho =
-        RootFinder::toms748(rootfunction, make_with_value<DType>(x_sq, 0.0),
-                            make_with_value<DType>(x_sq, sqrt(3.0)),
-                            10.0 * std::numeric_limits<double>::epsilon(),
-                            10.0 * std::numeric_limits<double>::epsilon());
+    const double tol = 10.0 * std::numeric_limits<double>::epsilon();
+    DType rho = RootFinder::toms748(
+        rootfunction, make_with_value<DType>(x_sq, 0.0),
+        make_with_value<DType>(x_sq, sqrt(3.0) + tol), tol, tol);
     for (size_t i = 0; i < get_size(rho); i++) {
       if (not(equal_within_roundoff(get_element(physical_r_squared, i), 0.0))) {
         get_element(rho, i) /= sqrt(get_element(physical_r_squared, i));


### PR DESCRIPTION
## Proposed changes

1. Remove the bounds tweaks in `toms748`, as per discussion in #439. Make corresponding changes to `toms748` tests.
1. Add note of how bounds are handled in `newton_raphson`.

### Types of changes:

- [x] Bugfix

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
