### PR TITLE
Add Newman and Hamlin method for inverting GRMHD variables

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -7,6 +7,8 @@ set(LIBRARY_SOURCES
   Characteristics.cpp
   ConservativeFromPrimitive.cpp
   Fluxes.cpp
+  NewmanHamlin.cpp
+  PrimitiveFromConservative.cpp
   Sources.cpp
   )
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.cpp
@@ -1,0 +1,181 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
+
+#include <algorithm>
+#include <array>
+#include <boost/none.hpp>
+#include <cmath>
+#include <limits>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Overloader.hpp"
+
+// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+
+/// \cond
+namespace grmhd {
+namespace ValenciaDivClean {
+namespace PrimitiveRecoverySchemes {
+
+template <size_t ThermodynamicDim>
+boost::optional<PrimitiveRecoveryData> NewmanHamlin::apply(
+    const double total_energy_density, const double momentum_density_squared,
+    const double momentum_density_dot_magnetic_field,
+    const double magnetic_field_squared,
+    const double rest_mass_density_times_lorentz_factor,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) noexcept {
+  // constant in cubic equation  f(eps) = eps^3 - a eps^2 + d
+  // whose root is being found at each point in the iteration below
+  const double d_in_cubic =
+      0.5 * (momentum_density_squared * magnetic_field_squared -
+             square(momentum_density_dot_magnetic_field));
+  if (UNLIKELY(0.0 > d_in_cubic)) {
+    // May need to allow small negative values, Francois Foucart suggests
+    // -1e-12*momentum_density_dot_magnetic_field
+    ERROR("Newman Hamlin inversion: unphysical d.");
+  }
+
+  const double initial_guess_for_pressure{0.0};
+  // bound needed so cubic equation has a positive root
+  const double minimum_pressure = cbrt(6.75 * d_in_cubic) -
+                                  total_energy_density -
+                                  0.5 * magnetic_field_squared;
+  double current_pressure =
+      std::max(minimum_pressure, initial_guess_for_pressure);
+  double previous_pressure{std::numeric_limits<double>::signaling_NaN()};
+  size_t iteration_step{0};
+  std::array<double, 3> aitken_pressure{
+      {current_pressure, std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+  size_t valid_entries_in_aitken_pressure = 1;
+  bool converged = false;
+
+  while (true) {  // will break when relative pressure change is < 1e-10
+    if (max_iterations_ == iteration_step and not converged) {
+      return boost::none;
+    }
+
+    ++iteration_step;
+    previous_pressure = current_pressure;
+    // enforces NH Eq.(5.9): d <= (4/27) a^3 so cubic has positive root
+    current_pressure = std::max(current_pressure, minimum_pressure);
+    const double a_in_cubic =
+        total_energy_density + current_pressure + 0.5 * magnetic_field_squared;
+
+    ASSERT(a_in_cubic >= 0.0,
+           "Newman Hamlin inversion:  unphysical a = " << a_in_cubic);
+
+    // NH Eq. (5.10): d = (4/27) a^3 cos^2(phi)
+    const double phi = acos(sqrt(6.75 * d_in_cubic / cube(a_in_cubic)));
+    // NH Eq. (5.11) with l=1 is desired positive root
+    const double root_of_cubic =
+        (a_in_cubic / 3.0) * (1.0 - 2.0 * cos((2.0 / 3.0) * (M_PI + phi)));
+    // NH Eq. (5.5) with their script L being rho_h_w_squared
+    // where rho is rest_mass_density, h is specific_enthalpy,
+    // and w is the lorentz factor
+    const double rho_h_w_squared = root_of_cubic - magnetic_field_squared;
+
+    ASSERT(rho_h_w_squared > 0.0,
+           "Newman Hamlin inversion:  unphysical rho_h_w_squared = "
+               << rho_h_w_squared);
+    // NH Eq. (5.2) with (5.5) substituted in denominator
+    const double v_squared =
+        (momentum_density_squared * square(rho_h_w_squared) +
+         square(momentum_density_dot_magnetic_field) *
+             (magnetic_field_squared + 2.0 * rho_h_w_squared)) /
+        square(rho_h_w_squared * root_of_cubic);
+
+    // If this fails, there was code in the Bitbucket version that adjusted
+    // the pressure to get the maximum allowed velocity in atmosphere.
+    // Instead, we could return boost::none and try the next inversion method.
+    ASSERT(0.0 <= v_squared and v_squared < 1.0,
+           "Newman Hamlin inversion:  unphysical v_squared = " << v_squared);
+
+    const double current_lorentz_factor = sqrt(1.0 / (1.0 - v_squared));
+    const double current_rest_mass_density =
+        rest_mass_density_times_lorentz_factor / current_lorentz_factor;
+
+    if (converged) {
+      return PrimitiveRecoveryData{current_rest_mass_density,
+                                   current_lorentz_factor, current_pressure,
+                                   rho_h_w_squared};
+    }
+
+    const double current_specific_enthalpy =
+        rho_h_w_squared /
+        (current_rest_mass_density * square(current_lorentz_factor));
+    current_pressure = get(make_overloader(
+        [&current_rest_mass_density](
+            const EquationsOfState::EquationOfState<true, 1>&
+                the_equation_of_state) noexcept {
+          return the_equation_of_state.pressure_from_density(
+              Scalar<double>(current_rest_mass_density));
+        },
+        [&current_rest_mass_density, &current_specific_enthalpy ](
+            const EquationsOfState::EquationOfState<true, 2>&
+                the_equation_of_state) noexcept {
+          return the_equation_of_state.pressure_from_density_and_enthalpy(
+              Scalar<double>(current_rest_mass_density),
+              Scalar<double>(current_specific_enthalpy));
+        })(equation_of_state));
+
+    gsl::at(aitken_pressure, valid_entries_in_aitken_pressure++) =
+        current_pressure;
+    if (3 == valid_entries_in_aitken_pressure) {
+      const double aitken_residual = (aitken_pressure[2] - aitken_pressure[1]) /
+                                     (aitken_pressure[1] - aitken_pressure[0]);
+      if (0.0 <= aitken_residual and aitken_residual < 1.0) {
+        previous_pressure = current_pressure;
+        current_pressure =
+            aitken_pressure[1] +
+            (aitken_pressure[2] - aitken_pressure[1]) / (1.0 - aitken_residual);
+        aitken_pressure = {{current_pressure,
+                            std::numeric_limits<double>::signaling_NaN(),
+                            std::numeric_limits<double>::signaling_NaN()}};
+        valid_entries_in_aitken_pressure = 1;
+      } else {
+        // Aitken extrapolation failed, retain latest 2 values for next attempt
+        aitken_pressure[0] = aitken_pressure[1];
+        aitken_pressure[1] = aitken_pressure[2];
+        valid_entries_in_aitken_pressure = 2;
+      }
+    }
+    if (fabs(current_pressure - previous_pressure) <
+        relative_tolerance_ * (current_pressure + previous_pressure)) {
+      converged = true;
+      // note primitives are recomputed above before being returned
+    }
+  }  // while loop
+}
+}  // namespace PrimitiveRecoverySchemes
+}  // namespace ValenciaDivClean
+}  // namespace grmhd
+
+#define THERMODIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define INSTANTIATION(_, data)                                                 \
+  template boost::optional<grmhd::ValenciaDivClean::PrimitiveRecoverySchemes:: \
+                               PrimitiveRecoveryData>                          \
+  grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin::apply<      \
+      THERMODIM(data)>(                                                        \
+      const double total_energy_density,                                       \
+      const double momentum_density_squared,                                   \
+      const double momentum_density_dot_magnetic_field,                        \
+      const double magnetic_field_squared,                                     \
+      const double rest_mass_density_times_lorentz_factor,                     \
+      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&          \
+          equation_of_state) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+
+#undef INSTANTIATION
+#undef THERMODIM
+/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <string>
+
+#include "PointwiseFunctions/EquationsOfState/EquationOfState.hpp"
+
+// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+
+namespace grmhd {
+namespace ValenciaDivClean {
+namespace PrimitiveRecoverySchemes {
+
+/// \cond
+struct PrimitiveRecoveryData;
+/// \endcond
+
+/*!
+ * \brief Compute the primitive variables from the conservative variables using
+ * the scheme of [Newman and Hamlin, SIAM J. Sci. Comput., 36(4)
+ * B661-B683 (2014)](https://epubs.siam.org/doi/10.1137/140956749).
+ *
+ * In the Newman and Hamlin paper, `total_energy_density` is \f$e\f$,
+ * `momentum_density_squared` is\f${\cal M}^2\f$,
+ * `momentum_density_dot_magnetic_field` is \f${\cal T}\f$,
+ * `magnetic_field_squared` is \f${\cal B}^2\f$, and
+ * `rest_mass_density_times_lorentz_factor` is \f${\tilde \rho}\f$.
+ * Furthermore, the returned `PrimitiveRecoveryData.rho_h_w_squared` is \f${\cal
+ * L}\f$.
+ *
+ * In terms of the conservative variables (in our notation):
+ * \f{align}
+ * e = & \frac{{\tilde D} + {\tilde \tau}}{\sqrt{\gamma}} \\
+ * {\cal M}^2 = & \frac{\gamma^{mn} {\tilde S}_m {\tilde S}_n}{\gamma} \\
+ * {\cal T} = & \frac{{\tilde B}^m {\tilde S}_m}{\gamma} \\
+ * {\cal B}^2 = & \frac{\gamma_{mn} {\tilde B}^m {\tilde B}^n}{\gamma} \\
+ * {\tilde \rho} = & \frac{\tilde D}{\sqrt{\gamma}}
+ * \f}
+ *
+ * where the conserved variables \f${\tilde D}\f$, \f${\tilde S}_i\f$,
+ * \f${\tilde \tau}\f$, and \f${\tilde B}^i\f$ are a generalized mass-energy
+ * density, momentum density, specific internal energy density, and magnetic
+ * field, and \f$\gamma\f$ and \f$\gamma^{mn}\f$ are the determinant and inverse
+ * of the spatial metric \f$\gamma_{mn}\f$.
+ */
+class NewmanHamlin {
+ public:
+  template <size_t ThermodynamicDim>
+  static boost::optional<PrimitiveRecoveryData> apply(
+      double total_energy_density, double momentum_density_squared,
+      double momentum_density_dot_magnetic_field, double magnetic_field_squared,
+      double rest_mass_density_times_lorentz_factor,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+          equation_of_state) noexcept;
+
+  static const std::string name() noexcept { return "Newman Hamlin"; }
+
+ private:
+  static constexpr size_t max_iterations_ = 50;
+  static constexpr double relative_tolerance_ = 1.e-10;
+};
+}  // namespace PrimitiveRecoverySchemes
+}  // namespace ValenciaDivClean
+}  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -1,0 +1,148 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+
+#include <boost/optional/optional.hpp>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
+#include "PointwiseFunctions/EquationsOfState/SpecificEnthalpy.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Overloader.hpp"
+
+// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_include <array>
+
+/// \cond
+namespace grmhd {
+namespace ValenciaDivClean {
+
+template <typename PrimitiveRecoveryScheme, size_t ThermodynamicDim>
+void primitive_from_conservative(
+    gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
+    gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+    gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+    gsl::not_null<Scalar<DataVector>*> pressure,
+    gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_phi,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) noexcept {
+  get(*divergence_cleaning_field) =
+      get(tilde_phi) / get(sqrt_det_spatial_metric);
+  for (size_t i = 0; i < 3; ++i) {
+    magnetic_field->get(i) = tilde_b.get(i) / get(sqrt_det_spatial_metric);
+  }
+  const DataVector total_energy_density =
+      (get(tilde_tau) + get(tilde_d)) / get(sqrt_det_spatial_metric);
+  const auto tilde_s_upper = raise_or_lower_index(tilde_s, inv_spatial_metric);
+  const DataVector momentum_density_squared =
+      get(dot_product(tilde_s, tilde_s_upper)) /
+      square(get(sqrt_det_spatial_metric));
+  const DataVector momentum_density_dot_magnetic_field =
+      get(dot_product(tilde_s, *magnetic_field)) / get(sqrt_det_spatial_metric);
+  const DataVector magnetic_field_squared =
+      get(dot_product(*magnetic_field, *magnetic_field, spatial_metric));
+  const DataVector rest_mass_density_times_lorentz_factor =
+      get(tilde_d) / get(sqrt_det_spatial_metric);
+
+  for (size_t s = 0; s < total_energy_density.size(); ++s) {
+    const boost::optional<PrimitiveRecoverySchemes::PrimitiveRecoveryData>
+        primitive_data =
+            PrimitiveRecoveryScheme::template apply<ThermodynamicDim>(
+                total_energy_density[s], momentum_density_squared[s],
+                momentum_density_dot_magnetic_field[s],
+                magnetic_field_squared[s],
+                rest_mass_density_times_lorentz_factor[s], equation_of_state);
+
+    if (primitive_data) {
+      get(*rest_mass_density)[s] = primitive_data.get().rest_mass_density;
+      const double coefficient_of_b =
+          momentum_density_dot_magnetic_field[s] /
+          (primitive_data.get().rho_h_w_squared *
+           (primitive_data.get().rho_h_w_squared + magnetic_field_squared[s]));
+      const double coefficient_of_s =
+          1.0 /
+          (get(sqrt_det_spatial_metric)[s] *
+           (primitive_data.get().rho_h_w_squared + magnetic_field_squared[s]));
+      for (size_t i = 0; i < 3; ++i) {
+        spatial_velocity->get(i)[s] =
+            coefficient_of_b * magnetic_field->get(i)[s] +
+            coefficient_of_s * tilde_s_upper.get(i)[s];
+      }
+      get(*lorentz_factor)[s] = primitive_data.get().lorentz_factor;
+      get(*pressure)[s] = primitive_data.get().pressure;
+    } else {
+      ERROR(PrimitiveRecoveryScheme::name()
+            << " primitive inversion scheme failed.");
+    }
+  }
+  *specific_internal_energy = make_overloader(
+      [&rest_mass_density](const EquationsOfState::EquationOfState<true, 1>&
+                               the_equation_of_state) noexcept {
+        return the_equation_of_state.specific_internal_energy_from_density(
+            *rest_mass_density);
+      },
+      [&rest_mass_density,
+       &pressure ](const EquationsOfState::EquationOfState<true, 2>&
+                       the_equation_of_state) noexcept {
+        return the_equation_of_state
+            .specific_internal_energy_from_density_and_pressure(
+                *rest_mass_density, *pressure);
+      })(equation_of_state);
+  *specific_enthalpy = EquationsOfState::specific_enthalpy(
+      *rest_mass_density, *specific_internal_energy, *pressure);
+}
+}  // namespace ValenciaDivClean
+}  // namespace grmhd
+
+#define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(_, data)                                                \
+  template void grmhd::ValenciaDivClean::primitive_from_conservative<         \
+      RECOVERY(data), THERMODIM(data)>(                                       \
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,                   \
+      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,            \
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>                 \
+          spatial_velocity,                                                   \
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field, \
+      gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,           \
+      gsl::not_null<Scalar<DataVector>*> lorentz_factor,                      \
+      gsl::not_null<Scalar<DataVector>*> pressure,                            \
+      gsl::not_null<Scalar<DataVector>*> specific_enthalpy,                   \
+      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau, \
+      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,                 \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                 \
+      const Scalar<DataVector>& tilde_phi,                                    \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,         \
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,     \
+      const Scalar<DataVector>& sqrt_det_spatial_metric,                      \
+      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&         \
+          equation_of_state) noexcept;
+
+GENERATE_INSTANTIATIONS(
+    INSTANTIATION,
+    (grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin), (1, 2))
+
+#undef INSTANTIATION
+#undef THERMODIM
+#undef RECOVERY
+/// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
@@ -1,0 +1,56 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/EquationsOfState/EquationOfState.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+class DataVector;
+/// \endcond
+
+// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+// IWYU pragma: no_forward_declare Tensor
+
+namespace grmhd {
+namespace ValenciaDivClean {
+/*!
+ * \brief Compute the primitive variables from the conservative variables
+ *
+ * For the Valencia formulation of the GRMHD system with divergence cleaning,
+ * the conversion of the evolved conserved variables to the primitive variables
+ * cannot be expressed in closed analytic form and requires a root find.
+ *
+ * [Siegel {\em et al}, The Astrophysical Journal 859:71(2018)]
+ * (http://iopscience.iop.org/article/10.3847/1538-4357/aabcc5/meta)
+ * compares several inversion methods.
+ */
+template <typename PrimitiveRecoveryScheme, size_t ThermodynamicDim>
+void primitive_from_conservative(
+    gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
+    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
+    gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+    gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+    gsl::not_null<Scalar<DataVector>*> pressure,
+    gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+    const Scalar<DataVector>& tilde_phi,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) noexcept;
+}  // namespace ValenciaDivClean
+}  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace grmhd {
+namespace ValenciaDivClean {
+
+/// \brief Schemes for recovering primitive variables from conservative
+/// variables.
+namespace PrimitiveRecoverySchemes {
+
+/*!
+ * \brief Data determined by PrimitiveRecoverySchemes at a single grid point.
+ *
+ * `rho_h_w_squared` is \f$\rho h W^2\f$ where \f$\rho\f$ is the rest mass
+ * density, \f$h\f$ is the specific enthalpy, and \f$W\f$ is the Lorentz factor.
+ */
+struct PrimitiveRecoveryData {
+  const double rest_mass_density;
+  const double lorentz_factor;
+  const double pressure;
+  const double rho_h_w_squared;
+};
+}  // namespace PrimitiveRecoverySchemes
+}  // namespace ValenciaDivClean
+}  // namespace grmhd

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/PrimitiveFromConservative.cpp
@@ -62,7 +62,7 @@ class FunctionOfZ {
             },
             [&rho, &epsilon ](const EquationsOfState::EquationOfState<true, 2>&
                                   equation_of_state) noexcept {
-              return equation_of_state.pressure_from_density(
+              return equation_of_state.pressure_from_density_and_energy(
                   Scalar<double>(rho), Scalar<double>(epsilon));
             })(equation_of_state_)
             .get();
@@ -131,7 +131,7 @@ void primitive_from_conservative(
       [&rest_mass_density, &specific_internal_energy ](
           const EquationsOfState::EquationOfState<true, 2>&
               the_equation_of_state) noexcept {
-        return the_equation_of_state.pressure_from_density(
+        return the_equation_of_state.pressure_from_density_and_energy(
             *rest_mass_density, *specific_internal_energy);
       })(equation_of_state);
 

--- a/src/PointwiseFunctions/EquationsOfState/CMakeLists.txt
+++ b/src/PointwiseFunctions/EquationsOfState/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   DarkEnergyFluid.cpp
   IdealFluid.cpp
   PolytropicFluid.cpp
+  SpecificEnthalpy.cpp
   )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/EquationsOfState/DarkEnergyFluid.cpp
+++ b/src/PointwiseFunctions/EquationsOfState/DarkEnergyFluid.cpp
@@ -16,8 +16,8 @@ template <bool IsRelativistic>
 DarkEnergyFluid<IsRelativistic>::DarkEnergyFluid(
     const double parameter_w) noexcept
     : parameter_w_(parameter_w) {
-  if (parameter_w_ == 0.0) {
-    ERROR("The w(z) parameter must not be 0.");
+  if (parameter_w_ <= 0.0) {
+    ERROR("The w(z) parameter must be positive.");
   }
 }
 
@@ -39,16 +39,28 @@ void DarkEnergyFluid<IsRelativistic>::pup(PUP::er& p) noexcept {
 
 template <bool IsRelativistic>
 template <class DataType>
-Scalar<DataType> DarkEnergyFluid<IsRelativistic>::pressure_from_density_impl(
+Scalar<DataType>
+DarkEnergyFluid<IsRelativistic>::pressure_from_density_and_energy_impl(
     const Scalar<DataType>& rest_mass_density,
     const Scalar<DataType>& specific_internal_energy) const noexcept {
   return Scalar<DataType>{parameter_w_ * get(rest_mass_density) *
                           (1.0 + get(specific_internal_energy))};
 }
 
+template <bool IsRelativistic>
+template <class DataType>
+Scalar<DataType>
+DarkEnergyFluid<IsRelativistic>::pressure_from_density_and_enthalpy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_enthalpy) const noexcept {
+  return Scalar<DataType>{(parameter_w_ / (parameter_w_ + 1.0)) *
+                          get(rest_mass_density) * get(specific_enthalpy)};
+}
+
 template <>
 template <class DataType>
-Scalar<DataType> DarkEnergyFluid<true>::specific_enthalpy_from_density_impl(
+Scalar<DataType>
+DarkEnergyFluid<true>::specific_enthalpy_from_density_and_energy_impl(
     const Scalar<DataType>& /*rest_mass_density*/,
     const Scalar<DataType>& specific_internal_energy) const noexcept {
   return Scalar<DataType>{(1.0 + parameter_w_) *
@@ -57,17 +69,18 @@ Scalar<DataType> DarkEnergyFluid<true>::specific_enthalpy_from_density_impl(
 
 template <bool IsRelativistic>
 template <class DataType>
-Scalar<DataType>
-DarkEnergyFluid<IsRelativistic>::specific_internal_energy_from_density_impl(
-    const Scalar<DataType>& rest_mass_density,
-    const Scalar<DataType>& pressure) const noexcept {
+Scalar<DataType> DarkEnergyFluid<IsRelativistic>::
+    specific_internal_energy_from_density_and_pressure_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& pressure) const noexcept {
   return Scalar<DataType>{
       get(pressure) / (parameter_w_ * get(rest_mass_density)) - 1.0};
 }
 
 template <bool IsRelativistic>
 template <class DataType>
-Scalar<DataType> DarkEnergyFluid<IsRelativistic>::chi_from_density_impl(
+Scalar<DataType>
+DarkEnergyFluid<IsRelativistic>::chi_from_density_and_energy_impl(
     const Scalar<DataType>& /*rest_mass_density*/,
     const Scalar<DataType>& specific_internal_energy) const noexcept {
   return Scalar<DataType>{parameter_w_ * (1.0 + get(specific_internal_energy))};
@@ -76,7 +89,7 @@ Scalar<DataType> DarkEnergyFluid<IsRelativistic>::chi_from_density_impl(
 template <bool IsRelativistic>
 template <class DataType>
 Scalar<DataType> DarkEnergyFluid<IsRelativistic>::
-    kappa_times_p_over_rho_squared_from_density_impl(
+    kappa_times_p_over_rho_squared_from_density_and_energy_impl(
         const Scalar<DataType>& /*rest_mass_density*/,
         const Scalar<DataType>& specific_internal_energy) const noexcept {
   return Scalar<DataType>{square(parameter_w_) *

--- a/src/PointwiseFunctions/EquationsOfState/DarkEnergyFluid.hpp
+++ b/src/PointwiseFunctions/EquationsOfState/DarkEnergyFluid.hpp
@@ -3,7 +3,13 @@
 
 #pragma once
 
+#include <boost/preprocessor/arithmetic/dec.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/control/expr_iif.hpp>
+#include <boost/preprocessor/list/adt.hpp>
+#include <boost/preprocessor/repetition/for.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/to_list.hpp>
 #include <limits>
 #include <pup.h>
 
@@ -27,10 +33,8 @@ namespace EquationsOfState {
  * p = w(z) \rho ( 1.0 + \epsilon)
  * \f]
  * where \f$\rho\f$ is the rest mass density, \f$\epsilon\f$ is the specific
- * internal energy, and \f$w(z)\f$ is a parameter depending on the redshift
+ * internal energy, and \f$w(z) > 0\f$ is a parameter depending on the redshift
  * \f$z\f$.
- *
- * \warning The numerical implementation requires \f$w\neq0\f$.
  */
 template <bool IsRelativistic>
 class DarkEnergyFluid : public EquationOfState<IsRelativistic, 2> {
@@ -62,13 +66,13 @@ class DarkEnergyFluid : public EquationOfState<IsRelativistic, 2> {
 
   explicit DarkEnergyFluid(double parameter_w) noexcept;
 
-  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(DarkEnergyFluid, 2);
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(DarkEnergyFluid, 2)
 
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(EquationOfState<IsRelativistic, 2>), DarkEnergyFluid);
 
  private:
-  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2);
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2)
 
   double parameter_w_ = std::numeric_limits<double>::signaling_NaN();
 };

--- a/src/PointwiseFunctions/EquationsOfState/IdealFluid.cpp
+++ b/src/PointwiseFunctions/EquationsOfState/IdealFluid.cpp
@@ -31,7 +31,8 @@ void IdealFluid<IsRelativistic>::pup(PUP::er& p) noexcept {
 
 template <bool IsRelativistic>
 template <class DataType>
-Scalar<DataType> IdealFluid<IsRelativistic>::pressure_from_density_impl(
+Scalar<DataType>
+IdealFluid<IsRelativistic>::pressure_from_density_and_energy_impl(
     const Scalar<DataType>& rest_mass_density,
     const Scalar<DataType>& specific_internal_energy) const noexcept {
   return Scalar<DataType>{get(rest_mass_density) *
@@ -41,7 +42,27 @@ Scalar<DataType> IdealFluid<IsRelativistic>::pressure_from_density_impl(
 
 template <>
 template <class DataType>
-Scalar<DataType> IdealFluid<true>::specific_enthalpy_from_density_impl(
+Scalar<DataType> IdealFluid<true>::pressure_from_density_and_enthalpy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_enthalpy) const noexcept {
+  return Scalar<DataType>{get(rest_mass_density) *
+                          (get(specific_enthalpy) - 1.0) *
+                          (adiabatic_index_ - 1.0) / adiabatic_index_};
+}
+
+template <>
+template <class DataType>
+Scalar<DataType> IdealFluid<false>::pressure_from_density_and_enthalpy_impl(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_enthalpy) const noexcept {
+  return Scalar<DataType>{get(rest_mass_density) * get(specific_enthalpy) *
+                          (adiabatic_index_ - 1.0) / adiabatic_index_};
+}
+
+template <>
+template <class DataType>
+Scalar<DataType>
+IdealFluid<true>::specific_enthalpy_from_density_and_energy_impl(
     const Scalar<DataType>& /*rest_mass_density*/,
     const Scalar<DataType>& specific_internal_energy) const noexcept {
   return Scalar<DataType>{1.0 +
@@ -50,7 +71,8 @@ Scalar<DataType> IdealFluid<true>::specific_enthalpy_from_density_impl(
 
 template <>
 template <class DataType>
-Scalar<DataType> IdealFluid<false>::specific_enthalpy_from_density_impl(
+Scalar<DataType>
+IdealFluid<false>::specific_enthalpy_from_density_and_energy_impl(
     const Scalar<DataType>& /*rest_mass_density*/,
     const Scalar<DataType>& specific_internal_energy) const noexcept {
   return Scalar<DataType>{adiabatic_index_ * get(specific_internal_energy)};
@@ -58,17 +80,17 @@ Scalar<DataType> IdealFluid<false>::specific_enthalpy_from_density_impl(
 
 template <bool IsRelativistic>
 template <class DataType>
-Scalar<DataType>
-IdealFluid<IsRelativistic>::specific_internal_energy_from_density_impl(
-    const Scalar<DataType>& rest_mass_density,
-    const Scalar<DataType>& pressure) const noexcept {
+Scalar<DataType> IdealFluid<IsRelativistic>::
+    specific_internal_energy_from_density_and_pressure_impl(
+        const Scalar<DataType>& rest_mass_density,
+        const Scalar<DataType>& pressure) const noexcept {
   return Scalar<DataType>{1.0 / (adiabatic_index_ - 1.0) * get(pressure) /
                           get(rest_mass_density)};
 }
 
 template <bool IsRelativistic>
 template <class DataType>
-Scalar<DataType> IdealFluid<IsRelativistic>::chi_from_density_impl(
+Scalar<DataType> IdealFluid<IsRelativistic>::chi_from_density_and_energy_impl(
     const Scalar<DataType>& /*rest_mass_density*/,
     const Scalar<DataType>& specific_internal_energy) const noexcept {
   return Scalar<DataType>{get(specific_internal_energy) *
@@ -77,10 +99,10 @@ Scalar<DataType> IdealFluid<IsRelativistic>::chi_from_density_impl(
 
 template <bool IsRelativistic>
 template <class DataType>
-Scalar<DataType>
-IdealFluid<IsRelativistic>::kappa_times_p_over_rho_squared_from_density_impl(
-    const Scalar<DataType>& /*rest_mass_density*/,
-    const Scalar<DataType>& specific_internal_energy) const noexcept {
+Scalar<DataType> IdealFluid<IsRelativistic>::
+    kappa_times_p_over_rho_squared_from_density_and_energy_impl(
+        const Scalar<DataType>& /*rest_mass_density*/,
+        const Scalar<DataType>& specific_internal_energy) const noexcept {
   return Scalar<DataType>{square(adiabatic_index_ - 1.0) *
                           get(specific_internal_energy)};
 }

--- a/src/PointwiseFunctions/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/EquationsOfState/IdealFluid.hpp
@@ -3,7 +3,13 @@
 
 #pragma once
 
+#include <boost/preprocessor/arithmetic/dec.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/control/expr_iif.hpp>
+#include <boost/preprocessor/list/adt.hpp>
+#include <boost/preprocessor/repetition/for.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/to_list.hpp>
 #include <limits>
 #include <pup.h>
 
@@ -55,13 +61,13 @@ class IdealFluid : public EquationOfState<IsRelativistic, 2> {
 
   explicit IdealFluid(double adiabatic_index) noexcept;
 
-  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(IdealFluid, 2);
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(IdealFluid, 2)
 
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(EquationOfState<IsRelativistic, 2>), IdealFluid);
 
  private:
-  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2);
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(2)
 
   double adiabatic_index_ = std::numeric_limits<double>::signaling_NaN();
 };

--- a/src/PointwiseFunctions/EquationsOfState/PolytropicFluid.cpp
+++ b/src/PointwiseFunctions/EquationsOfState/PolytropicFluid.cpp
@@ -24,19 +24,6 @@ EQUATION_OF_STATE_MEMBER_DEFINITIONS(template <bool IsRelativistic>,
                                      DataVector, 1)
 
 template <bool IsRelativistic>
-Scalar<double> PolytropicFluid<IsRelativistic>::rest_mass_density_from_enthalpy(
-    const Scalar<double>& specific_enthalpy) const noexcept {
-  return rest_mass_density_from_enthalpy_impl(specific_enthalpy);
-}
-
-template <bool IsRelativistic>
-Scalar<DataVector>
-PolytropicFluid<IsRelativistic>::rest_mass_density_from_enthalpy(
-    const Scalar<DataVector>& specific_enthalpy) const noexcept {
-  return rest_mass_density_from_enthalpy_impl(specific_enthalpy);
-}
-
-template <bool IsRelativistic>
 PolytropicFluid<IsRelativistic>::PolytropicFluid(
     CkMigrateMessage* /*unused*/) noexcept {}
 

--- a/src/PointwiseFunctions/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/EquationsOfState/PolytropicFluid.hpp
@@ -3,7 +3,13 @@
 
 #pragma once
 
+#include <boost/preprocessor/arithmetic/dec.hpp>
+#include <boost/preprocessor/arithmetic/inc.hpp>
+#include <boost/preprocessor/control/expr_iif.hpp>
+#include <boost/preprocessor/list/adt.hpp>
+#include <boost/preprocessor/repetition/for.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
+#include <boost/preprocessor/tuple/to_list.hpp>
 #include <limits>
 #include <pup.h>
 
@@ -61,22 +67,13 @@ class PolytropicFluid : public EquationOfState<IsRelativistic, 1> {
   PolytropicFluid(double polytropic_constant,
                   double polytropic_exponent) noexcept;
 
-  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(PolytropicFluid, 1);
-
-  Scalar<double> rest_mass_density_from_enthalpy(
-      const Scalar<double>& specific_enthalpy) const noexcept override;
-  Scalar<DataVector> rest_mass_density_from_enthalpy(
-      const Scalar<DataVector>& specific_enthalpy) const noexcept override;
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBERS(PolytropicFluid, 1)
 
   WRAPPED_PUPable_decl_base_template(  // NOLINT
       SINGLE_ARG(EquationOfState<IsRelativistic, 1>), PolytropicFluid);
 
  private:
-  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(1);
-
-  template <class DataType>
-  Scalar<DataType> rest_mass_density_from_enthalpy_impl(
-      const Scalar<DataType>& specific_enthalpy) const noexcept;
+  EQUATION_OF_STATE_FORWARD_DECLARE_MEMBER_IMPLS(1)
 
   double polytropic_constant_ = std::numeric_limits<double>::signaling_NaN();
   double polytropic_exponent_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/EquationsOfState/SpecificEnthalpy.cpp
+++ b/src/PointwiseFunctions/EquationsOfState/SpecificEnthalpy.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/EquationsOfState/SpecificEnthalpy.hpp"
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+/// \cond
+namespace EquationsOfState {
+template <typename DataType>
+Scalar<DataType> specific_enthalpy(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const Scalar<DataType>& pressure) noexcept {
+  return Scalar<DataType>{1.0 + get(specific_internal_energy) +
+                          get(pressure) / get(rest_mass_density)};
+}
+
+}  // namespace EquationsOfState
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                        \
+  template Scalar<DTYPE(data)> EquationsOfState::specific_enthalpy( \
+      const Scalar<DTYPE(data)>& rest_mass_density,                 \
+      const Scalar<DTYPE(data)>& specific_internal_energy,          \
+      const Scalar<DTYPE(data)>& pressure) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+/// \endcond

--- a/src/PointwiseFunctions/EquationsOfState/SpecificEnthalpy.hpp
+++ b/src/PointwiseFunctions/EquationsOfState/SpecificEnthalpy.hpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+namespace EquationsOfState {
+/*!
+ * \ingroup EquationsOfStateGroup
+ * \brief Computes the relativistic specific enthalpy \f$h\f$ as:
+ * \f$ h = 1 + \epsilon + \frac{p}{\rho} \f$
+ * where \f$\epsilon\f$ is the specific internal energy, \f$p\f$
+ * is the pressure, and \f$\rho\f$ is the rest mass density.
+ */
+template <typename DataType>
+Scalar<DataType> specific_enthalpy(
+    const Scalar<DataType>& rest_mass_density,
+    const Scalar<DataType>& specific_internal_energy,
+    const Scalar<DataType>& pressure) noexcept;
+}  // namespace EquationsOfState

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_Characteristics.cpp
   Test_ConservativeFromPrimitive.cpp
   Test_Fluxes.cpp
+  Test_PrimitiveFromConservative.cpp
   Test_Sources.cpp
   Test_ValenciaDivClean.cpp
   )

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
@@ -1,0 +1,264 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <utility>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "PointwiseFunctions/EquationsOfState/EquationOfState.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Overloader.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+#include "tests/Utilities/RandomUnitNormal.hpp"
+
+// IWYU pragma: no_forward_declare EquationsOfState::EquationOfState
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_include <array>
+
+namespace grmhd {
+namespace ValenciaDivClean {
+namespace PrimitiveRecoverySchemes {
+class NewmanHamlin;
+}  // namespace PrimitiveRecoverySchemes
+}  // namespace ValenciaDivClean
+}  // namespace grmhd
+
+namespace {
+
+Scalar<DataVector> random_density(const gsl::not_null<std::mt19937*> generator,
+                                  const DataVector& used_for_size) noexcept {
+  // 1 g/cm^3 = 1.62e-18 in geometric units
+  constexpr double minimum_density = 1.0e-5;
+  constexpr double maximum_density = 1.0e-3;
+  std::uniform_real_distribution<> distribution(log(minimum_density),
+                                                log(maximum_density));
+  return Scalar<DataVector>{exp(make_with_random_values<DataVector>(
+      generator, make_not_null(&distribution), used_for_size))};
+}
+
+Scalar<DataVector> random_lorentz_factor(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataVector& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-10.0, 3.0);
+  return Scalar<DataVector>{
+      1.0 + exp(make_with_random_values<DataVector>(
+                generator, make_not_null(&distribution), used_for_size))};
+}
+
+tnsr::I<DataVector, 3> random_velocity(
+    const gsl::not_null<std::mt19937*> generator,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::ii<DataVector, 3>& spatial_metric) noexcept {
+  tnsr::I<DataVector, 3> spatial_velocity =
+      random_unit_normal(generator, spatial_metric);
+  const DataVector v = sqrt(1.0 - 1.0 / square(get(lorentz_factor)));
+  get<0>(spatial_velocity) *= v;
+  get<1>(spatial_velocity) *= v;
+  get<2>(spatial_velocity) *= v;
+  return spatial_velocity;
+}
+
+tnsr::I<DataVector, 3> random_magnetic_field(
+    const gsl::not_null<std::mt19937*> generator,
+    const Scalar<DataVector>& pressure,
+    const tnsr::ii<DataVector, 3>& spatial_metric) noexcept {
+  tnsr::I<DataVector, 3> magnetic_field =
+      random_unit_normal(generator, spatial_metric);
+  std::uniform_real_distribution<> distribution(-8.0, 14.0);
+  const size_t number_of_points = get(pressure).size();
+  for (size_t s = 0; s < number_of_points; ++s) {
+    // magnitude of B set to vary ratio of magnetic pressure to fluid pressure
+    const double B = sqrt(get(pressure)[s] * exp(distribution(*generator)));
+    get<0>(magnetic_field)[s] *= B;
+    get<1>(magnetic_field)[s] *= B;
+    get<2>(magnetic_field)[s] *= B;
+  }
+  return magnetic_field;
+}
+
+// temperature in MeV
+Scalar<DataVector> random_temperature(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataVector& used_for_size) noexcept {
+  constexpr double minimum_temperature = 1.0;
+  constexpr double maximum_temperature = 50.0;
+  std::uniform_real_distribution<> distribution(log(minimum_temperature),
+                                                log(maximum_temperature));
+  return Scalar<DataVector>{exp(make_with_random_values<DataVector>(
+      generator, make_not_null(&distribution), used_for_size))};
+}
+
+// assumes gamma = 4/3 ideal fluid
+Scalar<DataVector> random_specific_internal_energy(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataVector& used_for_size) noexcept {
+  // assumes Ideal gas with gamma = 4/3
+  // For ideal fluid T = (m/k_b)(gamma - 1) epsilon
+  // where m = atomic mass unit, k_b = Boltzmann constant
+  return Scalar<DataVector>{3.21e-3 *
+                            get(random_temperature(generator, used_for_size))};
+}
+
+Scalar<DataVector> random_divergence_cleaning_field(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataVector& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-10.0, 10.0);
+  return make_with_random_values<Scalar<DataVector>>(
+      generator, make_not_null(&distribution), used_for_size);
+}
+
+tnsr::ii<DataVector, 3> random_spatial_metric(
+    const gsl::not_null<std::mt19937*> generator,
+    const DataVector& used_for_size) noexcept {
+  std::uniform_real_distribution<> distribution(-0.05, 0.05);
+  auto spatial_metric = make_with_random_values<tnsr::ii<DataVector, 3>>(
+      generator, make_not_null(&distribution), used_for_size);
+  for (size_t d = 0; d < 3; ++d) {
+    spatial_metric.get(d, d) += 1.0;
+  }
+  return spatial_metric;
+}
+
+Scalar<DataVector> specific_enthalpy(
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& pressure) noexcept {
+  return Scalar<DataVector>{1.0 + get(specific_internal_energy) +
+                            get(pressure) / get(rest_mass_density)};
+}
+
+template <typename PrimitiveRecoveryScheme, size_t ThermodynamicDim>
+void test_primitive_from_conservative(
+    const gsl::not_null<std::mt19937*> generator,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state,
+    const DataVector& used_for_size) noexcept {
+  // generate random primitives with interesting astrophysical values
+  const auto expected_rest_mass_density =
+      random_density(generator, used_for_size);
+  const auto expected_lorentz_factor =
+      random_lorentz_factor(generator, used_for_size);
+  const auto spatial_metric = random_spatial_metric(generator, used_for_size);
+  const auto expected_spatial_velocity =
+      random_velocity(generator, expected_lorentz_factor, spatial_metric);
+  const auto expected_specific_internal_energy = make_overloader(
+      [&expected_rest_mass_density](
+          const EquationsOfState::EquationOfState<true, 1>&
+              the_equation_of_state) noexcept {
+        return the_equation_of_state.specific_internal_energy_from_density(
+            expected_rest_mass_density);
+      },
+      [&generator,
+       &used_for_size ](const EquationsOfState::EquationOfState<true, 2>&
+                        /*the_equation_of_state*/) noexcept {
+        // note this call assumes an ideal fluid
+        return random_specific_internal_energy(generator, used_for_size);
+      })(equation_of_state);
+  const auto expected_pressure = make_overloader(
+      [&expected_rest_mass_density](
+          const EquationsOfState::EquationOfState<true, 1>&
+              the_equation_of_state) noexcept {
+        return the_equation_of_state.pressure_from_density(
+            expected_rest_mass_density);
+      },
+      [&expected_rest_mass_density, &expected_specific_internal_energy ](
+          const EquationsOfState::EquationOfState<true, 2>&
+              the_equation_of_state) noexcept {
+        return the_equation_of_state.pressure_from_density_and_energy(
+            expected_rest_mass_density, expected_specific_internal_energy);
+      })(equation_of_state);
+
+  const auto expected_specific_enthalpy =
+      specific_enthalpy(expected_rest_mass_density,
+                        expected_specific_internal_energy, expected_pressure);
+  const auto expected_magnetic_field =
+      random_magnetic_field(generator, expected_pressure, spatial_metric);
+  const auto expected_divergence_cleaning_field =
+      random_divergence_cleaning_field(generator, used_for_size);
+
+  const auto det_and_inv = determinant_and_inverse(spatial_metric);
+  const auto& inv_spatial_metric = det_and_inv.second;
+  const Scalar<DataVector> sqrt_det_spatial_metric =
+      Scalar<DataVector>{sqrt(get(det_and_inv.first))};
+
+  const size_t number_of_points = used_for_size.size();
+  Scalar<DataVector> tilde_d(number_of_points);
+  Scalar<DataVector> tilde_tau(number_of_points);
+  tnsr::i<DataVector, 3> tilde_s(number_of_points);
+  tnsr::I<DataVector, 3> tilde_b(number_of_points);
+  Scalar<DataVector> tilde_phi(number_of_points);
+
+  grmhd::ValenciaDivClean::conservative_from_primitive(
+      make_not_null(&tilde_d), make_not_null(&tilde_tau),
+      make_not_null(&tilde_s), make_not_null(&tilde_b),
+      make_not_null(&tilde_phi), expected_rest_mass_density,
+      expected_specific_internal_energy, expected_specific_enthalpy,
+      expected_pressure, expected_spatial_velocity, expected_lorentz_factor,
+      expected_magnetic_field, sqrt_det_spatial_metric, spatial_metric,
+      expected_divergence_cleaning_field);
+
+  Scalar<DataVector> rest_mass_density(number_of_points);
+  Scalar<DataVector> specific_internal_energy(number_of_points);
+  tnsr::I<DataVector, 3> spatial_velocity(number_of_points);
+  tnsr::I<DataVector, 3> magnetic_field(number_of_points);
+  Scalar<DataVector> divergence_cleaning_field(number_of_points);
+  Scalar<DataVector> lorentz_factor(number_of_points);
+  Scalar<DataVector> pressure(number_of_points);
+  Scalar<DataVector> specific_enthalpy(number_of_points);
+  grmhd::ValenciaDivClean::primitive_from_conservative<PrimitiveRecoveryScheme,
+                                                       ThermodynamicDim>(
+      make_not_null(&rest_mass_density),
+      make_not_null(&specific_internal_energy),
+      make_not_null(&spatial_velocity), make_not_null(&magnetic_field),
+      make_not_null(&divergence_cleaning_field), make_not_null(&lorentz_factor),
+      make_not_null(&pressure), make_not_null(&specific_enthalpy), tilde_d,
+      tilde_tau, tilde_s, tilde_b, tilde_phi, spatial_metric,
+      inv_spatial_metric, sqrt_det_spatial_metric, equation_of_state);
+
+  Approx larger_approx =
+      Approx::custom().epsilon(std::numeric_limits<double>::epsilon() * 1.e7);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_rest_mass_density, rest_mass_density,
+                               larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_specific_internal_energy,
+                               specific_internal_energy, larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_lorentz_factor, lorentz_factor,
+                               larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_specific_enthalpy, specific_enthalpy,
+                               larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_pressure, pressure, larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_spatial_velocity, spatial_velocity,
+                               larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_magnetic_field, magnetic_field,
+                               larger_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(expected_divergence_cleaning_field,
+                               divergence_cleaning_field, larger_approx);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.PrimitiveFromConservative",
+                  "[Unit][GrMhd]") {
+  std::random_device r;
+  const auto seed = r();
+  std::mt19937 generator(seed);
+  INFO("seed = " << seed);
+
+  EquationsOfState::PolytropicFluid<true> polytropic_fluid(100.0, 2.0);
+  EquationsOfState::IdealFluid<true> ideal_fluid(4.0 / 3.0);
+  const DataVector dv(5);
+  test_primitive_from_conservative<
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin, 1>(
+      &generator, polytropic_fluid, dv);
+  test_primitive_from_conservative<
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin, 2>(
+      &generator, ideal_fluid, dv);
+}

--- a/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/RelativisticEuler/Valencia/Test_PrimitiveFromConservative.cpp
@@ -146,7 +146,7 @@ void test_primitive_from_conservative(
       [&expected_rest_mass_density, &expected_specific_internal_energy ](
           const EquationsOfState::EquationOfState<true, 2>&
               the_equation_of_state) noexcept {
-        return the_equation_of_state.pressure_from_density(
+        return the_equation_of_state.pressure_from_density_and_energy(
             expected_rest_mass_density, expected_specific_internal_energy);
       })(equation_of_state);
 

--- a/tests/Unit/PointwiseFunctions/EquationsOfState/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/EquationsOfState/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_DarkEnergyFluid.cpp
   Test_IdealFluid.cpp
   Test_PolytropicFluid.cpp
+  Test_SpecificEnthalpy.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/EquationsOfState/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/EquationsOfState/TestFunctions.py
@@ -118,3 +118,13 @@ def polytropic_kappa_times_p_over_rho_squared_from_density(
 
 
 # End functions for testing PolytropicFluid.cpp
+
+
+# Functions for testing SpecificEnthalpy.cpp
+
+
+def specific_enthalpy(rest_mass_density, specific_internal_energy, pressure):
+    return pressure / rest_mass_density + 1.0 + specific_internal_energy
+
+
+# End functions for testing SpecificEnthalpy.cpp

--- a/tests/Unit/PointwiseFunctions/EquationsOfState/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/EquationsOfState/TestFunctions.py
@@ -5,27 +5,33 @@ import numpy as np
 
 
 # Functions for testing DarkEnergyFluid.cpp
-def dark_energy_fluid_pressure_from_density(
+def dark_energy_fluid_pressure_from_density_and_energy(
         rest_mass_density, specific_internal_energy, parameter_w):
     return parameter_w * rest_mass_density * (1.0 + specific_internal_energy)
 
 
-def dark_energy_fluid_rel_specific_enthalpy_from_density(
+def dark_energy_fluid_rel_pressure_from_density_and_enthalpy(
+        rest_mass_density, specific_enthalpy, parameter_w):
+    return (parameter_w * rest_mass_density *
+            specific_enthalpy / (parameter_w + 1.0))
+
+
+def dark_energy_fluid_rel_specific_enthalpy_from_density_and_energy(
         rest_mass_density, specific_internal_energy, parameter_w):
     return (parameter_w + 1.0) * (1.0 + specific_internal_energy)
 
 
-def dark_energy_fluid_specific_internal_energy_from_density(
+def dark_energy_fluid_specific_internal_energy_from_density_and_pressure(
         rest_mass_density, pressure, parameter_w):
     return pressure / (parameter_w * rest_mass_density) - 1.0
 
 
-def dark_energy_fluid_chi_from_density(rest_mass_density,
-                                       specific_internal_energy, parameter_w):
+def dark_energy_fluid_chi_from_density_and_energy(
+        rest_mass_density, specific_internal_energy, parameter_w):
     return parameter_w * (1.0 + specific_internal_energy)
 
 
-def dark_energy_fluid_kappa_times_p_over_rho_squared_from_density(
+def dark_energy_fluid_kappa_times_p_over_rho_squared_from_density_and_energy(
         rest_mass_density, specific_internal_energy, parameter_w):
     return parameter_w**2 * (1.0 + specific_internal_energy)
 
@@ -34,33 +40,45 @@ def dark_energy_fluid_kappa_times_p_over_rho_squared_from_density(
 
 
 # Functions for testing IdealFluid.cpp
-def ideal_fluid_pressure_from_density(
+def ideal_fluid_pressure_from_density_and_energy(
         rest_mass_density, specific_internal_energy, adiabatic_index):
     return rest_mass_density * specific_internal_energy * (
         adiabatic_index - 1.0)
 
 
-def ideal_fluid_rel_specific_enthalpy_from_density(
+def ideal_fluid_rel_pressure_from_density_and_enthalpy(
+        rest_mass_density, specific_enthalpy, adiabatic_index):
+    return (rest_mass_density * (specific_enthalpy - 1.0) *
+            (adiabatic_index - 1.0) / adiabatic_index)
+
+
+def ideal_fluid_newt_pressure_from_density_and_enthalpy(
+        rest_mass_density, specific_enthalpy, adiabatic_index):
+    return (rest_mass_density * specific_enthalpy *
+            (adiabatic_index - 1.0) / adiabatic_index)
+
+
+def ideal_fluid_rel_specific_enthalpy_from_density_and_energy(
         rest_mass_density, specific_internal_energy, adiabatic_index):
     return 1.0 + adiabatic_index * specific_internal_energy
 
 
-def ideal_fluid_newt_specific_enthalpy_from_density(
+def ideal_fluid_newt_specific_enthalpy_from_density_and_energy(
         rest_mass_density, specific_internal_energy, adiabatic_index):
     return adiabatic_index * specific_internal_energy
 
 
-def ideal_fluid_specific_internal_energy_from_density(
+def ideal_fluid_specific_internal_energy_from_density_and_pressure(
         rest_mass_density, pressure, adiabatic_index):
     return pressure / (adiabatic_index - 1.0) / rest_mass_density
 
 
-def ideal_fluid_chi_from_density(rest_mass_density, specific_internal_energy,
-                                 adiabatic_index):
+def ideal_fluid_chi_from_density_and_energy(
+        rest_mass_density, specific_internal_energy, adiabatic_index):
     return specific_internal_energy * (adiabatic_index - 1.0)
 
 
-def ideal_fluid_kappa_times_p_over_rho_squared_from_density(
+def ideal_fluid_kappa_times_p_over_rho_squared_from_density_and_energy(
         rest_mass_density, specific_internal_energy, adiabatic_index):
     return specific_internal_energy * (adiabatic_index - 1.0)**2
 

--- a/tests/Unit/PointwiseFunctions/EquationsOfState/Test_DarkEnergyFluid.cpp
+++ b/tests/Unit/PointwiseFunctions/EquationsOfState/Test_DarkEnergyFluid.cpp
@@ -25,26 +25,18 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.DarkEnergyFluid",
       "PointwiseFunctions/EquationsOfState/"};
   const double d_for_size = std::numeric_limits<double>::signaling_NaN();
   const DataVector dv_for_size(5);
-  TestHelpers::EquationsOfState::check(EoS::DarkEnergyFluid<true>(-1.0),
-                                       "dark_energy_fluid", d_for_size, -1.0);
+
   TestHelpers::EquationsOfState::check(EoS::DarkEnergyFluid<true>(1.0),
                                        "dark_energy_fluid", d_for_size, 1.0);
   TestHelpers::EquationsOfState::check(EoS::DarkEnergyFluid<true>(1.0 / 3.0),
                                        "dark_energy_fluid", dv_for_size,
                                        1.0 / 3.0);
-  TestHelpers::EquationsOfState::check(EoS::DarkEnergyFluid<true>(-1.0),
-                                       "dark_energy_fluid", dv_for_size, -1.0);
   TestHelpers::EquationsOfState::check(EoS::DarkEnergyFluid<true>(1.0),
                                        "dark_energy_fluid", dv_for_size, 1.0);
   TestHelpers::EquationsOfState::check(EoS::DarkEnergyFluid<true>(1.0 / 3.0),
                                        "dark_energy_fluid", d_for_size,
                                        1.0 / 3.0);
 
-  TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<true, 2>>(
-          {"  DarkEnergyFluid:\n"
-           "    ParameterW: -1.0\n"}),
-      "dark_energy_fluid", d_for_size, -1.0);
   TestHelpers::EquationsOfState::check(
       test_factory_creation<EoS::EquationOfState<true, 2>>(
           {"  DarkEnergyFluid:\n"
@@ -56,11 +48,6 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.DarkEnergyFluid",
            "    ParameterW: 0.3333333333333333\n"}),
       "dark_energy_fluid", d_for_size, 1.0 / 3.0);
 
-  TestHelpers::EquationsOfState::check(
-      test_factory_creation<EoS::EquationOfState<true, 2>>(
-          {"  DarkEnergyFluid:\n"
-           "    ParameterW: -1.0\n"}),
-      "dark_energy_fluid", dv_for_size, -1.0);
   TestHelpers::EquationsOfState::check(
       test_factory_creation<EoS::EquationOfState<true, 2>>(
           {"  DarkEnergyFluid:\n"

--- a/tests/Unit/PointwiseFunctions/EquationsOfState/Test_SpecificEnthalpy.cpp
+++ b/tests/Unit/PointwiseFunctions/EquationsOfState/Test_SpecificEnthalpy.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "PointwiseFunctions/EquationsOfState/SpecificEnthalpy.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace {
+
+template <typename DataType>
+void test_specific_enthalpy(const DataType& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      &EquationsOfState::specific_enthalpy<DataType>, "TestFunctions",
+      "specific_enthalpy", {{{0.01, 1.0}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.SpecificEnthalpy",
+                  "[Unit][EquationsOfState]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/EquationsOfState"};
+
+  test_specific_enthalpy(std::numeric_limits<double>::signaling_NaN());
+  test_specific_enthalpy(DataVector(5));
+}


### PR DESCRIPTION
## Proposed changes

To discuss:  
- what is best way of handling multiple recovery methods
- how to generalize EoS to enable Newman-Hamlin for arbitrary EoS

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

