### PR TITLE
Add RegularSphericalWave analytic solution

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY WaveEquation)
 
 set(LIBRARY_SOURCES
   PlaneWave.cpp
+  RegularSphericalWave.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.cpp
@@ -1,0 +1,116 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <pup.h>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"           // IWYU pragma: keep
+#include "Evolution/Systems/ScalarWave/Tags.hpp"  // IWYU pragma: keep
+#include "Parallel/PupStlCpp11.hpp"               // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+// IWYU pragma: no_forward_declare Tensor
+
+namespace ScalarWave {
+namespace Solutions {
+
+RegularSphericalWave::RegularSphericalWave(
+    std::unique_ptr<MathFunction<1>> profile) noexcept
+    : profile_(std::move(profile)) {}
+
+tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>
+RegularSphericalWave::variables(
+    const tnsr::I<DataVector, 3>& x, double t,
+    const tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>,
+                     ScalarWave::Psi> /*meta*/) const noexcept {
+  const DataVector r = get(magnitude(x));
+  // See class documentation for choice of cutoff
+  const double r_cutoff = cbrt(std::numeric_limits<double>::epsilon());
+  Scalar<DataVector> psi{r.size()};
+  Scalar<DataVector> dpsi_dt{r.size()};
+  tnsr::i<DataVector, 3> dpsi_dx{r.size()};
+  for (size_t i = 0; i < r.size(); i++) {
+    // Testing for r=0 here assumes a scale of order unity
+    if (equal_within_roundoff(r[i], 0., r_cutoff, 1.)) {
+      get(psi)[i] = 2. * profile_->first_deriv(-t);
+      get(dpsi_dt)[i] = -2. * profile_->second_deriv(-t);
+      for (size_t d = 0; d < 3; d++) {
+        dpsi_dx.get(d)[i] = 0.;
+      }
+    } else {
+      const auto F_out = profile_->operator()(r[i] - t);
+      const auto F_in = profile_->operator()(-r[i] - t);
+      const auto dF_out = profile_->first_deriv(r[i] - t);
+      const auto dF_in = profile_->first_deriv(-r[i] - t);
+      get(psi)[i] = (F_out - F_in) / r[i];
+      get(dpsi_dt)[i] = (-dF_out + dF_in) / r[i];
+      const double dpsi_dx_isotropic =
+          (dF_out + dF_in - get(psi)[i]) / square(r[i]);
+      for (size_t d = 0; d < 3; d++) {
+        dpsi_dx.get(d)[i] = dpsi_dx_isotropic * x.get(d)[i];
+      }
+    }
+  }
+  tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>
+      variables{std::move(dpsi_dt), std::move(dpsi_dx), std::move(psi)};
+  get<ScalarWave::Pi>(variables).get() *= -1.0;
+  return variables;
+}
+
+tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
+                    Tags::dt<ScalarWave::Psi>>
+RegularSphericalWave::variables(
+    const tnsr::I<DataVector, 3>& x, double t,
+    const tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
+                     Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept {
+  const DataVector r = get(magnitude(x));
+  // See class documentation for choice of cutoff
+  const double r_cutoff = cbrt(std::numeric_limits<double>::epsilon());
+  Scalar<DataVector> dpsi_dt{r.size()};
+  Scalar<DataVector> d2psi_dt2{r.size()};
+  tnsr::i<DataVector, 3> d2psi_dtdx{r.size()};
+  for (size_t i = 0; i < r.size(); i++) {
+    // Testing for r=0 here assumes a scale of order unity
+    if (equal_within_roundoff(r[i], 0., r_cutoff, 1.)) {
+      get(dpsi_dt)[i] = -2. * profile_->second_deriv(-t);
+      get(d2psi_dt2)[i] = 2. * profile_->third_deriv(-t);
+      for (size_t d = 0; d < 3; d++) {
+        d2psi_dtdx.get(d)[i] = 0.;
+      }
+    } else {
+      const auto dF_out = profile_->first_deriv(r[i] - t);
+      const auto dF_in = profile_->first_deriv(-r[i] - t);
+      const auto d2F_out = profile_->second_deriv(r[i] - t);
+      const auto d2F_in = profile_->second_deriv(-r[i] - t);
+      get(dpsi_dt)[i] = (-dF_out + dF_in) / r[i];
+      get(d2psi_dt2)[i] = (d2F_out - d2F_in) / r[i];
+      const double d2psi_dtdx_isotropic =
+          -(d2F_out + d2F_in + get(dpsi_dt)[i]) / square(r[i]);
+      for (size_t d = 0; d < 3; d++) {
+        d2psi_dtdx.get(d)[i] = d2psi_dtdx_isotropic * x.get(d)[i];
+      }
+    }
+  }
+  tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
+                      Tags::dt<ScalarWave::Psi>>
+      dt_variables{std::move(d2psi_dt2), std::move(d2psi_dtdx),
+                   std::move(dpsi_dt)};
+  get<Tags::dt<ScalarWave::Pi>>(dt_variables).get() *= -1.0;
+  return dt_variables;
+}
+
+void RegularSphericalWave::pup(PUP::er& p) noexcept {
+  p | profile_;
+}
+
+}  // namespace Solutions
+}  // namespace ScalarWave

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -1,0 +1,107 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines ScalarWave::Solutions::RegularSphericalWave
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+class DataVector;
+namespace ScalarWave {
+struct Pi;
+struct Psi;
+template <size_t Dim>
+struct Phi;
+}  // namespace ScalarWave
+namespace Tags {
+template <typename Tag>
+struct dt;
+}  // namespace Tags
+template <size_t VolumeDim>
+class MathFunction;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ScalarWave {
+namespace Solutions {
+/*!
+ * \brief A 3D spherical wave solution to the Euclidean wave equation that is
+ * regular at the origin
+ *
+ * The solution is given by \f$\Psi(\vec{x},t) = \Psi(r,t) =
+ * \frac{F(r-t)-F(-r-t)}{r}\f$ describing an outgoing and an ingoing wave
+ * with profile \f$F(u)\f$. For small \f$r\f$ the solution is approximated by
+ * its Taylor expansion \f$\Psi(r,t)=2 F^\prime(-t) + \mathcal{O}(r^2)\f$. The
+ * outgoing and ingoing waves meet at the origin (and cancel each other) when
+ * \f$F^\prime(-t)=0\f$.
+ *
+ * The expansion is employed where \f$r\f$ lies within the cubic root of the
+ * machine epsilon. Inside this radius we expect the error due to the truncation
+ * of the Taylor expansion to be smaller than the numerical error made when
+ * evaluating the full \f$\Psi(r,t)\f$. This is because the truncation error
+ * scales as \f$r^2\f$ (since we keep the zeroth order, and the linear order
+ * vanishes as all odd orders do) and the numerical error scales as
+ * \f$\frac{\epsilon}{r}\f$, so they are comparable at
+ * \f$r\propto\epsilon^\frac{1}{3}\f$.
+ *
+ * \requires the profile \f$F(u)\f$ to have a length scale of order unity so
+ * that "small" \f$r\f$ means \f$r\ll 1\f$. This is without loss of generality
+ * because of the scale invariance of the wave equation. The profile could be a
+ * Gausssian centered at 0 with width 1, for instance.
+ */
+class RegularSphericalWave {
+ public:
+  struct Profile {
+    using type = std::unique_ptr<MathFunction<1>>;
+    static constexpr OptionString help = {
+        "The radial profile of the spherical wave."};
+  };
+
+  using options = tmpl::list<Profile>;
+
+  static constexpr OptionString help = {
+      "A spherical wave solution of the Euclidean wave equation that is "
+      "regular at the origin"};
+
+  RegularSphericalWave() = default;
+  explicit RegularSphericalWave(
+      std::unique_ptr<MathFunction<1>> profile) noexcept;
+  RegularSphericalWave(const RegularSphericalWave&) noexcept = delete;
+  RegularSphericalWave& operator=(const RegularSphericalWave&) noexcept =
+      delete;
+  RegularSphericalWave(RegularSphericalWave&&) noexcept = default;
+  RegularSphericalWave& operator=(RegularSphericalWave&&) noexcept = default;
+  ~RegularSphericalWave() noexcept = default;
+
+  tuples::TaggedTuple<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>
+  variables(const tnsr::I<DataVector, 3>& x, double t,
+            tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>,
+                       ScalarWave::Psi> /*meta*/) const noexcept;
+
+  tuples::TaggedTuple<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
+                      Tags::dt<ScalarWave::Psi>>
+  variables(const tnsr::I<DataVector, 3>& x, double t,
+            tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
+                       Tags::dt<ScalarWave::Psi>> /*meta*/) const noexcept;
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  std::unique_ptr<MathFunction<1>> profile_;
+};
+}  // namespace Solutions
+}  // namespace ScalarWave

--- a/src/PointwiseFunctions/MathFunctions/Gaussian.cpp
+++ b/src/PointwiseFunctions/MathFunctions/Gaussian.cpp
@@ -35,6 +35,13 @@ DataVector Gaussian::second_deriv(const DataVector& x) const noexcept {
   return apply_second_deriv(x);
 }
 
+double Gaussian::third_deriv(const double& x) const noexcept {
+  return apply_third_deriv(x);
+}
+DataVector Gaussian::third_deriv(const DataVector& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
 template <typename T>
 T Gaussian::apply_call_operator(const T& x) const noexcept {
   return amplitude_ * exp(-square((x - center_) * inverse_width_));
@@ -50,6 +57,13 @@ template <typename T>
 T Gaussian::apply_second_deriv(const T& x) const noexcept {
   return (-2.0 * amplitude_ * square(inverse_width_)) *
          (1.0 - 2.0 * square(x - center_) * square(inverse_width_)) *
+         exp(-square((x - center_) * inverse_width_));
+}
+
+template <typename T>
+T Gaussian::apply_third_deriv(const T& x) const noexcept {
+  return 4.0 * amplitude_ * pow<4>(inverse_width_) * (x - center_) *
+         (3.0 - 2.0 * square((x - center_) * inverse_width_)) *
          exp(-square((x - center_) * inverse_width_));
 }
 

--- a/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
@@ -69,6 +69,9 @@ class Gaussian : public MathFunction<1> {
   double second_deriv(const double& x) const noexcept override;
   DataVector second_deriv(const DataVector& x) const noexcept override;
 
+  double third_deriv(const double& x) const noexcept override;
+  DataVector third_deriv(const DataVector& x) const noexcept override;
+
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) override;  // NOLINT
 
@@ -80,6 +83,8 @@ class Gaussian : public MathFunction<1> {
   T apply_first_deriv(const T& x) const noexcept;
   template <typename T>
   T apply_second_deriv(const T& x) const noexcept;
+  template <typename T>
+  T apply_third_deriv(const T& x) const noexcept;
 
   double amplitude_{};
   double inverse_width_{};

--- a/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
+++ b/src/PointwiseFunctions/MathFunctions/MathFunction.hpp
@@ -64,6 +64,12 @@ class MathFunction<1> : public PUP::able {
   virtual double second_deriv(const double& x) const noexcept = 0;
   virtual DataVector second_deriv(const DataVector& x) const noexcept = 0;
   //@}
+
+  //@{
+  /// Returns the third derivative at 'x'.
+  virtual double third_deriv(const double& x) const noexcept = 0;
+  virtual DataVector third_deriv(const DataVector& x) const noexcept = 0;
+  //@}
 };
 
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"

--- a/src/PointwiseFunctions/MathFunctions/PowX.cpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.cpp
@@ -31,6 +31,13 @@ DataVector PowX::second_deriv(const DataVector& x) const noexcept {
   return apply_second_deriv(x);
 }
 
+double PowX::third_deriv(const double& x) const noexcept {
+  return apply_third_deriv(x);
+}
+DataVector PowX::third_deriv(const DataVector& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
 template <typename T>
 T PowX::apply_call_operator(const T& x) const noexcept {
   return pow(x, power_);
@@ -47,6 +54,13 @@ T PowX::apply_second_deriv(const T& x) const noexcept {
   return 0 == power_ or 1 == power_
              ? make_with_value<T>(x, 0.0)
              : power_ * (power_ - 1) * pow(x, power_ - 2);
+}
+
+template <typename T>
+T PowX::apply_third_deriv(const T& x) const noexcept {
+  return 0 == power_ or 1 == power_ or 2 == power_
+             ? make_with_value<T>(x, 0.0)
+             : power_ * (power_ - 1) * (power_ - 2) * pow(x, power_ - 3);
 }
 
 void PowX::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/MathFunctions/PowX.hpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.hpp
@@ -57,6 +57,9 @@ class PowX : public MathFunction<1> {
   double second_deriv(const double& x) const noexcept override;
   DataVector second_deriv(const DataVector& x) const noexcept override;
 
+  double third_deriv(const double& x) const noexcept override;
+  DataVector third_deriv(const DataVector& x) const noexcept override;
+
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) override;  // NOLINT
 
@@ -68,6 +71,8 @@ class PowX : public MathFunction<1> {
   T apply_first_deriv(const T& x) const noexcept;
   template <typename T>
   T apply_second_deriv(const T& x) const noexcept;
+  template <typename T>
+  T apply_third_deriv(const T& x) const noexcept;
 
   double power_{};
 };

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.cpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.cpp
@@ -35,6 +35,13 @@ DataVector Sinusoid::second_deriv(const DataVector& x) const noexcept {
   return apply_second_deriv(x);
 }
 
+double Sinusoid::third_deriv(const double& x) const noexcept {
+  return apply_third_deriv(x);
+}
+DataVector Sinusoid::third_deriv(const DataVector& x) const noexcept {
+  return apply_third_deriv(x);
+}
+
 template <typename T>
 T Sinusoid::apply_call_operator(const T& x) const noexcept {
   return amplitude_ * sin(wavenumber_ * x + phase_);
@@ -47,7 +54,12 @@ T Sinusoid::apply_first_deriv(const T& x) const noexcept {
 
 template <typename T>
 T Sinusoid::apply_second_deriv(const T& x) const noexcept {
-  return - amplitude_ * square(wavenumber_) * sin(wavenumber_ * x + phase_);
+  return -amplitude_ * square(wavenumber_) * sin(wavenumber_ * x + phase_);
+}
+
+template <typename T>
+T Sinusoid::apply_third_deriv(const T& x) const noexcept {
+  return -amplitude_ * cube(wavenumber_) * cos(wavenumber_ * x + phase_);
 }
 
 void Sinusoid::pup(PUP::er& p) {

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
@@ -69,6 +69,9 @@ class Sinusoid : public MathFunction<1> {
   double second_deriv(const double& x) const noexcept override;
   DataVector second_deriv(const DataVector& x) const noexcept override;
 
+  double third_deriv(const double& x) const noexcept override;
+  DataVector third_deriv(const DataVector& x) const noexcept override;
+
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) override;  // NOLINT
 
@@ -80,6 +83,8 @@ class Sinusoid : public MathFunction<1> {
   T apply_first_deriv(const T& x) const noexcept;
   template <typename T>
   T apply_second_deriv(const T& x) const noexcept;
+  template <typename T>
+  T apply_third_deriv(const T& x) const noexcept;
 
   double amplitude_{};
   double wavenumber_{};

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_WaveEquation")
 
 set(LIBRARY_SOURCES
   Test_PlaneWave.cpp
+  Test_RegularSphericalWave.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_RegularSphericalWave.cpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <memory>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
+#include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/TestCreation.hpp"
+
+SPECTRE_TEST_CASE("Unit.AnalyticSolutions.WaveEquation.RegularSphericalWave",
+                  "[PointwiseFunctions][Unit]") {
+  const ScalarWave::Solutions::RegularSphericalWave solution{
+      std::make_unique<MathFunctions::Gaussian>(1., 1., 0.)};
+
+  const tnsr::I<DataVector, 3> x{std::array<DataVector, 3>{
+      {DataVector({0., 1., 2., 3.}), DataVector({0., 0., 0., 0.}),
+       DataVector({0., 0., 0., 0.})}}};
+  auto vars = solution.variables(
+      x, 1., tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{});
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Psi>(vars).get(),
+      DataVector({{1.471517764685769, 0.9816843611112658, 0.1838780156836778,
+                   0.006105175451186487}}));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Pi>(vars).get(),
+      DataVector({{1.471517764685769, -0.07326255555493672, -0.3682496705837024,
+                   -0.02442115194544483}}));
+  CHECK_ITERABLE_APPROX(
+      get<ScalarWave::Phi<3>>(vars).get(0),
+      DataVector({{0., -0.9084218055563291, -0.4594482196010212,
+                   -0.02645561024157515}}));
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Phi<3>>(vars).get(1),
+                        DataVector({{0., 0., 0., 0.}}));
+  CHECK_ITERABLE_APPROX(get<ScalarWave::Phi<3>>(vars).get(2),
+                        DataVector({{0., 0., 0., 0.}}));
+  auto dt_vars = solution.variables(
+      x, 1.,
+      tmpl::list<Tags::dt<ScalarWave::Pi>, Tags::dt<ScalarWave::Phi<3>>,
+                 Tags::dt<ScalarWave::Psi>>{});
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Psi>>(dt_vars).get(),
+      DataVector({{-1.471517764685769, 0.07326255555493672, 0.3682496705837024,
+                   0.02442115194544483}}));
+  CHECK_ITERABLE_APPROX(
+      get<Tags::dt<ScalarWave::Pi>>(dt_vars).get(),
+      DataVector({{2.943035529371539, 2.256418944442279, -0.3657814745019688,
+                   -0.08547065575381531}}));
+  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Phi<3>>>(dt_vars).get(0),
+                        DataVector({{0., 1.670318500002785, -0.5541022431327671,
+                                     -0.09361569118951865}}));
+  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Phi<3>>>(dt_vars).get(1),
+                        DataVector({{0., 0., 0., 0.}}));
+  CHECK_ITERABLE_APPROX(get<Tags::dt<ScalarWave::Phi<3>>>(dt_vars).get(2),
+                        DataVector({{0., 0., 0., 0.}}));
+
+  const auto created_solution =
+      test_creation<ScalarWave::Solutions::RegularSphericalWave>(
+          "  Profile:\n"
+          "    Gaussian:\n"
+          "      Amplitude: 1.\n"
+          "      Width: 1.\n"
+          "      Center: 0.\n");
+  CHECK(
+      created_solution.variables(
+          x, 1.,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{}) ==
+      vars);
+}

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Gaussian.cpp
@@ -45,20 +45,28 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Gaussian",
     CHECK(gauss.first_deriv(point) ==
           approx(-2. * (point - center) / square(width) * mapped_point));
     CHECK(gauss.second_deriv(point) ==
-          approx(
-              (4 * square(point - center) / pow<4>(width) - 2 / square(width)) *
-              mapped_point));
+          approx((4. * square(point - center) / pow<4>(width) -
+                  2. / square(width)) *
+                 mapped_point));
+    CHECK(gauss.third_deriv(point) ==
+          approx(-4. * (point - center) *
+                 (2. * square((point - center) / width) - 3.) / pow<4>(width) *
+                 mapped_point));
   }
 
   const DataVector one{1., 1.};
   const auto mapped_point = amplitude * exp(-square((one - center) / width));
   const auto first_deriv = -2. * (one - center) / square(width) * mapped_point;
   const auto second_deriv =
-      (4 * square(one - center) / pow<4>(width) - 2 / square(width)) *
+      (4. * square(one - center) / pow<4>(width) - 2. / square(width)) *
       mapped_point;
+  const auto third_deriv = -4. * (one - center) *
+                           (2. * square((one - center) / width) - 3.) /
+                           pow<4>(width) * mapped_point;
   CHECK_ITERABLE_APPROX(gauss(one), mapped_point);
   CHECK_ITERABLE_APPROX(gauss.first_deriv(one), first_deriv);
   CHECK_ITERABLE_APPROX(gauss.second_deriv(one), second_deriv);
+  CHECK_ITERABLE_APPROX(gauss.third_deriv(one), third_deriv);
 
   test_serialization(gauss);
   test_serialization_via_base<MathFunction<1>, MathFunctions::Gaussian>(

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
@@ -21,7 +21,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
                   "[PointwiseFunctions][Unit]") {
   const std::array<double, 3> test_values{{-1.4, 2.5, 0.}};
 
-  // Check i = 0 and i = 1 cases seperately
+  // Check i = 0, i = 1 and i = 2 cases seperately
   {
     MathFunctions::PowX power(0);
     for (size_t j = 0; j < 3; ++j) {
@@ -29,6 +29,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
       CHECK(power(value) == 1.);
       CHECK(power.first_deriv(value) == 0.);
       CHECK(power.second_deriv(value) == 0.);
+      CHECK(power.third_deriv(value) == 0.);
     }
   }
 
@@ -39,11 +40,23 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
       CHECK(power(value) == approx(value));
       CHECK(power.first_deriv(value) == 1.);
       CHECK(power.second_deriv(value) == 0.);
+      CHECK(power.third_deriv(value) == 0.);
+    }
+  }
+
+  {
+    MathFunctions::PowX power(2);
+    for (size_t j = 0; j < 3; ++j) {
+      const auto value = gsl::at(test_values, j);
+      CHECK(power(value) == approx(square(value)));
+      CHECK(power.first_deriv(value) == approx(2. * value));
+      CHECK(power.second_deriv(value) == 2.);
+      CHECK(power.third_deriv(value) == 0.);
     }
   }
 
   // Check several more powers
-  for (int i = 2; i < 5; ++i) {
+  for (int i = 3; i < 5; ++i) {
     MathFunctions::PowX power(i);
     for (size_t j = 0; j < 3; ++j) {
       const auto value = gsl::at(test_values, j);
@@ -51,6 +64,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
       CHECK(power.first_deriv(value) == approx(i * std::pow(value, i - 1)));
       CHECK(power.second_deriv(value) ==
             approx(i * (i - 1) * std::pow(value, i - 2)));
+      CHECK(power.third_deriv(value) ==
+            approx(i * (i - 1) * (i - 2) * std::pow(value, i - 3)));
     }
   }
   // Check negative powers
@@ -63,6 +78,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
       CHECK(power.first_deriv(value) == approx(i * std::pow(value, i - 1)));
       CHECK(power.second_deriv(value) ==
             approx(i * (i - 1) * std::pow(value, i - 2)));
+      CHECK(power.third_deriv(value) ==
+            approx(i * (i - 1) * (i - 2) * std::pow(value, i - 3)));
     }
   }
 
@@ -71,6 +88,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.PowX",
   CHECK(power(test_dv) == pow(test_dv, 3));
   CHECK(power.first_deriv(test_dv) == 3 * pow(test_dv, 2));
   CHECK(power.second_deriv(test_dv) == 6 * test_dv);
+  CHECK(power.third_deriv(test_dv) == 6.);
 
   test_serialization(power);
   test_serialization_via_base<MathFunction<1>, MathFunctions::PowX>(3);

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_PowX.cpp
@@ -11,6 +11,7 @@
 #include "Parallel/PupStlCpp11.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "PointwiseFunctions/MathFunctions/PowX.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_Sinusoid.cpp
@@ -41,6 +41,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid",
           approx(amplitude * wavenumber * cos(wavenumber * point + phase)));
     CHECK(sinusoid.second_deriv(point) ==
           approx(-square(wavenumber) * mapped_point));
+    CHECK(sinusoid.third_deriv(point) ==
+          approx(-amplitude * cube(wavenumber) *
+                 cos(wavenumber * point + phase)));
   }
 
   const DataVector one{1., 1.};
