### PR TITLE
Fix sign of divergence cleaning term to match docs/paper

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
@@ -146,7 +146,7 @@ void compute_source_terms_of_u(
   }
 
   get(*source_tilde_phi) =
-      (get(trace(extrinsic_curvature, inv_spatial_metric)) -
+      (-get(trace(extrinsic_curvature, inv_spatial_metric)) -
        constraint_damping_parameter) *
       get(lapse) * get(tilde_phi);
   for (size_t m = 0; m < 3; ++m) {

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
@@ -234,7 +234,7 @@ def source_tilde_phi(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
                      inv_spatial_metric, sqrt_det_spatial_metric,
                      extrinsic_curvature, constraint_damping_parameter):
     return (lapse * tilde_phi *
-            (np.einsum("ab, ab", inv_spatial_metric, extrinsic_curvature) -
+            (-np.einsum("ab, ab", inv_spatial_metric, extrinsic_curvature) -
              constraint_damping_parameter) +
             np.einsum("a, a", tilde_b, d_lapse))
 


### PR DESCRIPTION
## Proposed changes

Fix a sign error in source term for divergence cleaning variable in GRMHD system.

### Types of changes:

- [ x ] Bugfix
- [ ] New feature

### Component:

- [ x ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
