### PR TITLE
Speed up CMake runtime

### DIFF
--- a/cmake/AddCxxFlag.cmake
+++ b/cmake/AddCxxFlag.cmake
@@ -2,18 +2,94 @@
 # See LICENSE.txt for details.
 
 # Checks if a CXX flag is supported by the compiler and adds it if it is
+# - FLAG_TO_CHECK: the CXX flag to add if the compiler supports it
 function(check_and_add_cxx_flag FLAG_TO_CHECK)
-  include(CheckCXXCompilerFlag)
-  unset(CXX_FLAG_WORKS CACHE)
   # In order to check for a -Wno-* flag in gcc, you have to check the
   # -W* version instead.  See http://gcc.gnu.org/wiki/FAQ#wnowarning
-  string(REGEX REPLACE ^-Wno- -W FLAG_TO_CHECK_POSITIVE ${FLAG_TO_CHECK})
-  set(CMAKE_REQUIRED_QUIET 1)
-  check_cxx_compiler_flag(${FLAG_TO_CHECK_POSITIVE} CXX_FLAG_WORKS)
-  unset(CMAKE_REQUIRED_QUIET)
-  if (CXX_FLAG_WORKS)
+  string(REGEX REPLACE ^-Wno- -W POSITIVE_FLAG_TO_CHECK ${FLAG_TO_CHECK})
+  execute_process(
+    COMMAND
+    bash -c
+    "${CMAKE_CXX_COMPILER} -Werror ${POSITIVE_FLAG_TO_CHECK} -x c++ -c \
+- <<< \"\" -o /dev/null"
+    RESULT_VARIABLE RESULT
+    ERROR_VARIABLE ERROR_FROM_COMPILATION
+    OUTPUT_QUIET)
+  if(${RESULT} EQUAL 0)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG_TO_CHECK}" PARENT_SCOPE)
-  endif()
+  endif(${RESULT} EQUAL 0)
+endfunction()
+
+# Checks which of the CXX FLAGS_TO_CHECK are supported by the compiler and
+# adds them. If adding many flags, this will be much faster than
+# calling check_and_add_cxx_flag multiple times.
+# - FLAGS_TO_CHECK: a semicolon separated string of CXX flags to try to add
+#                   for compilation.
+function(check_and_add_cxx_flags FLAGS_TO_CHECK)
+  # In order to check for a -Wno-* flag in gcc, you have to check the
+  # -W* version instead.  See http://gcc.gnu.org/wiki/FAQ#wnowarning
+  set(POSITIVE_FLAGS_TO_CHECK)
+  foreach(FLAG_TO_CHECK ${FLAGS_TO_CHECK})
+    string(REGEX REPLACE ^-Wno- -W POSITIVE_FLAG_TO_CHECK ${FLAG_TO_CHECK})
+    list(APPEND POSITIVE_FLAGS_TO_CHECK ${POSITIVE_FLAG_TO_CHECK})
+  endforeach()
+  string(REPLACE ";" " "
+    POSITIVE_FLAGS_WITH_SPACES "${POSITIVE_FLAGS_TO_CHECK}")
+  execute_process(
+    COMMAND
+    bash -c
+    "${CMAKE_CXX_COMPILER} -Werror ${POSITIVE_FLAGS_WITH_SPACES} -x c++ -c \
+- <<< \"\" -o /dev/null"
+    RESULT_VARIABLE RESULT
+    ERROR_VARIABLE ERROR_FROM_COMPILATION
+    OUTPUT_QUIET)
+
+  if(${RESULT} EQUAL 0)
+    string(REPLACE ";" " " FLAGS_WITH_SPACES "${FLAGS_TO_CHECK}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_WITH_SPACES}" PARENT_SCOPE)
+  else(${RESULT} EQUAL 0)
+    # Check each flag to see if it was marked as "invalid" in the output
+    string(FIND "${ERROR_FROM_COMPILATION}" "‘" GCC_STYLE_QUOTE)
+    foreach(FLAG ${POSITIVE_FLAGS_TO_CHECK})
+      if(NOT ${GCC_STYLE_QUOTE} EQUAL -1)
+        string(FIND "${ERROR_FROM_COMPILATION}" "‘${FLAG}’" FOUND_POS)
+      else()
+        string(FIND "${ERROR_FROM_COMPILATION}" "'${FLAG}'" FOUND_POS)
+      endif()
+
+      if(${FOUND_POS} EQUAL -1)
+        # For some reason:
+        # list(FIND ${POSITIVE_FLAGS_TO_CHECK} ${FLAG} INDEX_OF_FLAG)
+        # doesn't work with some compilers. This makes no sense but such is
+        # life. As a work around we basically implement a find manually.
+
+        # Find the index of the current flag in the POSITIVE_FLAGS_TO_CHECK
+        # list. This is the index we use to get the original flag in the
+        # FLAGS_TO_CHECK list.
+        set(INDEX 0)
+        foreach(POS_FLAG ${POSITIVE_FLAGS_TO_CHECK})
+          if("${POS_FLAG}" STREQUAL "${FLAG}")
+            break()
+          endif()
+          MATH(EXPR INDEX "${INDEX}+1")
+        endforeach()
+        set(TARGET_INDEX ${INDEX})
+        set(INDEX 0)
+        # Get original flag
+        set(NEW_FLAG "")
+        foreach(ORIGINAL_FLAG ${FLAGS_TO_CHECK})
+          if(${INDEX} EQUAL ${TARGET_INDEX})
+            set(NEW_FLAG ${ORIGINAL_FLAG})
+            break()
+          endif()
+          MATH(EXPR INDEX "${INDEX}+1")
+        endforeach()
+        # Add the flag to the list of flags to add.
+        set(FLAGS_TO_ADD "${FLAGS_TO_ADD} ${NEW_FLAG}")
+      endif(${FOUND_POS} EQUAL -1)
+    endforeach(FLAG ${FLAGS_TO_CHECK})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_TO_ADD}" PARENT_SCOPE)
+  endif(${RESULT} EQUAL 0)
 endfunction()
 
 # Checks if a flag is supported by the linker and adds it if it is

