### PR TITLE
Fix ABN::can_change_step_size on jumping back step

### DIFF
--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -591,8 +591,10 @@ bool AdamsBashforthN::can_change_step_size(
   // changing the step size, but we need to wait during the main
   // evolution until the self-start history has been replaced with
   // "real" values.
-  return std::is_sorted(history.begin(), history.end(),
-                        SimulationLess(time_id.time_runs_forward()));
+  const SimulationLess less(time_id.time_runs_forward());
+  return history.size() == 0 or
+         (less(history.back(), time_id.time()) and
+          std::is_sorted(history.begin(), history.end(), less));
 }
 
 template <typename Iterator>


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
