### PR TITLE
adding missing dereferenciation in free_lock

### DIFF
--- a/src/Parallel/NodeLock.hpp
+++ b/src/Parallel/NodeLock.hpp
@@ -23,7 +23,7 @@ inline CmiNodeLock create_lock() noexcept { return CmiCreateLock(); }
 inline void free_lock(const gsl::not_null<CmiNodeLock*> node_lock) noexcept {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-  CmiDestroyLock(node_lock);
+  CmiDestroyLock(*node_lock);
 #pragma GCC diagnostic pop
 }
 


### PR DESCRIPTION
## Proposed changes

- fixing a missing dereferenciation in free_lock
- this made the compilation fail when building with charm mpi-linux

### Types of changes:

- Bugfix

### Component:

- Code

### Code review checklist

- [ ] Locally unit test 388 to 390 are not passed, but that seems to be a separate issue
- The code is documented and the documentation renders correctly.
- The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