--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -7,39 +7,39 @@ include(AddCxxFlag)
 # all the warnings enabled because we get flooded with system warnings.
 option(ENABLE_WARNINGS "Enable the default warning level" ON)
 if(${ENABLE_WARNINGS})
-  check_and_add_cxx_flag("-W")
-  check_and_add_cxx_flag("-Wall")
-  check_and_add_cxx_flag("-Wextra")
-  check_and_add_cxx_flag("-Wpedantic")
-
-  check_and_add_cxx_flag("-Wcast-align")
-  check_and_add_cxx_flag("-Wcast-qual")
-  check_and_add_cxx_flag("-Wdisabled-optimization")
-  check_and_add_cxx_flag("-Wdocumentation")
-  check_and_add_cxx_flag("-Wformat=2")
-  check_and_add_cxx_flag("-Wformat-nonliteral")
-  check_and_add_cxx_flag("-Wformat-security")
-  check_and_add_cxx_flag("-Wformat-y2k")
-  check_and_add_cxx_flag("-Winvalid-pch")
-  check_and_add_cxx_flag("-Wmissing-field-initializers")
-  check_and_add_cxx_flag("-Wmissing-format-attribute")
-  check_and_add_cxx_flag("-Wmissing-include-dirs")
-  check_and_add_cxx_flag("-Wmissing-noreturn")
-  check_and_add_cxx_flag("-Wnewline-eof")
-  check_and_add_cxx_flag("-Wno-documentation-unknown-command")
-  check_and_add_cxx_flag("-Wno-mismatched-tags")
-  check_and_add_cxx_flag("-Wnon-virtual-dtor")
-  check_and_add_cxx_flag("-Wold-style-cast")
-  check_and_add_cxx_flag("-Woverloaded-virtual")
-  check_and_add_cxx_flag("-Wpacked")
-  check_and_add_cxx_flag("-Wpointer-arith")
-  check_and_add_cxx_flag("-Wredundant-decls")
-  check_and_add_cxx_flag("-Wshadow")
-  check_and_add_cxx_flag("-Wsign-conversion")
-  check_and_add_cxx_flag("-Wstack-protector")
-  check_and_add_cxx_flag("-Wswitch-default")
-  check_and_add_cxx_flag("-Wunreachable-code")
-  check_and_add_cxx_flag("-Wwrite-strings")
+  check_and_add_cxx_flags(
+    "-W;\
+-Wall;\
+-Wextra;\
+-Wpedantic;\
+-Wcast-align;\
+-Wcast-qual;\
+-Wdisabled-optimization;\
+-Wdocumentation;\
+-Wformat=2;\
+-Wformat-nonliteral;\
+-Wformat-security;\
+-Wformat-y2k;\
+-Winvalid-pch;\
+-Wmissing-field-initializers;\
+-Wmissing-format-attribute;\
+-Wmissing-include-dirs;\
+-Wmissing-noreturn;\
+-Wnewline-eof;\
+-Wno-documentation-unknown-command;\
+-Wno-mismatched-tags;\
+-Wnon-virtual-dtor;\
+-Wold-style-cast;\
+-Woverloaded-virtual;\
+-Wpacked;\
+-Wpointer-arith;\
+-Wredundant-decls;\
+-Wshadow;\
+-Wsign-conversion;\
+-Wstack-protector;\
+-Wswitch-default;\
+-Wunreachable-code;\
+-Wwrite-strings")
 endif()
 
 # GCC 7.1ish and newer warn about noexcept changing mangled names,


### PR DESCRIPTION
## Proposed changes

Instead of using CMake's try_compile to check if a CXX flag works, directly
invoke the compiler doing so without creating a file to build and without
emitting a file. The reduced file system access speeds up check time by
~2x. Furthermore, combining multiple  flag checks (in this case all warnings)
into a single compiler call reduces the time for checking by more than 10x.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
