### PR TITLE
Update python, add missing \ in orca_gcc.sh

### DIFF
--- a/support/Environments/orca_gcc.sh
+++ b/support/Environments/orca_gcc.sh
@@ -8,7 +8,7 @@ spectre_setup_modules() {
 }
 
 spectre_unload_modules() {
-module unload python/2.7.8
+module unload python/2.7.15
 module unload spack
 module unload gcc/7.3.0
 module unload openmpi/3.1.0
@@ -28,7 +28,7 @@ module unload zlib-1.2.11-gcc-7.3.0-qzvtd4j
 }
 
 spectre_load_modules() {
-module load python/2.7.8
+module load python/2.7.15
 module load spack
 module load gcc/7.3.0
 module load openmpi/3.1.0
@@ -56,6 +56,6 @@ spectre_run_cmake() {
     cmake -D CHARM_ROOT=$CHARM_ROOT \
           -D CMAKE_BUILD_TYPE=Release \
           -D CMAKE_Fortran_COMPILER=gfortran \
-          -D PYTHON_EXECUTABLE=/share/apps/python/2.7.8/bin/python
+          -D PYTHON_EXECUTABLE=/share/apps/python/2.7.15/bin/python \
           $SPECTRE_HOME
 }


### PR DESCRIPTION
## Proposed changes

Update orca_gcc.sh environment. 2 changes:

1. Add missing \ that prevents spectre from compiling on orca (this is a simple bug that somehow got through code review last time)
2. Update to use python 2.7.15 module, recently installed on orca.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->