### PR TITLE
Fixed missing square of a term in tilde_tau

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp
@@ -25,7 +25,7 @@ namespace ValenciaDivClean {
  * {\tilde S}_i = & \sqrt{\gamma} \left( \rho h W^2 v_i + B^m B_m v_i - B^m v_m
  * B_i \right) \\
  * {\tilde \tau} = & \sqrt{\gamma} \left[ \rho h W^2 - p - \rho W - \frac{1}{2}
- * B^m v_m + \frac{1}{2} B^m B_m \left( 1 + v^m v_m \right) \right] \\
+ * (B^m v_m)^2 + \frac{1}{2} B^m B_m \left( 1 + v^m v_m \right) \right] \\
  * {\tilde B}^i = & \sqrt{\gamma} B^i \\
  * {\tilde \Phi} = & \sqrt{\gamma} \Phi
  * \f}
@@ -40,6 +40,13 @@ namespace ValenciaDivClean {
  * spatial velocity, \f$\epsilon\f$ is the specific internal energy, \f$p\f$ is
  * the pressure, \f$B^i\f$ is the spatial magnetic field measured by an Eulerian
  * observer, and \f$\Phi\f$ is a divergence cleaning field.
+ *
+ * The quantity \f${\tilde \tau}\f$ is rewritten as in `RelativisticEuler`
+ * to avoid cancellation error in the non-relativistic limit:
+ * \f[
+ * \left( \rho h W^2 - p - \rho W \right) \longrightarrow
+ *  W^2 \left[ \rho \left( \epsilon + v^2
+ * \frac{W}{W + 1} \right) + p v^2 \right] .\f]
  */
 void conservative_from_primitive(
     gsl::not_null<Scalar<DataVector>*> tilde_d,
@@ -48,6 +55,7 @@ void conservative_from_primitive(
     gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
     gsl::not_null<Scalar<DataVector>*> tilde_phi,
     const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
     const Scalar<DataVector>& specific_enthalpy,
     const Scalar<DataVector>& pressure,
     const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
@@ -47,26 +47,30 @@ def vsq(spatial_velocity, spatial_metric):
 
 
 # Functions for testing ConservativeFromPrimitive.cpp
-def tilde_d(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
-            lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
-            spatial_metric, divergence_cleaning_field):
+def tilde_d(rest_mass_density, specific_internal_energy, specific_enthalpy,
+            pressure, spatial_velocity, lorentz_factor, magnetic_field,
+            sqrt_det_spatial_metric, spatial_metric, divergence_cleaning_field):
     return lorentz_factor * rest_mass_density * sqrt_det_spatial_metric
 
 
-def tilde_tau(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
-              lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
-              spatial_metric, divergence_cleaning_field):
-    return ((rest_mass_density * specific_enthalpy * lorentz_factor**2 -
-             pressure - rest_mass_density * lorentz_factor +
+def tilde_tau(rest_mass_density, specific_internal_energy, specific_enthalpy,
+              pressure, spatial_velocity, lorentz_factor, magnetic_field,
+              sqrt_det_spatial_metric, spatial_metric,
+              divergence_cleaning_field):
+    spatial_velocity_squared = vsq(spatial_velocity, spatial_metric)
+    return ((((pressure * spatial_velocity_squared
+             + (lorentz_factor/(1.0 + lorentz_factor) * spatial_velocity_squared
+                + specific_internal_energy) * rest_mass_density)
+               * lorentz_factor**2) +
              0.5 * bsq(magnetic_field, spatial_metric) *
-             (1.0 + vsq(spatial_velocity, spatial_metric)) -
-             0.5 * b_dot_v(magnetic_field, spatial_velocity, spatial_metric)) *
-            sqrt_det_spatial_metric)
+             (1.0 + spatial_velocity_squared) -
+             0.5 * np.square(b_dot_v(magnetic_field, spatial_velocity,
+               spatial_metric))) * sqrt_det_spatial_metric)
 
 
-def tilde_s(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
-            lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
-            spatial_metric, divergence_cleaning_field):
+def tilde_s(rest_mass_density, specific_internal_energy, specific_enthalpy,
+            pressure, spatial_velocity, lorentz_factor, magnetic_field,
+            sqrt_det_spatial_metric, spatial_metric, divergence_cleaning_field):
     return ((spatial_velocity_one_form(spatial_velocity, spatial_metric) *
              (lorentz_factor**2 * specific_enthalpy * rest_mass_density + bsq(
                  magnetic_field, spatial_metric)) -
@@ -75,15 +79,16 @@ def tilde_s(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
             sqrt_det_spatial_metric)
 
 
-def tilde_b(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
-            lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
-            spatial_metric, divergence_cleaning_field):
+def tilde_b(rest_mass_density, specific_internal_energy, specific_enthalpy,
+            pressure, spatial_velocity, lorentz_factor, magnetic_field,
+            sqrt_det_spatial_metric, spatial_metric, divergence_cleaning_field):
     return sqrt_det_spatial_metric * magnetic_field
 
 
-def tilde_phi(rest_mass_density, specific_enthalpy, pressure, spatial_velocity,
-              lorentz_factor, magnetic_field, sqrt_det_spatial_metric,
-              spatial_metric, divergence_cleaning_field):
+def tilde_phi(rest_mass_density, specific_internal_energy, specific_enthalpy,
+              pressure, spatial_velocity, lorentz_factor, magnetic_field,
+              sqrt_det_spatial_metric, spatial_metric,
+              divergence_cleaning_field):
     return sqrt_det_spatial_metric * divergence_cleaning_field
 
 


### PR DESCRIPTION
Replaced part of tilde_tau definition with expression well-behaved in
Newtonian limit (as in RelativisticEuler)

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
