### PR TITLE
Add LeviCivitaIterator

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
     DataVector.cpp
     Index.cpp
     IndexIterator.cpp
+    LeviCivitaIterator.cpp
     SliceIterator.cpp
     StripeIterator.cpp
     VariablesHelpers.cpp

--- a/src/DataStructures/LeviCivitaIterator.cpp
+++ b/src/DataStructures/LeviCivitaIterator.cpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/LeviCivitaIterator.hpp"
+
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+constexpr void initialize_indexes_and_signs(
+    gsl::not_null<std::array<Index<Dim>, factorial(Dim + 1)>*> indexes,
+    gsl::not_null<std::array<int, factorial(Dim + 1)>*> signs) noexcept {
+  auto index = Index<Dim>();
+  std::iota(index.begin(), index.end(), 0);
+
+  // Add the initial index permutation to the list
+  // Also add the sign, which is always +1, because std::iota
+  // initializes the indexes as 0,1,...dim
+  (*indexes)[0] = index;
+  (*signs)[0] = 1;
+
+  size_t permutation_count = 1;
+  auto factoradic_counter = std::array<size_t, Dim>();
+
+  // std::next_permutation generates the different permuations of index,
+  // but how do you know whether the corresponding Levi Civita symbol is
+  // +1 or -1? To find out, compute the number, in the factorial number system,
+  // corresponding to each permutation, and sum the digits. If the sum is
+  // even (odd), the corresponding Levi-Civita symbol will be +1 (-1).
+  // This works because there are Dim! unique permutations of the
+  // Levi Civita symbol indices, so each one can be represented by a
+  // (dim+1)-digit factorial-number-system number. For more on the
+  // factorial number system, see
+  // https://en.wikipedia.org/wiki/Factorial_number_system
+  for (; std::next_permutation(index.begin(), index.end());) {
+    for (size_t i = 0; i < Dim; ++i) {
+      factoradic_counter[i]++;
+      if (factoradic_counter[i] < i + 1) {
+        break;
+      } else {
+        factoradic_counter[i] = 0;
+      }
+    }
+
+    (*indexes)[permutation_count] = index;
+    (*signs)[permutation_count] =
+        ((std::accumulate(factoradic_counter.begin(), factoradic_counter.end(),
+                          0) %
+          2) == 0)
+            ? 1
+            : -1;
+    ++permutation_count;
+  }
+}
+}  // namespace
+
+template <size_t Dim>
+LeviCivitaIterator<Dim>::LeviCivitaIterator() noexcept
+    : permutation_(0), valid_(true) {
+  initialize_indexes_and_signs<Dim>(&indexes_, &signs_);
+}
+
+template class LeviCivitaIterator<2>;
+template class LeviCivitaIterator<3>;
+template class LeviCivitaIterator<4>;

--- a/src/DataStructures/LeviCivitaIterator.hpp
+++ b/src/DataStructures/LeviCivitaIterator.hpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+/*!
+ * \ingroup DataStructuresGroup
+ *
+ * \brief Iterate over all nonzero index permutations for a Levi-Civita
+ * symbol.
+ *
+ * \details This class provides an iterator that allows you to loop over
+ * only the nonzero index permutations of a Levi-Civita symbol of dimension
+ * `dimension`. Inside the loop, the operator `()`
+ * returns an `Index` containing an ordered list of the indexes of this
+ * permutation, and the function `sign()` returns the sign of the Levi-Civita
+ * symbol for that permutation.
+ *
+ * \example
+ * \code
+ *   for(LeviCivitaIterator<3> it; it; ++it) {
+ *      it(); // ordered list of indexes for this permutation
+ *      it.sign(); // sign of Levi-Citivta symbol for this permutation
+ *   }
+ * \endcode
+ */
+template <std::size_t Dim>
+class LeviCivitaIterator {
+ public:
+  explicit LeviCivitaIterator() noexcept;
+
+  /// \cond HIDDEN_SYMBOLS
+  ~LeviCivitaIterator() = default;
+  // @{
+  /// No copy or move semantics
+  LeviCivitaIterator(const LeviCivitaIterator<Dim>&) = delete;
+  LeviCivitaIterator(LeviCivitaIterator<Dim>&&) = delete;
+  LeviCivitaIterator<Dim>& operator=(const LeviCivitaIterator<Dim>&) = delete;
+  LeviCivitaIterator<Dim>& operator=(LeviCivitaIterator<Dim>&&) = delete;
+  // @}
+  /// \endcond
+
+  // Return false if the end of the loop is reached
+  explicit operator bool() const noexcept { return valid_; }
+
+  // Increment the current permutation
+  LeviCivitaIterator& operator++() noexcept {
+    ++permutation_;
+    if (permutation_ < signs_.size()) {
+      valid_ = false;
+    }
+    return *this;
+  }
+
+  // Return the current (multi-index) Index, an ordered list of
+  // indices
+  const Index<Dim>& operator()() const noexcept {
+    return indexes_[permutation_];
+  }
+
+  // Return the sign of the Levi-Civita symbol with these indices
+  int sign() const noexcept { return signs_[permutation_]; }
+
+ private:
+  std::array<Index<Dim>, factorial(Dim + 1)> indexes_;
+  std::array<int, factorial(Dim + 1)> signs_;
+  size_t permutation_;
+  bool valid_;
+};

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_DenseMatrix.cpp
   Test_DenseVector.cpp
   Test_GeneralIndexIterator.cpp
