### PR TITLE
Add Tensor EagerMath cross product

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/CrossProduct.hpp
+++ b/src/DataStructures/Tensor/EagerMath/CrossProduct.hpp
@@ -1,0 +1,184 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines functions `cross_product` for flat and curved-space cross products.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/LeviCivitaIterator.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+/*!
+ * \ingroup TensorGroup
+ * \brief Compute the Euclidean cross product of two vectors or one forms
+ *
+ * \details
+ * Returns \f$A^j B^k \epsilon_{ljk} \delta^{il}\f$ for input vectors \f$A^j\f$
+ * and \f$B^k\f$ or \f$A_j B_k \epsilon^{ljk} \delta_{il}\f$ for input one
+ * forms \f$A_j\f$ and \f$B_k\f$.
+ */
+template <typename DataType, typename Index>
+Tensor<DataType, Symmetry<1>, index_list<Index>> cross_product(
+    const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector_a,
+    const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector_b) noexcept {
+  static_assert(Index::dim == 3, "cross_product vectors must have dimension 3");
+  static_assert(Index::index_type == IndexType::Spatial,
+                "cross_product vectors must be spatial");
+
+  auto cross_product =
+      make_with_value<Tensor<DataType, Symmetry<1>, index_list<Index>>>(
+          vector_a, 0.0);
+  for (LeviCivitaIterator<3> it; it; ++it) {
+    cross_product.get(it[0]) +=
+        it.sign() * vector_a.get(it[1]) * vector_b.get(it[2]);
+  }
+  return cross_product;
+}
+
+/*!
+ * \ingroup TensorGroup
+ * \brief Compute the Euclidean cross product of a vector and a one form
+ *
+ * \details
+ * Returns \f$A^j B_l \delta^{lk} \epsilon_{ijk}\f$ for input vector \f$A^j\f$
+ * and input one form \f$B_l\f$
+ * or \f$A_j B^l \delta_{lk} \epsilon^{ijk}\f$ for input one form \f$A_j\f$ and
+ * input vector \f$B^l\f$. Note that this function returns a vector if
+ * `vector_b` is a vector and a one form if `vector_b` is a one form.
+ */
+template <typename DataType, typename Index>
+Tensor<DataType, Symmetry<1>, index_list<change_index_up_lo<Index>>>
+cross_product(
+    const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector_a,
+    const Tensor<DataType, Symmetry<1>, index_list<change_index_up_lo<Index>>>&
+        vector_b) noexcept {
+  static_assert(Index::dim == 3, "cross_product vectors must have dimension 3");
+  static_assert(Index::index_type == IndexType::Spatial,
+                "cross_product vectors must be spatial");
+
+  auto cross_product = make_with_value<
+      Tensor<DataType, Symmetry<1>, index_list<change_index_up_lo<Index>>>>(
+      vector_b, 0.0);
+  for (LeviCivitaIterator<3> it; it; ++it) {
+    cross_product.get(it[0]) +=
+        it.sign() * vector_a.get(it[1]) * vector_b.get(it[2]);
+  }
+  return cross_product;
+}
+
+/*!
+ * \ingroup TensorGroup
+ * \brief Compute the cross product of two vectors or one forms
+ *
+ * \details
+ * Returns \f$\sqrt{g} g^{li} A^j B^k \epsilon_{ljk}\f$, where
+ * \f$A^j\f$ and \f$B^k\f$ are vectors and \f$g^{li}\f$ and \f$g\f$
+ * are the inverse and determinant, respectively, of
+ * the spatial metric (computed via `determinant_and_inverse`). In this case,
+ * the arguments `vector_a` and `vector_b` should be vectors,
+ * the argument `metric_or_inverse_metric` should be the inverse spatial
+ * metric  \f$g^{ij}\f$, and the argument `metric_determinant` should be the
+ * determinant of the spatial metric \f$\det(g_{ij})\f$.
+ * Or, returns \f$\sqrt{g}^{-1} g_{li} A_j B_k \epsilon^{ljk}\f$, where
+ * \f$A_j\f$ and \f$B_k\f$ are one forms and \f$g_{li}\f$ and \f$g\f$
+ * are the spatial metric and its determinant. In this case,
+ * the arguments `vector_a` and `vector_b` should be one forms,
+ * the argument `metric_or_inverse_metric` should be the spatial metric
+ * \f$g_{ij}\f$, and the argument `metric_determinant` should be the
+ * determinant of the spatial metric \f$\det(g_{ij})\f$.
+ */
+template <typename DataType, typename Index>
+Tensor<DataType, Symmetry<1>, index_list<Index>> cross_product(
+    const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector_a,
+    const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector_b,
+    const Tensor<DataType, Symmetry<1, 1>, index_list<Index, Index>>&
+        metric_or_inverse_metric,
+    const Scalar<DataType>& metric_determinant) noexcept {
+  static_assert(Index::dim == 3, "cross_product vectors must have dimension 3");
+  static_assert(Index::index_type == IndexType::Spatial,
+                "cross_product vectors must be spatial");
+
+  auto cross_product =
+      make_with_value<Tensor<DataType, Symmetry<1>, index_list<Index>>>(
+          vector_a, 0.);
+  for (size_t i = 0; i < Index::dim; ++i) {
+    for (LeviCivitaIterator<3> it; it; ++it) {
+      cross_product.get(i) += it.sign() * vector_a.get(it[1]) *
+                              vector_b.get(it[2]) *
+                              metric_or_inverse_metric.get(it[0], i);
+    }
+    if (Index::ul == UpLo::Up) {
+      cross_product.get(i) *= sqrt(get(metric_determinant));
+    } else {
+      cross_product.get(i) /= sqrt(get(metric_determinant));
+    }
+  }
+  return cross_product;
+}
+
+/*!
+ * \ingroup TensorGroup
+ * \brief Compute the cross product of a vector and a one form
+ *
+ * \details
+ * Returns \f$\sqrt{g} A^j B_l g^{lk} \epsilon_{ijk}\f$ for input vector
+ * \f$A^j\f$ and input one form \f$B_l\f$. In this case,
+ * the argument `vector_a` should be a vector, `vector_b` should be a one form,
+ * `metric_or_inverse_metric` should be the inverse spatial
+ * metric  \f$g^{ij}\f$, and `metric_determinant` should be the
+ * determinant of the spatial metric \f$\det(g_{ij})\f$.
+ * Or, returns \f$\sqrt{g}^{-1} A_j B^l g_{lk}
+ * \epsilon^{ijk}\f$ for input one form \f$A_j\f$ and input vector \f$B^l\f$.
+ * In this case,
+ * the argument `vector_a` should be a one form, `vector_b` should be a vector,
+ * `metric_or_inverse_metric` should be the spatial metric
+ * \f$g_{ij}\f$, and `metric_determinant` should be the
+ * determinant of the spatial metric \f$\det(g_{ij})\f$.
+ * Note that this function returns a vector if `vector_b` is a vector and a
+ * one form if `vector_b` is a one form.
+ */
+template <typename DataType, typename Index>
+Tensor<DataType, Symmetry<1>, index_list<change_index_up_lo<Index>>>
+cross_product(const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector_a,
+              const Tensor<DataType, Symmetry<1>,
+                           index_list<change_index_up_lo<Index>>>& vector_b,
+              const Tensor<DataType, Symmetry<1, 1>, index_list<Index, Index>>&
+                  metric_or_inverse_metric,
+              const Scalar<DataType>& metric_determinant) noexcept {
+  static_assert(Index::dim == 3, "cross_product vectors must have dimension 3");
+  static_assert(Index::index_type == IndexType::Spatial,
+                "cross_product vectors must be spatial");
+
+  auto cross_product = make_with_value<
+      Tensor<DataType, Symmetry<1>, index_list<change_index_up_lo<Index>>>>(
+      vector_b, 0.0);
+  for (LeviCivitaIterator<3> it; it; ++it) {
+    if (Index::ul == UpLo::Up) {
+      for (size_t l = 0; l < Index::dim; ++l) {
+        cross_product.get(it[0]) += it.sign() * vector_a.get(it[1]) *
+                                    vector_b.get(l) *
+                                    metric_or_inverse_metric.get(it[2], l);
+      }
+    } else {
+      for (size_t l = 0; l < Index::dim; ++l) {
+        cross_product.get(it[0]) += it.sign() * vector_a.get(l) *
+                                    vector_b.get(it[2]) *
+                                    metric_or_inverse_metric.get(it[1], l);
+      }
+    }
+  }
+
+  for (size_t i = 0; i < Index::dim; ++i) {
+    if (Index::ul == UpLo::Up) {
+      cross_product.get(i) *= sqrt(get(metric_determinant));
+    } else {
+      cross_product.get(i) /= sqrt(get(metric_determinant));
+    }
+  }
+  return cross_product;
+}

