### PR TITLE
Add parallel horizon finder.

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -485,6 +485,9 @@
  * invert.
  */
 
+/// \defgroup LoggingGroup Logging
+/// \brief Functions for logging progress of running code
+
 /// \defgroup MathFunctionsGroup Math Functions
 /// \brief Useful analytic functions
 

--- a/src/ApparentHorizons/HorizonComponent.hpp
+++ b/src/ApparentHorizons/HorizonComponent.hpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "ApparentHorizons/FastFlow.hpp"
+#include "ApparentHorizons/HorizonComponentActions.hpp"
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/DomainCreator.hpp"
+#include "Domain/Tags.hpp"
+#include "Informer/Tags.hpp"
+#include "Informer/Verbosity.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \ingroup SurfacesGroup
+/// Holds objects used by horizon finders.
+namespace ah {
+
+// This struct groups together options that can be specified
+// for a single horizon, so that in the input file they can
+// be specified under headings such as "AhA", "AhB", etc.
+namespace Finder_detail {
+template <typename Frame>
+struct OptionHolder {
+  struct Verbosity {
+    using type = ::Verbosity;
+    static constexpr OptionString help = {"Verbosity"};
+    static type default_value() { return ::Verbosity::Quiet; }
+  };
+  struct FastFlow {
+    using type = ::FastFlow;
+    static constexpr OptionString help = {"FastFlow"};
+  };
+  struct InitialGuess {
+    using type = Strahlkorper<Frame>;
+    static constexpr OptionString help = {"Strahlkorper for initial guess"};
+  };
+  using options = tmpl::list<Verbosity, FastFlow, InitialGuess>;
+  static constexpr OptionString help = {"Options for horizon finder"};
+
+  OptionHolder(::Verbosity verbosity_in, ::FastFlow&& fast_flow_in,
+               Strahlkorper<Frame>&& initial_guess_in)
+      : verbosity(verbosity_in),
+        // clang-tidy: move of trivially copyable type
+        fast_flow(std::move(fast_flow_in)),  // NOLINT
+        initial_guess(std::move(initial_guess_in)) {}
+
+  OptionHolder() = default;
+  OptionHolder(const OptionHolder& /*rhs*/) = default;
+  OptionHolder& operator=(const OptionHolder& /*rhs*/) = default;
+  OptionHolder(OptionHolder&& /*rhs*/) noexcept = default;
+  OptionHolder& operator=(OptionHolder&& /*rhs*/) noexcept = default;
+  ~OptionHolder() = default;
+
+  ::Verbosity verbosity{::Verbosity::Quiet};
+  ::FastFlow fast_flow{};
+  Strahlkorper<Frame> initial_guess{};
+};
+}  // namespace Finder_detail
+
+/// Tags for options.
+namespace OptionTags {
+// I haven't found a way to avoid having three different structs here.
+// (note that the option name in the input file is the struct name,
+//  so something like template<typename AhTag> struct AhOptions{...};
+//  doesn't work because it will look for 'AhOptions' in the input file).
+template <typename Frame>
+struct AhA {
+  using type = Finder_detail::OptionHolder<Frame>;
+  static constexpr OptionString help = {"Options for AhA"};
+};
+template <typename Frame>
+struct AhB {
+  using type = Finder_detail::OptionHolder<Frame>;
+  static constexpr OptionString help = {"Options for AhB"};
+};
+template <typename Frame>
+struct AhC {
+  using type = Finder_detail::OptionHolder<Frame>;
+  static constexpr OptionString help = {"Options for AhC"};
+};
+}  // namespace OptionTags
+
+/// Singleton component that holds a horizon.
+///
+/// \details
+/// A ah::Finder is responsible for finding a horizon and
+/// communicating with DataInterpolators to do so.  There are
+/// only a small number of ah::Finders, one for each horizon
+/// (e.g. for BBH inspirals there should be exactly three of them, which are
+/// often labeled AhA, AhB, and AhC; AhC is the common horizon that pops
+/// up at merger).
+///
+/// The AhTag is anything that has the following functions and type aliases:
+///   - a static function 'label()' returning a std::string or a const char *.
+///   - a type alias 'frame' indicating a frame from namespace ::Frame.
+///   - a type alias 'option_tag' containing something in Horizon::OptionTags.
+///   - a type alias 'convergence_hook' to a struct with a static function
+///     void apply(const Strahlkorper<AhTag::frame>&, const Time&,
+///                const Parallel::ConstGlobalCache<Metavariables>&) noexcept;
+///     that Finder will call when it converges.
+template <class Metavariables, typename AhTag>
+struct Finder {
+  using chare_type = Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename Actions::Finder::Initialize<AhTag>::return_tag_list>;
+  using options =
+      tmpl::list<typename AhTag::option_tag,
+                 ::OptionTags::DomainCreator<3, typename AhTag::frame>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<metavariables>& global_cache,
+      Finder_detail::OptionHolder<typename AhTag::frame>&& option_holder,
+      std::unique_ptr<DomainCreator<3, Frame::Inertial>>
+          domain_creator) noexcept;
+  static void execute_next_phase(
+      typename metavariables::Phase /*next_phase*/,
+      const Parallel::CProxy_ConstGlobalCache<metavariables>&
+      /*global_cache*/) noexcept {};
+};
+
+template <class Metavariables, typename AhTag>
+void Finder<Metavariables, AhTag>::initialize(
+    Parallel::CProxy_ConstGlobalCache<metavariables>& global_cache,
+    Finder_detail::OptionHolder<typename AhTag::frame>&& option_holder,
+    std::unique_ptr<DomainCreator<3, Frame::Inertial>>
+        domain_creator) noexcept {
+  auto& my_proxy =
+      Parallel::get_parallel_component<Finder>(*(global_cache.ckLocalBranch()));
+  auto domain = domain_creator->create_domain();
+  Parallel::simple_action<Actions::Finder::Initialize<AhTag>>(
+      my_proxy, std::move(option_holder.verbosity),
+      std::move(option_holder.fast_flow),
+      std::move(option_holder.initial_guess), std::move(domain));
+}
+}  // namespace ah

