### PR TITLE
Observer registration

### DIFF
--- a/cmake/SpectreParseTests.py
+++ b/cmake/SpectreParseTests.py
@@ -27,6 +27,7 @@ allowed_tags = [
                 "LinearOperators",
                 "LinearSolver",
                 "NumericalAlgorithms",
+                "Observers",
                 "Options",
                 "Parallel",
                 "PointwiseFunctions",

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -499,6 +499,11 @@
  */
 
 /*!
+ * \defgroup ObserversGroup Observers
+ * \brief Observing/writing data to disk.
+ */
+
+/*!
  * \defgroup OptionParsingGroup Option Parsing
  * Things related to parsing YAML input files.
  */

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
     H5/Helpers.cpp
     H5/OpenGroup.cpp
     H5/Version.cpp
+    Observer/ArrayComponentId.cpp
     VolumeDataFile.cpp
 )
 

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
     H5/OpenGroup.cpp
     H5/Version.cpp
     Observer/ArrayComponentId.cpp
+    Observer/TypeOfObservation.cpp
     VolumeDataFile.cpp
 )
 

--- a/src/IO/Observer/Actions.hpp
+++ b/src/IO/Observer/Actions.hpp
@@ -1,0 +1,128 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Index.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace observers {
+/*!
+ * \ingroup ObserversGroup
+ * \brief %Actions used by the observer parallel component
+ */
+namespace Actions {
+/*!
+ * \brief Action that is called on the Observer parallel component to register
+ * the parallel component that will send the data to the observer
+ */
+struct RegisterSenderWithSelf {
+  template <
+      typename DbTagList, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      typename TemporalId,
+      Requires<tmpl::list_contains_v<
+                   DbTagList, observers::Tags::ReductionArrayComponentIds> and
+               tmpl::list_contains_v<
+                   DbTagList, observers::Tags::VolumeArrayComponentIds>> =
+          nullptr>
+  static void apply(db::DataBox<DbTagList>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const TemporalId& /*temporal_id*/,
+                    const observers::ArrayComponentId& component_id,
+                    const TypeOfObservation& type_of_observation) noexcept {
+    const auto register_reduction = [&box, &component_id]() noexcept {
+      db::mutate<observers::Tags::ReductionArrayComponentIds>(
+          make_not_null(&box), [&component_id](
+                                   const auto array_component_ids) noexcept {
+            ASSERT(array_component_ids->count(component_id) == 0,
+                   "Trying to insert a component_id more than once for "
+                   "reduction. This means an element is registering itself "
+                   "with the observers more than once.");
+            array_component_ids->insert(component_id);
+          });
+    };
+    const auto register_volume = [&box, &component_id]() noexcept {
+      db::mutate<observers::Tags::VolumeArrayComponentIds>(
+          make_not_null(&box), [&component_id](
+                                   const auto array_component_ids) noexcept {
+            ASSERT(array_component_ids->count(component_id) == 0,
+                   "Trying to insert a component_id more than once for "
+                   "volume observation. This means an element is registering "
+                   "itself with the observers more than once.");
+            array_component_ids->insert(component_id);
+          });
+    };
+
+    switch (type_of_observation) {
+      case TypeOfObservation::ReductionAndVolume:
+        register_reduction();
+        register_volume();
+        return;
+      case TypeOfObservation::Reduction:
+        register_reduction();
+        return;
+      case TypeOfObservation::Volume:
+        register_volume();
+        return;
+      default:
+        ERROR(
+          "Registering an unknown TypeOfObservation. Should be one of "
+          "'Reduction', 'Volume', or 'ReductionAndVolume'");
+    };
+  }
+};
+
+/*!
+ * \brief Registers itself with the local observer parallel component so the
+ * observer knows to expect data from this component, and also whether to expect
+ * Reduction, Volume, or both Reduction and Volume data observation calls.
+ */
+template <observers::TypeOfObservation TypeOfObservation>
+struct RegisterWithObservers {
+  template <typename DbTagList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, typename TemporalId>
+  static void apply(const db::DataBox<DbTagList>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& array_index, const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const TemporalId& temporal_id) noexcept {
+    auto& observer =
+        *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    // TODO(): We should really loop through all the events, check if there are
+    // any reduction observers, and any volume observers, if so, then we
+    // register us as having one of:
+    // - TypeOfObservation::Reduction
+    // - TypeOfObservation::Volume
+    // - TypeOfObservation::ReductionAndVolume
+    //
+    // At that point we won't need the template parameter on the class anymore
+    // and everything can be read from an input file.
+    Parallel::simple_action<RegisterSenderWithSelf>(
+        observer, temporal_id,
+        observers::ArrayComponentId(
+            std::add_pointer_t<ParallelComponent>{nullptr},
+            Parallel::ArrayIndex<std::decay_t<ArrayIndex>>{array_index}),
+        TypeOfObservation);
+  }
+};
+}  // namespace Actions
+}  // namespace observers

