### PR TITLE
Allow time steppers to prevent local time-stepping

### DIFF
--- a/src/Time/TimeSteppers/RungeKutta3.hpp
+++ b/src/Time/TimeSteppers/RungeKutta3.hpp
@@ -75,6 +75,14 @@ class RungeKutta3 : public TimeStepper::Inherit {
   TimeId next_time_id(const TimeId& current_id,
                       const TimeDelta& time_step) const noexcept override;
 
+  template <typename Vars, typename DerivVars>
+  bool can_change_step_size(const TimeId& /*time_id*/,
+                            const TimeSteppers::History<Vars, DerivVars>&
+                                /*history*/) const noexcept {
+    // This integrator does not support local time-stepping.
+    return false;
+  }
+
   WRAPPED_PUPable_decl_template(RungeKutta3);  // NOLINT
 
   explicit RungeKutta3(CkMigrateMessage* /*unused*/) noexcept {}

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -5,11 +5,15 @@
 
 #include <memory>
 // IWYU pragma: no_include <pup.h>
+#include <string>
 #include <tuple>
+#include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "Time/Actions/ChangeStepSize.hpp"
+#include "Time/History.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/Constant.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
@@ -18,6 +22,8 @@
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"
+#include "Time/TimeSteppers/RungeKutta3.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/ActionTesting.hpp"
@@ -26,22 +32,33 @@ namespace {
 using step_choosers = tmpl::list<StepChoosers::Register::Constant>;
 using change_step_size = Actions::ChangeStepSize<step_choosers>;
 
+struct Var : db::SimpleTag {
+  static std::string name() noexcept { return "Var"; }
+  using type = double;
+};
+
+struct System {
+  using variables_tag = Var;
+};
+
 struct Metavariables;
 using component =
     ActionTesting::MockArrayComponent<Metavariables, int, tmpl::list<>>;
 
 struct Metavariables {
+  using system = System;
   using component_list = tmpl::list<component>;
   using const_global_cache_tag_list = change_step_size::const_global_cache_tags;
 };
 
-void check(const bool time_runs_forward, const Time& time, const double request,
-           const TimeDelta& expected_step) noexcept {
+void check(const bool time_runs_forward,
+           std::unique_ptr<TimeStepper> time_stepper, const Time& time,
+           const double request, const TimeDelta& expected_step) noexcept {
   CAPTURE(time);
   CAPTURE(request);
 
   ActionTesting::ActionRunner<Metavariables> runner{
-      {std::make_unique<TimeSteppers::AdamsBashforthN>(1),
+      {std::move(time_stepper),
        make_vector<std::unique_ptr<StepChooser<step_choosers>>>(
            std::make_unique<StepChoosers::Constant<step_choosers>>(
                2. * request),
@@ -50,12 +67,17 @@ void check(const bool time_runs_forward, const Time& time, const double request,
                2. * request)),
        std::make_unique<StepControllers::BinaryFraction>()}};
 
+  const TimeDelta initial_step_size =
+      (time_runs_forward ? 1 : -1) * time.slab().duration();
+  using history_tag = Tags::HistoryEvolvedVariables<Var, Tags::dt<Var>>;
   auto box =
       db::create<db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>,
-                                   Tags::TimeStep>>(
+                                   Tags::TimeStep, history_tag>>(
           TimeId(time_runs_forward, 0, time),
-          TimeId(time_runs_forward, 0, time.slab().start()),
-          (time_runs_forward ? 1 : -1) * time.slab().duration());
+          TimeId(time_runs_forward, 0,
+                 (time_runs_forward ? time.slab().start() : time.slab().end()) +
+                     initial_step_size),
+          initial_step_size, db::item_type<history_tag>{});
   box = std::get<0>(runner.apply<component, change_step_size>(box, 0));
 
   CHECK(db::get<Tags::TimeStep>(box) == expected_step);
@@ -67,12 +89,21 @@ void check(const bool time_runs_forward, const Time& time, const double request,
 SPECTRE_TEST_CASE("Unit.Time.Actions.ChangeStepSize", "[Unit][Time][Actions]") {
   const Slab slab(-5., -2.);
   const double slab_length = slab.duration().value();
-  check(true, slab.start() + slab.duration() / 4, slab_length / 5.,
+  check(true, std::make_unique<TimeSteppers::AdamsBashforthN>(1),
+        slab.start() + slab.duration() / 4, slab_length / 5.,
         slab.duration() / 8);
-  check(true, slab.start() + slab.duration() / 4, slab_length,
-        slab.duration() / 4);
-  check(false, slab.end() - slab.duration() / 4, slab_length / 5.,
+  check(true, std::make_unique<TimeSteppers::AdamsBashforthN>(1),
+        slab.start() + slab.duration() / 4, slab_length, slab.duration() / 4);
+  check(false, std::make_unique<TimeSteppers::AdamsBashforthN>(1),
+        slab.end() - slab.duration() / 4, slab_length / 5.,
         -slab.duration() / 8);
-  check(false, slab.end() - slab.duration() / 4, slab_length,
-        -slab.duration() / 4);
+  check(false, std::make_unique<TimeSteppers::AdamsBashforthN>(1),
+        slab.end() - slab.duration() / 4, slab_length, -slab.duration() / 4);
+  // The current step size used in the test function is the entire
+  // slab.  RK3 does not support local time-stepping, so this action
+  // should do nothing.
+  check(true, std::make_unique<TimeSteppers::RungeKutta3>(), slab.start(),
+        slab_length / 5., slab.duration());
+  check(false, std::make_unique<TimeSteppers::RungeKutta3>(), slab.end(),
+        slab_length / 5., -slab.duration());
 }

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -45,6 +45,22 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
       TimeStepperTestUtils::integrate_test(stepper, start_points, 1., epsilon);
     }
   }
+
+  const TimeSteppers::AdamsBashforthN stepper(2);
+  const Slab slab(0., 1.);
+  const TimeId time_id(true, 0, slab.start());
+  {
+    TimeSteppers::History<double, double> history;
+    history.insert(slab.start(), 0., 0.);
+    history.insert(slab.end(), 0., 0.);
+    CHECK(stepper.can_change_step_size(time_id, history));
+  }
+  {
+    TimeSteppers::History<double, double> history;
+    history.insert(slab.end(), 0., 0.);
+    history.insert(slab.start(), 0., 0.);
+    CHECK_FALSE(stepper.can_change_step_size(time_id, history));
+  }
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Variable",
@@ -85,6 +101,22 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Backwards",
           TimeSteppers::AdamsBashforthN(order, true), start_points, -1.,
           epsilon);
     }
+  }
+
+  const TimeSteppers::AdamsBashforthN stepper(2);
+  const Slab slab(0., 1.);
+  const TimeId time_id(false, 0, slab.start());
+  {
+    TimeSteppers::History<double, double> history;
+    history.insert(slab.start(), 0., 0.);
+    history.insert(slab.end(), 0., 0.);
+    CHECK_FALSE(stepper.can_change_step_size(time_id, history));
+  }
+  {
+    TimeSteppers::History<double, double> history;
+    history.insert(slab.end(), 0., 0.);
+    history.insert(slab.start(), 0., 0.);
+    CHECK(stepper.can_change_step_size(time_id, history));
   }
 }
 

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -4,6 +4,9 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include "Parallel/PupStlCpp11.hpp"
+#include "Time/History.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -15,6 +18,13 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3", "[Unit][Time]") {
   const TimeSteppers::RungeKutta3 stepper{};
   TimeStepperTestUtils::check_substep_properties(stepper);
   TimeStepperTestUtils::integrate_test(stepper, 0, 1., 1e-9);
+
+  const Slab slab(0., 1.);
+  const TimeId time_id(true, 0, slab.start());
+  TimeSteppers::History<double, double> history;
+  CHECK_FALSE(stepper.can_change_step_size(time_id, history));
+  history.insert(slab.start(), 0., 0.);
+  CHECK_FALSE(stepper.can_change_step_size(time_id, history));
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Variable",
@@ -27,6 +37,13 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Backwards",
                   "[Unit][Time]") {
   const TimeSteppers::RungeKutta3 stepper{};
   TimeStepperTestUtils::integrate_test(stepper, 0, -1., 1e-9);
+
+  const Slab slab(0., 1.);
+  const TimeId time_id(false, 0, slab.end());
+  TimeSteppers::History<double, double> history;
+  CHECK_FALSE(stepper.can_change_step_size(time_id, history));
+  history.insert(slab.start(), 0., 0.);
+  CHECK_FALSE(stepper.can_change_step_size(time_id, history));
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Stability",


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