--- a/src/ApparentHorizons/HorizonComponentActions.hpp
+++ b/src/ApparentHorizons/HorizonComponentActions.hpp
@@ -1,0 +1,389 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+
+#include "ApparentHorizons/FastFlow.hpp"
+#include "ApparentHorizons/HorizonManagerComponentActions.hpp"
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "ApparentHorizons/Tags.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Informer/Tags.hpp"
+#include "Informer/Verbosity.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/Algorithm.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \ingroup SurfacesGroup
+/// Holds objects used by horizon finders.
+namespace ah {
+template <class Metavariables>
+struct DataInterpolator;
+
+/// Tags for items held in the DataBox of an ah::Finder.
+namespace Tags {
+
+/// Keeps track of which points on the Strahlkorper have been filled
+/// with interpolated data.
+struct IndicesOfFilledInterpPoints : db::SimpleTag {
+  static std::string name() noexcept { return "IndicesOfFilledInterpPoints"; }
+  using type = std::unordered_set<size_t>;
+};
+
+/// Time steps on which to find horizons.
+struct Timesteps : db::SimpleTag {
+  using type = std::deque<Time>;
+  static std::string name() noexcept { return "Timesteps"; }
+};
+
+struct FastFlow : db::SimpleTag {
+  static std::string name() noexcept { return "FastFlow"; }
+  using type = ::FastFlow;
+};
+template <typename Frame>
+struct Strahlkorper : db::SimpleTag {
+  static std::string name() noexcept { return "Strahlkorper"; }
+  using type = ::Strahlkorper<Frame>;
+};
+template <size_t Dim, typename Frame>
+struct Domain : db::SimpleTag {
+  static std::string name() noexcept { return "Domain"; }
+  using type = ::Domain<Dim, Frame>;
+};
+}  // namespace Tags
+
+namespace Finder_detail {
+
+// Returns the next set of points, in Frame coordinates, that data
+// should be interpolated onto.
+template <typename Frame>
+const tnsr::I<DataVector, 3, Frame> next_interp_points(
+    const Strahlkorper<Frame>& strahlkorper,
+    const FastFlow& fast_flow) noexcept {
+  // Construct strahlkorper that has a larger mesh than the number of
+  // coefficients that are being minimized.  We interpolate to all points
+  // on this prolonged_strahlkorper, not on the current strahlkorper.
+  const size_t L_mesh = fast_flow.current_l_mesh(strahlkorper);
+  const auto prolonged_strahlkorper =
+      Strahlkorper<Frame>(L_mesh, L_mesh, strahlkorper);
+
+  // Make a DataBox so we can get coords from prolonged_strahlkorper
+  auto box = db::create<
+      db::AddSimpleTags<StrahlkorperTags::items_tags<Frame>>,
+      db::AddComputeTags<StrahlkorperTags::compute_items_tags<Frame>>>(
+      std::move(prolonged_strahlkorper));
+
+  return db::get<StrahlkorperTags::CartesianCoords<Frame>>(box);
+}
+
+// Sends to all the DataInterpolators a list of all the points that
+// need to be interpolated onto.
+// Also clears information about data that has been interpolated.
+template <typename AhTag, typename DbTags, typename Metavariables>
+void send_points_to_horizon_manager(
+    db::DataBox<DbTags>& box, Parallel::ConstGlobalCache<Metavariables>& cache,
+    const Time& timestep) noexcept {
+  using frame = typename AhTag::frame;
+  const auto& strahlkorper = db::get<Tags::Strahlkorper<frame>>(box);
+  const auto& fast_flow = db::get<Tags::FastFlow>(box);
+  const auto& domain = db::get<Tags::Domain<3, frame>>(box);
+  auto& receiver_proxy =
+      Parallel::get_parallel_component<ah::DataInterpolator<Metavariables>>(
+          cache);
+  auto coords = block_logical_coordinates(
+      domain, next_interp_points<frame>(strahlkorper, fast_flow));
+
+  db::mutate<Tags::IndicesOfFilledInterpPoints, vars_tags<frame>>(
+      make_not_null(&box),
+      [&coords](
+          const gsl::not_null<db::item_type<Tags::IndicesOfFilledInterpPoints>*>
+              indices_of_filled,
+          const gsl::not_null<db::item_type<vars_tags<frame>>*>
+              vars_dest) noexcept {
+        indices_of_filled->clear();
+        if (vars_dest->number_of_grid_points() != coords.size()) {
+          *vars_dest = typename vars_tags<frame>::type(coords.size());
+        }
+      });
+  Parallel::simple_action<
+      Actions::DataInterpolator::ReceiveInterpolationPoints<AhTag>>(
+      receiver_proxy, timestep, std::move(coords));
+}
+
+// Does a single iteration of the FastFlow algorithm.
+// If another iteration is needed, sends the new points to the
+// DataInterpolators (which starts the next iteration).
+// If converged, check if another horizon should be
+// found, and if so, send the new points to the DataInterpolators, starting
+// the next iteration.
+template <typename AhTag, typename DbTags, typename Metavariables>
+void do_fastflow_iteration(
+    db::DataBox<DbTags>& box,
+    Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+  const auto& verbose = db::get<::Tags::Verbosity>(box);
+  const auto& inv_g =
+      db::get<::gr::Tags::InverseSpatialMetric<3, typename AhTag::frame>>(box);
+  const auto& ex_curv =
+      db::get<::gr::Tags::ExtrinsicCurvature<3, typename AhTag::frame>>(box);
+  const auto& christ = db::get<
+      ::gr::Tags::SpatialChristoffelSecondKind<3, typename AhTag::frame>>(box);
+
+  if (verbose == ::Verbosity::Debug) {
+    Parallel::printf(
+        "### Node:%d  Proc:%d ###\n"
+        "%s: FastFlowIteration\n\n",
+        Parallel::my_node(), Parallel::my_proc(), AhTag::label());
+  }
+
+  std::pair<FastFlow::Status, FastFlow::IterInfo> status_and_info;
+
+  db::mutate<Tags::FastFlow, Tags::Strahlkorper<typename AhTag::frame>>(
+      make_not_null(&box),
+      [&inv_g, &ex_curv, &christ, &status_and_info ](
+          const gsl::not_null<::FastFlow*> fast_flow,
+          const gsl::not_null<::Strahlkorper<typename AhTag::frame>*>
+              strahlkorper) noexcept {
+        status_and_info =
+            fast_flow->template iterate_horizon_finder<typename AhTag::frame>(
+                strahlkorper, inv_g, ex_curv, christ);
+      });
+
+  const auto& status = status_and_info.first;
+  const auto& info = status_and_info.second;
+  if (verbose > ::Verbosity::Quiet or
+      (verbose > ::Verbosity::Silent and converged(status))) {
+    Parallel::printf(
+        "%s: its=%d: %.1e<R<%.0e, |R|=%.1g, "
+        "|R_grid|=%.1g, %.4g<r<%.4g\n",
+        AhTag::label(), info.iteration, info.min_residual, info.max_residual,
+        info.residual_ylm, info.residual_mesh, info.r_min, info.r_max);
+  }
+
+  if (converged(status)) {
+    const auto step = db::get<Tags::Timesteps>(box).front();
+    if (verbose > ::Verbosity::Quiet) {
+      Parallel::printf("FastFlowIteration: %s has converged, timestep %s\n",
+                       AhTag::label(), step);
+    }
+
+    // Tell all the DataInterpolators about the convergence.
+    // Eventually when there are Actions for observers, control
+    // systems, etc. that depend on the horizon, they should be called
+    // here.
+    auto& horizon_manager_proxy =
+        Parallel::get_parallel_component<ah::DataInterpolator<Metavariables>>(
+            cache);
+    Parallel::simple_action<
+        Actions::DataInterpolator::HorizonHasConverged<AhTag>>(
+        horizon_manager_proxy, step);
+
+    // Call the hook.
+    const auto& strahlkorper =
+        db::get<Tags::Strahlkorper<typename AhTag::frame>>(box);
+    AhTag::convergence_hook::apply(strahlkorper, step, cache);
+
+    // Prepare for finding horizon at a new time.
+    // For now, the initial guess for the new
+    // horizon is the result of the old one.
+    // Eventually ah::Finder will hold the previous horizons and
+    // will do time-extrapolation to set the next guess.
+    db::mutate<Tags::FastFlow, Tags::Timesteps>(
+        make_not_null(&box), [](const gsl::not_null<::FastFlow*> fast_flow,
+                                const gsl::not_null<
+                                    db::item_type<Tags::Timesteps>*>
+                                    steps) noexcept {
+          fast_flow->reset_for_next_find();
+          steps->pop_front();
+        });
+
+    const auto& timesteps = db::get<Tags::Timesteps>(box);
+    if (not timesteps.empty()) {
+      // There are still horizon searches to be done, so do the next one.
+      // Note that we haven't yet implemented time extrapolation for a
+      // new initial guess.  Currently the previous Strahlkorper
+      // (which is in the DataBox) is used for the initial guess of the
+      // next search.  To add the time extrapolation, we need to store
+      // one or more extra Strahlkorper(s) for the previous iteration(s),
+      // and do the extrapolation here.
+      send_points_to_horizon_manager<AhTag, DbTags, Metavariables>(
+          box, cache, timesteps.front());
+    }
+  } else if (status == FastFlow::Status::SuccessfulIteration) {
+    // Do another iteration of the same horizon search.
+    if (verbose == ::Verbosity::Debug) {
+      Parallel::printf(
+          "### Node:%d  Proc:%d ###\n"
+          "%s: FastFlowIteration: Horizon next iter %d\n\n",
+          Parallel::my_node(), Parallel::my_proc(), AhTag::label(),
+          info.iteration);
+    }
+    const auto& timesteps = db::get<Tags::Timesteps>(box);
+    send_points_to_horizon_manager<AhTag, DbTags, Metavariables>(
+        box, cache, timesteps.front());
+  } else {
+    Parallel::printf("Finder %s failed, reason = %s\n", AhTag::label(), status);
+    Parallel::abort("Finder failed");
+  }
+}
+}  // namespace Finder_detail
+
+namespace Actions {
+namespace Finder {
+template <typename AhTag>
+struct Initialize {
+  using return_tag_list =
+      tmpl::list<Tags::IndicesOfFilledInterpPoints, ::Tags::Verbosity,
+                 Tags::FastFlow, Tags::Strahlkorper<typename AhTag::frame>,
+                 Tags::Timesteps, Tags::Domain<3, typename AhTag::frame>,
+                 vars_tags<typename AhTag::frame>>;
+
+  template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    ::Verbosity verbosity, FastFlow&& fast_flow,
+                    Strahlkorper<typename AhTag::frame>&& strahlkorper,
+                    Domain<3, Frame::Inertial>&& domain) noexcept {
+    return std::make_tuple(db::create<db::get_items<return_tag_list>>(
+        Tags::IndicesOfFilledInterpPoints::type{}, verbosity,
+        // clang-tidy: std::move of trivially copyable type
+        std::move(fast_flow),  // NOLINT
+        std::move(strahlkorper), Tags::Timesteps::type{}, std::move(domain),
+        typename vars_tags<typename AhTag::frame>::type{}));
+  }
+};
+
+/// Adds time steps on which this horizon should be found, and starts
+/// a horizon search.  The time steps are removed once the horizon has
+/// been found.
+template <typename AhTag>
+struct AddTimeSteps {
+  using frame = typename AhTag::frame;
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<DbTags, typename Tags::FastFlow>> =
+                nullptr>
+  static void apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const std::vector<Time>& timesteps) noexcept {
+    // If the horizon finder is currently running, it is holding a
+    // non-empty list of timesteps.  Otherwise, we need to trigger a new
+    // horizon search (done below).
+    const bool start_horizon_finder = db::get<Tags::Timesteps>(box).empty();
+
+    db::mutate<Tags::Timesteps>(
+        make_not_null(&box), [&timesteps](const gsl::not_null<
+                                          db::item_type<Tags::Timesteps>*>
+                                              steps) noexcept {
+          steps->insert(steps->end(), timesteps.begin(), timesteps.end());
+        });
+
+    // Trigger horizon finder if necessary.
+    const auto& steps = db::get<Tags::Timesteps>(box);
+    if (start_horizon_finder and not steps.empty()) {
+      Finder_detail::send_points_to_horizon_manager<AhTag, DbTags,
+                                                    Metavariables>(
+          box, cache, steps.front());
+    }
+  }
+};
+
+/// Receives interpolated variables from the DataInterpolators.
+/// When enough data has been received, it does a horizon-finding
+/// iteration.
+template <typename AhTag>
+struct ReceiveInterpolatedVars {
+  using frame = typename AhTag::frame;
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<DbTags, typename Tags::FastFlow>> =
+                nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const std::vector<typename vars_tags<frame>::type>& vars_src,
+      const std::vector<std::vector<size_t>>& global_offsets) noexcept {
+    db::mutate<Tags::IndicesOfFilledInterpPoints, vars_tags<frame>>(
+        make_not_null(&box),
+        [
+          &vars_src, &global_offsets
+        ](const gsl::not_null<db::item_type<Tags::IndicesOfFilledInterpPoints>*>
+              indices_of_filled,
+          const gsl::not_null<db::item_type<vars_tags<frame>>*>
+              vars_dest) noexcept {
+          const size_t npts_dest = vars_dest->number_of_grid_points();
+          const size_t nvars = vars_dest->number_of_independent_components;
+          for (size_t j = 0; j < global_offsets.size(); ++j) {
+            const size_t npts_src = global_offsets[j].size();
+            for (size_t i = 0; i < npts_src; ++i) {
+              // If a point is on the boundary of two (or more)
+              // elements, it is possible that we have received data
+              // for this point from more than one DataInterpolator.
+              // This will rarely occur, but it does occur, e.g. when
+              // an initial-guess point is exactly on some symmetry
+              // boundary (such as the x-y plane) and this symmetry
+              // boundary is exactly the boundary between two
+              // elements.  If this happens, we accept the first
+              // duplicated point here, and we ignore subsequent
+              // duplicated points.  The points are easy to keep track
+              // of because global_offsets uniquely identifies the
+              // points.
+              if (indices_of_filled->insert(global_offsets[j][i]).second) {
+                for (size_t v = 0; v < nvars; ++v) {
+                  // clang-tidy: no pointer arithmetic
+                  vars_dest->data()[global_offsets[j][i] +   // NOLINT
+                                    v * npts_dest] =         // NOLINT
+                      vars_src[j].data()[i + v * npts_src];  // NOLINT
+                }
+              }
+            }
+          }
+        });
+
+    const auto& verbose = db::get<::Tags::Verbosity>(box);
+    if (verbose == ::Verbosity::Debug) {
+      Parallel::printf(
+          "### Node:%d  Proc:%d ###\n"
+          "{%s}: ReceiveInterpolatedVars:filled %d of %d points\n\n",
+          Parallel::my_node(), Parallel::my_proc(), AhTag::label(),
+          db::get<Tags::IndicesOfFilledInterpPoints>(box).size(),
+          db::get<vars_tags<frame>>(box).number_of_grid_points());
+    }
+
+    if (db::get<Tags::IndicesOfFilledInterpPoints>(box).size() ==
+        db::get<vars_tags<frame>>(box).number_of_grid_points()) {
+      Finder_detail::do_fastflow_iteration<AhTag, DbTags, Metavariables>(box,
+                                                                         cache);
+    }
+  }
+};
+}  // namespace Finder
+}  // namespace Actions
+}  // namespace ah