+  Test_LeviCivitaIterator.cpp
   Test_IdPair.cpp
   Test_Index.cpp
   Test_IndexIterator.cpp

--- a/tests/Unit/DataStructures/Test_LeviCivitaIterator.cpp
+++ b/tests/Unit/DataStructures/Test_LeviCivitaIterator.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "DataStructures/LeviCivitaIterator.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.LeviCivitaIterator",
+                  "[DataStructures][Unit]") {
+  // Test 2D
+  std::array<int, 6> signs_2d = {{1, -1}};
+  std::array<Index<2>, 2> indexes_2d = {{Index<2>(0, 1), Index<2>(1, 0)}};
+
+  size_t i = 0;
+  for (LeviCivitaIterator<2> it; it; ++it) {
+    CHECK(it() == indexes_2d[i]);
+    CHECK(it.sign() == signs_2d[i]);
+    ++i;
+  }
+
+  // Test 3D
+  std::array<int, 6> signs_3d = {{1, -1, -1, 1, 1, -1}};
+  std::array<Index<3>, 6> indexes_3d = {{Index<3>(0, 1, 2), Index<3>(0, 2, 1),
+                                         Index<3>(1, 0, 2), Index<3>(1, 2, 0),
+                                         Index<3>(2, 0, 1), Index<3>(2, 1, 0)}};
+
+  i = 0;
+  for (LeviCivitaIterator<3> it; it; ++it) {
+    CHECK(it() == indexes_3d[i]);
+    CHECK(it.sign() == signs_3d[i]);
+    ++i;
+  }
+
+  // Test 4D
+  std::array<int, 24> signs_4d = {{1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1,
+                                   1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1}};
+  std::array<Index<4>, 24> indexes_4d = {
+      {Index<4>(0, 1, 2, 3), Index<4>(0, 1, 3, 2), Index<4>(0, 2, 1, 3),
+       Index<4>(0, 2, 3, 1), Index<4>(0, 3, 1, 2), Index<4>(0, 3, 2, 1),
+       Index<4>(1, 0, 2, 3), Index<4>(1, 0, 3, 2), Index<4>(1, 2, 0, 3),
+       Index<4>(1, 2, 3, 0), Index<4>(1, 3, 0, 2), Index<4>(1, 3, 2, 0),
+       Index<4>(2, 0, 1, 3), Index<4>(2, 0, 3, 1), Index<4>(2, 1, 0, 3),
+       Index<4>(2, 1, 3, 0), Index<4>(2, 3, 0, 1), Index<4>(2, 3, 1, 0),
+       Index<4>(3, 0, 1, 2), Index<4>(3, 0, 2, 1), Index<4>(3, 1, 0, 2),
+       Index<4>(3, 1, 2, 0), Index<4>(3, 2, 0, 1), Index<4>(3, 2, 1, 0)}};
+
+  i = 0;
+  for (LeviCivitaIterator<4> it; it; ++it) {
+    CHECK(it() == indexes_4d[i]);
+    CHECK(it.sign() == signs_4d[i]);
+    ++i;
+  }
+}


### PR DESCRIPTION
## Proposed changes

Add an iterator that loops over all nonzero index permutations for a Levi-Civita symbol of a given dimension.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
