### PR TITLE
Feature/amr helpers

### DIFF
--- a/docs/Images/Domain/SegmentId.svg
+++ b/docs/Images/Domain/SegmentId.svg
@@ -1,0 +1,492 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="794px"
+   height="512px"
+   viewBox="0 0 794 512"
+   version="1.1"
+   style="background: #FFFFFF;"
+   id="svg150"
+   sodipodi:docname="SegmentId.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata154">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview152"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:zoom="0.40806045"
+     inkscape:cx="397"
+     inkscape:cy="256"
+     inkscape:window-x="497"
+     inkscape:window-y="110"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Page-1" />
+  <!-- Generator: Sketch 43.2 (39069) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title2">element_relationships</title>
+  <desc
+     id="desc4">Created with Sketch.</desc>
+  <defs
+     id="defs6" />
+  <g
+     id="Page-1"
+     stroke="none"
+     stroke-width="1"
+     fill="none"
+     fill-rule="evenodd">
+    <text
+       id="sibling"
+       font-family="HelveticaNeue, Helvetica Neue"
+       font-size="26"
+       font-weight="normal"
+       fill="#000000">
+      <tspan
+         x="260.443"
+         y="283"
+         id="tspan8">sibling</tspan>
+    </text>
+    <text
+       id="neighbor"
+       font-family="HelveticaNeue, Helvetica Neue"
+       font-size="26"
+       font-weight="normal"
+       fill="#3498DB">
+      <tspan
+         x="494.215"
+         y="283"
+         id="tspan11">neighbor</tspan>
+    </text>
+    <text
+       id="self"
+       font-family="HelveticaNeue, Helvetica Neue"
+       font-size="26"
+       font-weight="normal"
+       fill="#E74C3C">
+      <tspan
+         x="398.285"
+         y="283"
+         id="tspan14">self</tspan>
+    </text>
+    <text
+       id="parent"
+       font-family="HelveticaNeue, Helvetica Neue"
+       font-size="26"
+       font-weight="normal"
+       fill="#000000">
+      <tspan
+         x="318.411"
+         y="159"
+         id="tspan17">parent</tspan>
+    </text>
+    <text
+       id="grandparent"
+       font-family="HelveticaNeue, Helvetica Neue"
+       font-size="26"
+       font-weight="normal"
+       fill="#000000">
+      <tspan
+         x="423.202"
+         y="38"
+         id="tspan20">grandparent</tspan>
+    </text>
+    <text
+       id="(lower)-abutting-nib"
+       font-size="26"
+       font-weight="normal"
+       style="font-weight:normal;font-size:26px;font-family:HelveticaNeue, 'Helvetica Neue';fill:#9b59b6">
+      <tspan
+         x="198.05701"
+         y="493"
+         id="tspan23">abutting nibling</tspan>
+    </text>
+    <path
+       d="M325.5,436.5 L325.5,466.5"
+       id="Line"
+       stroke="#9B59B6"
+       stroke-width="3"
+       stroke-linecap="square" />
+    <path
+       id="Line-decoration-1"
+       d="M325.5,436.5 L328.5,447.3 L322.5,447.3 L325.5,436.5 Z"
+       stroke="#9B59B6"
+       stroke-width="3"
+       stroke-linecap="square" />
+    <text
+       id="children"
+       font-family="HelveticaNeue, Helvetica Neue"
+       font-size="26"
+       font-weight="normal"
+       fill="#27AE60">
+      <tspan
+         x="375.006"
+         y="399"
+         id="tspan28">children</tspan>
+    </text>
+    <text
+       id="lower-side"
+       font-family="HelveticaNeue, Helvetica Neue"
+       font-size="26"
+       font-weight="normal"
+       fill="#000000">
+      <tspan
+         x="177.298"
+         y="38"
+         id="tspan31">lower side</tspan>
+    </text>
+    <text
+       id="upper-side"
+       font-family="HelveticaNeue, Helvetica Neue"
+       font-size="26"
+       font-weight="normal"
+       fill="#000000">
+      <tspan
+         x="659.354"
+         y="38"
+         id="tspan34">upper side</tspan>
+    </text>
+    <path
+       d="M159,160 L159,344.010869"
+       id="path37"
+       stroke="#000000"
+       stroke-width="4"
+       stroke-linecap="square" />
+    <path
+       id="path39"
+       d="M159,344.010869 L162,333.210869 L156,333.210869 L159,344.010869 Z"
+       stroke="#000000"
+       stroke-width="4"
+       stroke-linecap="square" />
+    <text
+       id="refinement-level"
+       font-family="HelveticaNeue, Helvetica Neue"
+       font-size="26"
+       font-weight="normal"
+       fill="#000000">
+      <tspan
+         x="15.176"
+         y="240"
+         id="tspan41">refinement</tspan>
+      <tspan
+         x="85.532"
+         y="271"
+         id="tspan43">level</tspan>
+    </text>
+    <g
+       id="Group"
+       transform="translate(208.000000, 53.000000)"
+       stroke="#000000"
+       stroke-width="4"
+       stroke-linecap="square">
+      <path
+         d="M0,8 L551.522935,8"
+         id="path46" />
+      <path
+         id="path48"
+         d="M551.522935,8 L540.722935,5 L540.722935,11 L551.522935,8 Z" />
+      <g
+         id="Tick"
+         transform="translate(505.000000, 0.000000)">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="Line-Copy" />
+      </g>
+      <g
+         id="g54"
+         transform="translate(26.000000, 0.000000)">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path52" />
+      </g>
+    </g>
+    <g
+       id="Group-2"
+       transform="translate(207.000000, 173.333333)"
+       stroke-linecap="square">
+      <path
+         d="M0,8.5 L552,8.5"
+         id="Line-Copy-2"
+         stroke="#000000"
+         stroke-width="4" />
+      <path
+         id="Line-Copy-2-decoration-1"
+         d="M552,8.5 L541.2,5.5 L541.2,11.5 L552,8.5 Z"
+         stroke="#000000"
+         stroke-width="4" />
+      <path
+         d="M278,8 L505,8"
+         id="Line-Copy-23"
+         stroke="#3498DB"
+         stroke-width="8" />
+      <g
+         id="g62"
+         transform="translate(27.000000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path60" />
+      </g>
+      <g
+         id="g66"
+         transform="translate(274.500000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path64" />
+      </g>
+      <g
+         id="g70"
+         transform="translate(506.000000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path68" />
+      </g>
+    </g>
+    <g
+       id="Group-4"
+       transform="translate(207.000000, 414.000000)"
+       stroke-linecap="square">
+      <path
+         d="M0,8.5 L552,8.5"
+         id="Line-Copy-11"
+         stroke="#000000"
+         stroke-width="4" />
+      <path
+         id="Line-Copy-11-decoration-1"
+         d="M552,8.5 L541.2,5.5 L541.2,11.5 L552,8.5 Z"
+         stroke="#000000"
+         stroke-width="4" />
+      <path
+         d="M276,8.5 L335,8.5"
+         id="Line-Copy-22"
+         stroke="#3498DB"
+         stroke-width="8" />
+      <path
+         d="M93,8.5 L148.5,8.5"
+         id="Line-Copy-24"
+         stroke="#9B59B6"
+         stroke-width="8" />
+      <path
+         d="M153.989865,8.5 L273,8.5"
+         id="Line-Copy-25"
+         stroke="#27AE60"
+         stroke-width="8" />
+      <g
+         id="g80"
+         transform="translate(212.500000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path78" />
+      </g>
+      <g
+         id="g84"
+         transform="translate(150.666667, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path82" />
+      </g>
+      <g
+         id="g88"
+         transform="translate(88.833333, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path86" />
+      </g>
+      <g
+         id="g92"
+         transform="translate(27.000000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path90" />
+      </g>
+      <g
+         id="g96"
+         transform="translate(274.333333, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path94" />
+      </g>
+      <g
+         id="g100"
+         transform="translate(336.000000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path98" />
+      </g>
+      <g
+         id="g104"
+         transform="translate(451.000000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path102" />
+      </g>
+      <g
+         id="g108"
+         transform="translate(398.000000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path106" />
+      </g>
+      <g
+         id="g112"
+         transform="translate(504.000000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path110" />
+      </g>
+    </g>
+    <g
+       id="Group-3"
+       transform="translate(208.000000, 293.666667)"
+       stroke-linecap="square">
+      <path
+         d="M0,8.5 L550,8.5"
+         id="Line-Copy-6"
+         stroke="#000000"
+         stroke-width="4" />
+      <path
+         id="Line-Copy-6-decoration-1"
+         d="M550,8.5 L539.2,5.5 L539.2,11.5 L550,8.5 Z"
+         stroke="#000000"
+         stroke-width="4" />
+      <path
+         d="M154,8.5 L270,8.5"
+         id="path117"
+         stroke="#E74C3C"
+         stroke-width="8" />
+      <path
+         d="M278,8.5 L395,8.5"
+         id="Line-Copy-21"
+         stroke="#3498DB"
+         stroke-width="8" />
+      <g
+         id="g122"
+         transform="translate(505.000000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path120" />
+      </g>
+      <g
+         id="g126"
+         transform="translate(397.000000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path124" />
+      </g>
+      <g
+         id="g130"
+         transform="translate(273.333333, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path128" />
+      </g>
+      <g
+         id="g134"
+         transform="translate(149.666667, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path132" />
+      </g>
+      <g
+         id="g138"
+         transform="translate(26.000000, 0.000000)"
+         stroke="#000000"
+         stroke-width="4">
+        <path
+           d="M1,0.5 L1,15.5"
+           id="path136" />
+      </g>
+    </g>
+    <path
+       d="M234.5,78 L234.5,407"
+       id="path141"
+       stroke="#000000"
+       stroke-linecap="square"
+       stroke-dasharray="10,18" />
+    <path
+       d="M713.5,78 L713.5,407"
+       id="path143"
+       stroke="#000000"
+       stroke-linecap="square"
+       stroke-dasharray="10,18" />
+    <path
+       d="M358.5,316 L358.5,405.522344"
+       id="Line-Copy-3"
+       stroke="#000000"
+       stroke-linecap="square"
+       stroke-dasharray="10,18" />
+    <path
+       d="M482.5,316 L482.5,405.522344"
+       id="Line-Copy-4"
+       stroke="#000000"
+       stroke-linecap="square"
+       stroke-dasharray="10,18" />
+    <path
+       d="M606.5,316 L606.5,405.522344"
+       id="Line-Copy-5"
+       stroke="#000000"
+       stroke-linecap="square"
+       stroke-dasharray="10,18" />
+    <path
+       d="M482.5,197 L482.5,286.522344"
+       id="Line-Copy-7"
+       stroke="#000000"
+       stroke-linecap="square"
+       stroke-dasharray="10,18" />
+  </g>
+</svg>

