### PR TITLE
Generalize action testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,11 +123,11 @@ matrix:
     name: clang release
   - os: osx
     env: BUILD_TYPE=Debug
-    osx_image: xcode8.3
+    osx_image: xcode9.2
     compiler: clang
     name: osx debug
   - os: osx
-    osx_image: xcode8.3
+    osx_image: xcode9.2
     env: BUILD_TYPE=Release
     compiler: clang
     name: osx release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ include(SetupPapi)
 include(SetupPythonLibs)
 include(SetupYamlCpp)
 
+include(SetupLIBCXXCharm)
+
 # The precompiled header must be setup after all libraries have been found
 include(SetupPch)
 

--- a/cmake/SetupLIBCXX.cmake
+++ b/cmake/SetupLIBCXX.cmake
@@ -31,7 +31,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
       message(STATUS "libc++ libraries: ${LIBCXX_LIBRARIES}")
     endif()
 
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
     set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 
     option(

--- a/cmake/SetupLIBCXXCharm.cmake
+++ b/cmake/SetupLIBCXXCharm.cmake
@@ -1,0 +1,9 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# We need to add the link flag after finding packages because adding a
+# compilation flag to the linker flags causes packages/libraries to not be
+# always be found correctly.
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND USE_LIBCXX)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+endif()

