### PR TITLE
Extend Shell to allow for logarithmic radial mapping

### DIFF
--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -185,6 +185,24 @@ namespace CoordinateMaps {
  *  \end{bmatrix}
  *  \f]
  *
+ *  ### Changing the radial distribution of the gridpoints
+ *  By default, Wedge3D linearly distributes its gridpoints in the radial
+ *  direction. An exponential map can be applied to the sphere factor
+ *  \f$S(\zeta)\f$ in order to obtain a relatively higher resolution at smaller
+ *  radii. Since this is a radial rescaling of Wedge3D, this option is only
+ *  supported for fully spherical wedges with
+ *  `sphericity_inner` = `sphericity_outer` = 1.
+ *
+ *  The map then is:
+ *  \f[\vec{x}(\xi,\eta,\zeta) =
+ *  \frac{e^{S(\zeta)}}{\rho}\begin{bmatrix}
+ *  \Xi\\
+ *  \mathrm{H}\\
+ *  1\\
+ *  \end{bmatrix}\f]
+ *
+ *  The jacobian simplifies similarly.
+ *
  */
 class Wedge3D {
  public:
@@ -221,11 +239,15 @@ class Wedge3D {
    * the coordinates in the [-1,0] interval (value of `LowerOnly`) of the
    * full wedge, or the full wedge entirely (value of `Both`). Half wedges are
    * currently only useful in constructing domains for binary systems.
+   * \param with_logarithmic_map Determines whether to apply an exponential
+   * function mapping to the "sphere factor", the effect of which is to
+   * distribute the radial gridpoints logarithmically in physical space.
    */
   Wedge3D(double radius_inner, double radius_outer,
           OrientationMap<3> orientation_of_wedge, double sphericity_inner,
           double sphericity_outer, bool with_equiangular_map,
-          WedgeHalves halves_to_use = WedgeHalves::Both) noexcept;
+          WedgeHalves halves_to_use = WedgeHalves::Both,
+          bool with_logarithmic_map = false) noexcept;
 
   Wedge3D() = default;
   ~Wedge3D() = default;
@@ -275,6 +297,7 @@ class Wedge3D {
   double sphericity_outer_{std::numeric_limits<double>::signaling_NaN()};
   bool with_equiangular_map_ = false;
   WedgeHalves halves_to_use_ = WedgeHalves::Both;
+  bool with_logarithmic_map_ = false;
   double scaled_frustum_zero_{std::numeric_limits<double>::signaling_NaN()};
   double sphere_zero_{std::numeric_limits<double>::signaling_NaN()};
   double scaled_frustum_rate_{std::numeric_limits<double>::signaling_NaN()};

--- a/src/Domain/DomainCreators/Shell.cpp
+++ b/src/Domain/DomainCreators/Shell.cpp
@@ -31,16 +31,18 @@ Shell<TargetFrame>::Shell(
     typename InitialRefinement::type initial_refinement,
     typename InitialGridPoints::type initial_number_of_grid_points,
     typename UseEquiangularMap::type use_equiangular_map,
-    typename AspectRatio::type aspect_ratio) noexcept
+    typename AspectRatio::type aspect_ratio,
+    typename UseLogarithmicMap::type use_logarithmic_map) noexcept
     // clang-tidy: trivially copyable
-    : inner_radius_(std::move(inner_radius)),                // NOLINT
-      outer_radius_(std::move(outer_radius)),                // NOLINT
-      initial_refinement_(                                   // NOLINT
-          std::move(initial_refinement)),                    // NOLINT
-      initial_number_of_grid_points_(                        // NOLINT
-          std::move(initial_number_of_grid_points)),         // NOLINT
-      use_equiangular_map_(std::move(use_equiangular_map)),  // NOLINT
-      aspect_ratio_(std::move(aspect_ratio)) {}              // NOLINT
+    : inner_radius_(std::move(inner_radius)),                  // NOLINT
+      outer_radius_(std::move(outer_radius)),                  // NOLINT
+      initial_refinement_(                                     // NOLINT
+          std::move(initial_refinement)),                      // NOLINT
+      initial_number_of_grid_points_(                          // NOLINT
+          std::move(initial_number_of_grid_points)),           // NOLINT
+      use_equiangular_map_(std::move(use_equiangular_map)),    // NOLINT
+      aspect_ratio_(std::move(aspect_ratio)),                  // NOLINT
+      use_logarithmic_map_(std::move(use_logarithmic_map)) {}  // NOLINT
 
 template <typename TargetFrame>
 Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
@@ -48,7 +50,7 @@ Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
       std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
       coord_maps = wedge_coordinate_maps<TargetFrame>(
           inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_, 0.0,
-          false, aspect_ratio_);
+          false, aspect_ratio_, use_logarithmic_map_);
   return Domain<3, TargetFrame>{std::move(coord_maps),
                                 corners_for_radially_layered_domains(1, false)};
 }

--- a/src/Domain/DomainCreators/Shell.hpp
+++ b/src/Domain/DomainCreators/Shell.hpp
@@ -65,8 +65,16 @@ class Shell : public DomainCreator<3, TargetFrame> {
     static constexpr type default_value() noexcept { return 1.0; }
   };
 
