### PR TITLE
Template DataVector to DataVectorImpl<type>

### DIFF
--- a/src/ApparentHorizons/FastFlow.hpp
+++ b/src/ApparentHorizons/FastFlow.hpp
@@ -14,7 +14,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 namespace PUP {
 class er;
 }  // namespace PUP

--- a/src/ApparentHorizons/StrahlkorperGr.hpp
+++ b/src/ApparentHorizons/StrahlkorperGr.hpp
@@ -9,7 +9,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 class YlmSpherepack;
 template <typename X, typename Symm, typename IndexList>
 class Tensor;

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -12,7 +12,9 @@
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/TMPL.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 /// \ingroup SurfacesGroup
 /// Holds tags and ComputeItems associated with a `::Strahlkorper`.

--- a/src/DataStructures/DataBox/DataBoxHelpers.hpp
+++ b/src/DataStructures/DataBox/DataBoxHelpers.hpp
@@ -13,7 +13,9 @@
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 template <typename Tag, typename = std::nullptr_t>

--- a/src/DataStructures/Tensor/TypeAliases.hpp
+++ b/src/DataStructures/Tensor/TypeAliases.hpp
@@ -10,7 +10,9 @@
 #include "DataStructures/Tensor/Symmetry.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
 /// \endcond

--- a/src/Domain/BlockLogicalCoordinates.hpp
+++ b/src/Domain/BlockLogicalCoordinates.hpp
@@ -12,7 +12,9 @@
 namespace domain {
 class BlockId;
 }  // namespace domain
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t VolumeDim, typename TargetFrame>
 class Domain;
 template <typename IdType, typename DataType>

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -30,7 +30,9 @@
 #include "Utilities/Tuple.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 class FunctionOfTime;
 /// \endcond
 

--- a/src/Domain/ElementLogicalCoordinates.hpp
+++ b/src/Domain/ElementLogicalCoordinates.hpp
@@ -13,7 +13,9 @@
 namespace domain {
 class BlockId;
 }  // namespace domain
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t VolumeDim>
 class ElementId;
 template <typename IdType, typename DataType>

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -17,7 +17,9 @@
 /// \cond
 template <typename, typename, size_t>
 class CoordinateMapBase;
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t>
 class Direction;
 template <size_t Dim, typename Frame>

--- a/src/Domain/LogicalCoordinates.hpp
+++ b/src/Domain/LogicalCoordinates.hpp
@@ -16,7 +16,9 @@
 /// \cond
 template <size_t Dim>
 class Mesh;
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t Dim>
 class Direction;
 /// \endcond

--- a/src/Domain/MinimumGridSpacing.hpp
+++ b/src/Domain/MinimumGridSpacing.hpp
@@ -12,7 +12,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t Dim>
 class Index;
 template <size_t Dim>

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -31,7 +31,9 @@
 #include "Utilities/TypeTraits.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 namespace OptionTags {

