### PR TITLE
Additions to AddSpectreExecutable

### DIFF
--- a/cmake/AddSpectreExecutable.cmake
+++ b/cmake/AddSpectreExecutable.cmake
@@ -4,6 +4,8 @@
 # A function to add a SpECTRE executable that uses Charm++
 #
 # EXECUTABLE_NAME is the name of the executable (with no extension)
+# HPP_NAME        is the name of the hpp file (without the .hpp extension) that
+#                 contains the metavariables
 # SUBDIR_NAME     is the name of the directory relative to src that contains
 #                 a header file EXECUTABLE_NAME.hpp
 # METAVARS        is the name of the metavariables struct that will be used
@@ -16,7 +18,7 @@
 # The function creates EXECUTABLE_NAME.cpp in the build tree which is then
 # used to build EXECUTABLE_NAME which is put into the bin directory of the
 # the build tree
-function(add_spectre_executable EXECUTABLE_NAME SUBDIR_NAME METAVARS LINK_LIBS)
+function(add_spectre_executable EXECUTABLE_NAME HPP_NAME SUBDIR_NAME METAVARS LINK_LIBS)
   set(BUILD_TARGET_FILENAME
     "${CMAKE_BINARY_DIR}/${SUBDIR_NAME}/${EXECUTABLE_NAME}.cpp"
     )
@@ -28,7 +30,9 @@ function(add_spectre_executable EXECUTABLE_NAME SUBDIR_NAME METAVARS LINK_LIBS)
     "// Distributed under the MIT License.\n"
     "// See LICENSE.txt for details.\n"
     "\n"
-    "#include \"${SUBDIR_NAME}/${EXECUTABLE_NAME}.hpp\"\n"
+    "#include \"${SUBDIR_NAME}/${HPP_NAME}Fwd.hpp\"\n"
+    "using metavariables = ${METAVARS};\n"
+    "#include \"${SUBDIR_NAME}/${HPP_NAME}.hpp\"\n"
     "#include \"Parallel/Main.hpp\"\n"
     "\n"
     "using charmxx_main_component = Parallel::Main<${METAVARS}>;\n"

--- a/src/Evolution/Executables/Burgers/CMakeLists.txt
+++ b/src/Evolution/Executables/Burgers/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBS_TO_LINK
 
 add_spectre_executable(
   EvolveBurgers
+  EvolveBurgers
   Evolution/Executables/Burgers
   EvolutionMetavars
   "${LIBS_TO_LINK}"

--- a/src/Evolution/Executables/Burgers/EvolveBurgersFwd.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgersFwd.hpp
@@ -1,0 +1,6 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+struct EvolutionMetavars;

--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -1,47 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-function(add_scalar_wave_executable DIM)
-  set(EXECUTABLE_NAME "EvolveScalarWave${DIM}D")
-
-  set(SUBDIR_NAME "src/Evolution/Executables/ScalarWave/")
-  set(BUILD_TARGET_FILENAME
-    "${CMAKE_BINARY_DIR}/${SUBDIR_NAME}${EXECUTABLE_NAME}.cpp"
-    )
-  # We use both file(WRITE) and configure_file so that we
-  # cause a rebuild only if the contents of the written file
-  # has actually changed.
-  file(WRITE
-    "${BUILD_TARGET_FILENAME}.out"
-    "// Distributed under the MIT License.\n"
-    "// See LICENSE.txt for details.\n"
-    "\n"
-    "#include \"Evolution/Executables/ScalarWave/EvolveScalarWave.hpp\"\n"
-    "#include \"Parallel/Main.hpp\"\n"
-    "\n"
-    "using charmxx_main_component = Parallel::Main<EvolutionMetavars<${DIM}>>;\n"
-    "\n"
-    "#include \"Parallel/CharmMain.cpp\"\n"
-    )
-  configure_file(
-    "${BUILD_TARGET_FILENAME}.out"
-    ${BUILD_TARGET_FILENAME}
-    )
-
-  add_executable(
-    ${EXECUTABLE_NAME}
-    EXCLUDE_FROM_ALL
-    ${BUILD_TARGET_FILENAME}
-    )
-
-  add_dependencies(
-    ${EXECUTABLE_NAME}
-    module_ConstGlobalCache
-    module_Main
-    )
-
-  target_link_libraries(
-    ${EXECUTABLE_NAME}
+set(LIBS_TO_LINK
     CoordinateMaps
     DiscontinuousGalerkin
     DomainCreators
@@ -53,9 +13,26 @@ function(add_scalar_wave_executable DIM)
     Utilities
     WaveEquation
     ${SPECTRE_LIBRARIES}
-    )
-endfunction(add_scalar_wave_executable)
+  )
 
-add_scalar_wave_executable(1)
-add_scalar_wave_executable(2)
-add_scalar_wave_executable(3)
+add_spectre_executable(
+  EvolveScalarWave1D
+  EvolveScalarWave
+  Evolution/Executables/ScalarWave
+  EvolutionMetavars<1>
+  "${LIBS_TO_LINK}"
+)
+add_spectre_executable(
+  EvolveScalarWave2D
+  EvolveScalarWave
+  Evolution/Executables/ScalarWave
+  EvolutionMetavars<2>
+  "${LIBS_TO_LINK}"
+)
+add_spectre_executable(
+  EvolveScalarWave3D
+  EvolveScalarWave
+  Evolution/Executables/ScalarWave
+  EvolutionMetavars<3>
+  "${LIBS_TO_LINK}"
+)

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWaveFwd.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWaveFwd.hpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+template <size_t Dim>
+struct EvolutionMetavars;

--- a/src/Executables/Examples/HelloWorld/CMakeLists.txt
+++ b/src/Executables/Examples/HelloWorld/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBS_TO_LINK
 
 add_spectre_executable(
   SingletonHelloWorld
+  SingletonHelloWorld
   Executables/Examples/HelloWorld
   Metavars
   "${LIBS_TO_LINK}"

--- a/src/Executables/Examples/HelloWorld/SingletonHelloWorldFwd.hpp
+++ b/src/Executables/Examples/HelloWorld/SingletonHelloWorldFwd.hpp
@@ -1,0 +1,6 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+struct Metavars;


### PR DESCRIPTION
## Proposed changes

- Add an HPP_NAME parameter for when the executable name
  does not match the name of the hpp file.
- Include a HPP_NAMEFwd.hpp for forward declaring the
  metavariables struct. This is useful for when the
  metavariables is templated on a parameter that needs
  to be known by the `charm_init_node_funcs` function,
  for example.

Edit(Nils): Made it so the proposed changes are listed after the Proposed Changes heading.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
