### PR TITLE
Defined macros for easily defining operators on arrays

### DIFF
--- a/src/Utilities/StdArrayHelpers.hpp
+++ b/src/Utilities/StdArrayHelpers.hpp
@@ -188,3 +188,63 @@ auto map_array(const std::array<T, Dim>& array, const F& f) noexcept {
   return std_array_helpers_detail::map_array_impl(
       array, f, std::make_index_sequence<Dim>{});
 }
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Declares a binary function on an array, intended for binary
+ * operators such as `+`
+ *
+ * \param RESULT_TYPE the `value_type` that is the result of the operation
+ * (e.g. `A` for resulting `std::array<A,2>`)
+ *
+ * \param LTYPE the `value_type` of the first argument of the function (so the
+ * left value if the function is an operator overload)
+ *
+ * \param RTYPE the `value_type` of the second argument of the function
+ *
+ * \param OP_FUNCTION_NAME the function which should be declared
+ * (e.g. `operator+`)
+ *
+ * \param BINARY_OP the binary function which should be applied elementwise to
+ * the pair of arrays. (e.g. `std::plus<>()`)
+ */
+// clang-tidy: complaints about uninitialized member, but the transform will set
+// data
+#define DEFINE_ARRAY_BINOP(RESULT_TYPE, LTYPE, RTYPE, OP_FUNCTION_NAME, \
+                           BINARY_OP)                                   \
+  template <size_t Dim>                                                 \
+  std::array<RESULT_TYPE, Dim> OP_FUNCTION_NAME(                        \
+      const std::array<LTYPE, Dim>& lhs,                                \
+      const std::array<RTYPE, Dim>& rhs) noexcept {                     \
+    std::array<RESULT_TYPE, Dim> result; /*NOLINT*/                     \
+    std::transform(lhs.begin(), lhs.end(), rhs.begin(), result.begin(), \
+                   BINARY_OP);                                          \
+    return result;                                                      \
+  }
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Declares an in-place binary function on an array, intended for
+ * operations such as `+=`
+ *
+ * \param LTYPE the `value_type` of the first argument of the function which is
+ * also the result `value_tye` of the operation (so the left value if the
+ * function is an operator overload)
+ *
+ * \param RTYPE the `value_type` of the second argument of the function
+ *
+ * \param OP_FUNCTION_NAME the function which should be declared
+ * (e.g. `operator+=`)
+ *
+ * \param BINARY_OP the binary function which should be applied elementwise to
+ * the pair of arrays. (e.g. `std::plus<>()`)
+ */
+#define DEFINE_ARRAY_INPLACE_BINOP(LTYPE, RTYPE, OP_FUNCTION_NAME, BINARY_OP) \
+  template <size_t Dim>                                                       \
+  std::array<LTYPE, Dim>& OP_FUNCTION_NAME(                                   \
+      std::array<LTYPE, Dim>& lhs,                                            \
+      const std::array<RTYPE, Dim>& rhs) noexcept {                           \
+    std::transform(lhs.begin(), lhs.end(), rhs.begin(), lhs.begin(),          \
+                   BINARY_OP);                                                \
+    return lhs;                                                               \
+  }

--- a/tests/Unit/Utilities/Test_StdArrayHelpers.cpp
+++ b/tests/Unit/Utilities/Test_StdArrayHelpers.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <functional>
 
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
@@ -151,3 +152,30 @@ SPECTRE_TEST_CASE("Unit.Utilities.StdArrayHelpers.map_array",
         return x;
       }) == std::array<int, 1>{{4}});
 }
+
+namespace {
+DEFINE_ARRAY_BINOP(int, int, int, operator+, std::plus<>())
+DEFINE_ARRAY_BINOP(double, double, double, f, std::multiplies<>())
+
+DEFINE_ARRAY_INPLACE_BINOP(int, int, operator+=, std::plus<>())
+DEFINE_ARRAY_INPLACE_BINOP(double, double, g, std::multiplies<>())
+
+SPECTRE_TEST_CASE("Unit.Utilities.StdArrayHelpers.define_array_binop",
+                  "[Utilities][Unit]") {
+  // tests DEFINE_ARRAY_BINOP
+  CHECK(std::array<int, 2>{{1, 2}} + std::array<int, 2>{{2, 3}} ==
+        std::array<int, 2>{{3, 5}});
+  CHECK(
+      f(std::array<double, 2>{{1.0, 2.0}}, std::array<double, 2>{{2.0, 3.0}}) ==
+      std::array<double, 2>{{2.0, 6.0}});
+
+  // tests DEFINE_ARRAY_INPLACE_BINOP
+  std::array<int, 2> a{{1, 2}};
+  CHECK((a += std::array<int, 2>{{2, 3}}) == std::array<int, 2>{{3, 5}});
+  CHECK(a == std::array<int, 2>{{3, 5}});
+  std::array<double, 2> b{{1.0, 2.0}};
+  CHECK(g(b, std::array<double, 2>{{2.0, 3.0}}) ==
+        std::array<double, 2>{{2.0, 6.0}});
+  CHECK(b == std::array<double, 2>{{2.0, 6.0}});
+}
+}  // namespace


### PR DESCRIPTION
Added the two macros to StdArrayHelpers.hpp,
`DEFINE_ARRAY_BINOP` and `DEFINE_ARRAY_INPLACE_BINOP` to
conveniently define operators on arrays of arbitrary
storage types.

These macros are used in DataVector templatization [PR935](https://github.com/sxs-collaboration/spectre/pull/935)

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