--- a/src/Domain/Amr/CMakeLists.txt
+++ b/src/Domain/Amr/CMakeLists.txt
@@ -5,6 +5,8 @@ set(LIBRARY Amr)
 
 set(LIBRARY_SOURCES
   Flag.cpp
+  Helpers.cpp
+  UpdateAmrDecision.cpp
   )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Domain/Amr/Helpers.cpp
+++ b/src/Domain/Amr/Helpers.cpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Amr/Helpers.hpp"
+
+#include "Domain/Direction.hpp"       // IWYU pragma: keep
+#include "Domain/ElementId.hpp"       // IWYU pragma: keep
+#include "Domain/OrientationMap.hpp"  // IWYU pragma: keep
+#include "Domain/SegmentId.hpp"       // IWYU pragma: keep
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace amr {
+template <size_t VolumeDim>
+std::array<size_t, VolumeDim> desired_refinement_levels(
+    const ElementId<VolumeDim>& id,
+    const std::array<amr::Flag, VolumeDim>& flags) noexcept {
+  std::array<size_t, VolumeDim> result{};
+
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    ASSERT(amr::Flag::Undefined != gsl::at(flags, d),
+           "Undefined amr::Flag in dimension " << d);
+    gsl::at(result, d) = gsl::at(id.segment_ids(), d).refinement_level();
+    if (amr::Flag::Join == gsl::at(flags, d)) {
+      --gsl::at(result, d);
+    } else if (amr::Flag::Split == gsl::at(flags, d)) {
+      ++gsl::at(result, d);
+    }
+  }
+  return result;
+}
+
+template <size_t VolumeDim>
+std::array<size_t, VolumeDim> desired_refinement_levels_of_neighbor(
+    const ElementId<VolumeDim>& neighbor_id,
+    const std::array<amr::Flag, VolumeDim>& neighbor_flags,
+    const OrientationMap<VolumeDim>& orientation) noexcept {
+  if (orientation.is_aligned()) {
+    return desired_refinement_levels(neighbor_id, neighbor_flags);
+  }
+  std::array<size_t, VolumeDim> result{};
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    ASSERT(amr::Flag::Undefined != gsl::at(neighbor_flags, d),
+           "Undefined amr::Flag in dimension " << d);
+    const size_t mapped_dim = orientation(d);
+    gsl::at(result, d) =
+        gsl::at(neighbor_id.segment_ids(), mapped_dim).refinement_level();
+    if (amr::Flag::Join == gsl::at(neighbor_flags, mapped_dim)) {
+      --gsl::at(result, d);
+    } else if (amr::Flag::Split == gsl::at(neighbor_flags, mapped_dim)) {
+      ++gsl::at(result, d);
+    }
+  }
+  return result;
+}
+
+template <size_t VolumeDim>
+bool has_potential_sibling(const ElementId<VolumeDim>& element_id,
+                           const Direction<VolumeDim>& direction) noexcept {
+  return direction.side() ==
+         gsl::at(element_id.segment_ids(), direction.dimension())
+             .side_of_sibling();
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template std::array<size_t, DIM(data)> desired_refinement_levels<DIM(data)>( \
+      const ElementId<DIM(data)>&,                                             \
+      const std::array<amr::Flag, DIM(data)>&) noexcept;                       \
+  template std::array<size_t, DIM(data)>                                       \
+  desired_refinement_levels_of_neighbor<DIM(data)>(                            \
+      const ElementId<DIM(data)>&, const std::array<amr::Flag, DIM(data)>&,    \
+      const OrientationMap<DIM(data)>&) noexcept;                              \
+  template bool has_potential_sibling(                                         \
+      const ElementId<DIM(data)>& element_id,                                  \
+      const Direction<DIM(data)>& direction) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond
+}  // namespace amr

--- a/src/Domain/Amr/Helpers.hpp
+++ b/src/Domain/Amr/Helpers.hpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Functions used for adaptive mesh refinement decisions.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "Domain/Amr/Flag.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class Direction;
+
+template <size_t VolumeDim>
+class ElementId;
+
+template <size_t VolumeDim>
+class OrientationMap;
+/// \endcond
+
+namespace amr {
+/// \ingroup ComputationalDomainGroup
+/// \brief Computes the desired refinement level of the Element with ElementId
+/// `id` given the desired amr::Flag%s `flags`
+template <size_t VolumeDim>
+std::array<size_t, VolumeDim> desired_refinement_levels(
+    const ElementId<VolumeDim>& id,
+    const std::array<amr::Flag, VolumeDim>& flags) noexcept;
+
+/// \ingroup ComputationalDomainGroup
+/// \brief Computes the desired refinement level of a neighboring Element with
+/// ElementId `neighbor_id` given its desired amr::Flag%s `neighbor_flags`
+/// taking into account the OrientationMap `orientation` of the neighbor
+///
+/// \details The OrientationMap `orientation` is that from the Element that has
+/// a neighbor with ElementId `neighbor_id`
+template <size_t VolumeDim>
+std::array<size_t, VolumeDim> desired_refinement_levels_of_neighbor(
+    const ElementId<VolumeDim>& neighbor_id,
+    const std::array<amr::Flag, VolumeDim>& neighbor_flags,
+    const OrientationMap<VolumeDim>& orientation) noexcept;
+
+/// \ingroup ComputationalDomainGroup
+/// \brief Whether or not the Element with `element_id` can have a sibling
+/// in the given `direction`
+template <size_t VolumeDim>
+bool has_potential_sibling(const ElementId<VolumeDim>& element_id,
+                           const Direction<VolumeDim>& direction) noexcept;
+}  // namespace amr

--- a/src/Domain/Amr/UpdateAmrDecision.cpp
+++ b/src/Domain/Amr/UpdateAmrDecision.cpp
@@ -1,0 +1,120 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Amr/UpdateAmrDecision.hpp"
+
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"    // IWYU pragma: keep
+#include "Domain/ElementId.hpp"  // IWYU pragma: keep
+#include "Domain/Neighbors.hpp"  // IWYU pragma: keep
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+template <size_t VolumeDim>
+class OrientationMap;
+
+namespace amr {
+
+template <size_t VolumeDim>
+bool update_amr_decision(
+    gsl::not_null<std::array<amr::Flag, VolumeDim>*> my_current_amr_flags,
+    const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
+    const std::array<amr::Flag, VolumeDim>& neighbor_amr_flags) noexcept {
+  const auto& element_id = element.id();
+  bool my_amr_decision_changed = false;
+  bool neighbor_found = false;
+  std::array<size_t, VolumeDim> my_desired_levels =
+      amr::desired_refinement_levels(element_id, *my_current_amr_flags);
+
+  for (const auto& direction_neighbors : element.neighbors()) {
+    const Neighbors<VolumeDim>& neighbors_in_dir = direction_neighbors.second;
+
+    if (1 == neighbors_in_dir.ids().count(neighbor_id)) {
+      // finding the same neighbor twice (which can happen with periodic
+      // domains) is okay, and may be needed when examining a Join
+      neighbor_found = true;
+      const Direction<VolumeDim> direction_to_neighbor =
+          direction_neighbors.first;
+      const OrientationMap<VolumeDim>& orientation_of_neighbor =
+          neighbors_in_dir.orientation();
+      const std::array<size_t, VolumeDim> neighbor_desired_levels =
+          amr::desired_refinement_levels_of_neighbor(
+              neighbor_id, neighbor_amr_flags, orientation_of_neighbor);
+
+      // update flags if my element wants to be two or more levels
+      // coarser than the neighbor in any dimension
+      for (size_t d = 0; d < VolumeDim; ++d) {
+        if (amr::Flag::Split == gsl::at(*my_current_amr_flags, d) or
+            gsl::at(my_desired_levels, d) >=
+                gsl::at(neighbor_desired_levels, d)) {
+          continue;
+        }
+        const size_t difference =
+            gsl::at(neighbor_desired_levels, d) - gsl::at(my_desired_levels, d);
+        ASSERT(difference < 4 and difference > 0,
+               "neighbor level = " << gsl::at(neighbor_desired_levels, d)
+                                   << ", my level = "
+                                   << gsl::at(my_desired_levels, d));
+        if (amr::Flag::Join == gsl::at(*my_current_amr_flags, d)) {
+          if (3 == difference) {
+            // My split neighbor wants to split, so I need to split to keep
+            // refinement levels within one.
+            gsl::at(*my_current_amr_flags, d) = amr::Flag::Split;
+            gsl::at(my_desired_levels, d) += 2;
+            my_amr_decision_changed = true;
+          } else if (2 == difference) {
+            // My split neighbor wants to stay the same, or my neighbor
+            // split, so I need to stay the same to keep refinement levels
+            // within one.
+            gsl::at(*my_current_amr_flags, d) = amr::Flag::DoNothing;
+            ++gsl::at(my_desired_levels, d);
+            my_amr_decision_changed = true;
+          }
+        } else {
+          if (2 == difference) {
+            // my split neighbor wants to split, so I need to split to
+            // keep refinement levels within one
+            gsl::at(*my_current_amr_flags, d) = amr::Flag::Split;
+            ++gsl::at(my_desired_levels, d);
+            my_amr_decision_changed = true;
+          }
+        }
+      }
+
+      // update flags if the neighbor is a potential sibling that my element
+      // cannot join
+      const size_t dimension_of_direction_to_neighbor =
+          direction_to_neighbor.dimension();
+      if (amr::has_potential_sibling(element_id, direction_to_neighbor) and
+          amr::Flag::Join == gsl::at(*my_current_amr_flags,
+                                     dimension_of_direction_to_neighbor) and
+          (my_desired_levels != neighbor_desired_levels)) {
+        gsl::at(*my_current_amr_flags, dimension_of_direction_to_neighbor) =
+            amr::Flag::DoNothing;
+        ++gsl::at(my_desired_levels, dimension_of_direction_to_neighbor);
+        my_amr_decision_changed = true;
+      }
+    }
+  }
+  ASSERT(neighbor_found, "Could not find neighbor " << neighbor_id);
+  return my_amr_decision_changed;
+}
+
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template bool update_amr_decision(                                         \
+      gsl::not_null<std::array<amr::Flag, DIM(data)>*> my_current_amr_flags, \
+      const Element<DIM(data)>& element,                                     \
+      const ElementId<DIM(data)>& neighbor_id,                               \
+      const std::array<amr::Flag, DIM(data)>& neighbor_amr_flags) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef DIM
+#undef INSTANTIATE
+/// \endcond
+}  // namespace amr

