### PR TITLE
Add db::create_copy and factor algorithm code

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -509,6 +509,20 @@ class DataBox<tmpl::list<Tags...>>
   friend void mutate(gsl::not_null<DataBox<TagList>*> box,             // NOLINT
                      Invokable&& invokable, Args&&... args) noexcept;  // NOLINT
 
+  template <typename... SimpleTags>
+  SPECTRE_ALWAYS_INLINE void copy_simple_items(
+      const DataBox& box, tmpl::list<SimpleTags...> /*meta*/) noexcept;
+
+  // Creates a copy with no aliasing of items.
+  template <typename SimpleItemTags>
+  DataBox deep_copy() const noexcept;
+
+  template <typename TagsList_>
+      // clang-tidy: redundant declaration
+  friend SPECTRE_ALWAYS_INLINE constexpr DataBox<TagsList_>  // NOLINT
+  create_copy(                                               // NOLINT
+      const DataBox<TagsList_>& box) noexcept;
+
   /*!
    * \requires Type `T` is one of the Tags corresponding to an object stored in
    * the DataBox
@@ -895,6 +909,30 @@ constexpr DataBox<tmpl::list<Tags...>>::DataBox(
       args_tuple, tmpl::list<AddTags...>{},
       std::make_index_sequence<sizeof...(AddTags)>{},
       tmpl::list<AddComputeTags...>{});
+}
+
+////////////////////////////////////////////////////////////////
+// Create a copy of the DataBox with no aliasing items.
+template <typename... Tags>
+template <typename... SimpleTags>
+SPECTRE_ALWAYS_INLINE void DataBox<tmpl::list<Tags...>>::copy_simple_items(
+    const DataBox& box, tmpl::list<SimpleTags...> /*meta*/) noexcept {
+  EXPAND_PACK_LEFT_TO_RIGHT((get_deferred<SimpleTags>() =
+                                 box.get_deferred<SimpleTags>().deep_copy()));
+}
+
+template <typename... Tags>
+template <typename SimpleItemTags>
+DataBox<tmpl::list<Tags...>> DataBox<tmpl::list<Tags...>>::deep_copy() const
+    noexcept {
+  DataBox new_box{};
+  new_box.copy_simple_items(*this, simple_item_tags{});
+
+  std::tuple<> empty_tuple{};
+  new_box.add_items_to_box<tmpl::list<Tags...>>(empty_tuple, tmpl::list<>{},
+                                                std::make_index_sequence<0>{},
+                                                compute_item_tags{});
+  return new_box;
 }
 /// \endcond
 
@@ -1305,6 +1343,13 @@ SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box,
  * whose members cannot be modified.  When passed a (mutable) rvalue
  * this function will return a mutable DataBox.
  *
+ * Note that in the const lvalue case the output DataBox shares all
+ * items that were not removed with the input DataBox. This means if an item is
+ * mutated in the input DataBox it is also mutated in the output DataBox.
+ * Similarly, if a compute item is evaluated in either the returned DataBox or
+ * the input DataBox it is evaluated in both (at the cost of only evaluating it
+ * once).
+ *
  * \example
  * Removing an item or compute item is done using:
  * \snippet Test_DataBox.cpp create_from_remove
@@ -1326,13 +1371,12 @@ SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box,
  *@{
  */
 template <typename RemoveTags, typename AddTags = tmpl::list<>,
-          typename AddComputeTags = tmpl::list<>, typename Box,
-          Requires<cpp17::is_same_v<Box, std::decay_t<Box>>> = nullptr,
+          typename AddComputeTags = tmpl::list<>, typename TagsList,
           typename... Args>
-SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box,
+SPECTRE_ALWAYS_INLINE constexpr auto create_from(db::DataBox<TagsList>&& box,
                                                  Args&&... args) noexcept {
   return DataBox_detail::create_from<RemoveTags, AddTags, AddComputeTags>(
-      std::forward<Box>(box), std::forward<Args>(args)...);
+      std::move(box), std::forward<Args>(args)...);
 }
 
 /// \cond HIDDEN_SYMBOLS
