### PR TITLE
Fix #793, stack overflow on single core.

### DIFF
--- a/cmake/SetupCharmModuleFunctions.cmake
+++ b/cmake/SetupCharmModuleFunctions.cmake
@@ -134,7 +134,11 @@ function(generate_algorithms_impl ALGORITHM_NAME ALGORITHM_TYPE ALGORITHM_DIR)
      \
      \
      && perl -pi -e 's/ReceiveTag_temporal_id/typename ReceiveTag::temporal_id/g' Algorithm${ALGORITHM_NAME}.def.h \
-     && perl -pi -e 's/ReceiveTag_temporal_id/typename ReceiveTag::temporal_id/g' Algorithm${ALGORITHM_NAME}.decl.h"
+     && perl -pi -e 's/ReceiveTag_temporal_id/typename ReceiveTag::temporal_id/g' Algorithm${ALGORITHM_NAME}.decl.h \
+     \
+     \
+     && perl -pi -e 's/CK_MSG_INLINE/([]() { static const auto pes = CkNumPes(); return pes > 1; }() ? CK_MSG_INLINE : 0)/g' Algorithm${ALGORITHM_NAME}.def.h \
+     && perl -pi -e 's/if \\(obj\\)/if (obj && []() { static const auto pes = CkNumPes(); return pes > 1; }())/g' Algorithm${ALGORITHM_NAME}.def.h"
 
     WORKING_DIRECTORY ${ALGORITHM_DIR}
     RESULT_VARIABLE SUCCEEDED_GENERATING_CHARM


### PR DESCRIPTION
## Proposed changes

Charm++ inline methods were inline even on a single core, which results in crazy
recursion. The easiest solution is to simply have the methods not be inline on a
single core. We do this by patching Charm++'s generated files.

fix #793

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
