### PR TITLE
Add LeviCivitaIterator

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
     DataVector.cpp
     Index.cpp
     IndexIterator.cpp
+    LeviCivitaIterator.cpp
     SliceIterator.cpp
     StripeIterator.cpp
     VariablesHelpers.cpp

--- a/src/DataStructures/LeviCivitaIterator.cpp
+++ b/src/DataStructures/LeviCivitaIterator.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/LeviCivitaIterator.hpp"
+
+template <size_t Dim>
+constexpr cpp17::array<cpp17::array<size_t, Dim>, factorial(Dim)>
+    LeviCivitaIterator<Dim>::indexes_;
+
+template <size_t Dim>
+constexpr cpp17::array<int, factorial(Dim)> LeviCivitaIterator<Dim>::signs_;
+
+// We don't expect to use the Dim==0 case, so only instantiate Dim==1,2,3,4
+template class LeviCivitaIterator<1>;
+template class LeviCivitaIterator<2>;
+template class LeviCivitaIterator<3>;
+template class LeviCivitaIterator<4>;

--- a/src/DataStructures/LeviCivitaIterator.hpp
+++ b/src/DataStructures/LeviCivitaIterator.hpp
@@ -1,0 +1,135 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Array.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Numeric.hpp"
+
+/*!
+ * \ingroup DataStructuresGroup
+ *
+ * \brief Iterate over all nonzero index permutations for a Levi-Civita
+ * symbol.
+ *
+ * \details This class provides an iterator that allows you to loop over
+ * only the nonzero index permutations of a Levi-Civita symbol of dimension
+ * `dimension`. Inside the loop, the operator `()`
+ * returns an `std::array` containing an ordered list of the indices of this
+ * permutation, the operator `[]` returns a specific index from the same
+ * `std::array`, and the function `sign()` returns the sign of the
+ * Levi-Civita symbol for this permutation.
+ *
+ * \example
+ * \snippet Test_LeviCivitaIterator.cpp levi_civita_iterator_example
+ */
+template <size_t Dim>
+class LeviCivitaIterator {
+ public:
+  explicit LeviCivitaIterator() noexcept = default;
+
+  /// \cond HIDDEN_SYMBOLS
+  ~LeviCivitaIterator() = default;
+  // @{
+  /// No copy or move semantics
+  LeviCivitaIterator(const LeviCivitaIterator<Dim>&) = delete;
+  LeviCivitaIterator(LeviCivitaIterator<Dim>&&) = delete;
+  LeviCivitaIterator<Dim>& operator=(const LeviCivitaIterator<Dim>&) = delete;
+  LeviCivitaIterator<Dim>& operator=(LeviCivitaIterator<Dim>&&) = delete;
+  // @}
+  /// \endcond
+
+  // Return false if the end of the loop is reached
+  explicit operator bool() const noexcept { return valid_; }
+
+  // Increment the current permutation
+  LeviCivitaIterator& operator++() noexcept {
+    ++permutation_;
+    if (permutation_ >= signs_.size()) {
+      valid_ = false;
+    }
+    return *this;
+  }
+
+  /// Return a `std::array` containing the current multi-index, an ordered list
+  /// of indices for the current permutation.
+  const std::array<size_t, Dim> operator()() const noexcept {
+    return static_cast<std::array<size_t, Dim>>(indexes_[permutation_]);
+  }
+
+  /// Return a specific index from the multi-index of the current permutation.
+  const size_t& operator[](const size_t i) const noexcept {
+    return indexes_[permutation_][i];
+  }
+
+  /// Return the sign of the Levi-Civita symbol for the current permutation.
+  int sign() const noexcept { return signs_[permutation_]; };
+
+ private:
+  static constexpr cpp17::array<cpp17::array<size_t, Dim>, factorial(Dim)>
+  indexes() noexcept {
+    cpp17::array<cpp17::array<size_t, Dim>, factorial(Dim)> indexes{};
+    cpp17::array<size_t, Dim> index{};
+    cpp2b::iota(index.begin(), index.end(), size_t(0));
+
+    indexes[0] = index;
+
+    // cpp20::next_permutation generates the different permuations of index
+    // loop over them to fill in the rest of the permutations in indexes
+    size_t permutation = 1;
+    while (cpp20::next_permutation(index.begin(), index.end())) {
+      indexes[permutation] = index;
+      ++permutation;
+    }
+    return indexes;
+  };
+
+  static constexpr cpp17::array<int, factorial(Dim)> signs() noexcept {
+    cpp17::array<int, factorial(Dim)> signs{};
+    // By construction, the sign of the first permutation is +1
+    signs[0] = 1;
+
+    // How do you know whether the corresponding Levi Civita symbol is
+    // +1 or -1? To find out, compute the number, in the factoradic number
+    // system, corresponding to each permutation, and sum the digits. If the sum
+    // is even (odd), the corresponding Levi-Civita symbol will be +1 (-1). This
+    // works because there are Dim! unique permutations of the Levi Civita
+    // symbol indices, so each one can be represented by a
+    // (`Dim`)-digit factorial-number-system number. For more on the
+    // factoradic number system, see
+    // https://en.wikipedia.org/wiki/Factorial_number_system
+    auto factoradic_counter = cpp17::array<size_t, Dim>();
+    for (size_t permutation = 1; permutation < factorial(Dim); ++permutation) {
+      for (size_t i = 0; i < Dim; ++i) {
+        factoradic_counter[i]++;
+        if (factoradic_counter[i] < i + 1) {
+          break;
+        } else {
+          factoradic_counter[i] = 0;
+        }
+      }
+      signs[permutation] =
+          (cpp2b::accumulate(factoradic_counter.begin(),
+                             factoradic_counter.end(), size_t(0)) %
+           2) == 0
+              ? 1
+              : -1;
+    }
+    return signs;
+  };
+
+  // Note: here and throughout, use cpp17::array,
+  // which is constexpr (unlike std::array), to enable constexpr signs_
+  // and indexes_.
+  static constexpr cpp17::array<cpp17::array<size_t, Dim>, factorial(Dim)>
+      indexes_ = indexes();
+  static constexpr cpp17::array<int, factorial(Dim)> signs_{signs()};
+  size_t permutation_{0};
+  bool valid_{true};
+};