--- a/src/ApparentHorizons/HorizonManagerComponent.hpp
+++ b/src/ApparentHorizons/HorizonManagerComponent.hpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "ApparentHorizons/HorizonManagerComponentActions.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Informer/Tags.hpp"
+#include "Informer/Verbosity.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+
+/// \ingroup SurfacesGroup
+namespace ah {
+
+// Holds all the options for a DataInterpolator, so that
+// they can be specified under a DataInterpolator heading in the input file.
+namespace DataInterpolator_detail {
+struct OptionHolder {
+  struct Verbosity {
+    using type = ::Verbosity;
+    static constexpr OptionString help = {"Verbosity"};
+    static type default_value() { return ::Verbosity::Quiet; }
+  };
+  using options = tmpl::list<Verbosity>;
+  static constexpr OptionString help = {"Options for horizon manager"};
+
+  explicit OptionHolder(::Verbosity verbosity_in) : verbosity(verbosity_in) {}
+
+  OptionHolder() = default;
+  OptionHolder(const OptionHolder& /*rhs*/) = default;
+  OptionHolder& operator=(const OptionHolder& /*rhs*/) = default;
+  OptionHolder(OptionHolder&& /*rhs*/) noexcept = default;
+  OptionHolder& operator=(OptionHolder&& /*rhs*/) noexcept = default;
+  ~OptionHolder() = default;
+
+  ::Verbosity verbosity{::Verbosity::Quiet};
+};
+}  // namespace DataInterpolator_detail
+
+namespace OptionTags {
+struct DataInterpolator {
+  using type = DataInterpolator_detail::OptionHolder;
+  static constexpr OptionString help = {"Options for DataInterpolator"};
+};
+}  // namespace OptionTags
+
+/// Group component responsible for interpolating data to ah::Finders.
+/// Metavariables must contain (in addition to the usual things it contains)
+/// a type alias called horizon_tags that is a tmpl::list of AhTags,
+/// where each AhTag is a struct that contains:
+///         - a static function 'label()' returning std::string or const char*.
+///         - a type alias 'frame' to the ::Frame of the horizon.
+///         - a type alias 'option_tag' to something in Horizon::OptionTags.
+///         - a type alias 'convergence_hook' to a struct with a static function
+///       void apply(const Strahlkorper<AhTag::frame>&, const Time &,
+///                  const Parallel::ConstGlobalCache<Metavariables>&) noexcept;
+///           that the ah::Finder will call when it converges.
+/// There should be one AhTag for each ah::Finder.
+template <class Metavariables>
+struct DataInterpolator {
+  using chare_type = Parallel::Algorithms::Group;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using metavariables = Metavariables;
+  using action_list = tmpl::list<>;
+  using initial_databox =
+      db::compute_databox_type<typename Actions::DataInterpolator::Initialize::
+                                   return_tag_list<Metavariables>>;
+  using options = tmpl::list<OptionTags::DataInterpolator>;
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+      DataInterpolator_detail::OptionHolder&& option_holder);
+  static void execute_next_phase(typename Metavariables::Phase /*next_phase*/,
+                                 const Parallel::CProxy_ConstGlobalCache<
+                                     Metavariables>& /*global_cache*/){};
+};
+
+template <class Metavariables>
+void DataInterpolator<Metavariables>::initialize(
+    Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+    DataInterpolator_detail::OptionHolder&& option_holder) {
+  auto& my_proxy = Parallel::get_parallel_component<DataInterpolator>(
+      *(global_cache.ckLocalBranch()));
+  Parallel::simple_action<Actions::DataInterpolator::Initialize>(
+      my_proxy, option_holder.verbosity);
+}
+}  // namespace ah

