### PR TITLE
Remove duplicate entries from boost::variant type

### DIFF
--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -485,8 +485,8 @@ class AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
 
   bool terminate_{false};
   // Create a boost::variant that can hold any of the DataBox's
-  make_boost_variant_over<
-      tmpl::append<tmpl::list<db::DataBox<tmpl::list<>>>, databox_types>>
+  make_boost_variant_over<tmpl::remove_duplicates<
+      tmpl::append<tmpl::list<db::DataBox<tmpl::list<>>>, databox_types>>>
       box_;
   tuples::TaggedTupleTypelist<inbox_tags_list> inboxes_{};
   array_index array_index_;


### PR DESCRIPTION
Boost only supports a certain number of entries in a variant by
default.  (I believe 20.)  This is apparently a limit on the number of
entries in the type list, not the actual number of distinct types in
the variant.  Since most of the DataBox types in an algorithm are the
same, we can reduce the length of the list significantly by
deduplicating.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