--- a/src/Domain/Amr/UpdateAmrDecision.hpp
+++ b/src/Domain/Amr/UpdateAmrDecision.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "Domain/Amr/Flag.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+template <size_t VolumeDim>
+class Element;
+
+template <size_t VolumeDim>
+class ElementId;
+/// \endcond
+
+namespace amr {
+/// \ingroup ComputationalDomainGroup
+/// \brief Updates the AMR decisions `my_current_amr_flags` of the Element
+/// `element` based on the AMR decisions `neighbor_amr_flags` of a neighbor
+/// Element with ElementId `neighbor_id`.
+///
+/// \details  This function is called by each element when it receives the AMR
+/// decisions of one of its neighbors.  If any of its flags are updated, the
+/// element should send its new decisions to each of its neighbors.  The
+/// following changes are made to the current flags of the element:
+/// - If the neighbor wants to be two or more refinement levels higher than
+///   the element, the flag is updated to bring the element to within one level
+/// - If the element wants to join, and the neighbor is a potential sibling but
+///   wants to be at a different refinement level in any dimension, the flag is
+///   updated to not do h-refinement.
+///
+/// \returns true if any flag is changed
+///
+/// \note Modifies `my_current_amr_flags` which are the AMR decisions of
+/// `element`.
+template <size_t VolumeDim>
+bool update_amr_decision(
+    gsl::not_null<std::array<amr::Flag, VolumeDim>*> my_current_amr_flags,
+    const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
+    const std::array<amr::Flag, VolumeDim>& neighbor_amr_flags) noexcept;
+}  // namespace amr