-  using options = tmpl::list<InnerRadius, OuterRadius, InitialRefinement,
-                             InitialGridPoints, UseEquiangularMap, AspectRatio>;
+  struct UseLogarithmicMap {
+    using type = bool;
+    static constexpr OptionString help = {
+        "Use a logarithmically spaced radial grid."};
+    static constexpr type default_value() noexcept { return false; }
+  };
+
+  using options =
+      tmpl::list<InnerRadius, OuterRadius, InitialRefinement, InitialGridPoints,
+                 UseEquiangularMap, AspectRatio, UseLogarithmicMap>;
 
   static constexpr OptionString help{
       "Creates a 3D spherical shell with 6 Blocks. `UseEquiangularMap` has\n"
@@ -82,7 +90,8 @@ class Shell : public DomainCreator<3, TargetFrame> {
         typename InitialRefinement::type initial_refinement,
         typename InitialGridPoints::type initial_number_of_grid_points,
         typename UseEquiangularMap::type use_equiangular_map,
-        typename AspectRatio::type aspect_ratio = 1.0) noexcept;
+        typename AspectRatio::type aspect_ratio = 1.0,
+        typename UseLogarithmicMap::type use_logarithmic_map = false) noexcept;
 
   Shell() = default;
   Shell(const Shell&) = delete;
@@ -105,5 +114,6 @@ class Shell : public DomainCreator<3, TargetFrame> {
   typename InitialGridPoints::type initial_number_of_grid_points_{};
   typename UseEquiangularMap::type use_equiangular_map_ = true;
   typename AspectRatio::type aspect_ratio_ = 1.0;
+  typename UseLogarithmicMap::type use_logarithmic_map_ = false;
 };
 }  // namespace DomainCreators

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -480,30 +480,31 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const double outer_sphericity,
                       const bool use_equiangular_map,
                       const double x_coord_of_shell_center,
-                      const bool use_half_wedges,
-                      const double aspect_ratio) noexcept {
+                      const bool use_half_wedges, const double aspect_ratio,
+                      const bool use_logarithmic_map) noexcept {
   const auto wedge_orientations = orientations_for_wrappings();
 
   using Wedge3DMap = CoordinateMaps::Wedge3D;
+  using Halves = Wedge3DMap::WedgeHalves;
   std::vector<Wedge3DMap> wedges{};
   for (size_t i = 0; i < 6; i++) {
     wedges.emplace_back(inner_radius, outer_radius,
                         gsl::at(wedge_orientations, i), inner_sphericity,
-                        outer_sphericity, use_equiangular_map);
+                        outer_sphericity, use_equiangular_map, Halves::Both,
+                        use_logarithmic_map);
   }
 
   if (use_half_wedges) {
-    using Halves = Wedge3DMap::WedgeHalves;
     std::vector<Wedge3DMap> wedges_and_half_wedges{};
     for (size_t i = 0; i < 4; i++) {
       wedges_and_half_wedges.emplace_back(
           inner_radius, outer_radius, gsl::at(wedge_orientations, i),
           inner_sphericity, outer_sphericity, use_equiangular_map,
-          Halves::LowerOnly);
+          Halves::LowerOnly, use_logarithmic_map);
       wedges_and_half_wedges.emplace_back(
           inner_radius, outer_radius, gsl::at(wedge_orientations, i),
           inner_sphericity, outer_sphericity, use_equiangular_map,
-          Halves::UpperOnly);
+          Halves::UpperOnly, use_logarithmic_map);
     }
     wedges_and_half_wedges.push_back(wedges[4]);
     wedges_and_half_wedges.push_back(wedges[5]);
@@ -1004,8 +1005,8 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const double outer_sphericity,
                       const bool use_equiangular_map,
                       const double x_coord_of_shell_center,