--- a/src/ApparentHorizons/HorizonManagerComponentActions.hpp
+++ b/src/ApparentHorizons/HorizonManagerComponentActions.hpp
@@ -1,0 +1,598 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+#include <unordered_set>
+#include <utility>
+
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/IdPair.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/BlockId.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Informer/Tags.hpp"
+#include "Informer/Verbosity.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "Parallel/Algorithm.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \ingroup SurfacesGroup
+namespace ah {
+
+/// \cond
+template <class Metavariables, typename AhTag>
+struct Finder;
+
+namespace Actions {
+namespace Finder {
+template <typename AhTag>
+struct ReceiveInterpolatedVars;
+}  // namespace Finder
+}  // namespace Actions
+/// \endcond
+
+/// Tags describing items in a HorizonManager's DataBox.
+namespace Tags {
+// Number of elements on a particular HorizonManager.
+struct NumElements : db::SimpleTag {
+  static std::string name() noexcept { return "NumElements"; }
+  using type = size_t;
+};
+}  // namespace Tags
+
+/// Variables that are sent from Elements to DataInterpolators.
+using vars_tags_from_element = ::Tags::Variables<
+    tmpl::list<::gr::Tags::SpacetimeMetric<3>, ::GeneralizedHarmonic::Pi<3>,
+               ::GeneralizedHarmonic::Phi<3>>>;
+
+/// Variables that are sent from DataInterpolators to ah::Finders.
+template <typename Frame>
+using vars_tags = ::Tags::Variables<
+    tmpl::list<::gr::Tags::InverseSpatialMetric<3, Frame>,
+               ::gr::Tags::ExtrinsicCurvature<3, Frame>,
+               ::gr::Tags::SpatialChristoffelSecondKind<3, Frame>>>;
+
+namespace Tags {
+/// DataBox tag for type that holds all volume variables at all times
+/// on all elements associated with this DataInterpolator.
+struct VolumeVarsInfo : db::SimpleTag {
+  struct Info {
+    Mesh<3> mesh;
+    vars_tags<Frame::Inertial>::type vars;
+  };
+  using type = std::unordered_map<Time, std::unordered_map<ElementId<3>, Info>>;
+  static std::string name() noexcept { return "VolumeVarsInfo"; }
+};
+}  // namespace Tags
+
+/// Holds interpolated variables.
+template <typename Frame>
+struct InterpolatedVarsInfo {
+  /// block_coord_holders holds the list of points (in block logical
+  /// coordinates) that need to be interpolated onto by all
+  /// HorizonManagers.  The number of interpolated points that are
+  /// stored in this InterpolatedVarsInfo corresponds to a subset of
+  /// the points in block_coord_holders.  Moreover, the number of
+  /// interpolated points stored in this InterpolatedVarsInfo will
+  /// change as more elements interpolate, and will be less than or
+  /// equal to the size of 'block_coord_holders' even after all
+  /// Elements have interpolated (it is usually less than, because
+  /// this InterpolatedVarsInfo lives only on a single core, and this
+  /// core will not have access to all the Elements).
+  std::vector<
+      IdPair<domain::BlockId, tnsr::I<double, 3, typename ::Frame::Logical>>>
+      block_coord_holders;
+  /// `vars` holds the variables on some subset of the points in
+  /// `block_coord_holders`.  The grid points inside vars are indexed
+  /// according to `global_offsets`.  The size of 'vars' changes as more
+  /// elements interpolate.
+  std::vector<typename vars_tags<Frame>::type> vars{};
+  /// global_offsets[j][i] is the index into block_coord_holders that
+  /// corresponds to the index `i` of the DataVector held in `vars[j]`.
+  /// The size of 'global_offsets' changes as more elements
+  /// interpolate.
+  std::vector<std::vector<size_t>> global_offsets{};
+  /// Holds the elements that have already interpolated.
+  std::unordered_set<ElementId<3>> element_has_interpolated{};
+  /// Once all the elements have interpolated, the data will be sent
+  /// to a ah::Finder and data_has_been_sent will be set to true.
+  bool data_has_been_sent{false};
+};
+
+/// Holds interpolated variables at all times for a given AhTag.
+/// After a horizon has been found, the held data is cleared.
+template <typename AhTag>
+struct HorizonHolder {
+  // At some point in the future if we want to do time interpolation
+  // inside the horizon manager, Time here could go to a double.
+  std::unordered_map<Time, InterpolatedVarsInfo<typename AhTag::frame>>
+      interpolated_vars_info;
+  std::unordered_set<Time> time_steps_where_horizon_has_been_found;
+};
+
+/// Tag for indexing a particular HorizonHolder in a TaggedTuple.
+template <typename AhTag>
+struct HorizonHolderTag {
+  using type = HorizonHolder<AhTag>;
+};
+
+namespace horizon_holders_detail {
+template <typename T>
+struct wrapper {
+  using type = HorizonHolderTag<T>;
+};
+}  // namespace horizon_holders_detail
+
+namespace Tags {
+/// DataBox tag for a TaggedTuple containing all HorizonHolders.
+template <typename Metavariables>
+struct HorizonHolders : db::SimpleTag {
+  using type = tuples::TaggedTupleTypelist<
+      tmpl::transform<typename Metavariables::horizon_tags,
+                      horizon_holders_detail::wrapper<tmpl::_1>>>;
+  static std::string name() noexcept { return "HorizonHolders"; }
+};
+}  // namespace Tags
+
+namespace DataInterpolator_detail {
+// Interpolates data onto a set of points desired by a ah::Finder.
+template <typename Metavariables, typename DbTags, typename AhTag>
+void interpolate_data(db::DataBox<DbTags>& box, const Time& timestep) {
+  db::mutate_apply<tmpl::list<Tags::HorizonHolders<Metavariables>>,
+                   tmpl::list<::Tags::Verbosity, Tags::VolumeVarsInfo>>(
+      [&timestep](const gsl::not_null<
+                      db::item_type<Tags::HorizonHolders<Metavariables>>*>
+                      holders,
+                  const db::item_type<::Tags::Verbosity>& verbose,
+                  const db::item_type<Tags::VolumeVarsInfo>& volume_vars_info) {
+        auto& interp_info =
+            get<HorizonHolderTag<AhTag>>(*holders).interpolated_vars_info.at(
+                timestep);
+
+        if (verbose == ::Verbosity::Debug) {
+          Parallel::printf(
+              "### Node:%d  Proc:%d ###\n"
+              "{%s,%s} : interpolate_data\n\n",
+              Parallel::my_node(), Parallel::my_proc(), AhTag::label(),
+              timestep);
+        }
+
+        for (const auto& volume_info_outer : volume_vars_info) {
+          // Are we at the right time?
+          if (volume_info_outer.first != timestep) {
+            continue;
+          }
+
+          // Get list of ElementIds that have the same timestep as the
+          // HorizonId, and which have not yet been interpolated.
+          std::vector<ElementId<3>> element_ids;
+
+          for (const auto& volume_info_inner : volume_info_outer.second) {
+            // Have we interpolated this element before?
+            if (interp_info.element_has_interpolated.find(
+                    volume_info_inner.first) !=
+                interp_info.element_has_interpolated.end()) {
+              if (verbose == ::Verbosity::Debug) {
+                Parallel::printf(
+                    "### Node:%d  Proc:%d ###\n"
+                    "{%s,%s}: interpolate_data: Already interpolated %s\n\n",
+                    Parallel::my_node(), Parallel::my_proc(), AhTag::label(),
+                    timestep, volume_info_inner.first);
+              }
+            } else {
+              if (verbose == ::Verbosity::Debug) {
+                Parallel::printf(
+                    "### Node:%d  Proc:%d ###\n"
+                    "{%s,%s}: interpolate_data: Will try to interpolate %s\n\n",
+                    Parallel::my_node(), Parallel::my_proc(), AhTag::label(),
+                    timestep, volume_info_inner.first);
+              }
+              interp_info.element_has_interpolated.emplace(
+                  volume_info_inner.first);
+              element_ids.push_back(volume_info_inner.first);
+            }
+          }
+
+          // Get element logical coordinates.
+          const auto element_coord_holders = element_logical_coordinates(
+              element_ids, interp_info.block_coord_holders);
+
+          // Interpolate.
+          for (const auto& element_coord_pair : element_coord_holders) {
+            const auto& element_id = element_coord_pair.first;
+            const auto& element_coord_holder = element_coord_pair.second;
+            const auto& volume_info = volume_info_outer.second.at(element_id);
+
+            intrp::Irregular<3> interpolator(
+                volume_info.mesh, element_coord_holder.element_logical_coords);
+            interp_info.vars.emplace_back(
+                interpolator.interpolate(volume_info.vars));
+            interp_info.global_offsets.emplace_back(
+                element_coord_holder.offsets);
+          }
+        }
+      },
+      make_not_null(&box));
+}
+
+// Sends interpolated data to a ah::Finder.
+template <typename Metavariables, typename DbTags, typename AhTag>
+void send_data_to_ah_finder(db::DataBox<DbTags>& box,
+                            Parallel::ConstGlobalCache<Metavariables>& cache,
+                            const Time& timestep) noexcept {
+  const auto& verbose = db::get<::Tags::Verbosity>(box);
+  auto& holders = db::get<Tags::HorizonHolders<Metavariables>>(box);
+  auto& interp_info =
+      get<HorizonHolderTag<AhTag>>(holders).interpolated_vars_info.at(timestep);
+
+  if (verbose == ::Verbosity::Debug) {
+    size_t n_pts = 0;
+    for (const auto& glob_off : interp_info.global_offsets) {
+      n_pts += glob_off.size();
+    }
+    Parallel::printf(
+        "### Node:%d  Proc:%d ###\n"
+        "{%s,%s}: send_data_to_ah_finder: have %d points to send\n\n",
+        Parallel::my_node(), Parallel::my_proc(), AhTag::label(), timestep,
+        n_pts);
+  }
+
+  if (not interp_info.global_offsets.empty()) {
+    auto& receiver_proxy =
+        Parallel::get_parallel_component<ah::Finder<Metavariables, AhTag>>(
+            cache);
+    Parallel::simple_action<Actions::Finder::ReceiveInterpolatedVars<AhTag>>(
+        receiver_proxy, interp_info.vars, interp_info.global_offsets);
+  }
+
+  // Flag that the data has been sent, and clear the arrays that we
+  // don't need anymore so we free up memory.
+  db::mutate<Tags::HorizonHolders<Metavariables>>(
+      make_not_null(&box),
+      [&timestep](const gsl::not_null<
+                  db::item_type<Tags::HorizonHolders<Metavariables>>*>
+                      holders_l) {
+        auto& interp_info_l = get<HorizonHolderTag<AhTag>>(*holders_l)
+                                  .interpolated_vars_info.at(timestep);
+        interp_info_l.data_has_been_sent = true;
+        interp_info_l.vars.clear();
+        interp_info_l.global_offsets.clear();
+      });
+}
+
+// Try to interpolate the data it has, and if successful,
+// send interpolated data to the horizon finder.
+template <typename Metavariables, typename DbTags, typename AhTag>
+void try_to_interpolate_data(db::DataBox<DbTags>& box,
+                             Parallel::ConstGlobalCache<Metavariables>& cache,
+                             const Time& timestep) {
+  const auto& holders = db::get<Tags::HorizonHolders<Metavariables>>(box);
+  const auto& interp_vars_info =
+      get<HorizonHolderTag<AhTag>>(holders).interpolated_vars_info;
+
+  // If we don't yet have any points for this HorizonInfo,
+  // we should exit (we can't interpolate anyway).
+  // Also, if we have already reduced data for this HorizonInfo, we should
+  // exit (we don't want to send the HorizonChare the same
+  // information twice).
+  if (interp_vars_info.find(timestep) == interp_vars_info.end() or
+      interp_vars_info.at(timestep).data_has_been_sent) {
+    return;
+  }
+
+  interpolate_data<Metavariables, DbTags, AhTag>(box, timestep);
+
+  // Reduce the horizon data only if all of the elements have interpolated
+  // onto it.
+  const auto& verbose = db::get<::Tags::Verbosity>(box);
+  const auto& num_elements = db::get<Tags::NumElements>(box);
+  if (verbose == ::Verbosity::Debug) {
+    Parallel::printf(
+        "### Node:%d  Proc:%d ###\n"
+        "{%s,%s}: try_to_interpolate_data: did %d of %d elems\n\n",
+        Parallel::my_node(), Parallel::my_proc(), AhTag::label(), timestep,
+        interp_vars_info.at(timestep).element_has_interpolated.size(),
+        num_elements);
+  }
+  if (interp_vars_info.at(timestep).element_has_interpolated.size() ==
+      num_elements) {
+    send_data_to_ah_finder<Metavariables, DbTags, AhTag>(box, cache, timestep);
+  }
+}
+}  // namespace DataInterpolator_detail
+
+namespace Actions {
+namespace DataInterpolator {
+
+/// Simply prints the number of elements it talks to.
+/// Used for diagnostics.
+struct PrintNumElements {
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<tmpl::list_contains_v<DbTags, typename Tags::NumElements>> =
+          nullptr>
+  static void apply(const db::DataBox<DbTags>& box,  // HorizonManager's box
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const auto& num_elements = db::get<Tags::NumElements>(box);
+    const auto& verbose = db::get<::Tags::Verbosity>(box);
+    if (verbose > ::Verbosity::Quiet) {
+      Parallel::printf("Number of elements on proc %d is %d\n",
+                       Parallel::my_proc(), num_elements);
+    }
+  }
+};
+
+/// Every Element calls this once, so the DataInterpolator knows
+/// how many Elements it is talking to.
+///
+/// Obviously this will need to change with h-refinement AMR, since
+/// the number of elements will change.
+struct ReceiveNumElements {
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<tmpl::list_contains_v<DbTags, typename Tags::NumElements>> =
+          nullptr>
+  static void apply(db::DataBox<DbTags>& box,  // HorizonManager's box
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<Tags::NumElements>(
+        make_not_null(&box), [](const gsl::not_null<
+                                 db::item_type<Tags::NumElements>*>
+                                    num_elements) noexcept {
+          ++(*num_elements);
+        });
+  }
+};
+
+struct Initialize {
+  template <typename Metavariables>
+  using return_tag_list =
+      tmpl::list<Tags::NumElements, ::Tags::Verbosity, Tags::VolumeVarsInfo,
+                 Tags::HorizonHolders<Metavariables>>;
+  template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    ::Verbosity verbosity) noexcept {
+    return std::make_tuple(
+        db::create<db::get_items<return_tag_list<Metavariables>>>(
+            0_st, verbosity, Tags::VolumeVarsInfo::type{},
+            typename Tags::HorizonHolders<Metavariables>::type{}));
+  }
+};
+
+/// Receives volume data from an Element at some time step.
+///
+/// Stores the data and tries to interpolate it to horizon points if it can.
+struct GetVolumeDataFromElement {
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<tmpl::list_contains_v<DbTags, typename Tags::NumElements>> =
+          nullptr>
+  static void apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const Time& timestep, const ElementId<3>& element_id,
+                    const ::Mesh<3>& mesh,
+                    const vars_tags_from_element::type& vars) noexcept {
+    const auto& psi = get<::gr::Tags::SpacetimeMetric<3>>(vars);
+    const auto& pi = get<::GeneralizedHarmonic::Pi<3>>(vars);
+    const auto& phi = get<::GeneralizedHarmonic::Phi<3>>(vars);
+
+    db::item_type<vars_tags<Frame::Inertial>> output_vars(
+        mesh.number_of_grid_points());
+    auto& inv_g =
+        get<::gr::Tags::InverseSpatialMetric<3, Frame::Inertial>>(output_vars);
+    auto& ex_curv =
+        get<::gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>>(output_vars);
+    auto& christ =
+        get<::gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial>>(
+            output_vars);
+
+    inv_g = determinant_and_inverse(gr::spatial_metric(psi)).second;
+    const auto shift = gr::shift(psi, inv_g);
+    const auto lapse = gr::lapse(shift, psi);
+
+    ex_curv = GeneralizedHarmonic::extrinsic_curvature(
+        gr::spacetime_normal_vector(lapse, shift), pi, phi);
+    christ = raise_or_lower_first_index(
+        gr::christoffel_first_kind(
+            GeneralizedHarmonic::deriv_spatial_metric(phi)),
+        inv_g);
+
+    db::mutate<Tags::VolumeVarsInfo>(
+        make_not_null(&box),
+        [&timestep, &element_id, &mesh, &output_vars ](
+            const gsl::not_null<db::item_type<Tags::VolumeVarsInfo>*>
+                container) noexcept {
+
+          if (container->find(timestep) == container->end()) {
+            container->emplace(
+                timestep,
+                std::unordered_map<ElementId<3>, Tags::VolumeVarsInfo::Info>{});
+          }
+          container->at(timestep).emplace(std::make_pair(
+              element_id,
+              Tags::VolumeVarsInfo::Info{mesh, std::move(output_vars)}));
+        });
+
+    // Try to interpolate data for all AhTags
+    tmpl::for_each<typename Metavariables::horizon_tags>(
+        [&box, &cache, &timestep](auto x) {
+          using tag = typename decltype(x)::type;
+          DataInterpolator_detail::try_to_interpolate_data<Metavariables,
+                                                           DbTags, tag>(
+              box, cache, timestep);
+        });
+  }
+};
+
+/// Called by a ah::Finder to send its list of interpolation points.
+///
+/// Cleans up previous interpolation information, and tries to interpolate
+/// onto those points.  If it has interpolated to all the points it has
+/// control over, it sends the interpolated variables to the ah::Finder.
+template <typename AhTag>
+struct ReceiveInterpolationPoints {
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<tmpl::list_contains_v<DbTags, typename Tags::NumElements>> =
+          nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,  // HorizonManager's box
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/, const Time& timestep,
+      const std::vector<IdPair<domain::BlockId,
+                               tnsr::I<double, 3, typename ::Frame::Logical>>>&
+          block_coord_holders) noexcept {
+    db::mutate<Tags::HorizonHolders<Metavariables>>(
+        make_not_null(&box),
+        [timestep, &block_coord_holders](
+            const gsl::not_null<
+                db::item_type<Tags::HorizonHolders<Metavariables>>*>
+                HorizonHolders) {
+          auto& vars_info = get<HorizonHolderTag<AhTag>>(*HorizonHolders)
+                                .interpolated_vars_info;
+
+          // We are starting a new iteration at this timestep, so erase
+          // all information corresponding to the previous iteration at
+          // this timestep.
+          vars_info.erase(timestep);
+
+          // Now add the target interpolation points at this timestep.
+          vars_info.emplace(std::make_pair(
+              timestep, InterpolatedVarsInfo<typename AhTag::frame>{
+                            block_coord_holders}));
+        });
+
+    DataInterpolator_detail::try_to_interpolate_data<Metavariables, DbTags,
+                                                     AhTag>(box, cache,
+                                                            timestep);
+  }
+};
+
+/// Action called by an ah::Finder when the horizon search has converged.
+///
+/// This cleans up stored interpolated data and volume data that is no
+/// longer needed.
+template <typename AhTag>
+struct HorizonHasConverged {
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<tmpl::list_contains_v<DbTags, typename Tags::NumElements>> =
+          nullptr>
+  static void apply(db::DataBox<DbTags>& box,  // HorizonManager's box
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const Time& timestep) noexcept {
+    const auto& verbose = db::get<::Tags::Verbosity>(box);
+    if (verbose > ::Verbosity::Quiet) {
+      Parallel::printf(
+          "### Node:%d  Proc:%d ###\n"
+          "{%s,%s} : Converged!\n\n",
+          Parallel::my_node(), Parallel::my_proc(), AhTag::label(), timestep);
+    }
+
+    db::mutate<Tags::HorizonHolders<Metavariables>>(
+        make_not_null(&box),
+        [&timestep](const gsl::not_null<
+                    db::item_type<Tags::HorizonHolders<Metavariables>>*>
+                        holders) {
+          get<HorizonHolderTag<AhTag>>(*holders)
+              .time_steps_where_horizon_has_been_found.insert(timestep);
+        });
+
+    // If we don't need any of the volume data anymore for this
+    // timestep, we will remove them.
+    bool this_timestep_is_done = true;
+    const auto& holders = db::get<Tags::HorizonHolders<Metavariables>>(box);
+    tmpl::for_each<typename Metavariables::horizon_tags>([&](auto tag) {
+      using Tag = typename decltype(tag)::type;
+      const auto& found = get<HorizonHolderTag<Tag>>(holders)
+                              .time_steps_where_horizon_has_been_found;
+      if (found.find(timestep) == found.end()) {
+        this_timestep_is_done = false;
+      }
+    });
+
+    // We don't need any more volume data for this timestep,
+    // so remove it.
+    if (this_timestep_is_done) {
+      db::mutate<Tags::VolumeVarsInfo>(
+          make_not_null(&box),
+          [&timestep](const gsl::not_null<db::item_type<Tags::VolumeVarsInfo>*>
+                          volume_vars_info) {
+            for (auto it = volume_vars_info->begin();
+                 it != volume_vars_info->end();) {
+              if (timestep == it->first) {
+                it = volume_vars_info->erase(it);
+              } else {
+                ++it;
+              }
+            }
+          });
+    }
+
+    // We don't need interpolated variables for this timestep anymore,
+    // so remove them.
+    db::mutate<Tags::HorizonHolders<Metavariables>>(
+        make_not_null(&box),
+        [&timestep](const gsl::not_null<
+                    db::item_type<Tags::HorizonHolders<Metavariables>>*>
+                        holders_l) {
+          get<HorizonHolderTag<AhTag>>(*holders_l)
+              .interpolated_vars_info.erase(timestep);
+        });
+  }
+};
+}  // namespace DataInterpolator
+}  // namespace Actions
+}  // namespace ah

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "TagsDeclarations.hpp"
 
 class DataVector;
 