@@ -1343,11 +1387,10 @@ SPECTRE_ALWAYS_INLINE constexpr auto create_from(Box&& box,
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #endif
 template <typename RemoveTags, typename AddTags = tmpl::list<>,
-          typename AddComputeTags = tmpl::list<>, typename Box,
-          Requires<not cpp17::is_same_v<Box, std::decay_t<Box>>> = nullptr,
+          typename AddComputeTags = tmpl::list<>, typename TagsList,
           typename... Args>
 SPECTRE_ALWAYS_INLINE constexpr const auto create_from(
-    Box&& box, Args&&... args) noexcept {
+    const db::DataBox<TagsList>& box, Args&&... args) noexcept {
   return DataBox_detail::create_from<RemoveTags, AddTags, AddComputeTags>(
       box, std::forward<Args>(args)...);
 }
@@ -1356,6 +1399,23 @@ SPECTRE_ALWAYS_INLINE constexpr const auto create_from(
 #endif
 /// \endcond
 /**@}*/
+
+/*!
+ * \ingroup DataBoxGroup
+ * \brief Create a non-aliasing copy of the DataBox. That is, the new DataBox
+ * will not share items with the old one.
+ *
+ * \warning Currently all compute items will be reset in the new DataBox because
+ * copying of DataBoxes shouldn't be done in general. This does not lead to
+ * incorrect behavior, but is less efficient.
+ *
+ * \see db::create_from
+ */
+template <typename TagsList>
+SPECTRE_ALWAYS_INLINE constexpr DataBox<TagsList> create_copy(
+    const DataBox<TagsList>& box) noexcept {
+  return box.template deep_copy<typename DataBox<TagsList>::simple_item_tags>();
+}
 
 namespace DataBox_detail {
 template <typename Type, typename... Tags, typename... TagsInBox>

--- a/src/DataStructures/DataBox/Deferred.hpp
+++ b/src/DataStructures/DataBox/Deferred.hpp
@@ -58,6 +58,8 @@ class assoc_state {
   virtual void reset() noexcept = 0;
   // clang-tidy: no non-const references
   virtual void pack_unpack_lazy_function(PUP::er& p) noexcept = 0;  // NOLINT
+  virtual bool evaluated() const noexcept = 0;
+  virtual boost::shared_ptr<assoc_state<Rt>> deep_copy() const noexcept = 0;
   virtual ~assoc_state() = default;
 };
 
@@ -77,7 +79,31 @@ class simple_assoc_state : public assoc_state<Rt> {
     ERROR("Cannot send a Deferred that's not a lazily evaluated function");
   }
 
+  bool evaluated() const noexcept override {
+    return true;
+  }
+
+  boost::shared_ptr<assoc_state<Rt>> deep_copy() const noexcept override {
+    return deep_copy_impl();
+  }
+
  private:
+  template <typename T = Rt,
+            Requires<tt::can_be_copy_constructed_v<T>> = nullptr>
+  boost::shared_ptr<assoc_state<Rt>> deep_copy_impl() const noexcept {
+    return boost::make_shared<simple_assoc_state>(t_);
+  }
+
+  template <typename T = Rt,
+            Requires<not tt::can_be_copy_constructed_v<T>> = nullptr>
+  boost::shared_ptr<assoc_state<Rt>> deep_copy_impl() const noexcept {
+    ERROR(
+        "Cannot create a copy of a DataBox (e.g. using db::create_copy) that "
+        "holds a non-copyable simple item. The item type is '"
+        << pretty_type::get_name<T>() << "'.");
+    return nullptr;
+  }
+
   Rt t_;
 };
 
@@ -118,6 +144,18 @@ class deferred_assoc_state : public assoc_state<Rt> {
     if (evaluated_) {
       p | t_;
     }
+  }
+
+  bool evaluated() const noexcept override {
+    return evaluated_;
+  }
+
+  boost::shared_ptr<assoc_state<Rt>> deep_copy() const noexcept override {
+    ERROR(
+        "Have not yet implemented a deep_copy for deferred_assoc_state. It's "
+        "not at all clear if this is even possible because it is incorrect to "
+        "assume that the args_ have not changed.");
+    return nullptr;
   }
 
  private:
@@ -188,7 +226,13 @@ class Deferred {
     state_->pack_unpack_lazy_function(p);
   }
 
+  bool evaluated() const noexcept { return state_->evaluated(); }
+
   void reset() noexcept { state_->reset(); }
+
+  Deferred deep_copy() const noexcept {
+    return Deferred{state_->deep_copy()};
+  }
 
  private:
   boost::shared_ptr<Deferred_detail::assoc_state<Rt>> state_{nullptr};

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -24,6 +24,7 @@
 #include "Parallel/AlgorithmMetafunctions.hpp"
 #include "Parallel/CharmRegistration.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
+#include "Parallel/SimpleActionVisitation.hpp"
 #include "Parallel/TypeTraits.hpp"
 #include "Utilities/BoostHelpers.hpp"
 #include "Utilities/ForceInline.hpp"
@@ -94,96 +95,6 @@ inline void unlock(const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
 constexpr inline void unlock(
     const gsl::not_null<NoSuchType*> /*unused*/) noexcept {}
 /// \\endcond
-
-namespace Algorithm_detail {
-template <typename Invokable, typename InitialDataBox, typename ThisVariant,
-          typename... Variants, typename... Args,
-          Requires<is_apply_callable_v<
-              Invokable, std::add_lvalue_reference_t<ThisVariant>, Args&&...>> =
-              nullptr>
-void apply_visitor_helper(boost::variant<Variants...>& box,
-                          const gsl::not_null<int*> iter,
-                          const gsl::not_null<bool*> already_visited,
-                          Args&&... args) {
-  if (box.which() == *iter and not*already_visited) {
-    try {
-      make_overloader(
-          [&box](std::true_type /*returns_void*/, auto&&... my_args) {
-            Invokable::apply(boost::get<ThisVariant>(box),
-                             std::forward<Args>(my_args)...);
-          },
-          [&box](std::false_type /*returns_void*/, auto&&... my_args) {
-            box = std::get<0>(Invokable::apply(boost::get<ThisVariant>(box),
-                                               std::forward<Args>(my_args)...));
-            using return_box_type = decltype(std::get<0>(Invokable::apply(
-                boost::get<ThisVariant>(box), std::forward<Args>(my_args)...)));
-            static_assert(
-                cpp17::is_same_v<std::decay_t<return_box_type>,
-                                 InitialDataBox> and
-                    cpp17::is_same_v<db::DataBox<tmpl::list<>>, ThisVariant>,
-                "A simple action must return either void or take an empty "
-                "DataBox and return the initial_databox set in the parallel "
-                "component.");
-          })(
-          typename std::is_same<void, decltype(Invokable::apply(
-                                          std::declval<ThisVariant&>(),
-                                          std::declval<Args>()...))>::type{},
-          std::forward<Args>(args)...);
-
-    } catch (std::exception& e) {
-      ERROR("Fatal error: Failed to call single Action '"
-            << pretty_type::get_name<Invokable>() << "' on iteration '" << iter
-            << "' with DataBox type '" << pretty_type::get_name<ThisVariant>()
-            << "'\nThe exception is: '" << e.what() << "'\n");
-    }
-    *already_visited = true;
-  }
-  (*iter)++;
-}
-
-template <typename Invokable, typename InitialDataBox, typename ThisVariant,
-          typename... Variants, typename... Args,
-          Requires<not is_apply_callable_v<
-              Invokable, std::add_lvalue_reference_t<ThisVariant>, Args&&...>> =
-              nullptr>
-void apply_visitor_helper(boost::variant<Variants...>& box,
-                          const gsl::not_null<int*> iter,
-                          const gsl::not_null<bool*> already_visited,
-                          Args&&... /*args*/) {
-  if (box.which() == *iter and not*already_visited) {
-    ERROR("Cannot call apply function of '"
-          << pretty_type::get_name<Invokable>() << "' with DataBox type '"
-          << pretty_type::get_name<ThisVariant>() << "' and arguments '"
-          << pretty_type::get_name<tmpl::list<Args...>>() << "'");
-  }
-  (*iter)++;
-}
-
-/*!
- * \brief Calls an `Invokable`'s `apply` static member function with the current
- * type in the `boost::variant`.
- *
- * The primary use case for this is to allow executing a single Action at any
- * point in the Algorithm. The current best-known use case for this is setting
- * up initial data. However, the implementation is generic enough to handle a
- * call at any time that is valid. Here valid is defined as the `apply` function
- * only accesses members of the DataBox that are guaranteed to be present when
- * it is invoked, and returns a DataBox of a type that does not break the
- * Algorithm.
- */
-template <typename Invokable, typename InitialDataBox, typename... Variants,
-          typename... Args>
-void apply_visitor(boost::variant<Variants...>& box, Args&&... args) {
-  // iter is the current element of the variant in the "for loop"
-  int iter = 0;
-  // already_visited ensures that only one visitor is invoked
-  bool already_visited = false;
-  static_cast<void>(std::initializer_list<char>{
-      (apply_visitor_helper<Invokable, InitialDataBox, Variants>(
-           box, &iter, &already_visited, std::forward<Args>(args)...),
-       '0')...});
-}
-}  // namespace Algorithm_detail
 
 /// \cond
 template <typename ParallelComponent, typename ChareType,
@@ -397,7 +308,7 @@ class AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
   template <typename Action, typename... Args, size_t... Is>
   void forward_tuple_to_action(std::tuple<Args...>&& args,
                                std::index_sequence<Is...> /*meta*/) noexcept {
-    Algorithm_detail::apply_visitor<Action, InitialDataBox>(
+    Algorithm_detail::simple_action_visitor<Action, InitialDataBox>(
         box_, inboxes_, *const_global_cache_,
         static_cast<const array_index&>(array_index_), actions_list{},
         std::add_pointer_t<ParallelComponent>{},
@@ -519,7 +430,7 @@ void AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
         "no sense for a reduction.");
   }
   performing_action_ = true;
-  Algorithm_detail::apply_visitor<Action, InitialDataBox>(
+  Algorithm_detail::simple_action_visitor<Action, InitialDataBox>(
       box_, inboxes_, *const_global_cache_,
       static_cast<const array_index&>(array_index_), actions_list{},
       std::add_pointer_t<ParallelComponent>{}, std::forward<Arg>(arg));
@@ -570,7 +481,7 @@ void AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
         "we do not allow.");
   }
   performing_action_ = true;
-  Algorithm_detail::apply_visitor<Action, InitialDataBox>(
+  Algorithm_detail::simple_action_visitor<Action, InitialDataBox>(
       box_, inboxes_, *const_global_cache_,
       static_cast<const array_index&>(array_index_), actions_list{},
       std::add_pointer_t<ParallelComponent>{});
@@ -589,7 +500,7 @@ void AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
                    tmpl::list<ActionsPack...>, ArrayIndex,
                    InitialDataBox>::threaded_action(Args&&... args) noexcept {
   const gsl::not_null<CmiNodeLock*> node_lock{&node_lock_};
-  Algorithm_detail::apply_visitor<Action, InitialDataBox>(
+  Algorithm_detail::simple_action_visitor<Action, InitialDataBox>(
       box_, inboxes_, *const_global_cache_,
       static_cast<const array_index&>(array_index_), node_lock,
       std::forward<Args>(args)...);

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -21,6 +21,7 @@
 #include "ErrorHandling/Error.hpp"
 // Include... ourself?
 // IWYU pragma: no_include "Parallel/Algorithm.hpp"
+#include "Parallel/AlgorithmMetafunctions.hpp"
 #include "Parallel/CharmRegistration.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/TypeTraits.hpp"
@@ -95,55 +96,6 @@ constexpr inline void unlock(
 /// \\endcond
 
 namespace Algorithm_detail {
-template <bool, typename AdditionalArgsList>
-struct build_action_return_types_impl;
-
-template <typename... AdditionalArgs>
-struct build_action_return_types_impl<false, tmpl::list<AdditionalArgs...>> {
-  template <typename LastReturnType, typename ReturnTypeList>
-  using f = tmpl::push_back<ReturnTypeList, LastReturnType>;
-};
-
-template <typename... AdditionalArgs>
-struct build_action_return_types_impl<true, tmpl::list<AdditionalArgs...>> {
-  template <typename LastReturnType, typename ReturnTypeList, typename Action,
-            typename... Actions>
-  using f = typename build_action_return_types_impl<
-      sizeof...(Actions) != 0, tmpl::list<AdditionalArgs...>>::
-      template f<
-          std::decay_t<std::tuple_element_t<
-              0,
-              std::decay_t<decltype(Action::apply(
-                  std::declval<std::add_lvalue_reference_t<LastReturnType>>(),
-                  std::declval<
-                      std::add_lvalue_reference_t<AdditionalArgs>>()...))>>>,
-          tmpl::push_back<ReturnTypeList, LastReturnType>, Actions...>;
-};
-
-/*!
- * \ingroup ParallelGroup
- * \brief Returns a typelist of the return types of all Actions in ActionList
- *
- * \metareturns
- * typelist
- *
- * \tparam ActionsPack parameter pack of Actions taken
- * \tparam FirstInputParameterType the type of the first argument of the first
- * Action in the ActionsPack
- * \tparam AdditionalArgsList the types of the arguments after the first
- * argument, which must all be the same for all Actions in the ActionsPack
- */
-template <typename FirstInputParameterType, typename AdditionalArgsList,
-          typename... ActionsPack>
-using build_action_return_typelist =
-    typename Algorithm_detail::build_action_return_types_impl<
-        sizeof...(ActionsPack) != 0, AdditionalArgsList>::
-        template f<FirstInputParameterType, tmpl::list<>, ActionsPack...>;
-
-CREATE_IS_CALLABLE(is_ready)
-
-CREATE_IS_CALLABLE(apply)
-
 template <typename Invokable, typename InitialDataBox, typename ThisVariant,
           typename... Variants, typename... Args,
           Requires<is_apply_callable_v<

--- a/src/Parallel/AlgorithmMetafunctions.hpp
+++ b/src/Parallel/AlgorithmMetafunctions.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <utility>  // for declval
+
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace Parallel {
+namespace Algorithm_detail {
+template <bool, typename AdditionalArgsList>
+struct build_action_return_types_impl;
+
+template <typename... AdditionalArgs>
+struct build_action_return_types_impl<false, tmpl::list<AdditionalArgs...>> {
+  template <typename LastReturnType, typename ReturnTypeList>
+  using f = tmpl::push_back<ReturnTypeList, LastReturnType>;
+};
+
+template <typename... AdditionalArgs>
+struct build_action_return_types_impl<true, tmpl::list<AdditionalArgs...>> {
+  template <typename LastReturnType, typename ReturnTypeList, typename Action,
+            typename... Actions>
+  using f = typename build_action_return_types_impl<
+      sizeof...(Actions) != 0, tmpl::list<AdditionalArgs...>>::
+      template f<
+          std::decay_t<std::tuple_element_t<
+              0,
+              std::decay_t<decltype(Action::apply(
+                  std::declval<std::add_lvalue_reference_t<LastReturnType>>(),
+                  std::declval<
+                      std::add_lvalue_reference_t<AdditionalArgs>>()...))>>>,
+          tmpl::push_back<ReturnTypeList, LastReturnType>, Actions...>;
+};
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Returns a typelist of the return types of all Actions in ActionList
+ *
+ * \metareturns
+ * typelist
+ *
+ * \tparam ActionsPack parameter pack of Actions taken
+ * \tparam FirstInputParameterType the type of the first argument of the first
+ * Action in the ActionsPack
+ * \tparam AdditionalArgsList the types of the arguments after the first
+ * argument, which must all be the same for all Actions in the ActionsPack
+ */
+template <typename FirstInputParameterType, typename AdditionalArgsList,
+          typename... ActionsPack>
+using build_action_return_typelist =
+    typename Algorithm_detail::build_action_return_types_impl<
+        sizeof...(ActionsPack) != 0, AdditionalArgsList>::
+        template f<FirstInputParameterType, tmpl::list<>, ActionsPack...>;
+
+CREATE_IS_CALLABLE(is_ready)
+
+CREATE_IS_CALLABLE(apply)
+}  // namespace Algorithm_detail
+}  // namespace Parallel

--- a/src/Parallel/SimpleActionVisitation.hpp
+++ b/src/Parallel/SimpleActionVisitation.hpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/variant/variant.hpp>
+
+#include "DataStructures/DataBox/DataBox.hpp"  // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"
+#include "Parallel/AlgorithmMetafunctions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Overloader.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace Parallel {
+namespace Algorithm_detail {
+template <typename Invokable, typename InitialDataBox, typename ThisVariant,
+          typename... Variants, typename... Args,
+          Requires<is_apply_callable_v<
+              Invokable, std::add_lvalue_reference_t<ThisVariant>, Args&&...>> =
+              nullptr>
+void simple_action_visitor_helper(boost::variant<Variants...>& box,
+                                  const gsl::not_null<int*> iter,
+                                  const gsl::not_null<bool*> already_visited,
+                                  Args&&... args) {
+  if (box.which() == *iter and not*already_visited) {
+    try {
+      make_overloader(
+          [&box](std::true_type /*returns_void*/, auto&&... my_args) {
+            Invokable::apply(boost::get<ThisVariant>(box),
+                             std::forward<Args>(my_args)...);
+          },
+          [&box](std::false_type /*returns_void*/, auto&&... my_args) {
+            box = std::get<0>(Invokable::apply(boost::get<ThisVariant>(box),
+                                               std::forward<Args>(my_args)...));
+            using return_box_type = decltype(std::get<0>(Invokable::apply(
+                boost::get<ThisVariant>(box), std::forward<Args>(my_args)...)));
+            static_assert(
+                cpp17::is_same_v<std::decay_t<return_box_type>,
+                                 InitialDataBox> and
+                    cpp17::is_same_v<db::DataBox<tmpl::list<>>, ThisVariant>,
+                "A simple action must return either void or take an empty "
+                "DataBox and return the initial_databox set in the parallel "
+                "component.");
+          })(
+          typename std::is_same<void, decltype(Invokable::apply(
+                                          std::declval<ThisVariant&>(),
+                                          std::declval<Args>()...))>::type{},
+          std::forward<Args>(args)...);
+
+    } catch (std::exception& e) {
+      ERROR("Fatal error: Failed to call single Action '"
+            << pretty_type::get_name<Invokable>() << "' on iteration '" << iter
+            << "' with DataBox type '" << pretty_type::get_name<ThisVariant>()
+            << "'\nThe exception is: '" << e.what() << "'\n");
+    }
+    *already_visited = true;
+  }
+  (*iter)++;
+}
+
+template <typename Invokable, typename InitialDataBox, typename ThisVariant,
+          typename... Variants, typename... Args,
+          Requires<not is_apply_callable_v<
+              Invokable, std::add_lvalue_reference_t<ThisVariant>, Args&&...>> =
+              nullptr>
+void simple_action_visitor_helper(boost::variant<Variants...>& box,
+                                  const gsl::not_null<int*> iter,
+                                  const gsl::not_null<bool*> already_visited,
+                                  Args&&... /*args*/) {
+  if (box.which() == *iter and not*already_visited) {
+    ERROR("Cannot call apply function of '"
+          << pretty_type::get_name<Invokable>() << "' with DataBox type '"
+          << pretty_type::get_name<ThisVariant>() << "' and arguments '"
+          << pretty_type::get_name<tmpl::list<Args...>>() << "'");
+  }
+  (*iter)++;
+}
+
+/*!
+ * \brief Calls an `Invokable`'s `apply` static member function with the current
+ * type in the `boost::variant`.
+ *
+ * The primary use case for this is to allow executing a single Action at any
+ * point in the Algorithm. The current best-known use case for this is setting
+ * up initial data. However, the implementation is generic enough to handle a
+ * call at any time that is valid. Here valid is defined as the `apply` function
+ * only accesses members of the DataBox that are guaranteed to be present when
+ * it is invoked, and returns a DataBox of a type that does not break the
+ * Algorithm.
+ */
+template <typename Invokable, typename InitialDataBox, typename... Variants,
+          typename... Args>
+void simple_action_visitor(boost::variant<Variants...>& box, Args&&... args) {
+  // iter is the current element of the variant in the "for loop"
+  int iter = 0;
+  // already_visited ensures that only one visitor is invoked
+  bool already_visited = false;
+  static_cast<void>(std::initializer_list<char>{
+      (simple_action_visitor_helper<Invokable, InitialDataBox, Variants>(
+           box, &iter, &already_visited, std::forward<Args>(args)...),
+       '0')...});
+}
+}  // namespace Algorithm_detail
+}  // namespace Parallel

--- a/src/Utilities/BoostHelpers.hpp
+++ b/src/Utilities/BoostHelpers.hpp
@@ -16,6 +16,7 @@
 #include <utility>  // IWYU pragma: keep
 
 #include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 /// \cond
@@ -46,8 +47,8 @@ struct make_boost_variant_over_impl<Sequence<Ts...>> {
  * \metareturns boost::variant of all types inside `Sequence`
  */
 template <typename Sequence>
-using make_boost_variant_over =
-    typename detail::make_boost_variant_over_impl<Sequence>::type;
+using make_boost_variant_over = typename detail::make_boost_variant_over_impl<
+    tmpl::remove_duplicates<Sequence>>::type;
 
 namespace BoostVariant_detail {
 // clang-tidy: do not use non-const references

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -374,6 +374,32 @@ using remove_cvref_t = typename remove_cvref<T>::type;
 /// A collection of useful type traits
 namespace tt {
 // @{
+/*!
+ * \ingroup TypeTraitsGroup
+ * \brief Check if `T` is copy constructible
+ *
+ * The STL `std::is_copy_constructible` does not work as expected with some
+ * types, such as `std::unordered_map`. This is because
+ * `std::is_copy_constructible` only checks that the copy construction call is
+ * well-formed, not that it could actually be done in practice. To get around
+ * this for containers we check that `T::value_type` is also copy constructible.
+ */
+template <typename T, typename = void>
+struct can_be_copy_constructed : std::is_copy_constructible<T> {};
+
+/// \cond
+template <typename T>
+struct can_be_copy_constructed<T, cpp17::void_t<typename T::value_type>>
+    : cpp17::bool_constant<
+          cpp17::is_copy_constructible_v<T> and
+          cpp17::is_copy_constructible_v<typename T::value_type>> {};
+/// \endcond
+
+template <typename T>
+constexpr bool can_be_copy_constructed_v = can_be_copy_constructed<T>::value;
+// @}
+
+// @{
 /// \ingroup TypeTraitsGroup
 /// \brief Check if type T is a std::array
 ///

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -1651,6 +1651,184 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Subitems",
       "not change the type of the DataBox");
 }
 
+SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.create_copy_Variables",
+                  "[Unit][DataStructures]") {
+  auto original_box = db::create<
+      db::AddSimpleTags<Tags::Variables<tmpl::list<
+          test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>>,
+      db::AddComputeTags<test_databox_tags::MultiplyScalarByTwo,
+                         test_databox_tags::MultiplyScalarByFour,
+                         test_databox_tags::MultiplyScalarByThree,
+                         test_databox_tags::DivideScalarByThree,
+                         test_databox_tags::DivideScalarByTwo,
+                         test_databox_tags::MultiplyVariablesByTwo>>(
+      Variables<tmpl::list<test_databox_tags::ScalarTag,
+                           test_databox_tags::VectorTag>>(2, 3.));
+  const auto check_0 = [](const auto& box) {
+    CHECK(db::get<test_databox_tags::ScalarTag>(box) ==
+          Scalar<DataVector>(DataVector(2, 3.)));
+    CHECK(db::get<test_databox_tags::VectorTag>(box) ==
+          (tnsr::I<DataVector, 3>(DataVector(2, 3.))));
+    CHECK(db::get<test_databox_tags::ScalarTag2>(box) ==
+          Scalar<DataVector>(DataVector(2, 6.)));
+    CHECK(db::get<test_databox_tags::VectorTag2>(box) ==
+          (tnsr::I<DataVector, 3>(DataVector(2, 2.))));
+    CHECK(db::get<test_databox_tags::MultiplyScalarByFour>(box) ==
+          Scalar<DataVector>(DataVector(2, 24.)));
+    CHECK(db::get<test_databox_tags::MultiplyScalarByThree>(box) ==
+          Scalar<DataVector>(DataVector(2, 72.)));
+    CHECK(db::get<test_databox_tags::DivideScalarByThree>(box) ==
+          Scalar<DataVector>(DataVector(2, 24.)));
+    CHECK(db::get<test_databox_tags::ScalarTag3>(box) ==
+          Scalar<DataVector>(DataVector(2, 12.)));
+    CHECK(db::get<test_databox_tags::VectorTag3>(box) ==
+          (tnsr::I<DataVector, 3>(DataVector(2, 10.))));
+    CHECK(db::get<test_databox_tags::ScalarTag4>(box) ==
+          Scalar<DataVector>(DataVector(2, 6.)));
+    CHECK(db::get<test_databox_tags::VectorTag4>(box) ==
+          (tnsr::I<DataVector, 3>(DataVector(2, 6.))));
+    {
+      const auto& vars =
+          db::get<test_databox_tags::MultiplyVariablesByTwo>(box);
+      CHECK(get<test_databox_tags::ScalarTag4>(vars) ==
+            Scalar<DataVector>(DataVector(2, 6.)));
+      CHECK(get<test_databox_tags::VectorTag4>(vars) ==
+            (tnsr::I<DataVector, 3>(DataVector(2, 6.))));
+    }
+  };
+  check_0(original_box);
+  const auto copied_box = db::create_copy(original_box);
+  check_0(copied_box);
+
+  db::mutate<test_databox_tags::ScalarTag>(
+      make_not_null(&original_box),
+      [](const gsl::not_null<Scalar<DataVector>*> scalar) {
+        scalar->get() = 4.0;
+      });
+  check_0(copied_box);
+
+  CHECK(db::get<test_databox_tags::ScalarTag>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 4.)));
+  CHECK(db::get<test_databox_tags::VectorTag>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 3.))));
+  CHECK(db::get<test_databox_tags::ScalarTag2>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 8.)));
+  CHECK(db::get<test_databox_tags::VectorTag2>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 2.))));
+  CHECK(db::get<test_databox_tags::MultiplyScalarByFour>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 32.)));
+  CHECK(db::get<test_databox_tags::MultiplyScalarByThree>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 96.)));
+  CHECK(db::get<test_databox_tags::DivideScalarByThree>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 32.)));
+  CHECK(db::get<test_databox_tags::ScalarTag3>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 16.)));
+  CHECK(db::get<test_databox_tags::VectorTag3>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 10.))));
+  CHECK(db::get<test_databox_tags::ScalarTag4>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 8.)));
+  CHECK(db::get<test_databox_tags::VectorTag4>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 6.))));
+  {
+    const auto& vars =
+        db::get<test_databox_tags::MultiplyVariablesByTwo>(original_box);
+    CHECK(get<test_databox_tags::ScalarTag4>(vars) ==
+          Scalar<DataVector>(DataVector(2, 8.)));
+    CHECK(get<test_databox_tags::VectorTag4>(vars) ==
+          (tnsr::I<DataVector, 3>(DataVector(2, 6.))));
+  }
+
+  db::mutate<Tags::Variables<
+      tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>>(
+      make_not_null(&original_box), [](const auto vars) {
+        get<test_databox_tags::ScalarTag>(*vars).get() = 6.0;
+      });
+
+  CHECK(db::get<test_databox_tags::ScalarTag>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 6.)));
+  CHECK(db::get<test_databox_tags::VectorTag>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 3.))));
+  CHECK(db::get<test_databox_tags::ScalarTag2>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 12.)));
+  CHECK(db::get<test_databox_tags::VectorTag2>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 2.))));
+  CHECK(db::get<test_databox_tags::MultiplyScalarByFour>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 48.)));
+  CHECK(db::get<test_databox_tags::MultiplyScalarByThree>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 144.)));
+  CHECK(db::get<test_databox_tags::DivideScalarByThree>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 48.)));
+  CHECK(db::get<test_databox_tags::ScalarTag3>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 24.)));
+  CHECK(db::get<test_databox_tags::VectorTag3>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 10.))));
+  CHECK(db::get<test_databox_tags::ScalarTag4>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 12.)));
+  CHECK(db::get<test_databox_tags::VectorTag4>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 6.))));
+  {
+    const auto& vars =
+        db::get<test_databox_tags::MultiplyVariablesByTwo>(original_box);
+    CHECK(get<test_databox_tags::ScalarTag4>(vars) ==
+          Scalar<DataVector>(DataVector(2, 12.)));
+    CHECK(get<test_databox_tags::VectorTag4>(vars) ==
+          (tnsr::I<DataVector, 3>(DataVector(2, 6.))));
+  }
+  check_0(copied_box);
+
+  db::mutate<Tags::Variables<
+      tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>>>(
+      make_not_null(&original_box), [](const auto vars) {
+        get<test_databox_tags::ScalarTag>(*vars).get() = 4.0;
+        get<test_databox_tags::VectorTag>(*vars) =
+            tnsr::I<DataVector, 3>(DataVector(2, 6.));
+      });
+
+  CHECK(db::get<test_databox_tags::ScalarTag>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 4.)));
+  CHECK(db::get<test_databox_tags::VectorTag>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 6.))));
+  CHECK(db::get<test_databox_tags::ScalarTag2>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 8.)));
+  CHECK(db::get<test_databox_tags::VectorTag2>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 2.))));
+  CHECK(db::get<test_databox_tags::MultiplyScalarByFour>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 32.)));
+  CHECK(db::get<test_databox_tags::MultiplyScalarByThree>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 96.)));
+  CHECK(db::get<test_databox_tags::DivideScalarByThree>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 32.)));
+  CHECK(db::get<test_databox_tags::ScalarTag3>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 16.)));
+  CHECK(db::get<test_databox_tags::VectorTag3>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 10.))));
+  CHECK(db::get<test_databox_tags::ScalarTag4>(original_box) ==
+        Scalar<DataVector>(DataVector(2, 8.)));
+  CHECK(db::get<test_databox_tags::VectorTag4>(original_box) ==
+        (tnsr::I<DataVector, 3>(DataVector(2, 12.))));
+  {
+    const auto& vars =
+        db::get<test_databox_tags::MultiplyVariablesByTwo>(original_box);
+    CHECK(get<test_databox_tags::ScalarTag4>(vars) ==
+          Scalar<DataVector>(DataVector(2, 8.)));
+    CHECK(get<test_databox_tags::VectorTag4>(vars) ==
+          (tnsr::I<DataVector, 3>(DataVector(2, 12.))));
+  }
+  check_0(copied_box);
+}
+
+// [[OutputRegex, Cannot create a copy of a DataBox.*holds a non-copyable]]
+SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.create_copy_error",
+                  "[Unit][DataStructures]") {
+  ERROR_TEST();
+  auto box = db::create<db::AddSimpleTags<test_subitems::Parent<0>>,
+                        db::AddComputeTags<test_subitems::Parent<1, true>>>(
+      std::make_pair(
+          test_subitems::Boxed<int>(std::make_shared<int>(5)),
+          test_subitems::Boxed<double>(std::make_shared<double>(3.5))));
+  const auto copied_box = db::create_copy(box);
+}
+
 namespace test_databox_tags {
 struct Tag0Int : db::SimpleTag {
   using type = int;

--- a/tests/Unit/Utilities/Test_TypeTraits.cpp
+++ b/tests/Unit/Utilities/Test_TypeTraits.cpp
@@ -23,6 +23,7 @@
 
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/TestHelpers.hpp"  // IWYU pragma: keep
 
 namespace {
 
@@ -111,6 +112,16 @@ static_assert(cpp17::negation<cpp17::bool_constant<false>>::value,
 static_assert(std::is_same<cpp17::void_t<char, bool, double>, void>::value,
               "Failed testing type trait void_t");
 /// [void_t_example]
+
+static_assert(tt::can_be_copy_constructed_v<int>,
+              "Failed testing type trait is_copy_constructible");
+static_assert(tt::can_be_copy_constructed_v<std::vector<int>>,
+              "Failed testing type trait is_copy_constructible");
+static_assert(tt::can_be_copy_constructed_v<std::unordered_map<int, int>>,
+              "Failed testing type trait is_copy_constructible");
+static_assert(
+    not tt::can_be_copy_constructed_v<std::unordered_map<int, NonCopyable>>,
+    "Failed testing type trait is_copy_constructible");
 
 /// [is_std_array_example]
 static_assert(tt::is_std_array<std::array<double, 3>>::value,


### PR DESCRIPTION
## Proposed changes

- Want to be able to get a non-aliasing copy of a DataBox in the tests sometimes when testing Actions on multiple parallel components
- Factor some of the Algorithm helper functions so they can be used by the mocking framework.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