-                      const bool use_wedge_halves,
-                      const double aspect_ratio) noexcept;
+                      const bool use_wedge_halves, const double aspect_ratio,
+                      const bool use_logarithmic_map) noexcept;
 template std::vector<
     std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
 wedge_coordinate_maps(const double inner_radius, const double outer_radius,
@@ -1013,8 +1014,8 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const double outer_sphericity,
                       const bool use_equiangular_map,
                       const double x_coord_of_shell_center,
-                      const bool use_wedge_halves,
-                      const double aspect_ratio) noexcept;
+                      const bool use_wedge_halves, const double aspect_ratio,
+                      const bool use_logarithmic_map) noexcept;
 template std::vector<
     std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
 frustum_coordinate_maps(const double length_inner_cube,

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -94,15 +94,16 @@ corners_for_rectilinear_domains(const Index<VolumeDim>& domain_extents,
 /// The argument `aspect_ratio` sets the equatorial compression factor,
 /// used by the EquatorialCompression maps which get composed with the Wedges.
 /// This is done if `aspect_ratio` is set to something other than the default
-/// value of one.
+/// value of one. When the argument `use_logarithmic_map` is set to `true`,
+/// the radial gridpoints of the wedge map are set to be spaced logarithmically.
 template <typename TargetFrame>
 std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
 wedge_coordinate_maps(double inner_radius, double outer_radius,
                       double inner_sphericity, double outer_sphericity,
                       bool use_equiangular_map,
                       double x_coord_of_shell_center = 0.0,
-                      bool use_half_wedges = false,
-                      double aspect_ratio = 1.0) noexcept;
+                      bool use_half_wedges = false, double aspect_ratio = 1.0,
+                      bool use_logarithmic_map = false) noexcept;
 
 /// \ingroup ComputationalDomainGroup
 /// These are the ten Frustums used in the DomainCreators for binary compact

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -16,7 +16,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 
 namespace {
-void test_wedge3d_all_directions(const bool with_equiangular_map) {
+void test_wedge3d_all_directions() {
   // Set up random number generator
   const auto seed = std::random_device{}();
   std::mt19937 gen(seed);
@@ -38,102 +38,121 @@ void test_wedge3d_all_directions(const bool with_equiangular_map) {
       {WedgeHalves::UpperOnly, WedgeHalves::LowerOnly, WedgeHalves::Both}};
   for (const auto& halves : halves_array) {
     for (const auto& direction : all_wedge_directions()) {
-      const CoordinateMaps::Wedge3D wedge_map(
-          inner_radius, outer_radius, direction, inner_sphericity,
-          outer_sphericity, with_equiangular_map, halves);
-      test_suite_for_map_on_unit_cube(wedge_map);
+      for (const auto& with_equiangular_map : {true, false}) {
+        for (const auto& with_logarithmic_map : {true, false}) {
+          const CoordinateMaps::Wedge3D wedge_map(
+              inner_radius, outer_radius, direction,
+              with_logarithmic_map ? 1.0 : inner_sphericity,
+              with_logarithmic_map ? 1.0 : outer_sphericity,
+              with_equiangular_map, halves, with_logarithmic_map);
+          test_suite_for_map(wedge_map);
+        }
+      }
     }
   }
 }
 
-void test_wedge3d_alignment(const bool with_equiangular_map) {
+void test_wedge3d_alignment() {
   // This test tests that the logical axes point along the expected directions
   // in physical space
 
   const double inner_r = sqrt(3.0);
   const double outer_r = 2.0 * sqrt(3.0);
 
+  using WedgeHalves = CoordinateMaps::Wedge3D::WedgeHalves;
   const auto wedge_directions = all_wedge_directions();
-  const CoordinateMaps::Wedge3D map_upper_zeta(
-      inner_r, outer_r, wedge_directions[0], 0.0, 1.0,
-      with_equiangular_map);  // Upper Z wedge
-  const CoordinateMaps::Wedge3D map_upper_eta(
-      inner_r, outer_r, wedge_directions[2], 0.0, 1.0,
-      with_equiangular_map);  // Upper Y wedge
-  const CoordinateMaps::Wedge3D map_upper_xi(
-      inner_r, outer_r, wedge_directions[4], 0.0, 1.0,
-      with_equiangular_map);  // Upper X Wedge
-  const CoordinateMaps::Wedge3D map_lower_zeta(
-      inner_r, outer_r, wedge_directions[1], 0.0, 1.0,
-      with_equiangular_map);  // Lower Z wedge
-  const CoordinateMaps::Wedge3D map_lower_eta(
-      inner_r, outer_r, wedge_directions[3], 0.0, 1.0,
-      with_equiangular_map);  // Lower Y wedge
-  const CoordinateMaps::Wedge3D map_lower_xi(
-      inner_r, outer_r, wedge_directions[5], 0.0, 1.0,
-      with_equiangular_map);  // Lower X wedge
-  const std::array<double, 3> lowest_corner{{-1.0, -1.0, -1.0}};
-  const std::array<double, 3> along_xi{{1.0, -1.0, -1.0}};
-  const std::array<double, 3> along_eta{{-1.0, 1.0, -1.0}};
-  const std::array<double, 3> along_zeta{{-1.0, -1.0, 1.0}};
 
-  const std::array<double, 3> lowest_physical_corner_upper_zeta{
-      {-1.0, -1.0, 1.0}};
-  const std::array<double, 3> lowest_physical_corner_upper_eta{
-      {-1.0, 1.0, -1.0}};
-  const std::array<double, 3> lowest_physical_corner_upper_xi{
-      {1.0, -1.0, -1.0}};
-  const std::array<double, 3> lowest_physical_corner_lower_zeta{
-      {-1.0, 1.0, -1.0}};
-  const std::array<double, 3> lowest_physical_corner_lower_eta{
-      {-1.0, -1.0, 1.0}};
-  const std::array<double, 3> lowest_physical_corner_lower_xi{
-      {-1.0, 1.0, -1.0}};
+  for (const auto& with_equiangular_map : {true, false}) {
+    for (const auto& with_logarithmic_map : {true, false}) {
+      const double inner_sphericity = with_logarithmic_map ? 1.0 : 0.0;
+      const CoordinateMaps::Wedge3D map_upper_zeta(
+          inner_r, outer_r, wedge_directions[0], inner_sphericity, 1.0,
+          with_equiangular_map, WedgeHalves::Both,
+          with_logarithmic_map);  // Upper Z wedge
+      const CoordinateMaps::Wedge3D map_upper_eta(
+          inner_r, outer_r, wedge_directions[2], inner_sphericity, 1.0,
+          with_equiangular_map, WedgeHalves::Both,
+          with_logarithmic_map);  // Upper Y wedge
+      const CoordinateMaps::Wedge3D map_upper_xi(
+          inner_r, outer_r, wedge_directions[4], inner_sphericity, 1.0,
+          with_equiangular_map, WedgeHalves::Both,
+          with_logarithmic_map);  // Upper X Wedge
+      const CoordinateMaps::Wedge3D map_lower_zeta(
+          inner_r, outer_r, wedge_directions[1], inner_sphericity, 1.0,
+          with_equiangular_map, WedgeHalves::Both,
+          with_logarithmic_map);  // Lower Z wedge
+      const CoordinateMaps::Wedge3D map_lower_eta(
+          inner_r, outer_r, wedge_directions[3], inner_sphericity, 1.0,
+          with_equiangular_map, WedgeHalves::Both,
+          with_logarithmic_map);  // Lower Y wedge
+      const CoordinateMaps::Wedge3D map_lower_xi(
+          inner_r, outer_r, wedge_directions[5], inner_sphericity, 1.0,
+          with_equiangular_map, WedgeHalves::Both,
+          with_logarithmic_map);  // Lower X wedge
+      const std::array<double, 3> lowest_corner{{-1.0, -1.0, -1.0}};
+      const std::array<double, 3> along_xi{{1.0, -1.0, -1.0}};
+      const std::array<double, 3> along_eta{{-1.0, 1.0, -1.0}};
+      const std::array<double, 3> along_zeta{{-1.0, -1.0, 1.0}};
 
-  // Test that this map's logical axes point along +X, +Y, +Z:
-  CHECK(map_upper_zeta(along_xi)[0] == approx(1.0));
-  CHECK(map_upper_zeta(along_eta)[1] == approx(1.0));
-  CHECK(map_upper_zeta(along_zeta)[2] == approx(2.0));
-  CHECK_ITERABLE_APPROX(map_upper_zeta(lowest_corner),
-                        lowest_physical_corner_upper_zeta);
+      const std::array<double, 3> lowest_physical_corner_upper_zeta{
+          {-1.0, -1.0, 1.0}};
+      const std::array<double, 3> lowest_physical_corner_upper_eta{
+          {-1.0, 1.0, -1.0}};
+      const std::array<double, 3> lowest_physical_corner_upper_xi{
+          {1.0, -1.0, -1.0}};
+      const std::array<double, 3> lowest_physical_corner_lower_zeta{
+          {-1.0, 1.0, -1.0}};
+      const std::array<double, 3> lowest_physical_corner_lower_eta{
+          {-1.0, -1.0, 1.0}};
+      const std::array<double, 3> lowest_physical_corner_lower_xi{
+          {-1.0, 1.0, -1.0}};
 
-  // Test that this map's logical axes point along +Z, +X, +Y:
-  CHECK(map_upper_eta(along_xi)[2] == approx(1.0));
-  CHECK(map_upper_eta(along_eta)[0] == approx(1.0));
-  CHECK(map_upper_eta(along_zeta)[1] == approx(2.0));
-  CHECK_ITERABLE_APPROX(map_upper_eta(lowest_corner),
-                        lowest_physical_corner_upper_eta);
+      // Test that this map's logical axes point along +X, +Y, +Z:
+      CHECK(map_upper_zeta(along_xi)[0] == approx(1.0));
+      CHECK(map_upper_zeta(along_eta)[1] == approx(1.0));
+      CHECK(map_upper_zeta(along_zeta)[2] == approx(2.0));
+      CHECK_ITERABLE_APPROX(map_upper_zeta(lowest_corner),
+                            lowest_physical_corner_upper_zeta);
 
-  // Test that this map's logical axes point along +Y, +Z, +X:
-  CHECK(map_upper_xi(along_xi)[1] == approx(1.0));
-  CHECK(map_upper_xi(along_eta)[2] == approx(1.0));
-  CHECK(map_upper_xi(along_zeta)[0] == approx(2.0));
-  CHECK_ITERABLE_APPROX(map_upper_xi(lowest_corner),
-                        lowest_physical_corner_upper_xi);
+      // Test that this map's logical axes point along +Z, +X, +Y:
+      CHECK(map_upper_eta(along_xi)[2] == approx(1.0));
+      CHECK(map_upper_eta(along_eta)[0] == approx(1.0));
+      CHECK(map_upper_eta(along_zeta)[1] == approx(2.0));
+      CHECK_ITERABLE_APPROX(map_upper_eta(lowest_corner),
+                            lowest_physical_corner_upper_eta);
 
-  // Test that this map's logical axes point along +X, -Y, -Z:
-  CHECK(map_lower_zeta(along_xi)[0] == approx(1.0));
-  CHECK(map_lower_zeta(along_eta)[1] == approx(-1.0));
-  CHECK(map_lower_zeta(along_zeta)[2] == approx(-2.0));
-  CHECK_ITERABLE_APPROX(map_lower_zeta(lowest_corner),
-                        lowest_physical_corner_lower_zeta);
+      // Test that this map's logical axes point along +Y, +Z, +X:
+      CHECK(map_upper_xi(along_xi)[1] == approx(1.0));
+      CHECK(map_upper_xi(along_eta)[2] == approx(1.0));
+      CHECK(map_upper_xi(along_zeta)[0] == approx(2.0));
+      CHECK_ITERABLE_APPROX(map_upper_xi(lowest_corner),
+                            lowest_physical_corner_upper_xi);
 
-  // Test that this map's logical axes point along -Z, +X, -Y:
-  CHECK(map_lower_eta(along_xi)[2] == approx(-1.0));
-  CHECK(map_lower_eta(along_eta)[0] == approx(1.0));
-  CHECK(map_lower_eta(along_zeta)[1] == approx(-2.0));
-  CHECK_ITERABLE_APPROX(map_lower_eta(lowest_corner),
-                        lowest_physical_corner_lower_eta);
+      // Test that this map's logical axes point along +X, -Y, -Z:
+      CHECK(map_lower_zeta(along_xi)[0] == approx(1.0));
+      CHECK(map_lower_zeta(along_eta)[1] == approx(-1.0));
+      CHECK(map_lower_zeta(along_zeta)[2] == approx(-2.0));
+      CHECK_ITERABLE_APPROX(map_lower_zeta(lowest_corner),
+                            lowest_physical_corner_lower_zeta);
 
-  // Test that this map's logical axes point along -Y, +Z, -X:
-  CHECK(map_lower_xi(along_xi)[1] == approx(-1.0));
-  CHECK(map_lower_xi(along_eta)[2] == approx(1.0));
-  CHECK(map_lower_xi(along_zeta)[0] == approx(-2.0));
-  CHECK_ITERABLE_APPROX(map_lower_xi(lowest_corner),
-                        lowest_physical_corner_lower_xi);
+      // Test that this map's logical axes point along -Z, +X, -Y:
+      CHECK(map_lower_eta(along_xi)[2] == approx(-1.0));
+      CHECK(map_lower_eta(along_eta)[0] == approx(1.0));
+      CHECK(map_lower_eta(along_zeta)[1] == approx(-2.0));
+      CHECK_ITERABLE_APPROX(map_lower_eta(lowest_corner),
+                            lowest_physical_corner_lower_eta);
+
+      // Test that this map's logical axes point along -Y, +Z, -X:
+      CHECK(map_lower_xi(along_xi)[1] == approx(-1.0));
+      CHECK(map_lower_xi(along_eta)[2] == approx(1.0));
+      CHECK(map_lower_xi(along_zeta)[0] == approx(-2.0));
+      CHECK_ITERABLE_APPROX(map_lower_xi(lowest_corner),
+                            lowest_physical_corner_lower_xi);
+    }
+  }
 }
 
-void test_wedge3d_random_radii(const bool with_equiangular_map) {
+void test_wedge3d_random_radii() {
   // Set up random number generator:
   const auto seed = std::random_device{}();
   std::mt19937 gen(seed);
@@ -172,67 +191,81 @@ void test_wedge3d_random_radii(const bool with_equiangular_map) {
   const double random_outer_radius_upper_zeta = outer_dis(gen);
   CAPTURE_PRECISE(random_outer_radius_upper_zeta);
 
+  using WedgeHalves = CoordinateMaps::Wedge3D::WedgeHalves;
   const auto wedge_directions = all_wedge_directions();
-  const CoordinateMaps::Wedge3D map_lower_xi(
-      random_inner_radius_lower_xi, random_outer_radius_lower_xi,
-      wedge_directions[5], 0.0, 1.0, with_equiangular_map);
-  const CoordinateMaps::Wedge3D map_lower_eta(
-      random_inner_radius_lower_eta, random_outer_radius_lower_eta,
-      wedge_directions[3], 0.0, 1.0, with_equiangular_map);
-  const CoordinateMaps::Wedge3D map_lower_zeta(
-      random_inner_radius_lower_zeta, random_outer_radius_lower_zeta,
-      wedge_directions[1], 0.0, 1.0, with_equiangular_map);
-  const CoordinateMaps::Wedge3D map_upper_xi(
-      random_inner_radius_upper_xi, random_outer_radius_upper_xi,
-      wedge_directions[4], 0.0, 1.0, with_equiangular_map);
-  const CoordinateMaps::Wedge3D map_upper_eta(
-      random_inner_radius_upper_eta, random_outer_radius_upper_eta,
-      wedge_directions[2], 0.0, 1.0, with_equiangular_map);
-  const CoordinateMaps::Wedge3D map_upper_zeta(
-      random_inner_radius_upper_zeta, random_outer_radius_upper_zeta,
-      wedge_directions[0], 0.0, 1.0, with_equiangular_map);
-  CHECK(map_lower_xi(outer_corner)[0] ==
-        approx(-random_outer_radius_lower_xi / sqrt(3.0)));
-  CHECK(map_lower_eta(outer_corner)[1] ==
-        approx(-random_outer_radius_lower_eta / sqrt(3.0)));
-  CHECK(map_lower_zeta(outer_corner)[2] ==
-        approx(-random_outer_radius_lower_zeta / sqrt(3.0)));
-  CHECK(map_upper_xi(inner_corner)[0] ==
-        approx(random_inner_radius_upper_xi / sqrt(3.0)));
-  CHECK(map_upper_eta(inner_corner)[1] ==
-        approx(random_inner_radius_upper_eta / sqrt(3.0)));
-  CHECK(map_upper_zeta(inner_corner)[2] ==
-        approx(random_inner_radius_upper_zeta / sqrt(3.0)));
+  for (const auto& with_equiangular_map : {true, false}) {
+    for (const auto& with_logarithmic_map : {true, false}) {
+      const double inner_sphericity = with_logarithmic_map ? 1.0 : 0.0;
+      const CoordinateMaps::Wedge3D map_lower_xi(
+          random_inner_radius_lower_xi, random_outer_radius_lower_xi,
+          wedge_directions[5], inner_sphericity, 1.0, with_equiangular_map,
+          WedgeHalves::Both, with_logarithmic_map);
+      const CoordinateMaps::Wedge3D map_lower_eta(
+          random_inner_radius_lower_eta, random_outer_radius_lower_eta,
+          wedge_directions[3], inner_sphericity, 1.0, with_equiangular_map,
+          WedgeHalves::Both, with_logarithmic_map);
+      const CoordinateMaps::Wedge3D map_lower_zeta(
+          random_inner_radius_lower_zeta, random_outer_radius_lower_zeta,
+          wedge_directions[1], inner_sphericity, 1.0, with_equiangular_map,
+          WedgeHalves::Both, with_logarithmic_map);
+      const CoordinateMaps::Wedge3D map_upper_xi(
+          random_inner_radius_upper_xi, random_outer_radius_upper_xi,
+          wedge_directions[4], inner_sphericity, 1.0, with_equiangular_map,
+          WedgeHalves::Both, with_logarithmic_map);
+      const CoordinateMaps::Wedge3D map_upper_eta(
+          random_inner_radius_upper_eta, random_outer_radius_upper_eta,
+          wedge_directions[2], inner_sphericity, 1.0, with_equiangular_map,
+          WedgeHalves::Both, with_logarithmic_map);
+      const CoordinateMaps::Wedge3D map_upper_zeta(
+          random_inner_radius_upper_zeta, random_outer_radius_upper_zeta,
+          wedge_directions[0], inner_sphericity, 1.0, with_equiangular_map,
+          WedgeHalves::Both, with_logarithmic_map);
+      CHECK(map_lower_xi(outer_corner)[0] ==
+            approx(-random_outer_radius_lower_xi / sqrt(3.0)));
+      CHECK(map_lower_eta(outer_corner)[1] ==
+            approx(-random_outer_radius_lower_eta / sqrt(3.0)));
+      CHECK(map_lower_zeta(outer_corner)[2] ==
+            approx(-random_outer_radius_lower_zeta / sqrt(3.0)));
+      CHECK(map_upper_xi(inner_corner)[0] ==
+            approx(random_inner_radius_upper_xi / sqrt(3.0)));
+      CHECK(map_upper_eta(inner_corner)[1] ==
+            approx(random_inner_radius_upper_eta / sqrt(3.0)));
+      CHECK(map_upper_zeta(inner_corner)[2] ==
+            approx(random_inner_radius_upper_zeta / sqrt(3.0)));
 
-  // Check that random points on the edges of the reference cube map to the
-  // correct edges of the wedge.
-  const std::array<double, 3> random_outer_face{
-      {real_dis(gen), real_dis(gen), 1.0}};
-  const std::array<double, 3> random_inner_face{
-      {real_dis(gen), real_dis(gen), -1.0}};
-  CAPTURE_PRECISE(random_outer_face);
-  CAPTURE_PRECISE(random_inner_face);
+      // Check that random points on the edges of the reference cube map to the
+      // correct edges of the wedge.
+      const std::array<double, 3> random_outer_face{
+          {real_dis(gen), real_dis(gen), 1.0}};
+      const std::array<double, 3> random_inner_face{
+          {real_dis(gen), real_dis(gen), -1.0}};
+      CAPTURE_PRECISE(random_outer_face);
+      CAPTURE_PRECISE(random_inner_face);
 
-  CHECK(magnitude(map_lower_xi(random_outer_face)) ==
-        approx(random_outer_radius_lower_xi));
-  CHECK(map_lower_xi(random_inner_face)[0] ==
-        approx(-random_inner_radius_lower_xi / sqrt(3.0)));
-  CHECK(magnitude(map_lower_eta(random_outer_face)) ==
-        approx(random_outer_radius_lower_eta));
-  CHECK(map_lower_eta(random_inner_face)[1] ==
-        approx(-random_inner_radius_lower_eta / sqrt(3.0)));
-  CHECK(magnitude(map_upper_xi(random_outer_face)) ==
-        approx(random_outer_radius_upper_xi));
-  CHECK(map_upper_xi(random_inner_face)[0] ==
-        approx(random_inner_radius_upper_xi / sqrt(3.0)));
-  CHECK(magnitude(map_upper_eta(random_outer_face)) ==
-        approx(random_outer_radius_upper_eta));
-  CHECK(map_upper_eta(random_inner_face)[1] ==
-        approx(random_inner_radius_upper_eta / sqrt(3.0)));
-  CHECK(magnitude(map_lower_zeta(random_outer_face)) ==
-        approx(random_outer_radius_lower_zeta));
-  CHECK(magnitude(map_upper_zeta(random_outer_face)) ==
-        approx(random_outer_radius_upper_zeta));
+      if (not with_logarithmic_map) {
+        CHECK(map_lower_xi(random_inner_face)[0] ==
+              approx(-random_inner_radius_lower_xi / sqrt(3.0)));
+        CHECK(map_lower_eta(random_inner_face)[1] ==
+              approx(-random_inner_radius_lower_eta / sqrt(3.0)));
+        CHECK(map_upper_xi(random_inner_face)[0] ==
+              approx(random_inner_radius_upper_xi / sqrt(3.0)));
+        CHECK(map_upper_eta(random_inner_face)[1] ==
+              approx(random_inner_radius_upper_eta / sqrt(3.0)));
+      }
+      CHECK(magnitude(map_lower_xi(random_outer_face)) ==
+            approx(random_outer_radius_lower_xi));
+      CHECK(magnitude(map_lower_eta(random_outer_face)) ==
+            approx(random_outer_radius_lower_eta));
+      CHECK(magnitude(map_upper_xi(random_outer_face)) ==
+            approx(random_outer_radius_upper_xi));
+      CHECK(magnitude(map_upper_eta(random_outer_face)) ==
+            approx(random_outer_radius_upper_eta));
+      CHECK(magnitude(map_lower_zeta(random_outer_face)) ==
+            approx(random_outer_radius_lower_zeta));
+      CHECK(magnitude(map_upper_zeta(random_outer_face)) ==
+            approx(random_outer_radius_upper_zeta));
+    }
+  }
 }
 
 void test_wedge3d_fail() noexcept {
@@ -268,39 +301,16 @@ void test_wedge3d_fail() noexcept {
                           test_mapped_point7);
   }
 }
-
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Fail", "[Domain][Unit]") {
   test_wedge3d_fail();
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map.Equiangular",
-                  "[Domain][Unit]") {
-  test_wedge3d_all_directions(true);
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map.Equidistant",
-                  "[Domain][Unit]") {
-  test_wedge3d_all_directions(false);
-}
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Alignment.Equiangular",
-                  "[Domain][Unit]") {
-  test_wedge3d_alignment(true);
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Alignment.Equidistant",
-                  "[Domain][Unit]") {
-  test_wedge3d_alignment(false);
-}
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.RandomRadii.Equiangular",
-                  "[Domain][Unit]") {
-  test_wedge3d_random_radii(true);
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.RandomRadii.Equidistant",
-                  "[Domain][Unit]") {
-  test_wedge3d_random_radii(false);
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map", "[Domain][Unit]") {
+  test_wedge3d_all_directions();
+  test_wedge3d_alignment();
+  test_wedge3d_random_radii();
 }
 
 // [[OutputRegex, The radius of the inner surface must be greater than zero.]]
@@ -360,6 +370,19 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.RandomRadii.Equidistant",
 #ifdef SPECTRE_DEBUG
   auto failed_wedge3d =
       CoordinateMaps::Wedge3D(3.0, 4.0, OrientationMap<3>{}, 1.0, 0.0, true);
+  static_cast<void>(failed_wedge3d);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The logarithmic map is only supported for spherical wedges.]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.LogarithmicMap",
+                               "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  auto failed_wedge3d =
+      CoordinateMaps::Wedge3D(0.2, 4.0, OrientationMap<3>{}, 0.8, 0.9, true,
+                              CoordinateMaps::Wedge3D::WedgeHalves::Both, true);
   static_cast<void>(failed_wedge3d);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -45,7 +45,7 @@ void test_wedge3d_all_directions() {
               with_logarithmic_map ? 1.0 : inner_sphericity,
               with_logarithmic_map ? 1.0 : outer_sphericity,
               with_equiangular_map, halves, with_logarithmic_map);
-          test_suite_for_map(wedge_map);
+          test_suite_for_map_on_unit_cube(wedge_map);
         }
       }
     }