--- a/src/Informer/CMakeLists.txt
+++ b/src/Informer/CMakeLists.txt
@@ -4,7 +4,8 @@
 set(LIBRARY Informer)
 
 set(LIBRARY_SOURCES
-    Informer.cpp)
+    Informer.cpp
+    Verbosity.cpp)
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 

--- a/src/Informer/InfoFromBuild.hpp
+++ b/src/Informer/InfoFromBuild.hpp
@@ -9,7 +9,7 @@
 #include <string>
 
 /*!
- * \ingroup UtilitiesGroup
+ * \ingroup LoggingGroup
  * \brief Information about the version, date, host, git commit, and link time
  *
  * The information returned by this function is invaluable for identifying
@@ -19,31 +19,31 @@
 std::string info_from_build();
 
 /*!
- * \ingroup UtilitiesGroup
+ * \ingroup LoggingGroup
  * \brief Retrieve a string containing the current version of SpECTRE
  */
 std::string spectre_version();
 
 /*!
- * \ingroup UtilitiesGroup
+ * \ingroup LoggingGroup
  * \brief Returns major version
  */
 int spectre_major_version();
 
 /*!
- * \ingroup UtilitiesGroup
+ * \ingroup LoggingGroup
  * \brief Returns minor version
  */
 int spectre_minor_version();
 
 /*!
- * \ingroup UtilitiesGroup
+ * \ingroup LoggingGroup
  * \brief Returns patch version
  */
 int spectre_patch_version();
 
 /*!
- * \ingroup UtilitiesGroup
+ * \ingroup LoggingGroup
  * \brief Returns the path to the Unit test directory.
  */
 std::string unit_test_path() noexcept;

