### PR TITLE
Add AlignedBlocks

### DIFF
--- a/src/Domain/DomainCreators/AlignedLattice.cpp
+++ b/src/Domain/DomainCreators/AlignedLattice.cpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/DomainCreators/AlignedLattice.hpp"
+
+#include "Domain/Domain.hpp"
+#include "Domain/DomainHelpers.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace Frame {
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace DomainCreators {
+
+template <size_t VolumeDim, typename TargetFrame>
+AlignedLattice<VolumeDim, TargetFrame>::AlignedLattice(
+    const typename BlockBounds::type block_bounds,
+    const typename IsPeriodicIn::type is_periodic_in,
+    const typename InitialRefinement::type initial_refinement_levels,
+    const typename InitialGridPoints::type
+        initial_number_of_grid_points) noexcept
+    // clang-tidy: trivially copyable
+    : block_bounds_(std::move(block_bounds)),         // NOLINT
+      is_periodic_in_(std::move(is_periodic_in)),     // NOLINT
+      initial_refinement_levels_(                     // NOLINT
+          std::move(initial_refinement_levels)),      // NOLINT
+      initial_number_of_grid_points_(                 // NOLINT
+          std::move(initial_number_of_grid_points)),  // NOLINT
+      number_of_blocks_by_dim_{
+          map_array(block_bounds_, [](const std::vector<double>& v) noexcept {
+            return v.size() - 1;
+          })} {}
+
+template <size_t VolumeDim, typename TargetFrame>
+Domain<VolumeDim, TargetFrame>
+AlignedLattice<VolumeDim, TargetFrame>::create_domain() const noexcept {
+  return rectilinear_domain<VolumeDim, TargetFrame>(
+      number_of_blocks_by_dim_, block_bounds_, {}, {}, is_periodic_in_);
+}
+
+template <size_t VolumeDim, typename TargetFrame>
+std::vector<std::array<size_t, VolumeDim>>
+AlignedLattice<VolumeDim, TargetFrame>::initial_extents() const noexcept {
+  return {number_of_blocks_by_dim_.product(), initial_number_of_grid_points_};
+}
+
+template <size_t VolumeDim, typename TargetFrame>
+std::vector<std::array<size_t, VolumeDim>>
+AlignedLattice<VolumeDim, TargetFrame>::initial_refinement_levels() const
+    noexcept {
+  return {number_of_blocks_by_dim_.product(), initial_refinement_levels_};
+}
+}  // namespace DomainCreators
+
+template class DomainCreators::AlignedLattice<1, Frame::Inertial>;
+template class DomainCreators::AlignedLattice<1, Frame::Grid>;
+template class DomainCreators::AlignedLattice<2, Frame::Inertial>;
+template class DomainCreators::AlignedLattice<2, Frame::Grid>;
+template class DomainCreators::AlignedLattice<3, Frame::Inertial>;
+template class DomainCreators::AlignedLattice<3, Frame::Grid>;