--- a/src/Domain/OrientationMap.hpp
+++ b/src/Domain/OrientationMap.hpp
@@ -67,6 +67,15 @@ class OrientationMap {
   std::array<SegmentId, VolumeDim> operator()(
       const std::array<SegmentId, VolumeDim>& segmentIds) const;
 
+  /// An array whose elements are permuted such that
+  /// `result[d] = array_in_neighbor[this->operator()(d)]`
+  ///
+  /// \note the permutation depends only on how the dimension is mapped
+  /// and ignores the side of the mapped direction.
+  template <typename T>
+  std::array<T, VolumeDim> permute_from_neighbor(
+      const std::array<T, VolumeDim>& array_in_neighbor) const noexcept;
+
   /// The corresponding Orientation of the host in the frame of the neighbor.
   OrientationMap<VolumeDim> inverse_map() const noexcept;
 
@@ -93,6 +102,19 @@ template <size_t VolumeDim>
 bool operator!=(const OrientationMap<VolumeDim>& lhs,
                 const OrientationMap<VolumeDim>& rhs) noexcept {
   return not(lhs == rhs);
+}
+
+template <size_t VolumeDim>
+template <typename T>
+std::array<T, VolumeDim> OrientationMap<VolumeDim>::permute_from_neighbor(
+    const std::array<T, VolumeDim>& array_in_neighbor) const noexcept {
+  std::array<T, VolumeDim> result = array_in_neighbor;
+  if (not is_aligned_ and VolumeDim > 1) {
+    for (size_t i = 0; i < VolumeDim; i++) {
+      gsl::at(result, i) = gsl::at(array_in_neighbor, this->operator()(i));
+    }
+  }
+  return result;
 }
 
 /// \ingroup DomainCreatorsGroup

--- a/src/Domain/SegmentId.hpp
+++ b/src/Domain/SegmentId.hpp
@@ -18,11 +18,35 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
-/// \ingroup ComputationalDomainGroup
-/// A SegmentId labels a segment of the interval [-1,1].
-/// A SegmentId is used to (partially) identify an Element.
-/// The segment is the interval [-1 + 2*(N/D), -1 + 2*(N+1)/D]
-/// where N = index_ and D = 2 ^ refinement_level_.
+/*!
+ *  \ingroup ComputationalDomainGroup
+ *  \brief A SegmentId labels a segment of the interval [-1,1] and is used to
+ *  identify the bounds of an Element in a Block in each dimension.
+ *
+ *  In \f$d\f$ dimensions, \f$d\f$ SegmentId%s are used to identify an Element.
+ * In each dimension, a segment spans the subinterval \f$[-1 + 2 \frac{i}{N}, -1
+ * + 2 \frac{i+1}{N}]\f$ of the logical coordinates of a Block, where \f$i \f$=
+ * `index` and \f$N = 2^L\f$ where \f$L\f$ = `refinement_level`.
+ *
+ *  \image html SegmentId.svg  "SegmentIds"
+ *
+ * In the figure, The `index` of segments increase from the `lower side` to the
+ * `upper side` in each dimension of a Block, while the `refinement level`
+ * increases as the segments are subdivided.  For example, let the segment
+ * labeled `self` be on `refinement level` \f$L\f$, with `index` \f$i\f$.  Its
+ * `parent` segment is on `refinement level` \f$L-1\f$ with  `index`
+ * \f$\frac{i-1}{2}\f$. The `children` of `self` are on `refinement level`
+ * \f$L+1\f$, and have `index` \f$2i\f$ and \f$2i+1\f$ for the lower and upper
+ * child respectively.  Also labeled on the figure are the `sibling` and
+ * `abutting nibling` (child of sibling) of `self`. These relationships between
+ * segments are important for h-refinement, since in each dimension an Element
+ * can be flagged to split into its two `children` segments, or join with its
+ * `sibling` segment to form its `parent` segment.  As refinement levels of
+ * neighboring elements are kept within one, in the direction of its `sibling`,
+ * a segment can only abut its `sibling` or `abutting nibling`, while on the
+ * opposite side, it can abut a segment on its level, the next-lower, or the
+ * next-higher level.
+ */
 class SegmentId {
  public:
   /// Default constructor needed for Charm++ serialization.
@@ -44,6 +68,15 @@ class SegmentId {
   SegmentId id_of_parent() const noexcept;
 
   SegmentId id_of_child(Side side) const noexcept;
+
+  /// The other child of the parent of this segment
+  SegmentId id_of_sibling() const noexcept;
+
+  /// The child of the sibling of this segment that shares an endpoint with it
+  SegmentId id_of_abutting_nibling() const noexcept;
+
+  /// The side on which this segment shares an endpoint with its sibling
+  Side side_of_sibling() const noexcept;
 
   /// The id this segment would have if the coordinate axis were flipped.
   SegmentId id_if_flipped() const noexcept;
@@ -99,6 +132,25 @@ inline SegmentId SegmentId::id_of_child(Side side) const noexcept {
   return {refinement_level_ + 1, 1 + index_ * 2};
 }
 
+inline SegmentId SegmentId::id_of_sibling() const noexcept {
+  ASSERT(0 != refinement_level_,
+         "The segment on the root refinement level has no sibling");
+  return {refinement_level_, (0 == index_ % 2 ? index_ + 1 : index_ - 1)};
+}
+
+inline SegmentId SegmentId::id_of_abutting_nibling() const noexcept {
+  ASSERT(0 != refinement_level_,
+         "The segment on the root refinement level has no abutting nibling");
+  return {refinement_level_ + 1,
+          (0 == index_ % 2 ? 2 * index_ + 2 : 2 * index_ - 1)};
+}
+
+inline Side SegmentId::side_of_sibling() const noexcept {
+  ASSERT(0 != refinement_level_,
+         "The segment on the root refinement level has no sibling");
+  return 0 == index_ % 2 ? Side::Upper : Side::Lower;
+}
+
 inline SegmentId SegmentId::id_if_flipped() const noexcept {
   return {refinement_level_, two_to_the(refinement_level_) - 1 - index_};
 }
@@ -114,7 +166,7 @@ inline bool SegmentId::overlaps(const SegmentId& other) const noexcept {
   const size_t this_denom = two_to_the(refinement_level_);
   const size_t other_denom = two_to_the(other.refinement_level_);
   return index_ * other_denom < (other.index_ + 1) * this_denom and
-      other.index_ * this_denom < (index_ + 1) * other_denom;
+         other.index_ * this_denom < (index_ + 1) * other_denom;
 }
 
 // These are defined so that a SegmentId can be used as part of a key of an

--- a/tests/Unit/Domain/Amr/CMakeLists.txt
+++ b/tests/Unit/Domain/Amr/CMakeLists.txt
@@ -5,6 +5,8 @@ set(LIBRARY "Test_Amr")
 
 set(LIBRARY_SOURCES
   Test_Flag.cpp
+  Test_Helpers.cpp
+  Test_UpdateAmrDecision.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Domain/Amr/Test_Helpers.cpp
+++ b/tests/Unit/Domain/Amr/Test_Helpers.cpp
@@ -1,0 +1,160 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/Helpers.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Domain/SegmentId.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
+
+namespace {
+void test_desired_refinement_levels() noexcept {
+  ElementId<1> element_id_1d{0, {{SegmentId(2, 3)}}};
+  CHECK(amr::desired_refinement_levels(element_id_1d, {{amr::Flag::Split}}) ==
+        std::array<size_t, 1>{{3}});
+  CHECK(
+      amr::desired_refinement_levels(element_id_1d, {{amr::Flag::DoNothing}}) ==
+      std::array<size_t, 1>{{2}});
+  CHECK(amr::desired_refinement_levels(element_id_1d, {{amr::Flag::Join}}) ==
+        std::array<size_t, 1>{{1}});
+
+  ElementId<2> element_id_2d{1, {{SegmentId(3, 5), SegmentId(1, 1)}}};
+  CHECK(amr::desired_refinement_levels(element_id_2d,
+                                       {{amr::Flag::Split, amr::Flag::Join}}) ==
+        std::array<size_t, 2>{{4, 0}});
+  CHECK(amr::desired_refinement_levels(
+            element_id_2d, {{amr::Flag::Join, amr::Flag::DoNothing}}) ==
+        std::array<size_t, 2>{{2, 1}});
+  CHECK(amr::desired_refinement_levels(element_id_2d,
+                                       {{amr::Flag::Join, amr::Flag::Join}}) ==
+        std::array<size_t, 2>{{2, 0}});
+  CHECK(amr::desired_refinement_levels(
+            element_id_2d, {{amr::Flag::DoNothing, amr::Flag::Split}}) ==
+        std::array<size_t, 2>{{3, 2}});
+  CHECK(amr::desired_refinement_levels(
+            element_id_2d, {{amr::Flag::DoNothing, amr::Flag::DoNothing}}) ==
+        std::array<size_t, 2>{{3, 1}});
+
+  ElementId<3> element_id_3d{
+      7, {{SegmentId(5, 15), SegmentId(2, 0), SegmentId(4, 6)}}};
+  CHECK(amr::desired_refinement_levels(
+            element_id_3d,
+            {{amr::Flag::Split, amr::Flag::Join, amr::Flag::DoNothing}}) ==
+        std::array<size_t, 3>{{6, 1, 4}});
+}
+
+template <size_t VolumeDim>
+void check_desired_refinement_levels_of_neighbor(
+    const ElementId<VolumeDim>& neighbor_id,
+    const std::array<amr::Flag, VolumeDim>& neighbor_flags) noexcept {
+  for (OrientationMapIterator<VolumeDim> orientation{}; orientation;
+       ++orientation) {
+    const auto desired_levels_my_frame = desired_refinement_levels_of_neighbor(
+        neighbor_id, neighbor_flags, *orientation);
+    const auto desired_levels_neighbor_frame =
+        desired_refinement_levels(neighbor_id, neighbor_flags);
+    for (size_t d = 0; d < VolumeDim; ++d) {
+      CHECK(gsl::at(desired_levels_my_frame, d) ==
+            gsl::at(desired_levels_neighbor_frame, (*orientation)(d)));
+    }
+  }
+}
+
+void test_desired_refinement_levels_of_neighbor() noexcept {
+  ElementId<1> neighbor_id_1d{0, {{SegmentId(2, 3)}}};
+  check_desired_refinement_levels_of_neighbor(neighbor_id_1d,
+                                              {{amr::Flag::Split}});
+  check_desired_refinement_levels_of_neighbor(neighbor_id_1d,
+                                              {{amr::Flag::DoNothing}});
+  check_desired_refinement_levels_of_neighbor(neighbor_id_1d,
+                                              {{amr::Flag::Join}});
+
+  ElementId<2> neighbor_id_2d{1, {{SegmentId(3, 0), SegmentId(1, 1)}}};
+  check_desired_refinement_levels_of_neighbor(
+      neighbor_id_2d, {{amr::Flag::Split, amr::Flag::Join}});
+  check_desired_refinement_levels_of_neighbor(
+      neighbor_id_2d, {{amr::Flag::Join, amr::Flag::DoNothing}});
+  check_desired_refinement_levels_of_neighbor(
+      neighbor_id_2d, {{amr::Flag::Join, amr::Flag::Join}});
+  check_desired_refinement_levels_of_neighbor(
+      neighbor_id_2d, {{amr::Flag::DoNothing, amr::Flag::Split}});
+  check_desired_refinement_levels_of_neighbor(
+      neighbor_id_2d, {{amr::Flag::DoNothing, amr::Flag::DoNothing}});
+
+  ElementId<3> neighbor_id_3d{
+      7, {{SegmentId(5, 31), SegmentId(2, 0), SegmentId(4, 15)}}};
+  check_desired_refinement_levels_of_neighbor(
+      neighbor_id_3d,
+      {{amr::Flag::Split, amr::Flag::Join, amr::Flag::DoNothing}});
+  check_desired_refinement_levels_of_neighbor(
+      neighbor_id_3d,
+      {{amr::Flag::Join, amr::Flag::DoNothing, amr::Flag::Split}});
+}
+
+void test_has_potential_sibling() {
+  ElementId<1> element_id_1d{0, {{SegmentId(2, 3)}}};
+  CHECK(amr::has_potential_sibling(element_id_1d, Direction<1>::lower_xi()));
+  CHECK_FALSE(
+      amr::has_potential_sibling(element_id_1d, Direction<1>::upper_xi()));
+
+  ElementId<2> element_id_2d{0, {{SegmentId(3, 0), SegmentId{1, 1}}}};
+  CHECK(amr::has_potential_sibling(element_id_2d, Direction<2>::upper_xi()));
+  CHECK(amr::has_potential_sibling(element_id_2d, Direction<2>::lower_eta()));
+  CHECK_FALSE(
+      amr::has_potential_sibling(element_id_2d, Direction<2>::lower_xi()));
+  CHECK_FALSE(
+      amr::has_potential_sibling(element_id_2d, Direction<2>::upper_eta()));
+
+  ElementId<3> element_id_3d{
+      7, {{SegmentId(5, 31), SegmentId(2, 0), SegmentId(4, 15)}}};
+  CHECK(amr::has_potential_sibling(element_id_3d, Direction<3>::lower_xi()));
+  CHECK(amr::has_potential_sibling(element_id_3d, Direction<3>::upper_eta()));
+  CHECK(amr::has_potential_sibling(element_id_3d, Direction<3>::lower_zeta()));
+  CHECK_FALSE(
+      amr::has_potential_sibling(element_id_3d, Direction<3>::upper_xi()));
+  CHECK_FALSE(
+      amr::has_potential_sibling(element_id_3d, Direction<3>::lower_eta()));
+  CHECK_FALSE(
+      amr::has_potential_sibling(element_id_3d, Direction<3>::upper_zeta()));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Amr.Helpers", "[Domain][Unit]") {
+  test_desired_refinement_levels();
+  test_desired_refinement_levels_of_neighbor();
+  test_has_potential_sibling();
+}
+
+// [[OutputRegex, Undefined amr::Flag in dimension]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Amr.Helpers.BadFlag",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto bad_flag =
+      amr::desired_refinement_levels(ElementId<1>{0}, {{amr::Flag::Undefined}});
+  static_cast<void>(bad_flag);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Undefined amr::Flag in dimension]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Amr.Helpers.BadFlag2",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto bad_flag = amr::desired_refinement_levels_of_neighbor(
+      ElementId<1>{0}, {{amr::Flag::Undefined}},
+      OrientationMap<1>{{{Direction<1>::lower_xi()}}});
+  static_cast<void>(bad_flag);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}

--- a/tests/Unit/Domain/Amr/Test_UpdateAmrDecision.cpp
+++ b/tests/Unit/Domain/Amr/Test_UpdateAmrDecision.cpp
@@ -1,0 +1,736 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "Domain/Amr/Flag.hpp"
+#include "Domain/Amr/UpdateAmrDecision.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/Neighbors.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Domain/Side.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+
+namespace {
+
+template <size_t VolumeDim>
+void check_amr_decision_is_unchanged(
+    std::array<amr::Flag, VolumeDim> my_initial_amr_flags,
+    const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
+    const std::array<amr::Flag, VolumeDim>& neighbor_amr_flags) noexcept {
+  const auto expected_updated_flags = my_initial_amr_flags;
+  std::stringstream os;
+  os << neighbor_amr_flags;
+  INFO(os.str());
+  CHECK_FALSE(amr::update_amr_decision(make_not_null(&my_initial_amr_flags),
+                                       element, neighbor_id,
+                                       neighbor_amr_flags));
+  CHECK(expected_updated_flags == my_initial_amr_flags);
+}
+
+template <size_t VolumeDim>
+void check_amr_decision_is_changed(
+    std::array<amr::Flag, VolumeDim> my_initial_amr_flags,
+    const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
+    const std::array<amr::Flag, VolumeDim>& neighbor_amr_flags,
+    const std::array<amr::Flag, VolumeDim>& expected_updated_flags) noexcept {
+  std::stringstream os;
+  os << my_initial_amr_flags << " " << neighbor_amr_flags;
+  INFO(os.str());
+  CHECK(amr::update_amr_decision(make_not_null(&my_initial_amr_flags), element,
+                                 neighbor_id, neighbor_amr_flags));
+  CHECK(expected_updated_flags == my_initial_amr_flags);
+}
+
+template <size_t VolumeDim>
+using changed_flags_t = std::map<std::pair<std::array<amr::Flag, VolumeDim>,
+                                           std::array<amr::Flag, VolumeDim>>,
+                                 std::array<amr::Flag, VolumeDim>>;
+template <size_t VolumeDim>
+void check_update_amr_decision(
+    const Element<VolumeDim>& element, const ElementId<VolumeDim>& neighbor_id,
+    const std::vector<std::array<amr::Flag, VolumeDim>>& all_flags,
+    const changed_flags_t<VolumeDim>& changed_flags) noexcept {
+  for (const auto& my_flags : all_flags) {
+    for (const auto& neighbor_flags : all_flags) {
+      auto search =
+          changed_flags.find(std::make_pair(my_flags, neighbor_flags));
+      if (search == changed_flags.end()) {
+        check_amr_decision_is_unchanged(my_flags, element, neighbor_id,
+                                        neighbor_flags);
+      } else {
+        check_amr_decision_is_changed(my_flags, element, neighbor_id,
+                                      neighbor_flags, search->second);
+      }
+    }
+  }
+}
+
+Element<1> make_element(
+    const ElementId<1>& element_id,
+    const std::unordered_set<ElementId<1>>& lower_xi_neighbor_ids,
+    const std::unordered_set<ElementId<1>>& upper_xi_neighbor_ids) noexcept {
+  std::unordered_map<Direction<1>, Neighbors<1>> neighbors;
+  if (not lower_xi_neighbor_ids.empty()) {
+    neighbors.emplace(Direction<1>::lower_xi(),
+                      Neighbors<1>{{lower_xi_neighbor_ids}, {}});
+  }
+  if (not upper_xi_neighbor_ids.empty()) {
+    neighbors.emplace(Direction<1>::upper_xi(),
+                      Neighbors<1>{{upper_xi_neighbor_ids}, {}});
+  }
+  return Element<1>{element_id, std::move(neighbors)};
+}
+
+Element<2> make_element(
+    const ElementId<2>& element_id,
+    const std::unordered_set<ElementId<2>>& lower_xi_neighbor_ids,
+    const std::unordered_set<ElementId<2>>& upper_xi_neighbor_ids,
+    const std::unordered_set<ElementId<2>>& lower_eta_neighbor_ids,
+    const std::unordered_set<ElementId<2>>& upper_eta_neighbor_ids) noexcept {
+  std::unordered_map<Direction<2>, Neighbors<2>> neighbors;
+  if (not lower_xi_neighbor_ids.empty()) {
+    neighbors.emplace(Direction<2>::lower_xi(),
+                      Neighbors<2>{{lower_xi_neighbor_ids}, {}});
+  }
+  if (not upper_xi_neighbor_ids.empty()) {
+    neighbors.emplace(Direction<2>::upper_xi(),
+                      Neighbors<2>{{upper_xi_neighbor_ids}, {}});
+  }
+  if (not lower_eta_neighbor_ids.empty()) {
+    neighbors.emplace(Direction<2>::lower_eta(),
+                      Neighbors<2>{{lower_eta_neighbor_ids}, {}});
+  }
+  if (not upper_eta_neighbor_ids.empty()) {
+    neighbors.emplace(Direction<2>::upper_eta(),
+                      Neighbors<2>{{upper_eta_neighbor_ids}, {}});
+  }
+  return Element<2>{element_id, std::move(neighbors)};
+}
+
+void test_update_amr_decision_1d() noexcept {
+  const std::array<amr::Flag, 1> split{{amr::Flag::Split}};
+  const std::array<amr::Flag, 1> join{{amr::Flag::Join}};
+  const std::array<amr::Flag, 1> stay{{amr::Flag::DoNothing}};
+  const std::vector<std::array<amr::Flag, 1>> all_flags{split, join, stay};
+
+  const SegmentId x_segment{3, 5};
+  const SegmentId x_cousin{3, 6};
+
+  const ElementId<1> element_id{0, {{x_segment}}};
+  const ElementId<1> id_lx_s{0, {{x_segment.id_of_sibling()}}};
+  const ElementId<1> id_ux_c{0, {{x_cousin}}};
+
+  auto element = make_element(element_id, {id_lx_s}, {id_ux_c});
+  // changed flags: first flags of pair is initial_amr_flags
+  //                second flags of pair is neighbor_amr_flags
+  //                last flags are the new amr_flags for the element
+  check_update_amr_decision(
+      element, id_lx_s, all_flags,
+      changed_flags_t<1>{{{join, stay}, stay}, {{join, split}, stay}});
+  check_update_amr_decision(element, id_ux_c, all_flags,
+                            changed_flags_t<1>{{{join, split}, stay}});
+
+  const ElementId<1> id_lx_n{0, {{x_segment.id_of_abutting_nibling()}}};
+  const ElementId<1> id_ux_cp{0, {{x_cousin.id_of_parent()}}};
+  element = make_element(element_id, {id_lx_n}, {id_ux_cp});
+  check_update_amr_decision(element, id_lx_n, all_flags,
+                            changed_flags_t<1>{{{join, join}, stay},
+                                               {{join, stay}, stay},
+                                               {{join, split}, split},
+                                               {{stay, split}, split}});
+  check_update_amr_decision(element, id_ux_cp, all_flags, changed_flags_t<1>{});
+
+  // note having no lower neighbor is okay for this test
+  const ElementId<1> id_ux_cc{0, {{x_cousin.id_of_child(Side::Lower)}}};
+  element = make_element(element_id, {}, {id_ux_cc});
+  check_update_amr_decision(element, id_ux_cc, all_flags,
+                            changed_flags_t<1>{{{join, stay}, stay},
+                                               {{join, split}, split},
+                                               {{stay, split}, split}});
+}
+
+void test_update_amr_decision_2d() noexcept {
+  const std::array<amr::Flag, 2> split_split{
+      {amr::Flag::Split, amr::Flag::Split}};
+  const std::array<amr::Flag, 2> join_split{
+      {amr::Flag::Join, amr::Flag::Split}};
+  const std::array<amr::Flag, 2> stay_split{
+      {amr::Flag::DoNothing, amr::Flag::Split}};
+  const std::array<amr::Flag, 2> split_stay{
+      {amr::Flag::Split, amr::Flag::DoNothing}};
+  const std::array<amr::Flag, 2> join_stay{
+      {amr::Flag::Join, amr::Flag::DoNothing}};
+  const std::array<amr::Flag, 2> stay_stay{
+      {amr::Flag::DoNothing, amr::Flag::DoNothing}};
+  const std::array<amr::Flag, 2> split_join{
+      {amr::Flag::Split, amr::Flag::Join}};
+  const std::array<amr::Flag, 2> join_join{{amr::Flag::Join, amr::Flag::Join}};
+  const std::array<amr::Flag, 2> stay_join{
+      {amr::Flag::DoNothing, amr::Flag::Join}};
+
+  const std::vector<std::array<amr::Flag, 2>> all_flags{
+      split_split, join_split, stay_split, split_stay, join_stay,
+      stay_stay,   split_join, join_join,  stay_join};
+
+  const SegmentId x_segment{3, 5};
+  const SegmentId x_cousin{3, 6};
+  const SegmentId y_segment{6, 15};
+  const SegmentId y_cousin{6, 16};
+
+  const ElementId<2> element_id{0, {{x_segment, y_segment}}};
+
+  const ElementId<2> id_lx_s_s{0, {{x_segment.id_of_sibling(), y_segment}}};
+  const ElementId<2> id_ux_c_s{0, {{x_cousin, y_segment}}};
+  const ElementId<2> id_ly_s_n{
+      0, {{x_segment, y_segment.id_of_abutting_nibling()}}};
+  const ElementId<2> id_uy_s_cp{0, {{x_segment, y_cousin.id_of_parent()}}};
+  auto element = make_element(element_id, {id_lx_s_s}, {id_ux_c_s}, {id_ly_s_n},
+                              {id_uy_s_cp});
+
+  // changed flags: first flags of pair are initial_amr_flags
+  //                second flags of pair are neighbor_amr_flags
+  //                last flags are the new amr_flags for the element
+
+  // neighbor same refinement in x and y, sibling side in x
+  check_update_amr_decision<2>(
+      element, id_lx_s_s, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, stay_split},
+                         {{join_split, stay_split}, stay_split},
+                         {{join_split, split_stay}, stay_split},
+                         {{join_split, join_stay}, stay_split},
+                         {{join_split, stay_stay}, stay_split},
+                         {{join_split, split_join}, stay_split},
+                         {{join_split, join_join}, stay_split},
+                         {{join_split, stay_join}, stay_split},
+                         {{join_stay, split_split}, stay_stay},
+                         {{join_stay, stay_split}, stay_stay},
+                         {{join_stay, join_split}, stay_stay},
+                         {{join_stay, split_stay}, stay_stay},
+                         {{join_stay, stay_stay}, stay_stay},
+                         {{join_stay, split_join}, stay_stay},
+                         {{join_stay, join_join}, stay_stay},
+                         {{join_stay, stay_join}, stay_stay},
+                         {{split_join, split_split}, split_stay},
+                         {{split_join, join_split}, split_stay},
+                         {{split_join, stay_split}, split_stay},
+                         {{join_join, split_split}, stay_stay},
+                         {{join_join, join_split}, stay_stay},
+                         {{join_join, stay_split}, stay_stay},
+                         {{join_join, split_stay}, stay_join},
+                         {{join_join, join_stay}, stay_join},
+                         {{join_join, stay_stay}, stay_join},
+                         {{join_join, split_join}, stay_join},
+                         {{join_join, stay_join}, stay_join},
+                         {{stay_join, split_split}, stay_stay},
+                         {{stay_join, join_split}, stay_stay},
+                         {{stay_join, stay_split}, stay_stay}});
+  // neighbor same refinement in x and y, non-sibling side in x
+  check_update_amr_decision<2>(
+      element, id_ux_c_s, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, stay_split},
+                         {{join_split, split_stay}, stay_split},
+                         {{join_split, split_join}, stay_split},
+                         {{join_stay, split_split}, stay_stay},
+                         {{join_stay, split_stay}, stay_stay},
+                         {{join_stay, split_join}, stay_stay},
+                         {{split_join, split_split}, split_stay},
+                         {{split_join, join_split}, split_stay},
+                         {{split_join, stay_split}, split_stay},
+                         {{join_join, split_split}, stay_stay},
+                         {{join_join, join_split}, join_stay},
+                         {{join_join, stay_split}, join_stay},
+                         {{join_join, split_stay}, stay_join},
+                         {{join_join, split_join}, stay_join},
+                         {{stay_join, split_split}, stay_stay},
+                         {{stay_join, join_split}, stay_stay},
+                         {{stay_join, stay_split}, stay_stay}});
+  // neighbor same in x, coarser in y, sibling side of y
+  check_update_amr_decision<2>(
+      element, id_ly_s_n, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, stay_split},
+                         {{join_split, split_stay}, stay_split},
+                         {{join_split, split_join}, stay_split},
+                         {{split_stay, split_split}, split_split},
+                         {{split_stay, join_split}, split_split},
+                         {{split_stay, stay_split}, split_split},
+                         {{join_stay, split_split}, stay_split},
+                         {{join_stay, stay_split}, join_split},
+                         {{join_stay, join_split}, join_split},
+                         {{join_stay, split_stay}, stay_stay},
+                         {{join_stay, split_join}, stay_stay},
+                         {{stay_stay, split_split}, stay_split},
+                         {{stay_stay, join_split}, stay_split},
+                         {{stay_stay, stay_split}, stay_split},
+                         {{split_join, split_split}, split_split},
+                         {{split_join, join_split}, split_split},
+                         {{split_join, stay_split}, split_split},
+                         {{split_join, split_stay}, split_stay},
+                         {{split_join, join_stay}, split_stay},
+                         {{split_join, stay_stay}, split_stay},
+                         {{split_join, split_join}, split_stay},
+                         {{split_join, join_join}, split_stay},
+                         {{split_join, stay_join}, split_stay},
+                         {{join_join, split_split}, stay_split},
+                         {{join_join, join_split}, join_split},
+                         {{join_join, stay_split}, join_split},
+                         {{join_join, split_stay}, stay_stay},
+                         {{join_join, join_stay}, join_stay},
+                         {{join_join, stay_stay}, join_stay},
+                         {{join_join, split_join}, stay_stay},
+                         {{join_join, join_join}, join_stay},
+                         {{join_join, stay_join}, join_stay},
+                         {{stay_join, split_split}, stay_split},
+                         {{stay_join, join_split}, stay_split},
+                         {{stay_join, stay_split}, stay_split},
+                         {{stay_join, split_stay}, stay_stay},
+                         {{stay_join, join_stay}, stay_stay},
+                         {{stay_join, stay_stay}, stay_stay},
+                         {{stay_join, split_join}, stay_stay},
+                         {{stay_join, join_join}, stay_stay},
+                         {{stay_join, stay_join}, stay_stay}});
+  // neighbor same in x, coarser in y, non-sibling side of y
+  check_update_amr_decision<2>(
+      element, id_uy_s_cp, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, stay_split},
+                         {{join_split, split_stay}, stay_split},
+                         {{join_split, split_join}, stay_split},
+                         {{join_stay, split_split}, stay_stay},
+                         {{join_stay, split_stay}, stay_stay},
+                         {{join_stay, split_join}, stay_stay},
+                         {{join_join, split_split}, stay_join},
+                         {{join_join, split_stay}, stay_join},
+                         {{join_join, split_join}, stay_join}});
+
+  const ElementId<2> id_lx_s_p{
+      0, {{x_segment.id_of_sibling(), y_segment.id_of_parent()}}};
+  const ElementId<2> id_ly_p_n{
+      0, {{x_segment.id_of_parent(), y_segment.id_of_abutting_nibling()}}};
+  const ElementId<2> id_ux_c_p{0, {{x_cousin, y_segment.id_of_parent()}}};
+  const ElementId<2> id_uy_p_cp{
+      0, {{x_segment.id_of_parent(), y_cousin.id_of_parent()}}};
+  element = make_element(element_id, {id_lx_s_p}, {id_ux_c_p}, {id_ly_p_n},
+                         {id_uy_p_cp});
+  // neighbor same in x, coarser in y, sibling side of x
+  check_update_amr_decision<2>(
+      element, id_lx_s_p, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, stay_split},
+                         {{join_split, join_split}, stay_split},
+                         {{join_split, stay_split}, stay_split},
+                         {{join_split, split_stay}, stay_split},
+                         {{join_split, join_stay}, stay_split},
+                         {{join_split, stay_stay}, stay_split},
+                         {{join_split, split_join}, stay_split},
+                         {{join_split, join_join}, stay_split},
+                         {{join_split, stay_join}, stay_split},
+                         {{join_stay, split_split}, stay_stay},
+                         {{join_stay, stay_split}, stay_stay},
+                         {{join_stay, split_stay}, stay_stay},
+                         {{join_stay, stay_stay}, stay_stay},
+                         {{join_stay, join_stay}, stay_stay},
+                         {{join_stay, split_join}, stay_stay},
+                         {{join_stay, join_join}, stay_stay},
+                         {{join_stay, stay_join}, stay_stay},
+                         {{join_join, split_split}, stay_join},
+                         {{join_join, join_split}, stay_join},
+                         {{join_join, stay_split}, stay_join},
+                         {{join_join, split_stay}, stay_join},
+                         {{join_join, stay_stay}, stay_join},
+                         {{join_join, split_join}, stay_join},
+                         {{join_join, join_join}, stay_join},
+                         {{join_join, stay_join}, stay_join}});
+  // neighbor same in x, coarser in y, non-sibling side of x
+  check_update_amr_decision<2>(
+      element, id_ux_c_p, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, stay_split},
+                         {{join_split, split_stay}, stay_split},
+                         {{join_split, split_join}, stay_split},
+                         {{join_stay, split_split}, stay_stay},
+                         {{join_stay, split_stay}, stay_stay},
+                         {{join_stay, split_join}, stay_stay},
+                         {{join_join, split_split}, stay_join},
+                         {{join_join, split_stay}, stay_join},
+                         {{join_join, split_join}, stay_join}});
+  // neighbor coarser in x, finer in y, sibling side of y
+  check_update_amr_decision<2>(
+      element, id_ly_p_n, all_flags,
+      changed_flags_t<2>{{{split_stay, split_split}, split_split},
+                         {{split_stay, join_split}, split_split},
+                         {{split_stay, stay_split}, split_split},
+                         {{join_stay, split_split}, join_split},
+                         {{join_stay, stay_split}, join_split},
+                         {{join_stay, join_split}, join_split},
+                         {{stay_stay, split_split}, stay_split},
+                         {{stay_stay, join_split}, stay_split},
+                         {{stay_stay, stay_split}, stay_split},
+                         {{split_join, split_split}, split_split},
+                         {{split_join, join_split}, split_split},
+                         {{split_join, stay_split}, split_split},
+                         {{split_join, split_stay}, split_stay},
+                         {{split_join, join_stay}, split_stay},
+                         {{split_join, stay_stay}, split_stay},
+                         {{split_join, split_join}, split_stay},
+                         {{split_join, join_join}, split_stay},
+                         {{split_join, stay_join}, split_stay},
+                         {{join_join, split_split}, join_split},
+                         {{join_join, join_split}, join_split},
+                         {{join_join, stay_split}, join_split},
+                         {{join_join, split_stay}, join_stay},
+                         {{join_join, join_stay}, join_stay},
+                         {{join_join, stay_stay}, join_stay},
+                         {{join_join, split_join}, join_stay},
+                         {{join_join, join_join}, join_stay},
+                         {{join_join, stay_join}, join_stay},
+                         {{stay_join, split_split}, stay_split},
+                         {{stay_join, join_split}, stay_split},
+                         {{stay_join, stay_split}, stay_split},
+                         {{stay_join, split_stay}, stay_stay},
+                         {{stay_join, join_stay}, stay_stay},
+                         {{stay_join, stay_stay}, stay_stay},
+                         {{stay_join, split_join}, stay_stay},
+                         {{stay_join, join_join}, stay_stay},
+                         {{stay_join, stay_join}, stay_stay}});
+  // neighbor coarser in x and y, non-sibling side -f y
+  check_update_amr_decision<2>(element, id_uy_p_cp, all_flags,
+                               changed_flags_t<2>{});
+
+  const ElementId<2> id_lx_s_cl{
+      0, {{x_segment.id_of_sibling(), y_segment.id_of_child(Side::Lower)}}};
+  const ElementId<2> id_lx_s_cu{
+      0, {{x_segment.id_of_sibling(), y_segment.id_of_child(Side::Upper)}}};
+  const ElementId<2> id_ly_cl_n{0,
+                                {{x_segment.id_of_child(Side::Lower),
+                                  y_segment.id_of_abutting_nibling()}}};
+  const ElementId<2> id_ly_cu_n{0,
+                                {{x_segment.id_of_child(Side::Upper),
+                                  y_segment.id_of_abutting_nibling()}}};
+  const ElementId<2> id_ux_c_cl{
+      0, {{x_cousin, y_segment.id_of_child(Side::Lower)}}};
+  const ElementId<2> id_ux_c_cu{
+      0, {{x_cousin, y_segment.id_of_child(Side::Upper)}}};
+  const ElementId<2> id_uy_cl_cp{
+      0, {{x_segment.id_of_child(Side::Lower), y_cousin.id_of_parent()}}};
+  const ElementId<2> id_uy_cu_cp{
+      0, {{x_segment.id_of_child(Side::Upper), y_cousin.id_of_parent()}}};
+  element = make_element(element_id, {id_lx_s_cl, id_lx_s_cu},
+                         {id_ux_c_cl, id_ux_c_cu}, {id_ly_cl_n, id_ly_cu_n},
+                         {id_uy_cl_cp, id_uy_cu_cp});
+  // neighbor same in x, finer in y, sibling side of x
+  check_update_amr_decision<2>(
+      element, id_lx_s_cl, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, stay_split},
+                         {{join_split, join_split}, stay_split},
+                         {{join_split, stay_split}, stay_split},
+                         {{join_split, split_stay}, stay_split},
+                         {{join_split, stay_stay}, stay_split},
+                         {{join_split, split_join}, stay_split},
+                         {{join_split, join_join}, stay_split},
+                         {{join_split, stay_join}, stay_split},
+                         {{split_stay, split_split}, split_split},
+                         {{split_stay, join_split}, split_split},
+                         {{split_stay, stay_split}, split_split},
+                         {{join_stay, split_split}, stay_split},
+                         {{join_stay, join_split}, stay_split},
+                         {{join_stay, stay_split}, stay_split},
+                         {{join_stay, split_stay}, stay_stay},
+                         {{join_stay, join_stay}, stay_stay},
+                         {{join_stay, stay_stay}, stay_stay},
+                         {{join_stay, split_join}, stay_stay},
+                         {{join_stay, stay_join}, stay_stay},
+                         {{stay_stay, split_split}, stay_split},
+                         {{stay_stay, join_split}, stay_split},
+                         {{stay_stay, stay_split}, stay_split},
+                         {{split_join, split_split}, split_split},
+                         {{split_join, join_split}, split_split},
+                         {{split_join, stay_split}, split_split},
+                         {{split_join, split_stay}, split_stay},
+                         {{split_join, join_stay}, split_stay},
+                         {{split_join, stay_stay}, split_stay},
+                         {{join_join, split_split}, stay_split},
+                         {{join_join, join_split}, stay_split},
+                         {{join_join, stay_split}, stay_split},
+                         {{join_join, split_stay}, stay_stay},
+                         {{join_join, join_stay}, stay_stay},
+                         {{join_join, stay_stay}, stay_stay},
+                         {{join_join, split_join}, stay_join},
+                         {{join_join, join_join}, stay_join},
+                         {{join_join, stay_join}, stay_join},
+                         {{stay_join, split_split}, stay_split},
+                         {{stay_join, join_split}, stay_split},
+                         {{stay_join, stay_split}, stay_split},
+                         {{stay_join, split_stay}, stay_stay},
+                         {{stay_join, join_stay}, stay_stay},
+                         {{stay_join, stay_stay}, stay_stay}});
+  // neighbor same in x, finer in y, non-sibling side of x
+  check_update_amr_decision<2>(
+      element, id_ux_c_cu, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, stay_split},
+                         {{join_split, split_stay}, stay_split},
+                         {{join_split, split_join}, stay_split},
+                         {{split_stay, split_split}, split_split},
+                         {{split_stay, join_split}, split_split},
+                         {{split_stay, stay_split}, split_split},
+                         {{join_stay, split_split}, stay_split},
+                         {{join_stay, join_split}, join_split},
+                         {{join_stay, stay_split}, join_split},
+                         {{join_stay, split_stay}, stay_stay},
+                         {{join_stay, split_join}, stay_stay},
+                         {{stay_stay, split_split}, stay_split},
+                         {{stay_stay, join_split}, stay_split},
+                         {{stay_stay, stay_split}, stay_split},
+                         {{split_join, split_split}, split_split},
+                         {{split_join, join_split}, split_split},
+                         {{split_join, stay_split}, split_split},
+                         {{split_join, split_stay}, split_stay},
+                         {{split_join, join_stay}, split_stay},
+                         {{split_join, stay_stay}, split_stay},
+                         {{join_join, split_split}, stay_split},
+                         {{join_join, join_split}, join_split},
+                         {{join_join, stay_split}, join_split},
+                         {{join_join, split_stay}, stay_stay},
+                         {{join_join, join_stay}, join_stay},
+                         {{join_join, stay_stay}, join_stay},
+                         {{join_join, split_join}, stay_join},
+                         {{stay_join, split_split}, stay_split},
+                         {{stay_join, join_split}, stay_split},
+                         {{stay_join, stay_split}, stay_split},
+                         {{stay_join, split_stay}, stay_stay},
+                         {{stay_join, join_stay}, stay_stay},
+                         {{stay_join, stay_stay}, stay_stay}});
+  // neighbor finer in x and y, sibling side of y
+  check_update_amr_decision<2>(
+      element, id_ly_cl_n, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, split_split},
+                         {{join_split, stay_split}, stay_split},
+                         {{join_split, split_stay}, split_split},
+                         {{join_split, stay_stay}, stay_split},
+                         {{join_split, split_join}, split_split},
+                         {{join_split, stay_join}, stay_split},
+                         {{stay_split, split_split}, split_split},
+                         {{stay_split, split_stay}, split_split},
+                         {{stay_split, split_join}, split_split},
+                         {{split_stay, split_split}, split_split},
+                         {{split_stay, join_split}, split_split},
+                         {{split_stay, stay_split}, split_split},
+                         {{join_stay, split_split}, split_split},
+                         {{join_stay, join_split}, join_split},
+                         {{join_stay, stay_split}, stay_split},
+                         {{join_stay, split_stay}, split_stay},
+                         {{join_stay, stay_stay}, stay_stay},
+                         {{join_stay, split_join}, split_stay},
+                         {{join_stay, stay_join}, stay_stay},
+                         {{stay_stay, split_split}, split_split},
+                         {{stay_stay, join_split}, stay_split},
+                         {{stay_stay, stay_split}, stay_split},
+                         {{stay_stay, split_stay}, split_stay},
+                         {{stay_stay, split_join}, split_stay},
+                         {{split_join, split_split}, split_split},
+                         {{split_join, join_split}, split_split},
+                         {{split_join, stay_split}, split_split},
+                         {{split_join, split_stay}, split_stay},
+                         {{split_join, join_stay}, split_stay},
+                         {{split_join, stay_stay}, split_stay},
+                         {{split_join, split_join}, split_stay},
+                         {{split_join, join_join}, split_stay},
+                         {{split_join, stay_join}, split_stay},
+                         {{join_join, split_split}, split_split},
+                         {{join_join, join_split}, join_split},
+                         {{join_join, stay_split}, stay_split},
+                         {{join_join, split_stay}, split_stay},
+                         {{join_join, join_stay}, join_stay},
+                         {{join_join, stay_stay}, stay_stay},
+                         {{join_join, split_join}, split_stay},
+                         {{join_join, join_join}, join_stay},
+                         {{join_join, stay_join}, stay_stay},
+                         {{stay_join, split_split}, split_split},
+                         {{stay_join, join_split}, stay_split},
+                         {{stay_join, stay_split}, stay_split},
+                         {{stay_join, split_stay}, split_stay},
+                         {{stay_join, join_stay}, stay_stay},
+                         {{stay_join, stay_stay}, stay_stay},
+                         {{stay_join, split_join}, split_stay},
+                         {{stay_join, join_join}, stay_stay},
+                         {{stay_join, stay_join}, stay_stay}});
+  // neighbor finer in x, coarser in y, non-sibling side of y
+  check_update_amr_decision<2>(
+      element, id_uy_cu_cp, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, split_split},
+                         {{join_split, stay_split}, stay_split},
+                         {{join_split, split_stay}, split_split},
+                         {{join_split, stay_stay}, stay_split},
+                         {{join_split, split_join}, split_split},
+                         {{join_split, stay_join}, stay_split},
+                         {{stay_split, split_split}, split_split},
+                         {{stay_split, split_stay}, split_split},
+                         {{stay_split, split_join}, split_split},
+                         {{join_stay, split_split}, split_stay},
+                         {{join_stay, stay_split}, stay_stay},
+                         {{join_stay, split_stay}, split_stay},
+                         {{join_stay, stay_stay}, stay_stay},
+                         {{join_stay, split_join}, split_stay},
+                         {{join_stay, stay_join}, stay_stay},
+                         {{stay_stay, split_split}, split_stay},
+                         {{stay_stay, split_stay}, split_stay},
+                         {{stay_stay, split_join}, split_stay},
+                         {{join_join, split_split}, split_join},
+                         {{join_join, stay_split}, stay_join},
+                         {{join_join, split_stay}, split_join},
+                         {{join_join, stay_stay}, stay_join},
+                         {{join_join, split_join}, split_join},
+                         {{join_join, stay_join}, stay_join},
+                         {{stay_join, split_split}, split_join},
+                         {{stay_join, split_stay}, split_join},
+                         {{stay_join, split_join}, split_join}});
+
+  const ElementId<2> id_ux_cc_s{
+      0, {{x_cousin.id_of_child(Side::Lower), y_segment}}};
+  const ElementId<2> id_uy_cl_cc{0,
+                                 {{x_segment.id_of_child(Side::Lower),
+                                   y_cousin.id_of_child(Side::Lower)}}};
+  const ElementId<2> id_uy_cu_cc{0,
+                                 {{x_segment.id_of_child(Side::Upper),
+                                   y_cousin.id_of_child(Side::Lower)}}};
+
+  element = make_element(element_id, {}, {id_ux_cc_s}, {},
+                         {id_uy_cl_cc, id_uy_cu_cc});
+  // neighbor finer in x, same in y, non-sibling side of x
+  check_update_amr_decision<2>(
+      element, id_ux_cc_s, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, split_split},
+                         {{join_split, stay_split}, stay_split},
+                         {{join_split, split_stay}, split_split},
+                         {{join_split, stay_stay}, stay_split},
+                         {{join_split, split_join}, split_split},
+                         {{join_split, stay_join}, stay_split},
+                         {{stay_split, split_split}, split_split},
+                         {{stay_split, split_stay}, split_split},
+                         {{stay_split, split_join}, split_split},
+                         {{join_stay, split_split}, split_stay},
+                         {{join_stay, stay_split}, stay_stay},
+                         {{join_stay, split_stay}, split_stay},
+                         {{join_stay, stay_stay}, stay_stay},
+                         {{join_stay, split_join}, split_stay},
+                         {{join_stay, stay_join}, stay_stay},
+                         {{stay_stay, split_split}, split_stay},
+                         {{stay_stay, split_stay}, split_stay},
+                         {{stay_stay, split_join}, split_stay},
+                         {{split_join, split_split}, split_stay},
+                         {{split_join, join_split}, split_stay},
+                         {{split_join, stay_split}, split_stay},
+                         {{join_join, split_split}, split_stay},
+                         {{join_join, join_split}, join_stay},
+                         {{join_join, stay_split}, stay_stay},
+                         {{join_join, split_stay}, split_join},
+                         {{join_join, stay_stay}, stay_join},
+                         {{join_join, split_join}, split_join},
+                         {{join_join, stay_join}, stay_join},
+                         {{stay_join, split_split}, split_stay},
+                         {{stay_join, join_split}, stay_stay},
+                         {{stay_join, stay_split}, stay_stay},
+                         {{stay_join, split_stay}, split_join},
+                         {{stay_join, split_join}, split_join}});
+  // neighbor finer in x and y, non-sibling side of y
+  check_update_amr_decision<2>(
+      element, id_uy_cu_cc, all_flags,
+      changed_flags_t<2>{{{join_split, split_split}, split_split},
+                         {{join_split, stay_split}, stay_split},
+                         {{join_split, split_stay}, split_split},
+                         {{join_split, stay_stay}, stay_split},
+                         {{join_split, split_join}, split_split},
+                         {{join_split, stay_join}, stay_split},
+                         {{stay_split, split_split}, split_split},
+                         {{stay_split, split_stay}, split_split},
+                         {{stay_split, split_join}, split_split},
+                         {{split_stay, split_split}, split_split},
+                         {{split_stay, join_split}, split_split},
+                         {{split_stay, stay_split}, split_split},
+                         {{join_stay, split_split}, split_split},
+                         {{join_stay, join_split}, join_split},
+                         {{join_stay, stay_split}, stay_split},
+                         {{join_stay, split_stay}, split_stay},
+                         {{join_stay, stay_stay}, stay_stay},
+                         {{join_stay, split_join}, split_stay},
+                         {{join_stay, stay_join}, stay_stay},
+                         {{stay_stay, split_split}, split_split},
+                         {{stay_stay, join_split}, stay_split},
+                         {{stay_stay, stay_split}, stay_split},
+                         {{stay_stay, split_stay}, split_stay},
+                         {{stay_stay, split_join}, split_stay},
+                         {{split_join, split_split}, split_split},
+                         {{split_join, join_split}, split_split},
+                         {{split_join, stay_split}, split_split},
+                         {{split_join, split_stay}, split_stay},
+                         {{split_join, join_stay}, split_stay},
+                         {{split_join, stay_stay}, split_stay},
+                         {{join_join, split_split}, split_split},
+                         {{join_join, join_split}, join_split},
+                         {{join_join, stay_split}, stay_split},
+                         {{join_join, split_stay}, split_stay},
+                         {{join_join, join_stay}, join_stay},
+                         {{join_join, stay_stay}, stay_stay},
+                         {{join_join, split_join}, split_join},
+                         {{join_join, stay_join}, stay_join},
+                         {{stay_join, split_split}, split_split},
+                         {{stay_join, join_split}, stay_split},
+                         {{stay_join, stay_split}, stay_split},
+                         {{stay_join, split_stay}, split_stay},
+                         {{stay_join, join_stay}, stay_stay},
+                         {{stay_join, stay_stay}, stay_stay},
+                         {{stay_join, split_join}, split_join}});
+
+  const ElementId<2> id_uy_p_cc{
+      0, {{x_segment.id_of_parent(), y_cousin.id_of_child(Side::Lower)}}};
+  element = make_element(element_id, {}, {}, {}, {id_uy_p_cc});
+  // neighbor coarser in x, finer in y, non-sibling side of y
+  check_update_amr_decision<2>(
+      element, id_uy_p_cc, all_flags,
+      changed_flags_t<2>{{{split_stay, split_split}, split_split},
+                         {{split_stay, join_split}, split_split},
+                         {{split_stay, stay_split}, split_split},
+                         {{join_stay, split_split}, join_split},
+                         {{join_stay, join_split}, join_split},
+                         {{join_stay, stay_split}, join_split},
+                         {{stay_stay, split_split}, stay_split},
+                         {{stay_stay, join_split}, stay_split},
+                         {{stay_stay, stay_split}, stay_split},
+                         {{split_join, split_split}, split_split},
+                         {{split_join, join_split}, split_split},
+                         {{split_join, stay_split}, split_split},
+                         {{split_join, split_stay}, split_stay},
+                         {{split_join, join_stay}, split_stay},
+                         {{split_join, stay_stay}, split_stay},
+                         {{join_join, split_split}, join_split},
+                         {{join_join, join_split}, join_split},
+                         {{join_join, stay_split}, join_split},
+                         {{join_join, split_stay}, join_stay},
+                         {{join_join, join_stay}, join_stay},
+                         {{join_join, stay_stay}, join_stay},
+                         {{stay_join, split_split}, stay_split},
+                         {{stay_join, join_split}, stay_split},
+                         {{stay_join, stay_split}, stay_split},
+                         {{stay_join, split_stay}, stay_stay},
+                         {{stay_join, join_stay}, stay_stay},
+                         {{stay_join, stay_stay}, stay_stay}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Amr.UpdateAmrDecision", "[Domain][Unit]") {
+  test_update_amr_decision_1d();
+  test_update_amr_decision_2d();
+  // 3d is not tested for every case as the algorithm is independent of
+  // dimensions once there is a transverse direction for a neighbor and there
+  // are 729 AMR flag combinations for 45 different types of neighbors.
+}

--- a/tests/Unit/Domain/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Test_OrientationMap.cpp
@@ -49,6 +49,11 @@ void test_1d() {
         expected_antiparallel_segment_ids);
   CHECK(get_output(parallel_orientation) == "(+0)");
   CHECK(get_output(antiparallel_orientation) == "(-0)");
+  CHECK(std::array<int, 1>{{1}} ==
+        parallel_orientation.permute_from_neighbor(std::array<int, 1>{{1}}));
+  CHECK(
+      std::array<int, 1>{{1}} ==
+      antiparallel_orientation.permute_from_neighbor(std::array<int, 1>{{1}}));
 
   // Test comparison:
   CHECK(custom1 != custom2);
@@ -157,6 +162,15 @@ void test_2d() {
   CHECK_FALSE(rotated2d_pos_eta_neg_xi.is_aligned());
   CHECK(rotated2d_pos_xi_pos_eta.is_aligned());
 
+  const std::array<int, 2> input_array{{1, -3}};
+  const std::array<int, 2> flipped_array{{-3, 1}};
+  CHECK(rotated2d_neg_xi_neg_eta.permute_from_neighbor(input_array) ==
+        input_array);
+  CHECK(rotated2d_neg_eta_pos_xi.permute_from_neighbor(input_array) ==
+        flipped_array);
+  CHECK(rotated2d_pos_eta_neg_xi.permute_from_neighbor(input_array) ==
+        flipped_array);
+
   // The naming convention used in this test:
   //"neg_eta_pos_xi" means that -1 in the host maps to +0,
   // and that +0 in the host maps to +1, in the neighbor.
@@ -253,14 +267,17 @@ void test_3d() {
 
   // Test inverse:
   CHECK(default_orientation.inverse_map() == default_orientation);
-  CHECK(
-      OrientationMap<3>(std::array<Direction<3>, 3>{{Direction<3>::lower_eta(),
-                                                     Direction<3>::lower_zeta(),
-                                                     Direction<3>::upper_xi()}})
-          .inverse_map() ==
-      OrientationMap<3>(std::array<Direction<3>, 3>{
-          {Direction<3>::upper_zeta(), Direction<3>::lower_xi(),
-           Direction<3>::lower_eta()}}));
+  OrientationMap<3> custom3{std::array<Direction<3>, 3>{
+      {Direction<3>::lower_eta(), Direction<3>::lower_zeta(),
+       Direction<3>::upper_xi()}}};
+  OrientationMap<3> custom4{std::array<Direction<3>, 3>{
+      {Direction<3>::upper_zeta(), Direction<3>::lower_xi(),
+       Direction<3>::lower_eta()}}};
+  CHECK(custom3.inverse_map() == custom4);
+  CHECK(std::array<int, 3>{{-8, 12, 4}} ==
+        custom3.permute_from_neighbor(std::array<int, 3>{{4, -8, 12}}));
+  CHECK(std::array<int, 3>{{12, 4, -8}} ==
+        custom4.permute_from_neighbor(std::array<int, 3>{{4, -8, 12}}));
   CHECK(custom1.inverse_map().inverse_map() == custom1);
   CHECK(custom2.inverse_map().inverse_map() == custom2);
 }

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -222,6 +222,7 @@ license() {
               '.github/ISSUE_TEMPLATE.md' \
               '.github/PULL_REQUEST_TEMPLATE.md' \
               '.png' \
+              '.svg' \
               '.clang-format$' && \
         ! grep -q "Distributed under the MIT License" "$1"
 }
@@ -324,7 +325,7 @@ standard_checks+=(pragma_once)
 
 # Check for a newline at end of file
 final_newline() {
-    whitelist "$1" '.png' &&
+    whitelist "$1" '.png' '.svg' &&
     # Bash strips trailing newlines from $() output
     [ "$(tail -c 1 "$1" ; echo x)" != $'\n'x ]
 }


### PR DESCRIPTION
## Proposed changes

Start adding functionality for h-refinement.  
This PR adds a function that updates the refinement flags of an Element based on the refinement flags of one of its neighbors so that neighbors remain within one refinement level with each other, and so that siblings only join when all of them decide to do so.

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

This is the first in a series of PRs to implement the mechanics of h-refinement, so here I provide a brief outline of the hp-refinement algorithm I have in mind.  This will be fully documented in a tutorial when the pieces are in place.

- Each Element decides based on a set of refinement criteria whether to h-refine, p-refine, or stay the same independently in each dimension.  In increasing priority, the choices are Join (h-coarsen), DecreaseResolution (p-coarsen), DoNothing, IncreaseResolution (p-refine), Split (h-refine).  Elements can  change their refinement level or resolution in a given dimension by no more than one level or grid-point.  If multiple refinement criteria are used, the one with highest priority is chosen in a given dimension.
- Each Element sends its decisions to each of its face neighbors (i.e. neighbors with which the element shares a co-dimension 1 surface).  When an Element receives the decisions of a neighbor, it updates its decisions in order to maintain the requirement that refinement levels and resolution of neighbors are within one in each dimension.  Elements can only increase the priority of their flags so if two neighboring Elements decided they wanted to be two or more levels apart, the Element that desired to be coarser will update its decision.  Furthermore if an Element wants to Join, it can do so only if all of the potential siblings also decided to Join and every sibling wants to be at the same refinement level.
- If an Element changed its decision, it will send its new decision to its neighbors.  Once every Element has settled on its decision (which will be detected by no messages being exchanged between Elements), then the actual refinement will take place.
- New Elements will be created from those that wish to Split or Join, and then those Elements that Split or Joined will be deleted.

This PR adds the function that will be called to update an Element's decisions based on one of its neighbors decisions, taking only h-refinement into account.  p-refinement needs a little bit of infrastructure to enable, but will be much easier to add than h-refinement which must create/destroy objects, so that is why I am focusing on it first.