--- a/src/Elliptic/Systems/Poisson/Tags.hpp
+++ b/src/Elliptic/Systems/Poisson/Tags.hpp
@@ -12,7 +12,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 /*!

--- a/src/Elliptic/Systems/ThermalNoise/Tags.hpp
+++ b/src/Elliptic/Systems/ThermalNoise/Tags.hpp
@@ -12,7 +12,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 /*!

--- a/src/Elliptic/Systems/Xcts/Tags.hpp
+++ b/src/Elliptic/Systems/Xcts/Tags.hpp
@@ -12,7 +12,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 /*!

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -19,7 +19,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t VolumeDim>
 class Direction;
 template <size_t>

--- a/src/Evolution/Systems/Burgers/Equations.hpp
+++ b/src/Evolution/Systems/Burgers/Equations.hpp
@@ -9,7 +9,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 // IWYU pragma: no_forward_declare Tensor
 template <typename>
 class Variables;

--- a/src/Evolution/Systems/Burgers/Fluxes.hpp
+++ b/src/Evolution/Systems/Burgers/Fluxes.hpp
@@ -7,7 +7,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 // IWYU pragma: no_forward_declare Tensor
 namespace Burgers {
 namespace Tags {

--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -11,7 +11,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
 

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -12,7 +12,9 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace CurvedScalarWave {
 struct Psi : db::SimpleTag {

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -14,7 +14,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace Tags {
 template <typename>

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -8,7 +8,9 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace GeneralizedHarmonic {
 /*!

--- a/src/Evolution/Systems/GrMhd/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/Tags.hpp
@@ -9,7 +9,9 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 /// \ingroup EvolutionSystemsGroup
 /// \brief Items related to general relativistic magnetohydrodynamics (GRMHD)

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
@@ -8,7 +8,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 // IWYU pragma: no_forward_declare Tensor

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp
@@ -10,7 +10,9 @@ template <typename T>
 class not_null;
 }  // namespace gsl
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 // IWYU pragma: no_forward_declare Tensor
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
@@ -11,7 +11,9 @@ template <typename T>
 class not_null;
 }  // namespace gsl
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 // IWYU pragma: no_forward_declare Tensor

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp
@@ -13,7 +13,9 @@ template <typename T>
 class not_null;
 }  // namespace gsl
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 namespace grmhd {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -9,7 +9,9 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace grmhd {
 namespace ValenciaDivClean {

--- a/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Characteristics.hpp
@@ -9,7 +9,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 // IWYU pragma: no_forward_declare Tensor

--- a/src/Evolution/Systems/NewtonianEuler/Fluxes.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Fluxes.hpp
@@ -16,7 +16,9 @@ template <typename T>
 class not_null;
 }  // namespace gsl
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace Tags {
 template <typename>

--- a/src/Evolution/Systems/NewtonianEuler/NewtonianEulerSources/IsentropicVortexSource.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/NewtonianEulerSources/IsentropicVortexSource.hpp
@@ -30,7 +30,9 @@ struct Pressure;
 }  // namespace Tags
 }  // namespace NewtonianEuler
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 namespace NewtonianEuler {

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Characteristics.hpp
@@ -9,7 +9,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 // IWYU pragma: no_forward_declare Tensor

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Equations.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Equations.hpp
@@ -15,7 +15,9 @@ template <typename T>
 class not_null;
 }  // namespace gsl
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 namespace RelativisticEuler {

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Fluxes.hpp
@@ -13,7 +13,9 @@ template <typename T>
 class not_null;
 }  // namespace gsl
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 // IWYU pragma: no_forward_declare Tensor

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/Tags.hpp
@@ -9,7 +9,9 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace RelativisticEuler {
 namespace Valencia {

--- a/src/Evolution/Systems/ScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/ScalarWave/Equations.hpp
@@ -16,7 +16,9 @@
 template <typename>
 class Variables;
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace gsl {
 template <typename T>

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -12,7 +12,9 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace ScalarWave {
 struct Psi : db::SimpleTag {

--- a/src/IO/VolumeDataFile.cpp
+++ b/src/IO/VolumeDataFile.cpp
@@ -14,7 +14,9 @@
 #include "IO/H5/Type.hpp"
 #include "Utilities/StdHelpers.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t Dim>
 class Index;
 

--- a/src/IO/VolumeDataFile.hpp
+++ b/src/IO/VolumeDataFile.hpp
@@ -20,7 +20,9 @@
 #include "IO/H5/OpenGroup.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t Dim>
 class Index;
 /// \endcond

--- a/src/NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.hpp
+++ b/src/NumericalAlgorithms/LinearAlgebra/FindGeneralizedEigenvalues.hpp
@@ -7,7 +7,9 @@
 #pragma once
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 class Matrix;
 namespace gsl {
 template <typename T>

--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp
@@ -9,7 +9,9 @@
 #include <cstddef>
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t>
 class Mesh;
 /// \endcond

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -16,7 +16,9 @@
 #include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t Dim>
 class Mesh;
 template <typename TagsList>

--- a/src/NumericalAlgorithms/LinearOperators/Linearize.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Linearize.hpp
@@ -8,7 +8,9 @@
 
 #include <cstddef>
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t>
 class Mesh;
 

--- a/src/NumericalAlgorithms/LinearOperators/MeanValue.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/MeanValue.hpp
@@ -13,7 +13,9 @@
 #include "Utilities/ConstantExpressions.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t>
 class Mesh;
 /// \endcond

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -16,7 +16,9 @@
 
 /// \cond
 class Matrix;
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t>
 class Mesh;
 /// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp
@@ -13,7 +13,9 @@
 #include "Utilities/TaggedTuple.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 // IWYU pragma: no_forward_declare Tensor
 namespace PUP {
 class er;

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp
@@ -13,7 +13,9 @@
 #include "Utilities/TaggedTuple.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 // IWYU pragma: no_forward_declare Tensor
 namespace PUP {
 class er;

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Tov.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Tov.hpp
@@ -17,7 +17,9 @@ class er;
 /// \endcond
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 // IWYU pragma: no_forward_declare EquationsOfState::EquationOfState

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
@@ -13,7 +13,9 @@
 #include "Utilities/TaggedTuple.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 namespace PUP {
 class er;
 }  // namespace PUP

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
@@ -15,7 +15,9 @@
 #include "Utilities/TaggedTuple.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 namespace PUP {
 class er;
 }  // namespace PUP

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -18,7 +18,9 @@
 #include "Utilities/TaggedTuple.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 namespace ScalarWave {
 struct Pi;
 struct Psi;

--- a/src/PointwiseFunctions/EquationsOfState/DarkEnergyFluid.hpp
+++ b/src/PointwiseFunctions/EquationsOfState/DarkEnergyFluid.hpp
@@ -14,7 +14,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 namespace EquationsOfState {

--- a/src/PointwiseFunctions/EquationsOfState/EquationOfState.hpp
+++ b/src/PointwiseFunctions/EquationsOfState/EquationOfState.hpp
@@ -12,7 +12,9 @@
 #include "Utilities/TypeTraits.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 namespace EquationsOfState {
 template <bool IsRelativistic>
 class DarkEnergyFluid;

--- a/src/PointwiseFunctions/EquationsOfState/IdealFluid.hpp
+++ b/src/PointwiseFunctions/EquationsOfState/IdealFluid.hpp
@@ -14,7 +14,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 namespace EquationsOfState {

--- a/src/PointwiseFunctions/EquationsOfState/PolytropicFluid.hpp
+++ b/src/PointwiseFunctions/EquationsOfState/PolytropicFluid.hpp
@@ -14,7 +14,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 // IWYU pragma: no_forward_declare Tensor

--- a/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
@@ -7,7 +7,9 @@
 
 #include "DataStructures/Tensor/IndexType.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace gr {
 namespace Tags {

--- a/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Gaussian.hpp
@@ -14,7 +14,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 namespace MathFunctions {

--- a/src/PointwiseFunctions/MathFunctions/PowX.hpp
+++ b/src/PointwiseFunctions/MathFunctions/PowX.hpp
@@ -14,7 +14,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 namespace MathFunctions {

--- a/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
+++ b/src/PointwiseFunctions/MathFunctions/Sinusoid.hpp
@@ -14,7 +14,9 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 /// \endcond
 
 namespace MathFunctions {

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxTag.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxTag.cpp
@@ -7,7 +7,9 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace {
 struct Var : db::SimpleTag {

--- a/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
+++ b/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
@@ -29,7 +29,9 @@
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/TMPL.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t VolumeDim>
 class OrientationMap;
 

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -20,7 +20,9 @@ template <size_t VolumeDim>
 class BlockNeighbor;
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t VolumeDim>
 class Direction;
 template <size_t VolumeDim, typename TargetFrame>

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_InnerProduct.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_InnerProduct.cpp
@@ -10,7 +10,9 @@
 #include "NumericalAlgorithms/LinearSolver/InnerProduct.hpp"
 #include "Utilities/TMPL.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 
 namespace {
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp
@@ -15,7 +15,9 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
 /// \cond
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
 /// \endcond

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -30,7 +30,9 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
-class DataVector;
+template <typename T>
+class DataVectorImpl;
+using DataVector = DataVectorImpl<double>;
 template <size_t VolumeDim>
 class MathFunction;
 


### PR DESCRIPTION
Converts existing DataVector class construction to a templated DataVectorImpl<type>.
Added `using DataVector = DataVectorImpl<double>` to ensure all existing code remains
functional. All functions that survived templatization are templated, while the rest are
left as template specializations. Some shuffling between DataVector.hpp and DataVector.cpp
as necessary for inlines etc.

All forward declarations `class DataVector;` are replaced with

`template <typename T>
class DataVectorImpl;
using DataVector = DataVectorImpl<double>`

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