--- a/src/Utilities/Algorithm.hpp
+++ b/src/Utilities/Algorithm.hpp
@@ -1,0 +1,129 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+#pragma once
+
+#include <functional>
+#include <iterator>
+
+#include "Utilities/Gsl.hpp"
+
+namespace cpp20 {
+/*!
+ * \ingroup UtilitiesGroup
+ * Reimplementation of std::swap that is constexpr;
+ * taken from the LLVM source at
+ * https://github.com/llvm-mirror/libcxx/blob/master/include/type_traits
+ */
+template <class T>
+constexpr void swap(T& a, T& b) noexcept {
+  T c(std::move(a));
+  a = std::move(b);
+  b = std::move(c);
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * Reimplementation of std::iter_swap that is constexpr;
+ * taken from the LLVM source at
+ * https://github.com/llvm-mirror/libcxx/blob/master/include/type_traits
+ */
+template <class ForwardIt1, class ForwardIt2>
+constexpr void iter_swap(ForwardIt1 a, ForwardIt2 b) {
+  swap(*a, *b);
+}
+
+namespace detail {
+/*!
+ * \ingroup UtilitiesGroup
+ * Reimplementation of std::reverse that is constexpr, for bidirectional
+ * iterators; taken from the LLVM source at
+ * https://github.com/llvm-mirror/libcxx/blob/master/include/algorithm
+ */
+template <class BidirIt>
+constexpr void reverse(BidirIt first, BidirIt last,
+                       std::bidirectional_iterator_tag /* unused */) {
+  while (first != last) {
+    if (first == --last) {
+      break;
+    }
+    cpp20::iter_swap(first, last);
+    ++first;
+  }
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * Reimplementation of std::reverse that is constexpr, for random access
+ * iterators; taken from the LLVM source at
+ * https://github.com/llvm-mirror/libcxx/blob/master/include/algorithm
+ */
+template <class RandomAccessIterator>
+constexpr void reverse(RandomAccessIterator first, RandomAccessIterator last,
+                       std::random_access_iterator_tag /* unused */) {
+  if (first != last) {
+    for (; first < --last; ++first) {
+      cpp20::iter_swap(first, last);
+    }
+  }
+}
+}  // namespace detail
+
+/*!
+ * \ingroup UtilitiesGroup
+ * Reimplementation of std::reverse that is constexpr;
+ * taken from the LLVM source at
+ * https://github.com/llvm-mirror/libcxx/blob/master/include/algorithm
+ */
+template <class BidirectionalIterator>
+constexpr void reverse(BidirectionalIterator first,
+                       BidirectionalIterator last) {
+  cpp20::detail::reverse(first, last,
+                         typename std::iterator_traits<
+                             BidirectionalIterator>::iterator_category());
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * Reimplementation of std::next_permutation that is constexpr,
+ * for a generic comparator; taken from the LLVM source at
+ * https://github.com/llvm-mirror/libcxx/blob/master/include/algorithm
+ */
+template <class Compare, class BidirectionalIterator>
+constexpr bool next_permutation(BidirectionalIterator first,
+                                BidirectionalIterator last, Compare comp) {
+  BidirectionalIterator i = last;
+  if (first == last || first == --i) {
+    return false;
+  }
+  while (true) {
+    BidirectionalIterator ip1 = i;
+    if (comp(*--i, *ip1)) {
+      BidirectionalIterator j = last;
+      while (!comp(*i, *--j)) {
+      }
+      cpp20::swap(*i, *j);
+      cpp20::reverse(ip1, last);
+      return true;
+    }
+    if (i == first) {
+      cpp20::reverse(first, last);
+      return false;
+    }
+  }
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * Reimplementation of std::next_permutation that is constexpr,
+ * with less as the comparator; taken from the LLVM source at
+ * https://github.com/llvm-mirror/libcxx/blob/master/include/algorithm
+ */
+template <class BidirectionalIterator>
+constexpr bool next_permutation(BidirectionalIterator first,
+                                BidirectionalIterator last) {
+  return cpp20::next_permutation(
+      first, last,
+      std::less<
+          typename std::iterator_traits<BidirectionalIterator>::value_type>());
+}
+}  // namespace cpp20

--- a/src/Utilities/Numeric.hpp
+++ b/src/Utilities/Numeric.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+#pragma once
+
+#include "Utilities/Gsl.hpp"
+
+/// C++ STL code present in C++2b.
+namespace cpp2b {
+/*!
+ * \ingroup UtilitiesGroup
+ * Reimplementation of std::iota that is constexpr;
+ * taken from the LLVM source at
+ * https://github.com/llvm-mirror/libcxx/blob/master/include/numeric
+ */
+template <class ForwardIterator, class T>
+constexpr void iota(ForwardIterator first, ForwardIterator last, T value) {
+  for (; first != last; ++first, (void)++value) {
+    *first = value;
+  }
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * Reimplementation of std::accumulate that is constexpr;
+ * taken from the LLVM source at
+ * https://github.com/llvm-mirror/libcxx/blob/master/include/numeric
+ */
+template <class InputIt, class T>
+constexpr T accumulate(InputIt first, InputIt last, T init) {
+  for (; first != last; ++first) {
+    init = std::move(init) + *first;  // std::move since C++20
+  }
+  return init;
+}
+}  // namespace cpp2b

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_IdPair.cpp
   Test_Index.cpp
   Test_IndexIterator.cpp
+  Test_LeviCivitaIterator.cpp
   Test_OrientVariablesOnSlice.cpp
   Test_SliceIterator.cpp
   Test_StripeIterator.cpp

--- a/tests/Unit/DataStructures/Test_LeviCivitaIterator.cpp
+++ b/tests/Unit/DataStructures/Test_LeviCivitaIterator.cpp
@@ -1,0 +1,105 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/LeviCivitaIterator.hpp"
+#include "Utilities/Gsl.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.LeviCivitaIterator",
+                  "[DataStructures][Unit]") {
+  // Test 1D
+  std::array<int, 1> signs_1d = {{1}};
+  std::array<std::array<size_t, 1>, 1> indexes_1d = {
+      {std::array<size_t, 1>{{0}}}};
+
+  size_t i = 0;
+  for (LeviCivitaIterator<1> it; it; ++it) {
+    CHECK(it() == gsl::at(indexes_1d, i));
+    CHECK(it.sign() == gsl::at(signs_1d, i));
+    ++i;
+  }
+  CHECK(i == 1);
+
+  // Test 2D
+  std::array<int, 2> signs_2d = {{1, -1}};
+  std::array<std::array<size_t, 2>, 2> indexes_2d = {
+      {std::array<size_t, 2>{{0, 1}}, std::array<size_t, 2>{{1, 0}}}};
+
+  i = 0;
+  for (LeviCivitaIterator<2> it; it; ++it) {
+    CHECK(it() == gsl::at(indexes_2d, i));
+    CHECK(it.sign() == gsl::at(signs_2d, i));
+    ++i;
+  }
+  CHECK(i == 2);
+
+  // Test 3D
+  std::array<int, 6> signs_3d = {{1, -1, -1, 1, 1, -1}};
+  std::array<std::array<size_t, 3>, 6> indexes_3d = {
+      {std::array<size_t, 3>{{0, 1, 2}}, std::array<size_t, 3>{{0, 2, 1}},
+       std::array<size_t, 3>{{1, 0, 2}}, std::array<size_t, 3>{{1, 2, 0}},
+       std::array<size_t, 3>{{2, 0, 1}}, std::array<size_t, 3>{{2, 1, 0}}}};
+
+  i = 0;
+  for (LeviCivitaIterator<3> it; it; ++it) {
+    CHECK(it() == gsl::at(indexes_3d, i));
+    CHECK(it.sign() == gsl::at(signs_3d, i));
+    ++i;
+  }
+  CHECK(i == 6);
+
+  // Test 4D
+  std::array<int, 24> signs_4d = {{1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1,
+                                   1, -1, -1, 1, 1, -1, -1, 1, 1, -1, -1, 1}};
+  std::array<std::array<size_t, 4>, 24> indexes_4d = {
+      {std::array<size_t, 4>{{0, 1, 2, 3}},
+       std::array<size_t, 4>{{0, 1, 3, 2}},
+       std::array<size_t, 4>{{0, 2, 1, 3}},
+       std::array<size_t, 4>{{0, 2, 3, 1}},
+       std::array<size_t, 4>{{0, 3, 1, 2}},
+       std::array<size_t, 4>{{0, 3, 2, 1}},
+       std::array<size_t, 4>{{1, 0, 2, 3}},
+       std::array<size_t, 4>{{1, 0, 3, 2}},
+       std::array<size_t, 4>{{1, 2, 0, 3}},
+       std::array<size_t, 4>{{1, 2, 3, 0}},
+       std::array<size_t, 4>{{1, 3, 0, 2}},
+       std::array<size_t, 4>{{1, 3, 2, 0}},
+       std::array<size_t, 4>{{2, 0, 1, 3}},
+       std::array<size_t, 4>{{2, 0, 3, 1}},
+       std::array<size_t, 4>{{2, 1, 0, 3}},
+       std::array<size_t, 4>{{2, 1, 3, 0}},
+       std::array<size_t, 4>{{2, 3, 0, 1}},
+       std::array<size_t, 4>{{2, 3, 1, 0}},
+       std::array<size_t, 4>{{3, 0, 1, 2}},
+       std::array<size_t, 4>{{3, 0, 2, 1}},
+       std::array<size_t, 4>{{3, 1, 0, 2}},
+       std::array<size_t, 4>{{3, 1, 2, 0}},
+       std::array<size_t, 4>{{3, 2, 0, 1}},
+       std::array<size_t, 4>{{3, 2, 1, 0}}}};
+
+  i = 0;
+  for (LeviCivitaIterator<4> it; it; ++it) {
+    CHECK(it() == gsl::at(indexes_4d, i));
+    CHECK(it.sign() == gsl::at(signs_4d, i));
+    ++i;
+  }
+  CHECK(i == 24);
+
+  // Demonstrate using the iterator to compute a cross product
+  /// [levi_civita_iterator_example]
+  const std::array<double, 3> vector_a = {{2.0, 3.0, 4.0}};
+  const std::array<double, 3> vector_b = {{7.0, 6.0, 5.0}};
+  const std::array<double, 3> a_cross_b_expected = {{-9.0, 18.0, -9.0}};
+
+  std::array<double, 3> a_cross_b = {{0.0, 0.0, 0.0}};
+  for (LeviCivitaIterator<3> it; it; ++it) {
+    gsl::at(a_cross_b, it[0]) +=
+        it.sign() * gsl::at(vector_a, it[1]) * gsl::at(vector_b, it[2]);
+  }
+  CHECK_ITERABLE_APPROX(a_cross_b, a_cross_b_expected);
+  /// [levi_civita_iterator_example]
+}

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Utilities")
 
 set(LIBRARY_SOURCES
+  Test_Algorithm.cpp
   Test_Array.cpp
   Test_Blas.cpp
   Test_BoostHelpers.cpp
@@ -21,6 +22,7 @@ set(LIBRARY_SOURCES
   Test_MakeVector.cpp
   Test_MakeWithValue.cpp
   Test_Math.cpp
+  Test_Numeric.cpp
   Test_Overloader.cpp
   Test_PrettyType.cpp
   Test_Rational.cpp

--- a/tests/Unit/Utilities/Test_Algorithm.cpp
+++ b/tests/Unit/Utilities/Test_Algorithm.cpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <iterator>
+
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Array.hpp"  // IWYU pragma: associated
+#include "Utilities/Numeric.hpp"
+
+constexpr bool check_swap() noexcept {
+  int x = 4;
+  int y = 444;
+  cpp20::swap(x, y);
+  return x == 444 and y == 4;
+}
+
+constexpr bool check_iter_swap() noexcept {
+  const size_t size = 6;
+  cpp17::array<size_t, size> a{};
+  cpp2b::iota(a.begin(), a.end(), size_t(1));
+  cpp20::iter_swap(a.begin() + 1, a.begin() + 4);
+
+  cpp17::array<size_t, size> expected{{1, 5, 3, 4, 2, 6}};
+  return a == expected;
+}
+
+constexpr bool check_reverse() noexcept {
+  const size_t size = 6;
+  cpp17::array<size_t, size> a{};
+  cpp2b::iota(a.begin(), a.end(), size_t(1));
+  cpp20::detail::reverse(a.begin(), a.end(), std::bidirectional_iterator_tag());
+
+  cpp17::array<size_t, size> expected{{6, 5, 4, 3, 2, 1}};
+  return a == expected;
+}
+
+constexpr bool check_reverse_random_access() noexcept {
+  const size_t size = 6;
+  cpp17::array<size_t, size> a{};
+  cpp2b::iota(a.begin(), a.end(), size_t(1));
+  // a is a random_access_iterator, so the next line tests both the generic
+  // cpp20::reverse() and the one for random access iterators
+  cpp20::reverse(a.begin(), a.end());
+
+  cpp17::array<size_t, size> expected{{6, 5, 4, 3, 2, 1}};
+  return a == expected;
+}
+
+constexpr bool check_next_permutation() noexcept {
+  const size_t size = 6;
+  cpp17::array<size_t, size> a{{1, 2, 4, 6, 3, 5}};
+  cpp20::next_permutation(a.begin(), a.end());
+
+  cpp17::array<size_t, size> expected{{1, 2, 4, 6, 5, 3}};
+  return a == expected;
+}
+
+SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
+  // Check the functions at runtime
+  CHECK(check_swap());
+  CHECK(check_iter_swap());
+  CHECK(check_reverse());
+  CHECK(check_reverse_random_access());
+  CHECK(check_next_permutation());
+
+  // Check the functions at compile time
+  static_assert(check_swap(), "Failed test Unit.Utilities.Algorithm");
+  static_assert(check_iter_swap(), "Failed test Unit.Utilities.Algorithm");
+  static_assert(check_reverse(), "Failed test Unit.Utilities.Algorithm");
+  static_assert(check_reverse_random_access(),
+                "Failed test Unit.Utilities.Algorithm");
+  static_assert(check_next_permutation(),
+                "Failed test Unit.Utilities.Algorithm");
+}

--- a/tests/Unit/Utilities/Test_Numeric.cpp
+++ b/tests/Unit/Utilities/Test_Numeric.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "Utilities/Array.hpp"  // IWYU pragma: associated
+#include "Utilities/Numeric.hpp"
+
+constexpr bool check_iota() noexcept {
+  const size_t size = 6;
+  cpp17::array<size_t, size> a{};
+  cpp2b::iota(a.begin(), a.end(), size_t(1));
+  bool check{true};
+  for (size_t i = 0; i < size; ++i) {
+    check = check and a[i] == i + 1;
+  }
+  return check;
+}
+
+constexpr bool check_accumulate() noexcept {
+  cpp17::array<size_t, 6> a{};
+  cpp2b::iota(a.begin(), a.end(), size_t(1));
+  size_t sum = cpp2b::accumulate(a.begin(), a.end(), size_t(23));
+  return sum == 44;
+}
+
+SPECTRE_TEST_CASE("Unit.Utilities.Numeric", "[Unit][Utilities]") {
+  // Check the functions at runtime
+  CHECK(check_iota());
+  CHECK(check_accumulate());
+
+  // Check the functions at compile time
+  static_assert(check_iota(), "Failed test Unit.Utilities.Numeric");
+  static_assert(check_accumulate(), "Failed test Unit.Utilities.Numeric");
+}


### PR DESCRIPTION
## Proposed changes

Add an iterator that loops over all nonzero index permutations for a Levi-Civita symbol of a given dimension. (Replaces closed PR 895, which contained a buggy version of this code.)

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->