### PR TITLE
 Allow option structs to override option name

### DIFF
--- a/docs/DevGuide/OptionParsing.md
+++ b/docs/DevGuide/OptionParsing.md
@@ -13,13 +13,14 @@ are declared in `Options/Options.hpp`.
 
 ## General option format
 
-An option is defined by an "option struct".  The name of the struct
-(excluding any template parameters and scope information) is the name
-that will be expected in the input file.  At minimum, the struct must
-declare the type of the object to be parsed and provide a brief
-description of the meaning.  Several other pieces of information, such
-as defaults and limits, may be provided if desired.  This information
-is all included in the generated help output.
+An option is defined by an "option struct".  At minimum, the struct
+must declare the type of the object to be parsed and provide a brief
+description of the meaning.  The name of the option in the input file
+defaults to the name of the struct (excluding any template parameters
+and scope information), but can be overridden by providing a static
+`name()` function.  Several other pieces of information, such as
+defaults and limits, may be provided if desired.  This information is
+all included in the generated help output.
 
 Examples:
 \snippet Test_Options.cpp options_example_scalar_struct

--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -240,9 +240,8 @@ class Options {
             Requires<not Options_detail::has_default<T>::value> = nullptr>
   [[noreturn]] typename T::type get_default() const {
     PARSE_ERROR(context_,
-                "You did not specify the option '"
-                << pretty_type::short_name<T>() << "'.\n"
-                << help());
+                "You did not specify the option '" << Options_detail::name<T>()
+                << "'.\n" << help());
   }
   //@}
 
@@ -289,8 +288,7 @@ class Options {
             Requires<Options_detail::has_default<T>::value> = nullptr>
   void validate_default() const {
     OptionContext context;
-    context.append("Checking DEFAULT value for " +
-                   pretty_type::short_name<T>());
+    context.append("Checking DEFAULT value for " + Options_detail::name<T>());
     const auto default_value = T::default_value();
     check_lower_bound_on_size<T>(default_value, context);
     check_upper_bound_on_size<T>(default_value, context);
@@ -321,9 +319,7 @@ Options<OptionList>::Options(std::string help_text) noexcept
           tmpl::for_each<opts_t>(Options_detail::create_valid_names{}).value) {
   tmpl::for_each<opts_t>([](auto t) noexcept {
     using T = typename decltype(t)::type;
-    const std::string label = pretty_type::short_name<T>();
-    // These could be checked at compile time, but we couldn't print
-    // a useful error message.
+    const std::string label = Options_detail::name<T>();
     ASSERT(label.size() < max_label_size_,
            "The option name " << label << " is too long for nice formatting, "
            "please shorten the name to be under " << max_label_size_
@@ -403,7 +399,7 @@ typename T::type Options<OptionList>::get() const {
       not cpp17::is_same_v<tmpl::index_of<opts_t, T>, tmpl::no_such_type_>,
       "Could not find requested option in the list of options provided. Did "
       "you forget to add the option struct to the OptionList?");
-  const std::string label = pretty_type::short_name<T>();
+  const std::string label = Options_detail::name<T>();
 
   validate_default<T>();
   if (0 == parsed_options_.count(label)) {

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -66,9 +66,6 @@ void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
   tuples::get<LocalAlgsTag>(local_algs).emplace(0, db::DataBox<tmpl::list<>>{});
   ActionTesting::ActionRunner<Metavariables> runner{
       {serialize_and_deserialize(events_and_triggers)}, std::move(local_algs)};
-  auto& box = runner.template algorithms<my_component>()
-                  .at(0)
-                  .template get_databox<db::DataBox<tmpl::list<>>>();
 
   runner.next_action<component>(0);
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -682,10 +682,6 @@ SPECTRE_TEST_CASE(
   ActionTesting::ActionRunner<metavariables> runner{{NumericalFlux<3>{}},
                                                     std::move(local_algs)};
 
-  auto& start_box = runner.algorithms<my_component>()
-                        .at(self_id)
-                        .get_databox<typename my_component::initial_databox>();
-
   runner.next_action<my_component>(self_id);
 
   // Check local data


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