--- a/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
@@ -34,7 +34,7 @@ void test_shell_construction(
     const bool use_equiangular_map,
     const std::array<size_t, 2>& expected_shell_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
-    const double aspect_ratio = 1.0) {
+    const double aspect_ratio = 1.0, const bool use_logarithmic_map = false) {
   const auto domain = shell.create_domain();
   const OrientationMap<3> aligned_orientation{};
   const OrientationMap<3> quarter_turn_ccw_about_zeta(
@@ -91,41 +91,48 @@ void test_shell_construction(
   CHECK(shell.initial_extents() == expected_extents);
   CHECK(shell.initial_refinement_levels() == expected_refinement_level);
   using Wedge3DMap = CoordinateMaps::Wedge3D;
+  using Halves = Wedge3DMap::WedgeHalves;
   if (aspect_ratio == 1.0) {
     test_domain_construction(
         domain, expected_block_neighbors, expected_external_boundaries,
         make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{}, 1.0,
-                       1.0, use_equiangular_map},
+                       1.0, use_equiangular_map, Halves::Both,
+                       use_logarithmic_map},
             Wedge3DMap{inner_radius, outer_radius,
                        OrientationMap<3>{std::array<Direction<3>, 3>{
                            {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                             Direction<3>::lower_zeta()}}},
-                       1.0, 1.0, use_equiangular_map},
+                       1.0, 1.0, use_equiangular_map, Halves::Both,
+                       use_logarithmic_map},
             Wedge3DMap{
                 inner_radius, outer_radius,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                      Direction<3>::lower_eta()}}},
