### PR TITLE
Loosen strictness of exception string comparison

### DIFF
--- a/tests/Unit/NumericalAlgorithms/RootFinding/Test_TOMS748.cpp
+++ b/tests/Unit/NumericalAlgorithms/RootFinding/Test_TOMS748.cpp
@@ -5,9 +5,7 @@
 
 #include <cmath>
 #include <cstddef>
-#include <iomanip>
 #include <limits>
-#include <ostream>
 #include <stdexcept>
 #include <string>
 
@@ -76,25 +74,20 @@ SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748.Bounds",
         RootFinder::toms748(f_lambda, 0.0, sqrt(2.0) - abs_tol, abs_tol,
                             rel_tol);
       },
-      std::domain_error(prefix + "0"));
+      std::domain_error(prefix));
 
-  const std::string lower_bound_string = [&abs_tol]() {
-    std::stringstream s;
-    s << std::setprecision(17) << (sqrt(2.0) + abs_tol);
-    return s.str();
-  }();
   test_throw_exception(
       [&f_lambda, &abs_tol, &rel_tol]() {
         RootFinder::toms748(f_lambda, sqrt(2.0) + abs_tol, 2.0, abs_tol,
                             rel_tol);
       },
-      std::domain_error(prefix + lower_bound_string));
+      std::domain_error(prefix));
 
   test_throw_exception(
       [&f_lambda, &abs_tol, &rel_tol]() {
         RootFinder::toms748(f_lambda, -1.0, 1.0, abs_tol, rel_tol);
       },
-      std::domain_error(prefix + "-1"));
+      std::domain_error(prefix));
 }
 
 SPECTRE_TEST_CASE("Unit.Numerical.RootFinding.TOMS748.DataVector",

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <array>
+#include <boost/algorithm/string/predicate.hpp>
 #include <cstddef>
 #include <iterator>
 #include <memory>
@@ -299,6 +300,14 @@ class DoesThrow {
   ~DoesThrow() = default;
 };
 
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Execute `func` and check that it throws an exception `expected`.
+ *
+ * \note The `.what()` strings of the thrown and `expected` exceptions are
+ * compared for a partial match only: the `expected.what()` string must be
+ * contained in (or equal to) the `.what()` string of the thrown exception.
+ */
 template <typename Exception, typename ThrowingFunctor>
 void test_throw_exception(const ThrowingFunctor& func,
                           const Exception& expected) {
@@ -309,7 +318,7 @@ void test_throw_exception(const ThrowingFunctor& func,
   } catch (Exception& e) {
     CAPTURE(e.what());
     CAPTURE(expected.what());
-    CHECK(std::string(e.what()) == std::string(expected.what()));
+    CHECK(boost::contains(std::string(e.what()), std::string(expected.what())));
   } catch (...) {
     INFO("Failed to throw exception of type " +
          pretty_type::get_name<Exception>());


### PR DESCRIPTION
## Proposed changes

Following discussion in #771, this PR changes the string comparison in `test_throw_exception`.

Where before the code checked `thrown.what() == expected.what()`, now it checks `boost::contains(thrown.what(), expected.what())`. The reduced strictness of the comparison means that (possibly environment-dependent) diagnostic details included in the thrown exception's `.what()` string do not need to be recreated for the sake of testing.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
