### PR TITLE
Add Poisson solution ProductOfSinusoids

### DIFF
--- a/src/Elliptic/Systems/Poisson/Tags.hpp
+++ b/src/Elliptic/Systems/Poisson/Tags.hpp
@@ -35,7 +35,7 @@ struct Field : db::SimpleTag {
  */
 template <size_t Dim>
 struct AuxiliaryField : db::SimpleTag {
-  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+  using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
   static std::string name() noexcept { return "AuxiliaryField"; }
 };
 

--- a/src/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
@@ -4,4 +4,5 @@
 add_subdirectory(Burgers)
 add_subdirectory(EinsteinSolutions)
 add_subdirectory(NewtonianEulerSolutions)
+add_subdirectory(Poisson)
 add_subdirectory(WaveEquation)

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY PoissonSolutions)
+
+set(LIBRARY_SOURCES
+  ProductOfSinusoids.cpp
+  )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE ErrorHandling
+  INTERFACE Utilities
+  )

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.cpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp"
+
+#include <cmath>
+#include <pup.h>  // IWYU pragma: keep
+
+#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+// IWYU pragma: no_forward_declare Tensor
+
+namespace Poisson {
+namespace Solutions {
+
+template <size_t Dim>
+ProductOfSinusoids<Dim>::ProductOfSinusoids(
+    const std::array<double, Dim>& wave_numbers) noexcept
+    : wave_numbers_(wave_numbers) {}
+
+template <size_t Dim>
+tuples::TaggedTuple<Field, AuxiliaryField<Dim>>
+ProductOfSinusoids<Dim>::field_variables(
+    const tnsr::I<DataVector, Dim>& x) const noexcept {
+  auto field = make_with_value<Scalar<DataVector>>(x, 1.);
+  for (size_t d = 0; d < Dim; d++) {
+    field.get() *= sin(gsl::at(wave_numbers_, d) * x.get(d));
+  }
+  auto auxiliary_field =
+      make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(x, 1.);
+  for (size_t d = 0; d < Dim; d++) {
+    auxiliary_field.get(d) *=
+        gsl::at(wave_numbers_, d) * cos(gsl::at(wave_numbers_, d) * x.get(d));
+    for (size_t other_d = 0; other_d < Dim; other_d++) {
+      if (other_d != d) {
+        auxiliary_field.get(d) *=
+            sin(gsl::at(wave_numbers_, other_d) * x.get(other_d));
+      }
+    }
+  }
+  return {std::move(field), std::move(auxiliary_field)};
+}
+
+template <size_t Dim>
+tuples::TaggedTuple<::Tags::Source<Field>, ::Tags::Source<AuxiliaryField<Dim>>>
+ProductOfSinusoids<Dim>::source_variables(
+    const tnsr::I<DataVector, Dim>& x) const noexcept {
+  auto field_source = get<Field>(field_variables(x));
+  field_source.get() *= square(magnitude(wave_numbers_));
+  return {std::move(field_source),
+          make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(x, 0.)};
+}
+
+template <size_t Dim>
+void ProductOfSinusoids<Dim>::pup(PUP::er& p) noexcept {
+  p | wave_numbers_;
+}
+
+}  // namespace Solutions
+}  // namespace Poisson
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) \
+  template class Poisson::Solutions::ProductOfSinusoids<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"     // IWYU pragma: keep
+#include "Elliptic/Systems/Poisson/Tags.hpp"    // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Poisson {
+namespace Solutions {
+/*!
+ * \brief A product of sinusoids \f$u(\boldsymbol{x}) = \prod_i \sin(k_i x_i)\f$
+ *
+ * \details Solves the Poisson equation \f$-\Delta u(x)=f(x)\f$ for a source
+ * \f$f(x)=\boldsymbol{k}^2\prod_i \sin(k_i x_i)\f$.
+ */
+template <size_t Dim>
+class ProductOfSinusoids {
+ public:
+  struct WaveNumbers {
+    using type = std::array<double, Dim>;
+    static constexpr OptionString help{"The wave numbers of the sinusoids"};
+  };
+
+  using options = tmpl::list<WaveNumbers>;
+  static constexpr OptionString help{
+      "A product of sinusoids that are taken of a wave number times the "
+      "coordinate in each dimension."};
+
+  ProductOfSinusoids() = default;
+  ProductOfSinusoids(const ProductOfSinusoids&) noexcept = delete;
+  ProductOfSinusoids& operator=(const ProductOfSinusoids&) noexcept = delete;
+  ProductOfSinusoids(ProductOfSinusoids&&) noexcept = default;
+  ProductOfSinusoids& operator=(ProductOfSinusoids&&) noexcept = default;
+  ~ProductOfSinusoids() noexcept = default;
+
+  explicit ProductOfSinusoids(
+      const std::array<double, Dim>& wave_numbers) noexcept;
+
+  tuples::TaggedTuple<Field, AuxiliaryField<Dim>> field_variables(
+      const tnsr::I<DataVector, Dim>& x) const noexcept;
+
+  tuples::TaggedTuple<::Tags::Source<Field>,
+                      ::Tags::Source<AuxiliaryField<Dim>>>
+  source_variables(const tnsr::I<DataVector, Dim>& x) const noexcept;
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  const std::array<double, Dim>& wave_numbers() const noexcept {
+    return wave_numbers_;
+  }
+
+ private:
+  std::array<double, Dim> wave_numbers_{
+      {std::numeric_limits<double>::signaling_NaN()}};
+};
+
+template <size_t Dim>
+bool operator==(const ProductOfSinusoids<Dim>& lhs,
+                          const ProductOfSinusoids<Dim>& rhs) noexcept {
+  return lhs.wave_numbers() == rhs.wave_numbers();
+}
+
+template <size_t Dim>
+bool operator!=(const ProductOfSinusoids<Dim>& lhs,
+                          const ProductOfSinusoids<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace Solutions
+}  // namespace Poisson

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Solutions.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Solutions.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines Poisson::Solutions
+
+#pragma once
+
+namespace Poisson {
+/*!
+ * \brief Analytic solutions to the Poisson equation
+ * \f$-\Delta u(\vec{x}) = f(\vec{x})\f$
+ */
+namespace Solutions {}
+}  // namespace Poisson

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/CMakeLists.txt
@@ -4,4 +4,5 @@
 add_subdirectory(Burgers)
 add_subdirectory(EinsteinSolutions)
 add_subdirectory(NewtonianEulerSolutions)
+add_subdirectory(Poisson)
 add_subdirectory(WaveEquation)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_PoissonSolutions")
+
+set(LIBRARY_SOURCES
+  Test_ProductOfSinusoids.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "PointwiseFunctions/AnalyticSolutions/Poisson/"
+  "${LIBRARY_SOURCES}"
+  "PoissonSolutions;Utilities"
+  )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.py
@@ -1,0 +1,26 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Functions for testing ProductOfSinusoids.cpp
+def field(x, wave_numbers):
+    x, wave_numbers = np.asarray(x), np.asarray(wave_numbers)
+    return np.prod(np.sin(wave_numbers * x))
+
+def auxiliary_field(x, wave_numbers):
+    x, wave_numbers = np.asarray(x), np.asarray(wave_numbers)
+    try:
+        dim = len(x)
+    except TypeError:
+        dim = 1
+    return wave_numbers * np.cos(wave_numbers * x) * np.array([field(np.delete(x, d), np.delete(wave_numbers, d)) for d in range(dim)])
+
+def source(x, wave_numbers):
+    x, wave_numbers = np.asarray(x), np.asarray(wave_numbers)
+    return np.sum(wave_numbers**2) * field(x, wave_numbers)
+
+def auxiliary_source(x, wave_numbers):
+    return np.zeros(x.shape)
+# End functions for testing ProductOfSinusoids.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+template <size_t Dim>
+void test_solution(const std::array<double, Dim>& wave_numbers,
+                   const std::string& options) {
+  const Poisson::Solutions::ProductOfSinusoids<Dim> solution(wave_numbers);
+  pypp::check_with_random_values<
+      1, tmpl::list<Poisson::Field, Poisson::AuxiliaryField<Dim>>>(
+      &Poisson::Solutions::ProductOfSinusoids<Dim>::field_variables, solution,
+      "ProductOfSinusoids", {"field", "auxiliary_field"}, {{{0., 2. * M_PI}}},
+      std::make_tuple(wave_numbers), DataVector(5));
+  pypp::check_with_random_values<
+      1, tmpl::list<Tags::Source<Poisson::Field>,
+                    Tags::Source<Poisson::AuxiliaryField<Dim>>>>(
+      &Poisson::Solutions::ProductOfSinusoids<Dim>::source_variables, solution,
+      "ProductOfSinusoids", {"source", "auxiliary_source"}, {{{0., 2. * M_PI}}},
+      std::make_tuple(wave_numbers), DataVector(5));
+
+  Poisson::Solutions::ProductOfSinusoids<Dim> created_solution =
+      test_creation<Poisson::Solutions::ProductOfSinusoids<Dim>>(
+          "  WaveNumbers: " + options);
+  CHECK(created_solution == solution);
+  test_serialization(solution);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.Poisson.ProductOfSinusoids",
+    "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/Poisson"};
+  test_solution<1>({{0.5}}, "[0.5]");
+  test_solution<2>({{0.5, 3.}}, "[0.5, 3]");
+  test_solution<3>({{1., 0.5, 3.}}, "[1, 0.5, 3]");
+}


### PR DESCRIPTION
## Proposed changes

This PR adds the first and simplest solution of the Poisson equation, a product of sinusoids. It's particularly simple because the boundary contributions vanish on a rectangular domain of length $\pi$.

- [x] I placed this in Elliptic/Systems/Poisson/Solutions (as opposed to PointwiseFunctions) since it's directly related to the Poisson system and I wanted to avoid spreading the Poisson namespace over too many directories. If there is a reason to keep analytic solutions in PointwiseFunctions, even though they are not applicable to other systems, please let me know.

- [x] The test is not very detailed yet, could you comment on what else I should test?

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