--- a/src/Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp
+++ b/src/Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp
@@ -28,7 +28,7 @@ struct RunEventsAndTriggers {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
-  static auto apply(const db::DataBox<DbTags>& box,
+  static auto apply(db::DataBox<DbTags>& box,
                     tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index,
@@ -37,7 +37,7 @@ struct RunEventsAndTriggers {
     Parallel::get<Tags::EventsAndTriggersTagBase>(cache).run_events(
         box, cache, array_index, component);
 
-    return std::forward_as_tuple(box);
+    return std::forward_as_tuple(std::move(box));
   }
 };
 }  // namespace Actions

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -14,12 +14,14 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
+namespace ActionTesting {
 namespace ActionTesting_detail {
 template <typename Component>
 class MockLocalAlgorithm {
  public:
   void set_terminate(bool t) { terminate_ = t; }
   bool get_terminate() { return terminate_; }
+
  private:
   bool terminate_{false};
 };
@@ -58,6 +60,7 @@ class MockProxy {
       std::unordered_map<Index, MockLocalAlgorithm<Component>>;
 
   MockProxy() : inboxes_(nullptr) {}
+
   void set_data(LocalAlgorithms* local_algorithms,
                 Inboxes* inboxes) {
     local_algorithms_ = local_algorithms;
@@ -92,11 +95,12 @@ struct MockArrayChare {
       MockProxy<Component, Index, Parallel::get_inbox_tags<ActionList>>;
 };
 }  // namespace ActionTesting_detail
+}  // namespace ActionTesting
 
 /// \cond HIDDEN_SYMBOLS
 namespace Parallel {
 template <>
-struct get_array_index<ActionTesting_detail::MockArrayChare> {
+struct get_array_index<ActionTesting::ActionTesting_detail::MockArrayChare> {
   template <typename Component>
   using f = typename Component::index;
 };

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -142,9 +142,17 @@ namespace ActionTesting {
 /// A mock parallel component that acts like a component with
 /// chare_type Parallel::Algorithms::Array.
 template <typename Metavariables, typename Index,
-          typename ConstGlobalCacheTagList,
-          typename ActionList = tmpl::list<>>
+          typename ConstGlobalCacheTagList, typename ActionList = tmpl::list<>,
+          typename ComponentBeingMocked = void>
 struct MockArrayComponent {
+  // We need a way of grabbing the correct proxy from the ConstGlobalCache. The
+  // way we do that is by checking if the component passed to
+  // `Parallel::get_parallel_component` is in the
+  // `Metavariables::component_list`, if not then we search for the element of
+  // `Metavariables::component_list` that has `component_being_mocked` equal to
+  // the `ParallelComponentTag` passed to `Parallel::get_parallel_component`.
+  using component_being_mocked = ComponentBeingMocked;
+
   using metavariables = Metavariables;
   using chare_type = ActionTesting_detail::MockArrayChare;
   using index = Index;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -189,9 +189,10 @@ struct TestConservativeOrNonconservativeParts<true> {
   }
 };
 
-template <typename Metavariables, typename DomainCreatorType>
+template <typename Metavariables, typename DomainCreatorType,
+          typename CacheTuple>
 void test_initialize_element(
-    ActionTesting::ActionRunner<Metavariables>&& runner,
+    CacheTuple cache_tuple,
     const ElementId<Metavariables::system::volume_dim>& element_id,
     const double start_time, const double dt, const double slab_size,
     const DomainCreatorType& domain_creator) noexcept {
@@ -200,12 +201,25 @@ void test_initialize_element(
 
   const auto domain = domain_creator.create_domain();
 
-  db::DataBox<tmpl::list<>> empty_box{};
+  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using my_component = component<dim, Metavariables>;
+  using LocalAlgsTag =
+      typename ActionRunner::template LocalAlgorithmsTag<my_component>;
+  typename ActionRunner::LocalAlgorithms local_algs{};
+  tuples::get<LocalAlgsTag>(local_algs)
+      .emplace(element_id, db::DataBox<tmpl::list<>>{});
+
+  ActionTesting::ActionRunner<Metavariables> runner{std::move(cache_tuple),
+                                                    std::move(local_algs)};
+
   auto box = std::get<0>(
-      runner.template apply<tmpl::front<typename Metavariables::component_list>,
-                            dg::Actions::InitializeElement<dim>>(
-          empty_box, element_id, domain_creator.initial_extents(),
+      runner.template apply<my_component, dg::Actions::InitializeElement<dim>>(
+          runner.template algorithms<my_component>()
+              .at(element_id)
+              .template get_databox<db::DataBox<tmpl::list<>>>(),
+          element_id, domain_creator.initial_extents(),
           domain_creator.create_domain(), start_time, dt, slab_size));
+  CHECK(db::get<Tags::TimeStep>(box).value() == dt);
   CHECK(db::get<Tags::Next<Tags::TimeId>>(box).time_runs_forward());
   CHECK(db::get<Tags::Next<Tags::TimeId>>(box).slab_number() == 0);
   CHECK(db::get<Tags::Next<Tags::TimeId>>(box).time().value() == start_time);
@@ -216,7 +230,6 @@ void test_initialize_element(
   // algorithm loop.
   CHECK(box_contains<Tags::TimeId>(box));
   CHECK(box_contains<Tags::Time>(box));
-  CHECK(db::get<Tags::TimeStep>(box).value() == dt);
 
   const auto& my_block = domain.blocks()[element_id.block_id()];
   ElementMap<dim, Frame::Inertial> map{element_id,
@@ -315,9 +328,9 @@ void test_initialize_element(
 }
 
 void test_mortar_orientation() noexcept {
-  ActionTesting::ActionRunner<Metavariables<3, false, false, tmpl::list<>>>
-      runner{{std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
-              SystemAnalyticSolution{}}};
+  using metavariables = Metavariables<3, false, false, tmpl::list<>>;
+  ElementId<3> element_id(0);
+
   // This is the domain from the OrientationMap and corner numbering
   // tutorial.
   Domain<3, Frame::Inertial> domain(
@@ -328,11 +341,27 @@ void test_mortar_orientation() noexcept {
   const auto mortar_id = std::make_pair(neighbor_direction, ElementId<3>(1));
   const std::vector<std::array<size_t, 3>> extents{{{2, 2, 2}}, {{3, 4, 5}}};
 
-  db::DataBox<tmpl::list<>> empty_box{};
-  const auto box = std::get<0>(
-      runner.apply<component<3, Metavariables<3, false, false, tmpl::list<>>>,
-                   dg::Actions::InitializeElement<3>>(
-          empty_box, ElementId<3>(0), extents, std::move(domain), 0., 1., 1.));
+  using my_component = component<3, metavariables>;
+  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
+  using LocalAlgsTag =
+      typename ActionRunner::template LocalAlgorithmsTag<my_component>;
+  typename ActionRunner::LocalAlgorithms local_algs{};
+  tuples::get<LocalAlgsTag>(local_algs)
+      .emplace(ElementIndex<3>{element_id},
+               ActionTesting::MockLocalAlgorithm<my_component>{
+                   db::DataBox<tmpl::list<>>{}});
+
+  ActionTesting::ActionRunner<metavariables> runner{
+      {std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
+       SystemAnalyticSolution{}},
+      std::move(local_algs)};
+
+  const auto box = std::get<0>(runner.apply<component<3, metavariables>,
+                                            dg::Actions::InitializeElement<3>>(
+      runner.template algorithms<my_component>()
+          .at(element_id)
+          .template get_databox<db::DataBox<tmpl::list<>>>(),
+      element_id, extents, std::move(domain), 0., 1., 1.));
 
   CHECK(db::get<Tags::Mortars<Tags::Mesh<2>, 3>>(box).at(mortar_id).extents() ==
         Index<2>{{{3, 4}}});
@@ -341,48 +370,54 @@ void test_mortar_orientation() noexcept {
 
 SPECTRE_TEST_CASE("Unit.Evolution.dG.InitializeElement",
                   "[Unit][Evolution][Actions]") {
-  test_initialize_element(
-      ActionTesting::ActionRunner<Metavariables<1, false, false, tmpl::list<>>>{
-          {std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
-           SystemAnalyticSolution{}}},
+  test_initialize_element<Metavariables<1, false, false, tmpl::list<>>>(
+      ActionTesting::ActionRunner<
+          Metavariables<1, false, false, tmpl::list<>>>::CacheTuple{
+          std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
+          SystemAnalyticSolution{}},
       ElementId<1>{0, {{SegmentId{2, 1}}}}, 3., 1., 1.,
       DomainCreators::Interval<Frame::Inertial>{
           {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}});
 
-  test_initialize_element(
-      ActionTesting::ActionRunner<Metavariables<2, false, false, tmpl::list<>>>{
-          {std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
-           SystemAnalyticSolution{}}},
+  test_initialize_element<Metavariables<2, false, false, tmpl::list<>>>(
+      ActionTesting::ActionRunner<
+          Metavariables<2, false, false, tmpl::list<>>>::CacheTuple{
+          std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
+          SystemAnalyticSolution{}},
       ElementId<2>{0, {{SegmentId{2, 1}, SegmentId{3, 2}}}}, 3., 1., 1.,
       DomainCreators::Rectangle<Frame::Inertial>{
           {{-0.5, -0.75}}, {{1.5, 2.4}}, {{false, false}}, {{2, 3}}, {{4, 5}}});
 
-  test_initialize_element(
-      ActionTesting::ActionRunner<Metavariables<3, false, false, tmpl::list<>>>{
-          {std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
-           SystemAnalyticSolution{}}},
+  test_initialize_element<Metavariables<3, false, false, tmpl::list<>>>(
+      ActionTesting::ActionRunner<
+          Metavariables<3, false, false, tmpl::list<>>>::CacheTuple{
+          std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
+          SystemAnalyticSolution{}},
       ElementId<3>{0, {{SegmentId{2, 1}, SegmentId{3, 2}, SegmentId{1, 0}}}},
-      3., 1., 1., DomainCreators::Brick<Frame::Inertial>{{{-0.5, -0.75, -1.2}},
-                                                         {{1.5, 2.4, 1.2}},
-                                                         {{false, false, true}},
-                                                         {{2, 3, 1}},
-                                                         {{4, 5, 3}}});
+      3., 1., 1.,
+      DomainCreators::Brick<Frame::Inertial>{{{-0.5, -0.75, -1.2}},
+                                             {{1.5, 2.4, 1.2}},
+                                             {{false, false, true}},
+                                             {{2, 3, 1}},
+                                             {{4, 5, 3}}});
 
-  test_initialize_element(
-      ActionTesting::ActionRunner<Metavariables<2, true, false, tmpl::list<>>>{
-          {std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
-           SystemAnalyticSolution{}}},
+  test_initialize_element<Metavariables<2, true, false, tmpl::list<>>>(
+      ActionTesting::ActionRunner<
+          Metavariables<2, true, false, tmpl::list<>>>::CacheTuple{
+          std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
+          SystemAnalyticSolution{}},
       ElementId<2>{0, {{SegmentId{2, 1}, SegmentId{3, 2}}}}, 3., 1., 1.,
       DomainCreators::Rectangle<Frame::Inertial>{
           {{-0.5, -0.75}}, {{1.5, 2.4}}, {{false, false}}, {{2, 3}}, {{4, 5}}});
 
   // local time-stepping
-  test_initialize_element(
-      ActionTesting::ActionRunner<
-          Metavariables<2, false, true, tmpl::list<CacheTags::StepController>>>{
-          {std::make_unique<StepControllers::SplitRemaining>(),
-           std::make_unique<TimeSteppers::AdamsBashforthN>(4, true),
-           SystemAnalyticSolution{}}},
+  test_initialize_element<
+      Metavariables<2, false, true, tmpl::list<CacheTags::StepController>>>(
+      ActionTesting::ActionRunner<Metavariables<
+          2, false, true, tmpl::list<CacheTags::StepController>>>::CacheTuple{
+          std::make_unique<StepControllers::SplitRemaining>(),
+          std::make_unique<TimeSteppers::AdamsBashforthN>(4, true),
+          SystemAnalyticSolution{}},
       ElementId<2>{0, {{SegmentId{2, 1}, SegmentId{3, 2}}}}, 1.5, 0.25, 0.5,
       DomainCreators::Rectangle<Frame::Inertial>{
           {{-0.5, -0.75}}, {{1.5, 2.4}}, {{false, false}}, {{2, 3}}, {{4, 5}}});

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -22,9 +22,12 @@
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare db::DataBox
 
 namespace {
 struct DefaultClasses {
@@ -54,10 +57,18 @@ void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
   // Test pup
   Parallel::register_derived_classes_with_charm<Event<DefaultClasses>>();
   Parallel::register_derived_classes_with_charm<Trigger<DefaultClasses>>();
-  ActionTesting::ActionRunner<Metavariables> runner{{
-    serialize_and_deserialize(events_and_triggers)}};
 
-  const auto box = db::create<db::AddSimpleTags<>>();
+  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using my_component = component;
+  using LocalAlgsTag =
+      typename ActionRunner::template LocalAlgorithmsTag<my_component>;
+  typename ActionRunner::LocalAlgorithms local_algs{};
+  tuples::get<LocalAlgsTag>(local_algs).emplace(0, db::DataBox<tmpl::list<>>{});
+  ActionTesting::ActionRunner<Metavariables> runner{
+      {serialize_and_deserialize(events_and_triggers)}, std::move(local_algs)};
+  auto& box = runner.template algorithms<my_component>()
+                  .at(0)
+                  .template get_databox<db::DataBox<tmpl::list<>>>();
 
   runner.apply<component, Actions::RunEventsAndTriggers>(box, 0);
 

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -36,9 +36,11 @@ using events_and_triggers_tag =
     Tags::EventsAndTriggers<DefaultClasses, DefaultClasses>;
 
 struct Metavariables;
-using component =
-    ActionTesting::MockArrayComponent<Metavariables, int,
-                                      tmpl::list<events_and_triggers_tag>>;
+struct component
+    : ActionTesting::MockArrayComponent<Metavariables, int,
+                                        tmpl::list<events_and_triggers_tag>> {
+  using initial_databox = db::DataBox<tmpl::list<>>;
+};
 
 struct Metavariables {
   using component_list = tmpl::list<component>;

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -13,7 +13,7 @@
 #include <unordered_map>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"
+#include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
 #include "Evolution/EventsAndTriggers/Completion.hpp"
 #include "Evolution/EventsAndTriggers/Event.hpp"
 #include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"
@@ -39,9 +39,9 @@ using events_and_triggers_tag =
     Tags::EventsAndTriggers<DefaultClasses, DefaultClasses>;
 
 struct Metavariables;
-struct component
-    : ActionTesting::MockArrayComponent<Metavariables, int,
-                                        tmpl::list<events_and_triggers_tag>> {
+struct component : ActionTesting::MockArrayComponent<
+                       Metavariables, int, tmpl::list<events_and_triggers_tag>,
+                       tmpl::list<Actions::RunEventsAndTriggers>> {
   using initial_databox = db::DataBox<tmpl::list<>>;
 };
 
@@ -70,7 +70,7 @@ void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
                   .at(0)
                   .template get_databox<db::DataBox<tmpl::list<>>>();
 
-  runner.apply<component, Actions::RunEventsAndTriggers>(box, 0);
+  runner.next_action<component>(0);
 
   CHECK(runner.algorithms<component>()[0].get_terminate() == expected);
 }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -7,5 +7,6 @@ set(LIBRARY_SOURCES
   Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
   Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
   Actions/Test_FluxCommunication.cpp
+  Actions/Test_FluxCommunicationLts.cpp
   PARENT_SCOPE
   )

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -77,9 +77,11 @@ struct System {
 
 struct Metavariables;
 
-using component = ActionTesting::MockArrayComponent<
-    Metavariables, ElementIndex<2>,
-    tmpl::list<CacheTags::TimeStepper, NumericalFluxTag>>;
+struct component : ActionTesting::MockArrayComponent<
+                       Metavariables, ElementIndex<2>,
+                       tmpl::list<CacheTags::TimeStepper, NumericalFluxTag>> {
+  using initial_databox = db::DataBox<tmpl::list<>>;
+};
 
 struct Metavariables {
   using system = System;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -91,9 +91,11 @@ struct System {
 
 struct Metavariables;
 
-using component =
-    ActionTesting::MockArrayComponent<Metavariables, ElementIndex<2>,
-                                      tmpl::list<>>;
+struct component
+    : ActionTesting::MockArrayComponent<Metavariables, ElementIndex<2>,
+                                        tmpl::list<>> {
+  using initial_databox = db::DataBox<tmpl::list<>>;
+};
 
 struct Metavariables {
   using system = System;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -17,7 +17,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
-#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -52,7 +51,6 @@
 // IWYU pragma: no_include "Parallel/PupStlCpp11.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
-#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
@@ -124,13 +122,8 @@ struct System {
   using magnitude_tag = Tags::EuclideanMagnitude<Tag>;
 };
 
-template <size_t Dim>
-struct Metavariables;
-template <size_t Dim>
-using send_data_for_fluxes = dg::Actions::SendDataForFluxes<Metavariables<Dim>>;
-template <size_t Dim>
-using receive_data_for_fluxes =
-    dg::Actions::ReceiveDataForFluxes<Metavariables<Dim>>;
+template <typename Metavariables>
+using send_data_for_fluxes = dg::Actions::SendDataForFluxes<Metavariables>;
 
 template <size_t Dim, typename Tag>
 using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
@@ -164,7 +157,7 @@ template <size_t Dim, typename Metavariables>
 struct component
     : ActionTesting::MockArrayComponent<
           Metavariables, ElementIndex<Dim>, tmpl::list<NumericalFluxTag<Dim>>,
-          tmpl::list<receive_data_for_fluxes<Dim>>> {
+          tmpl::list<dg::Actions::ReceiveDataForFluxes<Metavariables>>> {
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
   using simple_tags =
@@ -215,8 +208,8 @@ Scalar<DataVector> reverse(Scalar<DataVector> x) noexcept {
 
 SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
                   "[Unit][NumericalAlgorithms][Actions]") {
-  ActionTesting::ActionRunner<Metavariables<2>> runner{{NumericalFlux<2>{}}};
-
+  using metavariables = Metavariables<2>;
+  using my_component = component<2, metavariables>;
   const Mesh<2> mesh{3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
 
@@ -321,41 +314,15 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
             other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
             mortar_next_temporal_ids_tag<2>, mortar_meshes_tag<2>,
             mortar_sizes_tag<2>>,
-        compute_items<component<2, Metavariables<2>>>>(
+        compute_items<my_component>>(
         0, 1, mesh, element, std::move(map), std::move(normal_dot_fluxes),
         std::move(other_data), std::move(mortar_history),
         std::move(mortar_next_temporal_ids), std::move(mortar_meshes),
         std::move(mortar_sizes));
-  }();
-
-  auto sent_box = std::get<0>(
-      runner.apply<component<2, Metavariables<2>>, send_data_for_fluxes<2>>(
-          start_box, self_id));
-
-  // Here, we just check that messages are sent to the correct places.
-  // We will check the received values on the central element later.
-  {
-    CHECK(runner.nonempty_inboxes<component<2, Metavariables<2>>,
-                                  fluxes_tag<flux_comm_types<2>>>() ==
-          std::unordered_set<ElementIndex<2>>{west_id, east_id, south_id});
-    const auto check_sent_data = [&runner, &self_id](
-        const ElementId<2>& id, const Direction<2>& direction) noexcept {
-      const auto& inboxes = runner.inboxes<component<2, Metavariables<2>>>();
-      const auto& flux_inbox =
-          tuples::get<fluxes_tag<flux_comm_types<2>>>(inboxes.at(id));
-      CHECK(flux_inbox.size() == 1);
-      CHECK(flux_inbox.count(0) == 1);
-      const auto& flux_inbox_at_time = flux_inbox.at(0);
-      CHECK(flux_inbox_at_time.size() == 1);
-      CHECK(flux_inbox_at_time.count({direction, self_id}) == 1);
-    };
-    check_sent_data(west_id, Direction<2>::lower_eta());
-    check_sent_data(east_id, Direction<2>::lower_xi());
-    check_sent_data(south_id, Direction<2>::lower_eta());
   }
+  ();
 
-  // Now check ReceiveDataForFluxes
-  const auto send_data = [&mesh, &runner, &self_id, &coordmap](
+  const auto create_neighbor_databox = [&mesh, &self_id, &coordmap ](
       const ElementId<2>& id, const Direction<2>& direction,
       const OrientationMap<2>& orientation,
       const Scalar<DataVector>& normal_dot_fluxes,
@@ -382,45 +349,121 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
     db::item_type<mortar_sizes_tag<2>> mortar_sizes{};
     mortar_sizes.insert({{direction, self_id}, {{Spectral::MortarSize::Full}}});
 
-    auto box = db::create<
+    return db::create<
         db::AddSimpleTags<
             TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
             Tags::ElementMap<2>, normal_dot_fluxes_tag<2, flux_comm_types<2>>,
             other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
-            mortar_meshes_tag<2>, mortar_sizes_tag<2>>,
-        compute_items<component<2, Metavariables<2>>>>(
+            mortar_next_temporal_ids_tag<2>, mortar_meshes_tag<2>,
+            mortar_sizes_tag<2>>,
+        compute_items<my_component>>(
         0, 1, mesh, element, std::move(map), std::move(normal_dot_fluxes_map),
         std::move(other_data_map), std::move(mortar_history),
+        db::item_type<mortar_next_temporal_ids_tag<2>>{},
         std::move(mortar_meshes), std::move(mortar_sizes));
-
-    runner.apply<component<2, Metavariables<2>>, send_data_for_fluxes<2>>(box,
-                                                                          id);
   };
 
-  CHECK_FALSE(runner.is_ready<component<2, Metavariables<2>>,
-                              receive_data_for_fluxes<2>>(sent_box, self_id));
-  send_data(south_id, Direction<2>::lower_eta(), {},
-            data.remote_fluxes.at(Direction<2>::upper_eta()),
-            data.remote_other_data.at(Direction<2>::upper_eta()));
-  CHECK_FALSE(runner.is_ready<component<2, Metavariables<2>>,
-                              receive_data_for_fluxes<2>>(sent_box, self_id));
-  send_data(east_id, Direction<2>::lower_xi(), {},
-            data.remote_fluxes.at(Direction<2>::upper_xi()),
-            data.remote_other_data.at(Direction<2>::upper_xi()));
-  CHECK_FALSE(runner.is_ready<component<2, Metavariables<2>>,
-                              receive_data_for_fluxes<2>>(sent_box, self_id));
-  send_data(west_id, Direction<2>::lower_eta(), block_orientation.inverse_map(),
-            data.remote_fluxes.at(Direction<2>::lower_xi()),
-            data.remote_other_data.at(Direction<2>::lower_xi()));
-  CHECK(runner.is_ready<component<2, Metavariables<2>>,
-                        receive_data_for_fluxes<2>>(sent_box, self_id));
+  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
+  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<my_component>;
+  ActionRunner::LocalAlgorithms local_algs{};
+  tuples::get<LocalAlgsTag>(local_algs).emplace(self_id, std::move(start_box));
+  tuples::get<LocalAlgsTag>(local_algs)
+      .emplace(south_id,
+               create_neighbor_databox(
+                   south_id, Direction<2>::lower_eta(), {},
+                   data.remote_fluxes.at(Direction<2>::upper_eta()),
+                   data.remote_other_data.at(Direction<2>::upper_eta())));
+  tuples::get<LocalAlgsTag>(local_algs)
+      .emplace(east_id,
+               create_neighbor_databox(
+                   east_id, Direction<2>::lower_xi(), {},
+                   data.remote_fluxes.at(Direction<2>::upper_xi()),
+                   data.remote_other_data.at(Direction<2>::upper_xi())));
+  tuples::get<LocalAlgsTag>(local_algs)
+      .emplace(west_id,
+               create_neighbor_databox(
+                   west_id, Direction<2>::lower_eta(),
+                   block_orientation.inverse_map(),
+                   data.remote_fluxes.at(Direction<2>::lower_xi()),
+                   data.remote_other_data.at(Direction<2>::lower_xi())));
+
+  ActionTesting::ActionRunner<Metavariables<2>> runner{{NumericalFlux<2>{}},
+                                                       std::move(local_algs)};
+
+  using initial_databox_type = db::compute_databox_type<tmpl::append<
+      db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
+                        Tags::Element<2>, Tags::ElementMap<2>,
+                        normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+                        other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
+                        mortar_next_temporal_ids_tag<2>, mortar_meshes_tag<2>,
+                        mortar_sizes_tag<2>>,
+      compute_items<my_component>>>;
+
+  auto sent_box = std::get<0>(
+      runner.apply<my_component, send_data_for_fluxes<metavariables>>(
+          runner.algorithms<my_component>()
+              .at(self_id)
+              .get_databox<initial_databox_type>(),
+          self_id));
+
+  // Here, we just check that messages are sent to the correct places.
+  // We will check the received values on the central element later.
+  {
+    CHECK(runner.nonempty_inboxes<component<2, Metavariables<2>>,
+                                  fluxes_tag<flux_comm_types<2>>>() ==
+          std::unordered_set<ElementIndex<2>>{west_id, east_id, south_id});
+    const auto check_sent_data = [&runner, &self_id ](
+        const ElementId<2>& id, const Direction<2>& direction) noexcept {
+      const auto& inboxes = runner.inboxes<component<2, Metavariables<2>>>();
+      const auto& flux_inbox =
+          tuples::get<fluxes_tag<flux_comm_types<2>>>(inboxes.at(id));
+      CHECK(flux_inbox.size() == 1);
+      CHECK(flux_inbox.count(0) == 1);
+      const auto& flux_inbox_at_time = flux_inbox.at(0);
+      CHECK(flux_inbox_at_time.size() == 1);
+      CHECK(flux_inbox_at_time.count({direction, self_id}) == 1);
+    };
+    check_sent_data(west_id, Direction<2>::lower_eta());
+    check_sent_data(east_id, Direction<2>::lower_xi());
+    check_sent_data(south_id, Direction<2>::lower_eta());
+  }
+
+  // Now check ReceiveDataForFluxes
+  CHECK_FALSE(runner.is_ready<my_component,
+                              dg::Actions::ReceiveDataForFluxes<metavariables>>(
+      sent_box, self_id));
+  runner.apply<my_component, send_data_for_fluxes<metavariables>>(
+      runner.algorithms<my_component>()
+          .at(south_id)
+          .get_databox<initial_databox_type>(),
+      south_id);
+  CHECK_FALSE(runner.is_ready<my_component,
+                              dg::Actions::ReceiveDataForFluxes<metavariables>>(
+      sent_box, self_id));
+  runner.apply<my_component, send_data_for_fluxes<metavariables>>(
+      runner.algorithms<my_component>()
+          .at(east_id)
+          .get_databox<initial_databox_type>(),
+      south_id);
+  CHECK_FALSE(runner.is_ready<my_component,
+                              dg::Actions::ReceiveDataForFluxes<metavariables>>(
+      sent_box, self_id));
+  runner.apply<my_component, send_data_for_fluxes<metavariables>>(
+      runner.algorithms<my_component>()
+          .at(west_id)
+          .get_databox<initial_databox_type>(),
+      south_id);
+  CHECK(runner.is_ready<my_component,
+                        dg::Actions::ReceiveDataForFluxes<metavariables>>(
+      sent_box, self_id));
 
   auto received_box = std::get<0>(
-      runner.apply<component<2, Metavariables<2>>, receive_data_for_fluxes<2>>(
-          sent_box, self_id));
+      runner.apply<my_component,
+                   dg::Actions::ReceiveDataForFluxes<metavariables>>(sent_box,
+                                                                     self_id));
 
   CHECK(tuples::get<fluxes_tag<flux_comm_types<2>>>(
-            runner.inboxes<component<2, Metavariables<2>>>()[self_id])
+            runner.inboxes<my_component>()[self_id])
             .empty());
 
   for (const auto& mortar_id : neighbor_mortar_ids) {
@@ -497,7 +540,16 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
 SPECTRE_TEST_CASE(
     "Unit.DiscontinuousGalerkin.Actions.FluxCommunication.NoNeighbors",
     "[Unit][NumericalAlgorithms][Actions]") {
-  ActionTesting::ActionRunner<Metavariables<2>> runner{{NumericalFlux<2>{}}};
+  using metavariables = Metavariables<2>;
+  using my_component = component<2, metavariables>;
+  using initial_databox_type = db::compute_databox_type<tmpl::append<
+      db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
+                        Tags::Element<2>, Tags::ElementMap<2>,
+                        normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+                        other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
+                        mortar_next_temporal_ids_tag<2>, mortar_meshes_tag<2>,
+                        mortar_sizes_tag<2>>,
+      compute_items<component<2, Metavariables<2>>>>>;
 
   const Mesh<2> mesh{3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
@@ -528,211 +580,43 @@ SPECTRE_TEST_CASE(
       db::item_type<mortar_meshes_tag<2>>{},
       db::item_type<mortar_sizes_tag<2>>{});
 
+  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
+  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<my_component>;
+  ActionRunner::LocalAlgorithms local_algs{};
+  tuples::get<LocalAlgsTag>(local_algs).emplace(self_id, std::move(start_box));
+  ActionTesting::ActionRunner<Metavariables<2>> runner{{NumericalFlux<2>{}},
+                                                       std::move(local_algs)};
+
   auto sent_box = std::get<0>(
-      runner.apply<component<2, Metavariables<2>>, send_data_for_fluxes<2>>(
-          start_box, self_id));
+      runner.apply<my_component, send_data_for_fluxes<metavariables>>(
+          runner.algorithms<my_component>()
+              .at(self_id)
+              .get_databox<initial_databox_type>(),
+          self_id));
 
   CHECK(db::get<mortar_data_tag<flux_comm_types<2>>>(sent_box).empty());
-  CHECK(runner
-            .nonempty_inboxes<component<2, Metavariables<2>>,
-                              fluxes_tag<flux_comm_types<2>>>()
+  CHECK(runner.nonempty_inboxes<my_component, fluxes_tag<flux_comm_types<2>>>()
             .empty());
 
-  CHECK(runner.is_ready<component<2, Metavariables<2>>,
-                        receive_data_for_fluxes<2>>(sent_box, self_id));
+  CHECK(runner.is_ready<my_component,
+                        dg::Actions::ReceiveDataForFluxes<metavariables>>(
+      sent_box, self_id));
 
   const auto received_box = std::get<0>(
-      runner.apply<component<2, Metavariables<2>>, receive_data_for_fluxes<2>>(
-          sent_box, self_id));
+      runner.apply<my_component,
+                   dg::Actions::ReceiveDataForFluxes<metavariables>>(sent_box,
+                                                                     self_id));
 
   CHECK(db::get<mortar_data_tag<flux_comm_types<2>>>(received_box).empty());
-  CHECK(runner
-            .nonempty_inboxes<component<2, Metavariables<2>>,
-                              fluxes_tag<flux_comm_types<2>>>()
+  CHECK(runner.nonempty_inboxes<my_component, fluxes_tag<flux_comm_types<2>>>()
             .empty());
-}
-
-namespace {
-struct DataRecorder {
-  // Only called on the sending sides, which are not interesting here.
-  void local_insert(int /*temporal_id*/,
-                    const LocalData<flux_comm_types<2>>& /*data*/) noexcept {}
-
-  void remote_insert(int temporal_id,
-                     PackagedData<flux_comm_types<2>> data) noexcept {
-    received_data.emplace_back(temporal_id, std::move(data));
-  }
-
-  std::vector<std::pair<int, PackagedData<flux_comm_types<2>>>> received_data{};
-};
-
-struct DataRecorderTag : db::SimpleTag {
-  static std::string name() { return "DataRecorderTag"; }
-  using type = DataRecorder;
-};
-
-struct MortarRecorderTag : Tags::VariablesBoundaryData,
-                           Tags::Mortars<DataRecorderTag, 2> {};
-
-void send_from_neighbor(
-    const gsl::not_null<ActionTesting::ActionRunner<Metavariables<2>>*> runner,
-    const Element<2>& element, const int start, const int end,
-    const double n_dot_f) noexcept {
-  const Direction<2>& send_direction = element.neighbors().begin()->first;
-  const ElementId<2>& receiver_id =
-      *element.neighbors().begin()->second.begin();
-
-  const Mesh<2> mesh{2, Spectral::Basis::Legendre,
-                     Spectral::Quadrature::GaussLobatto};
-
-  ElementMap<2, Frame::Inertial> map(
-      element.id(), make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                        CoordinateMaps::Identity<2>{}));
-
-  db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>> fluxes;
-  fluxes[send_direction].initialize(2, n_dot_f);
-
-  db::item_type<other_data_tag<2>> other_data;
-  other_data[send_direction].initialize(2, 0.);
-
-  db::item_type<mortar_meshes_tag<2>> mortar_meshes;
-  mortar_meshes.insert({{send_direction, receiver_id}, mesh.slice_away(0)});
-
-  db::item_type<mortar_sizes_tag<2>> mortar_sizes;
-  mortar_sizes.insert(
-      {{send_direction, receiver_id}, {{Spectral::MortarSize::Full}}});
-
-  db::item_type<MortarRecorderTag> recorders;
-  recorders.insert({{send_direction, receiver_id}, {}});
-
-  auto box = db::create<
-      db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
-                        Tags::Element<2>, Tags::ElementMap<2>,
-                        normal_dot_fluxes_tag<2, flux_comm_types<2>>,
-                        other_data_tag<2>, mortar_meshes_tag<2>,
-                        mortar_sizes_tag<2>, MortarRecorderTag>,
-      compute_items<component<2, Metavariables<2>>>>(
-      start, end, mesh, element, std::move(map), std::move(fluxes),
-      std::move(other_data), std::move(mortar_meshes), std::move(mortar_sizes),
-      std::move(recorders));
-
-  runner->apply<component<2, Metavariables<2>>, send_data_for_fluxes<2>>(
-      box, element.id());
-}
-
-// Sends the left steps, then the right steps.  The step must not be
-// ready until after the last send.
-void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
-                  const std::vector<int>& right_steps) noexcept {
-  ActionTesting::ActionRunner<Metavariables<2>> runner{{NumericalFlux<2>{}}};
-
-  const ElementId<2> left_id(0);
-  const ElementId<2> self_id(1);
-  const ElementId<2> right_id(2);
-
-  using MortarId = std::pair<Direction<2>, ElementId<2>>;
-  const MortarId left_mortar_id(Direction<2>::lower_xi(), left_id);
-  const MortarId right_mortar_id(Direction<2>::upper_xi(), right_id);
-
-  db::item_type<MortarRecorderTag> initial_recorders;
-  initial_recorders.insert({{Direction<2>::lower_xi(), left_id}, {}});
-  initial_recorders.insert({{Direction<2>::upper_xi(), right_id}, {}});
-  db::item_type<mortar_next_temporal_ids_tag<2>> initial_mortar_temporal_ids{
-      {left_mortar_id, left_steps.front()},
-      {right_mortar_id, right_steps.front()}};
-
-  auto box =
-      db::create<db::AddSimpleTags<Tags::Next<TemporalId>, MortarRecorderTag,
-                                   mortar_next_temporal_ids_tag<2>>>(
-          self_step_end, std::move(initial_recorders),
-          std::move(initial_mortar_temporal_ids));
-
-  const Element<2> left_element(left_id,
-                                {{Direction<2>::upper_xi(), {{self_id}, {}}}});
-  const Element<2> right_element(right_id,
-                                 {{Direction<2>::lower_xi(), {{self_id}, {}}}});
-
-  std::vector<int> relevant_left_steps{left_steps.front()};
-  for (size_t step = 1; step < left_steps.size(); ++step) {
-    CHECK_FALSE(runner.is_ready<component<2, Metavariables<2>>,
-                                receive_data_for_fluxes<2>>(box, self_id));
-    send_from_neighbor(&runner, left_element, left_steps[step - 1],
-                       left_steps[step], step);
-    if (left_steps[step - 1] < self_step_end) {
-      relevant_left_steps.push_back(left_steps[step]);
-    }
-  }
-  std::vector<int> relevant_right_steps{right_steps.front()};
-  for (size_t step = 1; step < right_steps.size(); ++step) {
-    CHECK_FALSE(runner.is_ready<component<2, Metavariables<2>>,
-                                receive_data_for_fluxes<2>>(box, self_id));
-    send_from_neighbor(&runner, right_element, right_steps[step - 1],
-                       right_steps[step], step);
-    if (right_steps[step - 1] < self_step_end) {
-      relevant_right_steps.push_back(right_steps[step]);
-    }
-  }
-  CHECK(runner.is_ready<component<2, Metavariables<2>>,
-                        receive_data_for_fluxes<2>>(box, self_id));
-
-  box = std::get<0>(
-      runner.apply<component<2, Metavariables<2>>, receive_data_for_fluxes<2>>(
-          box, self_id));
-
-  CHECK(db::get<mortar_next_temporal_ids_tag<2>>(box) ==
-        db::item_type<mortar_next_temporal_ids_tag<2>>{
-            {left_mortar_id, relevant_left_steps.back()},
-            {right_mortar_id, relevant_right_steps.back()}});
-
-  const auto& recorders = db::get<MortarRecorderTag>(box);
-  const auto check_data = [](const auto& recorder,
-                             const std::vector<int>& steps) noexcept {
-    const auto& received_data = recorder.received_data;
-    CHECK(received_data.size() == steps.size() - 1);
-
-    for (size_t step = 0; step < received_data.size(); ++step) {
-      CHECK(received_data[step].first == steps[step]);
-      CHECK(get(get<Var>(received_data[step].second)) ==
-            DataVector(2, 10. * (step + 1)));
-    }
-  };
-  check_data(recorders.at(left_mortar_id), relevant_left_steps);
-  check_data(recorders.at(right_mortar_id), relevant_right_steps);
-}
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication.lts",
-                  "[Unit][NumericalAlgorithms][Actions]") {
-  // Global step 0 -> 1
-  run_lts_case(1, {0, 1}, {0, 1});
-  // Global step 0 -> 1 with left element taking second step
-  run_lts_case(1, {0, 1, 2}, {0, 1});
-  // Neighbors stepping past element
-  run_lts_case(1, {0, 2}, {0, 1});
-  run_lts_case(1, {0, 1}, {0, 2});
-  run_lts_case(1, {0, 2}, {0, 2});
-  // No receives from one or both sides (because one or more neighbors
-  // have already made it to the desired time)
-  run_lts_case(1, {1}, {1});
-  run_lts_case(1, {1}, {2});
-  run_lts_case(1, {2}, {1});
-  run_lts_case(1, {2}, {2});
-  run_lts_case(1, {0, 1}, {1});
-  run_lts_case(1, {0, 1}, {2});
-  run_lts_case(1, {0, 2}, {1});
-  run_lts_case(1, {0, 2}, {2});
-  run_lts_case(1, {1}, {0, 1});
-  run_lts_case(1, {1}, {0, 2});
-  run_lts_case(1, {2}, {0, 1});
-  run_lts_case(1, {2}, {0, 2});
-  // Several steps to receive
-  run_lts_case(3, {0, 1, 3, 4}, {0, 1, 2, 4});
 }
 
 SPECTRE_TEST_CASE(
     "Unit.DiscontinuousGalerkin.Actions.FluxCommunication.p-refinement",
     "[Unit][NumericalAlgorithms][Actions]") {
-  ActionTesting::ActionRunner<Metavariables<3>> runner{{NumericalFlux<3>{}}};
+  using metavariables = Metavariables<3>;
+  using my_component = component<3, metavariables>;
 
   const ElementId<3> self_id(1);
   const ElementId<3> neighbor_id(2);
@@ -746,9 +630,8 @@ SPECTRE_TEST_CASE(
                         Direction<3>::lower_eta()}}}}}});
 
   ElementMap<3, Frame::Inertial> map(
-      self_id,
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::Identity<3>{}));
+      self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+                   CoordinateMaps::Identity<3>{}));
 
   const Mesh<3> mesh({{2, 3, 4}}, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
@@ -783,26 +666,54 @@ SPECTRE_TEST_CASE(
   db::item_type<other_data_tag<3>> other_data;
   other_data[mortar_id.first].initialize(face_mesh.number_of_grid_points(), 0.);
 
-  auto start_box = db::create<
+  using simple_tags =
       db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<3>,
                         Tags::Element<3>, Tags::ElementMap<3>,
                         normal_dot_fluxes_tag<3, flux_comm_types<3>>,
                         other_data_tag<3>, mortar_data_tag<flux_comm_types<3>>,
                         mortar_next_temporal_ids_tag<3>, mortar_meshes_tag<3>,
-                        mortar_sizes_tag<3>>,
-      compute_items<component<3, Metavariables<3>>>>(
-      0, 1, mesh, element, std::move(map), std::move(normal_dot_fluxes),
-      std::move(other_data),
-      db::item_type<mortar_data_tag<flux_comm_types<3>>>{{mortar_id, {}}},
-      db::item_type<mortar_next_temporal_ids_tag<3>>{{mortar_id, 1}},
-      db::item_type<mortar_meshes_tag<3>>{{mortar_id, mortar_mesh}},
-      db::item_type<mortar_sizes_tag<3>>{
-          {mortar_id,
-           {{Spectral::MortarSize::Full, Spectral::MortarSize::Full}}}});
+                        mortar_sizes_tag<3>>;
+
+  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
+  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<my_component>;
+  ActionRunner::LocalAlgorithms local_algs{};
+  tuples::get<LocalAlgsTag>(local_algs)
+      .emplace(
+          self_id,
+          db::create<simple_tags, compute_items<my_component>>(
+              0, 1, mesh, element, std::move(map), std::move(normal_dot_fluxes),
+              std::move(other_data),
+              db::item_type<mortar_data_tag<flux_comm_types<3>>>{
+                  {mortar_id, {}}},
+              db::item_type<mortar_next_temporal_ids_tag<3>>{{mortar_id, 1}},
+              db::item_type<mortar_meshes_tag<3>>{{mortar_id, mortar_mesh}},
+              db::item_type<mortar_sizes_tag<3>>{
+                  {mortar_id,
+                   {{Spectral::MortarSize::Full,
+                     Spectral::MortarSize::Full}}}}));
+  tuples::get<LocalAlgsTag>(local_algs)
+      .emplace(
+          neighbor_id,
+          db::create<simple_tags, compute_items<my_component>>(
+              0, 1, mesh, element, ElementMap<3, Frame::Inertial>{},
+              db::item_type<normal_dot_fluxes_tag<3, flux_comm_types<3>>>{},
+              db::item_type<other_data_tag<3>>{},
+              db::item_type<mortar_data_tag<flux_comm_types<3>>>{
+                  {mortar_id, {}}},
+              db::item_type<mortar_next_temporal_ids_tag<3>>{{mortar_id, 1}},
+              db::item_type<mortar_meshes_tag<3>>{{mortar_id, face_mesh}},
+              db::item_type<mortar_sizes_tag<3>>{{mortar_id, {{}}}}));
+
+  ActionTesting::ActionRunner<metavariables> runner{{NumericalFlux<3>{}},
+                                                    std::move(local_algs)};
+
+  auto& start_box = runner.algorithms<my_component>()
+                        .at(self_id)
+                        .get_databox<typename my_component::initial_databox>();
 
   auto sent_box = std::get<0>(
-      runner.apply<component<3, Metavariables<3>>, send_data_for_fluxes<3>>(
-          start_box, self_id));
+      runner.apply<my_component, send_data_for_fluxes<metavariables>>(start_box,
+                                                                      self_id));
 
   // Check local data
   {
@@ -828,12 +739,11 @@ SPECTRE_TEST_CASE(
 
   // Check sent data
   {
-    CHECK(runner
-              .nonempty_inboxes<component<3, Metavariables<3>>,
-                                fluxes_tag<flux_comm_types<3>>>()
-              .size() == 1);
+    CHECK(
+        runner.nonempty_inboxes<my_component, fluxes_tag<flux_comm_types<3>>>()
+            .size() == 1);
     const auto& inbox = tuples::get<fluxes_tag<flux_comm_types<3>>>(
-        runner.inboxes<component<3, Metavariables<3>>>().at(neighbor_id));
+        runner.inboxes<my_component>().at(neighbor_id));
 
     const auto& received_flux =
         inbox.at(0).at({Direction<3>::upper_xi(), self_id}).second;
@@ -847,8 +757,8 @@ SPECTRE_TEST_CASE(
 SPECTRE_TEST_CASE(
     "Unit.DiscontinuousGalerkin.Actions.FluxCommunication.h-refinement",
     "[Unit][NumericalAlgorithms][Actions]") {
-  ActionTesting::ActionRunner<Metavariables<2>> runner{{NumericalFlux<2>{}}};
-
+  using metavariables = Metavariables<2>;
+  using my_component = component<2, metavariables>;
   const Scalar<DataVector> n_dot_f{{{{2., 3.}}}};
   for (const auto& test :
        {std::make_pair(Spectral::MortarSize::Full, DataVector{2., 3.}),
@@ -897,23 +807,61 @@ SPECTRE_TEST_CASE(
     other_data[mortar_id.first].initialize(face_mesh.number_of_grid_points(),
                                            0.);
 
-    auto start_box = db::create<
-        db::AddSimpleTags<
-            TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
-            Tags::ElementMap<2>, normal_dot_fluxes_tag<2, flux_comm_types<2>>,
-            other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
-            mortar_next_temporal_ids_tag<2>, mortar_meshes_tag<2>,
-            mortar_sizes_tag<2>>,
-        compute_items<component<2, Metavariables<2>>>>(
-        0, 1, mesh, element, std::move(map), std::move(normal_dot_fluxes),
-        std::move(other_data),
-        db::item_type<mortar_data_tag<flux_comm_types<2>>>{{mortar_id, {}}},
-        db::item_type<mortar_next_temporal_ids_tag<2>>{{mortar_id, 1}},
-        db::item_type<mortar_meshes_tag<2>>{{mortar_id, face_mesh}},
-        db::item_type<mortar_sizes_tag<2>>{{mortar_id, {{test.first}}}});
+    using ActionRunner = ActionTesting::ActionRunner<metavariables>;
+    using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<my_component>;
+    ActionRunner::LocalAlgorithms local_algs{};
+    tuples::get<LocalAlgsTag>(local_algs)
+        .emplace(
+            self_id,
+            db::create<
+                db::AddSimpleTags<
+                    TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
+                    Tags::Element<2>, Tags::ElementMap<2>,
+                    normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+                    other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
+                    mortar_next_temporal_ids_tag<2>, mortar_meshes_tag<2>,
+                    mortar_sizes_tag<2>>,
+                compute_items<my_component>>(
+                0, 1, mesh, element, std::move(map),
+                std::move(normal_dot_fluxes), std::move(other_data),
+                db::item_type<mortar_data_tag<flux_comm_types<2>>>{
+                    {mortar_id, {}}},
+                db::item_type<mortar_next_temporal_ids_tag<2>>{{mortar_id, 1}},
+                db::item_type<mortar_meshes_tag<2>>{{mortar_id, face_mesh}},
+                db::item_type<mortar_sizes_tag<2>>{
+                    {mortar_id, {{test.first}}}}));
+    tuples::get<LocalAlgsTag>(local_algs)
+        .emplace(
+            neighbor_id,
+            db::create<
+                db::AddSimpleTags<
+                    TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
+                    Tags::Element<2>, Tags::ElementMap<2>,
+                    normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+                    other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
+                    mortar_next_temporal_ids_tag<2>, mortar_meshes_tag<2>,
+                    mortar_sizes_tag<2>>,
+                compute_items<my_component>>(
+                0, 1, mesh, element, ElementMap<2, Frame::Inertial>{},
+                db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>>{},
+                db::item_type<other_data_tag<2>>{},
+                db::item_type<mortar_data_tag<flux_comm_types<2>>>{
+                    {mortar_id, {}}},
+                db::item_type<mortar_next_temporal_ids_tag<2>>{{mortar_id, 1}},
+                db::item_type<mortar_meshes_tag<2>>{{mortar_id, face_mesh}},
+                db::item_type<mortar_sizes_tag<2>>{
+                    {mortar_id, {{test.first}}}}));
+
+    ActionTesting::ActionRunner<metavariables> runner{{NumericalFlux<2>{}},
+                                                      std::move(local_algs)};
+
+    auto& start_box =
+        runner.algorithms<my_component>()
+            .at(self_id)
+            .get_databox<typename my_component::initial_databox>();
 
     auto sent_box = std::get<0>(
-        runner.apply<component<2, Metavariables<2>>, send_data_for_fluxes<2>>(
+        runner.apply<my_component, send_data_for_fluxes<metavariables>>(
             start_box, self_id));
 
     // Check local data
@@ -938,12 +886,12 @@ SPECTRE_TEST_CASE(
 
     // Check sent data
     {
-      CHECK(runner
-                .nonempty_inboxes<component<2, Metavariables<2>>,
-                                  fluxes_tag<flux_comm_types<2>>>()
-                .size() == 1);
+      CHECK(
+          runner
+              .nonempty_inboxes<my_component, fluxes_tag<flux_comm_types<2>>>()
+              .size() == 1);
       auto& inbox = tuples::get<fluxes_tag<flux_comm_types<2>>>(
-          runner.inboxes<component<2, Metavariables<2>>>().at(neighbor_id));
+          runner.inboxes<my_component>().at(neighbor_id));
 
       const auto& received_flux =
           inbox.at(0).at({Direction<2>::lower_xi(), self_id}).second;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -132,41 +132,23 @@ template <size_t Dim>
 using receive_data_for_fluxes =
     dg::Actions::ReceiveDataForFluxes<Metavariables<Dim>>;
 
-template <size_t Dim>
-using component =
-    ActionTesting::MockArrayComponent<Metavariables<Dim>, ElementIndex<Dim>,
-                                      tmpl::list<NumericalFluxTag<Dim>>,
-                                      tmpl::list<receive_data_for_fluxes<Dim>>>;
-
-template <size_t Dim>
-struct Metavariables {
-  using system = System<Dim>;
-  using component_list = tmpl::list<component<Dim>>;
-  using temporal_id = TemporalId;
-  using const_global_cache_tag_list = tmpl::list<>;
-
-  using normal_dot_numerical_flux = NumericalFluxTag<Dim>;
-};
-
 template <size_t Dim, typename Tag>
 using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
 
-template <size_t Dim>
-using flux_comm_types = dg::FluxCommunicationTypes<Metavariables<Dim>>;
-template <size_t Dim>
-using mortar_data_tag = typename flux_comm_types<Dim>::simple_mortar_data_tag;
-template <size_t Dim>
-using LocalData = typename flux_comm_types<Dim>::LocalData;
-template <size_t Dim>
-using LocalMortarData = typename flux_comm_types<Dim>::LocalMortarData;
-template <size_t Dim>
-using PackagedData = typename flux_comm_types<Dim>::PackagedData;
-template <size_t Dim>
+template <typename FluxCommTypes>
+using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;
+template <typename FluxCommTypes>
+using LocalData = typename FluxCommTypes::LocalData;
+template <typename FluxCommTypes>
+using LocalMortarData = typename FluxCommTypes::LocalMortarData;
+template <typename FluxCommTypes>
+using PackagedData = typename FluxCommTypes::PackagedData;
+template <size_t Dim, typename FluxCommTypes>
 using normal_dot_fluxes_tag =
-    interface_tag<Dim, typename flux_comm_types<Dim>::normal_dot_fluxes_tag>;
+    interface_tag<Dim, typename FluxCommTypes::normal_dot_fluxes_tag>;
 
-template <size_t Dim>
-using fluxes_tag = typename flux_comm_types<Dim>::FluxesTag;
+template <typename FluxCommTypes>
+using fluxes_tag = typename FluxCommTypes::FluxesTag;
 
 template <size_t Dim>
 using other_data_tag =
@@ -178,14 +160,52 @@ using mortar_meshes_tag = Tags::Mortars<Tags::Mesh<Dim - 1>, Dim>;
 template <size_t Dim>
 using mortar_sizes_tag = Tags::Mortars<Tags::MortarSize<Dim - 1>, Dim>;
 
+template <size_t Dim, typename Metavariables>
+struct component
+    : ActionTesting::MockArrayComponent<
+          Metavariables, ElementIndex<Dim>, tmpl::list<NumericalFluxTag<Dim>>,
+          tmpl::list<receive_data_for_fluxes<Dim>>> {
+  using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
+
+  using simple_tags =
+      db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<Dim>,
+                        Tags::Element<Dim>, Tags::ElementMap<Dim>,
+                        normal_dot_fluxes_tag<Dim, flux_comm_types>,
+                        other_data_tag<Dim>, mortar_data_tag<flux_comm_types>,
+                        mortar_next_temporal_ids_tag<Dim>,
+                        mortar_meshes_tag<Dim>, mortar_sizes_tag<Dim>>;
+
+  using compute_tags = db::AddComputeTags<
+      Tags::InternalDirections<Dim>, interface_tag<Dim, Tags::Direction<Dim>>,
+      interface_tag<Dim, Tags::Mesh<Dim - 1>>,
+      interface_tag<Dim, Tags::UnnormalizedFaceNormal<Dim>>,
+      interface_tag<
+          Dim, Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+      interface_tag<Dim, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+
+  using initial_databox =
+      db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
+};
+
 template <size_t Dim>
-using compute_items = db::AddComputeTags<
-    Tags::InternalDirections<Dim>, interface_tag<Dim, Tags::Direction<Dim>>,
-    interface_tag<Dim, Tags::Mesh<Dim - 1>>,
-    interface_tag<Dim, Tags::UnnormalizedFaceNormal<Dim>>,
-    interface_tag<Dim,
-                  Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
-    interface_tag<Dim, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+struct Metavariables {
+  using system = System<Dim>;
+  using component_list = tmpl::list<component<Dim, Metavariables>>;
+  using temporal_id = TemporalId;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  using normal_dot_numerical_flux = NumericalFluxTag<Dim>;
+};
+
+template <typename Component>
+using simple_items = typename Component::simple_tags;
+
+template <typename Component>
+using compute_items = typename Component::compute_tags;
+
+template <size_t Dim>
+using flux_comm_types =
+    typename component<Dim, Metavariables<Dim>>::flux_comm_types;
 
 Scalar<DataVector> reverse(Scalar<DataVector> x) noexcept {
   std::reverse(get(x).begin(), get(x).end());
@@ -268,7 +288,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
 
     auto map = ElementMap<2, Frame::Inertial>(self_id, coordmap->get_clone());
 
-    db::item_type<normal_dot_fluxes_tag<2>> normal_dot_fluxes;
+    db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>>
+        normal_dot_fluxes;
     for (const auto& direction : neighbor_directions) {
       auto& flux_vars = normal_dot_fluxes[direction];
       flux_vars.initialize(3);
@@ -282,7 +303,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
       get<OtherData>(other_data_vars) = data.other_data.at(direction);
     }
 
-    db::item_type<mortar_data_tag<2>> mortar_history{};
+    db::item_type<mortar_data_tag<flux_comm_types<2>>> mortar_history{};
     db::item_type<mortar_next_temporal_ids_tag<2>> mortar_next_temporal_ids{};
     db::item_type<mortar_meshes_tag<2>> mortar_meshes{};
     db::item_type<mortar_sizes_tag<2>> mortar_sizes{};
@@ -294,30 +315,34 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
     }
 
     return db::create<
-        db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
-                          Tags::Element<2>, Tags::ElementMap<2>,
-                          normal_dot_fluxes_tag<2>, other_data_tag<2>,
-                          mortar_data_tag<2>, mortar_next_temporal_ids_tag<2>,
-                          mortar_meshes_tag<2>, mortar_sizes_tag<2>>,
-        compute_items<2>>(0, 1, mesh, element, std::move(map),
-                          std::move(normal_dot_fluxes), std::move(other_data),
-                          std::move(mortar_history),
-                          std::move(mortar_next_temporal_ids),
-                          std::move(mortar_meshes), std::move(mortar_sizes));
+        db::AddSimpleTags<
+            TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
+            Tags::ElementMap<2>, normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+            other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
+            mortar_next_temporal_ids_tag<2>, mortar_meshes_tag<2>,
+            mortar_sizes_tag<2>>,
+        compute_items<component<2, Metavariables<2>>>>(
+        0, 1, mesh, element, std::move(map), std::move(normal_dot_fluxes),
+        std::move(other_data), std::move(mortar_history),
+        std::move(mortar_next_temporal_ids), std::move(mortar_meshes),
+        std::move(mortar_sizes));
   }();
 
   auto sent_box = std::get<0>(
-      runner.apply<component<2>, send_data_for_fluxes<2>>(start_box, self_id));
+      runner.apply<component<2, Metavariables<2>>, send_data_for_fluxes<2>>(
+          start_box, self_id));
 
   // Here, we just check that messages are sent to the correct places.
   // We will check the received values on the central element later.
   {
-    CHECK(runner.nonempty_inboxes<component<2>, fluxes_tag<2>>() ==
+    CHECK(runner.nonempty_inboxes<component<2, Metavariables<2>>,
+                                  fluxes_tag<flux_comm_types<2>>>() ==
           std::unordered_set<ElementIndex<2>>{west_id, east_id, south_id});
     const auto check_sent_data = [&runner, &self_id](
         const ElementId<2>& id, const Direction<2>& direction) noexcept {
-      const auto& inboxes = runner.inboxes<component<2>>();
-      const auto& flux_inbox = tuples::get<fluxes_tag<2>>(inboxes.at(id));
+      const auto& inboxes = runner.inboxes<component<2, Metavariables<2>>>();
+      const auto& flux_inbox =
+          tuples::get<fluxes_tag<flux_comm_types<2>>>(inboxes.at(id));
       CHECK(flux_inbox.size() == 1);
       CHECK(flux_inbox.count(0) == 1);
       const auto& flux_inbox_at_time = flux_inbox.at(0);
@@ -338,7 +363,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
     const Element<2> element(id, {{direction, {{self_id}, orientation}}});
     auto map = ElementMap<2, Frame::Inertial>(id, coordmap->get_clone());
 
-    db::item_type<normal_dot_fluxes_tag<2>> normal_dot_fluxes_map{};
+    db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>>
+        normal_dot_fluxes_map{};
     normal_dot_fluxes_map[direction].initialize(get(normal_dot_fluxes).size());
     get<Tags::NormalDotFlux<Var>>(normal_dot_fluxes_map[direction]) =
         normal_dot_fluxes;
@@ -347,7 +373,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
     other_data_map[direction].initialize(get(other_data).size());
     get<OtherData>(other_data_map[direction]) = other_data;
 
-    db::item_type<mortar_data_tag<2>> mortar_history{};
+    db::item_type<mortar_data_tag<flux_comm_types<2>>> mortar_history{};
     mortar_history[std::make_pair(direction, self_id)];
 
     db::item_type<mortar_meshes_tag<2>> mortar_meshes{};
@@ -359,39 +385,42 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
     auto box = db::create<
         db::AddSimpleTags<
             TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
-            Tags::ElementMap<2>, normal_dot_fluxes_tag<2>, other_data_tag<2>,
-            mortar_data_tag<2>, mortar_meshes_tag<2>, mortar_sizes_tag<2>>,
-        compute_items<2>>(0, 1, mesh, element, std::move(map),
-                          std::move(normal_dot_fluxes_map),
-                          std::move(other_data_map), std::move(mortar_history),
-                          std::move(mortar_meshes), std::move(mortar_sizes));
+            Tags::ElementMap<2>, normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+            other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
+            mortar_meshes_tag<2>, mortar_sizes_tag<2>>,
+        compute_items<component<2, Metavariables<2>>>>(
+        0, 1, mesh, element, std::move(map), std::move(normal_dot_fluxes_map),
+        std::move(other_data_map), std::move(mortar_history),
+        std::move(mortar_meshes), std::move(mortar_sizes));
 
-    runner.apply<component<2>, send_data_for_fluxes<2>>(box, id);
+    runner.apply<component<2, Metavariables<2>>, send_data_for_fluxes<2>>(box,
+                                                                          id);
   };
 
-  CHECK_FALSE(runner.is_ready<component<2>, receive_data_for_fluxes<2>>(
-      sent_box, self_id));
+  CHECK_FALSE(runner.is_ready<component<2, Metavariables<2>>,
+                              receive_data_for_fluxes<2>>(sent_box, self_id));
   send_data(south_id, Direction<2>::lower_eta(), {},
             data.remote_fluxes.at(Direction<2>::upper_eta()),
             data.remote_other_data.at(Direction<2>::upper_eta()));
-  CHECK_FALSE(runner.is_ready<component<2>, receive_data_for_fluxes<2>>(
-      sent_box, self_id));
+  CHECK_FALSE(runner.is_ready<component<2, Metavariables<2>>,
+                              receive_data_for_fluxes<2>>(sent_box, self_id));
   send_data(east_id, Direction<2>::lower_xi(), {},
             data.remote_fluxes.at(Direction<2>::upper_xi()),
             data.remote_other_data.at(Direction<2>::upper_xi()));
-  CHECK_FALSE(runner.is_ready<component<2>, receive_data_for_fluxes<2>>(
-      sent_box, self_id));
+  CHECK_FALSE(runner.is_ready<component<2, Metavariables<2>>,
+                              receive_data_for_fluxes<2>>(sent_box, self_id));
   send_data(west_id, Direction<2>::lower_eta(), block_orientation.inverse_map(),
             data.remote_fluxes.at(Direction<2>::lower_xi()),
             data.remote_other_data.at(Direction<2>::lower_xi()));
-  CHECK(runner.is_ready<component<2>, receive_data_for_fluxes<2>>(sent_box,
-                                                                  self_id));
+  CHECK(runner.is_ready<component<2, Metavariables<2>>,
+                        receive_data_for_fluxes<2>>(sent_box, self_id));
 
-  auto received_box =
-      std::get<0>(runner.apply<component<2>, receive_data_for_fluxes<2>>(
+  auto received_box = std::get<0>(
+      runner.apply<component<2, Metavariables<2>>, receive_data_for_fluxes<2>>(
           sent_box, self_id));
 
-  CHECK(tuples::get<fluxes_tag<2>>(runner.inboxes<component<2>>()[self_id])
+  CHECK(tuples::get<fluxes_tag<flux_comm_types<2>>>(
+            runner.inboxes<component<2, Metavariables<2>>>()[self_id])
             .empty());
 
   for (const auto& mortar_id : neighbor_mortar_ids) {
@@ -400,8 +429,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
         1);
   };
 
-  auto mortar_history =
-      serialize_and_deserialize(db::get<mortar_data_tag<2>>(received_box));
+  auto mortar_history = serialize_and_deserialize(
+      db::get<mortar_data_tag<flux_comm_types<2>>>(received_box));
   CHECK(mortar_history.size() == 3);
   const auto check_mortar = [&mortar_history](
       const std::pair<Direction<2>, ElementId<2>>& mortar_id,
@@ -411,14 +440,14 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
       const Scalar<DataVector>& remote_other,
       const tnsr::i<DataVector, 2>& local_normal,
       const tnsr::i<DataVector, 2>& remote_normal) noexcept {
-    LocalMortarData<2> local_mortar_data(3);
+    LocalMortarData<flux_comm_types<2>> local_mortar_data(3);
     get<Tags::NormalDotFlux<Var>>(local_mortar_data) = local_flux;
     const auto magnitude_local_normal = magnitude(local_normal);
     auto normalized_local_normal = local_normal;
     for (auto& x : normalized_local_normal) {
       x /= get(magnitude_local_normal);
     }
-    PackagedData<2> local_packaged(3);
+    PackagedData<flux_comm_types<2>> local_packaged(3);
     NumericalFlux<2>{}.package_data(&local_packaged, local_flux, local_other,
                                     normalized_local_normal);
     local_mortar_data.assign_subset(local_packaged);
@@ -428,7 +457,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
     for (auto& x : normalized_remote_normal) {
       x /= get(magnitude_remote_normal);
     }
-    PackagedData<2> remote_packaged(3);
+    PackagedData<flux_comm_types<2>> remote_packaged(3);
     NumericalFlux<2>{}.package_data(&remote_packaged, remote_flux, remote_other,
                                     normalized_remote_normal);
 
@@ -486,45 +515,55 @@ SPECTRE_TEST_CASE(
   auto start_box = db::create<
       db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
                         Tags::Element<2>, Tags::ElementMap<2>,
-                        normal_dot_fluxes_tag<2>, other_data_tag<2>,
-                        mortar_data_tag<2>, mortar_next_temporal_ids_tag<2>,
-                        mortar_meshes_tag<2>, mortar_sizes_tag<2>>,
-      compute_items<2>>(0, 1, mesh, element, std::move(map),
-                        db::item_type<normal_dot_fluxes_tag<2>>{},
-                        db::item_type<other_data_tag<2>>{},
-                        db::item_type<mortar_data_tag<2>>{},
-                        db::item_type<mortar_next_temporal_ids_tag<2>>{},
-                        db::item_type<mortar_meshes_tag<2>>{},
-                        db::item_type<mortar_sizes_tag<2>>{});
+                        normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+                        other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
+                        mortar_next_temporal_ids_tag<2>, mortar_meshes_tag<2>,
+                        mortar_sizes_tag<2>>,
+      compute_items<component<2, Metavariables<2>>>>(
+      0, 1, mesh, element, std::move(map),
+      db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>>{},
+      db::item_type<other_data_tag<2>>{},
+      db::item_type<mortar_data_tag<flux_comm_types<2>>>{},
+      db::item_type<mortar_next_temporal_ids_tag<2>>{},
+      db::item_type<mortar_meshes_tag<2>>{},
+      db::item_type<mortar_sizes_tag<2>>{});
 
   auto sent_box = std::get<0>(
-      runner.apply<component<2>, send_data_for_fluxes<2>>(start_box, self_id));
+      runner.apply<component<2, Metavariables<2>>, send_data_for_fluxes<2>>(
+          start_box, self_id));
 
-  CHECK(db::get<mortar_data_tag<2>>(sent_box).empty());
-  CHECK(runner.nonempty_inboxes<component<2>, fluxes_tag<2>>().empty());
+  CHECK(db::get<mortar_data_tag<flux_comm_types<2>>>(sent_box).empty());
+  CHECK(runner
+            .nonempty_inboxes<component<2, Metavariables<2>>,
+                              fluxes_tag<flux_comm_types<2>>>()
+            .empty());
 
-  CHECK(runner.is_ready<component<2>, receive_data_for_fluxes<2>>(sent_box,
-                                                                  self_id));
+  CHECK(runner.is_ready<component<2, Metavariables<2>>,
+                        receive_data_for_fluxes<2>>(sent_box, self_id));
 
-  const auto received_box =
-      std::get<0>(runner.apply<component<2>, receive_data_for_fluxes<2>>(
+  const auto received_box = std::get<0>(
+      runner.apply<component<2, Metavariables<2>>, receive_data_for_fluxes<2>>(
           sent_box, self_id));
 
-  CHECK(db::get<mortar_data_tag<2>>(received_box).empty());
-  CHECK(runner.nonempty_inboxes<component<2>, fluxes_tag<2>>().empty());
+  CHECK(db::get<mortar_data_tag<flux_comm_types<2>>>(received_box).empty());
+  CHECK(runner
+            .nonempty_inboxes<component<2, Metavariables<2>>,
+                              fluxes_tag<flux_comm_types<2>>>()
+            .empty());
 }
 
 namespace {
 struct DataRecorder {
   // Only called on the sending sides, which are not interesting here.
   void local_insert(int /*temporal_id*/,
-                    const LocalData<2>& /*data*/) noexcept {}
+                    const LocalData<flux_comm_types<2>>& /*data*/) noexcept {}
 
-  void remote_insert(int temporal_id, PackagedData<2> data) noexcept {
+  void remote_insert(int temporal_id,
+                     PackagedData<flux_comm_types<2>> data) noexcept {
     received_data.emplace_back(temporal_id, std::move(data));
   }
 
-  std::vector<std::pair<int, PackagedData<2>>> received_data{};
+  std::vector<std::pair<int, PackagedData<flux_comm_types<2>>>> received_data{};
 };
 
 struct DataRecorderTag : db::SimpleTag {
@@ -550,7 +589,7 @@ void send_from_neighbor(
       element.id(), make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
                         CoordinateMaps::Identity<2>{}));
 
-  db::item_type<normal_dot_fluxes_tag<2>> fluxes;
+  db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>> fluxes;
   fluxes[send_direction].initialize(2, n_dot_f);
 
   db::item_type<other_data_tag<2>> other_data;
@@ -567,16 +606,18 @@ void send_from_neighbor(
   recorders.insert({{send_direction, receiver_id}, {}});
 
   auto box = db::create<
-      db::AddSimpleTags<
-          TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
-          Tags::ElementMap<2>, normal_dot_fluxes_tag<2>, other_data_tag<2>,
-          mortar_meshes_tag<2>, mortar_sizes_tag<2>, MortarRecorderTag>,
-      compute_items<2>>(start, end, mesh, element, std::move(map),
-                        std::move(fluxes), std::move(other_data),
-                        std::move(mortar_meshes), std::move(mortar_sizes),
-                        std::move(recorders));
+      db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
+                        Tags::Element<2>, Tags::ElementMap<2>,
+                        normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+                        other_data_tag<2>, mortar_meshes_tag<2>,
+                        mortar_sizes_tag<2>, MortarRecorderTag>,
+      compute_items<component<2, Metavariables<2>>>>(
+      start, end, mesh, element, std::move(map), std::move(fluxes),
+      std::move(other_data), std::move(mortar_meshes), std::move(mortar_sizes),
+      std::move(recorders));
 
-  runner->apply<component<2>, send_data_for_fluxes<2>>(box, element.id());
+  runner->apply<component<2, Metavariables<2>>, send_data_for_fluxes<2>>(
+      box, element.id());
 }
 
 // Sends the left steps, then the right steps.  The step must not be
@@ -613,8 +654,8 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
 
   std::vector<int> relevant_left_steps{left_steps.front()};
   for (size_t step = 1; step < left_steps.size(); ++step) {
-    CHECK_FALSE(runner.is_ready<component<2>, receive_data_for_fluxes<2>>(
-        box, self_id));
+    CHECK_FALSE(runner.is_ready<component<2, Metavariables<2>>,
+                                receive_data_for_fluxes<2>>(box, self_id));
     send_from_neighbor(&runner, left_element, left_steps[step - 1],
                        left_steps[step], step);
     if (left_steps[step - 1] < self_step_end) {
@@ -623,19 +664,20 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
   }
   std::vector<int> relevant_right_steps{right_steps.front()};
   for (size_t step = 1; step < right_steps.size(); ++step) {
-    CHECK_FALSE(runner.is_ready<component<2>, receive_data_for_fluxes<2>>(
-        box, self_id));
+    CHECK_FALSE(runner.is_ready<component<2, Metavariables<2>>,
+                                receive_data_for_fluxes<2>>(box, self_id));
     send_from_neighbor(&runner, right_element, right_steps[step - 1],
                        right_steps[step], step);
     if (right_steps[step - 1] < self_step_end) {
       relevant_right_steps.push_back(right_steps[step]);
     }
   }
-  CHECK(
-      runner.is_ready<component<2>, receive_data_for_fluxes<2>>(box, self_id));
+  CHECK(runner.is_ready<component<2, Metavariables<2>>,
+                        receive_data_for_fluxes<2>>(box, self_id));
 
   box = std::get<0>(
-      runner.apply<component<2>, receive_data_for_fluxes<2>>(box, self_id));
+      runner.apply<component<2, Metavariables<2>>, receive_data_for_fluxes<2>>(
+          box, self_id));
 
   CHECK(db::get<mortar_next_temporal_ids_tag<2>>(box) ==
         db::item_type<mortar_next_temporal_ids_tag<2>>{
@@ -724,14 +766,14 @@ SPECTRE_TEST_CASE(
     return Scalar<DataVector>(x * cube(y));
   };
   const auto packaged_data = [](const Scalar<DataVector>& var_flux) noexcept {
-    PackagedData<3> packaged(get(var_flux).size());
+    PackagedData<flux_comm_types<3>> packaged(get(var_flux).size());
     const tnsr::i<DataVector, 3, Frame::Inertial> normal(get(var_flux).size(),
                                                          1.);
     NumericalFlux<3>{}.package_data(&packaged, var_flux, var_flux, normal);
     return packaged;
   };
 
-  db::item_type<normal_dot_fluxes_tag<3>> normal_dot_fluxes;
+  db::item_type<normal_dot_fluxes_tag<3, flux_comm_types<3>>> normal_dot_fluxes;
   normal_dot_fluxes[mortar_id.first].initialize(
       face_mesh.number_of_grid_points());
   get<Tags::NormalDotFlux<Var>>(normal_dot_fluxes[mortar_id.first]) =
@@ -744,12 +786,14 @@ SPECTRE_TEST_CASE(
   auto start_box = db::create<
       db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<3>,
                         Tags::Element<3>, Tags::ElementMap<3>,
-                        normal_dot_fluxes_tag<3>, other_data_tag<3>,
-                        mortar_data_tag<3>, mortar_next_temporal_ids_tag<3>,
-                        mortar_meshes_tag<3>, mortar_sizes_tag<3>>,
-      compute_items<3>>(
+                        normal_dot_fluxes_tag<3, flux_comm_types<3>>,
+                        other_data_tag<3>, mortar_data_tag<flux_comm_types<3>>,
+                        mortar_next_temporal_ids_tag<3>, mortar_meshes_tag<3>,
+                        mortar_sizes_tag<3>>,
+      compute_items<component<3, Metavariables<3>>>>(
       0, 1, mesh, element, std::move(map), std::move(normal_dot_fluxes),
-      std::move(other_data), db::item_type<mortar_data_tag<3>>{{mortar_id, {}}},
+      std::move(other_data),
+      db::item_type<mortar_data_tag<flux_comm_types<3>>>{{mortar_id, {}}},
       db::item_type<mortar_next_temporal_ids_tag<3>>{{mortar_id, 1}},
       db::item_type<mortar_meshes_tag<3>>{{mortar_id, mortar_mesh}},
       db::item_type<mortar_sizes_tag<3>>{
@@ -757,13 +801,15 @@ SPECTRE_TEST_CASE(
            {{Spectral::MortarSize::Full, Spectral::MortarSize::Full}}}});
 
   auto sent_box = std::get<0>(
-      runner.apply<component<3>, send_data_for_fluxes<3>>(start_box, self_id));
+      runner.apply<component<3, Metavariables<3>>, send_data_for_fluxes<3>>(
+          start_box, self_id));
 
   // Check local data
   {
-    CHECK(db::get<mortar_data_tag<3>>(sent_box).size() == 1);
-    auto mortar_data = db::get<mortar_data_tag<3>>(sent_box).at(mortar_id);
-    mortar_data.remote_insert(0, PackagedData<3>{});
+    CHECK(db::get<mortar_data_tag<flux_comm_types<3>>>(sent_box).size() == 1);
+    auto mortar_data =
+        db::get<mortar_data_tag<flux_comm_types<3>>>(sent_box).at(mortar_id);
+    mortar_data.remote_insert(0, PackagedData<flux_comm_types<3>>{});
     const auto local_data = mortar_data.extract().first;
     CHECK(local_data.mortar_data.number_of_grid_points() ==
           mortar_mesh.number_of_grid_points());
@@ -782,9 +828,12 @@ SPECTRE_TEST_CASE(
 
   // Check sent data
   {
-    CHECK(runner.nonempty_inboxes<component<3>, fluxes_tag<3>>().size() == 1);
-    const auto& inbox = tuples::get<fluxes_tag<3>>(
-        runner.inboxes<component<3>>().at(neighbor_id));
+    CHECK(runner
+              .nonempty_inboxes<component<3, Metavariables<3>>,
+                                fluxes_tag<flux_comm_types<3>>>()
+              .size() == 1);
+    const auto& inbox = tuples::get<fluxes_tag<flux_comm_types<3>>>(
+        runner.inboxes<component<3, Metavariables<3>>>().at(neighbor_id));
 
     const auto& received_flux =
         inbox.at(0).at({Direction<3>::upper_xi(), self_id}).second;
@@ -830,14 +879,15 @@ SPECTRE_TEST_CASE(
 
     const auto packaged_data = [](const DataVector& var_flux) noexcept {
       const Scalar<DataVector> scalar_flux(var_flux);
-      PackagedData<2> packaged(var_flux.size());
+      PackagedData<flux_comm_types<2>> packaged(var_flux.size());
       const tnsr::i<DataVector, 2, Frame::Inertial> normal(var_flux.size(), 1.);
       NumericalFlux<2>{}.package_data(&packaged, scalar_flux, scalar_flux,
                                       normal);
       return packaged;
     };
 
-    db::item_type<normal_dot_fluxes_tag<2>> normal_dot_fluxes;
+    db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>>
+        normal_dot_fluxes;
     normal_dot_fluxes[mortar_id.first].initialize(
         face_mesh.number_of_grid_points());
     get<Tags::NormalDotFlux<Var>>(normal_dot_fluxes[mortar_id.first]) = n_dot_f;
@@ -848,28 +898,30 @@ SPECTRE_TEST_CASE(
                                            0.);
 
     auto start_box = db::create<
-        db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
-                          Tags::Element<2>, Tags::ElementMap<2>,
-                          normal_dot_fluxes_tag<2>, other_data_tag<2>,
-                          mortar_data_tag<2>, mortar_next_temporal_ids_tag<2>,
-                          mortar_meshes_tag<2>, mortar_sizes_tag<2>>,
-        compute_items<2>>(
+        db::AddSimpleTags<
+            TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
+            Tags::ElementMap<2>, normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+            other_data_tag<2>, mortar_data_tag<flux_comm_types<2>>,
+            mortar_next_temporal_ids_tag<2>, mortar_meshes_tag<2>,
+            mortar_sizes_tag<2>>,
+        compute_items<component<2, Metavariables<2>>>>(
         0, 1, mesh, element, std::move(map), std::move(normal_dot_fluxes),
         std::move(other_data),
-        db::item_type<mortar_data_tag<2>>{{mortar_id, {}}},
+        db::item_type<mortar_data_tag<flux_comm_types<2>>>{{mortar_id, {}}},
         db::item_type<mortar_next_temporal_ids_tag<2>>{{mortar_id, 1}},
         db::item_type<mortar_meshes_tag<2>>{{mortar_id, face_mesh}},
         db::item_type<mortar_sizes_tag<2>>{{mortar_id, {{test.first}}}});
 
-    auto sent_box =
-        std::get<0>(runner.apply<component<2>, send_data_for_fluxes<2>>(
+    auto sent_box = std::get<0>(
+        runner.apply<component<2, Metavariables<2>>, send_data_for_fluxes<2>>(
             start_box, self_id));
 
     // Check local data
     {
-      CHECK(db::get<mortar_data_tag<2>>(sent_box).size() == 1);
-      auto mortar_data = db::get<mortar_data_tag<2>>(sent_box).at(mortar_id);
-      mortar_data.remote_insert(0, PackagedData<2>{});
+      CHECK(db::get<mortar_data_tag<flux_comm_types<2>>>(sent_box).size() == 1);
+      auto mortar_data =
+          db::get<mortar_data_tag<flux_comm_types<2>>>(sent_box).at(mortar_id);
+      mortar_data.remote_insert(0, PackagedData<flux_comm_types<2>>{});
       const auto local_data = mortar_data.extract().first;
       CHECK(local_data.mortar_data.number_of_grid_points() ==
             face_mesh.number_of_grid_points());
@@ -886,9 +938,12 @@ SPECTRE_TEST_CASE(
 
     // Check sent data
     {
-      CHECK(runner.nonempty_inboxes<component<2>, fluxes_tag<2>>().size() == 1);
-      auto& inbox = tuples::get<fluxes_tag<2>>(
-          runner.inboxes<component<2>>().at(neighbor_id));
+      CHECK(runner
+                .nonempty_inboxes<component<2, Metavariables<2>>,
+                                  fluxes_tag<flux_comm_types<2>>>()
+                .size() == 1);
+      auto& inbox = tuples::get<fluxes_tag<flux_comm_types<2>>>(
+          runner.inboxes<component<2, Metavariables<2>>>().at(neighbor_id));
 
       const auto& received_flux =
           inbox.at(0).at({Direction<2>::lower_xi(), self_id}).second;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -1,0 +1,450 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+// IWYU pragma: no_include <boost/functional/hash/extensions.hpp>
+#include <cstddef>
+#include <functional>
+#include <initializer_list>  // IWYU pragma: keep
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+// IWYU pragma: no_include "DataStructures/VariablesHelpers.hpp"  // for Variables
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"  // IWYU pragma: keep
+#include "Domain/ElementMap.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Neighbors.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+// IWYU pragma: no_include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+// IWYU pragma: no_include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+
+namespace {
+struct TemporalId : db::SimpleTag {
+  static std::string name() noexcept { return "TemporalId"; }
+  using type = int;
+};
+
+struct Var : db::SimpleTag {
+  static std::string name() noexcept { return "Var"; }
+  using type = Scalar<DataVector>;
+};
+
+struct OtherData : db::SimpleTag {
+  static std::string name() noexcept { return "OtherData"; }
+  using type = Scalar<DataVector>;
+  static constexpr bool should_be_sliced_to_boundary = false;
+};
+
+template <size_t Dim>
+class NumericalFlux {
+ public:
+  struct ExtraData : db::SimpleTag {
+    static std::string name() noexcept { return "ExtraTag"; }
+    using type = tnsr::I<DataVector, 1>;
+  };
+
+  using package_tags = tmpl::list<ExtraData, Var>;
+  // This is a silly set of things to request, but it tests not
+  // requesting the evolved variables and requesting multiple other
+  // things.
+  using argument_tags =
+      tmpl::list<Tags::NormalDotFlux<Var>, OtherData,
+                 Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>;
+  void package_data(const gsl::not_null<Variables<package_tags>*> packaged_data,
+                    const Scalar<DataVector>& var_flux,
+                    const Scalar<DataVector>& other_data,
+                    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+                        interface_unit_normal) const noexcept {
+    get(get<Var>(*packaged_data)) = 10. * get(var_flux);
+    get<0>(get<ExtraData>(*packaged_data)) =
+        get(other_data) + 2. * get<0>(interface_unit_normal) +
+        3. * get<1>(interface_unit_normal);
+  }
+
+  // void operator()(...) is unused
+
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+template <size_t Dim>
+struct NumericalFluxTag {
+  using type = NumericalFlux<Dim>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr const size_t volume_dim = Dim;
+  using variables_tag = Tags::Variables<tmpl::list<Var>>;
+
+  template <typename Tag>
+  using magnitude_tag = Tags::EuclideanMagnitude<Tag>;
+};
+
+template <size_t Dim, typename Tag>
+using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
+
+template <typename FluxCommTypes>
+using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;
+template <typename FluxCommTypes>
+using LocalData = typename FluxCommTypes::LocalData;
+template <typename FluxCommTypes>
+using LocalMortarData = typename FluxCommTypes::LocalMortarData;
+template <typename FluxCommTypes>
+using PackagedData = typename FluxCommTypes::PackagedData;
+template <size_t Dim, typename FluxCommTypes>
+using normal_dot_fluxes_tag =
+    interface_tag<Dim, typename FluxCommTypes::normal_dot_fluxes_tag>;
+
+template <typename FluxCommTypes>
+using fluxes_tag = typename FluxCommTypes::FluxesTag;
+
+template <size_t Dim>
+using other_data_tag =
+    interface_tag<Dim, Tags::Variables<tmpl::list<OtherData>>>;
+template <size_t Dim>
+using mortar_next_temporal_ids_tag = Tags::Mortars<Tags::Next<TemporalId>, Dim>;
+template <size_t Dim>
+using mortar_meshes_tag = Tags::Mortars<Tags::Mesh<Dim - 1>, Dim>;
+template <size_t Dim>
+using mortar_sizes_tag = Tags::Mortars<Tags::MortarSize<Dim - 1>, Dim>;
+
+struct DataRecorder;
+
+struct DataRecorderTag : db::SimpleTag {
+  static std::string name() { return "DataRecorderTag"; }
+  using type = DataRecorder;
+};
+
+struct MortarRecorderTag : Tags::VariablesBoundaryData,
+                           Tags::Mortars<DataRecorderTag, 2> {};
+
+template <size_t Dim, typename MV>
+struct lts_component
+    : ActionTesting::MockArrayComponent<
+          MV, ElementIndex<Dim>, tmpl::list<NumericalFluxTag<Dim>>,
+          tmpl::list<dg::Actions::ReceiveDataForFluxes<MV>>> {
+  using flux_comm_types = dg::FluxCommunicationTypes<MV>;
+
+  using simple_tags = db::AddSimpleTags<
+      TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
+      Tags::ElementMap<2>, normal_dot_fluxes_tag<2, flux_comm_types>,
+      other_data_tag<2>, mortar_meshes_tag<2>, mortar_sizes_tag<2>,
+      MortarRecorderTag, mortar_next_temporal_ids_tag<2>>;
+
+  using compute_tags = db::AddComputeTags<
+      Tags::InternalDirections<Dim>, interface_tag<Dim, Tags::Direction<Dim>>,
+      interface_tag<Dim, Tags::Mesh<Dim - 1>>,
+      interface_tag<Dim, Tags::UnnormalizedFaceNormal<Dim>>,
+      interface_tag<
+          Dim, Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+      interface_tag<Dim, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+
+  using initial_databox =
+      db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
+};
+
+template <size_t Dim>
+struct LtsMetavariables {
+  using system = System<Dim>;
+  using component_list = tmpl::list<lts_component<Dim, LtsMetavariables>>;
+  using temporal_id = TemporalId;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  using normal_dot_numerical_flux = NumericalFluxTag<Dim>;
+};
+
+template <size_t Dim>
+using flux_comm_types = dg::FluxCommunicationTypes<LtsMetavariables<Dim>>;
+
+template <typename Component>
+using simple_items = typename Component::simple_tags;
+
+template <typename Component>
+using compute_items = typename Component::compute_tags;
+
+template <typename Metavariables>
+using send_data_for_fluxes = dg::Actions::SendDataForFluxes<Metavariables>;
+
+template <typename Metavariables>
+using receive_data_for_fluxes =
+    dg::Actions::ReceiveDataForFluxes<Metavariables>;
+
+struct DataRecorder {
+  // Only called on the sending sides, which are not interesting here.
+  void local_insert(int /*temporal_id*/,
+                    const LocalData<flux_comm_types<2>>& /*data*/) noexcept {}
+
+  void remote_insert(int temporal_id,
+                     PackagedData<flux_comm_types<2>> data) noexcept {
+    received_data.emplace_back(temporal_id, std::move(data));
+  }
+
+  std::vector<std::pair<int, PackagedData<flux_comm_types<2>>>> received_data{};
+};
+
+// Inserts the new neighbor element into the ActionRunner
+template <typename LocalAlg>
+void insert_neighbor(const gsl::not_null<LocalAlg*> local_alg,
+                     const Element<2>& element, const int start, const int end,
+                     const double n_dot_f) noexcept {
+  using metavariables = LtsMetavariables<2>;
+  using my_component = lts_component<2, metavariables>;
+  const Direction<2>& send_direction = element.neighbors().begin()->first;
+  const ElementId<2>& receiver_id =
+      *element.neighbors().begin()->second.begin();
+
+  const Mesh<2> mesh{2, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+
+  ElementMap<2, Frame::Inertial> map(
+      element.id(), make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+                        CoordinateMaps::Identity<2>{}));
+
+  db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>> fluxes;
+  fluxes[send_direction].initialize(2, n_dot_f);
+
+  db::item_type<other_data_tag<2>> other_data;
+  other_data[send_direction].initialize(2, 0.);
+
+  db::item_type<mortar_meshes_tag<2>> mortar_meshes;
+  mortar_meshes.insert({{send_direction, receiver_id}, mesh.slice_away(0)});
+
+  db::item_type<mortar_sizes_tag<2>> mortar_sizes;
+  mortar_sizes.insert(
+      {{send_direction, receiver_id}, {{Spectral::MortarSize::Full}}});
+
+  db::item_type<MortarRecorderTag> recorders;
+  recorders.insert({{send_direction, receiver_id}, {}});
+
+  auto box = db::create<
+      db::AddSimpleTags<
+          TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
+          Tags::ElementMap<2>, normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+          other_data_tag<2>, mortar_meshes_tag<2>, mortar_sizes_tag<2>,
+          MortarRecorderTag, mortar_next_temporal_ids_tag<2>>,
+      compute_items<my_component>>(
+      start, end, mesh, element, std::move(map), std::move(fluxes),
+      std::move(other_data), std::move(mortar_meshes), std::move(mortar_sizes),
+      std::move(recorders), db::item_type<mortar_next_temporal_ids_tag<2>>{});
+
+  local_alg->emplace(element.id(), std::move(box));
+}
+
+// Update the time and flux, then send the data
+template <typename Box>
+void send_from_neighbor(
+    const gsl::not_null<Box*> box,
+    const gsl::not_null<ActionTesting::ActionRunner<LtsMetavariables<2>>*>
+        runner,
+    const Element<2>& element, const int start, const int end,
+    const double n_dot_f) noexcept {
+  using metavariables = LtsMetavariables<2>;
+  using my_component = lts_component<2, metavariables>;
+  const Direction<2>& send_direction = element.neighbors().begin()->first;
+
+  db::mutate<TemporalId, Tags::Next<TemporalId>,
+             normal_dot_fluxes_tag<2, flux_comm_types<2>>, other_data_tag<2>>(
+      box, [&send_direction, n_dot_f, start, end](
+               auto tstart, auto tend, auto fluxes, auto other_data) {
+        *tstart = start;
+        *tend = end;
+        fluxes->operator[](send_direction).initialize(2, n_dot_f);
+        other_data->operator[](send_direction).initialize(2, 0.);
+      });
+
+  runner->apply<my_component, send_data_for_fluxes<metavariables>>(
+      *box, element.id());
+}
+
+// Sends the left steps, then the right steps.  The step must not be
+// ready until after the last send.
+void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
+                  const std::vector<int>& right_steps) noexcept {
+  using metavariables = LtsMetavariables<2>;
+  using my_component = lts_component<2, metavariables>;
+  using initial_databox_type = typename my_component::initial_databox;
+
+  const int self_step_start = 0;  // We always start at 0
+
+  const ElementId<2> left_id(0);
+  const ElementId<2> self_id(1);
+  const ElementId<2> right_id(2);
+
+  using MortarId = std::pair<Direction<2>, ElementId<2>>;
+  const MortarId left_mortar_id(Direction<2>::lower_xi(), left_id);
+  const MortarId right_mortar_id(Direction<2>::upper_xi(), right_id);
+
+  db::item_type<MortarRecorderTag> initial_recorders;
+  initial_recorders.insert({{Direction<2>::lower_xi(), left_id}, {}});
+  initial_recorders.insert({{Direction<2>::upper_xi(), right_id}, {}});
+  db::item_type<mortar_next_temporal_ids_tag<2>> initial_mortar_temporal_ids{
+      {left_mortar_id, left_steps.front()},
+      {right_mortar_id, right_steps.front()}};
+
+  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
+  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<my_component>;
+  ActionRunner::LocalAlgorithms local_algs{};
+  tuples::get<LocalAlgsTag>(local_algs)
+      .emplace(
+          self_id,
+          ActionTesting::MockLocalAlgorithm<my_component>{db::create<
+              db::AddSimpleTags<
+                  TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
+                  Tags::Element<2>, Tags::ElementMap<2>,
+                  normal_dot_fluxes_tag<2, flux_comm_types<2>>,
+                  other_data_tag<2>, mortar_meshes_tag<2>, mortar_sizes_tag<2>,
+                  MortarRecorderTag, mortar_next_temporal_ids_tag<2>>,
+              typename my_component::compute_tags>(
+              self_step_start, self_step_end,
+              Mesh<2>{2, Spectral::Basis::Legendre,
+                      Spectral::Quadrature::GaussLobatto},
+              Element<2>{},
+              ElementMap<2, Frame::Inertial>{
+                  self_id,
+                  make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+                      CoordinateMaps::Identity<2>{})},
+              db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>>{},
+              db::item_type<other_data_tag<2>>{},
+              db::item_type<mortar_meshes_tag<2>>{},
+              db::item_type<mortar_sizes_tag<2>>{},
+              std::move(initial_recorders),
+              std::move(initial_mortar_temporal_ids))});
+
+  // Insert the left and right neighbor
+  const Element<2> left_element(left_id,
+                                {{Direction<2>::upper_xi(), {{self_id}, {}}}});
+  const Element<2> right_element(right_id,
+                                 {{Direction<2>::lower_xi(), {{self_id}, {}}}});
+
+  insert_neighbor(make_not_null(&tuples::get<LocalAlgsTag>(local_algs)),
+                  left_element, 0, 1, 0.0);
+  insert_neighbor(make_not_null(&tuples::get<LocalAlgsTag>(local_algs)),
+                  right_element, 0, 1, 0.0);
+
+  ActionTesting::ActionRunner<metavariables> runner{{NumericalFlux<2>{}},
+                                                    std::move(local_algs)};
+  auto& box = runner.algorithms<my_component>()
+                  .at(self_id)
+                  .get_databox<initial_databox_type>();
+
+  std::vector<int> relevant_left_steps{left_steps.front()};
+  for (size_t step = 1; step < left_steps.size(); ++step) {
+    CHECK_FALSE(
+        runner.is_ready<my_component,
+                        dg::Actions::ReceiveDataForFluxes<metavariables>>(
+            box, self_id));
+    send_from_neighbor(make_not_null(&runner.algorithms<my_component>()
+                                          .at(left_element.id())
+                                          .get_databox<initial_databox_type>()),
+                       &runner, left_element, left_steps[step - 1],
+                       left_steps[step], step);
+    if (left_steps[step - 1] < self_step_end) {
+      relevant_left_steps.push_back(left_steps[step]);
+    }
+  }
+  std::vector<int> relevant_right_steps{right_steps.front()};
+  for (size_t step = 1; step < right_steps.size(); ++step) {
+    CHECK_FALSE(
+        runner.is_ready<my_component,
+                        dg::Actions::ReceiveDataForFluxes<metavariables>>(
+            box, self_id));
+    send_from_neighbor(make_not_null(&runner.algorithms<my_component>()
+                                          .at(right_element.id())
+                                          .get_databox<initial_databox_type>()),
+                       &runner, right_element, right_steps[step - 1],
+                       right_steps[step], step);
+    if (right_steps[step - 1] < self_step_end) {
+      relevant_right_steps.push_back(right_steps[step]);
+    }
+  }
+  CHECK(runner.is_ready<my_component, receive_data_for_fluxes<metavariables>>(
+      box, self_id));
+
+  box = std::get<0>(
+      runner.apply<my_component, receive_data_for_fluxes<metavariables>>(
+          box, self_id));
+
+  CHECK(db::get<mortar_next_temporal_ids_tag<2>>(box) ==
+        db::item_type<mortar_next_temporal_ids_tag<2>>{
+            {left_mortar_id, relevant_left_steps.back()},
+            {right_mortar_id, relevant_right_steps.back()}});
+
+  const auto& recorders = db::get<MortarRecorderTag>(box);
+  const auto check_data = [](const auto& recorder,
+                             const std::vector<int>& steps) noexcept {
+    const auto& received_data = recorder.received_data;
+    CHECK(received_data.size() == steps.size() - 1);
+
+    for (size_t step = 0; step < received_data.size(); ++step) {
+      CHECK(received_data[step].first == steps[step]);
+      CHECK(get(get<Var>(received_data[step].second)) ==
+            DataVector(2, 10. * (step + 1)));
+    }
+  };
+  check_data(recorders.at(left_mortar_id), relevant_left_steps);
+  check_data(recorders.at(right_mortar_id), relevant_right_steps);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication.lts",
+                  "[Unit][NumericalAlgorithms][Actions]") {
+  // Global step 0 -> 1
+  run_lts_case(1, {0, 1}, {0, 1});
+  // Global step 0 -> 1 with left element taking second step
+  run_lts_case(1, {0, 1, 2}, {0, 1});
+  // Neighbors stepping past element
+  run_lts_case(1, {0, 2}, {0, 1});
+  run_lts_case(1, {0, 1}, {0, 2});
+  run_lts_case(1, {0, 2}, {0, 2});
+  // No receives from one or both sides (because one or more neighbors
+  // have already made it to the desired time)
+  run_lts_case(1, {1}, {1});
+  run_lts_case(1, {1}, {2});
+  run_lts_case(1, {2}, {1});
+  run_lts_case(1, {2}, {2});
+  run_lts_case(1, {0, 1}, {1});
+  run_lts_case(1, {0, 1}, {2});
+  run_lts_case(1, {0, 2}, {1});
+  run_lts_case(1, {0, 2}, {2});
+  run_lts_case(1, {1}, {0, 1});
+  run_lts_case(1, {1}, {0, 2});
+  run_lts_case(1, {2}, {0, 1});
+  run_lts_case(1, {2}, {0, 2});
+  // Several steps to receive
+  run_lts_case(3, {0, 1, 3, 4}, {0, 1, 2, 4});
+}

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -24,9 +24,11 @@
 
 namespace {
 struct Metavariables;
-using component =
-    ActionTesting::MockArrayComponent<Metavariables, int,
-                                      tmpl::list<CacheTags::TimeStepper>>;
+struct component
+    : ActionTesting::MockArrayComponent<Metavariables, int,
+                                        tmpl::list<CacheTags::TimeStepper>> {
+  using initial_databox = db::DataBox<tmpl::list<>>;
+};
 
 struct Metavariables {
   using component_list = tmpl::list<component>;

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -7,15 +7,14 @@
 #include <cstddef>
 // IWYU pragma: no_include <initializer_list>
 #include <memory>
-#include <tuple>
 #include <utility>
 // IWYU pragma: no_include <unordered_map>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
-#include "Time/Actions/AdvanceTime.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "Time/Actions/AdvanceTime.hpp"         // IWYU pragma: keep
 #include "Time/Slab.hpp"
-#include "Time/Tags.hpp"
+#include "Time/Tags.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"
@@ -31,7 +30,8 @@ namespace {
 struct Metavariables;
 struct component
     : ActionTesting::MockArrayComponent<Metavariables, int,
-                                        tmpl::list<CacheTags::TimeStepper>> {
+                                        tmpl::list<CacheTags::TimeStepper>,
+                                        tmpl::list<Actions::AdvanceTime>> {
   using simple_tags =
       db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>;
   using initial_databox = db::compute_databox_type<simple_tags>;
@@ -46,36 +46,37 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
   const std::array<TimeDelta, 3> substep_offsets{
       {time_step * 0, time_step, time_step / 2}};
 
+  using simple_tags =
+      db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>;
   using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
   using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<component>;
   ActionRunner::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
-      .emplace(0,
-               ActionTesting::MockLocalAlgorithm<component>{
-                   db::create<db::AddSimpleTags<
-                       Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>>(
-                       TimeId(time_step.is_positive(), 8, start),
-                       TimeId(time_step.is_positive(), 8, start, 1,
-                              start + substep_offsets[1]),
-                       time_step)});
+      .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
+                      db::create<simple_tags>(
+                          TimeId(time_step.is_positive(), 8, start),
+                          TimeId(time_step.is_positive(), 8, start, 1,
+                                 start + substep_offsets[1]),
+                          time_step)});
   ActionRunner runner{{std::make_unique<TimeSteppers::RungeKutta3>()},
                       std::move(local_algs)};
-  auto& box =
-      runner.algorithms<component>()
-          .at(0)
-          .get_databox<db::compute_databox_type<db::AddSimpleTags<
-              Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>>>();
 
   for (const auto& step_start : {start, start + time_step}) {
     for (size_t substep = 0; substep < 3; ++substep) {
+      auto& box = runner.algorithms<component>()
+                      .at(0)
+                      .get_databox<db::compute_databox_type<simple_tags>>();
       CHECK(db::get<Tags::TimeId>(box) ==
             TimeId(time_step.is_positive(), 8, step_start, substep,
                    step_start + gsl::at(substep_offsets, substep)));
       CHECK(db::get<Tags::TimeStep>(box) == time_step);
-      box = std::get<0>(runner.apply<component, Actions::AdvanceTime>(box, 0));
+      runner.next_action<component>(0);
     }
   }
 
+  auto& box = runner.algorithms<component>()
+                  .at(0)
+                  .get_databox<db::compute_databox_type<simple_tags>>();
   const auto& final_time_id = db::get<Tags::TimeId>(box);
   const auto& expected_slab = start.slab().advance_towards(time_step);
   CHECK(final_time_id.time().slab() == expected_slab);
@@ -96,17 +97,20 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
                           time_step)});
   ActionRunner runner{{std::make_unique<TimeSteppers::AdamsBashforthN>(1)},
                       std::move(local_algs)};
-  auto& box = runner.algorithms<component>()
-                  .at(0)
-                  .get_databox<typename component::initial_databox>();
 
   for (const auto& step_start : {start, start + time_step}) {
+    auto& box = runner.algorithms<component>()
+                    .at(0)
+                    .get_databox<typename component::initial_databox>();
     CHECK(db::get<Tags::TimeId>(box) ==
           TimeId(time_step.is_positive(), 8, step_start));
     CHECK(db::get<Tags::TimeStep>(box) == time_step);
-    box = std::get<0>(runner.apply<component, Actions::AdvanceTime>(box, 0));
+    runner.next_action<component>(0);
   }
 
+  auto& box = runner.algorithms<component>()
+                  .at(0)
+                  .get_databox<typename component::initial_databox>();
   const auto& final_time_id = db::get<Tags::TimeId>(box);
   const auto& expected_slab = start.slab().advance_towards(time_step);
   CHECK(final_time_id.time().slab() == expected_slab);

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -6,7 +6,6 @@
 #include <memory>
 // IWYU pragma: no_include <pup.h>
 #include <string>
-#include <tuple>
 #include <utility>
 // IWYU pragma: no_include <unordered_map>
 
@@ -47,7 +46,8 @@ struct System {
 
 struct Metavariables;
 struct component
-    : ActionTesting::MockArrayComponent<Metavariables, int, tmpl::list<>> {
+    : ActionTesting::MockArrayComponent<Metavariables, int, tmpl::list<>,
+                                        tmpl::list<change_step_size>> {
   using simple_tags = db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>,
                                         Tags::TimeStep, history_tag>;
   using initial_databox = db::compute_databox_type<simple_tags>;
@@ -92,11 +92,10 @@ void check(const bool time_runs_forward,
        std::make_unique<StepControllers::BinaryFraction>()},
       std::move(local_algs)};
 
+  runner.next_action<component>(0);
   auto& box = runner.algorithms<component>()
                   .at(0)
                   .get_databox<typename component::initial_databox>();
-
-  box = std::get<0>(runner.apply<component, change_step_size>(box, 0));
 
   CHECK(db::get<Tags::TimeStep>(box) == expected_step);
   CHECK(db::get<Tags::Next<Tags::TimeId>>(box) ==

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -8,10 +8,11 @@
 #include <string>
 #include <tuple>
 #include <utility>
+// IWYU pragma: no_include <unordered_map>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "Time/Actions/ChangeStepSize.hpp"
 #include "Time/History.hpp"
 #include "Time/Slab.hpp"
@@ -26,6 +27,7 @@
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 
 namespace {
@@ -37,6 +39,8 @@ struct Var : db::SimpleTag {
   using type = double;
 };
 
+using history_tag = Tags::HistoryEvolvedVariables<Var, Tags::dt<Var>>;
+
 struct System {
   using variables_tag = Var;
 };
@@ -44,7 +48,9 @@ struct System {
 struct Metavariables;
 struct component
     : ActionTesting::MockArrayComponent<Metavariables, int, tmpl::list<>> {
-  using initial_databox = db::DataBox<tmpl::list<>>;
+  using simple_tags = db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>,
+                                        Tags::TimeStep, history_tag>;
+  using initial_databox = db::compute_databox_type<simple_tags>;
 };
 
 struct Metavariables {
@@ -60,27 +66,36 @@ void check(const bool time_runs_forward,
   CAPTURE(time);
   CAPTURE(request);
 
-  ActionTesting::ActionRunner<Metavariables> runner{
-      {std::move(time_stepper),
-       make_vector<std::unique_ptr<StepChooser<step_choosers>>>(
-           std::make_unique<StepChoosers::Constant<step_choosers>>(
-               2. * request),
-           std::make_unique<StepChoosers::Constant<step_choosers>>(request),
-           std::make_unique<StepChoosers::Constant<step_choosers>>(
-               2. * request)),
-       std::make_unique<StepControllers::BinaryFraction>()}};
-
   const TimeDelta initial_step_size =
       (time_runs_forward ? 1 : -1) * time.slab().duration();
-  using history_tag = Tags::HistoryEvolvedVariables<Var, Tags::dt<Var>>;
-  auto box =
-      db::create<db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>,
-                                   Tags::TimeStep, history_tag>>(
-          TimeId(time_runs_forward, 0, time),
-          TimeId(time_runs_forward, 0,
-                 (time_runs_forward ? time.slab().start() : time.slab().end()) +
-                     initial_step_size),
-          initial_step_size, db::item_type<history_tag>{});
+
+  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<component>;
+  ActionRunner::LocalAlgorithms local_algs{};
+  tuples::get<LocalAlgsTag>(local_algs)
+      .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
+                      db::create<typename component::simple_tags>(
+                          TimeId(time_runs_forward, 0, time),
+                          TimeId(time_runs_forward, 0,
+                                 (time_runs_forward ? time.slab().start()
+                                                    : time.slab().end()) +
+                                     initial_step_size),
+                          initial_step_size, db::item_type<history_tag>{})});
+  ActionRunner runner{
+      {std::move(time_stepper),
+       make_vector<std::unique_ptr<StepChooser<step_choosers>>>(
+           std::make_unique<StepChoosers::Constant<step_choosers>>(2. *
+                                                                   request),
+           std::make_unique<StepChoosers::Constant<step_choosers>>(request),
+           std::make_unique<StepChoosers::Constant<step_choosers>>(2. *
+                                                                   request)),
+       std::make_unique<StepControllers::BinaryFraction>()},
+      std::move(local_algs)};
+
+  auto& box = runner.algorithms<component>()
+                  .at(0)
+                  .get_databox<typename component::initial_databox>();
+
   box = std::get<0>(runner.apply<component, change_step_size>(box, 0));
 
   CHECK(db::get<Tags::TimeStep>(box) == expected_step);

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -42,8 +42,10 @@ struct System {
 };
 
 struct Metavariables;
-using component =
-    ActionTesting::MockArrayComponent<Metavariables, int, tmpl::list<>>;
+struct component
+    : ActionTesting::MockArrayComponent<Metavariables, int, tmpl::list<>> {
+  using initial_databox = db::DataBox<tmpl::list<>>;
+};
 
 struct Metavariables {
   using system = System;

--- a/tests/Unit/Time/Actions/Test_FinalTime.cpp
+++ b/tests/Unit/Time/Actions/Test_FinalTime.cpp
@@ -18,9 +18,11 @@
 
 namespace {
 struct Metavariables;
-using component =
-    ActionTesting::MockArrayComponent<Metavariables, int,
-                                      tmpl::list<CacheTags::FinalTime>>;
+struct component
+    : ActionTesting::MockArrayComponent<Metavariables, int,
+                                        tmpl::list<CacheTags::FinalTime>> {
+  using initial_databox = db::DataBox<tmpl::list<>>;
+};
 
 struct Metavariables {
   using component_list = tmpl::list<component>;

--- a/tests/Unit/Time/Actions/Test_FinalTime.cpp
+++ b/tests/Unit/Time/Actions/Test_FinalTime.cpp
@@ -4,12 +4,11 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
-#include <tuple>
 #include <utility>
 // IWYU pragma: no_include <unordered_map>
 
 #include "DataStructures/DataBox/DataBox.hpp"
-#include "Time/Actions/FinalTime.hpp"
+#include "Time/Actions/FinalTime.hpp"  // IWYU pragma: keep
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"  // IWYU pragma: keep
 #include "Time/Time.hpp"
@@ -23,7 +22,8 @@ namespace {
 struct Metavariables;
 struct component
     : ActionTesting::MockArrayComponent<Metavariables, int,
-                                        tmpl::list<CacheTags::FinalTime>> {
+                                        tmpl::list<CacheTags::FinalTime>,
+                                        tmpl::list<Actions::FinalTime>> {
   using simple_tags = db::AddSimpleTags<Tags::TimeId, Tags::TimeStep>;
   using compute_tags = db::AddComputeTags<Tags::Time>;
   using initial_databox =
@@ -70,9 +70,8 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.FinalTime", "[Unit][Time][Actions]") {
           *time_step = test.time_step;
         });
 
-    bool terminate;
-    std::tie(box, terminate) =
-        runner.apply<component, Actions::FinalTime>(box, 0);
-    CHECK(test.expected_result == terminate);
+    runner.next_action<component>(0);
+    CHECK(test.expected_result ==
+          runner.algorithms<component>().at(0).get_terminate());
   }
 }

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -30,8 +30,10 @@ struct System {
 };
 
 struct Metavariables;
-using component =
-    ActionTesting::MockArrayComponent<Metavariables, int, tmpl::list<>>;
+struct component
+    : ActionTesting::MockArrayComponent<Metavariables, int, tmpl::list<>> {
+  using initial_databox = db::DataBox<tmpl::list<>>;
+};
 
 struct Metavariables {
   using system = System;

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -7,14 +7,13 @@
 #include <cstddef>
 #include <memory>
 #include <string>
-#include <tuple>
 #include <utility>
 // IWYU pragma: no_include <unordered_map>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "Time/Actions/UpdateU.hpp"
+#include "Time/Actions/UpdateU.hpp"  // IWYU pragma: keep
 // IWYU pragma: no_include "Time/History.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags.hpp"
@@ -43,7 +42,8 @@ using history_tag =
 struct Metavariables;
 struct component
     : ActionTesting::MockArrayComponent<Metavariables, int,
-                                        tmpl::list<CacheTags::TimeStepper>> {
+                                        tmpl::list<CacheTags::TimeStepper>,
+                                        tmpl::list<Actions::UpdateU>> {
   using simple_tags =
       db::AddSimpleTags<Tags::TimeStep, variables_tag, history_tag>;
   using initial_databox = db::compute_databox_type<simple_tags>;
@@ -73,10 +73,6 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
   ActionRunner runner{{std::make_unique<TimeSteppers::RungeKutta3>()},
                       std::move(local_algs)};
 
-  auto& box = runner.algorithms<component>()
-                  .at(0)
-                  .get_databox<typename component::initial_databox>();
-
   const std::array<Time, 3> substep_times{
     {slab.start(), slab.start() + time_step, slab.start() + time_step / 2}};
   // The exact answer is y = x^2, but the integrator would need a
@@ -84,17 +80,23 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
   const std::array<double, 3> expected_values{{3., 3., 10./3.}};
 
   for (size_t substep = 0; substep < 3; ++substep) {
+    auto& before_box = runner.algorithms<component>()
+                           .at(0)
+                           .get_databox<typename component::initial_databox>();
     db::mutate<history_tag>(
-        make_not_null(&box),
+        make_not_null(&before_box),
         [&rhs, &substep, &substep_times ](
             const gsl::not_null<db::item_type<history_tag>*> history,
             const double& vars) noexcept {
           const Time& time = gsl::at(substep_times, substep);
           history->insert(time, vars, rhs(time.value(), vars));
         },
-        db::get<variables_tag>(box));
+        db::get<variables_tag>(before_box));
 
-    box = std::get<0>(runner.apply<component, Actions::UpdateU>(box, 0));
+    runner.next_action<component>(0);
+    auto& box = runner.algorithms<component>()
+                    .at(0)
+                    .get_databox<typename component::initial_databox>();
 
     CHECK(db::get<variables_tag>(box) ==
           approx(gsl::at(expected_values, substep)));

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -33,9 +33,11 @@ struct System {
 };
 
 struct Metavariables;
-using component =
-    ActionTesting::MockArrayComponent<Metavariables, int,
-                                      tmpl::list<CacheTags::TimeStepper>>;
+struct component
+    : ActionTesting::MockArrayComponent<Metavariables, int,
+                                        tmpl::list<CacheTags::TimeStepper>> {
+  using initial_databox = db::DataBox<tmpl::list<>>;
+};
 
 struct Metavariables {
   using system = System;

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -8,6 +8,8 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <utility>
+// IWYU pragma: no_include <unordered_map>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -20,6 +22,7 @@
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 
 namespace {
@@ -32,11 +35,18 @@ struct System {
   using variables_tag = Var;
 };
 
+using variables_tag = Var;
+using dt_variables_tag = Tags::dt<Var>;
+using history_tag =
+    Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>;
+
 struct Metavariables;
 struct component
     : ActionTesting::MockArrayComponent<Metavariables, int,
                                         tmpl::list<CacheTags::TimeStepper>> {
-  using initial_databox = db::DataBox<tmpl::list<>>;
+  using simple_tags =
+      db::AddSimpleTags<Tags::TimeStep, variables_tag, history_tag>;
+  using initial_databox = db::compute_databox_type<simple_tags>;
 };
 
 struct Metavariables {
@@ -47,23 +57,25 @@ struct Metavariables {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
-  ActionTesting::ActionRunner<Metavariables> runner{
-    {std::make_unique<TimeSteppers::RungeKutta3>()}};
-  using variables_tag = Var;
-  using dt_variables_tag = Tags::dt<Var>;
-
   const Slab slab(1., 3.);
   const TimeDelta time_step = slab.duration() / 2;
-
-  using history_tag =
-      Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>;
 
   const auto rhs =
       [](const double t, const double y) { return 2. * t - 2. * (y - t * t); };
 
-  auto box =
-      db::create<db::AddSimpleTags<Tags::TimeStep, variables_tag, history_tag>>(
-          time_step, 1., history_tag::type{});
+  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<component>;
+  ActionRunner::LocalAlgorithms local_algs{};
+  tuples::get<LocalAlgsTag>(local_algs)
+      .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
+                      db::create<typename component::simple_tags>(
+                          time_step, 1., history_tag::type{})});
+  ActionRunner runner{{std::make_unique<TimeSteppers::RungeKutta3>()},
+                      std::move(local_algs)};
+
+  auto& box = runner.algorithms<component>()
+                  .at(0)
+                  .get_databox<typename component::initial_databox>();
 
   const std::array<Time, 3> substep_times{
     {slab.start(), slab.start() + time_step, slab.start() + time_step / 2}};


### PR DESCRIPTION
## Proposed changes

Generalize action testing framework to:

- Have a local algorithm hold the DataBox (necessary for Actions that call a simple action)
- Replace some uses of `apply` with a function called `next_action` that evaluates only the next action in the action list. If the action is not ready and `ERROR` is hit.
- Replace remaining uses of `apply` with a function call `simple_action` that invokes the simple action on the component.

**Note:** Only commits the following commits are new:
- Replace apply with simple_action in mocking framework
- Add next_action, is_ready support to mocking framework
- Change returned DataBox type to rvalue in EventsAndTriggers
- Have mocking framework create all local algorithms
- Allow actions to retrieve component mocks
- Compute DataBox types in mocking framework
- Enclose ActionTesting_detail in ActionTesting namespace
- Move code around ActionRunner class

Depends on:
- [x] #912 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
