### PR TITLE
Add local Lax-Friedrichs flux

### DIFF
--- a/cmake/SpectreParseTests.py
+++ b/cmake/SpectreParseTests.py
@@ -18,6 +18,7 @@ allowed_tags = [
                 "EquationsOfState",
                 "ErrorHandling",
                 "Evolution",
+                "Fluxes",
                 "GeneralizedHarmonic",
                 "GrMhd",
                 "H5",

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -462,6 +462,11 @@
  */
 
 /*!
+ * \defgroup NumericalFluxesGroup Numerical Fluxes
+ * \brief The set of available numerical fluxes
+ */
+
+/*!
  * \defgroup OptionParsingGroup Option Parsing
  * Things related to parsing YAML input files.
  */

--- a/src/Evolution/Systems/Burgers/Equations.hpp
+++ b/src/Evolution/Systems/Burgers/Equations.hpp
@@ -28,6 +28,7 @@ struct NormalDotFlux;
 /// \endcond
 
 namespace Burgers {
+/// \ingroup NumericalFluxesGroup
 struct LocalLaxFriedrichsFlux {
   using options = tmpl::list<>;
   static constexpr OptionString help{

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -99,6 +99,7 @@ struct ComputeNormalDotFluxes {
 };
 
 /*!
+ * \ingroup NumericalFluxesGroup
  * \brief Computes the upwind flux
  *
  * The upwind flux is given by:

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp
@@ -1,0 +1,173 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace dg {
+namespace NumericalFluxes {
+
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \ingroup NumericalFluxesGroup
+ * \brief Compute the local Lax-Friedrichs numerical flux.
+ *
+ * Let \f$U\f$ and \f$F^i(U)\f$ be the state vector of the system and its
+ * corresponding volume flux, respectively. Let \f$n_i\f$ be the unit normal to
+ * the interface. Defining \f$F_n(U) := n_i F^i(U)\f$, and denoting the
+ * corresponding projections of the numerical fluxes as \f${F_n}^*(U)\f$, the
+ * local Lax-Friedrichs flux for each variable is
+ *
+ * \f{align*}
+ * {F_n}^*(U) = \frac{F_n(U_\text{int}) + F_n(U_\text{ext})}{2} +
+ * \frac{\alpha}{2}\left( U_\text{int} - U_\text{ext}\right),
+ * \f}
+ *
+ * where "int" and "ext" stand for interior and exterior, respectively,
+ * and \f$\alpha\f$ is the maximum eigenvalue of either
+ * \f$|\Lambda(U_\text{int}; n_\text{int})|\f$ or
+ * \f$|\Lambda(U_\text{ext}; n_\text{ext})|\f$, where
+ * \f$\Lambda(U; n)\f$ is the diagonal matrix whose entries are the
+ * characteristic speeds of the system.
+ */
+template <typename System>
+struct LocalLaxFriedrichs {
+ private:
+  using char_speeds_tag = typename System::char_speeds_tag;
+  using variables_tags = typename System::variables_tags;
+
+ public:
+  // The maximum characteristic speed modulus on one side of the interface.
+  struct MaxAbsCharSpeed : db::SimpleTag {
+    using type = Scalar<DataVector>;
+    static std::string name() noexcept { return "MaxAbsCharSpeed"; }
+  };
+
+  using package_tags =
+      tmpl::push_back<tmpl::append<db::split_tag<db::add_tag_prefix<
+                                       ::Tags::NormalDotFlux, variables_tags>>,
+                                   db::split_tag<variables_tags>>,
+                      MaxAbsCharSpeed>;
+
+  using argument_tags = tmpl::append<
+      db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux, variables_tags>>,
+      db::split_tag<variables_tags>, char_speeds_tag>;
+
+ private:
+  template <typename VariablesTagList, typename NormalDoFluxTagList>
+  struct package_data_helper;
+
+  template <typename... VariablesTags, typename... NormalDotFluxTags>
+  struct package_data_helper<tmpl::list<VariablesTags...>,
+                             tmpl::list<NormalDotFluxTags...>> {
+    static void function(
+        const gsl::not_null<Variables<package_tags>*> packaged_data,
+        const db::item_type<NormalDotFluxTags>&... n_dot_f_to_package,
+        const db::item_type<VariablesTags>&... u_to_package,
+        const db::item_type<char_speeds_tag>& characteristic_speeds) noexcept {
+      expand_pack((get<VariablesTags>(*packaged_data) = u_to_package)...);
+      expand_pack(
+          (get<NormalDotFluxTags>(*packaged_data) = n_dot_f_to_package)...);
+      get<MaxAbsCharSpeed>(
+          *packaged_data) = [&characteristic_speeds]() noexcept {
+        auto result = make_with_value<Scalar<DataVector>>(
+            characteristic_speeds[0],
+            std::numeric_limits<double>::signaling_NaN());
+        for (size_t s = 0; s < characteristic_speeds[0].size(); ++s) {
+          double local_max_speed = 0.0;
+          for (size_t u = 0; u < characteristic_speeds.size(); ++u) {
+            local_max_speed =
+                std::max(local_max_speed,
+                         std::abs(gsl::at(characteristic_speeds, u)[s]));
+          }
+          get(result)[s] = local_max_speed;
+        }
+        return result;
+      }
+      ();
+    }
+  };
+
+  template <typename NormalDotNumericalFluxTagList, typename VariablesTagList,
+            typename NormalDotFluxTagList>
+  struct call_operator_helper;
+
+  template <typename... NormalDotNumericalFluxTags, typename... VariablesTags,
+            typename... NormalDotFluxTags>
+  struct call_operator_helper<tmpl::list<NormalDotNumericalFluxTags...>,
+                              tmpl::list<VariablesTags...>,
+                              tmpl::list<NormalDotFluxTags...>> {
+    static void function(
+        const gsl::not_null<
+            db::item_type<NormalDotNumericalFluxTags>*>... n_dot_numerical_f,
+        const db::item_type<NormalDotFluxTags>&... n_dot_f_interior,
+        const db::item_type<VariablesTags>&... u_interior,
+        const db::item_type<MaxAbsCharSpeed>& max_abs_speed_interior,
+        const db::item_type<NormalDotFluxTags>&... minus_n_dot_f_exterior,
+        const db::item_type<VariablesTags>&... u_exterior,
+        const db::item_type<MaxAbsCharSpeed>& max_abs_speed_exterior) noexcept {
+      const auto max_abs_speed =
+          [&max_abs_speed_interior, &max_abs_speed_exterior ]() noexcept {
+        auto result = make_with_value<db::item_type<MaxAbsCharSpeed>>(
+            max_abs_speed_interior,
+            std::numeric_limits<double>::signaling_NaN());
+        for (size_t s = 0; s < result.begin()->size(); ++s) {
+          get(result)[s] = std::max(get(max_abs_speed_interior)[s],
+                                    get(max_abs_speed_exterior)[s]);
+        }
+        return result;
+      }
+      ();
+      const auto assemble_numerical_flux = [&max_abs_speed](
+          const auto n_dot_num_f, const auto& n_dot_f_in, const auto& u_in,
+          const auto& minus_n_dot_f_ex, const auto& u_ex) noexcept {
+        for (size_t i = 0; i < n_dot_num_f->size(); ++i) {
+          (*n_dot_num_f)[i] = 0.5 * (n_dot_f_in[i] - minus_n_dot_f_ex[i] +
+                                     get(max_abs_speed) * (u_in[i] - u_ex[i]));
+        }
+        return nullptr;
+      };
+      expand_pack(assemble_numerical_flux(n_dot_numerical_f, n_dot_f_interior,
+                                          u_interior, minus_n_dot_f_exterior,
+                                          u_exterior)...);
+    }
+  };
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr OptionString help = {
+      "Computes the local Lax-Friedrichs numerical flux."};
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+
+  template <class... Args>
+  void package_data(const Args&... args) const noexcept {
+    package_data_helper<
+        db::split_tag<variables_tags>,
+        db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux,
+                                         variables_tags>>>::function(args...);
+  }
+
+  template <class... Args>
+  void operator()(const Args&... args) const noexcept {
+    call_operator_helper<
+        db::split_tag<
+            db::add_tag_prefix<::Tags::NormalDotNumericalFlux, variables_tags>>,
+        db::split_tag<variables_tags>,
+        db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux,
+                                         variables_tags>>>::function(args...);
+  }
+};
+
+}  // namespace NumericalFluxes
+}  // namespace dg

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   )
 
 add_subdirectory(Actions)
+add_subdirectory(NumericalFluxes)
 
 add_test_library(
   ${LIBRARY}

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_NumericalFluxes")
+
+set(LIBRARY_SOURCES
+  Test_LocalLaxFriedrichs.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/"
+  "${LIBRARY_SOURCES}"
+  "" # Header-only, link dependencies included from testing lib
+  )

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestFunctions.py
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestFunctions.py
@@ -1,0 +1,61 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def characteristic_speeds(var_1, var_2, var_3):
+    return [np.cos(i) * var_1 - (1.0 - np.sin(i)) * np.dot(var_2, var_3)
+            for i in range((var_2.size + 1) * (var_2.size + 1))]
+
+
+# Functions for testing LocalLaxFriedrichs.hpp
+def max_abs_speed(var_1, var_2, var_3):
+    return max([abs(x) for x in characteristic_speeds(var_1, var_2, var_3)])
+
+
+def llf_flux(ndotf_int, minus_ndotf_ext, var_int, var_ext, max_speed):
+    return 0.5 * (ndotf_int - minus_ndotf_ext + max_speed * (var_int - var_ext))
+
+
+def apply_var_1_llf_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
+                         var_1_int, var_2_int, var_3_int, var_4_int,
+                         minus_ndotf_1_ext, minus_ndotf_2_ext,
+                         minus_ndotf_3_ext, minus_ndotf_4_ext,
+                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
+    return llf_flux(ndotf_1_int, minus_ndotf_1_ext, var_1_int, var_1_ext,
+                    max(max_abs_speed(var_1_int, var_2_int, var_3_int),
+                        max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
+
+
+def apply_var_2_llf_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
+                         var_1_int, var_2_int, var_3_int, var_4_int,
+                         minus_ndotf_1_ext, minus_ndotf_2_ext,
+                         minus_ndotf_3_ext, minus_ndotf_4_ext,
+                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
+    return llf_flux(ndotf_2_int, minus_ndotf_2_ext, var_2_int, var_2_ext,
+                    max(max_abs_speed(var_1_int, var_2_int, var_3_int),
+                        max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
+
+
+def apply_var_3_llf_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
+                         var_1_int, var_2_int, var_3_int, var_4_int,
+                         minus_ndotf_1_ext, minus_ndotf_2_ext,
+                         minus_ndotf_3_ext, minus_ndotf_4_ext,
+                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
+    return llf_flux(ndotf_3_int, minus_ndotf_3_ext, var_3_int, var_3_ext,
+                    max(max_abs_speed(var_1_int, var_2_int, var_3_int),
+                        max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
+
+
+def apply_var_4_llf_flux(ndotf_1_int, ndotf_2_int, ndotf_3_int, ndotf_4_int,
+                         var_1_int, var_2_int, var_3_int, var_4_int,
+                         minus_ndotf_1_ext, minus_ndotf_2_ext,
+                         minus_ndotf_3_ext, minus_ndotf_4_ext,
+                         var_1_ext, var_2_ext, var_3_ext, var_4_ext):
+    return llf_flux(ndotf_4_int, minus_ndotf_4_ext, var_4_int, var_4_ext,
+                    max(max_abs_speed(var_1_int, var_2_int, var_3_int),
+                        max_abs_speed(var_1_ext, var_2_ext, var_3_ext)))
+
+
+# End functions for testing LocalLaxFriedrichs.hpp

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace TestHelpers {
+namespace NumericalFluxes {
+
+namespace Tags {
+struct Variable1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "Variable1"; }
+};
+
+template <size_t Dim>
+struct Variable2 : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+  static std::string name() noexcept { return "Variable2"; }
+};
+
+template <size_t Dim>
+struct Variable3 : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim>;
+  static std::string name() noexcept { return "Variable3"; }
+};
+
+template <size_t Dim>
+struct Variable4 : db::SimpleTag {
+  using type = tnsr::Ij<DataVector, Dim>;
+  static std::string name() noexcept { return "Variable4"; }
+};
+
+template <size_t Dim>
+struct CharacteristicSpeeds : db::SimpleTag {
+  using type = std::array<DataVector, (Dim + 1) * (Dim + 1)>;
+  static std::string name() noexcept { return "CharacteristicSpeeds"; }
+};
+
+}  // namespace Tags
+
+template <size_t Dim>
+std::array<DataVector, (Dim + 1) * (Dim + 1)> characteristic_speeds(
+    const Scalar<DataVector>& var_1, const tnsr::I<DataVector, Dim>& var_2,
+    const tnsr::i<DataVector, Dim>& var_3) noexcept {
+  std::array<DataVector, (Dim + 1) * (Dim + 1)> result;
+  // Any expression for the characteristic speeds is fine.
+  for (size_t i = 0; i < result.size(); ++i) {
+    gsl::at(result, i) =
+        cos(static_cast<double>(i)) * get(var_1) -
+        (1.0 - sin(static_cast<double>(i))) * get(dot_product(var_2, var_3));
+  }
+  return result;
+}
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using variables_tags =
+      ::Tags::Variables<tmpl::list<Tags::Variable1, Tags::Variable2<Dim>,
+                                   Tags::Variable3<Dim>, Tags::Variable4<Dim>>>;
+  using char_speeds_tag = Tags::CharacteristicSpeeds<Dim>;
+};
+
+template <typename Var>
+using n_dot_f = ::Tags::NormalDotFlux<Var>;
+
+template <size_t Dim>
+using n_dot_f_tags =
+    tmpl::list<n_dot_f<Tags::Variable1>, n_dot_f<Tags::Variable2<Dim>>,
+               n_dot_f<Tags::Variable3<Dim>>, n_dot_f<Tags::Variable4<Dim>>>;
+
+template <class... PackageDataTags, class FluxType,
+          class... NormalDotNumericalFluxTypes>
+void apply_numerical_flux(
+    const FluxType& flux,
+    const Variables<tmpl::list<PackageDataTags...>>& packaged_data_int,
+    const Variables<tmpl::list<PackageDataTags...>>& packaged_data_ext,
+    NormalDotNumericalFluxTypes&&... normal_dot_numerical_flux) noexcept {
+  flux(std::forward<NormalDotNumericalFluxTypes>(normal_dot_numerical_flux)...,
+       get<PackageDataTags>(packaged_data_int)...,
+       get<PackageDataTags>(packaged_data_ext)...);
+}
+
+}  // namespace NumericalFluxes
+}  // namespace TestHelpers

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_LocalLaxFriedrichs.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_LocalLaxFriedrichs.cpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+template <size_t Dim>
+void test_llf_flux_tags() noexcept {
+  using system = TestHelpers::NumericalFluxes::System<Dim>;
+  using llf_flux = dg::NumericalFluxes::LocalLaxFriedrichs<system>;
+
+  static_assert(
+      cpp17::is_same_v<typename llf_flux::argument_tags,
+                       tmpl::push_back<tmpl::append<
+                           TestHelpers::NumericalFluxes::n_dot_f_tags<Dim>,
+                           db::split_tag<typename system::variables_tags>,
+                           typename system::char_speeds_tag>>>,
+      "Failed testing dg::NumericalFluxes::LocalLaxFriedrichs::argument_tags");
+
+  static_assert(
+      cpp17::is_same_v<
+          typename llf_flux::package_tags,
+          tmpl::push_back<
+              tmpl::append<TestHelpers::NumericalFluxes::n_dot_f_tags<Dim>,
+                           db::split_tag<typename system::variables_tags>>,
+              typename llf_flux::MaxAbsCharSpeed>>,
+      "Failed testing dg::NumericalFluxes::LocalLaxFriedrichs::package_tags");
+}
+
+template <size_t Dim>
+void apply_llf_flux(
+    const gsl::not_null<Scalar<DataVector>*> n_dot_num_f_1,
+    const gsl::not_null<tnsr::I<DataVector, Dim>*> n_dot_num_f_2,
+    const gsl::not_null<tnsr::i<DataVector, Dim>*> n_dot_num_f_3,
+    const gsl::not_null<tnsr::Ij<DataVector, Dim>*> n_dot_num_f_4,
+    const Scalar<DataVector>& n_dot_f_1_int,
+    const tnsr::I<DataVector, Dim>& n_dot_f_2_int,
+    const tnsr::i<DataVector, Dim>& n_dot_f_3_int,
+    const tnsr::Ij<DataVector, Dim>& n_dot_f_4_int,
+    const Scalar<DataVector>& var_1_int,
+    const tnsr::I<DataVector, Dim>& var_2_int,
+    const tnsr::i<DataVector, Dim>& var_3_int,
+    const tnsr::Ij<DataVector, Dim>& var_4_int,
+    const Scalar<DataVector>& minus_n_dot_f_1_ext,
+    const tnsr::I<DataVector, Dim>& minus_n_dot_f_2_ext,
+    const tnsr::i<DataVector, Dim>& minus_n_dot_f_3_ext,
+    const tnsr::Ij<DataVector, Dim>& minus_n_dot_f_4_ext,
+    const Scalar<DataVector>& var_1_ext,
+    const tnsr::I<DataVector, Dim>& var_2_ext,
+    const tnsr::i<DataVector, Dim>& var_3_ext,
+    const tnsr::Ij<DataVector, Dim>& var_4_ext) noexcept {
+  using llf_flux = dg::NumericalFluxes::LocalLaxFriedrichs<
+      TestHelpers::NumericalFluxes::System<Dim>>;
+
+  llf_flux flux_computer{};
+
+  Variables<typename llf_flux::package_tags> packaged_data_interior(
+      n_dot_f_1_int.begin()->size(),
+      std::numeric_limits<double>::signaling_NaN());
+  flux_computer.package_data(
+      make_not_null(&packaged_data_interior), n_dot_f_1_int, n_dot_f_2_int,
+      n_dot_f_3_int, n_dot_f_4_int, var_1_int, var_2_int, var_3_int, var_4_int,
+      TestHelpers::NumericalFluxes::characteristic_speeds(var_1_int, var_2_int,
+                                                          var_3_int));
+
+  Variables<typename llf_flux::package_tags> packaged_data_exterior(
+      n_dot_f_1_int.begin()->size(),
+      std::numeric_limits<double>::signaling_NaN());
+  flux_computer.package_data(
+      make_not_null(&packaged_data_exterior), minus_n_dot_f_1_ext,
+      minus_n_dot_f_2_ext, minus_n_dot_f_3_ext, minus_n_dot_f_4_ext, var_1_ext,
+      var_2_ext, var_3_ext, var_4_ext,
+      TestHelpers::NumericalFluxes::characteristic_speeds(var_1_ext, var_2_ext,
+                                                          var_3_ext));
+
+  TestHelpers::NumericalFluxes::apply_numerical_flux(
+      flux_computer, packaged_data_interior, packaged_data_exterior,
+      n_dot_num_f_1, n_dot_num_f_2, n_dot_num_f_3, n_dot_num_f_4);
+}
+
+template <size_t Dim>
+void test_llf_flux(const DataVector& used_for_size) noexcept {
+  pypp::check_with_random_values<16>(
+      &apply_llf_flux<Dim>, "TestFunctions",
+      {"apply_var_1_llf_flux", "apply_var_2_llf_flux", "apply_var_3_llf_flux",
+       "apply_var_4_llf_flux"},
+      {{{-1.0, 1.0},
+        {-1.0, 1.0},
+        {-1.0, 1.0},
+        {-1.0, 1.0},
+        {0.0, 1.0},
+        {-1.0, 1.0},
+        {-1.0, 1.0},
+        {-1.0, 1.0},
+        {-1.0, 1.0},
+        {-1.0, 1.0},
+        {-1.0, 1.0},
+        {-1.0, 1.0},
+        {0.0, 1.0},
+        {-1.0, 1.0},
+        {-1.0, 1.0},
+        {-1.0, 1.0}}},
+      used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Fluxes.LocalLaxFriedrichs",
+                  "[Unit][NumericalAlgorithms][Fluxes]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes"};
+
+  INVOKE_TEST_FUNCTION(test_llf_flux_tags, (), (1, 2, 3));
+
+  GENERATE_UNINITIALIZED_DATAVECTOR;
+  CHECK_FOR_DATAVECTORS(test_llf_flux, (1, 2, 3))
+}


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