--- a/src/IO/Observer/ArrayComponentId.cpp
+++ b/src/IO/Observer/ArrayComponentId.cpp
@@ -1,0 +1,24 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/Observer/ArrayComponentId.hpp"
+
+#include <pup.h>
+
+namespace observers {
+void ArrayComponentId::pup(PUP::er& p) noexcept {
+  p | component_id_;
+  p | array_index_;
+}
+
+bool operator==(const ArrayComponentId& lhs,
+                const ArrayComponentId& rhs) noexcept {
+  return lhs.component_id() == rhs.component_id() and
+         lhs.array_index() == rhs.array_index();
+}
+
+bool operator!=(const ArrayComponentId& lhs,
+                const ArrayComponentId& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace observers

--- a/src/IO/Observer/ArrayComponentId.hpp
+++ b/src/IO/Observer/ArrayComponentId.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <ckarrayindex.h>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+#include "Utilities/PrettyType.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
+
+namespace observers {
+/*!
+ * \ingroup ObserversGroup
+ * \brief An ID type that identifies both the parallel component and the index
+ * in the parallel component.
+ *
+ * A specialization of `std::hash` is provided to allow using `ArrayComponentId`
+ * as a key in associative containers.
+ */
+class ArrayComponentId {
+ public:
+  ArrayComponentId() = default;  // Needed for Charm++ serialization
+
+  template <typename ParallelComponent>
+  ArrayComponentId(const ParallelComponent* /*meta*/,
+                   const CkArrayIndex& index) noexcept;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept;
+
+  size_t component_id() const noexcept { return component_id_; }
+
+  const CkArrayIndex& array_index() const noexcept { return array_index_; }
+
+ private:
+  size_t component_id_{0};
+  CkArrayIndex array_index_{};
+};
+
+template <typename ParallelComponent>
+ArrayComponentId::ArrayComponentId(const ParallelComponent* const /*meta*/,
+                                   const CkArrayIndex& index) noexcept
+    : component_id_(
+          std::hash<std::string>{}(pretty_type::get_name<ParallelComponent>())),
+      array_index_(index) {}
+
+bool operator==(const ArrayComponentId& lhs,
+                const ArrayComponentId& rhs) noexcept;
+
+bool operator!=(const ArrayComponentId& lhs,
+                const ArrayComponentId& rhs) noexcept;
+}  // namespace observers
+
+namespace std {
+template <>
+struct hash<observers::ArrayComponentId> {
+  size_t operator()(const observers::ArrayComponentId& t) const {
+    size_t result = t.component_id();
+    boost::hash_combine(result, t.array_index().hash());
+    return result;
+  }
+};
+}  // namespace std

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -1,0 +1,44 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace observers {
+namespace Actions {
+/*!
+ * \brief Initializes the DataBox on the observer parallel component
+ */
+struct Initialize {
+  using simple_tags =
+      db::AddSimpleTags<Tags::NumberOfEvents, Tags::ReductionArrayComponentIds,
+                        Tags::VolumeArrayComponentIds, Tags::TensorData>;
+  using compute_tags = db::AddComputeTags<>;
+
+  using return_tag_list = tmpl::append<simple_tags, compute_tags>;
+
+  template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    return std::make_tuple(db::create<simple_tags>(
+        db::item_type<Tags::NumberOfEvents>{},
+        db::item_type<Tags::ReductionArrayComponentIds>{},
+        db::item_type<Tags::VolumeArrayComponentIds>{},
+        db::item_type<Tags::TensorData>{}));
+  }
+};
+}  // namespace Actions
+}  // namespace observers

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "AlgorithmNodegroup.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Initialize.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+
+namespace observers {
+/*!
+ * \ingroup ObserversGroup
+ * \brief The nodegroup parallel component that is responsible for reducing data
+ * to be observed and for writing data to disk.
+ */
+template <class Metavariables>
+struct Observer {
+  using chare_type = Parallel::Algorithms::Nodegroup;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using metavariables = Metavariables;
+  using action_list = tmpl::list<>;
+
+  using initial_databox =
+      db::compute_databox_type<typename Actions::Initialize::return_tag_list>;
+
+  using options = tmpl::list<>;
+
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::simple_action<Actions::Initialize>(
+        Parallel::get_parallel_component<Observer>(local_cache));
+  }
+
+  static void execute_next_global_actions(
+      const typename Metavariables::Phase /*next_phase*/,
+      Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*global_cache*/) noexcept {}
+};
+
+}  // namespace observers

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -1,0 +1,54 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+
+/// \cond
+class DataVector;
+namespace observers {
+class ArrayComponentId;
+}  // namespace observers
+/// \endcond
+
+namespace observers {
+/// \ingroup ObserversGroup
+/// %Tags used on the observer parallel component
+namespace Tags {
+/// The number of events registered with the observer.
+struct NumberOfEvents : db::SimpleTag {
+  using type =
+      std::unordered_map<ArrayComponentId, std::unique_ptr<std::atomic_int>>;
+  static std::string name() noexcept { return "NumberOfEvents"; }
+};
+
+/// All the ids of all the components registered to an observer for doing
+/// reduction observations.
+struct ReductionArrayComponentIds : db::SimpleTag {
+  using type = std::unordered_set<ArrayComponentId>;
+  static std::string name() noexcept { return "ReductionArrayComponentIds"; }
+};
+
+/// All the ids of all the components registered to an observer for doing
+/// volume observations.
+struct VolumeArrayComponentIds : db::SimpleTag {
+  using type = std::unordered_set<ArrayComponentId>;
+  static std::string name() noexcept { return "VolumeArrayComponentIds"; }
+};
+
+/// Volume tensor data to be written to disk.
+struct TensorData : db::SimpleTag {
+  static std::string name() noexcept { return "TensorData"; }
+  using type =
+      std::unordered_map<std::string,
+                         std::vector<std::pair<std::string, DataVector>>>;
+};
+}  // namespace Tags
+}  // namespace observers

