### PR TITLE
Add separate Travis build for documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,59 +59,73 @@ matrix:
     dist: trusty
     env: CHECK_COMMITS=true
     compiler: clang
+    name: check commits
   - os: linux
     dist: trusty
     env: CHECK_FILES=true
     compiler: clang
+    name: check files
   - os: linux
     dist: trusty
     env: RUN_CLANG_TIDY=true BUILD_TYPE=Release
     compiler: clang
+    name: clang-tidy release
   - os: linux
     dist: trusty
     env: RUN_CLANG_TIDY=true BUILD_TYPE=Debug
     compiler: clang
+    name: clang-tidy debug
   - os: linux
     dist: trusty
     env: RUN_IWYU=true BUILD_TYPE=Debug
     compiler: clang
+    name: include what you use
   - os: linux
     dist: trusty
     env: TEST_CHECK_FILES=true
     compiler: clang
+    name: test check files
     # Run full builds after static analysis
   - os: linux
     compiler: gcc
     dist: trusty
     env: BUILD_TYPE=Debug COVERAGE=ON
+    name: gcc debug with coverage
   - os: linux
     compiler: gcc
     dist: trusty
     env: BUILD_TYPE=Release
+    name: gcc release
   - os: linux
     compiler: gcc-6
     dist: trusty
     env: BUILD_TYPE=Debug COMPILER=gcc-6
+    name: gcc-6 debug
   - os: linux
     compiler: gcc-6
     dist: trusty
     env: BUILD_TYPE=Release COMPILER=gcc-6
+    name: gcc-6 release
   - os: linux
     compiler: clang
     dist: trusty
     env: BUILD_TYPE=Debug
+    name: clang debug
   - os: linux
     compiler: clang
     dist: trusty
     env: BUILD_TYPE=Release
+    name: clang release
   - os: osx
     env: BUILD_TYPE=Debug
     osx_image: xcode8.3
     compiler: clang
+    name: osx debug
   - os: osx
     osx_image: xcode8.3
     env: BUILD_TYPE=Release
     compiler: clang
+    name: osx release
 
 
 # Travis allows caching of data between builds to reduce build times or perform

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,13 +45,10 @@ sudo: required
 services:
 - docker
 
-# Set up travis configurations of Linux and macOS. We use the 14.04 Ubuntu build
-# env. We target 10.11 Debug and 10.12 Release builds.
+# Set up travis configurations of Linux and macOS.
 #
 # We also have separate targets for running shell scripts that enforce what
 # would normally be done as pre-push hooks, CHECK_COMMITS and CHECK_FILES
-#
-# We run two static analyzers, and clang-tidy.
 #
 # NOTE: The static analysis targets are run first since these are typically
 #       fast to run and provide the most useful feedback.

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,11 @@ matrix:
     name: include what you use
   - os: linux
     dist: trusty
+    env: BUILD_DOC=true BUILD_TYPE=Debug
+    compiler: clang
+    name: documentation
+  - os: linux
+    dist: trusty
     env: TEST_CHECK_FILES=true
     compiler: clang
     name: test check files
@@ -298,6 +303,7 @@ script:
         --build-arg COVERALLS_TOKEN=${COVERALLS_TOKEN}
         --build-arg RUN_CLANG_TIDY=${RUN_CLANG_TIDY}
         --build-arg RUN_IWYU=${RUN_IWYU}