-                1.0, 1.0, use_equiangular_map},
+                1.0, 1.0, use_equiangular_map, Halves::Both,
+                use_logarithmic_map},
             Wedge3DMap{
                 inner_radius, outer_radius,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                      Direction<3>::upper_eta()}}},
-                1.0, 1.0, use_equiangular_map},
+                1.0, 1.0, use_equiangular_map, Halves::Both,
+                use_logarithmic_map},
             Wedge3DMap{
                 inner_radius, outer_radius,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                      Direction<3>::upper_eta()}}},
-                1.0, 1.0, use_equiangular_map},
+                1.0, 1.0, use_equiangular_map, Halves::Both,
+                use_logarithmic_map},
             Wedge3DMap{
                 inner_radius, outer_radius,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                      Direction<3>::upper_eta()}}},
-                1.0, 1.0, use_equiangular_map}
+                1.0, 1.0, use_equiangular_map, Halves::Both,
+                use_logarithmic_map}
 
             ));
   } else {
@@ -136,7 +143,8 @@ void test_shell_construction(
         make_vector(
             make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
                 Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{}, 1.0,
-                           1.0, use_equiangular_map},
+                           1.0, use_equiangular_map, Halves::Both,
+                           use_logarithmic_map},
                 compression),
             make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
                 Wedge3DMap{
@@ -144,7 +152,8 @@ void test_shell_construction(
                     OrientationMap<3>{std::array<Direction<3>, 3>{
                         {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                          Direction<3>::lower_zeta()}}},
-                    1.0, 1.0, use_equiangular_map},
+                    1.0, 1.0, use_equiangular_map, Halves::Both,
+                    use_logarithmic_map},
                 compression),
             make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
                 Wedge3DMap{
@@ -152,7 +161,8 @@ void test_shell_construction(
                     OrientationMap<3>{std::array<Direction<3>, 3>{
                         {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                          Direction<3>::lower_eta()}}},
-                    1.0, 1.0, use_equiangular_map},
+                    1.0, 1.0, use_equiangular_map, Halves::Both,
+                    use_logarithmic_map},
                 compression),
             make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
                 Wedge3DMap{
@@ -160,7 +170,8 @@ void test_shell_construction(
                     OrientationMap<3>{std::array<Direction<3>, 3>{
                         {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                          Direction<3>::upper_eta()}}},
-                    1.0, 1.0, use_equiangular_map},
+                    1.0, 1.0, use_equiangular_map, Halves::Both,
+                    use_logarithmic_map},
                 compression),
             make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
                 Wedge3DMap{
@@ -168,7 +179,8 @@ void test_shell_construction(
                     OrientationMap<3>{std::array<Direction<3>, 3>{
                         {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                          Direction<3>::upper_eta()}}},
-                    1.0, 1.0, use_equiangular_map},
+                    1.0, 1.0, use_equiangular_map, Halves::Both,
+                    use_logarithmic_map},
                 compression),
             make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
                 Wedge3DMap{
@@ -176,7 +188,8 @@ void test_shell_construction(
                     OrientationMap<3>{std::array<Direction<3>, 3>{
                         {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                          Direction<3>::upper_eta()}}},
-                    1.0, 1.0, use_equiangular_map},
+                    1.0, 1.0, use_equiangular_map, Halves::Both,
+                    use_logarithmic_map},
                 compression)
 
                 ));
