### PR TITLE
Add BibTex citations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ compile_commands.json
 *.blg
 *.out
 *.bak
-*.bib
 
 # Python related files
 *.pyc

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -147,3 +147,18 @@ RUN apt-get update && apt-get install -y \
     export LC_ALL=en_US.UTF-8 && \
     locale-gen en_US.UTF-8 && \
     dpkg-reconfigure locales
+
+# Install bibtex for Doxygen bibliography management
+# We first install the TeXLive infrastructure according to the configuration in
+# support/TeXLive/texlive.profile and then use it to install the bibtex package.
+RUN mkdir /work/texlive
+WORKDIR /work/texlive
+RUN wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz \
+    && tar -xzf install-tl-unx.tar.gz \
+    && rm install-tl-unx.tar.gz \
+    && wget https://raw.githubusercontent.com/sxs-collaboration/spectre/develop/support/TeXLive/texlive.profile \
+    && install-tl-*/install-tl -profile=texlive.profile \
+    && rm -r install-tl-* texlive.profile install-tl.log \
+    && echo "export PATH=\$PATH:/work/texlive/bin/x86_64-linux" >> /root/.bashrc \
+    && /work/texlive/bin/x86_64-linux/tlmgr install bibtex
+WORKDIR /work

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -71,6 +71,8 @@ GENERATE_BUGLIST       = NO
 
 STRIP_CODE_COMMENTS    = NO
 
+CITE_BIB_FILES         = @PROJECT_SOURCE_DIR@/docs/References.bib
+
 #---------------------------------------------------------------------------
 # configuration options related to the input files
 #---------------------------------------------------------------------------

--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1,0 +1,10 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+@Book{Kopriva,
+ author    = "David A. {Kopriva}",
+ title     = "Implementing Spectral Methods for Partial Differential Equations",
+ publisher = "Springer",
+ year      =  2009,
+ url       = "https://doi.org/10.1007/978-90-481-2261-5"
+}

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -36,6 +36,9 @@ class Mesh;
  * \note Generally you should prefer working with a Mesh. Use its
  * Mesh::slice_through() method to retrieve the mesh in a particular dimension:
  * \snippet Test_Spectral.cpp get_points_for_mesh
+ *
+ *
+ * Most algorithms in this namespace are adapted from \cite Kopriva.
  */
 namespace Spectral {
 

--- a/support/TeXLive/texlive.profile
+++ b/support/TeXLive/texlive.profile
@@ -1,0 +1,14 @@
+selected_scheme scheme-infraonly
+
+TEXDIR ./
+
+TEXMFCONFIG $TEXMFSYSCONFIG
+TEXMFHOME $TEXMFLOCAL
+TEXMFLOCAL ./texmf-local
+TEXMFSYSCONFIG ./texmf-config
+TEXMFSYSVAR ./texmf-var
+TEXMFVAR $TEXMFSYSVAR
+
+tlpdbopt_install_docfiles 0
+tlpdbopt_install_srcfiles 0
+tlpdbopt_autobackup 0

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -218,6 +218,7 @@ license() {
               'docs/config/header.html' \
               'docs/config/layout.xml' \
               'LICENSE' \
+              'support/TeXLive/texlive.profile' \
               'tools/Iwyu/boost-all.imp$' \
               '.github/ISSUE_TEMPLATE.md' \
               '.github/PULL_REQUEST_TEMPLATE.md' \


### PR DESCRIPTION
## Proposed changes

This PR adds a `References.bib` file and with it the capability to `\cite` its entries in Doxygen comments. The inline citations render in the HTML documentation like this:

![bildschirmfoto 2018-08-17 um 12 30 57](https://user-images.githubusercontent.com/746230/44261930-76741000-a219-11e8-980e-8548b572b555.png)

They link to a bibliography page:

![bildschirmfoto 2018-08-17 um 12 31 11](https://user-images.githubusercontent.com/746230/44261969-96a3cf00-a219-11e8-83e6-34a340bd4e2b.png)

The rendering requires `bibtex` and `perl` in the search path and fails <s>silently</s> if those are not available, i.e. just skips producing the bibliography.

### Types of changes:

- [x] New feature

### Component:

- [x] Documentation