### PR TITLE
Action testing mock simple actions

### DIFF
--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -157,7 +157,7 @@ class AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
   // The types held by the boost::variant, box_
   using databox_types = Algorithm_detail::build_action_return_typelist<
       InitialDataBox,
-      tmpl::list<tuples::TaggedTupleTypelist<inbox_tags_list>,
+      tmpl::list<tuples::tagged_tuple_from_typelist<inbox_tags_list>,
                  Parallel::ConstGlobalCache<metavariables>, array_index,
                  actions_list, std::add_pointer_t<ParallelComponent>>,
       ActionsPack...>;
@@ -308,7 +308,7 @@ class AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
   make_boost_variant_over<tmpl::remove_duplicates<
       tmpl::append<tmpl::list<db::DataBox<tmpl::list<>>>, databox_types>>>
       box_;
-  tuples::TaggedTupleTypelist<inbox_tags_list> inboxes_{};
+  tuples::tagged_tuple_from_typelist<inbox_tags_list> inboxes_{};
   array_index array_index_;
 };
 
@@ -544,7 +544,8 @@ AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
         [this, &box](std::true_type /*has_is_ready*/, auto t) {
           return decltype(t)::is_ready(
               static_cast<const this_databox&>(*box),
-              static_cast<const tuples::TaggedTupleTypelist<inbox_tags_list>&>(
+              static_cast<
+                  const tuples::tagged_tuple_from_typelist<inbox_tags_list>&>(
                   inboxes_),
               *const_global_cache_,
               static_cast<const array_index&>(array_index_));
@@ -554,7 +555,7 @@ AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
     if (not check_if_ready(
             Algorithm_detail::is_is_ready_callable_t<
                 this_action, this_databox,
-                tuples::TaggedTupleTypelist<inbox_tags_list>,
+                tuples::tagged_tuple_from_typelist<inbox_tags_list>,
                 Parallel::ConstGlobalCache<Metavariables>, array_index>{},
             this_action{})) {
       take_next_action = false;

--- a/src/Parallel/ConstGlobalCache.ci
+++ b/src/Parallel/ConstGlobalCache.ci
@@ -10,10 +10,10 @@ module ConstGlobalCache {
   template <typename Metavariables>
   nodegroup[migratable] ConstGlobalCache {
     entry ConstGlobalCache(
-        tuples::TaggedTupleTypelist<
+        tuples::tagged_tuple_from_typelist<
             typename ConstGlobalCache_detail::make_tag_list<Metavariables>>&);
     entry void set_parallel_components(
-        tuples::TaggedTupleTypelist<tmpl::transform<
+        tuples::tagged_tuple_from_typelist<tmpl::transform<
             typename Metavariables::component_list,
             tmpl::bind<tmpl::type_,
                        tmpl::bind<Parallel::proxy_from_parallel_component,

--- a/src/Parallel/ConstGlobalCache.hpp
+++ b/src/Parallel/ConstGlobalCache.hpp
@@ -85,7 +85,7 @@ class ConstGlobalCache : public CBase_ConstGlobalCache<Metavariables> {
   using component_list = typename Metavariables::component_list;
 
   explicit ConstGlobalCache(
-      tuples::TaggedTupleTypelist<tag_list> const_global_cache) noexcept
+      tuples::tagged_tuple_from_typelist<tag_list> const_global_cache) noexcept
       : const_global_cache_(std::move(const_global_cache)) {}
   explicit ConstGlobalCache(CkMigrateMessage* /*msg*/) {}
   ~ConstGlobalCache() noexcept override {
@@ -102,7 +102,7 @@ class ConstGlobalCache : public CBase_ConstGlobalCache<Metavariables> {
 
   /// Entry method to set the ParallelComponents (should only be called once)
   void set_parallel_components(
-      tuples::TaggedTupleTypelist<parallel_component_tag_list>&
+      tuples::tagged_tuple_from_typelist<parallel_component_tag_list>&
           parallel_components,
       const CkCallback& callback) noexcept;
 
@@ -129,14 +129,15 @@ class ConstGlobalCache : public CBase_ConstGlobalCache<Metavariables> {
               typename MV::component_list,
               ParallelComponentTag>>&;  // NOLINT
 
-  tuples::TaggedTupleTypelist<tag_list> const_global_cache_;
-  tuples::TaggedTupleTypelist<parallel_component_tag_list> parallel_components_;
+  tuples::tagged_tuple_from_typelist<tag_list> const_global_cache_;
+  tuples::tagged_tuple_from_typelist<parallel_component_tag_list>
+      parallel_components_;
   bool parallel_components_have_been_set_{false};
 };
 
 template <typename Metavariables>
 void ConstGlobalCache<Metavariables>::set_parallel_components(
-    tuples::TaggedTupleTypelist<parallel_component_tag_list>&
+    tuples::tagged_tuple_from_typelist<parallel_component_tag_list>&
         parallel_components,
     const CkCallback& callback) noexcept {
   ASSERT(!parallel_components_have_been_set_,

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -199,11 +199,11 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept
   const_global_cache_proxy_ =
       options_.template apply<const_global_cache_tags>([](auto... args) {
         return CProxy_ConstGlobalCache<Metavariables>::ckNew(
-            tuples::TaggedTupleTypelist<const_global_cache_tags>(
+            tuples::tagged_tuple_from_typelist<const_global_cache_tags>(
                 std::move(args)...));
       });
 
-  tuples::TaggedTupleTypelist<parallel_component_tag_list>
+  tuples::tagged_tuple_from_typelist<parallel_component_tag_list>
       the_parallel_components;
 
   // Construct the group proxies with a dependency on the ConstGlobalCache proxy

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
@@ -52,9 +52,9 @@ void KerrSchild::pup(PUP::er& p) noexcept {
 }
 
 template <typename DataType>
-tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::variables(
-    const tnsr::I<DataType, 3>& x, const double /*t*/,
-    tags<DataType> /*meta*/) const noexcept {
+tuples::tagged_tuple_from_typelist<KerrSchild::tags<DataType>>
+KerrSchild::variables(const tnsr::I<DataType, 3>& x, const double /*t*/,
+                      tags<DataType> /*meta*/) const noexcept {
   // Input spin is dimensionless spin.  But below we use `spin` = the
   // Kerr spin parameter `a`, which is `J/M` where `J` is the angular
   // momentum.  So compute `spin=a` here.
@@ -246,12 +246,12 @@ tuples::TaggedTupleTypelist<KerrSchild::tags<DataType>> KerrSchild::variables(
 }
 }  // namespace EinsteinSolutions
 
-template tuples::TaggedTupleTypelist<
+template tuples::tagged_tuple_from_typelist<
     EinsteinSolutions::KerrSchild::tags<DataVector>>
 EinsteinSolutions::KerrSchild::variables(
     const tnsr::I<DataVector, 3>& x, const double /*t*/,
     KerrSchild::tags<DataVector> /*meta*/) const noexcept;
-template tuples::TaggedTupleTypelist<
+template tuples::tagged_tuple_from_typelist<
     EinsteinSolutions::KerrSchild::tags<double>>
 EinsteinSolutions::KerrSchild::variables(
     const tnsr::I<double, 3>& x, const double /*t*/,

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
@@ -262,7 +262,7 @@ class KerrSchild {
       DerivSpatialMetric<DataType>>;
 
   template <typename DataType>
-  tuples::TaggedTupleTypelist<tags<DataType>> variables(
+  tuples::tagged_tuple_from_typelist<tags<DataType>> variables(
       const tnsr::I<DataType, 3>& x, double t, tags<DataType> /*meta*/) const
       noexcept;
 

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/IsentropicVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/IsentropicVortex.cpp
@@ -58,7 +58,7 @@ Scalar<DataType> IsentropicVortex::perturbation(const DataType& coord_z) const
 }
 
 template <typename DataType>
-tuples::TaggedTupleTypelist<IsentropicVortex::primitive_t<DataType>>
+tuples::tagged_tuple_from_typelist<IsentropicVortex::primitive_t<DataType>>
 IsentropicVortex::primitive_variables(const tnsr::I<DataType, 3>& x,
                                       const double t) const noexcept {
   const auto adiabatic_index_minus_one = adiabatic_index_ - 1.0;
@@ -75,9 +75,8 @@ IsentropicVortex::primitive_variables(const tnsr::I<DataType, 3>& x,
   }
   ();
 
-  auto result = make_with_value<
-      tuples::TaggedTupleTypelist<IsentropicVortex::primitive_t<DataType>>>(
-      x, 0.0);
+  auto result = make_with_value<tuples::tagged_tuple_from_typelist<
+      IsentropicVortex::primitive_t<DataType>>>(x, 0.0);
 
   const DataType temp = 0.5 * strength_ *
                         exp(0.5 - 0.5 * get(dot_product(x_tilde, x_tilde))) /
@@ -106,14 +105,13 @@ IsentropicVortex::primitive_variables(const tnsr::I<DataType, 3>& x,
 }
 
 template <typename DataType>
-tuples::TaggedTupleTypelist<IsentropicVortex::conservative_t<DataType>>
+tuples::tagged_tuple_from_typelist<IsentropicVortex::conservative_t<DataType>>
 IsentropicVortex::conservative_variables(const tnsr::I<DataType, 3>& x,
                                          const double t) const noexcept {
   const auto primitives = primitive_variables(x, t);
 
-  auto result = make_with_value<
-      tuples::TaggedTupleTypelist<IsentropicVortex::conservative_t<DataType>>>(
-      x, 0.0);
+  auto result = make_with_value<tuples::tagged_tuple_from_typelist<
+      IsentropicVortex::conservative_t<DataType>>>(x, 0.0);
 
   get<Tags::MassDensity<DataType>>(result) =
       get<Tags::MassDensity<DataType>>(primitives);
@@ -137,11 +135,11 @@ IsentropicVortex::conservative_variables(const tnsr::I<DataType, 3>& x,
   template Scalar<DTYPE(data)>                                               \
   NewtonianEuler::Solutions::IsentropicVortex::perturbation(                 \
       const DTYPE(data) & coord_z) const noexcept;                           \
-  template tuples::TaggedTupleTypelist<                                      \
+  template tuples::tagged_tuple_from_typelist<                               \
       NewtonianEuler::Solutions::IsentropicVortex::primitive_t<DTYPE(data)>> \
   NewtonianEuler::Solutions::IsentropicVortex::primitive_variables(          \
       const tnsr::I<DTYPE(data), 3>& x, const double t) const noexcept;      \
-  template tuples::TaggedTupleTypelist<                                      \
+  template tuples::tagged_tuple_from_typelist<                               \
       NewtonianEuler::Solutions::IsentropicVortex::conservative_t<DTYPE(     \
           data)>>                                                            \
   NewtonianEuler::Solutions::IsentropicVortex::conservative_variables(       \

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/IsentropicVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEulerSolutions/IsentropicVortex.hpp
@@ -146,12 +146,13 @@ class IsentropicVortex {
   Scalar<DataType> perturbation(const DataType& coord_z) const noexcept;
 
   template <typename DataType>
-  tuples::TaggedTupleTypelist<primitive_t<DataType>> primitive_variables(
+  tuples::tagged_tuple_from_typelist<primitive_t<DataType>> primitive_variables(
       const tnsr::I<DataType, 3>& x, double t) const noexcept;
 
   template <typename DataType>
-  tuples::TaggedTupleTypelist<conservative_t<DataType>> conservative_variables(
-      const tnsr::I<DataType, 3>& x, double t) const noexcept;
+  tuples::tagged_tuple_from_typelist<conservative_t<DataType>>
+  conservative_variables(const tnsr::I<DataType, 3>& x, double t) const
+      noexcept;
 
   // clang-tidy: no runtime references
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT

--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -710,7 +710,7 @@ struct tagged_tuple_typelist_impl<List<Tags...>> {
 
 /// \ingroup UtilitiesGroup
 template <typename T>
-using TaggedTupleTypelist =
+using tagged_tuple_from_typelist =
     typename TaggedTuple_detail::tagged_tuple_typelist_impl<T>::type;
 
 /// Stream operator for TaggedTuple

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -525,7 +525,7 @@ class MockProxy {
                << index << "' but found " << local_algorithms_->count(index)
                << ". The known keys are " << keys_of(*local_algorithms_)
                << ". Did you forget to add a local algorithm when constructing "
-                  "the ActionRunner?");
+                  "the MockRuntimeSystem?");
     return MockArrayElementProxy<Component, InboxTagList>(
         local_algorithms_->at(index), inboxes_->operator[](index));
   }
@@ -627,14 +627,14 @@ struct MockArrayComponent {
 /// handles most of the arguments to the apply and is_ready action
 /// methods.
 template <typename Metavariables>
-class ActionRunner {
+class MockRuntimeSystem {
  public:
   // No moving, since MockProxy holds a pointer to us.
-  ActionRunner(const ActionRunner&) = delete;
-  ActionRunner(ActionRunner&&) = delete;
-  ActionRunner& operator=(const ActionRunner&) = delete;
-  ActionRunner& operator=(ActionRunner&&) = delete;
-  ~ActionRunner() = default;
+  MockRuntimeSystem(const MockRuntimeSystem&) = delete;
+  MockRuntimeSystem(MockRuntimeSystem&&) = delete;
+  MockRuntimeSystem& operator=(const MockRuntimeSystem&) = delete;
+  MockRuntimeSystem& operator=(MockRuntimeSystem&&) = delete;
+  ~MockRuntimeSystem() = default;
 
   template <typename Component>
   struct InboxesTag {
@@ -661,8 +661,8 @@ class ActionRunner {
                       tmpl::bind<InboxesTag, tmpl::_1>>>;
 
   /// Construct from the tuple of ConstGlobalCache objects.
-  explicit ActionRunner(CacheTuple cache_contents,
-                        LocalAlgorithms local_algorithms)
+  explicit MockRuntimeSystem(CacheTuple cache_contents,
+                             LocalAlgorithms local_algorithms)
       : cache_(std::move(cache_contents)),
         local_algorithms_(std::move(local_algorithms)) {
     tmpl::for_each<typename Metavariables::component_list>(

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -510,12 +510,13 @@ class MockProxy {
  public:
   using Inboxes =
       std::unordered_map<Index, tuples::TaggedTupleTypelist<InboxTagList>>;
-  using LocalAlgorithms =
+  using TupleOfMockDistributedObjects =
       std::unordered_map<Index, MockDistributedObject<Component>>;
 
   MockProxy() : inboxes_(nullptr) {}
 
-  void set_data(LocalAlgorithms* local_algorithms, Inboxes* inboxes) {
+  void set_data(TupleOfMockDistributedObjects* local_algorithms,
+                Inboxes* inboxes) {
     local_algorithms_ = local_algorithms;
     inboxes_ = inboxes;
   }
@@ -571,7 +572,7 @@ class MockProxy {
   }
 
  private:
-  LocalAlgorithms* local_algorithms_;
+  TupleOfMockDistributedObjects* local_algorithms_;
   Inboxes* inboxes_;
 };
 
@@ -655,7 +656,7 @@ class MockRuntimeSystem {
   using GlobalCache = Parallel::ConstGlobalCache<Metavariables>;
   using CacheTuple =
       tuples::TaggedTupleTypelist<typename GlobalCache::tag_list>;
-  using LocalAlgorithms = tuples::TaggedTupleTypelist<
+  using TupleOfMockDistributedObjects = tuples::TaggedTupleTypelist<
       tmpl::transform<typename Metavariables::component_list,
                       tmpl::bind<LocalAlgorithmsTag, tmpl::_1>>>;
   using Inboxes = tuples::TaggedTupleTypelist<
@@ -664,7 +665,7 @@ class MockRuntimeSystem {
 
   /// Construct from the tuple of ConstGlobalCache objects.
   explicit MockRuntimeSystem(CacheTuple cache_contents,
-                             LocalAlgorithms local_algorithms)
+                             TupleOfMockDistributedObjects local_algorithms)
       : cache_(std::move(cache_contents)),
         local_algorithms_(std::move(local_algorithms)) {
     tmpl::for_each<typename Metavariables::component_list>(
@@ -788,6 +789,6 @@ class MockRuntimeSystem {
  private:
   GlobalCache cache_;
   Inboxes inboxes_;
-  LocalAlgorithms local_algorithms_;
+  TupleOfMockDistributedObjects local_algorithms_;
 };
 }  // namespace ActionTesting

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -471,6 +471,8 @@ bool MockDistributedObject<Component>::is_ready(
 }
 
 namespace ActionTesting_detail {
+// A mock class for the Charm++ generated CProxyElement_AlgorithmArray (we use
+// an array for everything, so no need to mock groups, nodegroups, singletons).
 template <typename Component, typename InboxTagList>
 class MockArrayElementProxy {
  public:
@@ -506,6 +508,8 @@ class MockArrayElementProxy {
   Inbox& inbox_;
 };
 
+// A mock class for the Charm++ generated CProxy_AlgorithmArray (we use an array
+// for everything, so no need to mock groups, nodegroups, singletons).
 template <typename Component, typename Index, typename InboxTagList>
 class MockProxy {
  public:
@@ -579,6 +583,7 @@ class MockProxy {
 };
 }  // namespace ActionTesting_detail
 
+/// A mock class for the CMake-generated `Parallel::Algorithms::Array`
 struct MockArrayChare {
   template <typename Component, typename Metavariables, typename ActionList,
             typename Index, typename InitialDataBox>

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -648,7 +648,7 @@ class MockRuntimeSystem {
   };
 
   template <typename Component>
-  struct LocalAlgorithmsTag {
+  struct MockDistributedObjectsTag {
     using type = std::unordered_map<typename Component::index,
                                     MockDistributedObject<Component>>;
   };
@@ -658,7 +658,7 @@ class MockRuntimeSystem {
       tuples::TaggedTupleTypelist<typename GlobalCache::tag_list>;
   using TupleOfMockDistributedObjects = tuples::TaggedTupleTypelist<
       tmpl::transform<typename Metavariables::component_list,
-                      tmpl::bind<LocalAlgorithmsTag, tmpl::_1>>>;
+                      tmpl::bind<MockDistributedObjectsTag, tmpl::_1>>>;
   using Inboxes = tuples::TaggedTupleTypelist<
       tmpl::transform<typename Metavariables::component_list,
                       tmpl::bind<InboxesTag, tmpl::_1>>>;
@@ -672,7 +672,8 @@ class MockRuntimeSystem {
         [this](auto component) {
           using Component = tmpl::type_from<decltype(component)>;
           Parallel::get_parallel_component<Component>(cache_).set_data(
-              &tuples::get<LocalAlgorithmsTag<Component>>(local_algorithms_),
+              &tuples::get<MockDistributedObjectsTag<Component>>(
+                  local_algorithms_),
               &tuples::get<InboxesTag<Component>>(inboxes_));
 
           for (auto& local_alg_pair : this->template algorithms<Component>()) {
@@ -781,7 +782,7 @@ class MockRuntimeSystem {
   /// Access the mocked algorithms for a component, indexed by array index.
   template <typename Component>
   auto& algorithms() noexcept {
-    return tuples::get<LocalAlgorithmsTag<Component>>(local_algorithms_);
+    return tuples::get<MockDistributedObjectsTag<Component>>(local_algorithms_);
   }
 
   const GlobalCache& cache() noexcept { return cache_; }

--- a/tests/Unit/CMakeLists.txt
+++ b/tests/Unit/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(executable RunTests)
 
 set(SPECTRE_TESTS
+  "Test_ActionTesting.cpp"
   "Test_TestHelpers.cpp"
   "Test_TestingFramework.cpp"
   )

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
@@ -41,9 +41,12 @@ struct System {
 using ElementIndexType = ElementIndex<2>;
 
 template <typename Metavariables>
-struct component : ActionTesting::MockArrayComponent<
-                       Metavariables, ElementIndexType, tmpl::list<>,
-                       tmpl::list<Actions::ComputeVolumeDuDt<2>>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndexType;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<Actions::ComputeVolumeDuDt<2>>;
   using initial_databox =
       db::compute_databox_type<tmpl::list<var_tag, Tags::dt<var_tag>>>;
 };

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
@@ -64,7 +64,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeDuDt",
   const ElementId<2> self_id(1, {{{1, 0}, {1, 0}}});
 
   using simple_tags = db::AddSimpleTags<var_tag, Tags::dt<var_tag>>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(self_id, db::create<simple_tags>(3, -100));
   MockRuntimeSystem runner{{}, std::move(local_algs)};

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
@@ -64,10 +64,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeDuDt",
   const ElementId<2> self_id(1, {{{1, 0}, {1, 0}}});
 
   using simple_tags = db::AddSimpleTags<var_tag, Tags::dt<var_tag>>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(self_id, db::create<simple_tags>(3, -100));
-  MockRuntimeSystem runner{{}, std::move(local_algs)};
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
   const auto get_box = [&runner, &self_id]() -> decltype(auto) {
     return runner.algorithms<component<Metavariables>>()
         .at(self_id)

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
@@ -58,14 +58,14 @@ struct Metavariables {
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeDuDt",
                   "[Unit][Evolution][Actions]") {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag =
-      MockRuntimeSystem::LocalAlgorithmsTag<component<Metavariables>>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component<Metavariables>>;
 
   const ElementId<2> self_id(1, {{{1, 0}, {1, 0}}});
 
   using simple_tags = db::AddSimpleTags<var_tag, Tags::dt<var_tag>>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(self_id, db::create<simple_tags>(3, -100));
   MockRuntimeSystem runner{{}, std::move(local_algs)};
   const auto get_box = [&runner, &self_id]() -> decltype(auto) {

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeDuDt.cpp
@@ -57,17 +57,17 @@ struct Metavariables {
 
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeDuDt",
                   "[Unit][Evolution][Actions]") {
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag =
-      ActionRunner::LocalAlgorithmsTag<component<Metavariables>>;
+      MockRuntimeSystem::LocalAlgorithmsTag<component<Metavariables>>;
 
   const ElementId<2> self_id(1, {{{1, 0}, {1, 0}}});
 
   using simple_tags = db::AddSimpleTags<var_tag, Tags::dt<var_tag>>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(self_id, db::create<simple_tags>(3, -100));
-  ActionRunner runner{{}, std::move(local_algs)};
+  MockRuntimeSystem runner{{}, std::move(local_algs)};
   const auto get_box = [&runner, &self_id]() -> decltype(auto) {
     return runner.algorithms<component<Metavariables>>()
         .at(self_id)

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
@@ -58,9 +58,12 @@ struct System {
 using ElementIndexType = ElementIndex<dim>;
 
 template <typename Metavariables>
-struct component : ActionTesting::MockArrayComponent<
-                       Metavariables, ElementIndexType, tmpl::list<>,
-                       tmpl::list<Actions::ComputeVolumeFluxes>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndexType;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<Actions::ComputeVolumeFluxes>;
   using initial_databox =
       db::compute_databox_type<tmpl::list<Var1, Var2, flux_tag>>;
 };

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
@@ -75,14 +75,14 @@ struct Metavariables {
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeFluxes",
                   "[Unit][Evolution][Actions]") {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag =
-      MockRuntimeSystem::LocalAlgorithmsTag<component<Metavariables>>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component<Metavariables>>;
 
   const ElementId<dim> self_id(1);
 
   using simple_tags = db::AddSimpleTags<Var1, Var2, flux_tag>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(self_id,
                db::create<simple_tags>(db::item_type<Var1>{{{3.}}},
                                        db::item_type<Var2>{{{7., 12.}}},

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
@@ -81,7 +81,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeFluxes",
   const ElementId<dim> self_id(1);
 
   using simple_tags = db::AddSimpleTags<Var1, Var2, flux_tag>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(self_id,
                db::create<simple_tags>(db::item_type<Var1>{{{3.}}},

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
@@ -74,20 +74,20 @@ struct Metavariables {
 
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeFluxes",
                   "[Unit][Evolution][Actions]") {
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag =
-      ActionRunner::LocalAlgorithmsTag<component<Metavariables>>;
+      MockRuntimeSystem::LocalAlgorithmsTag<component<Metavariables>>;
 
   const ElementId<dim> self_id(1);
 
   using simple_tags = db::AddSimpleTags<Var1, Var2, flux_tag>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(self_id,
                db::create<simple_tags>(db::item_type<Var1>{{{3.}}},
                                        db::item_type<Var2>{{{7., 12.}}},
                                        db::item_type<flux_tag>{{{-100.}}}));
-  ActionRunner runner{{}, std::move(local_algs)};
+  MockRuntimeSystem runner{{}, std::move(local_algs)};
 
   runner.next_action<component<Metavariables>>(self_id);
 

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeFluxes.cpp
@@ -81,13 +81,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeFluxes",
   const ElementId<dim> self_id(1);
 
   using simple_tags = db::AddSimpleTags<Var1, Var2, flux_tag>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(self_id,
                db::create<simple_tags>(db::item_type<Var1>{{{3.}}},
                                        db::item_type<Var2>{{{7., 12.}}},
                                        db::item_type<flux_tag>{{{-100.}}}));
-  MockRuntimeSystem runner{{}, std::move(local_algs)};
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
 
   runner.next_action<component<Metavariables>>(self_id);
 

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
@@ -95,11 +95,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeSources",
 
   using simple_tags =
       db::AddSimpleTags<System::variables_tag, Var3, source_tag>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(self_id, db::create<simple_tags>(std::move(vars), var3,
                                                 db::item_type<source_tag>(2)));
-  MockRuntimeSystem runner{{}, std::move(local_algs)};
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
 
   runner.next_action<component<Metavariables>>(self_id);
 

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
@@ -83,8 +83,8 @@ struct Metavariables {
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeSources",
                   "[Unit][Evolution][Actions]") {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag =
-      MockRuntimeSystem::LocalAlgorithmsTag<component<Metavariables>>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component<Metavariables>>;
 
   const ElementId<dim> self_id(1);
   const Scalar<DataVector> var1{{{{3., 4.}}}};
@@ -96,7 +96,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeSources",
   using simple_tags =
       db::AddSimpleTags<System::variables_tag, Var3, source_tag>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(self_id, db::create<simple_tags>(std::move(vars), var3,
                                                 db::item_type<source_tag>(2)));
   MockRuntimeSystem runner{{}, std::move(local_algs)};

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
@@ -82,9 +82,9 @@ struct Metavariables {
 
 SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeSources",
                   "[Unit][Evolution][Actions]") {
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag =
-      ActionRunner::LocalAlgorithmsTag<component<Metavariables>>;
+      MockRuntimeSystem::LocalAlgorithmsTag<component<Metavariables>>;
 
   const ElementId<dim> self_id(1);
   const Scalar<DataVector> var1{{{{3., 4.}}}};
@@ -95,11 +95,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeSources",
 
   using simple_tags =
       db::AddSimpleTags<System::variables_tag, Var3, source_tag>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(self_id, db::create<simple_tags>(std::move(vars), var3,
                                                 db::item_type<source_tag>(2)));
-  ActionRunner runner{{}, std::move(local_algs)};
+  MockRuntimeSystem runner{{}, std::move(local_algs)};
 
   runner.next_action<component<Metavariables>>(self_id);
 

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
@@ -95,7 +95,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.ComputeVolumeSources",
 
   using simple_tags =
       db::AddSimpleTags<System::variables_tag, Var3, source_tag>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(self_id, db::create<simple_tags>(std::move(vars), var3,
                                                 db::item_type<source_tag>(2)));

--- a/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
+++ b/tests/Unit/Evolution/Actions/Test_ComputeVolumeSources.cpp
@@ -66,9 +66,12 @@ using source_tag =
     Tags::Source<Tags::Variables<tmpl::list<Tags::Source<Var2>>>>;
 
 template <typename Metavariables>
-struct component : ActionTesting::MockArrayComponent<
-                       Metavariables, ElementIndexType, tmpl::list<>,
-                       tmpl::list<Actions::ComputeVolumeSources>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndexType;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<Actions::ComputeVolumeSources>;
   using initial_databox = db::compute_databox_type<
       tmpl::list<System::variables_tag, Var3, source_tag>>;
 };

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -117,12 +117,14 @@ struct NormalDotNumericalFluxTag {
 };
 
 template <size_t Dim, typename Metavariables>
-struct component
-    : ActionTesting::MockArrayComponent<
-          Metavariables, ElementIndex<Dim>,
-          tmpl::list<OptionTags::TimeStepper,
-                     OptionTags::AnalyticSolution<SystemAnalyticSolution>>,
-          tmpl::list<>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<Dim>;
+  using const_global_cache_tag_list =
+      tmpl::list<OptionTags::TimeStepper,
+                 OptionTags::AnalyticSolution<SystemAnalyticSolution>>;
+  using action_list = tmpl::list<>;
   using initial_databox =
       db::compute_databox_type<typename dg::Actions::InitializeElement<
           Dim>::template return_tag_list<Metavariables>>;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -216,10 +216,11 @@ void test_initialize_element(
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using my_component = component<dim, Metavariables>;
-  using LocalAlgsTag =
-      typename MockRuntimeSystem::template LocalAlgorithmsTag<my_component>;
+  using MockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          my_component>;
   typename MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(element_id,
                ActionTesting::MockDistributedObject<my_component>{});
 
@@ -367,10 +368,11 @@ void test_mortar_orientation() noexcept {
 
   using my_component = component<3, metavariables>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
-  using LocalAlgsTag =
-      typename MockRuntimeSystem::template LocalAlgorithmsTag<my_component>;
+  using MockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          my_component>;
   typename MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(ElementIndex<3>{element_id},
                ActionTesting::MockDistributedObject<my_component>{});
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -219,13 +219,13 @@ void test_initialize_element(
   using MockDistributedObjectsTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<
           my_component>;
-  typename MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  typename MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(element_id,
                ActionTesting::MockDistributedObject<my_component>{});
 
-  ActionTesting::MockRuntimeSystem<Metavariables> runner{std::move(cache_tuple),
-                                                         std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      std::move(cache_tuple), std::move(dist_objects)};
 
   runner.template simple_action<my_component,
                                 dg::Actions::InitializeElement<dim>>(
@@ -371,15 +371,15 @@ void test_mortar_orientation() noexcept {
   using MockDistributedObjectsTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<
           my_component>;
-  typename MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  typename MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(ElementIndex<3>{element_id},
                ActionTesting::MockDistributedObject<my_component>{});
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
        SystemAnalyticSolution{}},
-      std::move(local_algs)};
+      std::move(dist_objects)};
 
   runner.simple_action<my_component, dg::Actions::InitializeElement<3>>(
       element_id, extents, std::move(domain), 0., 1., 1.);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -214,16 +214,16 @@ void test_initialize_element(
 
   const auto domain = domain_creator.create_domain();
 
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using my_component = component<dim, Metavariables>;
   using LocalAlgsTag =
-      typename ActionRunner::template LocalAlgorithmsTag<my_component>;
-  typename ActionRunner::LocalAlgorithms local_algs{};
+      typename MockRuntimeSystem::template LocalAlgorithmsTag<my_component>;
+  typename MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(element_id, ActionTesting::MockLocalAlgorithm<my_component>{});
 
-  ActionTesting::ActionRunner<Metavariables> runner{std::move(cache_tuple),
-                                                    std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{std::move(cache_tuple),
+                                                         std::move(local_algs)};
 
   runner.template simple_action<my_component,
                                 dg::Actions::InitializeElement<dim>>(
@@ -365,15 +365,15 @@ void test_mortar_orientation() noexcept {
   const std::vector<std::array<size_t, 3>> extents{{{2, 2, 2}}, {{3, 4, 5}}};
 
   using my_component = component<3, metavariables>;
-  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using LocalAlgsTag =
-      typename ActionRunner::template LocalAlgorithmsTag<my_component>;
-  typename ActionRunner::LocalAlgorithms local_algs{};
+      typename MockRuntimeSystem::template LocalAlgorithmsTag<my_component>;
+  typename MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(ElementIndex<3>{element_id},
                ActionTesting::MockLocalAlgorithm<my_component>{});
 
-  ActionTesting::ActionRunner<metavariables> runner{
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
       {std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
        SystemAnalyticSolution{}},
       std::move(local_algs)};
@@ -393,7 +393,7 @@ void test_mortar_orientation() noexcept {
 SPECTRE_TEST_CASE("Unit.Evolution.dG.InitializeElement",
                   "[Unit][Evolution][Actions]") {
   test_initialize_element<Metavariables<1, false, false, tmpl::list<>>>(
-      ActionTesting::ActionRunner<
+      ActionTesting::MockRuntimeSystem<
           Metavariables<1, false, false, tmpl::list<>>>::CacheTuple{
           std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
           SystemAnalyticSolution{}},
@@ -402,7 +402,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.InitializeElement",
           {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}});
 
   test_initialize_element<Metavariables<2, false, false, tmpl::list<>>>(
-      ActionTesting::ActionRunner<
+      ActionTesting::MockRuntimeSystem<
           Metavariables<2, false, false, tmpl::list<>>>::CacheTuple{
           std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
           SystemAnalyticSolution{}},
@@ -411,7 +411,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.InitializeElement",
           {{-0.5, -0.75}}, {{1.5, 2.4}}, {{false, false}}, {{2, 3}}, {{4, 5}}});
 
   test_initialize_element<Metavariables<3, false, false, tmpl::list<>>>(
-      ActionTesting::ActionRunner<
+      ActionTesting::MockRuntimeSystem<
           Metavariables<3, false, false, tmpl::list<>>>::CacheTuple{
           std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
           SystemAnalyticSolution{}},
@@ -424,7 +424,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.InitializeElement",
                                              {{4, 5, 3}}});
 
   test_initialize_element<Metavariables<2, true, false, tmpl::list<>>>(
-      ActionTesting::ActionRunner<
+      ActionTesting::MockRuntimeSystem<
           Metavariables<2, true, false, tmpl::list<>>>::CacheTuple{
           std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),
           SystemAnalyticSolution{}},
@@ -435,7 +435,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.dG.InitializeElement",
   // local time-stepping
   test_initialize_element<
       Metavariables<2, false, true, tmpl::list<OptionTags::StepController>>>(
-      ActionTesting::ActionRunner<Metavariables<
+      ActionTesting::MockRuntimeSystem<Metavariables<
           2, false, true, tmpl::list<OptionTags::StepController>>>::CacheTuple{
           std::make_unique<StepControllers::SplitRemaining>(),
           std::make_unique<TimeSteppers::AdamsBashforthN>(4, true),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -218,7 +218,7 @@ void test_initialize_element(
   using my_component = component<dim, Metavariables>;
   using LocalAlgsTag =
       typename MockRuntimeSystem::template LocalAlgorithmsTag<my_component>;
-  typename MockRuntimeSystem::LocalAlgorithms local_algs{};
+  typename MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(element_id,
                ActionTesting::MockDistributedObject<my_component>{});
@@ -369,7 +369,7 @@ void test_mortar_orientation() noexcept {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using LocalAlgsTag =
       typename MockRuntimeSystem::template LocalAlgorithmsTag<my_component>;
-  typename MockRuntimeSystem::LocalAlgorithms local_algs{};
+  typename MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(ElementIndex<3>{element_id},
                ActionTesting::MockDistributedObject<my_component>{});

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -220,7 +220,8 @@ void test_initialize_element(
       typename MockRuntimeSystem::template LocalAlgorithmsTag<my_component>;
   typename MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
-      .emplace(element_id, ActionTesting::MockLocalAlgorithm<my_component>{});
+      .emplace(element_id,
+               ActionTesting::MockDistributedObject<my_component>{});
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{std::move(cache_tuple),
                                                          std::move(local_algs)};
@@ -371,7 +372,7 @@ void test_mortar_orientation() noexcept {
   typename MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(ElementIndex<3>{element_id},
-               ActionTesting::MockLocalAlgorithm<my_component>{});
+               ActionTesting::MockDistributedObject<my_component>{});
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {std::make_unique<TimeSteppers::AdamsBashforthN>(4, false),

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -60,10 +60,12 @@ void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using my_component = component;
-  using LocalAlgsTag =
-      typename MockRuntimeSystem::template LocalAlgorithmsTag<my_component>;
+  using MockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          my_component>;
   typename MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs).emplace(0, db::DataBox<tmpl::list<>>{});
+  tuples::get<MockDistributedObjectsTag>(local_algs)
+      .emplace(0, db::DataBox<tmpl::list<>>{});
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
       {serialize_and_deserialize(events_and_triggers)}, std::move(local_algs)};
 

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -39,9 +39,12 @@ using events_and_triggers_tag =
     Tags::EventsAndTriggers<DefaultClasses, DefaultClasses>;
 
 struct Metavariables;
-struct component : ActionTesting::MockArrayComponent<
-                       Metavariables, int, tmpl::list<events_and_triggers_tag>,
-                       tmpl::list<Actions::RunEventsAndTriggers>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<events_and_triggers_tag>;
+  using action_list = tmpl::list<Actions::RunEventsAndTriggers>;
   using initial_databox = db::DataBox<tmpl::list<>>;
 };
 

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -62,7 +62,7 @@ void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
   using my_component = component;
   using LocalAlgsTag =
       typename MockRuntimeSystem::template LocalAlgorithmsTag<my_component>;
-  typename MockRuntimeSystem::LocalAlgorithms local_algs{};
+  typename MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs).emplace(0, db::DataBox<tmpl::list<>>{});
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
       {serialize_and_deserialize(events_and_triggers)}, std::move(local_algs)};

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -63,11 +63,15 @@ void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
   using MockDistributedObjectsTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<
           my_component>;
-  typename MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  typename MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(0, db::DataBox<tmpl::list<>>{});
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {serialize_and_deserialize(events_and_triggers)}, std::move(local_algs)};
+      {serialize_and_deserialize(events_and_triggers)},
+      std::move(dist_objects)};
+  auto& box = runner.template algorithms<my_component>()
+                  .at(0)
+                  .template get_databox<db::DataBox<tmpl::list<>>>();
 
   runner.next_action<component>(0);
 

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -58,13 +58,13 @@ void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
   Parallel::register_derived_classes_with_charm<Event<DefaultClasses>>();
   Parallel::register_derived_classes_with_charm<Trigger<DefaultClasses>>();
 
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using my_component = component;
   using LocalAlgsTag =
-      typename ActionRunner::template LocalAlgorithmsTag<my_component>;
-  typename ActionRunner::LocalAlgorithms local_algs{};
+      typename MockRuntimeSystem::template LocalAlgorithmsTag<my_component>;
+  typename MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs).emplace(0, db::DataBox<tmpl::list<>>{});
-  ActionTesting::ActionRunner<Metavariables> runner{
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
       {serialize_and_deserialize(events_and_triggers)}, std::move(local_algs)};
 
   runner.next_action<component>(0);

--- a/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
@@ -48,13 +48,14 @@ struct Metavariables {
 
 SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.Actions",
                   "[Unit][Evolution][VariableFixing]") {
-  using LocalAlgorithms =
-      typename ActionTesting::MockRuntimeSystem<Metavariables>::LocalAlgorithms;
+  using TupleOfMockDistributedObjects =
+      typename ActionTesting::MockRuntimeSystem<
+          Metavariables>::TupleOfMockDistributedObjects;
   using component = mock_component<Metavariables>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag =
       typename MockRuntimeSystem::template LocalAlgorithmsTag<component>;
-  LocalAlgorithms local_algs{};
+  TupleOfMockDistributedObjects local_algs{};
   const DataVector x{-2.0, -1.0, 0.0, 1.0, 2.0};
   const DataVector y{-2.0, -1.0, 0.0, 1.0, 2.0};
   const DataVector z{-2.0, -1.0, 0.0, 1.0, 2.0};

--- a/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
@@ -53,14 +53,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.Actions",
           Metavariables>::TupleOfMockDistributedObjects;
   using component = mock_component<Metavariables>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag =
-      typename MockRuntimeSystem::template LocalAlgorithmsTag<component>;
+  using MockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<component>;
   TupleOfMockDistributedObjects local_algs{};
   const DataVector x{-2.0, -1.0, 0.0, 1.0, 2.0};
   const DataVector y{-2.0, -1.0, 0.0, 1.0, 2.0};
   const DataVector z{-2.0, -1.0, 0.0, 1.0, 2.0};
 
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(0,
                ActionTesting::MockDistributedObject<component>{db::create<
                    db::AddSimpleTags<hydro::Tags::RestMassDensity<DataVector>,

--- a/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
@@ -61,7 +61,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.Actions",
 
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0,
-               ActionTesting::MockLocalAlgorithm<component>{db::create<
+               ActionTesting::MockDistributedObject<component>{db::create<
                    db::AddSimpleTags<hydro::Tags::RestMassDensity<DataVector>,
                                      hydro::Tags::Pressure<DataVector>,
                                      ::Tags::Coordinates<3, Frame::Inertial>>>(

--- a/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
@@ -28,10 +28,12 @@ using VariableFixer = VariableFixing::RadiallyFallingFloor<
     hydro::Tags::Pressure<DataVector>>;
 
 template <typename Metavariables>
-struct mock_component
-    : ActionTesting::MockArrayComponent<
-          Metavariables, size_t, tmpl::list<>,
-          tmpl::list<::Actions::ApplyVariableFixer<VariableFixer>>> {
+struct mock_component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<::Actions::ApplyVariableFixer<VariableFixer>>;
   using initial_databox = db::compute_databox_type<
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
                  hydro::Tags::Pressure<DataVector>,

--- a/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
@@ -49,11 +49,11 @@ struct Metavariables {
 SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.Actions",
                   "[Unit][Evolution][VariableFixing]") {
   using LocalAlgorithms =
-      typename ActionTesting::ActionRunner<Metavariables>::LocalAlgorithms;
+      typename ActionTesting::MockRuntimeSystem<Metavariables>::LocalAlgorithms;
   using component = mock_component<Metavariables>;
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag =
-      typename ActionRunner::template LocalAlgorithmsTag<component>;
+      typename MockRuntimeSystem::template LocalAlgorithmsTag<component>;
   LocalAlgorithms local_algs{};
   const DataVector x{-2.0, -1.0, 0.0, 1.0, 2.0};
   const DataVector y{-2.0, -1.0, 0.0, 1.0, 2.0};
@@ -69,7 +69,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.Actions",
                    Scalar<DataVector>{DataVector{0.0, 1.e-8, 2.0, -5.5, 3.2}},
                    tnsr::I<DataVector, 3, Frame::Inertial>{{{x, y, z}}})});
   const double radius_at_which_to_begin_applying_floor = 1.e-4;
-  ActionTesting::ActionRunner<Metavariables> runner{
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
       {radius_at_which_to_begin_applying_floor}, std::move(local_algs)};
   auto& box = runner.template algorithms<component>()
                   .at(0)

--- a/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_Actions.cpp
@@ -55,12 +55,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.Actions",
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using MockDistributedObjectsTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<component>;
-  TupleOfMockDistributedObjects local_algs{};
+  TupleOfMockDistributedObjects dist_objects{};
   const DataVector x{-2.0, -1.0, 0.0, 1.0, 2.0};
   const DataVector y{-2.0, -1.0, 0.0, 1.0, 2.0};
   const DataVector z{-2.0, -1.0, 0.0, 1.0, 2.0};
 
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(0,
                ActionTesting::MockDistributedObject<component>{db::create<
                    db::AddSimpleTags<hydro::Tags::RestMassDensity<DataVector>,
@@ -71,7 +71,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.Actions",
                    tnsr::I<DataVector, 3, Frame::Inertial>{{{x, y, z}}})});
   const double radius_at_which_to_begin_applying_floor = 1.e-4;
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
-      {radius_at_which_to_begin_applying_floor}, std::move(local_algs)};
+      {radius_at_which_to_begin_applying_floor}, std::move(dist_objects)};
   auto& box = runner.template algorithms<component>()
                   .at(0)
                   .template get_databox<typename component::initial_databox>();

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -42,12 +42,12 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Initialize", "[Unit][Observers]") {
   using ObserverMockDistributedObjectsTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<
           obs_component>;
-  TupleOfMockDistributedObjects local_algs{};
-  tuples::get<ObserverMockDistributedObjectsTag>(local_algs)
+  TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<ObserverMockDistributedObjectsTag>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
 
-  ActionTesting::MockRuntimeSystem<Metavariables> runner{{},
-                                                         std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {}, std::move(dist_objects)};
 
   runner.simple_action<obs_component, observers::Actions::Initialize>(0);
   const auto& observer_box =

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -42,7 +42,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Initialize", "[Unit][Observers]") {
       typename MockRuntimeSystem::template LocalAlgorithmsTag<obs_component>;
   LocalAlgorithms local_algs{};
   tuples::get<ObserverLocalAlgsTag>(local_algs)
-      .emplace(0, ActionTesting::MockLocalAlgorithm<obs_component>{});
+      .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{},
                                                          std::move(local_algs)};

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -19,9 +19,12 @@
 
 namespace {
 template <typename Metavariables>
-struct observer_component
-    : ActionTesting::MockArrayComponent<Metavariables, size_t, tmpl::list<>,
-                                        tmpl::list<>> {
+struct observer_component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
       typename observers::Actions::Initialize::return_tag_list>;
 };

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -39,10 +39,11 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Initialize", "[Unit][Observers]") {
           Metavariables>::TupleOfMockDistributedObjects;
   using obs_component = observer_component<Metavariables>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using ObserverLocalAlgsTag =
-      typename MockRuntimeSystem::template LocalAlgorithmsTag<obs_component>;
+  using ObserverMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          obs_component>;
   TupleOfMockDistributedObjects local_algs{};
-  tuples::get<ObserverLocalAlgsTag>(local_algs)
+  tuples::get<ObserverMockDistributedObjectsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{},

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -35,16 +35,17 @@ struct Metavariables {
 
 SPECTRE_TEST_CASE("Unit.IO.Observers.Initialize", "[Unit][Observers]") {
   using LocalAlgorithms =
-      typename ActionTesting::ActionRunner<Metavariables>::LocalAlgorithms;
+      typename ActionTesting::MockRuntimeSystem<Metavariables>::LocalAlgorithms;
   using obs_component = observer_component<Metavariables>;
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using ObserverLocalAlgsTag =
-      typename ActionRunner::template LocalAlgorithmsTag<obs_component>;
+      typename MockRuntimeSystem::template LocalAlgorithmsTag<obs_component>;
   LocalAlgorithms local_algs{};
   tuples::get<ObserverLocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockLocalAlgorithm<obs_component>{});
 
-  ActionTesting::ActionRunner<Metavariables> runner{{}, std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{},
+                                                         std::move(local_algs)};
 
   runner.simple_action<obs_component, observers::Actions::Initialize>(0);
   const auto& observer_box =

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -34,13 +34,14 @@ struct Metavariables {
 };
 
 SPECTRE_TEST_CASE("Unit.IO.Observers.Initialize", "[Unit][Observers]") {
-  using LocalAlgorithms =
-      typename ActionTesting::MockRuntimeSystem<Metavariables>::LocalAlgorithms;
+  using TupleOfMockDistributedObjects =
+      typename ActionTesting::MockRuntimeSystem<
+          Metavariables>::TupleOfMockDistributedObjects;
   using obs_component = observer_component<Metavariables>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using ObserverLocalAlgsTag =
       typename MockRuntimeSystem::template LocalAlgorithmsTag<obs_component>;
-  LocalAlgorithms local_algs{};
+  TupleOfMockDistributedObjects local_algs{};
   tuples::get<ObserverLocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
 

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -63,12 +63,14 @@ void check_observer_registration() {
   using element_comp = element_component<Metavariables>;
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using ObserverLocalAlgsTag =
-      typename MockRuntimeSystem::template LocalAlgorithmsTag<obs_component>;
-  using ElementLocalAlgsTag =
-      typename MockRuntimeSystem::template LocalAlgorithmsTag<element_comp>;
+  using ObserverMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          obs_component>;
+  using ElementMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          element_comp>;
   TupleOfMockDistributedObjects local_algs{};
-  tuples::get<ObserverLocalAlgsTag>(local_algs)
+  tuples::get<ObserverMockDistributedObjectsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
 
   // Specific IDs have no significance, just need different IDs.
@@ -78,7 +80,7 @@ void check_observer_registration() {
                                               {1, {{{1, 0}, {5, 4}}}},
                                               {0, {{{1, 0}, {1, 0}}}}};
   for (const auto& id : element_ids) {
-    tuples::get<ElementLocalAlgsTag>(local_algs)
+    tuples::get<ElementMockDistributedObjectsTag>(local_algs)
         .emplace(ElementIndex<2>{id},
                  ActionTesting::MockDistributedObject<element_comp>{});
   }

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -56,8 +56,9 @@ struct Metavariables {
 
 template <observers::TypeOfObservation TypeOfObservation>
 void check_observer_registration() {
-  using LocalAlgorithms =
-      typename ActionTesting::MockRuntimeSystem<Metavariables>::LocalAlgorithms;
+  using TupleOfMockDistributedObjects =
+      typename ActionTesting::MockRuntimeSystem<
+          Metavariables>::TupleOfMockDistributedObjects;
   using obs_component = observer_component<Metavariables>;
   using element_comp = element_component<Metavariables>;
 
@@ -66,7 +67,7 @@ void check_observer_registration() {
       typename MockRuntimeSystem::template LocalAlgorithmsTag<obs_component>;
   using ElementLocalAlgsTag =
       typename MockRuntimeSystem::template LocalAlgorithmsTag<element_comp>;
-  LocalAlgorithms local_algs{};
+  TupleOfMockDistributedObjects local_algs{};
   tuples::get<ObserverLocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
 

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -68,7 +68,7 @@ void check_observer_registration() {
       typename MockRuntimeSystem::template LocalAlgorithmsTag<element_comp>;
   LocalAlgorithms local_algs{};
   tuples::get<ObserverLocalAlgsTag>(local_algs)
-      .emplace(0, ActionTesting::MockLocalAlgorithm<obs_component>{});
+      .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
 
   // Specific IDs have no significance, just need different IDs.
   const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
@@ -79,7 +79,7 @@ void check_observer_registration() {
   for (const auto& id : element_ids) {
     tuples::get<ElementLocalAlgsTag>(local_algs)
         .emplace(ElementIndex<2>{id},
-                 ActionTesting::MockLocalAlgorithm<element_comp>{});
+                 ActionTesting::MockDistributedObject<element_comp>{});
   }
 
   ActionTesting::MockRuntimeSystem<Metavariables> runner{{},

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -102,6 +102,9 @@ void check_observer_registration() {
     runner.simple_action<
         element_comp,
         observers::Actions::RegisterWithObservers<TypeOfObservation>>(id, 0);
+    // Invoke the simple_action RegisterSenderWithSelf that was called on the
+    // observer component by the RegisterWithObservers action.
+    runner.invoke_queued_simple_action<obs_component>(0);
   }
 
   // Test registration occurred as expected

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -16,7 +16,7 @@
 #include "Domain/ElementIndex.hpp"
 #include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
 #include "IO/Observer/ArrayComponentId.hpp"
-#include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/Initialize.hpp"         // IWYU pragma: keep
 #include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
 #include "IO/Observer/Tags.hpp"               // IWYU pragma: keep
 #include "IO/Observer/TypeOfObservation.hpp"

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -69,8 +69,8 @@ void check_observer_registration() {
   using ElementMockDistributedObjectsTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<
           element_comp>;
-  TupleOfMockDistributedObjects local_algs{};
-  tuples::get<ObserverMockDistributedObjectsTag>(local_algs)
+  TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<ObserverMockDistributedObjectsTag>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
 
   // Specific IDs have no significance, just need different IDs.
@@ -80,13 +80,13 @@ void check_observer_registration() {
                                               {1, {{{1, 0}, {5, 4}}}},
                                               {0, {{{1, 0}, {1, 0}}}}};
   for (const auto& id : element_ids) {
-    tuples::get<ElementMockDistributedObjectsTag>(local_algs)
+    tuples::get<ElementMockDistributedObjectsTag>(dist_objects)
         .emplace(ElementIndex<2>{id},
                  ActionTesting::MockDistributedObject<element_comp>{});
   }
 
-  ActionTesting::MockRuntimeSystem<Metavariables> runner{{},
-                                                         std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {}, std::move(dist_objects)};
 
   runner.simple_action<obs_component, observers::Actions::Initialize>(0);
   // Test initial state

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -29,17 +29,24 @@ namespace {
 using ElementIndexType = ElementIndex<2>;
 
 template <typename Metavariables>
-struct element_component
-    : ActionTesting::MockArrayComponent<Metavariables, ElementIndexType,
-                                        tmpl::list<>, tmpl::list<>> {
+struct element_component {
+  using component_being_mocked = void;  // Not needed
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndexType;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
   using initial_databox = db::DataBox<tmpl::list<>>;
 };
 
 template <typename Metavariables>
-struct observer_component
-    : ActionTesting::MockArrayComponent<Metavariables, size_t, tmpl::list<>,
-                                        tmpl::list<>,
-                                        observers::Observer<Metavariables>> {
+struct observer_component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using component_being_mocked = observers::Observer<Metavariables>;
   using simple_tags = observers::Actions::Initialize::simple_tags;
   using compute_tags = observers::Actions::Initialize::compute_tags;
   using initial_databox =

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -57,15 +57,15 @@ struct Metavariables {
 template <observers::TypeOfObservation TypeOfObservation>
 void check_observer_registration() {
   using LocalAlgorithms =
-      typename ActionTesting::ActionRunner<Metavariables>::LocalAlgorithms;
+      typename ActionTesting::MockRuntimeSystem<Metavariables>::LocalAlgorithms;
   using obs_component = observer_component<Metavariables>;
   using element_comp = element_component<Metavariables>;
 
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using ObserverLocalAlgsTag =
-      typename ActionRunner::template LocalAlgorithmsTag<obs_component>;
+      typename MockRuntimeSystem::template LocalAlgorithmsTag<obs_component>;
   using ElementLocalAlgsTag =
-      typename ActionRunner::template LocalAlgorithmsTag<element_comp>;
+      typename MockRuntimeSystem::template LocalAlgorithmsTag<element_comp>;
   LocalAlgorithms local_algs{};
   tuples::get<ObserverLocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockLocalAlgorithm<obs_component>{});
@@ -82,7 +82,8 @@ void check_observer_registration() {
                  ActionTesting::MockLocalAlgorithm<element_comp>{});
   }
 
-  ActionTesting::ActionRunner<Metavariables> runner{{}, std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{},
+                                                         std::move(local_algs)};
 
   runner.simple_action<obs_component, observers::Actions::Initialize>(0);
   // Test initial state

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
@@ -195,17 +195,17 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ApplyBoundaryFluxesGlobalTimeStepping",
                         Tags::dt<Tags::Variables<tmpl::list<Tags::dt<Var>>>>,
                         mortar_data_tag>;
 
-  using ActionRunner =
-      ActionTesting::ActionRunner<Metavariables<2, NumericalFlux>>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<
+  using MockRuntimeSystem =
+      ActionTesting::MockRuntimeSystem<Metavariables<2, NumericalFlux>>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<
       component<2, NumericalFlux, Metavariables<2, NumericalFlux>>>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(id, db::create<simple_tags>(mesh, logical_coordinates(mesh),
                                            std::move(mortar_meshes),
                                            std::move(mortar_sizes), initial_dt,
                                            std::move(mortar_data)));
-  ActionRunner runner{{NumericalFlux{}}, std::move(local_algs)};
+  MockRuntimeSystem runner{{NumericalFlux{}}, std::move(local_algs)};
 
   runner.next_action<my_component>(id);
 
@@ -305,15 +305,15 @@ SPECTRE_TEST_CASE(
         typename mortar_data_tag::type{});
   };
 
-  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<
       component<3, RefinementNumericalFlux, metavariables>>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(id_0, make_initial_box({{3, 4, 5}}));
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(id_1, make_initial_box({{4, 2, 6}}));
-  ActionRunner runner{{RefinementNumericalFlux{}}, std::move(local_algs)};
+  MockRuntimeSystem runner{{RefinementNumericalFlux{}}, std::move(local_algs)};
 
   auto& box1 = runner.algorithms<my_component>()
                    .at(id_0)
@@ -462,10 +462,10 @@ SPECTRE_TEST_CASE(
                         mortar_data_tag>;
   using db_type = db::compute_databox_type<simple_tags>;
 
-  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<
       component<3, RefinementNumericalFlux, metavariables>>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(self_id,
                db::create<simple_tags>(mesh, logical_coordinates(mesh),
@@ -569,7 +569,7 @@ SPECTRE_TEST_CASE(
   add_neighbor({{MortarSize::LowerHalf, MortarSize::LowerHalf}}, {{-0.5, -0.5}},
                {{0.5, 0.5}}, ElementId<3>{13});
 
-  ActionRunner runner{{RefinementNumericalFlux{}}, std::move(local_algs)};
+  MockRuntimeSystem runner{{RefinementNumericalFlux{}}, std::move(local_algs)};
   runner.next_action<my_component>(self_id);
 
   // These ids don't describe elements that fit together correctly,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
@@ -95,10 +95,13 @@ struct System {
 };
 
 template <size_t Dim, typename Flux, typename Metavariables>
-struct component
-    : ActionTesting::MockArrayComponent<
-          Metavariables, ElementIndex<Dim>, tmpl::list<NumericalFluxTag<Flux>>,
-          tmpl::list<dg::Actions::ApplyBoundaryFluxesGlobalTimeStepping>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<Dim>;
+  using const_global_cache_tag_list = tmpl::list<NumericalFluxTag<Flux>>;
+  using action_list =
+      tmpl::list<dg::Actions::ApplyBoundaryFluxesGlobalTimeStepping>;
   using initial_databox = db::compute_databox_type<
       tmpl::list<Tags::Mesh<Dim>, Tags::Coordinates<Dim, Frame::Logical>,
                  Tags::Mortars<Tags::Mesh<Dim - 1>, Dim>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
@@ -199,7 +199,7 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ApplyBoundaryFluxesGlobalTimeStepping",
       ActionTesting::MockRuntimeSystem<Metavariables<2, NumericalFlux>>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<
       component<2, NumericalFlux, Metavariables<2, NumericalFlux>>>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(id, db::create<simple_tags>(mesh, logical_coordinates(mesh),
                                            std::move(mortar_meshes),
@@ -308,7 +308,7 @@ SPECTRE_TEST_CASE(
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<
       component<3, RefinementNumericalFlux, metavariables>>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(id_0, make_initial_box({{3, 4, 5}}));
   tuples::get<LocalAlgsTag>(local_algs)
@@ -465,7 +465,7 @@ SPECTRE_TEST_CASE(
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<
       component<3, RefinementNumericalFlux, metavariables>>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(self_id,
                db::create<simple_tags>(mesh, logical_coordinates(mesh),

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesGlobalTimeStepping.cpp
@@ -197,10 +197,11 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ApplyBoundaryFluxesGlobalTimeStepping",
 
   using MockRuntimeSystem =
       ActionTesting::MockRuntimeSystem<Metavariables<2, NumericalFlux>>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<
-      component<2, NumericalFlux, Metavariables<2, NumericalFlux>>>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<
+          component<2, NumericalFlux, Metavariables<2, NumericalFlux>>>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(id, db::create<simple_tags>(mesh, logical_coordinates(mesh),
                                            std::move(mortar_meshes),
                                            std::move(mortar_sizes), initial_dt,
@@ -306,12 +307,13 @@ SPECTRE_TEST_CASE(
   };
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<
-      component<3, RefinementNumericalFlux, metavariables>>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<
+          component<3, RefinementNumericalFlux, metavariables>>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(id_0, make_initial_box({{3, 4, 5}}));
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(id_1, make_initial_box({{4, 2, 6}}));
   MockRuntimeSystem runner{{RefinementNumericalFlux{}}, std::move(local_algs)};
 
@@ -463,10 +465,11 @@ SPECTRE_TEST_CASE(
   using db_type = db::compute_databox_type<simple_tags>;
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<
-      component<3, RefinementNumericalFlux, metavariables>>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<
+          component<3, RefinementNumericalFlux, metavariables>>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(self_id,
                db::create<simple_tags>(mesh, logical_coordinates(mesh),
                                        typename mortar_meshes_tag::type{},
@@ -529,7 +532,7 @@ SPECTRE_TEST_CASE(
         mesh.extents(), direction.dimension(),
         index_to_slice_at(mesh.extents(), direction));
 
-    tuples::get<LocalAlgsTag>(local_algs)
+    tuples::get<MockDistributedObjectsTag>(local_algs)
         .emplace(neighbor_id, db::create<simple_tags>(
                                   mesh, std::move(neighbor_coords),
                                   typename mortar_meshes_tag::type{
@@ -542,7 +545,7 @@ SPECTRE_TEST_CASE(
                                   std::move(neighbor_dt_vars),
                                   std::move(neighbor_mortar_data)));
 
-    auto& self_box = tuples::get<LocalAlgsTag>(local_algs)
+    auto& self_box = tuples::get<MockDistributedObjectsTag>(local_algs)
                          .at(self_id)
                          .get_databox<db_type>();
     db::mutate<mortar_data_tag, mortar_meshes_tag, mortar_sizes_tag>(

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -169,14 +169,14 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ApplyBoundaryFluxesLocalTimeStepping",
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<component<Metavariables>>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(id, db::create<typename component<Metavariables>::simple_tags>(
                        mesh, mortar_meshes, mortar_sizes, time_step, variables,
                        std::move(mortar_data)));
   MockRuntimeSystem runner{
       {std::make_unique<TimeSteppers::AdamsBashforthN>(1), NumericalFlux{}},
-      std::move(local_algs)};
+      std::move(dist_objects)};
 
   runner.next_action<component<Metavariables>>(id);
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -166,15 +166,15 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ApplyBoundaryFluxesLocalTimeStepping",
   mortar_data[fast_mortar].remote_insert(TimeId(true, 0, now + time_step / 3),
                                          gsl::at(remote_data, 2));
 
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag =
-      ActionRunner::LocalAlgorithmsTag<component<Metavariables>>;
-  ActionRunner::LocalAlgorithms local_algs{};
+      MockRuntimeSystem::LocalAlgorithmsTag<component<Metavariables>>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(id, db::create<typename component<Metavariables>::simple_tags>(
                        mesh, mortar_meshes, mortar_sizes, time_step, variables,
                        std::move(mortar_data)));
-  ActionRunner runner{
+  MockRuntimeSystem runner{
       {std::make_unique<TimeSteppers::AdamsBashforthN>(1), NumericalFlux{}},
       std::move(local_algs)};
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -77,11 +77,14 @@ struct System {
 };
 
 template <typename Metavariables>
-struct component
-    : ActionTesting::MockArrayComponent<
-          Metavariables, ElementIndex<2>,
-          tmpl::list<OptionTags::TimeStepper, NumericalFluxTag>,
-          tmpl::list<dg::Actions::ApplyBoundaryFluxesLocalTimeStepping>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<2>;
+  using const_global_cache_tag_list =
+      tmpl::list<OptionTags::TimeStepper, NumericalFluxTag>;
+  using action_list =
+      tmpl::list<dg::Actions::ApplyBoundaryFluxesLocalTimeStepping>;
   using simple_tags =
       db::AddSimpleTags<Tags::Mesh<2>, Tags::Mortars<Tags::Mesh<1>, 2>,
                         Tags::Mortars<Tags::MortarSize<1>, 2>, Tags::TimeStep,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -167,10 +167,10 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ApplyBoundaryFluxesLocalTimeStepping",
                                          gsl::at(remote_data, 2));
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag =
-      MockRuntimeSystem::LocalAlgorithmsTag<component<Metavariables>>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component<Metavariables>>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(id, db::create<typename component<Metavariables>::simple_tags>(
                        mesh, mortar_meshes, mortar_sizes, time_step, variables,
                        std::move(mortar_data)));

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -169,7 +169,7 @@ SPECTRE_TEST_CASE("Unit.DG.Actions.ApplyBoundaryFluxesLocalTimeStepping",
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag =
       MockRuntimeSystem::LocalAlgorithmsTag<component<Metavariables>>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(id, db::create<typename component<Metavariables>::simple_tags>(
                        mesh, mortar_meshes, mortar_sizes, time_step, variables,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -151,9 +151,10 @@ auto run_action(
   using compute_tags = typename component::compute_tags;
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(ElementIndex<2>{element.id()},
                ActionTesting::MockDistributedObject<component>{
                    db::create<simple_tags, compute_tags>(

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -101,10 +101,13 @@ using VarsType = Variables<tmpl::list<Var, Var2>>;
 
 struct Metavariables;
 
-struct component
-    : ActionTesting::MockArrayComponent<
-          Metavariables, ElementIndex<2>, tmpl::list<>,
-          tmpl::list<dg::Actions::ComputeNonconservativeBoundaryFluxes>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<2>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list =
+      tmpl::list<dg::Actions::ComputeNonconservativeBoundaryFluxes>;
   using simple_tags =
       db::AddSimpleTags<Tags::Element<2>, Tags::Mesh<2>, Tags::ElementMap<2>,
                         interface_tag<Tags::Variables<tmpl::list<Var, Var2>>>,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -155,7 +155,7 @@ auto run_action(
   MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(ElementIndex<2>{element.id()},
-               ActionTesting::MockLocalAlgorithm<component>{
+               ActionTesting::MockDistributedObject<component>{
                    db::create<simple_tags, compute_tags>(
                        element, mesh, std::move(element_map), vars, other_arg,
                        std::move(n_dot_f_storage))});

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -153,14 +153,14 @@ auto run_action(
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(ElementIndex<2>{element.id()},
                ActionTesting::MockDistributedObject<component>{
                    db::create<simple_tags, compute_tags>(
                        element, mesh, std::move(element_map), vars, other_arg,
                        std::move(n_dot_f_storage))});
-  MockRuntimeSystem runner{{}, std::move(local_algs)};
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
   runner.next_action<component>(element.id());
   // std::move call on returned value is intentional.
   return std::move(runner.algorithms<component>()

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -152,7 +152,7 @@ auto run_action(
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(ElementIndex<2>{element.id()},
                ActionTesting::MockDistributedObject<component>{

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -150,16 +150,16 @@ auto run_action(
   using simple_tags = typename component::simple_tags;
   using compute_tags = typename component::compute_tags;
 
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(ElementIndex<2>{element.id()},
                ActionTesting::MockLocalAlgorithm<component>{
                    db::create<simple_tags, compute_tags>(
                        element, mesh, std::move(element_map), vars, other_arg,
                        std::move(n_dot_f_storage))});
-  ActionRunner runner{{}, std::move(local_algs)};
+  MockRuntimeSystem runner{{}, std::move(local_algs)};
   runner.next_action<component>(element.id());
   // std::move call on returned value is intentional.
   return std::move(runner.algorithms<component>()

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -155,11 +155,14 @@ template <size_t Dim>
 using mortar_sizes_tag = Tags::Mortars<Tags::MortarSize<Dim - 1>, Dim>;
 
 template <size_t Dim, typename Metavariables>
-struct component
-    : ActionTesting::MockArrayComponent<
-          Metavariables, ElementIndex<Dim>, tmpl::list<NumericalFluxTag<Dim>>,
-          tmpl::list<dg::Actions::SendDataForFluxes<Metavariables>,
-                     dg::Actions::ReceiveDataForFluxes<Metavariables>>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<Dim>;
+  using const_global_cache_tag_list = tmpl::list<NumericalFluxTag<Dim>>;
+  using action_list =
+      tmpl::list<dg::Actions::SendDataForFluxes<Metavariables>,
+                 dg::Actions::ReceiveDataForFluxes<Metavariables>>;
   using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
 
   using simple_tags =

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -370,22 +370,22 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(self_id, std::move(start_box));
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(south_id,
                create_neighbor_databox(
                    south_id, Direction<2>::lower_eta(), {},
                    data.remote_fluxes.at(Direction<2>::upper_eta()),
                    data.remote_other_data.at(Direction<2>::upper_eta())));
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(east_id,
                create_neighbor_databox(
                    east_id, Direction<2>::lower_xi(), {},
                    data.remote_fluxes.at(Direction<2>::upper_xi()),
                    data.remote_other_data.at(Direction<2>::upper_xi())));
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(west_id,
                create_neighbor_databox(
                    west_id, Direction<2>::lower_eta(),
@@ -394,7 +394,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
                    data.remote_other_data.at(Direction<2>::lower_xi())));
 
   ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
-      {NumericalFlux<2>{}}, std::move(local_algs)};
+      {NumericalFlux<2>{}}, std::move(dist_objects)};
 
   using initial_databox_type = db::compute_databox_type<tmpl::append<
       db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
@@ -549,8 +549,8 @@ SPECTRE_TEST_CASE(
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(
           self_id,
           db::create<simple_tags,
@@ -563,7 +563,7 @@ SPECTRE_TEST_CASE(
               db::item_type<mortar_meshes_tag<2>>{},
               db::item_type<mortar_sizes_tag<2>>{}));
   ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
-      {NumericalFlux<2>{}}, std::move(local_algs)};
+      {NumericalFlux<2>{}}, std::move(dist_objects)};
 
   runner.next_action<my_component>(self_id);
 
@@ -655,8 +655,8 @@ SPECTRE_TEST_CASE(
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(
           self_id,
           db::create<simple_tags, compute_items<my_component>>(
@@ -670,7 +670,7 @@ SPECTRE_TEST_CASE(
                   {mortar_id,
                    {{Spectral::MortarSize::Full,
                      Spectral::MortarSize::Full}}}}));
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(
           neighbor_id,
           db::create<simple_tags, compute_items<my_component>>(
@@ -683,8 +683,8 @@ SPECTRE_TEST_CASE(
               db::item_type<mortar_meshes_tag<3>>{{mortar_id, face_mesh}},
               db::item_type<mortar_sizes_tag<3>>{{mortar_id, {{}}}}));
 
-  ActionTesting::MockRuntimeSystem<metavariables> runner{{NumericalFlux<3>{}},
-                                                         std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {NumericalFlux<3>{}}, std::move(dist_objects)};
 
   runner.next_action<my_component>(self_id);
 
@@ -786,8 +786,8 @@ SPECTRE_TEST_CASE(
     using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
     using MockDistributedObjectsTag =
         MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
-    MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-    tuples::get<MockDistributedObjectsTag>(local_algs)
+    MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+    tuples::get<MockDistributedObjectsTag>(dist_objects)
         .emplace(
             self_id,
             db::create<
@@ -807,7 +807,7 @@ SPECTRE_TEST_CASE(
                 db::item_type<mortar_meshes_tag<2>>{{mortar_id, face_mesh}},
                 db::item_type<mortar_sizes_tag<2>>{
                     {mortar_id, {{test.first}}}}));
-    tuples::get<MockDistributedObjectsTag>(local_algs)
+    tuples::get<MockDistributedObjectsTag>(dist_objects)
         .emplace(
             neighbor_id,
             db::create<
@@ -830,7 +830,7 @@ SPECTRE_TEST_CASE(
                     {mortar_id, {{test.first}}}}));
 
     ActionTesting::MockRuntimeSystem<metavariables> runner{
-        {NumericalFlux<2>{}}, std::move(local_algs)};
+        {NumericalFlux<2>{}}, std::move(dist_objects)};
 
     runner.next_action<my_component>(self_id);
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -369,7 +369,7 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs).emplace(self_id, std::move(start_box));
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(south_id,
@@ -546,7 +546,7 @@ SPECTRE_TEST_CASE(
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(
           self_id,
@@ -651,7 +651,7 @@ SPECTRE_TEST_CASE(
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(
           self_id,
@@ -781,7 +781,7 @@ SPECTRE_TEST_CASE(
 
     using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
     using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
-    MockRuntimeSystem::LocalAlgorithms local_algs{};
+    MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
     tuples::get<LocalAlgsTag>(local_algs)
         .emplace(
             self_id,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -368,22 +368,24 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
   };
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs).emplace(self_id, std::move(start_box));
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
+      .emplace(self_id, std::move(start_box));
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(south_id,
                create_neighbor_databox(
                    south_id, Direction<2>::lower_eta(), {},
                    data.remote_fluxes.at(Direction<2>::upper_eta()),
                    data.remote_other_data.at(Direction<2>::upper_eta())));
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(east_id,
                create_neighbor_databox(
                    east_id, Direction<2>::lower_xi(), {},
                    data.remote_fluxes.at(Direction<2>::upper_xi()),
                    data.remote_other_data.at(Direction<2>::upper_xi())));
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(west_id,
                create_neighbor_databox(
                    west_id, Direction<2>::lower_eta(),
@@ -545,9 +547,10 @@ SPECTRE_TEST_CASE(
                        {-1., 1., 3., 7.}, {-1., 1., -2., 4.})));
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(
           self_id,
           db::create<simple_tags,
@@ -650,9 +653,10 @@ SPECTRE_TEST_CASE(
       tmpl::append<simple_tags, compute_items<my_component>>>;
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(
           self_id,
           db::create<simple_tags, compute_items<my_component>>(
@@ -666,7 +670,7 @@ SPECTRE_TEST_CASE(
                   {mortar_id,
                    {{Spectral::MortarSize::Full,
                      Spectral::MortarSize::Full}}}}));
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(
           neighbor_id,
           db::create<simple_tags, compute_items<my_component>>(
@@ -780,9 +784,10 @@ SPECTRE_TEST_CASE(
                                            0.);
 
     using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
-    using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
+    using MockDistributedObjectsTag =
+        MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
     MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-    tuples::get<LocalAlgsTag>(local_algs)
+    tuples::get<MockDistributedObjectsTag>(local_algs)
         .emplace(
             self_id,
             db::create<
@@ -802,7 +807,7 @@ SPECTRE_TEST_CASE(
                 db::item_type<mortar_meshes_tag<2>>{{mortar_id, face_mesh}},
                 db::item_type<mortar_sizes_tag<2>>{
                     {mortar_id, {{test.first}}}}));
-    tuples::get<LocalAlgsTag>(local_algs)
+    tuples::get<MockDistributedObjectsTag>(local_algs)
         .emplace(
             neighbor_id,
             db::create<

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -367,9 +367,9 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
         std::move(mortar_meshes), std::move(mortar_sizes));
   };
 
-  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<my_component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs).emplace(self_id, std::move(start_box));
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(south_id,
@@ -391,8 +391,8 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
                    data.remote_fluxes.at(Direction<2>::lower_xi()),
                    data.remote_other_data.at(Direction<2>::lower_xi())));
 
-  ActionTesting::ActionRunner<Metavariables<2>> runner{{NumericalFlux<2>{}},
-                                                       std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
+      {NumericalFlux<2>{}}, std::move(local_algs)};
 
   using initial_databox_type = db::compute_databox_type<tmpl::append<
       db::AddSimpleTags<TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
@@ -544,9 +544,9 @@ SPECTRE_TEST_CASE(
                                                   CoordinateMaps::Affine>(
                        {-1., 1., 3., 7.}, {-1., 1., -2., 4.})));
 
-  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<my_component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(
           self_id,
@@ -559,8 +559,8 @@ SPECTRE_TEST_CASE(
               db::item_type<mortar_next_temporal_ids_tag<2>>{},
               db::item_type<mortar_meshes_tag<2>>{},
               db::item_type<mortar_sizes_tag<2>>{}));
-  ActionTesting::ActionRunner<Metavariables<2>> runner{{NumericalFlux<2>{}},
-                                                       std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
+      {NumericalFlux<2>{}}, std::move(local_algs)};
 
   runner.next_action<my_component>(self_id);
 
@@ -649,9 +649,9 @@ SPECTRE_TEST_CASE(
   using initial_databox_type = db::compute_databox_type<
       tmpl::append<simple_tags, compute_items<my_component>>>;
 
-  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<my_component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(
           self_id,
@@ -679,8 +679,8 @@ SPECTRE_TEST_CASE(
               db::item_type<mortar_meshes_tag<3>>{{mortar_id, face_mesh}},
               db::item_type<mortar_sizes_tag<3>>{{mortar_id, {{}}}}));
 
-  ActionTesting::ActionRunner<metavariables> runner{{NumericalFlux<3>{}},
-                                                    std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{NumericalFlux<3>{}},
+                                                         std::move(local_algs)};
 
   runner.next_action<my_component>(self_id);
 
@@ -779,9 +779,9 @@ SPECTRE_TEST_CASE(
     other_data[mortar_id.first].initialize(face_mesh.number_of_grid_points(),
                                            0.);
 
-    using ActionRunner = ActionTesting::ActionRunner<metavariables>;
-    using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<my_component>;
-    ActionRunner::LocalAlgorithms local_algs{};
+    using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+    using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
+    MockRuntimeSystem::LocalAlgorithms local_algs{};
     tuples::get<LocalAlgsTag>(local_algs)
         .emplace(
             self_id,
@@ -824,8 +824,8 @@ SPECTRE_TEST_CASE(
                 db::item_type<mortar_sizes_tag<2>>{
                     {mortar_id, {{test.first}}}}));
 
-    ActionTesting::ActionRunner<metavariables> runner{{NumericalFlux<2>{}},
-                                                      std::move(local_algs)};
+    ActionTesting::MockRuntimeSystem<metavariables> runner{
+        {NumericalFlux<2>{}}, std::move(local_algs)};
 
     runner.next_action<my_component>(self_id);
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -318,9 +318,10 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
       {right_mortar_id, right_steps.front()}};
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(
           self_id,
           ActionTesting::MockDistributedObject<my_component>{db::create<
@@ -352,10 +353,12 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
   const Element<2> right_element(right_id,
                                  {{Direction<2>::lower_xi(), {{self_id}, {}}}});
 
-  insert_neighbor(make_not_null(&tuples::get<LocalAlgsTag>(local_algs)),
-                  left_element, 0, 1, 0.0);
-  insert_neighbor(make_not_null(&tuples::get<LocalAlgsTag>(local_algs)),
-                  right_element, 0, 1, 0.0);
+  insert_neighbor(
+      make_not_null(&tuples::get<MockDistributedObjectsTag>(local_algs)),
+      left_element, 0, 1, 0.0);
+  insert_neighbor(
+      make_not_null(&tuples::get<MockDistributedObjectsTag>(local_algs)),
+      right_element, 0, 1, 0.0);
 
   ActionTesting::MockRuntimeSystem<metavariables> runner{{NumericalFlux<2>{}},
                                                          std::move(local_algs)};

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -319,7 +319,7 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(
           self_id,

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -214,7 +214,7 @@ struct DataRecorder {
   std::vector<std::pair<int, PackagedData<flux_comm_types<2>>>> received_data{};
 };
 
-// Inserts the new neighbor element into the ActionRunner
+// Inserts the new neighbor element into the MockRuntimeSystem
 template <typename LocalAlg>
 void insert_neighbor(const gsl::not_null<LocalAlg*> local_alg,
                      const Element<2>& element, const int start, const int end,
@@ -264,7 +264,7 @@ void insert_neighbor(const gsl::not_null<LocalAlg*> local_alg,
 
 // Update the time and flux, then send the data
 void send_from_neighbor(
-    const gsl::not_null<ActionTesting::ActionRunner<LtsMetavariables<2>>*>
+    const gsl::not_null<ActionTesting::MockRuntimeSystem<LtsMetavariables<2>>*>
         runner,
     const Element<2>& element, const int start, const int end,
     const double n_dot_f) noexcept {
@@ -317,9 +317,9 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
       {left_mortar_id, left_steps.front()},
       {right_mortar_id, right_steps.front()}};
 
-  using ActionRunner = ActionTesting::ActionRunner<metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<my_component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<my_component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(
           self_id,
@@ -357,8 +357,8 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
   insert_neighbor(make_not_null(&tuples::get<LocalAlgsTag>(local_algs)),
                   right_element, 0, 1, 0.0);
 
-  ActionTesting::ActionRunner<metavariables> runner{{NumericalFlux<2>{}},
-                                                    std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{NumericalFlux<2>{}},
+                                                         std::move(local_algs)};
 
   runner.next_action<my_component>(self_id);  // SendDataForFluxes
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -155,11 +155,13 @@ struct MortarRecorderTag : Tags::VariablesBoundaryData,
                            Tags::Mortars<DataRecorderTag, 2> {};
 
 template <size_t Dim, typename MV>
-struct lts_component
-    : ActionTesting::MockArrayComponent<
-          MV, ElementIndex<Dim>, tmpl::list<NumericalFluxTag<Dim>>,
-          tmpl::list<dg::Actions::SendDataForFluxes<MV>,
-                     dg::Actions::ReceiveDataForFluxes<MV>>> {
+struct lts_component {
+  using metavariables = MV;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<Dim>;
+  using const_global_cache_tag_list = tmpl::list<NumericalFluxTag<Dim>>;
+  using action_list = tmpl::list<dg::Actions::SendDataForFluxes<MV>,
+                                 dg::Actions::ReceiveDataForFluxes<MV>>;
   using flux_comm_types = dg::FluxCommunicationTypes<MV>;
 
   using simple_tags = db::AddSimpleTags<

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -320,8 +320,8 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(
           self_id,
           ActionTesting::MockDistributedObject<my_component>{db::create<
@@ -354,14 +354,14 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
                                  {{Direction<2>::lower_xi(), {{self_id}, {}}}});
 
   insert_neighbor(
-      make_not_null(&tuples::get<MockDistributedObjectsTag>(local_algs)),
+      make_not_null(&tuples::get<MockDistributedObjectsTag>(dist_objects)),
       left_element, 0, 1, 0.0);
   insert_neighbor(
-      make_not_null(&tuples::get<MockDistributedObjectsTag>(local_algs)),
+      make_not_null(&tuples::get<MockDistributedObjectsTag>(dist_objects)),
       right_element, 0, 1, 0.0);
 
-  ActionTesting::MockRuntimeSystem<metavariables> runner{{NumericalFlux<2>{}},
-                                                         std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {NumericalFlux<2>{}}, std::move(dist_objects)};
 
   runner.next_action<my_component>(self_id);  // SendDataForFluxes
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -323,7 +323,7 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(
           self_id,
-          ActionTesting::MockLocalAlgorithm<my_component>{db::create<
+          ActionTesting::MockDistributedObject<my_component>{db::create<
               db::AddSimpleTags<
                   TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>,
                   Tags::Element<2>, Tags::ElementMap<2>,

--- a/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCache.cpp
@@ -152,7 +152,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
                          tmpl::list<name, age, height, shape_of_nametag>>,
         "Wrong tag_list in ConstGlobalCache test");
 
-    tuples::TaggedTupleTypelist<tag_list> const_data_to_be_cached(
+    tuples::tagged_tuple_from_typelist<tag_list> const_data_to_be_cached(
         "Nobody", 178, 2.2, std::make_unique<Square>());
     Parallel::ConstGlobalCache<TestMetavariables> cache(
         std::move(const_data_to_be_cached));
@@ -171,7 +171,7 @@ SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCache", "[Unit][Parallel]") {
                          tmpl::list<name, age, height, shape_of_nametag>>,
         "Wrong tag_list in ConstGlobalCache test");
 
-    tuples::TaggedTupleTypelist<tag_list> const_data_to_be_cached(
+    tuples::tagged_tuple_from_typelist<tag_list> const_data_to_be_cached(
         "Nobody", 178, 2.2, std::make_unique<Square>());
 
     Parallel::CProxy_ConstGlobalCache<TestMetavariables>

--- a/tests/Unit/Test_ActionTesting.cpp
+++ b/tests/Unit/Test_ActionTesting.cpp
@@ -37,9 +37,12 @@ struct PassedToB : db::SimpleTag {
 };
 
 template <typename Metavariables>
-struct component_for_simple_action_mock
-    : ActionTesting::MockArrayComponent<Metavariables, size_t, tmpl::list<>,
-                                        tmpl::list<>> {
+struct component_for_simple_action_mock {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
   using initial_databox =
       db::compute_databox_type<tmpl::list<ValueTag, PassedToB>>;
 

--- a/tests/Unit/Test_ActionTesting.cpp
+++ b/tests/Unit/Test_ActionTesting.cpp
@@ -1,0 +1,174 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+// IWYU pragma: no_forward_declare db::DataBox
+
+namespace {
+struct simple_action_a;
+struct simple_action_a_mock;
+struct simple_action_c;
+struct simple_action_c_mock;
+
+struct ValueTag : db::SimpleTag {
+  using type = int;
+  static std::string name() noexcept { return "ValueTag"; }
+};
+
+struct PassedToB : db::SimpleTag {
+  using type = int;
+  static std::string name() noexcept { return "PassedToB"; }
+};
+
+template <typename Metavariables>
+struct component_for_simple_action_mock
+    : ActionTesting::MockArrayComponent<Metavariables, size_t, tmpl::list<>,
+                                        tmpl::list<>> {
+  using initial_databox =
+      db::compute_databox_type<tmpl::list<ValueTag, PassedToB>>;
+
+  using replace_these_simple_actions =
+      tmpl::list<simple_action_a, simple_action_c>;
+  using with_these_simple_actions =
+      tmpl::list<simple_action_a_mock, simple_action_c_mock>;
+};
+
+struct simple_action_a_mock {
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent, typename ArrayIndex>
+  static void apply(
+      db::DataBox<tmpl::list<ValueTag, PassedToB>>& box,  // NOLINT
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/, const int value) noexcept {
+    db::mutate<ValueTag>(
+        make_not_null(&box), [&value](
+                                 const gsl::not_null<int*> value_box) noexcept {
+          *value_box = value;
+        });
+  }
+};
+
+struct simple_action_b {
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent, typename ArrayIndex>
+  static void apply(
+      db::DataBox<tmpl::list<ValueTag, PassedToB>>& box,  // NOLINT
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,  // NOLINT
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/, const int to_call) noexcept {
+    // simple_action_b is the action that we are testing, but it calls some
+    // other actions that we don't want to test. Those are mocked where the body
+    // of the mock actions records something in the DataBox that we check to
+    // verify the mock actions were actually called.
+    //
+    // We do some "work" here by updating the `PassedToB` tag in the DataBox.
+    db::mutate<PassedToB>(
+        make_not_null(&box), [&to_call](const gsl::not_null<int*>
+                                            passed_to_b) noexcept {
+          *passed_to_b = to_call;
+        });
+    if (to_call == 0) {
+      Parallel::simple_action<simple_action_a>(
+          Parallel::get_parallel_component<
+              component_for_simple_action_mock<Metavariables>>(cache),
+          11);
+    } else if (to_call == 1) {
+      Parallel::simple_action<simple_action_a>(
+          Parallel::get_parallel_component<
+              component_for_simple_action_mock<Metavariables>>(cache),
+          14);
+    } else if (to_call == 2) {
+      Parallel::simple_action<simple_action_c>(
+          Parallel::get_parallel_component<
+              component_for_simple_action_mock<Metavariables>>(cache));
+    } else if (to_call == 3) {
+      Parallel::simple_action<simple_action_c>(
+          Parallel::get_parallel_component<
+              component_for_simple_action_mock<Metavariables>>(cache)[0]);
+    } else {
+      ERROR("to_call should be 0, 1, 2, or 3");
+    }
+  }
+};
+
+struct simple_action_c_mock {
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent, typename ArrayIndex>
+  static void apply(
+      db::DataBox<tmpl::list<ValueTag, PassedToB>>& box,  // NOLINT
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<ValueTag>(
+        make_not_null(&box), [](const gsl::not_null<int*> value_box) noexcept {
+          *value_box = 25;
+        });
+  }
+};
+
+struct SimpleActionMockMetavariables {
+  using component_list = tmpl::list<
+      component_for_simple_action_mock<SimpleActionMockMetavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  enum class Phase { Initialize, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
+  using metavars = SimpleActionMockMetavariables;
+  using LocalAlgorithms =
+      typename ActionTesting::ActionRunner<metavars>::LocalAlgorithms;
+  using ActionRunner = ActionTesting::ActionRunner<metavars>;
+  LocalAlgorithms local_algs{};
+  using LocalAlgTag = typename ActionRunner::template LocalAlgorithmsTag<
+      component_for_simple_action_mock<metavars>>;
+  tuples::get<LocalAlgTag>(local_algs)
+      .emplace(0,
+               ActionTesting::MockLocalAlgorithm<
+                   component_for_simple_action_mock<metavars>>{
+                   db::create<db::AddSimpleTags<ValueTag, PassedToB>>(0, -1)});
+  ActionTesting::ActionRunner<metavars> runner{{}, std::move(local_algs)};
+  const auto& box =
+      runner.template algorithms<component_for_simple_action_mock<metavars>>()
+          .at(0)
+          .template get_databox<typename component_for_simple_action_mock<
+              metavars>::initial_databox>();
+  CHECK(db::get<PassedToB>(box) == -1);
+  runner.simple_action<component_for_simple_action_mock<metavars>,
+                       simple_action_b>(0, 0);
+  CHECK(db::get<PassedToB>(box) == 0);
+  CHECK(db::get<ValueTag>(box) == 11);
+  runner.simple_action<component_for_simple_action_mock<metavars>,
+                       simple_action_b>(0, 2);
+  CHECK(db::get<PassedToB>(box) == 2);
+  CHECK(db::get<ValueTag>(box) == 25);
+  runner.simple_action<component_for_simple_action_mock<metavars>,
+                       simple_action_b>(0, 1);
+  CHECK(db::get<PassedToB>(box) == 1);
+  CHECK(db::get<ValueTag>(box) == 14);
+  runner.simple_action<component_for_simple_action_mock<metavars>,
+                       simple_action_b>(0, 3);
+  CHECK(db::get<PassedToB>(box) == 3);
+  CHECK(db::get<ValueTag>(box) == 25);
+}
+}  // namespace

--- a/tests/Unit/Test_ActionTesting.cpp
+++ b/tests/Unit/Test_ActionTesting.cpp
@@ -136,10 +136,11 @@ struct SimpleActionMockMetavariables {
 
 SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
   using metavars = SimpleActionMockMetavariables;
-  using LocalAlgorithms =
-      typename ActionTesting::MockRuntimeSystem<metavars>::LocalAlgorithms;
+  using TupleOfMockDistributedObjects =
+      typename ActionTesting::MockRuntimeSystem<
+          metavars>::TupleOfMockDistributedObjects;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  LocalAlgorithms local_algs{};
+  TupleOfMockDistributedObjects local_algs{};
   using LocalAlgTag = typename MockRuntimeSystem::template LocalAlgorithmsTag<
       component_for_simple_action_mock<metavars>>;
   tuples::get<LocalAlgTag>(local_algs)

--- a/tests/Unit/Test_ActionTesting.cpp
+++ b/tests/Unit/Test_ActionTesting.cpp
@@ -137,17 +137,17 @@ struct SimpleActionMockMetavariables {
 SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
   using metavars = SimpleActionMockMetavariables;
   using LocalAlgorithms =
-      typename ActionTesting::ActionRunner<metavars>::LocalAlgorithms;
-  using ActionRunner = ActionTesting::ActionRunner<metavars>;
+      typename ActionTesting::MockRuntimeSystem<metavars>::LocalAlgorithms;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   LocalAlgorithms local_algs{};
-  using LocalAlgTag = typename ActionRunner::template LocalAlgorithmsTag<
+  using LocalAlgTag = typename MockRuntimeSystem::template LocalAlgorithmsTag<
       component_for_simple_action_mock<metavars>>;
   tuples::get<LocalAlgTag>(local_algs)
       .emplace(0,
                ActionTesting::MockLocalAlgorithm<
                    component_for_simple_action_mock<metavars>>{
                    db::create<db::AddSimpleTags<ValueTag, PassedToB>>(0, -1)});
-  ActionTesting::ActionRunner<metavars> runner{{}, std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<metavars> runner{{}, std::move(local_algs)};
   const auto& box =
       runner.template algorithms<component_for_simple_action_mock<metavars>>()
           .at(0)

--- a/tests/Unit/Test_ActionTesting.cpp
+++ b/tests/Unit/Test_ActionTesting.cpp
@@ -141,8 +141,9 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
           metavars>::TupleOfMockDistributedObjects;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   TupleOfMockDistributedObjects local_algs{};
-  using LocalAlgTag = typename MockRuntimeSystem::template LocalAlgorithmsTag<
-      component_for_simple_action_mock<metavars>>;
+  using LocalAlgTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          component_for_simple_action_mock<metavars>>;
   tuples::get<LocalAlgTag>(local_algs)
       .emplace(0,
                ActionTesting::MockDistributedObject<

--- a/tests/Unit/Test_ActionTesting.cpp
+++ b/tests/Unit/Test_ActionTesting.cpp
@@ -156,18 +156,30 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
   CHECK(db::get<PassedToB>(box) == -1);
   runner.simple_action<component_for_simple_action_mock<metavars>,
                        simple_action_b>(0, 0);
+  runner
+      .invoke_queued_simple_action<component_for_simple_action_mock<metavars>>(
+          0);
   CHECK(db::get<PassedToB>(box) == 0);
   CHECK(db::get<ValueTag>(box) == 11);
   runner.simple_action<component_for_simple_action_mock<metavars>,
                        simple_action_b>(0, 2);
+  runner
+      .invoke_queued_simple_action<component_for_simple_action_mock<metavars>>(
+          0);
   CHECK(db::get<PassedToB>(box) == 2);
   CHECK(db::get<ValueTag>(box) == 25);
   runner.simple_action<component_for_simple_action_mock<metavars>,
                        simple_action_b>(0, 1);
+  runner
+      .invoke_queued_simple_action<component_for_simple_action_mock<metavars>>(
+          0);
   CHECK(db::get<PassedToB>(box) == 1);
   CHECK(db::get<ValueTag>(box) == 14);
   runner.simple_action<component_for_simple_action_mock<metavars>,
                        simple_action_b>(0, 3);
+  runner
+      .invoke_queued_simple_action<component_for_simple_action_mock<metavars>>(
+          0);
   CHECK(db::get<PassedToB>(box) == 3);
   CHECK(db::get<ValueTag>(box) == 25);
 }

--- a/tests/Unit/Test_ActionTesting.cpp
+++ b/tests/Unit/Test_ActionTesting.cpp
@@ -144,7 +144,7 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
       component_for_simple_action_mock<metavars>>;
   tuples::get<LocalAlgTag>(local_algs)
       .emplace(0,
-               ActionTesting::MockLocalAlgorithm<
+               ActionTesting::MockDistributedObject<
                    component_for_simple_action_mock<metavars>>{
                    db::create<db::AddSimpleTags<ValueTag, PassedToB>>(0, -1)});
   ActionTesting::MockRuntimeSystem<metavars> runner{{}, std::move(local_algs)};

--- a/tests/Unit/Test_ActionTesting.cpp
+++ b/tests/Unit/Test_ActionTesting.cpp
@@ -140,16 +140,17 @@ SPECTRE_TEST_CASE("Unit.ActionTesting.MockSimpleAction", "[Unit]") {
       typename ActionTesting::MockRuntimeSystem<
           metavars>::TupleOfMockDistributedObjects;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  TupleOfMockDistributedObjects local_algs{};
+  TupleOfMockDistributedObjects dist_objects{};
   using LocalAlgTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<
           component_for_simple_action_mock<metavars>>;
-  tuples::get<LocalAlgTag>(local_algs)
+  tuples::get<LocalAlgTag>(dist_objects)
       .emplace(0,
                ActionTesting::MockDistributedObject<
                    component_for_simple_action_mock<metavars>>{
                    db::create<db::AddSimpleTags<ValueTag, PassedToB>>(0, -1)});
-  ActionTesting::MockRuntimeSystem<metavars> runner{{}, std::move(local_algs)};
+  ActionTesting::MockRuntimeSystem<metavars> runner{{},
+                                                    std::move(dist_objects)};
   const auto& box =
       runner.template algorithms<component_for_simple_action_mock<metavars>>()
           .at(0)

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -28,10 +28,12 @@
 
 namespace {
 struct Metavariables;
-struct component
-    : ActionTesting::MockArrayComponent<Metavariables, int,
-                                        tmpl::list<OptionTags::TimeStepper>,
-                                        tmpl::list<Actions::AdvanceTime>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<OptionTags::TimeStepper>;
+  using action_list = tmpl::list<Actions::AdvanceTime>;
   using simple_tags =
       db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>;
   using initial_databox = db::compute_databox_type<simple_tags>;

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -48,9 +48,9 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
 
   using simple_tags =
       db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>;
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
                       db::create<simple_tags>(
@@ -58,8 +58,8 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
                           TimeId(time_step.is_positive(), 8, start, 1,
                                  start + substep_offsets[1]),
                           time_step)});
-  ActionRunner runner{{std::make_unique<TimeSteppers::RungeKutta3>()},
-                      std::move(local_algs)};
+  MockRuntimeSystem runner{{std::make_unique<TimeSteppers::RungeKutta3>()},
+                           std::move(local_algs)};
 
   for (const auto& step_start : {start, start + time_step}) {
     for (size_t substep = 0; substep < 3; ++substep) {
@@ -86,17 +86,17 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
 }
 
 void check_abn(const Time& start, const TimeDelta& time_step) {
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
                       db::create<typename component::simple_tags>(
                           TimeId(time_step.is_positive(), 8, start),
                           TimeId(time_step.is_positive(), 8, start + time_step),
                           time_step)});
-  ActionRunner runner{{std::make_unique<TimeSteppers::AdamsBashforthN>(1)},
-                      std::move(local_algs)};
+  MockRuntimeSystem runner{{std::make_unique<TimeSteppers::AdamsBashforthN>(1)},
+                           std::move(local_algs)};
 
   for (const auto& step_start : {start, start + time_step}) {
     auto& box = runner.algorithms<component>()

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -49,9 +49,10 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
   using simple_tags =
       db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<simple_tags>(
                           TimeId(time_step.is_positive(), 8, start),
@@ -87,9 +88,10 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
 
 void check_abn(const Time& start, const TimeDelta& time_step) {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(
                           TimeId(time_step.is_positive(), 8, start),

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -51,8 +51,8 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<simple_tags>(
                           TimeId(time_step.is_positive(), 8, start),
@@ -60,7 +60,7 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
                                  start + substep_offsets[1]),
                           time_step)});
   MockRuntimeSystem runner{{std::make_unique<TimeSteppers::RungeKutta3>()},
-                           std::move(local_algs)};
+                           std::move(dist_objects)};
 
   for (const auto& step_start : {start, start + time_step}) {
     for (size_t substep = 0; substep < 3; ++substep) {
@@ -90,15 +90,15 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(
                           TimeId(time_step.is_positive(), 8, start),
                           TimeId(time_step.is_positive(), 8, start + time_step),
                           time_step)});
   MockRuntimeSystem runner{{std::make_unique<TimeSteppers::AdamsBashforthN>(1)},
-                           std::move(local_algs)};
+                           std::move(dist_objects)};
 
   for (const auto& step_start : {start, start + time_step}) {
     auto& box = runner.algorithms<component>()

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -50,7 +50,7 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
       db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<simple_tags>(
@@ -88,7 +88,7 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
 void check_abn(const Time& start, const TimeDelta& time_step) {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -52,7 +52,7 @@ void check_rk3(const Time& start, const TimeDelta& time_step) {
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
   MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
-      .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
+      .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<simple_tags>(
                           TimeId(time_step.is_positive(), 8, start),
                           TimeId(time_step.is_positive(), 8, start, 1,
@@ -90,7 +90,7 @@ void check_abn(const Time& start, const TimeDelta& time_step) {
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
   MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
-      .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
+      .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(
                           TimeId(time_step.is_positive(), 8, start),
                           TimeId(time_step.is_positive(), 8, start + time_step),

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -72,8 +72,8 @@ void check(const bool time_runs_forward,
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(
                           TimeId(time_runs_forward, 0, time),
@@ -91,7 +91,7 @@ void check(const bool time_runs_forward,
            std::make_unique<StepChoosers::Constant<step_choosers>>(2. *
                                                                    request)),
        std::make_unique<StepControllers::BinaryFraction>()},
-      std::move(local_algs)};
+      std::move(dist_objects)};
 
   runner.next_action<component>(0);
   auto& box = runner.algorithms<component>()

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -69,9 +69,9 @@ void check(const bool time_runs_forward,
   const TimeDelta initial_step_size =
       (time_runs_forward ? 1 : -1) * time.slab().duration();
 
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
                       db::create<typename component::simple_tags>(
@@ -81,7 +81,7 @@ void check(const bool time_runs_forward,
                                                     : time.slab().end()) +
                                      initial_step_size),
                           initial_step_size, db::item_type<history_tag>{})});
-  ActionRunner runner{
+  MockRuntimeSystem runner{
       {std::move(time_stepper),
        make_vector<std::unique_ptr<StepChooser<step_choosers>>>(
            std::make_unique<StepChoosers::Constant<step_choosers>>(2. *

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -70,9 +70,10 @@ void check(const bool time_runs_forward,
       (time_runs_forward ? 1 : -1) * time.slab().duration();
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(
                           TimeId(time_runs_forward, 0, time),

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -73,7 +73,7 @@ void check(const bool time_runs_forward,
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
   MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
-      .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
+      .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(
                           TimeId(time_runs_forward, 0, time),
                           TimeId(time_runs_forward, 0,

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -45,9 +45,12 @@ struct System {
 };
 
 struct Metavariables;
-struct component
-    : ActionTesting::MockArrayComponent<Metavariables, int, tmpl::list<>,
-                                        tmpl::list<change_step_size>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<change_step_size>;
   using simple_tags = db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>,
                                         Tags::TimeStep, history_tag>;
   using initial_databox = db::compute_databox_type<simple_tags>;

--- a/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Actions/Test_ChangeStepSize.cpp
@@ -71,7 +71,7 @@ void check(const bool time_runs_forward,
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(

--- a/tests/Unit/Time/Actions/Test_FinalTime.cpp
+++ b/tests/Unit/Time/Actions/Test_FinalTime.cpp
@@ -42,13 +42,13 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.FinalTime", "[Unit][Time][Actions]") {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags,
                                  typename component::compute_tags>(
                           TimeId{}, TimeDelta{})});
-  MockRuntimeSystem runner{{5.}, std::move(local_algs)};
+  MockRuntimeSystem runner{{5.}, std::move(dist_objects)};
   auto& box = runner.algorithms<component>()
                   .at(0)
                   .get_databox<typename component::initial_databox>();

--- a/tests/Unit/Time/Actions/Test_FinalTime.cpp
+++ b/tests/Unit/Time/Actions/Test_FinalTime.cpp
@@ -20,10 +20,12 @@
 
 namespace {
 struct Metavariables;
-struct component
-    : ActionTesting::MockArrayComponent<Metavariables, int,
-                                        tmpl::list<OptionTags::FinalTime>,
-                                        tmpl::list<Actions::FinalTime>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<OptionTags::FinalTime>;
+  using action_list = tmpl::list<Actions::FinalTime>;
   using simple_tags = db::AddSimpleTags<Tags::TimeId, Tags::TimeStep>;
   using compute_tags = db::AddComputeTags<Tags::Time>;
   using initial_databox =

--- a/tests/Unit/Time/Actions/Test_FinalTime.cpp
+++ b/tests/Unit/Time/Actions/Test_FinalTime.cpp
@@ -40,9 +40,10 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.FinalTime", "[Unit][Time][Actions]") {
   const Slab slab(3., 6.);
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags,
                                  typename component::compute_tags>(

--- a/tests/Unit/Time/Actions/Test_FinalTime.cpp
+++ b/tests/Unit/Time/Actions/Test_FinalTime.cpp
@@ -39,15 +39,15 @@ struct Metavariables {
 SPECTRE_TEST_CASE("Unit.Time.Actions.FinalTime", "[Unit][Time][Actions]") {
   const Slab slab(3., 6.);
 
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
                       db::create<typename component::simple_tags,
                                  typename component::compute_tags>(
                           TimeId{}, TimeDelta{})});
-  ActionRunner runner{{5.}, std::move(local_algs)};
+  MockRuntimeSystem runner{{5.}, std::move(local_algs)};
   auto& box = runner.algorithms<component>()
                   .at(0)
                   .get_databox<typename component::initial_databox>();

--- a/tests/Unit/Time/Actions/Test_FinalTime.cpp
+++ b/tests/Unit/Time/Actions/Test_FinalTime.cpp
@@ -43,7 +43,7 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.FinalTime", "[Unit][Time][Actions]") {
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
   MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
-      .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
+      .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags,
                                  typename component::compute_tags>(
                           TimeId{}, TimeDelta{})});

--- a/tests/Unit/Time/Actions/Test_FinalTime.cpp
+++ b/tests/Unit/Time/Actions/Test_FinalTime.cpp
@@ -41,7 +41,7 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.FinalTime", "[Unit][Time][Actions]") {
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags,

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -63,9 +63,10 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
   history.insert(slab.end(), 2., 3.);
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags,
                                  typename component::compute_tags>(

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -65,13 +65,13 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags,
                                  typename component::compute_tags>(
                           time_id, 4., 5., std::move(history))});
-  MockRuntimeSystem runner{{}, std::move(local_algs)};
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
 
   runner.next_action<component>(0);
   const auto& box = runner.algorithms<component>()

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -66,7 +66,7 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
   MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
-      .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
+      .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags,
                                  typename component::compute_tags>(
                           time_id, 4., 5., std::move(history))});

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -36,9 +36,12 @@ using history_tag =
     Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>;
 
 struct Metavariables;
-struct component : ActionTesting::MockArrayComponent<
-                       Metavariables, int, tmpl::list<>,
-                       tmpl::list<Actions::RecordTimeStepperData>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<Actions::RecordTimeStepperData>;
   using simple_tags = db::AddSimpleTags<Tags::TimeId, variables_tag,
                                         dt_variables_tag, history_tag>;
   using compute_tags = db::AddComputeTags<Tags::Time>;

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -62,15 +62,15 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
   history_tag::type history{};
   history.insert(slab.end(), 2., 3.);
 
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
                       db::create<typename component::simple_tags,
                                  typename component::compute_tags>(
                           time_id, 4., 5., std::move(history))});
-  ActionRunner runner{{}, std::move(local_algs)};
+  MockRuntimeSystem runner{{}, std::move(local_algs)};
 
   runner.next_action<component>(0);
   const auto& box = runner.algorithms<component>()

--- a/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
+++ b/tests/Unit/Time/Actions/Test_RecordTimeStepperData.cpp
@@ -64,7 +64,7 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.RecordTimeStepperData",
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags,

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -64,9 +64,10 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
       [](const double t, const double y) { return 2. * t - 2. * (y - t * t); };
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
-  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<component>;
   MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<LocalAlgsTag>(local_algs)
+  tuples::get<MockDistributedObjectsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(
                           time_step, 1., history_tag::type{})});

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -66,13 +66,13 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using MockDistributedObjectsTag =
       MockRuntimeSystem::MockDistributedObjectsTag<component>;
-  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
-  tuples::get<MockDistributedObjectsTag>(local_algs)
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(
                           time_step, 1., history_tag::type{})});
   MockRuntimeSystem runner{{std::make_unique<TimeSteppers::RungeKutta3>()},
-                           std::move(local_algs)};
+                           std::move(dist_objects)};
 
   const std::array<Time, 3> substep_times{
     {slab.start(), slab.start() + time_step, slab.start() + time_step / 2}};

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -65,7 +65,7 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
-  MockRuntimeSystem::LocalAlgorithms local_algs{};
+  MockRuntimeSystem::TupleOfMockDistributedObjects local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -63,15 +63,15 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
   const auto rhs =
       [](const double t, const double y) { return 2. * t - 2. * (y - t * t); };
 
-  using ActionRunner = ActionTesting::ActionRunner<Metavariables>;
-  using LocalAlgsTag = ActionRunner::LocalAlgorithmsTag<component>;
-  ActionRunner::LocalAlgorithms local_algs{};
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
+  MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
       .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
                       db::create<typename component::simple_tags>(
                           time_step, 1., history_tag::type{})});
-  ActionRunner runner{{std::make_unique<TimeSteppers::RungeKutta3>()},
-                      std::move(local_algs)};
+  MockRuntimeSystem runner{{std::make_unique<TimeSteppers::RungeKutta3>()},
+                           std::move(local_algs)};
 
   const std::array<Time, 3> substep_times{
     {slab.start(), slab.start() + time_step, slab.start() + time_step / 2}};

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -67,7 +67,7 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.UpdateU", "[Unit][Time][Actions]") {
   using LocalAlgsTag = MockRuntimeSystem::LocalAlgorithmsTag<component>;
   MockRuntimeSystem::LocalAlgorithms local_algs{};
   tuples::get<LocalAlgsTag>(local_algs)
-      .emplace(0, ActionTesting::MockLocalAlgorithm<component>{
+      .emplace(0, ActionTesting::MockDistributedObject<component>{
                       db::create<typename component::simple_tags>(
                           time_step, 1., history_tag::type{})});
   MockRuntimeSystem runner{{std::make_unique<TimeSteppers::RungeKutta3>()},

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -40,10 +40,12 @@ using history_tag =
     Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>;
 
 struct Metavariables;
-struct component
-    : ActionTesting::MockArrayComponent<Metavariables, int,
-                                        tmpl::list<OptionTags::TimeStepper>,
-                                        tmpl::list<Actions::UpdateU>> {
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<OptionTags::TimeStepper>;
+  using action_list = tmpl::list<Actions::UpdateU>;
   using simple_tags =
       db::AddSimpleTags<Tags::TimeStep, variables_tag, history_tag>;
   using initial_databox = db::compute_databox_type<simple_tags>;


### PR DESCRIPTION
## Proposed changes

- Adds support for actions that call simple actions inside of them.
- Adds ability to mock a simple action by having the ActionTesting framework call a replacement action whenever a specific action is called. This will be useful for #844
- Do renames discussed in #943 

*Note:* The first commit is necessary for observers too.

**Breaking changes**:
- Renames all the action testing things and changes the way mock components are written. This is done in isolated commits, so check those.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