@@ -186,19 +199,21 @@ void test_shell_construction(
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.Boundaries.Equiangular",
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.Boundaries",
                   "[Domain][Unit]") {
   const double inner_radius = 1.0, outer_radius = 2.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
 
-  const DomainCreators::Shell<Frame::Inertial> shell{
-      inner_radius, outer_radius, refinement_level, grid_points_r_angular,
-      true};
-  test_physical_separation(shell.create_domain().blocks());
-  test_shell_construction(shell, inner_radius, outer_radius, true,
-                          grid_points_r_angular,
-                          {6, make_array<3>(refinement_level)});
+  for (const auto& use_equiangular_map : {true, false}) {
+    const DomainCreators::Shell<Frame::Inertial> shell{
+        inner_radius, outer_radius, refinement_level, grid_points_r_angular,
+        use_equiangular_map};
+    test_physical_separation(shell.create_domain().blocks());
+    test_shell_construction(shell, inner_radius, outer_radius,
+                            use_equiangular_map, grid_points_r_angular,
+                            {6, make_array<3>(refinement_level)});
+  }
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.Factory.Equiangular",
@@ -216,21 +231,6 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.Factory.Equiangular",
       dynamic_cast<const DomainCreators::Shell<Frame::Inertial>&>(*shell),
       inner_radius, outer_radius, true, grid_points_r_angular,
       {6, make_array<3>(refinement_level)});
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.Boundaries.Equidistant",
-                  "[Domain][Unit]") {
-  const double inner_radius = 1.0, outer_radius = 2.0;
-  const size_t refinement_level = 2;
-  const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
-
-  const DomainCreators::Shell<Frame::Inertial> shell{
-      inner_radius, outer_radius, refinement_level, grid_points_r_angular,
-      false};
-  test_physical_separation(shell.create_domain().blocks());
-  test_shell_construction(shell, inner_radius, outer_radius, false,
-                          grid_points_r_angular,
-                          {6, make_array<3>(refinement_level)});
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.Factory.Equidistant",
@@ -285,4 +285,43 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.Factory.AspectRatio",
       dynamic_cast<const DomainCreators::Shell<Frame::Inertial>&>(*shell),
       inner_radius, outer_radius, false, grid_points_r_angular,
       {6, make_array<3>(refinement_level)}, aspect_ratio);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.Boundaries.LogarithmicMap",