--- a/src/IO/Observer/TypeOfObservation.cpp
+++ b/src/IO/Observer/TypeOfObservation.cpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/Observer/TypeOfObservation.hpp"
+
+#include <ostream>
+
+#include "ErrorHandling/Error.hpp"
+
+namespace observers {
+std::ostream& operator<<(std::ostream& os,
+                         const TypeOfObservation& t) noexcept {
+  switch (t) {
+    case TypeOfObservation::Reduction:
+      return os << "Reduction";
+    case TypeOfObservation::Volume:
+      return os << "Volume";
+    case TypeOfObservation::ReductionAndVolume:
+      return os << "ReductionAndVolume";
+    default:
+      ERROR("Unknown TypeOfObservation.");
+  }
+  return os;
+}
+}  // namespace observers

--- a/src/IO/Observer/TypeOfObservation.hpp
+++ b/src/IO/Observer/TypeOfObservation.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <iosfwd>
+
+namespace observers {
+/*!
+ * \ingroup ObserversGroup
+ * \brief Specifies the type of observation.
+ *
+ * Below `sender` is the component passing the data, reduction or volume, to the
+ * observer component.
+ */
+enum class TypeOfObservation {
+  /// The sender will only perform reduction observations
+  Reduction,
+  /// The sender will only perform volume observations
+  Volume,
+  /// The sender will perform both reduction and volume observations
+  ReductionAndVolume
+};
+
+std::ostream& operator<<(std::ostream& os, const TypeOfObservation& t) noexcept;
+}  // namespace observers

--- a/src/Parallel/NodeLock.hpp
+++ b/src/Parallel/NodeLock.hpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <lrtslock.h>
+
+#include "Utilities/Gsl.hpp"
+#include "Utilities/NoSuchType.hpp"
+
+namespace Parallel {
+/*!
+ * \ingroup ParallelGroup
+ * \brief Create a converse CmiNodeLock
+ */
+inline CmiNodeLock create_lock() noexcept { return CmiCreateLock(); }
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Free a converse CmiNodeLock. Using the lock after free is undefined
+ * behavior.
+ */
+inline void free_lock(const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  CmiDestroyLock(node_lock);
+#pragma GCC diagnostic pop
+}
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Lock a converse CmiNodeLock
+ */
+inline void lock(const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  CmiLock(*node_lock);
+#pragma GCC diagnostic pop
+}
+
+/// \cond
+constexpr inline void lock(
+    const gsl::not_null<NoSuchType*> /*unused*/) noexcept {}
+/// \endcond
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Returns true if the lock was successfully acquired and false if the
+ * lock is already acquired by another processor.
+ */
+inline bool try_lock(const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  return CmiTryLock(*node_lock) == 0;
+#pragma GCC diagnostic pop
+}
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Unlock a converse CmiNodeLock
+ */
+inline void unlock(const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  CmiUnlock(*node_lock);
+#pragma GCC diagnostic pop
+}
+
+/// \cond
+constexpr inline void unlock(
+    const gsl::not_null<NoSuchType*> /*unused*/) noexcept {}
+/// \endcond
+}  // namespace Parallel

