### PR TITLE
Volume observer PR1

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
     LeviCivitaIterator.cpp
     SliceIterator.cpp
     StripeIterator.cpp
+    Tensor/TensorData.cpp
     VariablesHelpers.cpp
     )
 

--- a/src/DataStructures/Tensor/TensorData.cpp
+++ b/src/DataStructures/Tensor/TensorData.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/Tensor/TensorData.hpp"
+
+#include <ostream>
+#include <pup.h>
+#include <pup_stl.h>
+
+void TensorComponent::pup(PUP::er& p) noexcept {
+  p | name;
+  p | data;
+}
+
+std::ostream& operator<<(std::ostream& os, const TensorComponent& t) noexcept {
+  return os << "(" << t.name << ", " << t.data << ")";
+}
+
+bool operator==(const TensorComponent& lhs,
+                const TensorComponent& rhs) noexcept {
+  return lhs.name == rhs.name and lhs.data == rhs.data;
+}
+
+bool operator!=(const TensorComponent& lhs,
+                const TensorComponent& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+void ExtentsAndTensorVolumeData::pup(PUP::er& p) noexcept {
+  p | extents;
+  p | tensor_components;
+}

--- a/src/DataStructures/Tensor/TensorData.hpp
+++ b/src/DataStructures/Tensor/TensorData.hpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iosfwd>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief An untyped tensor component with a name for observation.
+ *
+ * The name should be a path inside an H5 file, typically starting with the name
+ * of the volume subfile. For example,
+ * `element_volume_data.vol/ObservationId[ID]/[ElementIdName]/psi_xx`.
+ */
+struct TensorComponent {
+  TensorComponent() = default;
+  TensorComponent(std::string n, DataVector d) noexcept
+      : name(std::move(n)), data(std::move(d)) {}
+  void pup(PUP::er& p) noexcept;  // NOLINT
+  std::string name{};
+  DataVector data{};
+};
+
+std::ostream& operator<<(std::ostream& os, const TensorComponent& t) noexcept;
+
+bool operator==(const TensorComponent& lhs,
+                const TensorComponent& rhs) noexcept;
+
+bool operator!=(const TensorComponent& lhs,
+                const TensorComponent& rhs) noexcept;
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief Holds the extents of the mesh and the tensor components on the mesh.
+ *
+ * The extents is a `std::vector<size_t>` where each element is the number of
+ * grid points in the given dimension. The `TensorComponent`s must live on the
+ * grid of the size of the extents. We use runtime extents instead of the
+ * `Index` class because observers may write 1D, 2D, or 3D data in a 3D
+ * simulation.
+ */
+struct ExtentsAndTensorVolumeData {
+  ExtentsAndTensorVolumeData() = default;
+  ExtentsAndTensorVolumeData(std::vector<size_t> exts,
+                             std::vector<TensorComponent> components) noexcept
+      : extents(std::move(exts)), tensor_components(std::move(components)) {}
+  void pup(PUP::er& p) noexcept;  // NOLINT
+  std::vector<size_t> extents{};
+  std::vector<TensorComponent> tensor_components{};
+};

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
     H5/OpenGroup.cpp
     H5/Version.cpp
     Observer/ArrayComponentId.cpp
+    Observer/ObservationId.cpp
     Observer/TypeOfObservation.cpp
     VolumeDataFile.cpp
 )

--- a/src/IO/H5/File.hpp
+++ b/src/IO/H5/File.hpp
@@ -20,16 +20,11 @@
 #include "ErrorHandling/Error.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/CheckH5.hpp"
+#include "IO/H5/Header.hpp"  // IWYU pragma: keep
 #include "IO/H5/Object.hpp"
 #include "IO/H5/OpenGroup.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/PrettyType.hpp"