--- a/src/Informer/Informer.hpp
+++ b/src/Informer/Informer.hpp
@@ -10,7 +10,7 @@
 class CkArgMsg;
 /// \endcond
 
-/// \ingroup UtilitiesGroup
+/// \ingroup LoggingGroup
 /// The Informer manages textual output regarding the status of a simulation.
 class Informer {
  public:

--- a/src/Informer/Tags.hpp
+++ b/src/Informer/Tags.hpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+
+/// \cond
+enum class Verbosity;
+/// \endcond
+
+namespace Tags {
+/// \ingroup LoggingGroup
+/// \brief Tag for putting 'Verbosity' in a DataBox.
+struct Verbosity : db::SimpleTag {
+  static std::string name() noexcept { return "Verbosity"; }
+  using type = ::Verbosity;
+};
+}  // namespace Tags

--- a/src/Informer/Verbosity.cpp
+++ b/src/Informer/Verbosity.cpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Informer/Verbosity.hpp"
+
+#include "ErrorHandling/Error.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+
+Verbosity create_from_yaml<Verbosity>::create(const Option& options) {
+  const std::string type_read = options.parse_as<std::string>();
+  if ("Silent" == type_read) {
+    return Verbosity::Silent;
+  } else if ("Quiet" == type_read) {
+    return Verbosity::Quiet;
+  } else if ("Verbose" == type_read) {
+    return Verbosity::Verbose;
+  } else if ("Debug" == type_read) {
+    return Verbosity::Debug;
+  }
+  PARSE_ERROR(options.context(),
+              "Failed to convert \"" << type_read
+                                     << "\" to Verbosity. Must be one "
+                                        "of Silent, Quiet, Verbose, or Debug.");
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const Verbosity& verbosity) noexcept {
+  switch (verbosity) {
+    case Verbosity::Silent:
+      return os << "Silent";
+    case Verbosity::Quiet:
+      return os << "Quiet";
+    case Verbosity::Verbose:
+      return os << "Verbose";
+    case Verbosity::Debug:
+      return os << "Debug";
+    default:  // LCOV_EXCL_LINE
+      // LCOV_EXCL_START
+      ERROR("Need to add another case, don't understand value of 'verbosity'");
+      // LCOV_EXCL_STOP
+  }
+}

--- a/src/Informer/Verbosity.hpp
+++ b/src/Informer/Verbosity.hpp
@@ -1,0 +1,22 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iosfwd>
+
+/// \cond
+template <typename T> struct create_from_yaml;
+class Option;
+/// \endcond
+
+/// \ingroup LoggingGroup
+/// \brief Indicates how much informative output a class should output.
+enum class Verbosity { Silent, Quiet, Verbose, Debug };
+
+std::ostream& operator<<(std::ostream& os, const Verbosity& verbosity) noexcept;
+
+template <>
+struct create_from_yaml<Verbosity> {
+  static Verbosity create(const Option& options);
+};

--- a/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
@@ -59,6 +59,11 @@ struct SpacetimeChristoffelSecondKind : db::SimpleTag {
   static std::string name() noexcept { return "SpactimeChristoffelSecondKind"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
+struct SpatialChristoffelSecondKind : db::SimpleTag {
+  using type = tnsr::Ijj<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "SpatialChristoffelSecondKind"; }
+};
+template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeNormalOneForm : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
   static std::string name() noexcept { return "SpacetimeNormalOneForm"; }

--- a/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
@@ -41,6 +41,9 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct SpacetimeChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
+struct SpatialChristoffelSecondKind;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct SpacetimeNormalOneForm;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
@@ -48,11 +51,14 @@ struct SpacetimeNormalVector;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct TraceSpacetimeChristoffelFirstKind;
-template <size_t Dim, typename Frame, typename DataType>
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct TraceSpatialChristoffelSecondKind;
-template <size_t Dim, typename Frame, typename DataType>
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct ExtrinsicCurvature;
-template <size_t Dim, typename Frame, typename DataType>
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct TraceExtrinsicCurvature;
 }  // namespace Tags
 }  // namespace gr

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -1,6 +1,45 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_executable(
+  Test_HorizonManager
+  Test_HorizonManager.cpp
+)
+
+add_dependencies(
+  Test_HorizonManager
+  module_ConstGlobalCache
+  module_Main
+ )
+
+target_link_libraries(
+  Test_HorizonManager
+  ApparentHorizons
+  DataStructures
+  DomainCreators
+  CoordinateMaps
+  EinsteinSolutions
+  ErrorHandling
+  GeneralRelativity
+  Informer
+  Interpolation
+  LinearAlgebra
+  Time
+  Utilities
+  ${SPECTRE_LIBRARIES}
+)
+
+add_dependencies(test-executables Test_HorizonManager)
+
+add_test(NAME "\"Integration.HorizonManager\""
+  COMMAND ${CMAKE_BINARY_DIR}/bin/Test_HorizonManager +p2 --input-file ${CMAKE_SOURCE_DIR}/tests/Unit/ApparentHorizons/Test_HorizonManager.input)
+
+set_tests_properties(
+  "\"Integration.HorizonManager\"" PROPERTIES
+  TIMEOUT 30
+  LABELS "integration"
+  ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+
 set(LIBRARY "Test_ApparentHorizons")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/ApparentHorizons/TestHorizonManagerHelper_ElementActions.hpp
+++ b/tests/Unit/ApparentHorizons/TestHorizonManagerHelper_ElementActions.hpp
@@ -1,0 +1,156 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+
+#include "ApparentHorizons/HorizonManagerComponentActions.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Algorithm.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace test_ah {
+namespace Actions {
+namespace DgElementArray {
+
+struct InitializeElement {
+  using return_tag_list = tmpl::list<Tags::Mesh<3>, ah::vars_tags_from_element>;
+
+  template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& array_index, const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const std::vector<std::array<size_t, 3>>& initial_extents,
+                    const Domain<3, Frame::Inertial>& domain) noexcept {
+    ElementId<3> element_id{array_index};
+    const auto& my_block = domain.blocks()[element_id.block_id()];
+    ::Mesh<3> mesh{initial_extents[element_id.block_id()],
+                   Spectral::Basis::Legendre,
+                   Spectral::Quadrature::GaussLobatto};
+
+    // Coordinates
+    ElementMap<3, Frame::Inertial> map{element_id,
+                                       my_block.coordinate_map().get_clone()};
+    auto inertial_coords = map(logical_coordinates(mesh));
+
+    EinsteinSolutions::KerrSchild solution(1.0, {{0., 0., 0.}}, {{0., 0., 0.}});
+    const auto input_vars =
+        solution.variables(inertial_coords, 0.0,
+                           EinsteinSolutions::KerrSchild::tags<DataVector>{});
+    const auto& lapse =
+        get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(input_vars);
+    const auto& dt_lapse =
+        get<Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>>(
+            input_vars);
+    const auto& d_lapse =
+        get<EinsteinSolutions::KerrSchild::DerivLapse<DataVector>>(input_vars);
+    const auto& shift =
+        get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(input_vars);
+    const auto& d_shift =
+        get<EinsteinSolutions::KerrSchild::DerivShift<DataVector>>(input_vars);
+    const auto& dt_shift =
+        get<Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>(
+            input_vars);
+    const auto& g =
+        get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(
+            input_vars);
+    const auto& dt_g =
+        get<Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
+            input_vars);
+    const auto& d_g =
+        get<EinsteinSolutions::KerrSchild::DerivSpatialMetric<DataVector>>(
+            input_vars);
+
+    db::item_type<ah::vars_tags_from_element> output_vars(
+        mesh.number_of_grid_points());
+    auto& psi = get<::gr::Tags::SpacetimeMetric<3>>(output_vars);
+    auto& pi = get<::GeneralizedHarmonic::Pi<3>>(output_vars);
+    auto& phi = get<::GeneralizedHarmonic::Phi<3>>(output_vars);
+    psi = gr::spacetime_metric(lapse, shift, g);
+    phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift, g, d_g);
+    pi =
+        GeneralizedHarmonic::pi(lapse, dt_lapse, shift, dt_shift, g, dt_g, phi);
+
+    db::compute_databox_type<return_tag_list> outbox =
+        db::create<db::get_items<return_tag_list>>(
+            // clang-tidy: std::move of trivially-copyable type
+            std::move(mesh),  // NOLINT
+            std::move(output_vars));
+    return std::make_tuple(std::move(outbox));
+  }
+};
+
+template <typename ParallelComponentOfReceiver>
+struct SendNumElements {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static void apply(const db::DataBox<DbTags>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    auto& receiver_proxy =
+        Parallel::get_parallel_component<ParallelComponentOfReceiver>(cache);
+
+    Parallel::simple_action<ah::Actions::DataInterpolator::ReceiveNumElements>(
+        *receiver_proxy.ckLocalBranch());
+  }
+};
+
+template <typename ParallelComponentOfReceiver>
+struct BeginHorizonSearch {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<DbTags, Tags::Mesh<3>>> = nullptr>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index, const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const std::vector<Time>& timesteps) noexcept {
+    auto& receiver_proxy =
+        Parallel::get_parallel_component<ParallelComponentOfReceiver>(cache);
+
+    const ElementId<3> element_id{array_index};
+    const auto& vars = db::get<ah::vars_tags_from_element>(box);
+    const auto& mesh = db::get<Tags::Mesh<3>>(box);
+
+    for (const auto& timestep : timesteps) {
+      Parallel::simple_action<
+          ah::Actions::DataInterpolator::GetVolumeDataFromElement>(
+          *receiver_proxy.ckLocalBranch(), timestep, element_id, mesh, vars);
+    }
+  }
+};
+
+}  // namespace DgElementArray
+}  // namespace Actions
+}  // namespace test_ah

