### PR TITLE
Add flags for adaptive mesh refinement

### DIFF
--- a/src/Domain/Amr/CMakeLists.txt
+++ b/src/Domain/Amr/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY Amr)
+
+set(LIBRARY_SOURCES
+  Flag.cpp
+  )
+
+add_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE Domain
+  INTERFACE ErrorHandling
+  )

--- a/src/Domain/Amr/Flag.cpp
+++ b/src/Domain/Amr/Flag.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Amr/Flag.hpp"
+#include "ErrorHandling/Error.hpp"
+
+#include <ostream>
+
+namespace amr {
+
+std::ostream& operator<<(std::ostream& os, const Flag& flag) {
+  switch (flag) {
+    case Flag::Undefined:
+      os << "Undefined";
+      break;
+    case Flag::Join:
+      os << "Join";
+      break;
+    case Flag::DecreaseResolution:
+      os << "DecreaseResolution";
+      break;
+    case Flag::DoNothing:
+      os << "DoNothing";
+      break;
+    case Flag::IncreaseResolution:
+      os << "IncreaseResolution";
+      break;
+    case Flag::Split:
+      os << "Split";
+      break;
+    default:
+      ERROR("An undefined flag was passed to the stream operator.");
+  }
+  return os;
+}
+}  // namespace amr

--- a/src/Domain/Amr/Flag.hpp
+++ b/src/Domain/Amr/Flag.hpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines enum class amr::Flag.
+
+#pragma once
+
+#include <iosfwd>
+
+/// \ingroup ComputationalDomainGroup
+/// Items for adaptive mesh refinement
+namespace amr {
+
+/// \ingroup ComputationalDomainGroup
+/// \brief Flags that represent decisions about mesh refinement
+///
+/// In order to support anisotropic mesh refinement, a flag is specified for
+/// each dimension.
+enum class Flag {
+  Undefined,          /**< used to initialize flags before a decision is made */
+  Join,               /**< join the sibling of an Element */
+  DecreaseResolution, /**< decrease number of points in an Element */
+  DoNothing,          /**< stay the same */
+  IncreaseResolution, /**< increase number of points in an Element */
+  Split               /**< split the Element into two smaller elements */
+};
+
+/// Output operator for a Flag.
+std::ostream& operator<<(std::ostream& os, const Flag& flag);
+}  // namespace amr

--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Amr)
 add_subdirectory(CoordinateMaps)
 add_subdirectory(DomainCreators)
 

--- a/tests/Unit/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Domain/Amr/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_Amr")
+
+set(LIBRARY_SOURCES
+  Test_Flag.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Domain/Amr"
+  "${LIBRARY_SOURCES}"
+  "Amr;Utilities"
+  )

--- a/tests/Unit/Domain/Amr/Test_Flag.cpp
+++ b/tests/Unit/Domain/Amr/Test_Flag.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "Domain/Amr/Flag.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Domain.Amr.Flag", "[Domain][Unit]") {
+  CHECK(get_output(amr::Flag::Undefined) == "Undefined");
+  CHECK(get_output(amr::Flag::Join) == "Join");
+  CHECK(get_output(amr::Flag::DecreaseResolution) == "DecreaseResolution");
+  CHECK(get_output(amr::Flag::DoNothing) == "DoNothing");
+  CHECK(get_output(amr::Flag::IncreaseResolution) == "IncreaseResolution");
+  CHECK(get_output(amr::Flag::Split) == "Split");
+}

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LIBRARY_SOURCES
   Test_Side.cpp
   )
 
+add_subdirectory(Amr)
 add_subdirectory(CoordinateMaps)
 add_subdirectory(DomainCreators)
 


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
