### PR TITLE
Add FunctionOfTimeUpdater and tests

### DIFF
--- a/src/ControlSystem/CMakeLists.txt
+++ b/src/ControlSystem/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY ControlSystem)
 set(LIBRARY_SOURCES
     Averager.cpp
     Controller.cpp
+    FunctionOfTimeUpdater.cpp
     PiecewisePolynomial.cpp
     SettleToConstant.cpp
     TimescaleTuner.cpp

--- a/src/ControlSystem/FunctionOfTimeUpdater.cpp
+++ b/src/ControlSystem/FunctionOfTimeUpdater.cpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ControlSystem/FunctionOfTimeUpdater.hpp"
+
+#include <algorithm>
+#include <array>
+
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/Gsl.hpp"
+
+template <size_t DerivOrder>
+FunctionOfTimeUpdater<DerivOrder>::FunctionOfTimeUpdater(
+    Averager<DerivOrder>&& averager, Controller<DerivOrder>&& controller,
+    TimescaleTuner&& timescale_tuner) noexcept
+    : averager_{std::move(averager)},
+      controller_{std::move(controller)},
+      timescale_tuner_{std::move(timescale_tuner)} {}
+
+template <size_t DerivOrder>
+void FunctionOfTimeUpdater<DerivOrder>::measure(
+    double time, const DataVector& raw_q) noexcept {
+  averager_.update(time, raw_q, timescale_tuner_.current_timescale());
+}
+
+template <size_t DerivOrder>
+void FunctionOfTimeUpdater<DerivOrder>::modify(
+    gsl::not_null<FunctionsOfTime::PiecewisePolynomial<DerivOrder>*> f_of_t,
+    double time) noexcept {
+  if (averager_(time)) {
+    std::array<DataVector, DerivOrder + 1> q_and_derivs = averager_(time).get();
+    // get the time offset due to averaging
+    const double t_offset_of_qdot = time - averager_.average_time(time)[0];
+    const double t_offset_of_q =
+        (averager_.using_average_0th_deriv_of_q() ? t_offset_of_qdot : 0.0);
+
+    const DataVector control_signal =
+        controller_(timescale_tuner_.current_timescale(), q_and_derivs,
+                    t_offset_of_q, t_offset_of_qdot);
+    f_of_t->update(averager_.last_time_updated(), control_signal);
+    timescale_tuner_.update_timescale({{q_and_derivs[0], q_and_derivs[1]}});
+  }
+}
+
+/// \cond
+template class FunctionOfTimeUpdater<2>;
+/// \endcond

--- a/src/ControlSystem/FunctionOfTimeUpdater.hpp
+++ b/src/ControlSystem/FunctionOfTimeUpdater.hpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "ControlSystem/Averager.hpp"
+#include "ControlSystem/Controller.hpp"
+#include "ControlSystem/PiecewisePolynomial.hpp"
+#include "ControlSystem/TimescaleTuner.hpp"
+
+// IWYU pragma: no_forward_declare FunctionsOfTime::PiecewisePolynomial
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+/// \ingroup ControlSystemGroup
+/// Responsible for updating the FunctionOfTime map parameters.
+/// `modify`: updates the FunctionOfTime map parameters, changing the maps.
+/// `measure`: provides updated information to the ControlSystem, without
+/// modifying the maps.
+///
+/// `modify` computes the control signal, which relies on \f$Q\f$ and its
+/// derivatives. The Averager is responsible for numerically computing the
+/// derivatives, and as such, requires sufficient data (the number of points
+/// being dependent on the `DerivOrder`). This data is provided to the Averager
+/// through `measure`. We do not `modify` at every `measure` (even once the
+/// Averager has sufficient data to compute derivatives) since `modify` requires
+/// updating the maps, which could potentially hold up other processes that rely
+/// on these maps.
+template <size_t DerivOrder>
+class FunctionOfTimeUpdater {
+ public:
+  FunctionOfTimeUpdater(Averager<DerivOrder>&& averager,
+                        Controller<DerivOrder>&& controller,
+                        TimescaleTuner&& timescale_tuner) noexcept;
+
+  FunctionOfTimeUpdater(FunctionOfTimeUpdater&&) noexcept = default;
+  FunctionOfTimeUpdater& operator=(FunctionOfTimeUpdater&&) noexcept = default;
+  FunctionOfTimeUpdater(const FunctionOfTimeUpdater&) = delete;
+  FunctionOfTimeUpdater& operator=(const FunctionOfTimeUpdater&) = delete;
+  ~FunctionOfTimeUpdater() = default;
+
+  /// Provides \f$Q(t)\f$ to the averager, which internally updates the averaged
+  /// values of \f$Q\f$ and derivatives stored by the averager
+  void measure(double time, const DataVector& raw_q) noexcept;
+
+  /// Computes the control signal, updates the FunctionOfTime and updates the
+  /// TimescaleTuner
+  void modify(
+      gsl::not_null<FunctionsOfTime::PiecewisePolynomial<DerivOrder>*> f_of_t,
+      double time) noexcept;
+
+ private:
+  Averager<DerivOrder> averager_;
+  Controller<DerivOrder> controller_;
+  TimescaleTuner timescale_tuner_;
+};

--- a/tests/Unit/ControlSystem/CMakeLists.txt
+++ b/tests/Unit/ControlSystem/CMakeLists.txt
@@ -6,9 +6,11 @@ set(LIBRARY "Test_ControlSystem")
 set(LIBRARY_SOURCES
   Test_Averager.cpp
   Test_Controller.cpp
+  Test_FuntionOfTimeUpdater.cpp
   Test_PiecewisePolynomial.cpp
   Test_SettleToConstant.cpp
   Test_TimescaleTuner.cpp
+  FoTUpdater_Helper.cpp
   )
 
 add_test_library(

--- a/tests/Unit/ControlSystem/FoTUpdater_Helper.cpp
+++ b/tests/Unit/ControlSystem/FoTUpdater_Helper.cpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/ControlSystem/FoTUpdater_Helper.hpp"
+
+#include <algorithm>
+
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+namespace FunctionsOfTime {
+template <size_t DerivOrder>
+class PiecewisePolynomial;
+}  // namespace FunctionsOfTime
+/// \endcond
+
+namespace TestHelpers {
+namespace ControlErrors {
+
+template <size_t DerivOrder>
+Translation<DerivOrder>::Translation(DataVector target_coords) noexcept
+    : target_coords_{std::move(target_coords)} {}
+
+template <size_t DerivOrder>
+void Translation<DerivOrder>::operator()(
+    gsl::not_null<FunctionOfTimeUpdater<DerivOrder>*> updater,
+    const FunctionsOfTime::PiecewisePolynomial<DerivOrder>& f_of_t, double time,
+    const DataVector& coords) noexcept {
+  const DataVector q = coords - target_coords_ - f_of_t.func(time)[0];
+  updater->measure(time, q);
+}
+}  // namespace ControlErrors
+}  // namespace TestHelpers
+
+/// \cond
+template class TestHelpers::ControlErrors::Translation<2>;
+/// \endcond

--- a/tests/Unit/ControlSystem/FoTUpdater_Helper.hpp
+++ b/tests/Unit/ControlSystem/FoTUpdater_Helper.hpp
@@ -1,0 +1,49 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "ControlSystem/FunctionOfTimeUpdater.hpp"
+#include "DataStructures/DataVector.hpp"
+
+// IWYU pragma: no_forward_declare FunctionOfTimeUpdater
+
+/// \cond
+namespace FunctionsOfTime {
+template <size_t DerivOrder>
+class PiecewisePolynomial;
+}  // namespace FunctionsOfTime
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace TestHelpers {
+namespace ControlErrors {
+// This is a simple 1-d case of a ControlError for testing purposes only
+template <size_t DerivOrder>
+class Translation {
+ public:
+  explicit Translation(DataVector target_coords) noexcept;
+
+  Translation(Translation&&) noexcept = default;
+  Translation& operator=(Translation&&) noexcept = default;
+  Translation(const Translation&) = delete;
+  Translation& operator=(const Translation&) = delete;
+  ~Translation() = default;
+
+  // computes the error in the translation map and provides it to the
+  // FunctionOfTimeUpdater
+  void operator()(
+      gsl::not_null<FunctionOfTimeUpdater<DerivOrder>*> updater,
+      const FunctionsOfTime::PiecewisePolynomial<DerivOrder>& f_of_t,
+      double time, const DataVector& coords) noexcept;
+
+ private:
+  DataVector target_coords_;
+};
+}  // namespace ControlErrors
+}  // namespace TestHelpers

--- a/tests/Unit/ControlSystem/Test_FuntionOfTimeUpdater.cpp
+++ b/tests/Unit/ControlSystem/Test_FuntionOfTimeUpdater.cpp
@@ -1,0 +1,88 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/ControlSystem/FoTUpdater_Helper.hpp"
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+#include "ControlSystem/Averager.hpp"
+#include "ControlSystem/Controller.hpp"
+#include "ControlSystem/FunctionOfTimeUpdater.hpp"
+#include "ControlSystem/PiecewisePolynomial.hpp"
+#include "ControlSystem/TimescaleTuner.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/Gsl.hpp"
+
+SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionOfTimeUpdater.Translation",
+                  "[ControlSystem][Unit]") {
+  // A simple Translation `ControlError` is defined in FoTUpdater_Helper,
+  // located in this test dir, in order to test the FunctionOfTimeUpdater.
+  // The full Translation ControlError will be more complicated, since it will
+  // need information from a DataBox.
+  // Here, we utilize the simple 1-d case for testing purposes.
+
+  double t = 0.0;
+  const double dt = 1.0e-3;
+  const double final_time = 4.0;
+  const constexpr size_t deriv_order = 2;
+
+  // This translation test is a simple 1-D test with time-dependent
+  // `inertial` coordinates. We want to test that the f_of_t (denoted \lambda(t)
+  // here) updates properly and continually maps the grid_coords to match the
+  // inertial_coords: grid_coords -> grid_coords + \lambda(t)
+  // The target map parameter is
+  // \lambda_target(t) = inertial_coords(t) - grid_coords
+  // The error in the mapping is defined as Q = \lambda_target - \lambda.
+  // This is implemented in FoTUpdater_Helper, wehere we define the error as:
+  // Q = inertial_coords(t) - grid_coords - f_of_t
+  // where f_of_t is the current map parameter \lambda(t)
+  DataVector grid_coords{{0.2}};
+  // Here we set up the inertial coords to have a sinusoidal time
+  // dependence, which agrees with the grid_coords at t=0
+  const double amp = 0.7;
+  const double omega = 4.0 * M_PI;
+  DataVector inertial_coords{grid_coords};
+
+  // initialize our FunctionOfTime to agree at t=0
+  const std::array<DataVector, deriv_order + 1> init_func{
+      {{0.0}, {amp * omega}, {0.0}}};
+  FunctionsOfTime::PiecewisePolynomial<deriv_order> f_of_t(t, init_func);
+
+  Averager<deriv_order> averager(0.25, false);
+  Controller<deriv_order> control_signal;
+
+  const double decrease_timescale_threshold = 1.0e-2;
+  const double increase_timescale_threshold = 1.0e-4;
+  const double increase_factor = 1.01;
+  const double decrease_factor = 0.99;
+  const double max_timescale = 10.0;
+  const double min_timescale = 1.0e-3;
+  const double initial_timescale = 2.0e-3;
+  TimescaleTuner tst({initial_timescale}, max_timescale, min_timescale,
+                     decrease_timescale_threshold, increase_timescale_threshold,
+                     increase_factor, decrease_factor);
+
+  FunctionOfTimeUpdater<deriv_order> updater(
+      std::move(averager),
+      std::move(control_signal),  // NOLINT
+      std::move(tst));
+
+  TestHelpers::ControlErrors::Translation<deriv_order> trans_error(grid_coords);
+
+  while (t < final_time) {
+    // make the error measurement
+    trans_error(&updater, f_of_t, t, inertial_coords);
+    // update the FunctionOfTime
+    updater.modify(&f_of_t, t);
+    // check that Q is within the specified tolerance
+    CHECK(fabs(inertial_coords[0] - grid_coords[0] - f_of_t.func(t)[0][0]) <=
+          decrease_timescale_threshold);
+    // increase time and get inertial_coords(t)
+    t += dt;
+    inertial_coords = grid_coords + amp * sin(omega * t);
+  }
+}


### PR DESCRIPTION
## Proposed changes
Add the FunctionOfTimeUpdater and test it.

Additionally, a simple ControlError (which computes the Qs for each map) for a 
1-D Translation map was added to the ControlSystem unit test directory in order 
to test the FunctionOfTimeUpdater.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
