### PR TITLE
Add Poisson solution with discontinuous first derivative

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY PoissonSolutions)
 
 set(LIBRARY_SOURCES
+  Moustache.cpp
   ProductOfSinusoids.cpp
   )
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
@@ -1,0 +1,110 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp"
+
+#include <algorithm>
+#include <array>
+#include <pup.h>  // IWYU pragma: keep
+
+#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp"
+// IWYU pragma: no_forward_declare Tensor
+
+namespace Poisson {
+namespace Solutions {
+
+namespace {
+
+tnsr::I<DataVector, 1> auxiliary_field(
+    const tnsr::I<DataVector, 1>& x,
+    const DataVector& precomputed_norm_square) noexcept {
+  auto result = make_with_value<tnsr::I<DataVector, 1>>(x, 0.);
+  const auto& x_d = get<0>(x);
+  get<0>(result) = sqrt(precomputed_norm_square) *
+                   evaluate_polynomial<double>({0.25, -3., 7.5, -5.}, x_d);
+  return result;
+}
+
+tnsr::I<DataVector, 2> auxiliary_field(
+    const tnsr::I<DataVector, 2>& x,
+    const DataVector& precomputed_norm_square) noexcept {
+  auto result = make_with_value<tnsr::I<DataVector, 2>>(x, 0.);
+  for (size_t d = 0; d < 2; d++) {
+    const auto& x_d = x.get(d);
+    const auto& x_p = x.get((d + 1) % 2);
+    result.get(d) = sqrt(precomputed_norm_square) * x_p * (1. - x_p) *
+                    (evaluate_polynomial<double>({0.25, -3.5, 7.5, -5.}, x_d) +
+                     evaluate_polynomial<double>({0.25, -1., 1.}, x_p) +
+                     2. * x_d * x_p - 2. * x_d * square(x_p));
+  }
+  return result;
+}
+
+}  // namespace
+
+template <size_t Dim>
+tuples::TaggedTuple<Field, AuxiliaryField<Dim>> Moustache<Dim>::field_variables(
+    const tnsr::I<DataVector, Dim>& x) const noexcept {
+  auto field = make_with_value<Scalar<DataVector>>(x, 1.);
+  for (size_t d = 0; d < Dim; d++) {
+    get(field) *= x.get(d) * (1. - x.get(d));
+  }
+  auto norm_square = make_with_value<DataVector>(get<0>(x), 0.);
+  for (size_t d = 0; d < Dim; d++) {
+    norm_square += square(x.get(d) - 0.5);
+  }
+  get(field) *= pow(norm_square, 3. / 2.);
+  return {std::move(field), auxiliary_field(x, norm_square)};
+}
+
+/// \cond
+template <>
+tuples::TaggedTuple<::Tags::Source<Field>, ::Tags::Source<AuxiliaryField<1>>>
+Moustache<1>::source_variables(const tnsr::I<DataVector, 1>& x) const noexcept {
+  const auto& x1 = get<0>(x);
+  // This polynomial is minus the laplacian of the 1D solution
+  Scalar<DataVector> field_source(
+      evaluate_polynomial<double>({0.875, -8.5, 28.5, -40., 20.}, x1) /
+      abs(x1 - 0.5));
+  return {std::move(field_source),
+          make_with_value<tnsr::I<DataVector, 1, Frame::Inertial>>(x, 0.)};
+}
+
+template <>
+tuples::TaggedTuple<::Tags::Source<Field>, ::Tags::Source<AuxiliaryField<2>>>
+Moustache<2>::source_variables(const tnsr::I<DataVector, 2>& x) const noexcept {
+  auto norm_square = make_with_value<DataVector>(get<0>(x), 0.);
+  for (size_t d = 0; d < 2; d++) {
+    norm_square += square(x.get(d) - 0.5);
+  }
+  const auto& x1 = get<0>(x);
+  const auto& x2 = get<1>(x);
+  // This polynomial is minus the laplacian of the 2D solution
+  Scalar<DataVector> field_source(
+      evaluate_polynomial<DataVector>(
+          {evaluate_polynomial<double>({0., 2., -7., 12., -11., 6., -2.}, x2),
+           evaluate_polynomial<double>({2., -26.5, 65.5, -78., 39.}, x2),
+           evaluate_polynomial<double>({-7., 65.5, -104.5, 78., -39.}, x2),
+           evaluate_polynomial<double>({12., -78., 78.}, x2),
+           evaluate_polynomial<double>({-11., 39., -39.}, x2),
+           make_with_value<DataVector>(x2, 6.),
+           make_with_value<DataVector>(x2, -2.)},
+          x1) /
+      sqrt(norm_square));
+  return {std::move(field_source),
+          make_with_value<tnsr::I<DataVector, 2, Frame::Inertial>>(x, 0.)};
+}
+/// \endcond
+
+template <size_t Dim>
+void Moustache<Dim>::pup(PUP::er& /*p*/) noexcept {}
+
+}  // namespace Solutions
+}  // namespace Poisson
+
+template class Poisson::Solutions::Moustache<1>;
+template class Poisson::Solutions::Moustache<2>;

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
@@ -1,0 +1,88 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"     // IWYU pragma: keep
+#include "Elliptic/Systems/Poisson/Tags.hpp"    // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Poisson {
+namespace Solutions {
+
+/*!
+ * \brief A solution to the Poisson equation with a discontinuous first
+ * derivative.
+ *
+ * \details This implements the solution \f$u(x,y)=x\left(1-x\right)
+ * y\left(1-y\right)\left(\left(x-\frac{1}{2}\right)^2+\left(y-
+ * \frac{1}{2}\right)^2\right)^\frac{3}{2}\f$ to the Poisson equation
+ * in two dimensions, and
+ * \f$u(x)=x\left(1-x\right)\left|x-\frac{1}{2}\right|^3\f$ in one dimension.
+ * Their boundary conditions vanish on the square \f$[0,1]^2\f$ or interval
+ * \f$[0,1]\f$, respectively.
+ *
+ * The corresponding source \f$f=-\Delta u\f$ has a discontinuous first
+ * derivative at \f$\frac{1}{2}\f$. This accomplishes two things:
+ *
+ * - It makes it useful to test the convergence behaviour of our elliptic DG
+ * solver.
+ * - It makes it look like a moustache (at least in 1D).
+ *
+ * This solution is taken from _B. Stamm and T. Wihler, Mathematics of
+ * Computation 79, 2117 (2010)_. It is also investigated in _T. Vincent and H.P.
+ * Pfeiffer, in preparation_.
+ */
+template <size_t Dim>
+class Moustache {
+ public:
+  using options = tmpl::list<>;
+  static constexpr OptionString help{
+      "A solution with a discontinuous first derivative of its source at 1/2 "
+      "that also happens to look like a moustache. It vanishes at zero and one "
+      "in each dimension"};
+
+  Moustache() = default;
+  Moustache(const Moustache&) noexcept = delete;
+  Moustache& operator=(const Moustache&) noexcept = delete;
+  Moustache(Moustache&&) noexcept = default;
+  Moustache& operator=(Moustache&&) noexcept = default;
+  ~Moustache() noexcept = default;
+
+  auto field_variables(const tnsr::I<DataVector, Dim>& x) const noexcept
+      -> tuples::TaggedTuple<Field, AuxiliaryField<Dim>>;
+
+  auto source_variables(const tnsr::I<DataVector, Dim>& x) const noexcept
+      -> tuples::TaggedTuple<::Tags::Source<Field>,
+                             ::Tags::Source<AuxiliaryField<Dim>>>;
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
+};
+
+template <size_t Dim>
+constexpr bool operator==(const Moustache<Dim>& /*lhs*/,
+                          const Moustache<Dim>& /*rhs*/) noexcept {
+  return true;
+}
+
+template <size_t Dim>
+constexpr bool operator!=(const Moustache<Dim>& lhs,
+                          const Moustache<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace Solutions
+}  // namespace Poisson

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Solutions.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Solutions.hpp
@@ -8,6 +8,7 @@
 
 namespace Poisson {
 /*!
+ * \ingroup AnalyticSolutionsGroup
  * \brief Analytic solutions to the Poisson equation
  * \f$-\Delta u(\vec{x}) = f(\vec{x})\f$
  */

--- a/src/Utilities/Math.hpp
+++ b/src/Utilities/Math.hpp
@@ -4,8 +4,11 @@
 #pragma once
 
 #include <cmath>
+#include <numeric>
+#include <vector>
 
 #include "Utilities/ForceInline.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 /*!
@@ -18,4 +21,27 @@ SPECTRE_ALWAYS_INLINE T number_of_digits(const T number) {
                 "Must call number_of_digits with an integer number");
   return number == 0 ? 1 : static_cast<decltype(number)>(
                                std::ceil(std::log10(std::abs(number) + 1)));
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Evaluate a polynomial \f$\sum_{p=0}^N c_p x^p\f$ with Horner's rule
+ *
+ * \param coeffs The polynomial coefficients \f$c_p\f$ ordered from constant to
+ * largest power
+ * \param x The polynomial variable \f$x\f$
+ *
+ * \tparam U The type of the polynomial coefficients \p coeffs. Can be `double`,
+ * which means the coefficients are constant for all values in \p x. Can also be
+ * a vector type of typically the same size as `T`, which means the coefficients
+ * vary with the elements in \p x.
+ * \tparam T The type of the polynomial variable \p x. Must support
+ * `make_with_value<T, T>`, as well as (elementwise) addition with `U` and
+ * multiplication with `T`.
+ */
+template <typename U, typename T>
+T evaluate_polynomial(const std::vector<U>& coeffs, const T& x) noexcept {
+  return std::accumulate(
+      coeffs.rbegin(), coeffs.rend(), make_with_value<T>(x, 0.),
+      [&x](const T& state, const U& element) { return state * x + element; });
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_PoissonSolutions")
 
 set(LIBRARY_SOURCES
+  Test_Moustache.cpp
   Test_ProductOfSinusoids.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.py
@@ -1,0 +1,39 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Functions for testing ProductOfSinusoids.cpp
+def poly(x, coeffs):
+    return np.sum(c * x**p for p, c in enumerate(coeffs))
+
+def field(x):
+    return np.prod(x * (1. - x)) * np.sum((x - 0.5)**2)**(3. / 2.)
+
+def auxiliary_field(x):
+    if len(x) == 1:
+        return np.abs(x - 0.5) * poly(x, [0.25, -3, 7.5, -5])
+    elif len(x) == 2:
+        return np.sqrt(np.sum((x - 0.5)**2)) * np.array([
+            x[d - 1] * (1. - x[d - 1]) * (poly(x[d], [
+                0.5, poly(x[d - 1], [-3.5, 2, -2]), 7.5, -5
+                ]) + poly(x[d - 1], [0, -1, 1]))
+            for d in range(len(x))])
+
+def source(x):
+    if len(x) == 1:
+        return (poly(x, [0.875, -8.5, 28.5, -40., 20.]) / np.abs(x - 0.5))[0]
+    elif len(x) == 2:
+        return poly(x[0], [
+            poly(x[1], [0., 2., -7., 12., -11., 6., -2.]),
+            poly(x[1], [2., -26.5, 65.5, -78., 39.]),
+            poly(x[1], [-7., 65.5, -104.5, 78., -39.]),
+            poly(x[1], [12., -78., 78.]),
+            poly(x[1], [-11., 39., -39.]),
+            6., -2.
+        ]) / np.linalg.norm(x - 0.5)
+
+def auxiliary_source(x):
+    return np.zeros(len(x))
+# End functions for testing ProductOfSinusoids.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+template <size_t Dim>
+void test_solution() {
+  const Poisson::Solutions::Moustache<Dim> solution{};
+  pypp::check_with_random_values<
+      1, tmpl::list<Poisson::Field, Poisson::AuxiliaryField<Dim>>>(
+      &Poisson::Solutions::Moustache<Dim>::field_variables, solution,
+      "Moustache", {"field", "auxiliary_field"}, {{{0., 1.}}},
+      std::make_tuple(), DataVector(5));
+  pypp::check_with_random_values<
+      1, tmpl::list<Tags::Source<Poisson::Field>,
+                    Tags::Source<Poisson::AuxiliaryField<Dim>>>>(
+      &Poisson::Solutions::Moustache<Dim>::source_variables, solution,
+      "Moustache", {"source", "auxiliary_source"}, {{{0., 1.}}},
+      std::make_tuple(), DataVector(5));
+
+  Poisson::Solutions::Moustache<Dim> created_solution =
+      test_creation<Poisson::Solutions::Moustache<Dim>>("  ");
+  CHECK(created_solution == solution);
+  test_serialization(solution);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Poisson.Moustache",
+                  "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/Poisson"};
+  test_solution<1>();
+  test_solution<2>();
+}

--- a/tests/Unit/Pypp/CheckWithRandomValues.hpp
+++ b/tests/Unit/Pypp/CheckWithRandomValues.hpp
@@ -159,6 +159,7 @@ void check_with_random_values_impl(
   size_t count = 0;
   tmpl::for_each<TagsList>([&f, &klass, &args, &used_for_size, &member_args,
                             &module_name, &function_names, &count](auto tag) {
+    (void)member_args;    // Avoid compiler warning
     (void)used_for_size;  // Avoid compiler warning
     using Tag = tmpl::type_from<decltype(tag)>;
     const auto result =

--- a/tests/Unit/Utilities/Test_Math.cpp
+++ b/tests/Unit/Utilities/Test_Math.cpp
@@ -3,13 +3,31 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
 #include "Utilities/Math.hpp"
 
 SPECTRE_TEST_CASE("Unit.Utilities.Math", "[Unit][Utilities]") {
-  // Test number_of_digits
-  CHECK(2 == number_of_digits(10));
-  CHECK(1 == number_of_digits(0));
-  CHECK(1 == number_of_digits(-1));
-  CHECK(1 == number_of_digits(9));
-  CHECK(2 == number_of_digits(-99));
+  SECTION("Test number_of_digits") {
+    CHECK(2 == number_of_digits(10));
+    CHECK(1 == number_of_digits(0));
+    CHECK(1 == number_of_digits(-1));
+    CHECK(1 == number_of_digits(9));
+    CHECK(2 == number_of_digits(-99));
+  }
+
+  SECTION("Test evaluate_polynomial") {
+    const std::vector<double> poly_coeffs{1., 2.5, 0.3, 1.5};
+    CHECK_ITERABLE_APPROX(evaluate_polynomial(poly_coeffs, 0.5), 2.5125);
+    CHECK_ITERABLE_APPROX(
+        evaluate_polynomial(poly_coeffs,
+                            DataVector({-0.5, -0.1, 0., 0.8, 1., 12.})),
+        DataVector({-0.3625, 0.7515, 1., 3.96, 5.3, 2666.2}));
+    const std::vector<DataVector> poly_variable_coeffs{DataVector{1., 0., 2.},
+                                                       DataVector{0., 2., 1.}};
+    CHECK_ITERABLE_APPROX(
+        evaluate_polynomial(poly_variable_coeffs, DataVector({0., 0.5, 1.})),
+        DataVector({1., 1., 3.}));
+  }
 }


### PR DESCRIPTION
## Proposed changes

This solution to the Poisson equation has a discontinuous first derivative at x=1/2=y which makes it useful to test convergence and (eventually) AMR for the elliptic solver:

The two-dimensional solution is:

```math
u(x) = x (1 - x) y (1 - y) ((x - 1/2)^2 + (y - 1/2)^2)^3/2
```

For reasons that should be clear from looking at the shape of the source (see 1D plot below) I named it `Poisson::Solutions::Moustache`. Renaming suggestions welcome :)

![bildschirmfoto 2018-07-28 um 00 26 01](https://user-images.githubusercontent.com/746230/43348906-dec708ce-91fc-11e8-963c-1ddb1a908aa4.png)

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).