### PR TITLE
Add exception for convergence failure

### DIFF
--- a/src/ErrorHandling/Exceptions.hpp
+++ b/src/ErrorHandling/Exceptions.hpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <stdexcept>
+
+/// \ingroup ErrorHandlingGroup
+/// Exception indicating convergence failure
+class convergence_error : public std::runtime_error {
+ public:
+  explicit convergence_error(const std::string& message)
+      : runtime_error(message) {}
+};

--- a/src/NumericalAlgorithms/RootFinding/NewtonRaphson.hpp
+++ b/src/NumericalAlgorithms/RootFinding/NewtonRaphson.hpp
@@ -11,6 +11,7 @@
 #include <limits>
 
 #include "DataStructures/DataVector.hpp"
+#include "ErrorHandling/Exceptions.hpp"
 
 namespace RootFinder {
 /*!
@@ -26,7 +27,10 @@ namespace RootFinder {
  *
  * \requires Function `f` is invokable with a `double`
  * \note The parameter `digits` specifies the precision of the result in its
- * desired number of base-10 digits
+ * desired number of base-10 digits.
+ *
+ * \throws `convergence_error` if the requested precision is not met after
+ * `max_iterations` iterations.
  */
 template <typename Function>
 double newton_raphson(const Function& f, const double initial_guess,
@@ -41,9 +45,14 @@ double newton_raphson(const Function& f, const double initial_guess,
 
   boost::uintmax_t max_iters = max_iterations;
   // clang-tidy: internal boost warning, can't fix it.
-  return boost::math::tools::newton_raphson_iterate(  // NOLINT
+  const auto result = boost::math::tools::newton_raphson_iterate(  // NOLINT
       f, initial_guess, lower_bound, upper_bound,
       std::round(std::log2(std::pow(10, digits))), max_iters);
+  if (max_iters >= max_iterations) {
+    throw convergence_error(
+        "newton_raphson reached max iterations without converging");
+  }
+  return result;
 }
 
 /*!
@@ -63,7 +72,10 @@ double newton_raphson(const Function& f, const double initial_guess,
  *
  * \requires Function `f` be callable with a `double` and a `size_t`
  * \note The parameter `digits` specifies the precision of the result in its
- * desired number of base-10 digits
+ * desired number of base-10 digits.
+ *
+ * \throws `convergence_error` if, for any index, the requested precision is not
+ * met after `max_iterations` iterations.
  */
 template <typename Function>
 DataVector newton_raphson(const Function& f, const DataVector& initial_guess,
@@ -85,6 +97,10 @@ DataVector newton_raphson(const Function& f, const DataVector& initial_guess,
     result_vector[i] = boost::math::tools::newton_raphson_iterate(  // NOLINT
         [&f, i ](double x) noexcept { return f(x, i); }, initial_guess[i],
         lower_bound[i], upper_bound[i], digits_binary, max_iters);
+    if (max_iters >= max_iterations) {
+      throw convergence_error(
+          "newton_raphson reached max iterations without converging");
+    }
   }
   return result_vector;
 }

--- a/tests/Unit/ErrorHandling/CMakeLists.txt
+++ b/tests/Unit/ErrorHandling/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_ErrorHandling")
 set(LIBRARY_SOURCES
   Test_AbortWithErrorMessage.cpp
   Test_AssertAndError.cpp
+  Test_Exceptions.cpp
   Test_FloatingPointExceptions.cpp
   )
 

--- a/tests/Unit/ErrorHandling/Test_Exceptions.cpp
+++ b/tests/Unit/ErrorHandling/Test_Exceptions.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <stdexcept>
+#include <string>
+
+#include "ErrorHandling/Exceptions.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.ErrorHandling.Exceptions.convergence_error",
+                  "[ErrorHandling][Unit]") {
+  const std::string what = "Test throw";
+  const auto thrower = [&what]() { throw convergence_error(what); };
+  test_throw_exception(thrower, convergence_error(what));
+  test_throw_exception(thrower, std::runtime_error(what));
+}

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -298,3 +298,21 @@ class DoesThrow {
   DoesThrow& operator=(DoesThrow&&) noexcept(false);
   ~DoesThrow() = default;
 };
+
+template <typename Exception, typename ThrowingFunctor>
+void test_throw_exception(const ThrowingFunctor& func,
+                          const Exception& expected) {
+  try {
+    func();
+    INFO("Failed to throw any exception");
+    CHECK(false);
+  } catch (Exception& e) {
+    CAPTURE(e.what());
+    CAPTURE(expected.what());
+    CHECK(std::string(e.what()) == std::string(expected.what()));
+  } catch (...) {
+    INFO("Failed to throw exception of type " +
+         pretty_type::get_name<Exception>());
+    CHECK(false);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add exception type `convergence_error`. Use this exception to throw on convergence failure in the Toms748 and Newton-Raphson root finders.

Closes #838.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
