### PR TITLE
Compatibility for compiling with GCC8.

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -123,9 +123,9 @@ class Variables<tmpl::list<Tags...>> {
   // @{
   /// Copy and move semantics for wrapped variables
   template <typename... WrappedTags,
-            Requires<tmpl2::flat_all_v<
-                cpp17::is_same_v<db::remove_all_prefixes<WrappedTags>,
-                                 db::remove_all_prefixes<Tags>>...>> = nullptr>
+            Requires<tmpl2::flat_all_v<std::is_same<
+                db::remove_all_prefixes<WrappedTags>,
+                db::remove_all_prefixes<Tags>>::value...>> = nullptr>
   explicit Variables(Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept;
   template <typename... WrappedTags,
             Requires<tmpl2::flat_all_v<
@@ -474,9 +474,10 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
 }
 
 template <typename... Tags>
-template <typename... WrappedTags, Requires<tmpl2::flat_all_v<cpp17::is_same_v<
-                                       db::remove_all_prefixes<WrappedTags>,
-                                       db::remove_all_prefixes<Tags>>...>>>
+template <typename... WrappedTags,
+          Requires<tmpl2::flat_all_v<
+              std::is_same<db::remove_all_prefixes<WrappedTags>,
+                           db::remove_all_prefixes<Tags>>::value...>>>
 Variables<tmpl::list<Tags...>>::Variables(
     Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept
     : variable_data_impl_(std::move(rhs.variable_data_impl_)),

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -286,7 +286,7 @@ class CoordinateMap
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) override {  // NOLINT
     CoordinateMapBase<SourceFrame, TargetFrame, dim>::pup(p);
-    p | maps_;
+    PUP::pup(p, maps_);
   }
 
  private:

--- a/src/Evolution/Conservative/Tags.hpp
+++ b/src/Evolution/Conservative/Tags.hpp
@@ -43,8 +43,9 @@ struct ComputeNormalDotFlux : db::add_tag_prefix<NormalDotFlux, Tag>,
     auto result = make_with_value<
         ::Variables<db::wrap_tags_in<NormalDotFlux, tags_list>>>(flux, 0.);
 
-    tmpl::for_each<tags_list>([&result, &flux, &normal](auto tag) noexcept {
-      using tensor_tag = tmpl::type_from<decltype(tag)>;
+    tmpl::for_each<tags_list>([&result, &flux,
+                               &normal ](auto local_tag) noexcept {
+      using tensor_tag = tmpl::type_from<decltype(local_tag)>;
       auto& result_tensor = get<NormalDotFlux<tensor_tag>>(result);
       const auto& flux_tensor =
           get<Flux<tensor_tag, tmpl::size_t<VolumeDim>, Fr>>(flux);

--- a/tests/Unit/DataStructures/DataBox/Test_Deferred.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_Deferred.cpp
@@ -322,6 +322,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Deferred.PupNonfunction",
   ERROR_TEST();
   Deferred<double> deferred{3.89};
   auto data = std::make_unique<char[]>(10);
-  PUP::fromMem p{static_cast<const void* const>(data.get())};
+  PUP::fromMem p{static_cast<const void*>(data.get())};
   deferred.pack_unpack_lazy_function(p);
 }

--- a/tests/Unit/Domain/Test_ElementIndex.cpp
+++ b/tests/Unit/Domain/Test_ElementIndex.cpp
@@ -28,7 +28,14 @@ void check(const size_t block1,
   ElementIndex<VolumeDim> element_index1{}, element_index2{};
   // Check for nondeterminacy due to previous memory state.
   std::memset(&element_index1, 0, sizeof(element_index1));
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ > 7)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif  // defined(__GNUC__) && !defined(__clang__) && (__GNUC__ > 7)
   std::memset(&element_index2, 255, sizeof(element_index2));
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ > 7)
+#pragma GCC diagnostic pop
+#endif  // defined(__GNUC__) && !defined(__clang__) && (__GNUC__ > 7)
   new (&element_index1) ElementIndex<VolumeDim>(id1);
   new (&element_index2) ElementIndex<VolumeDim>(id2);
 


### PR DESCRIPTION
## Proposed changes

- Adds support for GCC8, tested on my machine. Adding GCC8 to travis will be a later project since that's not a priority.

- There's a namespace resolution issue or something (not sure if it's ADL related, didn't investigate) that requires call `PUP::pup` in CoordinateMap.
- Other changes are to deal with warnings.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
