### PR TITLE
Add an inner product for the linear solver

### DIFF
--- a/src/NumericalAlgorithms/LinearSolver/InnerProduct.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/InnerProduct.hpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+///\file
+/// Defines an inner product for the linear solver
+
+#pragma once
+
+#include <array>
+
+#include "DataStructures/Variables.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/Blaze.hpp"
+#include "Utilities/ForceInline.hpp"
+
+namespace LinearSolver {
+
+/// \ingroup LinearSolverGroup
+/// Implementations of LinearSolver::inner_product.
+namespace InnerProductImpls {
+
+/// The inner product between any types that have a `dot` product
+template <typename Lhs, typename Rhs>
+struct InnerProductImpl {
+  static double apply(const Lhs& lhs, const Rhs& rhs) noexcept {
+    return dot(lhs, rhs);
+  }
+};
+
+/// The inner product between `Variables`
+template <typename LhsTagsList, typename RhsTagsList>
+struct InnerProductImpl<Variables<LhsTagsList>, Variables<RhsTagsList>> {
+  static double apply(const Variables<LhsTagsList>& lhs,
+                      const Variables<RhsTagsList>& rhs) noexcept {
+    const auto size = lhs.size();
+    ASSERT(size == rhs.size(),
+           "The Variables must be of the same size to take an inner product");
+    return ddot_(size, lhs.data(), 1, rhs.data(), 1);
+  }
+};
+
+}  // namespace InnerProductImpls
+
+/*!
+ * \ingroup LinearSolverGroup
+ * \brief The local part of the Euclidean inner product on the vector space
+ * w.r.t. which the addition and scalar multiplication of both `Lhs` and `Rhs`
+ * is defined.
+ *
+ * \details The linear solver works under the following assumptions:
+ * - The data represented by \p lhs and \p rhs can each be interpreted as the
+ * local chunk of a vector of the same vector space \f$V\f$. _Local_ means there
+ * are vectors \f$q, p\in V\f$ such that \p lhs and \p rhs represent the
+ * components of these vectors w.r.t. a subset \f$B_i\f$ of a basis
+ * \f$B\subset V\f$.
+ * - The `*` and `+` operators of `Lhs` and `Rhs` implement the scalar
+ * multiplication and addition in the vector space _locally_, i.e. restricted to
+ * \f$B_i\f$ in the above sense.
+ * - The inner product is the local part \f$\langle p,q\rangle|_{B_i}\f$ of the
+ * standard Euclidean dot product in the vector space so that globally it is
+ * \f$\langle p,q\rangle=\sum_{i}\langle p,q\rangle|_{B_i}\f$ for
+ * \f$B=\mathop{\dot{\bigcup}}_i B_i\f$.
+ *
+ * In practice this means that the full vectors \f$p\f$ and \f$q\f$ can be
+ * distributed on many elements, where each only holds local chunks \p lhs and
+ * \p rhs of the components. Scalar multiplication and addition can be performed
+ * locally as expected, but computing the full inner product requires a global
+ * reduction over all elements that sums their local `inner_product`s.
+ */
+template <typename Lhs, typename Rhs>
+SPECTRE_ALWAYS_INLINE double inner_product(const Lhs& lhs,
+                                           const Rhs& rhs) noexcept {
+  return InnerProductImpls::InnerProductImpl<Lhs, Rhs>::apply(lhs, rhs);
+}
+
+}  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Tags.hpp
@@ -73,7 +73,7 @@ struct Residual : db::PrefixTag, db::SimpleTag {
 
 /*!
  * \ingroup LinearSolverGroup
- * \brief The magnitude square of the residual \f$\langle r,r\rangle_A\f$ w.r.t.
+ * \brief The magnitude square of the residual \f$\langle r,r\rangle\f$ w.r.t.
  * the `LinearSolver::inner_product`
  */
 template <typename Tag>

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_LinearSolver")
 
 set(LIBRARY_SOURCES
+  Test_InnerProduct.cpp
   Test_IterationId.cpp
   Test_Tags.cpp
   )
@@ -12,5 +13,5 @@ add_test_library(
   ${LIBRARY}
   "NumericalAlgorithms/LinearSolver/"
   "${LIBRARY_SOURCES}"
-  "LinearSolver"
+  "DataStructures;LinearSolver"
   )

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_InnerProduct.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_InnerProduct.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DenseVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
+#include "Utilities/TMPL.hpp"
+
+class DataVector;
+
+namespace {
+
+struct ScalarFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+struct AnotherScalarFieldTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.InnerProduct",
+                  "[Unit][NumericalAlgorithms][LinearSolver]") {
+  const DenseVector<double> lhs{1., 0., 2.};
+  const DenseVector<double> rhs{1.5, 1., 3.};
+  CHECK(LinearSolver::inner_product(lhs, rhs) == dot(lhs, rhs));
+
+  const Variables<tmpl::list<ScalarFieldTag>> vars{3, 1.};
+  const Variables<tmpl::list<AnotherScalarFieldTag>> other_vars{3, 2.};
+  CHECK(LinearSolver::inner_product(vars, other_vars) == 6.);
+}


### PR DESCRIPTION
## Proposed changes

The linear solver requires an inner product on the vector space it is operating on. This PR implements this inner product for data represented by Blaze vectors or a `Variables`. Since this inner product makes little sense outside of the context of the linear solver, it is encapsulated in the `LinearSolver` namespace.

- [x] Depends on #854, so please ignore the first commit

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