-
-/// \cond
-namespace h5 {
-class Header;
-}  // namespace h5
-/// \endcond
 
 namespace h5 {
 /*!

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -9,6 +9,7 @@
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/NodeLock.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -20,7 +21,8 @@ namespace Actions {
 struct Initialize {
   using simple_tags =
       db::AddSimpleTags<Tags::NumberOfEvents, Tags::ReductionArrayComponentIds,
-                        Tags::VolumeArrayComponentIds, Tags::TensorData>;
+                        Tags::VolumeArrayComponentIds, Tags::TensorData,
+                        Tags::ReductionDataLock, Tags::VolumeDataLock>;
   using compute_tags = db::AddComputeTags<>;
 
   using return_tag_list = tmpl::append<simple_tags, compute_tags>;
@@ -37,7 +39,8 @@ struct Initialize {
         db::item_type<Tags::NumberOfEvents>{},
         db::item_type<Tags::ReductionArrayComponentIds>{},
         db::item_type<Tags::VolumeArrayComponentIds>{},
-        db::item_type<Tags::TensorData>{}));
+        db::item_type<Tags::TensorData>{}, Parallel::create_lock(),
+        Parallel::create_lock()));
   }
 };
 }  // namespace Actions

--- a/src/IO/Observer/ObservationId.cpp
+++ b/src/IO/Observer/ObservationId.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/Observer/ObservationId.hpp"
+
+#include <pup.h>
+
+namespace observers {
+void ObservationId::pup(PUP::er& p) noexcept {
+  p | combined_hash_;
+  p | value_;
+}
+
+bool operator==(const ObservationId& lhs, const ObservationId& rhs) noexcept {
+  return lhs.hash() == rhs.hash() and lhs.value() == rhs.value();
+}
+
+bool operator!=(const ObservationId& lhs, const ObservationId& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace observers

--- a/src/IO/Observer/ObservationId.hpp
+++ b/src/IO/Observer/ObservationId.hpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <functional>
+#include <string>
+
+#include "Utilities/PrettyType.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace observers {
+/*!
+ * \ingroup ObserversGroup
+ * \brief A type-erased identifier that combines the identifier's type
+ * and hash used to uniquely identify an observation inside of a
+ * `h5::File::SUB_FILE`.
+ *
+ * The ObservationId is used to uniquely identify an observation inside our H5
+ * subfiles that can be agreed upon across the system. That is, it does not
+ * depend on hardware rounding of floating points because it is an integral. One
+ * example would be a `Time` for output observed every `N` steps in a global
+ * time stepping evolution. Another example could be having a counter class for
+ * dense output observations that increments the counter for each observation
+ * but has a value equal to the physical time.
+ *
+ * The identifier must have a `value()` method that returns a double
+ * representing the current "time" at which we are observing. For an evolution
+ * this could be the physical time, while for an elliptic solve this could be a
+ * combination of nonlinear and linear iteration.
+ *
+ * A specialization of `std::hash` is provided to allow using `ObservationId`
+ * as a key in associative containers.
+ */
+class ObservationId {
+ public:
+  ObservationId() = default;
+
+  /*!
+   * \brief Construct from an ID of type `Id`
+   */
+  template <typename Id>
+  explicit ObservationId(const Id& t) noexcept;
+
+  size_t hash() const noexcept { return combined_hash_; }
+
+  double value() const noexcept { return value_; }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept;
+
+ private:
+  size_t combined_hash_;
+  double value_;
+};
+
+template <typename Id>
+ObservationId::ObservationId(const Id& t) noexcept
+    : combined_hash_([&t]() {
+        size_t combined = std::hash<std::string>{}(pretty_type::get_name<Id>());
+        boost::hash_combine(combined, t);
+        return combined;
+      }()),
+      value_(t.value()) {}
+
+bool operator==(const ObservationId& lhs, const ObservationId& rhs) noexcept;
+bool operator!=(const ObservationId& lhs, const ObservationId& rhs) noexcept;
+}  // namespace observers
+
+namespace std {
+template <>
+struct hash<observers::ObservationId> {
+  size_t operator()(const observers::ObservationId& t) const noexcept {
+    return t.hash();
+  }
+};
+}  // namespace std

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <lrtslock.h>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -11,7 +12,9 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
 
 namespace observers {
 /// \ingroup ObserversGroup
@@ -42,8 +45,21 @@ struct VolumeArrayComponentIds : db::SimpleTag {
 struct TensorData : db::SimpleTag {
   static std::string name() noexcept { return "TensorData"; }
   using type =
-      std::unordered_map<std::string,
-                         std::vector<std::pair<std::string, DataVector>>>;
+      std::unordered_map<observers::ObservationId,
+                         std::unordered_map<observers::ArrayComponentId,
+                                            ExtentsAndTensorVolumeData>>;
+};
+
+/// Node lock used when needing a lock for volume data.
+struct VolumeDataLock : db::SimpleTag {
+  static std::string name() noexcept { return "VolumeDataLock"; }
+  using type = CmiNodeLock;
+};
+
+/// Node lock used when needing a lock for reduction data.
+struct ReductionDataLock : db::SimpleTag {
+  static std::string name() noexcept { return "ReductionDataLock"; }
+  using type = CmiNodeLock;
 };
 }  // namespace Tags
 }  // namespace observers

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -10,13 +10,8 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-
-/// \cond
-class DataVector;
-namespace observers {
-class ArrayComponentId;
-}  // namespace observers
-/// \endcond
+#include "DataStructures/DataVector.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
 
 namespace observers {
 /// \ingroup ObserversGroup

--- a/src/Utilities/MakeString.hpp
+++ b/src/Utilities/MakeString.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <sstream>
+#include <string>
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Make a string by streaming into object.
+ *
+ * \snippet Test_MakeString.cpp make_string
+ */
+class MakeString {
+ public:
+  MakeString() = default;
+  MakeString(const MakeString&) = delete;
+  MakeString& operator=(const MakeString&) = delete;
+  MakeString(MakeString&&) = default;
+  MakeString& operator=(MakeString&&) = delete;
+  ~MakeString() = default;
+
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  operator std::string() const noexcept { return stream_.str(); }
+
+  template <class T>
+  friend MakeString operator<<(MakeString&& ms, const T& t) noexcept {
+    // clang-tidy: can get unintentional pointer casts
+    ms.stream_ << t;  // NOLINT
+    return std::move(ms);
+  }
+
+  template <class T>
+  friend MakeString& operator<<(MakeString& ms, const T& t) noexcept {
+    // clang-tidy: can get unintentional pointer casts
+    ms.stream_ << t;  // NOLINT
+    return ms;
+  }
+
+ private:
+  std::stringstream stream_{};
+};

--- a/tests/Unit/DataStructures/Tensor/CMakeLists.txt
+++ b/tests/Unit/DataStructures/Tensor/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Tensor")
 set(LIBRARY_SOURCES
   Test_Identity.cpp
   Test_Tensor.cpp
+  Test_TensorData.cpp
   )
 
 add_subdirectory(EagerMath)

--- a/tests/Unit/DataStructures/Tensor/Test_TensorData.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_TensorData.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.TensorData", "[Unit]") {
+  TensorComponent tc0("T_x", DataVector{8.9, 7.6, -3.4, 9.0});
+  TensorComponent tc1("T_y", DataVector{8.9, 7.6, -3.4, 9.0});
+  TensorComponent tc2("T_x", DataVector{8.9, 7.6, -3.4, 9.1});
+  CHECK(get_output(tc0) == "(T_x, (8.9,7.6,-3.4,9))");
+  CHECK(tc0 == tc0);
+  CHECK(tc0 != tc1);
+  CHECK(tc0 != tc2);
+  CHECK(tc1 != tc2);
+  test_serialization(tc0);
+
+  ExtentsAndTensorVolumeData etvd0({2, 2}, {tc0, tc1, tc2});
+  const auto after = serialize_and_deserialize(etvd0);
+  CHECK(after.extents == etvd0.extents);
+  CHECK(after.tensor_components == etvd0.tensor_components);
+}

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Observers/Test_Initialize.cpp
   Observers/Test_RegisterElements.cpp
   Observers/Test_Tags.cpp
