### PR TITLE
Adopt base tag for derivative compute item

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
@@ -85,10 +85,7 @@ namespace Actions {
 ///                       Tags::LogicalCoordinates<Dim>>
 ///   * Tags::InverseJacobian<Tags::ElementMap<Dim>,
 ///                           Tags::LogicalCoordinates<Dim>>
-///   * Tags::deriv<System::variables_tag::tags_list,
-///                 System::gradients_tags,
-///                 Tags::InverseJacobian<Tags::ElementMap<Dim>,
-///                                       Tags::LogicalCoordinates<Dim>>>
+///   * Tags::deriv<System::gradients_tags>
 ///   * db::add_tag_prefix<Tags::dt, System::variables_tag>
 ///   * Tags::UnnormalizedFaceNormal<Dim>
 /// - Removes: nothing
@@ -253,11 +250,11 @@ struct InitializeElement {
               bool IsConservative = LocalSystem::is_conservative>
     struct ComputeTags {
       using type = db::AddComputeTags<
-          Tags::Time,
-          Tags::deriv<typename variables_tag::tags_list,
-                      typename System::gradients_tags,
-                      Tags::InverseJacobian<Tags::ElementMap<Dim>,
-                                            Tags::LogicalCoordinates<Dim>>>>;
+          Tags::Time, Tags::ComputeDeriv<
+                          variables_tag,
+                          Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                                                Tags::LogicalCoordinates<Dim>>,
+                          typename System::gradients_tags>>;
     };
 
     template <typename LocalSystem>

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -14,11 +15,6 @@
 class DataVector;
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
-
-namespace Tags {
-template <typename, typename, typename>
-struct deriv;
-}  // namespace Tags
 
 namespace CurvedScalarWave {
 struct Psi;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
@@ -21,8 +22,6 @@ template <typename>
 class dt;
 template <typename>
 struct NormalDotFlux;
-template <typename, typename, typename>
-class deriv;
 }  // namespace Tags
 
 namespace gsl {

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
@@ -24,8 +25,6 @@ class not_null;
 }  // namespace gsl
 
 namespace Tags {
-template <typename, typename, typename>
-struct deriv;
 template <typename>
 struct NormalDotFlux;
 template <typename>

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -25,40 +25,42 @@ template <size_t Dim>
 struct Mesh;
 template <class TagList>
 struct Variables;
-
-namespace Tags_detail {
-template <typename T, typename S, typename U,
-          typename = std::nullptr_t>
-struct deriv_impl;
-}  // namespace Tags_detail
 /// \endcond
 
 /*!
  * \ingroup DataBoxTagsGroup
- * \brief Prefix for a spatial derivative
+ * \brief Prefix indicating spatial derivatives
  *
- * There are three variants of this tag that change how the derivatives are
- * computed depending on which is chosen. The simplest is the non-compute
- * item version for a Tensor tag. This takes three template parameters:
- * 1. The tag to wrap
- * 2. The volume dim as a type (e.g. `tmpl::size_t<Dim>`)
- * 3. The frame of the derivative index
+ * Prefix indicating the spatial derivatives of a Tensor or that a Variables
+ * contains spatial derivatives of Tensors.
  *
- * The second variant of the derivative tag is a compute item that computes
- * the partial derivatives in a Frame that is not the logical frame. This
- * compute item is used by specifying the list of tags in the
- * `Tags::Variables<tmpl::list<Tags...>>`, the list of tags to be
- * differentiated, and the Tag for inverse Jacobian between the logical frame
- * and the frame in which the derivative is taken. Note that the derivative Tags
- * must be a contiguous subset from the head of the `Tags...` pack.
+ * \tparam Tag The tag to wrap
+ * \tparam Dim The volume dim as a type (e.g. `tmpl::size_t<Dim>`)
+ * \tparam Frame The frame of the derivative index
  *
- * The third variant of the derivative tag is a compute item that computes the
- * partial derivatives in the logical frame. In that case the template
- * parameters must be the list of Variables tags and derivative tags, with the
- * last parameter being a `std::integral_constant` of the dimension of the mesh.
+ * \see Tags::ComputeDeriv
  */
-template <typename T, typename S = void, typename U = void>
-struct deriv : Tags_detail::deriv_impl<T, S, U> {};
+template <typename Tag, typename Dim, typename Frame, typename = std::nullptr_t>
+struct deriv;
+
+template <typename Tag, typename Dim, typename Frame>
+struct deriv<Tag, Dim, Frame, Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
+    : db::PrefixTag, db::SimpleTag {
+  using type =
+      TensorMetafunctions::prepend_spatial_index<db::item_type<Tag>, Dim::value,
+                                                 UpLo::Lo, Frame>;
+  using tag = Tag;
+  static std::string name() noexcept { return "deriv(" + Tag::name() + ")"; }
+};
+template <typename Tag, typename Dim, typename Frame>
+struct deriv<Tag, Dim, Frame,
+             Requires<tt::is_a_v<::Variables, db::item_type<Tag>>>>
+    : db::PrefixTag, db::SimpleTag {
+  using type = db::item_type<Tag>;
+  using tag = Tag;
+  static std::string name() noexcept { return "deriv(" + Tag::name() + ")"; }
+};
+
 }  // namespace Tags
 
 /// \ingroup NumericalAlgorithmsGroup
@@ -98,55 +100,42 @@ auto partial_derivatives(
                                   tmpl::size_t<Dim>, DerivativeFrame>>;
 
 namespace Tags {
-namespace Tags_detail {
-template <typename Tag, typename VolumeDim, typename Frame>
-struct deriv_impl<Tag, VolumeDim, Frame,
-                  Requires<tt::is_a_v<Tensor, db::item_type<Tag>>>>
-    : db::PrefixTag, db::SimpleTag {
-  using type = TensorMetafunctions::prepend_spatial_index<
-      db::item_type<Tag>, VolumeDim::value, UpLo::Lo, Frame>;
-  using tag = Tag;
-  static std::string name() noexcept { return "deriv"; }
-};
 
-// Partial derivatives with derivative index in the frame related to the logical
-// coordinates by InverseJacobianTag
-template <typename... VariablesTags, typename... DerivativeTags,
-          typename InverseJacobianTag>
-struct deriv_impl<
-    tmpl::list<VariablesTags...>, tmpl::list<DerivativeTags...>,
-    InverseJacobianTag,
-    Requires<tt::is_a_v<Tensor, db::item_type<InverseJacobianTag>>>>
-    : db::ComputeTag {
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \brief Compute the spatial derivatives of tags in a Variables
+ *
+ * Computes the spatial derivatives of the Tensors in the Variables represented
+ * by `VariablesTag` in the frame mapped to by `InverseJacobianTag`. To only
+ * take the derivatives of a subset of these Tensors you can set the
+ * `DerivTags` template parameter. It takes a `tmpl::list` of the desired
+ * tags and defaults to the full `tags_list` of the Variables.
+ *
+ * This tag may be retrieved via `db::variables_tag_with_tags_list<VariablesTag,
+ * DerivTags>` prefixed with `Tags::deriv`.
+ */
+template <typename VariablesTag, typename InverseJacobianTag,
+          typename DerivTags = typename db::item_type<VariablesTag>::tags_list>
+struct ComputeDeriv
+    : db::add_tag_prefix<
+          deriv, db::variables_tag_with_tags_list<VariablesTag, DerivTags>,
+          tmpl::size_t<tmpl::back<
+              typename db::item_type<InverseJacobianTag>::index_list>::dim>,
+          typename tmpl::back<
+              typename db::item_type<InverseJacobianTag>::index_list>::Frame>,
+      db::ComputeTag {
  private:
-  using derivative_frame_index =
-      tmpl::back<typename db::item_type<InverseJacobianTag>::index_list>;
-  using variables_tags = tmpl::list<VariablesTags...>;
+  using inv_jac_indices =
+      typename db::item_type<InverseJacobianTag>::index_list;
+  static constexpr auto Dim = tmpl::back<inv_jac_indices>::dim;
 
  public:
-  static std::string name() noexcept { return "deriv"; }
   static constexpr auto function =
-      partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
-                          derivative_frame_index::dim,
-                          typename derivative_frame_index::Frame>;
-  using argument_tags = tmpl::list<Tags::Variables<variables_tags>,
-                                   Tags::Mesh<derivative_frame_index::dim>,
-                                   InverseJacobianTag>;
+      partial_derivatives<DerivTags,
+                          typename db::item_type<VariablesTag>::tags_list, Dim,
+                          typename tmpl::back<inv_jac_indices>::Frame>;
+  using argument_tags =
+      tmpl::list<VariablesTag, Tags::Mesh<Dim>, InverseJacobianTag>;
 };
 
-// Logical partial derivatives
-template <typename... VariablesTags, typename... DerivativeTags, typename T,
-          T Dim>
-struct deriv_impl<tmpl::list<VariablesTags...>, tmpl::list<DerivativeTags...>,
-                  std::integral_constant<T, Dim>,
-                  Requires<(0 < Dim and 4 > Dim)>> : db::ComputeTag {
-  using variables_tags = tmpl::list<VariablesTags...>;
-  static std::string name() noexcept { return "deriv"; }
-  static constexpr auto function =
-      logical_partial_derivatives<tmpl::list<DerivativeTags...>, variables_tags,
-                                  Dim>;
-  using argument_tags =
-      tmpl::list<Tags::Variables<variables_tags>, Tags::Mesh<Dim>>;
-};
-}  // namespace Tags_detail
 }  // namespace Tags

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -162,12 +162,11 @@ struct TestConservativeOrNonconservativeParts {
     using system = typename Metavariables::system;
     constexpr size_t dim = system::volume_dim;
 
-    CHECK(box_contains<
-          Tags::deriv<typename system::variables_tag::tags_list,
-                      typename system::gradients_tags,
-                      Tags::InverseJacobian<Tags::ElementMap<dim>,
-                                            Tags::LogicalCoordinates<dim>>>>(
-        *box));
+    CHECK(box_contains<Tags::ComputeDeriv<
+              typename system::variables_tag,
+              Tags::InverseJacobian<Tags::ElementMap<dim>,
+                                    Tags::LogicalCoordinates<dim>>,
+              typename system::gradients_tags>>(*box));
   }
 };
 


### PR DESCRIPTION
## Proposed changes

This PR adds a compute item for the gradient of tensors in a Variables `ComputeDeriv`, similar to the existing `ComputeDiv`.

- [x] It is purely additive right now, and I'd like to get some feedback on the concepts, before removing the existing compute item functionality built into `Tags::deriv`. The change in the test shows that the new compute item works as expected.

The reason for this PR is mostly that I found the existing compute item functionality in `Tags::deriv` does not allow for prefixed variables because it takes a tags list instead of a Variables tag.

- [x] Depends on #900

### What breaks:

- Code that used `Tags::deriv` as a compute items needs to adopt the new `Tags::ComputeDeriv`. No changes are needed for code that used `Tags::deriv` as a simple item.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).