--- a/src/Domain/DomainCreators/AlignedLattice.hpp
+++ b/src/Domain/DomainCreators/AlignedLattice.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+#include "DataStructures/Index.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/DomainCreator.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace DomainCreators {
+
+/// \ingroup DomainCreatorsGroup
+/// \brief Create a Domain consisting of multiple aligned Blocks arrayed in a
+/// lattice.
+///
+/// This is useful for setting up problems with piecewise smooth initial data,
+/// problems that specify different boundary conditions on distinct parts of
+/// the boundary, or problems that need different length scales initially.
+///
+/// \note Adaptive mesh refinement can never join Block%s, so use the fewest
+/// number of Block%s that your problem needs.  More initial Element%s can be
+/// created by specifying a larger `InitialRefinement`.
+template <size_t VolumeDim, typename TargetFrame>
+class AlignedLattice : public DomainCreator<VolumeDim, TargetFrame> {
+ public:
+  struct BlockBounds {
+    using type = std::array<std::vector<double>, VolumeDim>;
+    static constexpr OptionString help = {
+        "Coordinates of block boundaries in each dimension."};
+  };
+
+  struct IsPeriodicIn {
+    using type = std::array<bool, VolumeDim>;
+    static constexpr OptionString help = {
+        "Whether the domain is periodic in each dimension."};
+    static type default_value() { return make_array<VolumeDim>(false); }
+  };
+
+  struct InitialRefinement {
+    using type = std::array<size_t, VolumeDim>;
+    static constexpr OptionString help = {
+        "Initial refinement level in each dimension."};
+  };
+
+  struct InitialGridPoints {
+    using type = std::array<size_t, VolumeDim>;
+    static constexpr OptionString help = {
+        "Initial number of grid points in each dimension."};
+  };
+
+  using options = tmpl::list<BlockBounds, IsPeriodicIn, InitialRefinement,
+                             InitialGridPoints>;
+
+  static constexpr OptionString help = {
+      "AlignedLattice creates a regular lattice of blocks whose corners are\n"
+      "given by tensor products of the specified BlockBounds."};
+
+  AlignedLattice(
+      typename BlockBounds::type block_bounds,
+      typename IsPeriodicIn::type is_periodic_in,
+      typename InitialRefinement::type initial_refinement_levels,
+      typename InitialGridPoints::type initial_number_of_grid_points) noexcept;
+
+  AlignedLattice() = default;
+  AlignedLattice(const AlignedLattice&) = delete;
+  AlignedLattice(AlignedLattice&&) noexcept = default;
+  AlignedLattice& operator=(const AlignedLattice&) = delete;
+  AlignedLattice& operator=(AlignedLattice&&) noexcept = default;
+  ~AlignedLattice() override = default;
+
+  Domain<VolumeDim, TargetFrame> create_domain() const noexcept override;
+
+  std::vector<std::array<size_t, VolumeDim>> initial_extents() const
+      noexcept override;
+
+  std::vector<std::array<size_t, VolumeDim>> initial_refinement_levels() const
+      noexcept override;
+
+ private:
+  typename BlockBounds::type block_bounds_{
+      make_array<VolumeDim, std::vector<double>>({})};
+  typename IsPeriodicIn::type is_periodic_in_{make_array<VolumeDim>(false)};
+  typename InitialRefinement::type initial_refinement_levels_{
+      make_array<VolumeDim>(std::numeric_limits<size_t>::max())};
+  typename InitialGridPoints::type initial_number_of_grid_points_{
+      make_array<VolumeDim>(std::numeric_limits<size_t>::max())};
+  Index<VolumeDim> number_of_blocks_by_dim_{};
+};
+}  // namespace DomainCreators