--- a/tests/Unit/DataStructures/Tensor/EagerMath/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EagerMath")
 
 set(LIBRARY_SOURCES
+  Test_CrossProduct.cpp
   Test_Determinant.cpp
   Test_DeterminantAndInverse.cpp
   Test_DivideBy.cpp

--- a/tests/Unit/DataStructures/Tensor/EagerMath/TestFunctions.py
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/TestFunctions.py
@@ -1,0 +1,12 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Curved-space cross product returning a vector, given vectors a, b
+def cross_product_up(a, b, inverse_metric, det_metric):
+    return np.einsum('ij,j', inverse_metric, np.cross(a,b)) * np.sqrt(det_metric)
+
+# Curved-space cross product returning a covector, given vector a, covector b
+def cross_product_lo(a, b, inverse_metric, det_metric):
+    return np.cross(a, np.einsum('ij,j', inverse_metric, b)) * np.sqrt(det_metric)

--- a/tests/Unit/DataStructures/Tensor/EagerMath/Test_CrossProduct.cpp
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/Test_CrossProduct.cpp
@@ -1,0 +1,210 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/CrossProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+template <typename DataType>
+void check_cross_product(const DataType& used_for_size) noexcept {
+  // Make constants used to create vectors and one_forms
+  const auto zero = make_with_value<DataType>(used_for_size, 0.0);
+  const auto one_over_three_hundred_twenty_seven =
+      make_with_value<DataType>(used_for_size, 1.0 / 327.0);
+  const auto one_half = make_with_value<DataType>(used_for_size, 0.5);
+  const auto minus_one_half = make_with_value<DataType>(used_for_size, -0.5);
+  const auto one = make_with_value<DataType>(used_for_size, 1.0);
+  const auto minus_one = make_with_value<DataType>(used_for_size, -1.0);
+  const auto two = make_with_value<DataType>(used_for_size, 2.0);
+  const auto minus_two = make_with_value<DataType>(used_for_size, -2.0);
+  const auto minus_three = make_with_value<DataType>(used_for_size, -3.0);
+  const auto four = make_with_value<DataType>(used_for_size, 4.0);
+  const auto minus_five = make_with_value<DataType>(used_for_size, -5.0);
+  const auto twelve = make_with_value<DataType>(used_for_size, 12.0);
+  const auto twenty_two = make_with_value<DataType>(used_for_size, 22.0);
+  const auto minus_thirty_three =
+      make_with_value<DataType>(used_for_size, -33.0);
+  const auto forty_four = make_with_value<DataType>(used_for_size, 44.0);
+  const auto sixty_four = make_with_value<DataType>(used_for_size, 64.0);
+
+  // Test Euclidean cross product for a known generic case
+  const tnsr::I<DataType, 3, Frame::Grid> vector_a{
+      {{minus_three, twelve, four}}};
+  const tnsr::I<DataType, 3, Frame::Grid> vector_b{{{four, minus_five, two}}};
+  const tnsr::i<DataType, 3, Frame::Grid> covector_b{{{four, minus_five, two}}};
+  const tnsr::I<DataType, 3, Frame::Grid> vector_expected{
+      {{forty_four, twenty_two, minus_thirty_three}}};
+  const tnsr::i<DataType, 3, Frame::Grid> covector_expected{
+      {{forty_four, twenty_two, minus_thirty_three}}};
+  CHECK_ITERABLE_APPROX(cross_product(vector_a, vector_b), vector_expected);
+  CHECK_ITERABLE_APPROX(cross_product(vector_a, covector_b), covector_expected);
+
+  // Test curved-space cross product for a known generic case
+  const tnsr::II<DataType, 3, Frame::Grid> inverse_metric = [&used_for_size]() {
+    auto tensor =
+        make_with_value<tnsr::II<DataType, 3, Frame::Grid>>(used_for_size, 0.0);
+    get<0, 0>(tensor) = 2.0;
+    get<0, 1>(tensor) = -3.0;
+    get<0, 2>(tensor) = 4.0;
+    get<1, 1>(tensor) = -5.0;
+    get<1, 2>(tensor) = -12.0;
+    get<2, 2>(tensor) = -13.0;
+    return tensor;
+  }();
+
+  const auto det_metric = Scalar<DataType>{one_over_three_hundred_twenty_seven};
+
+  // The known case for curved-space happens to involve the same vector_a
+  // but different vector_b as for the Euclidean cross product test
+  const tnsr::I<DataType, 3, Frame::Grid> curved_vector_b{
+      {{minus_five, four, two}}};
+  const tnsr::i<DataType, 3, Frame::Grid> curved_covector_b =
+      [&used_for_size]() {
+        auto tensor = make_with_value<tnsr::i<DataType, 3, Frame::Grid>>(
+            used_for_size, 0.0);
+        get<0>(tensor) = 53.0 / 109.0;
+        get<1>(tensor) = 97.0 / 109.0;
+        get<2>(tensor) = -90.0 / 109.0;
+        return tensor;
+      }();
+
+  const tnsr::I<DataType, 3, Frame::Grid> curved_vector_expected =
+      [&det_metric]() {
+        auto tensor = make_with_value<tnsr::I<DataType, 3, Frame::Grid>>(
+            get(det_metric), 0.0);
+        get<0>(tensor) = 250.0 * sqrt(get(det_metric));
+        get<1>(tensor) = -530.0 * sqrt(get(det_metric));
+        get<2>(tensor) = -424.0 * sqrt(get(det_metric));
+        return tensor;
+      }();
+  const tnsr::i<DataType, 3, Frame::Grid> curved_covector_expected =
+      [&det_metric]() {
+        auto tensor = make_with_value<tnsr::i<DataType, 3, Frame::Grid>>(
+            get(det_metric), 0.0);
+        get<0>(tensor) = 8.0 * sqrt(get(det_metric));
+        get<1>(tensor) = -14.0 * sqrt(get(det_metric));
+        get<2>(tensor) = 48.0 * sqrt(get(det_metric));
+        return tensor;
+      }();
+
+  CHECK_ITERABLE_APPROX(
+      cross_product(vector_a, curved_vector_b, inverse_metric, det_metric),
+      curved_vector_expected);
+  CHECK_ITERABLE_APPROX(
+      cross_product(vector_a, curved_covector_b, inverse_metric, det_metric),
+      curved_covector_expected);
+
+  // Test Euclidean cross product for orthogonal unit vectors
+  const tnsr::I<DataType, 3, Frame::Grid> vector_x_hat{{{one, zero, zero}}};
+  const tnsr::I<DataType, 3, Frame::Grid> covector_x_hat{{{one, zero, zero}}};
+  const tnsr::I<DataType, 3, Frame::Grid> vector_y_hat{{{zero, one, zero}}};
+  const tnsr::I<DataType, 3, Frame::Grid> covector_y_hat{{{zero, one, zero}}};
+  const tnsr::I<DataType, 3, Frame::Grid> vector_z_hat{{{zero, zero, one}}};
+  const tnsr::I<DataType, 3, Frame::Grid> covector_z_hat{{{zero, zero, one}}};
+  const tnsr::I<DataType, 3, Frame::Grid> vector_minus_z_hat{
+      {{zero, zero, minus_one}}};
+  const tnsr::I<DataType, 3, Frame::Grid> covector_minus_z_hat{
+      {{zero, zero, minus_one}}};
+  CHECK_ITERABLE_APPROX(cross_product(vector_x_hat, vector_y_hat),
+                        vector_z_hat);
+  CHECK_ITERABLE_APPROX(cross_product(vector_x_hat, covector_y_hat),
+                        covector_z_hat);
+  CHECK_ITERABLE_APPROX(cross_product(vector_y_hat, vector_x_hat),
+                        vector_minus_z_hat);
+  CHECK_ITERABLE_APPROX(cross_product(vector_y_hat, covector_x_hat),
+                        covector_minus_z_hat);
+
+  // Test curved-space cross product for orthogonal unit vectors
+  const tnsr::I<DataType, 3, Frame::Grid> curved_vector_x_hat{
+      {{one_half, zero, zero}}};
+  const tnsr::i<DataType, 3, Frame::Grid> curved_covector_x_hat{
+      {{two, zero, zero}}};
+  const tnsr::I<DataType, 3, Frame::Grid> curved_vector_y_hat{
+      {{zero, one_half, zero}}};
+  const tnsr::i<DataType, 3, Frame::Grid> curved_covector_y_hat{
+      {{zero, two, zero}}};
+  const tnsr::I<DataType, 3, Frame::Grid> curved_vector_z_hat{
+      {{zero, zero, one_half}}};
+  const tnsr::i<DataType, 3, Frame::Grid> curved_covector_z_hat{
+      {{zero, zero, two}}};
+  const tnsr::I<DataType, 3, Frame::Grid> curved_vector_minus_z_hat{
+      {{zero, zero, minus_one_half}}};
+  const tnsr::i<DataType, 3, Frame::Grid> curved_covector_minus_z_hat{
+      {{zero, zero, minus_two}}};
+
+  const tnsr::II<DataType, 3, Frame::Grid> inverse_metric_simple =
+      [&used_for_size]() {
+        auto tensor = make_with_value<tnsr::II<DataType, 3, Frame::Grid>>(
+            used_for_size, 0.0);
+        get<0, 0>(tensor) = 0.25;
+        get<1, 1>(tensor) = 0.25;
+        get<2, 2>(tensor) = 0.25;
+        return tensor;
+      }();
+  const auto det_metric_simple = Scalar<DataType>{sixty_four};
+
+  CHECK_ITERABLE_APPROX(cross_product(curved_vector_x_hat, curved_vector_y_hat,
+                                      inverse_metric_simple, det_metric_simple),
+                        curved_vector_z_hat);
+  CHECK_ITERABLE_APPROX(
+      cross_product(curved_vector_x_hat, curved_covector_y_hat,
+                    inverse_metric_simple, det_metric_simple),
+      curved_covector_z_hat);
+  CHECK_ITERABLE_APPROX(cross_product(curved_vector_y_hat, curved_vector_x_hat,
+                                      inverse_metric_simple, det_metric_simple),
+                        curved_vector_minus_z_hat);
+  CHECK_ITERABLE_APPROX(
+      cross_product(curved_vector_y_hat, curved_covector_x_hat,
+                    inverse_metric_simple, det_metric_simple),
+      curved_covector_minus_z_hat);
+
+  // Test c++ vs. python using random values
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::I<DataType, 3, Frame::Grid> (*)(
+          const tnsr::I<DataType, 3, Frame::Grid>&,
+          const tnsr::I<DataType, 3, Frame::Grid>&)>(
+          &cross_product<DataType, SpatialIndex<3, UpLo::Up, Frame::Grid>>),
+      "numpy", "cross", {{{-10.0, 10.0}}}, vector_x_hat);
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::i<DataType, 3, Frame::Grid> (*)(
+          const tnsr::I<DataType, 3, Frame::Grid>&,
+          const tnsr::i<DataType, 3, Frame::Grid>&)>(
+          &cross_product<DataType, SpatialIndex<3, UpLo::Up, Frame::Grid>>),
+      "numpy", "cross", {{{-10.0, 10.0}}}, vector_x_hat);
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::I<DataType, 3, Frame::Grid> (*)(
+          const tnsr::I<DataType, 3, Frame::Grid>&,
+          const tnsr::I<DataType, 3, Frame::Grid>&,
+          const tnsr::II<DataType, 3, Frame::Grid>&, const Scalar<DataType>&)>(
+          &cross_product<DataType, SpatialIndex<3, UpLo::Up, Frame::Grid>>),
+      "TestFunctions", "cross_product_up", {{{1.0, 10.0}}},
+      curved_vector_x_hat);
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::i<DataType, 3, Frame::Grid> (*)(
+          const tnsr::I<DataType, 3, Frame::Grid>&,
+          const tnsr::i<DataType, 3, Frame::Grid>&,
+          const tnsr::II<DataType, 3, Frame::Grid>&, const Scalar<DataType>&)>(
+          &cross_product<DataType, SpatialIndex<3, UpLo::Up, Frame::Grid>>),
+      "TestFunctions", "cross_product_lo", {{{1.0, 10.0}}},
+      curved_vector_x_hat);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tensor.EagerMath.CrossProduct",
+                  "[DataStructures][Unit]") {
+  // Set up a python environment for check_with_random_values
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "DataStructures/Tensor/EagerMath/");
+  check_cross_product(std::numeric_limits<double>::signaling_NaN());
+  check_cross_product(
+      DataVector(5, std::numeric_limits<double>::signaling_NaN()));
+}


### PR DESCRIPTION
## Proposed changes

Add cross product, analogous to dot product, in Tensor/EagerMath.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