+                  "[Domain][Unit]") {
+  const double inner_radius = 1.0, outer_radius = 2.0;
+  const size_t refinement_level = 2;
+  const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
+  const double aspect_ratio = 1.0;
+  const bool use_logarithmic_map = true;
+
+  const DomainCreators::Shell<Frame::Inertial> shell{
+      inner_radius, outer_radius, refinement_level,   grid_points_r_angular,
+      false,        aspect_ratio, use_logarithmic_map};
+  test_physical_separation(shell.create_domain().blocks());
+  test_shell_construction(
+      shell, inner_radius, outer_radius, false, grid_points_r_angular,
+      {6, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.Factory.LogarithmicMap",
+                  "[Domain][Unit]") {
+  const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+      "  Shell:\n"
+      "    InnerRadius: 1\n"
+      "    OuterRadius: 3\n"
+      "    InitialRefinement: 2\n"
+      "    InitialGridPoints: [2,3]\n"
+      "    UseEquiangularMap: false\n"
+      "    AspectRatio: 2.0        \n"
+      "    UseLogarithmicMap: true\n");
+  const double inner_radius = 1.0, outer_radius = 3.0;
+  const size_t refinement_level = 2;
+  const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
+  const double aspect_ratio = 2.0;
+  const bool use_logarithmic_map = true;
+  test_shell_construction(
+      dynamic_cast<const DomainCreators::Shell<Frame::Inertial>&>(*shell),
+      inner_radius, outer_radius, false, grid_points_r_angular,
+      {6, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map);
 }


### PR DESCRIPTION
## Proposed changes

Allows for the optional application of an exponential map to a variable in the Wedge3D coordinate map that results in a logarithmically spaced radial grid.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