--- a/src/Domain/DomainCreators/CMakeLists.txt
+++ b/src/Domain/DomainCreators/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY DomainCreators)
 
 set(LIBRARY_SOURCES
+  AlignedLattice.cpp
   Brick.cpp
   Cylinder.cpp
   Disk.cpp

--- a/src/Domain/DomainCreators/DomainCreator.hpp
+++ b/src/Domain/DomainCreators/DomainCreator.hpp
@@ -25,6 +25,8 @@ class Domain;
 /// Defines classes that create Domains.
 namespace DomainCreators {
 /// \cond
+template <size_t VolumeDim, typename TargetFrame>
+class AlignedLattice;
 template <typename TargetFrame>
 class Brick;
 template <typename TargetFrame>
@@ -55,21 +57,24 @@ struct domain_creators;
 template <>
 struct domain_creators<1> {
   template <typename Frame>
-  using creators = tmpl::list<DomainCreators::Interval<Frame>,
+  using creators = tmpl::list<DomainCreators::AlignedLattice<1, Frame>,
+                              DomainCreators::Interval<Frame>,
                               DomainCreators::RotatedIntervals<Frame>>;
 };
 template <>
 struct domain_creators<2> {
   template <typename Frame>
   using creators =
-      tmpl::list<DomainCreators::Disk<Frame>, DomainCreators::Rectangle<Frame>,
+      tmpl::list<DomainCreators::AlignedLattice<2, Frame>,
+                 DomainCreators::Disk<Frame>, DomainCreators::Rectangle<Frame>,
                  DomainCreators::RotatedRectangles<Frame>>;
 };
 template <>
 struct domain_creators<3> {
   template <typename Frame>
   using creators =
-      tmpl::list<DomainCreators::Brick<Frame>, DomainCreators::Cylinder<Frame>,
+      tmpl::list<DomainCreators::AlignedLattice<3, Frame>,
+                 DomainCreators::Brick<Frame>, DomainCreators::Cylinder<Frame>,
                  DomainCreators::RotatedBricks<Frame>,
                  DomainCreators::Shell<Frame>, DomainCreators::Sphere<Frame>>;
 };
@@ -102,6 +107,7 @@ class DomainCreator {
       const noexcept = 0;
 };
 
+#include "Domain/DomainCreators/AlignedLattice.hpp"
 #include "Domain/DomainCreators/Brick.hpp"
 #include "Domain/DomainCreators/Cylinder.hpp"
 #include "Domain/DomainCreators/Disk.hpp"

--- a/tests/Unit/Domain/DomainCreators/CMakeLists.txt
+++ b/tests/Unit/Domain/DomainCreators/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_DomainCreators")
 
 set(LIBRARY_SOURCES
+  Test_AlignedLattice.cpp
   Test_Brick.cpp
   Test_Cylinder.cpp
   Test_Disk.cpp

--- a/tests/Unit/Domain/DomainCreators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_AlignedLattice.cpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <memory>
+
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/AlignedLattice.hpp"
+#include "Domain/DomainCreators/DomainCreator.hpp"
+#include "tests/Unit/Domain/DomainTestHelpers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+
+// IWYU pragma: no_include <vector>
+
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+
+namespace {
+template <size_t VolumeDim>
+void test_aligned_blocks(
+    const DomainCreators::AlignedLattice<VolumeDim, Frame::Inertial>&
+        aligned_blocks) noexcept {
+  const auto domain = aligned_blocks.create_domain();
+  test_initial_domain(domain, aligned_blocks.initial_refinement_levels());
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.AlignedLattice",
+                  "[Domain][Unit]") {
+  const auto domain_creator_1d =
+      test_factory_creation<DomainCreator<1, Frame::Inertial>>(
+          "  AlignedLattice:\n"
+          "    BlockBounds: [[0.1, 2.6, 5.1, 5.2, 7.2]]\n"
+          "    IsPeriodicIn: [false]\n"
+          "    InitialGridPoints: [3]\n"
+          "    InitialRefinement: [2]\n");
+  const auto* aligned_blocks_creator_1d =
+      dynamic_cast<const DomainCreators::AlignedLattice<1, Frame::Inertial>*>(
+          domain_creator_1d.get());
+  test_aligned_blocks(*aligned_blocks_creator_1d);
+
+  const auto domain_creator_2d =
+      test_factory_creation<DomainCreator<2, Frame::Inertial>>(
+          "  AlignedLattice:\n"
+          "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2, 8.9]]\n"
+          "    IsPeriodicIn: [false, true]\n"
+          "    InitialGridPoints: [3, 4]\n"
+          "    InitialRefinement: [2, 1]\n");
+  const auto* aligned_blocks_creator_2d =
+      dynamic_cast<const DomainCreators::AlignedLattice<2, Frame::Inertial>*>(
+          domain_creator_2d.get());
+  test_aligned_blocks(*aligned_blocks_creator_2d);
+
+  const auto domain_creator_3d =
+      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+          "  AlignedLattice:\n"
+          "    BlockBounds: [[0.1, 2.6, 5.1], [-0.4, 3.2, 6.2], [-0.2, 3.2]]\n"
+          "    IsPeriodicIn: [false, true, false]\n"
+          "    InitialGridPoints: [3, 4, 5]\n"
+          "    InitialRefinement: [2, 1, 0]\n");
+  const auto* aligned_blocks_creator_3d =
+      dynamic_cast<const DomainCreators::AlignedLattice<3, Frame::Inertial>*>(
+          domain_creator_3d.get());
+  test_aligned_blocks(*aligned_blocks_creator_3d);
+}


### PR DESCRIPTION
## Proposed changes

Add a DomainCreator that creates an edifice of aligned Blocks.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

This will be useful for setting up a domain for a problem with piecewise smooth initial data.