--- a/tests/Unit/ApparentHorizons/TestHorizonManagerHelper_ElementComponent.hpp
+++ b/tests/Unit/ApparentHorizons/TestHorizonManagerHelper_ElementComponent.hpp
@@ -1,0 +1,135 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+#include <utility>
+
+#include "ApparentHorizons/HorizonManagerComponent.hpp"
+#include "ApparentHorizons/HorizonManagerComponentActions.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/DomainCreator.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/InitialElementIds.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/Algorithm.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ApparentHorizons/TestHorizonManagerHelper_ElementActions.hpp"
+
+namespace test_ah {
+template <class Metavariables>
+struct DgElementArray {
+  using chare_type = Parallel::Algorithms::Array;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using metavariables = Metavariables;
+  using action_list = tmpl::list<>;
+  using array_index = ElementIndex<3>;
+  using initial_databox = db::compute_databox_type<
+      typename Actions::DgElementArray::InitializeElement::return_tag_list>;
+  using options = tmpl::list<typename Metavariables::domain_creator_tag>;
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+      std::unique_ptr<DomainCreator<3, Frame::Inertial>>
+          domain_creator) noexcept;
+  static void execute_next_phase(
+      typename Metavariables::Phase next_phase,
+      const Parallel::CProxy_ConstGlobalCache<Metavariables>&
+          global_cache) noexcept;
+};
+
+template <class Metavariables>
+void DgElementArray<Metavariables>::execute_next_phase(
+    const typename Metavariables::Phase next_phase,
+    const Parallel::CProxy_ConstGlobalCache<Metavariables>&
+        global_cache) noexcept {
+  if (next_phase == Metavariables::Phase::InitialCommunication) {
+    auto& dg_element_array = Parallel::get_parallel_component<DgElementArray>(
+        *(global_cache.ckLocalBranch()));
+
+    Parallel::simple_action<Actions::DgElementArray::SendNumElements<
+        ah::DataInterpolator<Metavariables>>>(dg_element_array);
+  }
+  if (next_phase == Metavariables::Phase::CheckAnswer) {
+    auto& my_proxy =
+        Parallel::get_parallel_component<ah::DataInterpolator<Metavariables>>(
+            *(global_cache.ckLocalBranch()));
+    Parallel::simple_action<ah::Actions::DataInterpolator::PrintNumElements>(
+        my_proxy);
+  }
+  if (next_phase == Metavariables::Phase::BeginHorizonSearch) {
+    // Time steps on which to find the horizon
+    Slab slab(0.0, 1.0);
+    const std::vector<Time> timesteps = {Time(slab, 0), Time(slab, 1)};
+
+    auto& dg_element_array = Parallel::get_parallel_component<DgElementArray>(
+        *(global_cache.ckLocalBranch()));
+
+    Parallel::simple_action<Actions::DgElementArray::BeginHorizonSearch<
+        ah::DataInterpolator<Metavariables>>>(dg_element_array, timesteps);
+
+    tmpl::for_each<typename Metavariables::horizon_tags>(
+        [&global_cache, &timesteps](auto x) {
+          using tag = typename decltype(x)::type;
+          auto& my_proxy =
+              Parallel::get_parallel_component<ah::Finder<Metavariables, tag>>(
+                  *(global_cache.ckLocalBranch()));
+          Parallel::simple_action<ah::Actions::Finder::AddTimeSteps<tag>>(
+              my_proxy, timesteps);
+        });
+  }
+}
+
+template <class Metavariables>
+void DgElementArray<Metavariables>::initialize(
+    Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+    std::unique_ptr<DomainCreator<3, Frame::Inertial>>
+        domain_creator) noexcept {
+  auto& dg_element_array = Parallel::get_parallel_component<DgElementArray>(
+      *(global_cache.ckLocalBranch()));
+
+  auto domain = domain_creator->create_domain();
+  const int number_of_procs = Parallel::number_of_procs();
+  for (const auto& block : domain.blocks()) {
+    const auto initial_ref_levs =
+        domain_creator->initial_refinement_levels()[block.id()];
+    const std::vector<ElementId<3>> element_ids =
+        initial_element_ids(block.id(), initial_ref_levs);
+    int which_proc = 0;
+    for (const auto& element_id : element_ids) {
+      dg_element_array(ElementIndex<3>(element_id))
+          .insert(global_cache, which_proc);
+      ++which_proc %= number_of_procs;
+    }
+  }
+  dg_element_array.doneInserting();
+
+  dg_element_array
+      .template simple_action<Actions::DgElementArray::InitializeElement>(
+          std::make_tuple(domain_creator->initial_extents(),
+                          std::move(domain)));
+}
+}  // namespace test_ah

