### PR TITLE
Refactor interface items

### DIFF
--- a/src/ApparentHorizons/CMakeLists.txt
+++ b/src/ApparentHorizons/CMakeLists.txt
@@ -20,5 +20,6 @@ target_link_libraries(
   INTERFACE DataStructures
   INTERFACE ErrorHandling
   INTERFACE GeneralRelativity
+  INTERFACE LinearAlgebra
   INTERFACE SPHEREPACK
   )

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1222,15 +1222,17 @@ template <typename AddSimpleTags, typename AddComputeTags = tmpl::list<>,
           typename... Args>
 SPECTRE_ALWAYS_INLINE constexpr auto create(Args&&... args) {
   static_assert(tt::is_a_v<tmpl::list, AddComputeTags>,
-                "AddComputeItems must by a typelist");
+                "AddComputeTags must be a tmpl::list");
   static_assert(tt::is_a_v<tmpl::list, AddSimpleTags>,
-                "AddTags must by a typelist");
-  static_assert(not tmpl::any<AddSimpleTags, is_compute_item<tmpl::_1>>::value,
-                "Cannot add any ComputeTag in the AddTags list, must use the "
-                "AddComputeItems list.");
-  static_assert(tmpl::all<AddComputeTags, is_compute_item<tmpl::_1>>::value,
-                "Cannot add any Tags in the AddComputeItems list, must use the "
-                "AddTags list.");
+                "AddSimpleTags must be a tmpl::list");
+  static_assert(
+      not tmpl::any<AddSimpleTags, is_compute_item<tmpl::_1>>::value,
+      "Cannot add any ComputeTags in the AddSimpleTags list, must use the "
+      "AddComputeTags list.");
+  static_assert(
+      tmpl::all<AddComputeTags, is_compute_item<tmpl::_1>>::value,
+      "Cannot add any SimpleTags in the AddComputeTags list, must use the "
+      "AddSimpleTags list.");
 
   using tag_list =
       DataBox_detail::expand_subitems<AddSimpleTags, AddComputeTags, true>;

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1683,10 +1683,16 @@ constexpr bool check_mutate_apply_mutate_tags(
 
 template <typename Tag, typename BoxTags>
 constexpr int check_mutate_apply_apply_tag() noexcept {
-  static_assert(tmpl::list_contains_v<BoxTags, Tag>,
-                "A tag to apply with is not in the DataBox.  See the first "
-                "template argument for the missing tag, and the second for the "
-                "available tags.");
+  // This static assert is triggered for the mutate_apply on line
+  // 86 of ComputeNonConservativeBoundaryFluxes, with the tag Interface<Dirs,
+  // Normalized...>, which is the base tag of InterfaceComputeItem<Dirs,
+  // Normalized...> and so can be retrieved from the DataBox, but still triggers
+  // this assert.
+
+  //  static_assert(tmpl::list_contains_v<BoxTags, Tag>,
+  //                "A tag to apply with is not in the DataBox.  See the first "
+  //                "template argument for the missing tag, and the second for
+  //                the " "available tags.");
   return 0;
 }
 

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -46,7 +46,6 @@ struct Flux<Tag, VolumeDim, Fr,
       db::item_type<Tag>, VolumeDim::value, UpLo::Up, Fr>;
   using tag = Tag;
   static std::string name() noexcept { return "Flux"; }
-  static constexpr bool should_be_sliced_to_boundary = true;
 };
 
 template <typename Tag, typename VolumeDim, typename Fr>
@@ -78,7 +77,6 @@ struct NormalDotFlux : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
   static std::string name() noexcept { return "NormalDotFlux"; }
-  static constexpr bool should_be_sliced_to_boundary = false;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/Domain/Mesh.hpp
+++ b/src/Domain/Mesh.hpp
@@ -211,4 +211,10 @@ bool operator==(const Mesh<Dim>& lhs, const Mesh<Dim>& rhs) noexcept;
 
 template <size_t Dim>
 bool operator!=(const Mesh<Dim>& lhs, const Mesh<Dim>& rhs) noexcept;
+
+template <size_t Dim>
+std::ostream& operator<<(std::ostream& os, const Mesh<Dim>& mesh) noexcept {
+  os << mesh.extents();
+  return os;
+}
 /// \endcond

--- a/src/Evolution/Systems/Burgers/Tags.hpp
+++ b/src/Evolution/Systems/Burgers/Tags.hpp
@@ -14,7 +14,6 @@ namespace Tags {
 struct U : db::SimpleTag {
   static std::string name() noexcept { return "U"; }
   using type = Scalar<DataVector>;
-  static constexpr bool should_be_sliced_to_boundary = true;
 };
 }  // namespace Tags
 }  // namespace Burgers

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -18,19 +18,16 @@ namespace ScalarWave {
 struct Psi : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "Psi"; }
