### PR TITLE
Test quadratic root accuracy for |b| >> |a c|

### DIFF
--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_QuadraticEquation.cpp
@@ -3,6 +3,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
 
 #include "ErrorHandling/Error.hpp"
@@ -51,4 +52,17 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.RealRoots",
   auto roots = real_roots(2.0, -11.0, 5.0);
   CHECK(approx(0.5) == roots[0]);
   CHECK(approx(5.0) == roots[1]);
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.Accuracy",
+                  "[NumericalAlgorithms][RootFinding][Unit]") {
+  auto small_positive = real_roots(1e-8, 1.0 - 1e-16, -1e-8);
+  std::sort(small_positive.begin(), small_positive.end());
+  CHECK(approx(-1e8) == small_positive[0]);
+  CHECK(approx(1e-8) == small_positive[1]);
+
+  auto small_negative = real_roots(1e-8, -(1.0 - 1e-16), -1e-8);
+  std::sort(small_negative.begin(), small_negative.end());
+  CHECK(approx(-1e-8) == small_negative[0]);
+  CHECK(approx(1e8) == small_negative[1]);
 }


### PR DESCRIPTION
From today's meeting: "We have a quadratic equation solver."  "Is it a good one?"  "Probably?"

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