--- a/tests/Unit/ApparentHorizons/Test_HorizonManager.cpp
+++ b/tests/Unit/ApparentHorizons/Test_HorizonManager.cpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// Need CATCH_CONFIG_RUNNER to avoid linking errors with Catch2
+#define CATCH_CONFIG_RUNNER
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+#include <vector>
+
+#include "AlgorithmArray.hpp"                            // IWYU pragma: keep
+#include "AlgorithmGroup.hpp"                            // IWYU pragma: keep
+#include "AlgorithmSingleton.hpp"                        // IWYU pragma: keep
+#include "ApparentHorizons/HorizonComponent.hpp"         // IWYU pragma: keep
+#include "ApparentHorizons/HorizonManagerComponent.hpp"  // IWYU pragma: keep
+#include "ApparentHorizons/Strahlkorper.hpp"             // IWYU pragma: keep
+#include "DataStructures/Tensor/IndexType.hpp"           // IWYU pragma: keep
+#include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/InitializationFunctions.hpp"
+#include "Parallel/Main.hpp"
+#include "Parallel/Printf.hpp"
+#include "Time/Time.hpp"                                 // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ApparentHorizons/TestHorizonManagerHelper_ElementActions.hpp"  // IWYU pragma: keep
+#include "tests/Unit/ApparentHorizons/TestHorizonManagerHelper_ElementComponent.hpp"  // IWYU pragma: keep
+
+// IWYU pragma: no_forward_declare DgElementArray
+// IWYU pragma: no_forward_declare Frame::Inertial
+// IWYU pragma: no_forward_declare HorizonComponent
+// IWYU pragma: no_forward_declare HorizonManagerComponent
+
+// This is a function that each ah::Finder will call when it
+// converges.
+template <typename Metavariables, typename AhTag, typename Frame>
+struct TestFunction {
+  static void apply(
+      const Strahlkorper<Frame>& strahlkorper, const Time& timestep,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/) noexcept {
+    Parallel::printf(
+        "### Node:%d  Proc:%d ###\n"
+        "{%s, time %s}: Radius is %f\n\n",
+        Parallel::my_node(), Parallel::my_proc(), AhTag::label(), timestep,
+        strahlkorper.average_radius());
+    SPECTRE_PARALLEL_REQUIRE(strahlkorper.average_radius() < 2.01);
+    SPECTRE_PARALLEL_REQUIRE(strahlkorper.average_radius() > 1.99);
+  }
+};
+
+struct TestMetavariables {
+  // Tags for horizons.
+  struct AhATag {
+    using frame = Frame::Inertial;
+    static std::string label() noexcept { return "AhA"; }
+    using option_tag = ah::OptionTags::AhA<frame>;
+    using convergence_hook = TestFunction<TestMetavariables, AhATag, frame>;
+  };
+  struct AhBTag {
+    using frame = Frame::Inertial;
+    static std::string label() noexcept { return "AhB"; }
+    using option_tag = ah::OptionTags::AhB<frame>;
+    using convergence_hook = TestFunction<TestMetavariables, AhBTag, frame>;
+  };
+  using horizon_tags = tmpl::list<AhATag, AhBTag>;
+
+  using component_list = tmpl::list<ah::DataInterpolator<TestMetavariables>,
+                                    test_ah::DgElementArray<TestMetavariables>,
+                                    ah::Finder<TestMetavariables, AhATag>,
+                                    ah::Finder<TestMetavariables, AhBTag>>;
+
+  static constexpr const char* const help{"Test HorizonManager in parallel"};
+  static constexpr bool ignore_unrecognized_command_line_options = false;
+
+  using domain_creator_tag = OptionTags::DomainCreator<3, Frame::Inertial>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  enum class Phase {
+    Initialization,
+    InitialCommunication,
+    CheckAnswer,
+    BeginHorizonSearch,
+    Exit
+  };
+  static Phase determine_next_phase(
+      const Phase& current_phase,
+      const Parallel::CProxy_ConstGlobalCache<
+          TestMetavariables>& /*cache_proxy*/) noexcept {
+    if (current_phase == Phase::Initialization) {
+      return Phase::InitialCommunication;
+    }
+    if (current_phase == Phase::InitialCommunication) {
+      return Phase::CheckAnswer;
+    }
+    if (current_phase == Phase::CheckAnswer) {
+      return Phase::BeginHorizonSearch;
+    }
+    return Phase::Exit;
+  }
+};
+
+static const std::vector<void (*)()> charm_init_node_funcs{
+    &setup_error_handling, &DomainCreators::register_derived_with_charm};
+static const std::vector<void (*)()> charm_init_proc_funcs{
+    &enable_floating_point_exceptions};
+
+using charmxx_main_component = Parallel::Main<TestMetavariables>;
+
+#include "Parallel/CharmMain.cpp"

--- a/tests/Unit/ApparentHorizons/Test_HorizonManager.input
+++ b/tests/Unit/ApparentHorizons/Test_HorizonManager.input
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+# Executable: Test_HorizonManager
+# Check: execute
+DomainCreator:
+  Shell:
+    InnerRadius: 1.9
+    OuterRadius: 4.9
+    InitialRefinement: 1
+    InitialGridPoints: [5, 5]
+
+DataInterpolator:
+  Verbosity: Quiet
+
+AhA:
+  Verbosity: Quiet
+  InitialGuess:
+    Lmax: 6
+    Radius: 4.0
+    Center: [0.,0.,0.]
+  FastFlow:
+
+AhB:
+  Verbosity: Quiet
+  InitialGuess:
+    Lmax: 6
+    Radius: 3.5
+    Center: [0.,0.,0.]
+  FastFlow:


### PR DESCRIPTION
## Proposed changes

Adds horizon finder and an Integration Test for it.

The test finds two Schwarzschild horizons in parallel on two subsequent timesteps, on
a Cubed Sphere Domain with 48 Elements.

Depends on #755 and #794 (which now have been merged).

Depends on #960 and #962

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
