### PR TITLE
Fix small Averager issues

### DIFF
--- a/src/ControlSystem/Averager.cpp
+++ b/src/ControlSystem/Averager.cpp
@@ -24,12 +24,38 @@ Averager<DerivOrder>::Averager(const double avg_timescale_frac,
 }
 
 template <size_t DerivOrder>
-boost::optional<std::array<DataVector, DerivOrder + 1>> Averager<DerivOrder>::
-operator()(const double time) const noexcept {
+Averager<DerivOrder>::Averager(Averager&& rhs) noexcept
+    : avg_tscale_frac_(std::move(rhs.avg_tscale_frac_)),
+      average_0th_deriv_of_q_(std::move(rhs.average_0th_deriv_of_q_)),
+      averaged_values_(std::move(rhs.averaged_values_)),
+      boost_none_(std::move(rhs.boost_none_)),
+      times_(std::move(rhs.times_)),
+      raw_qs_(std::move(rhs.raw_qs_)),
+      weight_k_(std::move(rhs.weight_k_)),
+      tau_k_(std::move(rhs.tau_k_)) {}
+
+template <size_t DerivOrder>
+Averager<DerivOrder>& Averager<DerivOrder>::operator=(Averager&& rhs) noexcept {
+  if (this != &rhs) {
+    avg_tscale_frac_ = std::move(rhs.avg_tscale_frac_);
+    average_0th_deriv_of_q_ = std::move(rhs.average_0th_deriv_of_q_);
+    averaged_values_ = std::move(rhs.averaged_values_);
+    boost_none_ = std::move(rhs.boost_none_);
+    times_ = std::move(rhs.times_);
+    raw_qs_ = std::move(rhs.raw_qs_);
+    weight_k_ = std::move(rhs.weight_k_);
+    tau_k_ = std::move(rhs.tau_k_);
+  }
+  return *this;
+}
+
+template <size_t DerivOrder>
+const boost::optional<std::array<DataVector, DerivOrder + 1>>&
+Averager<DerivOrder>::operator()(const double time) const noexcept {
   if (times_.size() > DerivOrder and time == times_[0]) {
     return averaged_values_;
   }
-  return boost::none;
+  return boost_none_;
 }
 
 template <size_t DerivOrder>

--- a/src/ControlSystem/Averager.hpp
+++ b/src/ControlSystem/Averager.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <boost/none.hpp>
 #include <boost/optional.hpp>
 #include <cstddef>
 #include <deque>
@@ -45,6 +46,15 @@ class Averager {
   /// whether to return an averaged value for the 0th derivative piece of the
   /// function.
   Averager(double avg_timescale_frac, bool average_0th_deriv_of_q) noexcept;
+
+  // Explicitly defined move constructor due to the fact that the std::deque
+  // move constructor is not marked noexcept
+  Averager(Averager&& rhs) noexcept;
+  Averager& operator=(Averager&& rhs) noexcept;
+  Averager(const Averager&) = delete;
+  Averager& operator=(const Averager&) = delete;
+  ~Averager() = default;
+
   /// Returns \f$Q\f$ and its derivatives at \f$t=\f$`time`, provided there is
   /// sufficient data. The averager is limited by the need for at least
   /// (`DerivOrder` + 1) data points in order to provide the `DerivOrder`'th
@@ -54,7 +64,7 @@ class Averager {
   /// returned 0th derivative of \f$Q\f$ is also averaged. In the case that
   /// there is insufficient data, the operator returns an
   /// unitialized `boost::optional` (`boost::none`).
-  boost::optional<std::array<DataVector, DerivOrder + 1>> operator()(
+  const boost::optional<std::array<DataVector, DerivOrder + 1>>& operator()(
       double time) const noexcept;
   /// A function that allows for resetting the averager.
   void clear() noexcept;
@@ -94,6 +104,8 @@ class Averager {
   double avg_tscale_frac_;
   bool average_0th_deriv_of_q_;
   boost::optional<std::array<DataVector, DerivOrder + 1>> averaged_values_{};
+  boost::optional<std::array<DataVector, DerivOrder + 1>> boost_none_ =
+      boost::none;
   std::deque<double> times_;
   std::deque<DataVector> raw_qs_;
   DataVector weight_k_{0.0};


### PR DESCRIPTION
## Proposed changes

Make Averager moves noexcept.
This was to fix the error associated with trying to specify noexcept on the 
move constructor in FunctionOfTimeUpdater (since Averager is a member 
variable of FunctionOfTimeUpdater). The Averager was noexcept due to 
member variables of type std::deque and boost::optional, neither of which 
have noexcept moves.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