+  Observers/Test_ObservationId.cpp
   Observers/Test_TypeOfObservation.cpp
   Test_H5.cpp
   )

--- a/tests/Unit/IO/Observers/Test_ObservationId.cpp
+++ b/tests/Unit/IO/Observers/Test_ObservationId.cpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <functional>
+
+#include "IO/Observer/ObservationId.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace observer_testing_detail {
+class DummyTimeId {
+ public:
+  explicit DummyTimeId(const size_t value) : value_(value) {}
+  size_t value() const { return value_; }
+
+ private:
+  size_t value_;
+};
+size_t hash_value(const DummyTimeId& id) noexcept { return id.value(); }
+}  // namespace observer_testing_detail
+
+namespace std {
+template <>
+struct hash<observer_testing_detail::DummyTimeId> {
+  size_t operator()(const observer_testing_detail::DummyTimeId& id) const
+      noexcept {
+    return id.value();
+  }
+};
+}  // namespace std
+
+using DummyTimeId = observer_testing_detail::DummyTimeId;
+namespace observers {
+SPECTRE_TEST_CASE("Unit.IO.Observers.ObservationId", "[Unit][Observers]") {
+  ObservationId id0(DummyTimeId(4));
+  ObservationId id1(DummyTimeId(8));
+  CHECK(id0 == id0);
+  CHECK(id0.hash() == id0.hash());
+  CHECK(id0 == ObservationId(DummyTimeId(4)));
+  CHECK(id0 != id1);
+  CHECK(id0.hash() != id1.hash());
+  CHECK(id0.value() == 4.0);
+  CHECK(id1.value() == 8.0);
+
+  ObservationId time0(Time(Slab{0.0, 1.0}, 0));
+  ObservationId time1(Time(Slab{0.0, 1.0}, Time::rational_t(1, 2)));
+  CHECK(time0 != id0);
+  CHECK(time0.hash() != id0.hash());
+  CHECK(time0 == time0);
+  CHECK(time0.hash() == time0.hash());
+  CHECK(time0 != time1);
+  CHECK(time0.hash() != time1.hash());
+  CHECK(time0.value() == 0.0);
+  CHECK(time1.value() == 0.5);
+
+  // Test PUP
+  test_serialization(id0);
+  test_serialization(id1);
+  test_serialization(time0);
+  test_serialization(time1);
+}
+}  // namespace observers

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -40,12 +40,10 @@ struct observer_component
     : ActionTesting::MockArrayComponent<Metavariables, size_t, tmpl::list<>,
                                         tmpl::list<>,
                                         observers::Observer<Metavariables>> {
-  using simple_tags =
-      db::AddSimpleTags<observers::Tags::NumberOfEvents,
-                        observers::Tags::ReductionArrayComponentIds,
-                        observers::Tags::VolumeArrayComponentIds,
-                        observers::Tags::TensorData>;
-  using initial_databox = db::compute_databox_type<simple_tags>;
+  using simple_tags = observers::Actions::Initialize::simple_tags;
+  using compute_tags = observers::Actions::Initialize::compute_tags;
+  using initial_databox =
+      db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
 };
 
 struct Metavariables {

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -7,11 +7,15 @@
 
 #include "IO/Observer/Tags.hpp"
 
+namespace observers {
+namespace Tags {
 SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
-  CHECK(observers::Tags::NumberOfEvents::name() == "NumberOfEvents");
-  CHECK(observers::Tags::ReductionArrayComponentIds::name() ==
-        "ReductionArrayComponentIds");
-  CHECK(observers::Tags::VolumeArrayComponentIds::name() ==
-        "VolumeArrayComponentIds");
-  CHECK(observers::Tags::TensorData::name() == "TensorData");
+  CHECK(NumberOfEvents::name() == "NumberOfEvents");
+  CHECK(ReductionArrayComponentIds::name() == "ReductionArrayComponentIds");
+  CHECK(VolumeArrayComponentIds::name() == "VolumeArrayComponentIds");
+  CHECK(TensorData::name() == "TensorData");
+  CHECK(VolumeDataLock::name() == "VolumeDataLock");
+  CHECK(ReductionDataLock::name() == "ReductionDataLock");
 }
+}  // namespace Tags
+}  // namespace observers

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBRARY_SOURCES
   Test_GetOutput.cpp
   Test_Gsl.cpp
   Test_MakeArray.cpp
+  Test_MakeString.cpp
   Test_MakeVector.cpp
   Test_MakeWithValue.cpp
   Test_Math.cpp

--- a/tests/Unit/Utilities/Test_MakeString.cpp
+++ b/tests/Unit/Utilities/Test_MakeString.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <string>
+
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/StdHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.MakeString", "[Unit][Utilities]") {
+  /// [make_string]
+  std::array<int, 3> arr{{2, 3, 4}};
+  const std::string t = MakeString{} << "Test" << 2 << arr << "Done";
+  /// [make_string]
+  CHECK(t == "Test2" + get_output(arr) + "Done");
+}


### PR DESCRIPTION
## Proposed changes

Adds some classes and functions that'll be necessary for volume observers

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
