### PR TITLE
Add characteristic speeds for Valencia GRMHD

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY ValenciaDivClean)
 
 set(LIBRARY_SOURCES
+  Characteristics.cpp
   ConservativeFromPrimitive.cpp
   Fluxes.cpp
   Sources.cpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+namespace grmhd {
+namespace ValenciaDivClean {
+
+std::array<DataVector, 9> characteristic_speeds(
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,
+    const tnsr::I<DataVector, 3>& spatial_velocity,
+    const Scalar<DataVector>& spatial_velocity_squared,
+    const Scalar<DataVector>& sound_speed_squared,
+    const Scalar<DataVector>& alfven_speed_squared,
+    const tnsr::i<DataVector, 3>& normal) noexcept {
+  auto characteristic_speeds =
+      make_array<9, DataVector>(-1.0 * get(dot_product(normal, shift)));
+
+  const auto auxiliary_speeds =
+      RelativisticEuler::Valencia::characteristic_speeds(
+          lapse, shift, spatial_velocity, spatial_velocity_squared,
+          Scalar<DataVector>{get(sound_speed_squared) +
+                             get(alfven_speed_squared) *
+                                 (1.0 - get(sound_speed_squared))},
+          normal);
+
+  characteristic_speeds[0] -= get(lapse);
+  characteristic_speeds[1] = auxiliary_speeds[0];
+  for (size_t i = 2; i < 7; ++i) {
+    // auxiliary_speeds[1], auxiliary_speeds[2], and auxiliary_speeds[3]
+    // are the same.
+    gsl::at(characteristic_speeds, i) = auxiliary_speeds[2];
+  }
+  characteristic_speeds[7] = auxiliary_speeds[4];
+  characteristic_speeds[8] += get(lapse);
+
+  return characteristic_speeds;
+}
+
+}  // namespace ValenciaDivClean
+}  // namespace grmhd
+/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace grmhd {
+namespace ValenciaDivClean {
+
+/*!
+ * \brief Compute the characteristic speeds for the Valencia formulation of
+ * GRMHD with divergence cleaning.
+ *
+ * Obtaining the exact form of the characteristic speeds involves the solution
+ * of a nontrivial quartic equation for the fast and slow modes. Here we make
+ * use of a common approximation in the literature (e.g. \ref char_ref "[1]")
+ * where the resulting characteristic speeds are analogous to those of the
+ * Valencia formulation of the 3-D relativistic Euler system
+ * (see RelativisticEuler::Valencia::characteristic_speeds),
+ *
+ * \f{align*}
+ * \lambda_2 &= \alpha \Lambda^- - \beta_n,\\
+ * \lambda_{3, 4, 5, 6, 7} &= \alpha v_n - \beta_n,\\
+ * \lambda_{8} &= \alpha \Lambda^+ - \beta_n,
+ * \f}
+ *
+ * with the substitution
+ *
+ * \f{align*}
+ * c_s^2 \longrightarrow c_s^2 + v_A^2(1 - c_s^2)
+ * \f}
+ *
+ * in the definition of \f$\Lambda^\pm\f$. Here \f$v_A\f$ is the Alfvén
+ * speed. In addition, two more speeds corresponding to the divergence cleaning
+ * mode and the longitudinal magnetic field are added,
+ *
+ * \f{align*}
+ * \lambda_1 = -\alpha - \beta_n,\\
+ * \lambda_9 = \alpha - \beta_n.
+ * \f}
+ *
+ * \note The ordering assumed here is such that, in the Newtonian limit,
+ * the exact expressions for \f$\lambda_{2, 8}\f$, \f$\lambda_{3, 7}\f$,
+ * and \f$\lambda_{4, 6}\f$ should reduce to the
+ * corresponding fast modes, Alfvén modes, and slow modes, respectively.
+ * See \ref mhd_ref "[2]" for a detailed description of the hyperbolic
+ * characterization of Newtonian MHD.
+ *
+ * \anchor char_ref [1] C.F Gammie, J.C McKinney, G. Tóth, HARM: A Numerical
+ * Scheme for General Relativistic Magnetohydrodynamics, ApJ.
+ * [589 (2003) 444](http://iopscience.iop.org/article/10.1086/374594/meta)
+ *
+ * \anchor mhd_ref [2] A. Dedner et al., Hyperbolic Divergence Cleaning for the
+ * MHD Equations, J. Comput. Phys.
+ * [175 (2002) 645](https://doi.org/10.1006/jcph.2001.6961)
+ */
+std::array<DataVector, 9> characteristic_speeds(
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,
+    const tnsr::I<DataVector, 3>& spatial_velocity,
+    const Scalar<DataVector>& spatial_velocity_squared,
+    const Scalar<DataVector>& sound_speed_squared,
+    const Scalar<DataVector>& alfven_speed_squared,
+    const tnsr::i<DataVector, 3>& normal) noexcept;
+
+}  // namespace ValenciaDivClean
+}  // namespace grmhd

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_ValenciaDivClean")
 
 set(LIBRARY_SOURCES
+  Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_Fluxes.cpp
   Test_Sources.cpp

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
@@ -46,6 +46,31 @@ def vsq(spatial_velocity, spatial_metric):
                      np.outer(spatial_velocity, spatial_velocity))
 
 
+# Functions for testing Characteristics.cpp
+def characteristic_speeds(lapse, shift, spatial_velocity, spatial_velocity_sqrd,
+                          sound_speed_sqrd, alfven_speed_sqrd, normal_oneform):
+    normal_velocity = np.dot(spatial_velocity, normal_oneform)
+    normal_shift = np.dot(shift, normal_oneform)
+    sound_speed_sqrd += alfven_speed_sqrd * (1.0 - sound_speed_sqrd)
+    prefactor = lapse / (1.0 - spatial_velocity_sqrd * sound_speed_sqrd)
+    first_term = prefactor * normal_velocity * (1.0 - sound_speed_sqrd)
+    second_term = (prefactor * np.sqrt(sound_speed_sqrd) *
+                   np.sqrt((1.0 - spatial_velocity_sqrd) *
+                           (1.0 - spatial_velocity_sqrd * sound_speed_sqrd
+                            - normal_velocity * normal_velocity *
+                            (1.0 - sound_speed_sqrd))))
+    result = [-lapse - normal_shift]
+    result.append(first_term - second_term - normal_shift)
+    for i in range(0, spatial_velocity.size + 2):
+        result.append(lapse * normal_velocity - normal_shift)
+    result.append(first_term + second_term - normal_shift)
+    result.append(lapse - normal_shift)
+    return result
+
+
+# End functions for testing Characteristics.cpp
+
+
 # Functions for testing ConservativeFromPrimitive.cpp
 def tilde_d(rest_mass_density, specific_internal_energy, specific_enthalpy,
             pressure, spatial_velocity, lorentz_factor, magnetic_field,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Characteristics.cpp
@@ -1,0 +1,92 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Direction.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp"
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/Domain/DomainTestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/Pypp.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+void test_characteristic_speeds(const DataVector& used_for_size) noexcept {
+  //  Arbitrary random numbers can produce a negative radicand in Lambda^\pm.
+  //  This bound helps to prevent that situation.
+  const double max_value = 1.0 / sqrt(3);
+  pypp::check_with_random_values<7>(
+      &grmhd::ValenciaDivClean::characteristic_speeds, "TestFunctions",
+      "characteristic_speeds",
+      {{{0.0, 1.0},
+        {-1.0, 1.0},
+        {-max_value, max_value},
+        {0.0, 1.0},
+        {0.0, 1.0},
+        {0.0, 1.0},
+        {-max_value, max_value}}},
+      used_for_size);
+}
+
+void test_with_normal_along_coordinate_axes(
+    const DataVector& used_for_size) noexcept {
+  const auto seed = std::random_device{}();
+  CAPTURE(seed);
+  std::mt19937 generator(seed);
+  std::uniform_real_distribution<> distribution(0.0, 1.0);
+
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_distribution = make_not_null(&distribution);
+
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto shift = make_with_random_values<tnsr::I<DataVector, 3>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto spatial_velocity = make_with_random_values<tnsr::I<DataVector, 3>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto spatial_velocity_squared =
+      make_with_random_values<Scalar<DataVector>>(nn_generator, nn_distribution,
+                                                  used_for_size);
+  const auto sound_speed_squared = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+  const auto alfven_speed_squared = make_with_random_values<Scalar<DataVector>>(
+      nn_generator, nn_distribution, used_for_size);
+
+  for (const auto& direction : Direction<3>::all_directions()) {
+    const auto normal = euclidean_basis_vector(direction, used_for_size);
+
+    CHECK_ITERABLE_APPROX(
+        grmhd::ValenciaDivClean::characteristic_speeds(
+            lapse, shift, spatial_velocity, spatial_velocity_squared,
+            sound_speed_squared, alfven_speed_squared, normal),
+        (pypp::call<std::array<DataVector, 9>>(
+            "TestFunctions", "characteristic_speeds", lapse, shift,
+            spatial_velocity, spatial_velocity_squared, sound_speed_squared,
+            alfven_speed_squared, normal)));
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Characteristics",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GrMhd/ValenciaDivClean"};
+
+  const DataVector dv(5);
+  test_characteristic_speeds(dv);
+  // Test with aligned normals to check the code works
+  // with vector components being 0.
+  test_with_normal_along_coordinate_axes(dv);
+}


### PR DESCRIPTION
## Proposed changes

This PR adds the approximate characteristic speeds we had in the bitbucket repo.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