--- a/src/Parallel/SimpleActionVisitation.hpp
+++ b/src/Parallel/SimpleActionVisitation.hpp
@@ -72,10 +72,15 @@ void simple_action_visitor_helper(boost::variant<Variants...>& box,
                                   const gsl::not_null<bool*> already_visited,
                                   Args&&... /*args*/) {
   if (box.which() == *iter and not*already_visited) {
-    ERROR("Cannot call apply function of '"
+    ERROR("\nCannot call apply function of '"
           << pretty_type::get_name<Invokable>() << "' with DataBox type '"
           << pretty_type::get_name<ThisVariant>() << "' and arguments '"
-          << pretty_type::get_name<tmpl::list<Args...>>() << "'");
+          << pretty_type::get_name<tmpl::list<Args...>>() << "'.\n"
+          << "If the argument types to the apply function match, then it is "
+             "possible that the apply function has non-deducible template "
+             "parameters. This could occur from removing an apply function "
+             "argument and forgetting to remove its associated template "
+             "parameters.\n");
   }
   (*iter)++;
 }

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -14,6 +14,7 @@
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/SimpleActionVisitation.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/NoSuchType.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -32,7 +33,7 @@ class MockLocalAlgorithm {
   using metavariables = typename Component::metavariables;
 
  private:
-  template <typename ActiontList>
+  template <typename ActionsList>
   struct compute_databox_type;
 
   template <typename... ActionsPack>
@@ -148,7 +149,7 @@ template <size_t... Is>
 void MockLocalAlgorithm<Component>::next_action(
     std::index_sequence<Is...> /*meta*/) noexcept {
   auto& const_global_cache = *const_global_cache_;
-  if (performing_action_) {
+  if (UNLIKELY(performing_action_)) {
     ERROR(
         "Cannot call an Action while already calling an Action on the same "
         "MockLocalAlgorithm (an element of a parallel component array, or a "

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -402,6 +402,11 @@ struct get_array_index<ActionTesting::ActionTesting_detail::MockArrayChare> {
 }  // namespace Parallel
 /// \endcond
 
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief Structures used for mocking the parallel components framework in order
+ * to test actions.
+ */
 namespace ActionTesting {
 /// \ingroup TestingFrameworkGroup
 /// A mock parallel component that acts like a component with

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -355,6 +356,16 @@ class MockProxy {
                   "the ActionRunner?");
     return MockArrayElementProxy<Component, InboxTagList>(
         local_algorithms_->at(index), inboxes_->operator[](index));
+  }
+
+  MockLocalAlgorithm<Component>* ckLocalBranch() noexcept {
+    ASSERT(
+        local_algorithms_->size() == 1,
+        "Can only have one algorithm when getting the ckLocalBranch, but have "
+            << local_algorithms_->size());
+    // We always retrieve the 0th local branch because we are assuming running
+    // on a single core.
+    return std::addressof(local_algorithms_->at(0));
   }
 
   // clang-tidy: no non-const references

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -54,6 +54,21 @@ class MockLocalAlgorithm {
   explicit MockLocalAlgorithm(typename Component::initial_databox initial_box)
       : box_(std::move(initial_box)) {}
 
+  void set_index(typename Component::index index) noexcept {
+    array_index_ = std::move(index);
+  }
+
+  void set_cache(Parallel::ConstGlobalCache<typename Component::metavariables>*
+                     cache_ptr) noexcept {
+    const_global_cache_ = cache_ptr;
+  }
+
+  void set_inboxes(tuples::TaggedTupleTypelist<
+                   Parallel::get_inbox_tags<typename Component::action_list>>*
+                       inboxes_ptr) noexcept {
+    inboxes_ = inboxes_ptr;
+  }
+
   void set_terminate(bool t) { terminate_ = t; }
   bool get_terminate() { return terminate_; }
 
@@ -76,20 +91,12 @@ class MockLocalAlgorithm {
   }
 
   template <size_t... Is>
-  void next_action(
-      std::index_sequence<Is...> /*meta*/,
-      const typename Component::index& array_index,
-      gsl::not_null<tuples::TaggedTupleTypelist<inbox_tags_list>*> inboxes,
-      gsl::not_null<Parallel::ConstGlobalCache<metavariables>*>
-          const_global_cache_ptr) noexcept;
+  void next_action(std::index_sequence<Is...> /*meta*/) noexcept;
 
   template <size_t... Is>
   bool is_ready(
-      std::index_sequence<Is...> /*meta*/,
-      const typename Component::index& array_index,
-      gsl::not_null<tuples::TaggedTupleTypelist<inbox_tags_list>*> inboxes,
-      gsl::not_null<Parallel::ConstGlobalCache<metavariables>*>
-          const_global_cache) noexcept;
+      std::index_sequence<Is...> /*meta*/) noexcept;
+
 
  private:
   bool terminate_{false};
@@ -99,17 +106,20 @@ class MockLocalAlgorithm {
   // The next action we should execute.
   size_t algorithm_step_ = 0;
   bool performing_action_ = false;
+
+  typename Component::index array_index_{};
+  Parallel::ConstGlobalCache<typename Component::metavariables>*
+      const_global_cache_{nullptr};
+  tuples::TaggedTupleTypelist<
+      Parallel::get_inbox_tags<typename Component::action_list>>* inboxes_{
+      nullptr};
 };
 
 template <typename Component>
 template <size_t... Is>
 void MockLocalAlgorithm<Component>::next_action(
-    std::index_sequence<Is...> /*meta*/,
-    const typename Component::index& array_index,
-    const gsl::not_null<tuples::TaggedTupleTypelist<inbox_tags_list>*> inboxes,
-    const gsl::not_null<Parallel::ConstGlobalCache<metavariables>*>
-        const_global_cache_ptr) noexcept {
-  auto& const_global_cache = *const_global_cache_ptr;
+    std::index_sequence<Is...> /*meta*/) noexcept {
+  auto& const_global_cache = *const_global_cache_;
   if (performing_action_) {
     ERROR(
         "Cannot call an Action while already calling an Action on the same "
@@ -120,7 +130,8 @@ void MockLocalAlgorithm<Component>::next_action(
   // to only evaluate one per call.
   bool already_did_an_action = false;
   const auto helper = [
-    this, &array_index, &inboxes, &const_global_cache, &already_did_an_action
+    this, &array_index = array_index_, &inboxes = *inboxes_,
+    &const_global_cache, &already_did_an_action
   ](auto iteration) noexcept {
     constexpr size_t iter = decltype(iteration)::value;
     using this_action = tmpl::at_c<actions_list, iter>;
@@ -151,7 +162,7 @@ void MockLocalAlgorithm<Component>::next_action(
         [&box, &array_index, &const_global_cache, &inboxes](
             std::true_type /*has_is_ready*/, auto t) {
           return decltype(t)::is_ready(
-              cpp17::as_const(box), cpp17::as_const(*inboxes),
+              cpp17::as_const(box), cpp17::as_const(inboxes),
               const_global_cache, cpp17::as_const(array_index));
         },
         [](std::false_type /*has_is_ready*/, auto) { return true; });
@@ -174,26 +185,26 @@ void MockLocalAlgorithm<Component>::next_action(
             auto& my_box, std::integral_constant<size_t, 1> /*meta*/)
             SPECTRE_JUST_ALWAYS_INLINE noexcept {
               std::tie(box_) = this_action::apply(
-                  my_box, *inboxes, const_global_cache,
+                  my_box, inboxes, const_global_cache,
                   cpp17::as_const(array_index), actions_list{}, component_ptr);
             },
         [ this, &array_index, component_ptr, &const_global_cache, &inboxes ](
             auto& my_box, std::integral_constant<size_t, 2> /*meta*/)
             SPECTRE_JUST_ALWAYS_INLINE noexcept {
               std::tie(box_, terminate_) = this_action::apply(
-                  my_box, *inboxes, const_global_cache,
+                  my_box, inboxes, const_global_cache,
                   cpp17::as_const(array_index), actions_list{}, component_ptr);
             },
         [ this, &array_index, component_ptr, &const_global_cache, &inboxes ](
             auto& my_box, std::integral_constant<size_t, 3> /*meta*/)
             SPECTRE_JUST_ALWAYS_INLINE noexcept {
               std::tie(box_, terminate_, algorithm_step_) = this_action::apply(
-                  my_box, *inboxes, const_global_cache,
+                  my_box, inboxes, const_global_cache,
                   cpp17::as_const(array_index), actions_list{}, component_ptr);
             })(
         box,
         typename std::tuple_size<decltype(this_action::apply(
-            box, *inboxes, const_global_cache, cpp17::as_const(array_index),
+            box, inboxes, const_global_cache, cpp17::as_const(array_index),
             actions_list{}, component_ptr))>::type{});
     performing_action_ = false;
     already_did_an_action = true;
@@ -211,14 +222,11 @@ void MockLocalAlgorithm<Component>::next_action(
 template <typename Component>
 template <size_t... Is>
 bool MockLocalAlgorithm<Component>::is_ready(
-    std::index_sequence<Is...> /*meta*/,
-    const typename Component::index& array_index,
-    const gsl::not_null<tuples::TaggedTupleTypelist<inbox_tags_list>*> inboxes,
-    const gsl::not_null<Parallel::ConstGlobalCache<metavariables>*>
-        const_global_cache) noexcept {
+    std::index_sequence<Is...> /*meta*/) noexcept {
   bool next_action_is_ready = false;
   const auto helper = [
-    this, &array_index, &inboxes, &const_global_cache, &next_action_is_ready
+    this, &array_index = array_index_, &inboxes = *inboxes_,
+    &const_global_cache = const_global_cache_, &next_action_is_ready
   ](auto iteration) noexcept {
     constexpr size_t iter = decltype(iteration)::value;
     using this_action = tmpl::at_c<actions_list, iter>;
@@ -249,7 +257,7 @@ bool MockLocalAlgorithm<Component>::is_ready(
         [&box, &array_index, &const_global_cache, &inboxes](
             std::true_type /*has_is_ready*/, auto t) {
           return decltype(t)::is_ready(
-              cpp17::as_const(box), cpp17::as_const(*inboxes),
+              cpp17::as_const(box), cpp17::as_const(inboxes),
               *const_global_cache, cpp17::as_const(array_index));
         },
         [](std::false_type /*has_is_ready*/, auto) { return true; });
@@ -430,6 +438,15 @@ class ActionRunner {
           Parallel::get_parallel_component<Component>(cache_).set_data(
               &tuples::get<LocalAlgorithmsTag<Component>>(local_algorithms_),
               &tuples::get<InboxesTag<Component>>(inboxes_));
+
+          for (auto& local_alg_pair : this->template algorithms<Component>()) {
+            const auto& index = local_alg_pair.first;
+            auto& local_alg = local_alg_pair.second;
+            local_alg.set_index(index);
+            local_alg.set_cache(&cache_);
+            local_alg.set_inboxes(
+                &(tuples::get<InboxesTag<Component>>(inboxes_)[index]));
+          }
         });
   }
 
@@ -470,10 +487,8 @@ class ActionRunner {
     algorithms<Component>()
         .at(array_index)
         .next_action(
-            std::make_index_sequence<tmpl::size<
-                typename MockLocalAlgorithm<Component>::actions_list>::value>{},
-            array_index, make_not_null(&inboxes<Component>()[array_index]),
-            &cache_);
+            std::make_index_sequence<tmpl::size<typename MockLocalAlgorithm<
+                Component>::actions_list>::value>{});
   }
 
   /// Call is_ready on the next action in the action list as if on the portion
@@ -483,10 +498,8 @@ class ActionRunner {
     return algorithms<Component>()
         .at(array_index)
         .is_ready(
-            std::make_index_sequence<tmpl::size<
-                typename MockLocalAlgorithm<Component>::actions_list>::value>{},
-            array_index, make_not_null(&inboxes<Component>()[array_index]),
-            &cache_);
+            std::make_index_sequence<tmpl::size<typename MockLocalAlgorithm<
+                Component>::actions_list>::value>{});
   }
 
   /// Access the inboxes for a given component.

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_IO")
 set(LIBRARY_SOURCES
   Observers/Test_ArrayComponentId.cpp
   Observers/Test_Initialize.cpp
+  Observers/Test_RegisterElements.cpp
   Observers/Test_Tags.cpp
   Observers/Test_TypeOfObservation.cpp
   Test_H5.cpp

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_IO")
 
 set(LIBRARY_SOURCES
   Observers/Test_ArrayComponentId.cpp
+  Observers/Test_TypeOfObservation.cpp
   Test_H5.cpp
   )
 

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_IO")
 
 set(LIBRARY_SOURCES
   Observers/Test_ArrayComponentId.cpp
+  Observers/Test_Initialize.cpp
   Observers/Test_Tags.cpp
   Observers/Test_TypeOfObservation.cpp
   Test_H5.cpp

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_IO")
 
 set(LIBRARY_SOURCES
   Observers/Test_ArrayComponentId.cpp
+  Observers/Test_Tags.cpp
   Observers/Test_TypeOfObservation.cpp
   Test_H5.cpp
   )

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_IO")
 
 set(LIBRARY_SOURCES
+  Observers/Test_ArrayComponentId.cpp
   Test_H5.cpp
   )
 

--- a/tests/Unit/IO/Observers/Test_ArrayComponentId.cpp
+++ b/tests/Unit/IO/Observers/Test_ArrayComponentId.cpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <ckarrayindex.h>
+#include <functional>
+#include <type_traits>
+
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+struct Component0 {};
+struct Component1 {};
+
+SPECTRE_TEST_CASE("Unit.IO.Observers.ArrayComponentId", "[Unit][Observers]") {
+  using ArrayComponentId = observers::ArrayComponentId;
+  using Hash = std::hash<ArrayComponentId>;
+  ArrayComponentId c0id0{
+      std::add_pointer_t<Component0>{nullptr},
+      Parallel::ArrayIndex<ElementIndex<1>>(ElementIndex<1>{ElementId<1>{0}})};
+  ArrayComponentId c0id1{
+      std::add_pointer_t<Component0>{nullptr},
+      Parallel::ArrayIndex<ElementIndex<1>>(ElementIndex<1>{ElementId<1>{1}})};
+
+  ArrayComponentId c1id0{
+      std::add_pointer_t<Component1>{nullptr},
+      Parallel::ArrayIndex<ElementIndex<1>>(ElementIndex<1>{ElementId<1>{0}})};
+  ArrayComponentId c1id1{
+      std::add_pointer_t<Component1>{nullptr},
+      Parallel::ArrayIndex<ElementIndex<1>>(ElementIndex<1>{ElementId<1>{1}})};
+
+  CHECK(c0id0 == c0id0);
+  CHECK_FALSE(c0id0 != c0id0);
+  CHECK(c0id0 != c0id1);
+  CHECK(c0id0 != c1id0);
+  CHECK(c0id0 != c1id1);
+
+  CHECK(c0id0.component_id() == c0id0.component_id());
+  CHECK_FALSE(c0id0.component_id() != c0id0.component_id());
+  CHECK(c0id0.component_id() == c0id1.component_id());
+  CHECK(c0id0.component_id() != c1id0.component_id());
+  CHECK(c0id0.component_id() != c1id1.component_id());
+
+  CHECK(c0id0.array_index() == c0id0.array_index());
+  CHECK_FALSE(c0id0.array_index() == c0id1.array_index());
+  CHECK(c0id0.array_index() == c1id0.array_index());
+  CHECK_FALSE(c0id0.array_index() == c1id1.array_index());
+
+  CHECK(Hash{}(c0id0) == Hash{}(c0id0));
+  CHECK(Hash{}(c0id0) != Hash{}(c0id1));
+  CHECK(Hash{}(c0id0) != Hash{}(c1id0));
+  CHECK(Hash{}(c0id0) != Hash{}(c1id1));
+  CHECK(Hash{}(c1id0) == Hash{}(c1id0));
+  CHECK(Hash{}(c1id0) != Hash{}(c1id1));
+
+  // Test PUP
+  test_serialization(c0id0);
+  test_serialization(c0id1);
+  test_serialization(c1id0);
+  test_serialization(c1id1);
+}
+}  // namespace

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+// IWYU pragma: no_include <exception>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"  // IWYU pragma: keep
+#include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/Tags.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace {
+template <typename Metavariables>
+struct observer_component
+    : ActionTesting::MockArrayComponent<Metavariables, size_t, tmpl::list<>,
+                                        tmpl::list<>> {
+  using initial_databox = db::compute_databox_type<
+      typename observers::Actions::Initialize::return_tag_list>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<observer_component<Metavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  enum class Phase { Initialize, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.IO.Observers.Initialize", "[Unit][Observers]") {
+  using LocalAlgorithms =
+      typename ActionTesting::ActionRunner<Metavariables>::LocalAlgorithms;
+  using obs_component = observer_component<Metavariables>;
+  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using ObserverLocalAlgsTag =
+      typename ActionRunner::template LocalAlgorithmsTag<obs_component>;
+  LocalAlgorithms local_algs{};
+  tuples::get<ObserverLocalAlgsTag>(local_algs)
+      .emplace(0, ActionTesting::MockLocalAlgorithm<obs_component>{});
+
+  ActionTesting::ActionRunner<Metavariables> runner{{}, std::move(local_algs)};
+
+  runner.simple_action<obs_component, observers::Actions::Initialize>(0);
+  const auto& observer_box =
+      runner.template algorithms<obs_component>()
+          .at(0)
+          .template get_databox<typename obs_component::initial_databox>();
+  CHECK(db::get<observers::Tags::NumberOfEvents>(observer_box).empty());
+  CHECK(db::get<observers::Tags::ReductionArrayComponentIds>(observer_box)
+            .empty());
+  CHECK(
+      db::get<observers::Tags::VolumeArrayComponentIds>(observer_box).empty());
+  CHECK(db::get<observers::Tags::TensorData>(observer_box).empty());
+}
+}  // namespace

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -1,0 +1,150 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <exception>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/Tags.hpp"               // IWYU pragma: keep
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace {
+using ElementIndexType = ElementIndex<2>;
+
+template <typename Metavariables>
+struct element_component
+    : ActionTesting::MockArrayComponent<Metavariables, ElementIndexType,
+                                        tmpl::list<>, tmpl::list<>> {
+  using initial_databox = db::DataBox<tmpl::list<>>;
+};
+
+template <typename Metavariables>
+struct observer_component
+    : ActionTesting::MockArrayComponent<Metavariables, size_t, tmpl::list<>,
+                                        tmpl::list<>,
+                                        observers::Observer<Metavariables>> {
+  using simple_tags =
+      db::AddSimpleTags<observers::Tags::NumberOfEvents,
+                        observers::Tags::ReductionArrayComponentIds,
+                        observers::Tags::VolumeArrayComponentIds,
+                        observers::Tags::TensorData>;
+  using initial_databox = db::compute_databox_type<simple_tags>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<element_component<Metavariables>,
+                                    observer_component<Metavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  enum class Phase { Initialize, Exit };
+};
+
+template <observers::TypeOfObservation TypeOfObservation>
+void check_observer_registration() {
+  using LocalAlgorithms =
+      typename ActionTesting::ActionRunner<Metavariables>::LocalAlgorithms;
+  using obs_component = observer_component<Metavariables>;
+  using element_comp = element_component<Metavariables>;
+
+  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using ObserverLocalAlgsTag =
+      typename ActionRunner::template LocalAlgorithmsTag<obs_component>;
+  using ElementLocalAlgsTag =
+      typename ActionRunner::template LocalAlgorithmsTag<element_comp>;
+  LocalAlgorithms local_algs{};
+  tuples::get<ObserverLocalAlgsTag>(local_algs)
+      .emplace(0, ActionTesting::MockLocalAlgorithm<obs_component>{});
+
+  // Specific IDs have no significance, just need different IDs.
+  const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
+                                              {1, {{{1, 1}, {1, 0}}}},
+                                              {1, {{{1, 0}, {2, 3}}}},
+                                              {1, {{{1, 0}, {5, 4}}}},
+                                              {0, {{{1, 0}, {1, 0}}}}};
+  for (const auto& id : element_ids) {
+    tuples::get<ElementLocalAlgsTag>(local_algs)
+        .emplace(ElementIndex<2>{id},
+                 ActionTesting::MockLocalAlgorithm<element_comp>{});
+  }
+
+  ActionTesting::ActionRunner<Metavariables> runner{{}, std::move(local_algs)};
+
+  runner.simple_action<obs_component, observers::Actions::Initialize>(0);
+  // Test initial state
+  const auto& observer_box =
+      runner.template algorithms<obs_component>()
+          .at(0)
+          .template get_databox<typename obs_component::initial_databox>();
+  CHECK(db::get<observers::Tags::NumberOfEvents>(observer_box).empty());
+  CHECK(db::get<observers::Tags::ReductionArrayComponentIds>(observer_box)
+            .empty());
+  CHECK(
+      db::get<observers::Tags::VolumeArrayComponentIds>(observer_box).empty());
+  CHECK(db::get<observers::Tags::TensorData>(observer_box).empty());
+
+  // Register elements
+  for (const auto& id : element_ids) {
+    runner.simple_action<
+        element_comp,
+        observers::Actions::RegisterWithObservers<TypeOfObservation>>(id, 0);
+  }
+
+  // Test registration occurred as expected
+  CHECK(db::get<observers::Tags::NumberOfEvents>(observer_box).empty());
+  CHECK(db::get<observers::Tags::ReductionArrayComponentIds>(observer_box)
+            .size() ==
+        (TypeOfObservation == observers::TypeOfObservation::Volume
+             ? size_t{0}
+             : element_ids.size()));
+  CHECK(
+      db::get<observers::Tags::VolumeArrayComponentIds>(observer_box).size() ==
+      (TypeOfObservation == observers::TypeOfObservation::Reduction
+           ? size_t{0}
+           : element_ids.size()));
+  CHECK(db::get<observers::Tags::TensorData>(observer_box).empty());
+  for (const auto& id : element_ids) {
+    CHECK(
+        db::get<observers::Tags::ReductionArrayComponentIds>(observer_box)
+            .count(observers::ArrayComponentId(
+                std::add_pointer_t<element_comp>{nullptr},
+                Parallel::ArrayIndex<ElementIndex<2>>(ElementIndex<2>(id)))) ==
+        (TypeOfObservation == observers::TypeOfObservation::Volume ? 0 : 1));
+    CHECK(
+        db::get<observers::Tags::VolumeArrayComponentIds>(observer_box)
+            .count(observers::ArrayComponentId(
+                std::add_pointer_t<element_comp>{nullptr},
+                Parallel::ArrayIndex<ElementIndex<2>>(ElementIndex<2>(id)))) ==
+        (TypeOfObservation == observers::TypeOfObservation::Reduction ? 0 : 1));
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.IO.Observers.RegisterElements", "[Unit]") {
+  SECTION("Register as requiring reduction observer support") {
+    check_observer_registration<observers::TypeOfObservation::Reduction>();
+  }
+  SECTION("Register as requiring volume observer support") {
+    check_observer_registration<observers::TypeOfObservation::Volume>();
+  }
+  SECTION("Register as requiring both reduction and volume  observer support") {
+    check_observer_registration<
+        observers::TypeOfObservation::ReductionAndVolume>();
+  }
+}
+}  // namespace

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "IO/Observer/Tags.hpp"
+
+SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
+  CHECK(observers::Tags::NumberOfEvents::name() == "NumberOfEvents");
+  CHECK(observers::Tags::ReductionArrayComponentIds::name() ==
+        "ReductionArrayComponentIds");
+  CHECK(observers::Tags::VolumeArrayComponentIds::name() ==
+        "VolumeArrayComponentIds");
+  CHECK(observers::Tags::TensorData::name() == "TensorData");
+}

--- a/tests/Unit/IO/Observers/Test_TypeOfObservation.cpp
+++ b/tests/Unit/IO/Observers/Test_TypeOfObservation.cpp
@@ -1,0 +1,17 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Utilities/GetOutput.hpp"
+
+SPECTRE_TEST_CASE("Unit.IO.Observers.TypeOfObservation", "[Unit][Observers]") {
+  using observers::TypeOfObservation;
+  CHECK(get_output(TypeOfObservation::Reduction) == "Reduction");
+  CHECK(get_output(TypeOfObservation::Volume) == "Volume");
+  CHECK(get_output(TypeOfObservation::ReductionAndVolume) ==
+        "ReductionAndVolume");
+}


### PR DESCRIPTION
## Proposed changes

- Add support for nodegroups and groups to mocking framework, but we treat them as arrays.
- Add classes and actions to initialize observer component and register elements with a local observer.

Depends on:
- [x] #913 

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