@@ -48,9 +51,12 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.MathFunctions.Sinusoid",
   const DataVector mapped_first_deriv =
       amplitude * wavenumber * cos(wavenumber * one + phase);
   const DataVector mapped_second_deriv = -square(wavenumber) * mapped_point;
+  const DataVector mapped_third_deriv =
+      -amplitude * cube(wavenumber) * cos(wavenumber * one + phase);
   CHECK_ITERABLE_APPROX(sinusoid(one), mapped_point);
   CHECK_ITERABLE_APPROX(sinusoid.first_deriv(one), mapped_first_deriv);
   CHECK_ITERABLE_APPROX(sinusoid.second_deriv(one), mapped_second_deriv);
+  CHECK_ITERABLE_APPROX(sinusoid.third_deriv(one), mapped_third_deriv);
 
   test_serialization(sinusoid);
   test_serialization_via_base<MathFunction<1>, MathFunctions::Sinusoid>(


### PR DESCRIPTION
## Proposed changes

This implements $\Psi(r,t) = F(r-t)/r - F(r+t)/r$ that solves the wave equation $\partial^2_t \Psi - \Delta \Psi = 0$. It describes an outgoing and ingoing wave profile $F$ that meet at the origin (and cancel each other) at $t=0$. The solution is always regular at $r=0$.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

I'll add more tests once we have agreed that this is the analytic solution we want.