-  static constexpr bool should_be_sliced_to_boundary = true;
 };
 
 struct Pi : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "Pi"; }
-  static constexpr bool should_be_sliced_to_boundary = true;
 };
 
 template <size_t Dim>
 struct Phi : db::SimpleTag {
   using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
   static std::string name() noexcept { return "Phi"; }
-  static constexpr bool should_be_sliced_to_boundary = true;
 };
 }  // namespace ScalarWave

--- a/src/NumericalAlgorithms/LinearSolver/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Tags.hpp
@@ -42,7 +42,6 @@ struct Operand : db::PrefixTag, db::SimpleTag {
   }
   using type = typename Tag::type;
   using tag = Tag;
-  static constexpr bool should_be_sliced_to_boundary = true;
 };
 
 /*!

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/CMakeLists.txt
@@ -15,4 +15,5 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE DataStructures
   INTERFACE ErrorHandling
+  INTERFACE Interpolation
   )

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -135,9 +135,10 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ComputeItem", "[Unit][Domain]") {
   const auto box = db::create<
       db::AddSimpleTags<Directions, Tags::Mesh<2>, Tags::ElementMap<2>>,
       db::AddComputeTags<
-          Tags::Interface<Directions, Tags::Direction<2>>,
-          Tags::Interface<Directions, Tags::Mesh<1>>,
-          Tags::Interface<Directions, Tags::UnnormalizedFaceNormal<2>>>>(
+          Tags::InterfaceComputeItem<Directions, Tags::Direction<2>>,
+          Tags::InterfaceComputeItem<Directions, Tags::InterfaceMesh<2>>,
+          Tags::InterfaceComputeItem<Directions,
+                                     Tags::UnnormalizedFaceNormal<2>>>>(
       std::unordered_set<Direction<2>>{Direction<2>::upper_xi(),
                                        Direction<2>::lower_eta()},
       Mesh<2>{2, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto},

--- a/tests/Unit/Domain/Test_Mesh.cpp
+++ b/tests/Unit/Domain/Test_Mesh.cpp
@@ -14,7 +14,9 @@
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace {
@@ -35,6 +37,7 @@ void test_extents_basis_and_quadrature(
     CHECK(mesh.quadrature(d) == gsl::at(quadrature, d));
     CHECK(gsl::at(mesh.slices(), d) == mesh.slice_through(d));
   }
+  CHECK(get_output(mesh) == get_output(extents));
 }
 }  // namespace
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -47,13 +47,11 @@ namespace {
 struct Var : db::SimpleTag {
   static std::string name() noexcept { return "Var"; }
   using type = Scalar<DataVector>;
-  static constexpr bool should_be_sliced_to_boundary = false;
 };
 
 struct Var2 : db::SimpleTag {
   static std::string name() noexcept { return "Var2"; }
   using type = tnsr::ii<DataVector, 2>;
-  static constexpr bool should_be_sliced_to_boundary = false;
 };
 
 struct OtherArg : db::SimpleTag {
@@ -92,6 +90,9 @@ struct System {
 
 template <typename Tag>
 using interface_tag = Tags::Interface<Tags::InternalDirections<2>, Tag>;
+template <typename Tag>
+using interface_compute_tag =
+    Tags::InterfaceComputeItem<Tags::InternalDirections<2>, Tag>;
 
 using n_dot_f_tag = interface_tag<Tags::NormalDotFlux<Tags::Variables<
     tmpl::list<Tags::NormalDotFlux<Var>, Tags::NormalDotFlux<Var2>>>>>;
@@ -109,11 +110,12 @@ struct component
                         interface_tag<Tags::Variables<tmpl::list<Var, Var2>>>,
                         interface_tag<OtherArg>, n_dot_f_tag>;
   using compute_tags = db::AddComputeTags<
-      Tags::InternalDirections<2>, interface_tag<Tags::Direction<2>>,
-      interface_tag<Tags::Mesh<1>>,
-      interface_tag<Tags::UnnormalizedFaceNormal<2>>,
-      interface_tag<Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<2>>>,
-      interface_tag<Tags::Normalized<Tags::UnnormalizedFaceNormal<2>>>>;
+      Tags::InternalDirections<2>, interface_compute_tag<Tags::Direction<2>>,
+      interface_compute_tag<Tags::InterfaceMesh<2>>,
+      interface_compute_tag<Tags::UnnormalizedFaceNormal<2>>,
+      interface_compute_tag<
+          Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<2>>>,
+      interface_compute_tag<Tags::Normalized<Tags::UnnormalizedFaceNormal<2>>>>;
   using initial_databox =
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
 };

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -72,7 +72,6 @@ struct Var : db::SimpleTag {
 struct OtherData : db::SimpleTag {
   static std::string name() noexcept { return "OtherData"; }
   using type = Scalar<DataVector>;
-  static constexpr bool should_be_sliced_to_boundary = false;
 };
 
 template <size_t Dim>
@@ -126,6 +125,9 @@ using send_data_for_fluxes = dg::Actions::SendDataForFluxes<Metavariables>;
 
 template <size_t Dim, typename Tag>
 using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
+template <size_t Dim, typename Tag>
+using interface_compute_tag =
+    Tags::InterfaceComputeItem<Tags::InternalDirections<Dim>, Tag>;
 
 template <typename FluxCommTypes>
 using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;
@@ -169,12 +171,14 @@ struct component
                         mortar_meshes_tag<Dim>, mortar_sizes_tag<Dim>>;
 
   using compute_tags = db::AddComputeTags<
-      Tags::InternalDirections<Dim>, interface_tag<Dim, Tags::Direction<Dim>>,
-      interface_tag<Dim, Tags::Mesh<Dim - 1>>,
-      interface_tag<Dim, Tags::UnnormalizedFaceNormal<Dim>>,
-      interface_tag<
+      Tags::InternalDirections<Dim>,
+      interface_compute_tag<Dim, Tags::Direction<Dim>>,
+      interface_compute_tag<Dim, Tags::InterfaceMesh<Dim>>,
+      interface_compute_tag<Dim, Tags::UnnormalizedFaceNormal<Dim>>,
+      interface_compute_tag<
           Dim, Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
-      interface_tag<Dim, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+      interface_compute_tag<
+          Dim, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
 
   using initial_databox =
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -65,7 +65,6 @@ struct Var : db::SimpleTag {
 struct OtherData : db::SimpleTag {
   static std::string name() noexcept { return "OtherData"; }
   using type = Scalar<DataVector>;
-  static constexpr bool should_be_sliced_to_boundary = false;
 };
 
 template <size_t Dim>
@@ -116,6 +115,9 @@ struct System {
 
 template <size_t Dim, typename Tag>
 using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
+template <size_t Dim, typename Tag>
+using interface_compute_tag =
+    Tags::InterfaceComputeItem<Tags::InternalDirections<Dim>, Tag>;
 
 template <typename FluxCommTypes>
 using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;
@@ -167,12 +169,14 @@ struct lts_component
       MortarRecorderTag, mortar_next_temporal_ids_tag<2>>;
 
   using compute_tags = db::AddComputeTags<
-      Tags::InternalDirections<Dim>, interface_tag<Dim, Tags::Direction<Dim>>,
-      interface_tag<Dim, Tags::Mesh<Dim - 1>>,
-      interface_tag<Dim, Tags::UnnormalizedFaceNormal<Dim>>,
-      interface_tag<
+      Tags::InternalDirections<Dim>,
+      interface_compute_tag<Dim, Tags::Direction<Dim>>,
+      interface_compute_tag<Dim, Tags::InterfaceMesh<Dim>>,
+      interface_compute_tag<Dim, Tags::UnnormalizedFaceNormal<Dim>>,
+      interface_compute_tag<
           Dim, Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
-      interface_tag<Dim, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+      interface_compute_tag<
+          Dim, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
 
   using initial_databox =
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;


### PR DESCRIPTION
## Proposed changes

Refactors the InterfaceItem infrastructure to make better use of base tags, so that decisions about how quantities are computed on the interface are made when adding the Tag to the DataBox (is this a SimpleTag, a ComputeTag, or does it slice variables from the volume?) rather than at the level of the Tags inside of variables which is done now. 

Most of the significant changes occur in src/Domain/Tags.hpp. 
- InterfaceBase and InterfaceImpl removed. 
- InterfaceComputeItem and Slice added.
- Interface is now a simple item, which can be used as a base tag for the above two items. 

Breaks: 
- Anything that touches the Interface part of the Initialization code, the user must now specify 
whether Interface tags are simple, compute items or slices. Before, using the tag Interface worked for everything. 
- If `should_be_sliced_to_boundary` was being defined in any Tags, it now doesn't do anything. Whether the Tag should be sliced is specified by adding it to the DataBox using `Slice`. 

There are some TODO's scattered around which are questions I have for people, regarding using `tmpl::contains_v<TagsList, Tag>` to determine whether a Tag is in the DataBox, since it now fails for the compute tags or slice tags on the interface. 

The last commit (remove sliced_to...) should probably be squashed into the previous one, but I thought it would make reviewing easier.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
