### PR TITLE
Suppress clang-tidy warning from boost

### DIFF
--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -79,6 +79,7 @@ DType scaling_factor(RootFunction<DType>&& rootfunction) noexcept {
   const DType& physical_r_squared = rootfunction.get_r_sq();
   try {
     const double tol = 10.0 * std::numeric_limits<double>::epsilon();
+    // NOLINTNEXTLINE(clang-analyzer-core)
     DType rho = RootFinder::toms748(
         rootfunction, make_with_value<DType>(x_sq, 0.0),
         make_with_value<DType>(x_sq, sqrt(3.0) + tol), tol, tol);
@@ -160,6 +161,7 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> BulgedCube::inverse(
   const ReturnType z_sq = square(physical_z);
   const ReturnType physical_r_squared = x_sq + y_sq + z_sq;
   const auto scaling_factor =
+      // NOLINTNEXTLINE(clang-analyzer-core)
       ::scaling_factor<ReturnType>(RootFunction<ReturnType>{
           radius_, sphericity_, physical_r_squared, x_sq, y_sq, z_sq});
   if (use_equiangular_map_) {

--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_TOMS748.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_TOMS748.cpp
@@ -69,8 +69,10 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748.Bounds",
       "Error in function boost::math::tools::toms748_solve<double>: "
       "Parameters a and b do not bracket the root: a=";
 
+  // NOLINTNEXTLINE(clang-analyzer-core)
   test_throw_exception(
       [&f_lambda, &abs_tol, &rel_tol]() {
+        // NOLINTNEXTLINE(clang-analyzer-core)
         RootFinder::toms748(f_lambda, 0.0, sqrt(2.0) - abs_tol, abs_tol,
                             rel_tol);
       },
@@ -155,6 +157,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748.DataVector",
   double lower = sqrt(2.0) - abs_tol;
   const auto f_lambda = [](double x) { return 2.0 - square(x); };
 
+  // NOLINTNEXTLINE(clang-analyzer-core)
   RootFinder::toms748(f_lambda, lower, upper, abs_tol, rel_tol);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif


### PR DESCRIPTION
## Proposed changes



### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