+        --build-arg BUILD_DOC=${BUILD_DOC}
         --build-arg USE_PCH=${USE_PCH}
         --build-arg UPSTREAM_REPO=${UPSTREAM_REPO}
         --build-arg UPSTREAM_BRANCH=${UPSTREAM_BRANCH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -283,7 +283,6 @@ script:
         --build-arg GH_PAGES_SOURCE_BRANCH=${GH_PAGES_SOURCE_BRANCH}
         --build-arg COVERALLS_TOKEN=${COVERALLS_TOKEN}
         --build-arg RUN_CLANG_TIDY=${RUN_CLANG_TIDY}
-        --build-arg RUN_CPPCHECK=${RUN_CPPCHECK}
         --build-arg RUN_IWYU=${RUN_IWYU}
         --build-arg USE_PCH=${USE_PCH}
         --build-arg UPSTREAM_REPO=${UPSTREAM_REPO}

--- a/.travis/TravisPushDocumentation.sh
+++ b/.travis/TravisPushDocumentation.sh
@@ -8,9 +8,7 @@
 
 # We use cron jobs to deploy to gh-pages. Since this still runs all jobs we
 # only actually build documentation for one job but let the others run tests.
-if [ ${CC} = gcc ] \
-&& [ ${TRAVIS_SECURE_ENV_VARS} = true ] \
-&& [ ${COVERAGE} ] \
+if [ ${TRAVIS_SECURE_ENV_VARS} = true ] \
 && [ ${TRAVIS_BRANCH} = ${GH_PAGES_SOURCE_BRANCH} ] \
 && [ ${TRAVIS_PULL_REQUEST} == false ]; then
   cd /work/gh-pages

--- a/containers/Dockerfile.travis
+++ b/containers/Dockerfile.travis
@@ -42,7 +42,6 @@ ARG GH_PAGES_REPO
 ARG GH_PAGES_SOURCE_BRANCH
 ARG COVERALLS_TOKEN
 ARG RUN_CLANG_TIDY
-ARG RUN_CPPCHECK
 ARG RUN_IWYU
 ARG USE_PCH
 ARG UPSTREAM_REPO
@@ -94,10 +93,6 @@ RUN bash -c ". /etc/profile.d/lmod.sh; \
 # Build all Charm++ modules
 RUN make module_All
 
-RUN if [ ${RUN_CPPCHECK} ]; then \
-      make cppcheck; \
-    fi
-
 RUN if [ ${RUN_CLANG_TIDY} ]; then \
       /work/spectre/.travis/RunClangTidy.sh; \
     fi
@@ -107,8 +102,7 @@ RUN if [ ${RUN_IWYU} ]; then \
     fi
 
 # TravisCI currently has 2 cores for a job, so we build on 2.
-RUN if [ -z "${RUN_CPPCHECK}" ] \
-    && [ -z "${RUN_CLANG_TIDY}" ] \
+RUN if [ -z "${RUN_CLANG_TIDY}" ] \
     && [ -z "${RUN_IWYU}" ]; then \
       bash -c ". /etc/profile.d/lmod.sh; \
                export PATH=$PATH:/work/spack/bin; \
@@ -131,7 +125,6 @@ RUN if [ -z "${RUN_CPPCHECK}" ] \
 # can search the file for warnings
 RUN if [ "${CC}" = "gcc" ] \
     && [ $BUILD_TYPE = Debug ] \
-    && [ -z "${RUN_CPPCHECK}" ] \
     && [ -z "${RUN_CLANG_TIDY}" ] \
     && [ -z "${RUN_IWYU}" ]; then \
       make doc | tee doxygen.log; \
@@ -139,7 +132,6 @@ RUN if [ "${CC}" = "gcc" ] \
     fi
 
 RUN if [ "${CHARM_CC}" = "gcc" ] \
-    && [ -z "${RUN_CPPCHECK}" ] \
     && [ -z "${RUN_CLANG_TIDY}" ] \
     && [ -z "${RUN_IWYU}" ] \
     && [ ${COVERAGE} = ON ]; then \
@@ -167,7 +159,6 @@ RUN if [ "${CHARM_CC}" = "gcc" ] \
 # for one job but let the others run tests, i.e.
 # we add documentation only for one specific build matrix entry.
 RUN if [ ${CC} = gcc ] \
-    && [ -z "${RUN_CPPCHECK}" ] \
     && [ -z "${RUN_CLANG_TIDY}" ] \
     && [ -z "${RUN_IWYU}" ] \
     && [ ${TRAVIS_SECURE_ENV_VARS} = true ] \
@@ -191,8 +182,7 @@ RUN if [ ${CC} = gcc ] \
     fi
 
 # push documentation to GitHub pages
-RUN if  [ -z "${RUN_CPPCHECK}" ] \
-    && [ -z "${RUN_CLANG_TIDY}" ] \
+RUN if [ -z "${RUN_CLANG_TIDY}" ] \
     && [ -z "${RUN_IWYU}" ]; then \
       /work/spectre/.travis/TravisPushDocumentation.sh; \
     fi

--- a/containers/Dockerfile.travis
+++ b/containers/Dockerfile.travis
@@ -43,6 +43,7 @@ ARG GH_PAGES_SOURCE_BRANCH
 ARG COVERALLS_TOKEN
 ARG RUN_CLANG_TIDY
 ARG RUN_IWYU
+ARG BUILD_DOC
 ARG USE_PCH
 ARG UPSTREAM_REPO
 ARG UPSTREAM_BRANCH
@@ -103,7 +104,8 @@ RUN if [ ${RUN_IWYU} ]; then \
 
 # TravisCI currently has 2 cores for a job, so we build on 2.
 RUN if [ -z "${RUN_CLANG_TIDY}" ] \
-    && [ -z "${RUN_IWYU}" ]; then \
+    && [ -z "${RUN_IWYU}" ] \
+    && [ -z "${BUILD_DOC}" ]; then \
       bash -c ". /etc/profile.d/lmod.sh; \
                export PATH=$PATH:/work/spack/bin; \
                . /work/spack/share/spack/setup-env.sh; \
@@ -123,10 +125,7 @@ RUN if [ -z "${RUN_CLANG_TIDY}" ] \
 
 # Check documentation output for warnings write to stdout and to file so we
 # can search the file for warnings
-RUN if [ "${CC}" = "gcc" ] \
-    && [ $BUILD_TYPE = Debug ] \
-    && [ -z "${RUN_CLANG_TIDY}" ] \
-    && [ -z "${RUN_IWYU}" ]; then \
+RUN if [ ${BUILD_DOC} ]; then \
       make doc | tee doxygen.log; \
       ! grep 'warning' ./doxygen.log; \
     fi
@@ -134,6 +133,7 @@ RUN if [ "${CC}" = "gcc" ] \
 RUN if [ "${CHARM_CC}" = "gcc" ] \
     && [ -z "${RUN_CLANG_TIDY}" ] \
     && [ -z "${RUN_IWYU}" ] \
+    && [ -z "${BUILD_DOC}" ] \
     && [ ${COVERAGE} = ON ]; then \
     bash -c ". /etc/profile.d/lmod.sh; \
                export PATH=$PATH:/work/spack/bin; \
@@ -158,11 +158,8 @@ RUN if [ "${CHARM_CC}" = "gcc" ] \
 # Since this still runs all jobs we only actually build documentation
 # for one job but let the others run tests, i.e.
 # we add documentation only for one specific build matrix entry.
-RUN if [ ${CC} = gcc ] \
-    && [ -z "${RUN_CLANG_TIDY}" ] \
-    && [ -z "${RUN_IWYU}" ] \
+RUN if [ ${BUILD_DOC} ] \
     && [ ${TRAVIS_SECURE_ENV_VARS} = true ] \
-    && [ ${COVERAGE} ] \
     && [ ${TRAVIS_BRANCH} = ${GH_PAGES_SOURCE_BRANCH} ] \
     && [ ${TRAVIS_PULL_REQUEST} = false ]; then \
       make doc-coverage; \
@@ -182,7 +179,6 @@ RUN if [ ${CC} = gcc ] \
     fi
 
 # push documentation to GitHub pages
-RUN if [ -z "${RUN_CLANG_TIDY}" ] \
-    && [ -z "${RUN_IWYU}" ]; then \
+RUN if [ ${BUILD_DOC} ]; then \
       /work/spectre/.travis/TravisPushDocumentation.sh; \
     fi


### PR DESCRIPTION
## Proposed changes

Name builds and add a separate build for documentation

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
