### PR TITLE
Work around broken libc++ array implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ include(SetupSanitizers)
 include(SetupListTargets)
 include(AddSpectreExecutable)
 
+include(CheckBrokenArray0)
+
 include(SetupBlas)
 include(SetupBlaze)
 include(SetupBoost)

--- a/cmake/CheckBrokenArray0.cmake
+++ b/cmake/CheckBrokenArray0.cmake
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Check whether the standard library is affected by
+# https://bugs.llvm.org/show_bug.cgi?id=35491
+
+message(STATUS "Checking for broken std::array<..., 0>")
+try_compile(
+  ARRAY0_WORKS
+  ${CMAKE_BINARY_DIR}
+  ${CMAKE_SOURCE_DIR}/cmake/CheckBrokenArray0.cpp
+  CMAKE_FLAGS
+  -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+  -DCMAKE_CXX_STANDARD_REQUIRED=${CMAKE_CXX_STANDARD_REQUIRED}
+  -DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}
+  )
+if (ARRAY0_WORKS)
+  message(STATUS "Checking for broken std::array<..., 0> -- works")
+else (ARRAY0_WORKS)
+  message(STATUS "Checking for broken std::array<..., 0> -- broken")
+  add_definitions(-DHAVE_BROKEN_ARRAY0)
+endif (ARRAY0_WORKS)

--- a/cmake/CheckBrokenArray0.cpp
+++ b/cmake/CheckBrokenArray0.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// Copyright (c) 2009-2017 by the contributors to libc++, listed at
+// https://llvm.org/svn/llvm-project/libcxx/trunk/CREDITS.TXT
+
+// This is a portion of
+// https://llvm.org/svn/llvm-project/libcxx/trunk/test/std/containers/sequences/array/begin.pass.cpp
+
+#include <array>
+#include <cassert>
+
+int main() {
+  struct NoDefault {
+    NoDefault(int) {}
+  };
+  typedef NoDefault T;
+  typedef std::array<T, 0> C;
+  C c = {};
+  assert(c.begin() == c.end());
+}

--- a/src/Utilities/MakeArray.hpp
+++ b/src/Utilities/MakeArray.hpp
@@ -45,8 +45,14 @@ template <>
 struct MakeArray<true> {
   template <typename T, typename... Args>
   static SPECTRE_ALWAYS_INLINE constexpr std::array<T, 0> apply(
-      std::index_sequence<> /* unused */, Args&&... /*args*/) noexcept {
+      std::index_sequence<> /* unused */, Args&&... args) noexcept {
+#ifndef HAVE_BROKEN_ARRAY0
+    expand_pack(args...);  // Used in other preprocessor branch
     return std::array<T, 0>{{}};
+#else  // HAVE_BROKEN_ARRAY0
+    // https://bugs.llvm.org/show_bug.cgi?id=35491
+    return {{T(std::forward<Args>(args)...)}};
+#endif  // HAVE_BROKEN_ARRAY0
   }
 };
 }  // namespace MakeArray_detail

--- a/tests/Unit/Utilities/Test_MakeArray.cpp
+++ b/tests/Unit/Utilities/Test_MakeArray.cpp
@@ -111,6 +111,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.MakeArray", "[Unit][Utilities]") {
   // Check make_array with an rvalue sequence
   {
     std::vector<MyNonCopyable<int>> vector;
+    vector.reserve(3);
     for (int i = 0; i < 3; ++i) {
       vector.emplace_back(i);
     }

--- a/tests/Unit/Utilities/Test_MakeArray.cpp
+++ b/tests/Unit/Utilities/Test_MakeArray.cpp
@@ -130,4 +130,20 @@ SPECTRE_TEST_CASE("Unit.Utilities.MakeArray", "[Unit][Utilities]") {
       CHECK(vector[i] == (std::vector<int>{1, 2, 3}));
     }
   }
+
+  // Check that make_array works with non-default-constructible types
+  {
+    struct NonDefaultConstructible {
+      NonDefaultConstructible() = delete;
+      explicit NonDefaultConstructible(int /*unused*/) noexcept {}
+    };
+    const NonDefaultConstructible ndc{1};
+    // We just check that these compile, since there's not any
+    // realistic way they could give a wrong answer.
+    make_array<0>(ndc);
+    make_array<1>(ndc);
+    make_array<2>(ndc);
+    make_array(ndc, ndc);
+    make_array(ndc, ndc, ndc);
+  }
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
