### PR TITLE
Volume observer PR2 (Does not depend on #954)

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -158,6 +158,7 @@ EXPAND_ONLY_PREDEF     = YES
 SEARCH_INCLUDES        = YES
 
 PREDEFINED             = SPECTRE_ALWAYS_INLINE= \
+                         OVERLOADER_CONSTEXPR= \
                          SPECTRE_DOXYGEN_INVOKED
 
 #---------------------------------------------------------------------------

--- a/src/IO/Connectivity.cpp
+++ b/src/IO/Connectivity.cpp
@@ -97,7 +97,7 @@ std::vector<CellInTopology> tensor_product_cells(
 }
 
 template <size_t Dim>
-std::vector<CellInTopology> compute_cells(const Index<Dim>& extents) {
+std::vector<CellInTopology> compute_cells(const Index<Dim>& extents) noexcept {
   std::vector<CellInTopology> cells;
   std::vector<std::vector<CellInTopology>> cells_per_topology;
   std::vector<size_t> size_per_topology;
@@ -118,9 +118,27 @@ std::vector<CellInTopology> compute_cells(const Index<Dim>& extents) {
   return cells;
 }
 
+std::vector<CellInTopology> compute_cells(
+    const std::vector<size_t>& extents) noexcept {
+  if (extents.size() == 1) {
+    return compute_cells(Index<1>{extents[0]});
+  } else if (extents.size() == 2) {
+    return compute_cells(Index<2>{extents[0], extents[1]});
+  } else if (extents.size() == 3) {
+    return compute_cells(Index<3>{extents[0], extents[1], extents[2]});
+  }
+  ERROR(
+      "Only know how to compute connectivity for extents of size 1, 2, and 3, "
+      "not "
+      << extents.size());
+}
+
 // Explicit instantiations
-template std::vector<CellInTopology> compute_cells<1>(const Index<1>& extents);
-template std::vector<CellInTopology> compute_cells<2>(const Index<2>& extents);
-template std::vector<CellInTopology> compute_cells<3>(const Index<3>& extents);
+template std::vector<CellInTopology> compute_cells<1>(
+    const Index<1>& extents) noexcept;
+template std::vector<CellInTopology> compute_cells<2>(
+    const Index<2>& extents) noexcept;
+template std::vector<CellInTopology> compute_cells<3>(
+    const Index<3>& extents) noexcept;
 }  // namespace detail
 }  // namespace vis

--- a/src/IO/Connectivity.hpp
+++ b/src/IO/Connectivity.hpp
@@ -46,6 +46,7 @@ struct CellInTopology {
   std::vector<size_t> bounding_indices{};
 };
 
+// @{
 /*!
  * \brief Compute the cells in the element.
  *
@@ -59,6 +60,10 @@ struct CellInTopology {
  * same.
  */
 template <size_t Dim>
-std::vector<CellInTopology> compute_cells(const Index<Dim>& extents);
+std::vector<CellInTopology> compute_cells(const Index<Dim>& extents) noexcept;
+
+std::vector<CellInTopology> compute_cells(
+    const std::vector<size_t>& extents) noexcept;
+// @}
 }  // namespace detail
 }  // namespace vis

--- a/src/IO/H5/Dat.cpp
+++ b/src/IO/H5/Dat.cpp
@@ -69,7 +69,7 @@ Dat::Dat(const bool exists, detail::OpenGroup&& group, const hid_t location,
       ERROR("Invalid number of dimensions in file on disk.");  // LCOV_EXCL_LINE
     }
     CHECK_H5(H5Sclose(space_id), "Failed to close dataspace");
-    legend_ = detail::read_strings_from_attribute(dataset_id_, "Legend"s);
+    legend_ = read_rank1_attribute<std::string>(dataset_id_, "Legend"s);
   } else {  // file does not exist
     dataset_id_ = h5::detail::create_extensible_dataset(
         location, name_, size_, std::array<hsize_t, 2>{{4, legend_.size()}},
@@ -85,7 +85,7 @@ Dat::Dat(const bool exists, detail::OpenGroup&& group, const hid_t location,
       header_ = header.get_header();
     }
     // Capitalized for compatibility with SpEC output
-    detail::write_strings_to_attribute(dataset_id_, "Legend"s, legend_);
+    write_to_attribute(dataset_id_, "Legend"s, legend_);
   }
 }
 

--- a/src/IO/H5/File.cpp
+++ b/src/IO/H5/File.cpp
@@ -12,6 +12,7 @@
 #include "IO/H5/CheckH5.hpp"
 #include "IO/H5/Header.hpp"  // IWYU pragma: keep
 #include "IO/H5/Object.hpp"
+#include "IO/H5/Wrappers.hpp"
 #include "Utilities/FileSystem.hpp"
 
 namespace h5 {
@@ -38,16 +39,13 @@ H5File<Access_t>::H5File(std::string file_name, bool append_to_file)
                       "explicitly delete the file first using the file_system "
                       "library in SpECTRE or through your shell.");
   }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
   file_id_ = file_exists
                  ? H5Fopen(file_name_.c_str(),
-                           AccessType::ReadOnly == Access_t ? H5F_ACC_RDONLY
-                                                            : H5F_ACC_RDWR,
-                           H5P_DEFAULT)
-                 : H5Fcreate(file_name_.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT,
-                             H5P_DEFAULT);
-#pragma GCC diagnostic pop
+                           AccessType::ReadOnly == Access_t ? h5f_acc_rdonly()
+                                                            : h5f_acc_rdwr(),
+                           h5p_default())
+                 : H5Fcreate(file_name_.c_str(), h5f_acc_trunc(), h5p_default(),
+                             h5p_default());
   CHECK_H5(file_id_, "Failed to open file '" << file_name_ << "'");
   if (not file_exists) {
     insert_header();

--- a/src/IO/H5/Header.cpp
+++ b/src/IO/H5/Header.cpp
@@ -18,8 +18,8 @@ Header::Header(const bool exists, detail::OpenGroup&& group,
                const hid_t location, const std::string& name)
     : group_(std::move(group)) {
   if (exists) {
-    header_info_ = h5::detail::read_strings_from_attribute(
-        location, name + extension())[0];
+    header_info_ =
+        h5::read_rank1_attribute<std::string>(location, name + extension())[0];
   } else {
     std::vector<std::string> header_info{[]() {
       std::stringstream ss;
@@ -28,8 +28,7 @@ Header::Header(const bool exists, detail::OpenGroup&& group,
       ss << std::regex_replace(build_info, std::regex{"\n"}, "\n# ");
       return ss.str();
     }()};
-    detail::write_strings_to_attribute(location, name + extension(),
-                                       header_info);
+    write_to_attribute(location, name + extension(), header_info);
     header_info_ = header_info[0];
   }
 }

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -339,24 +339,6 @@ bool contains_attribute(const hid_t file_id, const std::string& group_name,
          std::end(names);
 }
 
-double get_time(const hid_t file_id, const std::string& group_name,
-                const std::string& attr_name) {
-  if (not contains_attribute(file_id, group_name, attr_name)) {
-    ERROR("group " << group_name << " does not contain attribute '" << attr_name
-                   << "'");
-  }
-  detail::OpenGroup my_group(file_id, group_name, AccessType::ReadOnly);
-  const hid_t group_id = my_group.id();
-// Read the attr_name attribute and close the attribute.
-  const hid_t attr_id = H5Aopen(group_id, attr_name.c_str(), h5p_default());
-  CHECK_H5(attr_id, "Failed to open attribute");
-  double time;
-  CHECK_H5(H5Aread(attr_id, h5_type<double>(), &time),
-           "Failed to read attribute");
-  H5Aclose(attr_id);
-  return time;
-}
-
 DataVector read_data(const hid_t group_id, const std::string& dataset_name) {
   // Read a DataVector from the group
   const hid_t dataset_id =

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -21,19 +21,6 @@
 #include "Utilities/MakeArray.hpp"
 
 namespace h5 {
-void write_time(const hid_t group_id, const double time) {
-  // Write the time as an attribute to the group
-  hid_t s_id = H5Screate(H5S_SCALAR);
-  CHECK_H5(s_id, "Failed to create scalar for time");
-  hid_t att_id = H5Acreate2(group_id, "Time", h5_type<double>(), s_id,
-                            h5p_default(), h5p_default());
-  CHECK_H5(att_id, "Failed to create attribute for time");
-  CHECK_H5(H5Awrite(att_id, h5_type<double>(), static_cast<const void*>(&time)),
-           "Failed to write time");
-  CHECK_H5(H5Sclose(s_id), "Failed to close space_id");
-  CHECK_H5(H5Aclose(att_id), "Failed to close attribute for time");
-}
-
 template <size_t Dim>
 void write_data(const hid_t group_id, const DataVector& data,
                 const Index<Dim>& extents, const std::string& name) {

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -15,6 +15,7 @@
 #include "IO/H5/OpenGroup.hpp"
 #include "IO/H5/Type.hpp"
 #include "IO/H5/Wrappers.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -114,6 +115,11 @@ std::vector<std::string> get_group_names(
     names.push_back(name);
   }
   return names;
+}
+
+bool contains_dataset_or_group(const hid_t id, const std::string& group_name,
+                               const std::string& dataset_name) noexcept {
+  return alg::found(get_group_names(id, group_name), dataset_name);
 }
 
 template <typename Type>

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -41,16 +41,18 @@ void write_extents(hid_t group_id, const Index<Dim>& extents,
 
 /*!
  * \ingroup HDF5Group
- * \brief Write the connectivity into the group in the H5 file
+ * \brief Write a value of type `Type` to an HDF5 attribute named `name`
  */
-void write_connectivity(hid_t group_id, const std::vector<int>& connectivity);
+template <typename Type>
+void write_to_attribute(hid_t location_id, const std::string& name,
+                        const Type& value) noexcept;
 
 /*!
  * \ingroup HDF5Group
- * \brief Get the names of all the groups in a group
+ * \brief Read a value of type `Type` from an HDF5 attribute named `name`
  */
-std::vector<std::string> get_group_names(hid_t file_id,
-                                         const std::string& group_name);
+template <typename Type>
+Type read_value_attribute(hid_t location_id, const std::string& name) noexcept;
 
 /*!
  * \ingroup HDF5Group
@@ -58,6 +60,20 @@ std::vector<std::string> get_group_names(hid_t file_id,
  */
 std::vector<std::string> get_attribute_names(hid_t file_id,
                                              const std::string& group_name);
+
+/*!
+ * \ingroup HDF5Group
+ * \brief Write the connectivity into the group in the H5 file
+ */
+void write_connectivity(hid_t group_id,
+                        const std::vector<int>& connectivity) noexcept;
+
+/*!
+ * \ingroup HDF5Group
+ * \brief Get the names of all the groups and datasets in a group
+ */
+std::vector<std::string> get_group_names(
+    hid_t file_id, const std::string& group_name) noexcept;
 
 /*!
  * \ingroup HDF5Group
@@ -86,7 +102,6 @@ DataVector read_data(hid_t group_id, const std::string& dataset_name);
 template <size_t Dim>
 Index<Dim> read_extents(hid_t group_id,
                         const std::string& extents_name = "Extents");
-
 }  // namespace h5
 
 namespace h5 {
@@ -110,21 +125,6 @@ void write_strings_to_attribute(hid_t dataset_id, const std::string& name,
  */
 std::vector<std::string> read_strings_from_attribute(hid_t group_id,
                                                      const std::string& name);
-
-/*!
- * \ingroup HDF5Group
- * \brief Write a value of type `Type` to an HDF5 attribute named `name`
- */
-template <typename Type>
-void write_value_to_attribute(hid_t location_id, const std::string& name,
-                              const Type& value);
-
-/*!
- * \ingroup HDF5Group
- * \brief Read a value of type `Type` from an HDF5 attribute named `name`
- */
-template <typename Type>
-Type read_value_from_attribute(hid_t location_id, const std::string& name);
 
 /*!
  * \ingroup HDF5Group

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -125,26 +125,6 @@ namespace h5 {
 namespace detail {
 /*!
  * \ingroup HDF5Group
- * \brief Write a vector of strings into an H5 dataset as an attribute
- *
- * \requires `dataset_id` is an open dataset
- * \effects Writes the `string_array` into an HDF5 attribute with name `name`
- */
-void write_strings_to_attribute(hid_t dataset_id, const std::string& name,
-                                const std::vector<std::string>& string_array);
-
-/*!
- * \ingroup HDF5Group
- * \brief Read a vector of strings from an attribute inside an H5 dataset
- *
- * \requires `dataset_id` is an open dataset
- * \effects Reads the HDF5 attribute with name `name` as a vector of strings
- */
-std::vector<std::string> read_strings_from_attribute(hid_t group_id,
-                                                     const std::string& name);
-
-/*!
- * \ingroup HDF5Group
  * \brief Create a dataset that can be extended/appended to
  *
  * \requires group_id is an open group, each element of `initial_size` is less

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -26,6 +26,14 @@ void write_data(hid_t group_id, const DataVector& data,
 
 /*!
  * \ingroup HDF5Group
+ * \brief Write a DataVector named `name` to the group `group_id`
+ */
+void write_data(hid_t group_id, const DataVector& data,
+                const std::vector<size_t>& extents,
+                const std::string& name = "scalar") noexcept;
+
+/*!
+ * \ingroup HDF5Group
  * \brief Write the extents as an attribute named `name` to the group
  * `group_id`.
  */

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -18,12 +18,6 @@
 namespace h5 {
 /*!
  * \ingroup HDF5Group
- * \brief Write a "Time" attribute to the group
- */
-void write_time(hid_t group_id, double time);
-
-/*!
- * \ingroup HDF5Group
  * \brief Write a DataVector named `name` to the group `group_id`
  */
 template <size_t Dim>

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -94,6 +94,16 @@ std::vector<std::string> get_group_names(
 
 /*!
  * \ingroup HDF5Group
+ * \brief Check if `name` is a dataset or group in the subgroup `group_name` of
+ * `id`.
+ *
+ * \note To check the current id for `name`, pass `""` as `group_name`.
+ */
+bool contains_dataset_or_group(hid_t id, const std::string& group_name,
+                               const std::string& dataset_name) noexcept;
+
+/*!
+ * \ingroup HDF5Group
  * \brief Check if an attribute is in a group
  */
 bool contains_attribute(hid_t file_id, const std::string& group_name,

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -49,10 +49,27 @@ void write_to_attribute(hid_t location_id, const std::string& name,
 
 /*!
  * \ingroup HDF5Group
+ * \brief Write the vector `data` to the attribute `attribute_name` in the group
+ * `group_id`.
+ */
+template <typename T>
+void write_to_attribute(hid_t group_id, const std::string& name,
+                        const std::vector<T>& data) noexcept;
+
+/*!
+ * \ingroup HDF5Group
  * \brief Read a value of type `Type` from an HDF5 attribute named `name`
  */
 template <typename Type>
 Type read_value_attribute(hid_t location_id, const std::string& name) noexcept;
+
+/*!
+ * \ingroup HDF5Group
+ * \brief Read rank-1 of type `Type` from an HDF5 attribute named `name`
+ */
+template <typename T>
+std::vector<T> read_rank1_attribute(hid_t group_id,
+                                    const std::string& name) noexcept;
 
 /*!
  * \ingroup HDF5Group

--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -113,13 +113,6 @@ bool contains_attribute(hid_t file_id, const std::string& group_name,
 
 /*!
  * \ingroup HDF5Group
- * \brief Get the "Time" attribute from a group
- */
-double get_time(hid_t file_id, const std::string& group_name,
-                const std::string& attr_name = "Time");
-
-/*!
- * \ingroup HDF5Group
  * \brief Read a DataVector from a dataset in a group
  */
 DataVector read_data(hid_t group_id, const std::string& dataset_name);

--- a/src/IO/H5/OpenGroup.cpp
+++ b/src/IO/H5/OpenGroup.cpp
@@ -12,6 +12,7 @@
 
 #include "ErrorHandling/Error.hpp"
 #include "IO/H5/CheckH5.hpp"
+#include "IO/H5/Wrappers.hpp"
 
 namespace {
 std::vector<std::string> split_strings(const std::string& s,
@@ -39,21 +40,15 @@ OpenGroup::OpenGroup(hid_t file_id, const std::string& group_name,
     if (not current_group.empty()) {
       const auto status = H5Lexists(group_id, current_group.c_str(), 0);
       if (0 < status) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-        group_id = H5Gopen(group_id, current_group.c_str(), H5P_DEFAULT);
-#pragma GCC diagnostic pop
+        group_id = H5Gopen(group_id, current_group.c_str(), h5p_default());
       } else if (0 == status) {
         if (AccessType::ReadOnly == access_type) {
           ERROR("Cannot create group '" << current_group.c_str()
                                         << "' in path: " << group_name
                                         << " because the access is ReadOnly");
         }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-        group_id = H5Gcreate(group_id, current_group.c_str(), H5P_DEFAULT,
-                             H5P_DEFAULT, H5P_DEFAULT);
-#pragma GCC diagnostic pop
+        group_id = H5Gcreate(group_id, current_group.c_str(), h5p_default(),
+                             h5p_default(), h5p_default());
       } else {
         ERROR("Failed to open the group '"
               << current_group

--- a/src/IO/H5/Type.hpp
+++ b/src/IO/H5/Type.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <type_traits>
 
+#include "IO/H5/CheckH5.hpp"
 #include "Utilities/ForceInline.hpp"
 
 namespace h5 {
@@ -61,11 +62,28 @@ SPECTRE_ALWAYS_INLINE hid_t h5_type<char>() {
 template <>
 SPECTRE_ALWAYS_INLINE hid_t h5_type<std::string>() {
   hid_t datatype = H5Tcopy(H5T_C_S1);
+  CHECK_H5(datatype, "Failed to allocate string.");
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-  H5Tset_size(datatype, H5T_VARIABLE);
+  CHECK_H5(H5Tset_size(datatype, H5T_VARIABLE),
+           "Failed to set size of string.");
 #pragma GCC diagnostic pop
   return datatype;
 }
 /// \endcond
+
+/*!
+ * \ingroup HDF5Group
+ * \brief Create an H5 FORTRAN string.
+ */
+SPECTRE_ALWAYS_INLINE hid_t fortran_string() noexcept {
+  hid_t datatype = H5Tcopy(H5T_FORTRAN_S1);
+  CHECK_H5(datatype, "Failed to allocate string.");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  CHECK_H5(H5Tset_size(datatype, H5T_VARIABLE),
+           "Failed to set size of string.");
+#pragma GCC diagnostic pop
+  return datatype;
+}
 }  // namespace h5

--- a/src/IO/H5/Version.cpp
+++ b/src/IO/H5/Version.cpp
@@ -13,10 +13,9 @@ Version::Version(bool exists, detail::OpenGroup&& group, hid_t location,
                  std::string name, const uint32_t version)
     : version_([&exists, &location, &version, &name]() {
         if (exists) {
-          return detail::read_value_from_attribute<uint32_t>(
-              location, name + extension());
+          return read_value_attribute<uint32_t>(location, name + extension());
         }
-        detail::write_value_to_attribute(location, name + extension(), version);
+        write_to_attribute(location, name + extension(), version);
         return version;
       }()),
       group_(std::move(group)) {}

--- a/src/IO/H5/Wrappers.hpp
+++ b/src/IO/H5/Wrappers.hpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <hdf5.h>
+
+#include "Utilities/ForceInline.hpp"
+
+// H5F wrappers
+namespace h5 {
+/// \ingroup HDF5Group
+SPECTRE_ALWAYS_INLINE auto h5f_acc_rdonly() noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  return H5F_ACC_RDONLY;
+#pragma GCC diagnostic pop
+}
+
+/// \ingroup HDF5Group
+SPECTRE_ALWAYS_INLINE auto h5f_acc_rdwr() noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  return H5F_ACC_RDWR;
+#pragma GCC diagnostic pop
+}
+
+
+SPECTRE_ALWAYS_INLINE auto h5f_acc_trunc() noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  return H5F_ACC_TRUNC;
+#pragma GCC diagnostic pop
+}
+}  // namespace h5
+
+// H5P wrappers
+namespace h5 {
+/// \ingroup HDF5Group
+SPECTRE_ALWAYS_INLINE auto h5p_default() noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  return H5P_DEFAULT;
+#pragma GCC diagnostic pop
+}
+}  // namespace h5
+
+// H5S wrappers
+namespace h5 {
+/// \ingroup HDF5Group
+SPECTRE_ALWAYS_INLINE auto h5s_all() noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  return H5S_ALL;
+#pragma GCC diagnostic pop
+}
+
+/// \ingroup HDF5Group
+SPECTRE_ALWAYS_INLINE auto h5s_unlimited() noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  return H5S_UNLIMITED;
+#pragma GCC diagnostic pop
+}
+
+/// \ingroup HDF5Group
+SPECTRE_ALWAYS_INLINE auto h5s_scalar() noexcept {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+  return H5S_SCALAR;
+#pragma GCC diagnostic pop
+}
+}  // namespace h5

--- a/src/IO/VolumeDataFile.cpp
+++ b/src/IO/VolumeDataFile.cpp
@@ -42,7 +42,7 @@ void VolumeFile::write_element_time(const double time,
                                     const std::string& element_id) {
   const h5::detail::OpenGroup group(file_id_, "/" + element_id,
                                     h5::AccessType::ReadWrite);
-  h5::write_time(group.id(), time);
+  h5::write_to_attribute(group.id(), "Time", time);
 }
 
 template <size_t Dim>

--- a/src/IO/VolumeDataFile.cpp
+++ b/src/IO/VolumeDataFile.cpp
@@ -3,8 +3,8 @@
 
 #include "VolumeDataFile.hpp"
 
+#include <cerrno>
 #include <cstring>
-#include <errno.h>
 #include <numeric>
 
 #include "ErrorHandling/Assert.hpp"
@@ -12,6 +12,7 @@
 #include "IO/Connectivity.hpp"
 #include "IO/H5/CheckH5.hpp"
 #include "IO/H5/Type.hpp"
+#include "IO/H5/Wrappers.hpp"
 #include "Utilities/StdHelpers.hpp"
 
 class DataVector;
@@ -175,21 +176,15 @@ void VolumeFile::write_element_data(
 }
 
 void VolumeFile::create_file() {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
-  file_id_ =
-      H5Fcreate(h5_file_name_.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-#pragma GCC diagnostic pop
+  file_id_ = H5Fcreate(h5_file_name_.c_str(), H5F_ACC_TRUNC, h5::h5p_default(),
+                       h5::h5p_default());
   CHECK_H5(file_id_, "Failed to create file '" << h5_file_name_ << "'");
   const h5::detail::OpenGroup group(file_id_, "/", h5::AccessType::ReadWrite);
   hid_t s_id = H5Screate(H5S_SCALAR);
   CHECK_H5(s_id, "Failed to create dataspace");
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wold-style-cast"
   const hid_t att_id = H5Acreate2(group.id(), "FileFormatVersion",
                                   h5::h5_type<decltype(format_id_)>(), s_id,
-                                  H5P_DEFAULT, H5P_DEFAULT);
-#pragma GCC diagnostic pop
+                                  h5::h5p_default(), h5::h5p_default());
   CHECK_H5(att_id, "Failed to create attribute 'FileFormatVersion'");
   CHECK_H5(H5Awrite(att_id, h5::h5_type<decltype(format_id_)>(),
                     static_cast<void*>(&format_id_)),

--- a/src/Utilities/Algorithm.hpp
+++ b/src/Utilities/Algorithm.hpp
@@ -2,6 +2,7 @@
 // See LICENSE.txt for details.
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <iterator>
 
@@ -127,3 +128,101 @@ constexpr bool next_permutation(BidirectionalIterator first,
           typename std::iterator_traits<BidirectionalIterator>::value_type>());
 }
 }  // namespace cpp20
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Utility functions wrapping STL algorithms and additional algorithms.
+ */
+namespace alg {
+/// Convenience wrapper around std::all_of
+template <class Container, class UnaryPredicate>
+decltype(auto) all_of(const Container& c, UnaryPredicate&& unary_predicate) {
+  using std::begin;
+  using std::end;
+  return std::all_of(begin(c), end(c),
+                     std::forward<UnaryPredicate>(unary_predicate));
+}
+
+/// Convenience wrapper around std::any_of
+template <class Container, class UnaryPredicate>
+decltype(auto) any_of(const Container& c, UnaryPredicate&& unary_predicate) {
+  using std::begin;
+  using std::end;
+  return std::any_of(begin(c), end(c),
+                     std::forward<UnaryPredicate>(unary_predicate));
+}
+
+/// Convenience wrapper around std::none_of
+template <class Container, class UnaryPredicate>
+decltype(auto) none_of(const Container& c, UnaryPredicate&& unary_predicate) {
+  using std::begin;
+  using std::end;
+  return std::none_of(begin(c), end(c),
+                      std::forward<UnaryPredicate>(unary_predicate));
+}
+
+/// Convenience wrapper around std::find
+template <class Container, class T>
+decltype(auto) find(const Container& c, const T& value) {
+  using std::begin;
+  using std::end;
+  return std::find(begin(c), end(c), value);
+}
+
+/// Convenience wrapper around std::find_if
+template <class Container, class UnaryPredicate>
+decltype(auto) find_if(const Container& c, UnaryPredicate&& unary_predicate) {
+  using std::begin;
+  using std::end;
+  return std::find_if(begin(c), end(c),
+                      std::forward<UnaryPredicate>(unary_predicate));
+}
+
+/// Convenience wrapper around std::find_if_not
+template <class Container, class UnaryPredicate>
+decltype(auto) find_if_not(const Container& c,
+                           UnaryPredicate&& unary_predicate) {
+  using std::begin;
+  using std::end;
+  return std::find_if_not(begin(c), end(c),
+                          std::forward<UnaryPredicate>(unary_predicate));
+}
+
+/// Convenience wrapper around std::find, returns `true` if `value` is in `c`.
+template <class Container, class T>
+bool found(const Container& c, const T& value) {
+  using std::begin;
+  using std::end;
+  return std::find(begin(c), end(c), value) != end(c);
+}
+
+/// Convenience wrapper around std::find_if, returns `true` if the result of
+/// `std::find_if` is not equal to `end(c)`.
+template <class Container, class UnaryPredicate>
+bool found_if(const Container& c, UnaryPredicate&& unary_predicate) {
+  using std::begin;
+  using std::end;
+  return std::find_if(begin(c), end(c),
+                      std::forward<UnaryPredicate>(unary_predicate)) != end(c);
+}
+
+/// Convenience wrapper around std::find_if_not, returns `true` if the result of
+/// `std::find_if_not` is not equal to `end(c)`.
+template <class Container, class UnaryPredicate>
+bool found_if_not(const Container& c, UnaryPredicate&& unary_predicate) {
+  using std::begin;
+  using std::end;
+  return std::find_if_not(begin(c), end(c),
+                          std::forward<UnaryPredicate>(unary_predicate)) !=
+         end(c);
+}
+
+/// Convenience wrapper around std::for_each, returns the result of
+/// `std::for_each(begin(c), end(c), f)`.
+template <class Container, class UnaryFunction>
+decltype(auto) for_each(const Container& c, UnaryFunction&& f) {
+  using std::begin;
+  using std::end;
+  return std::for_each(begin(c), end(c), std::forward<UnaryFunction>(f));
+}
+}  // namespace alg

--- a/src/Utilities/MakeArray.hpp
+++ b/src/Utilities/MakeArray.hpp
@@ -80,11 +80,10 @@ make_array(Args&&... args) noexcept(
  * \tparam Size the size of the array
  */
 template <size_t Size, typename T>
-SPECTRE_ALWAYS_INLINE constexpr std::array<std::decay_t<T>, Size>
-make_array(T&& t) noexcept(noexcept(
+SPECTRE_ALWAYS_INLINE constexpr auto make_array(T&& t) noexcept(noexcept(
     MakeArray_detail::MakeArray<Size == 0>::template apply<std::decay_t<T>>(
         std::make_index_sequence<(Size == 0 ? Size : Size - 1)>{},
-        std::forward<T>(t)))) {
+        std::forward<T>(t)))) -> std::array<std::decay_t<T>, Size> {
   return MakeArray_detail::MakeArray<Size == 0>::template apply<
       std::decay_t<T>>(
       std::make_index_sequence<(Size == 0 ? Size : Size - 1)>{},
@@ -97,11 +96,10 @@ make_array(T&& t) noexcept(noexcept(
  * arguments
  */
 template <typename T, typename... V, Requires<(sizeof...(V) > 0)> = nullptr>
-SPECTRE_ALWAYS_INLINE constexpr std::array<typename std::decay_t<T>,
-                                           sizeof...(V) + 1>
-make_array(T&& t, V&&... values) noexcept(
+SPECTRE_ALWAYS_INLINE constexpr auto make_array(T&& t, V&&... values) noexcept(
     noexcept(std::array<std::decay_t<T>, sizeof...(V) + 1>{
-        {std::forward<T>(t), std::forward<V>(values)...}})) {
+        {std::forward<T>(t), std::forward<V>(values)...}}))
+    -> std::array<typename std::decay_t<T>, sizeof...(V) + 1> {
   static_assert(
       tmpl2::flat_all_v<cpp17::is_same_v<std::decay_t<T>, std::decay_t<V>>...>,
       "all types to make_array(...) must be the same");

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -459,17 +459,6 @@ SPECTRE_TEST_CASE("Unit.IO.H5.contains_attribute_false", "[Unit][IO][H5]") {
   CHECK_H5(H5Fclose(file_id), "Failed to close file: '" << file_name << "'");
 }
 
-/// [[OutputRegex, group / does not contain attribute 'Time']]
-SPECTRE_TEST_CASE("Unit.IO.H5.get_time_error", "[Unit][IO][H5]") {
-  ERROR_TEST();
-  const std::string file_name("Unit.IO.H5.get_time_error.h5");
-  const hid_t file_id =
-      H5Fcreate(file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-  CHECK_H5(file_id, "Failed to open file: " << file_name);
-  h5::get_time(file_id, "/");
-  CHECK_H5(H5Fclose(file_id), "Failed to close file: '" << file_name << "'");
-}
-
 /// [[OutputRegex, could not open dataset 'no_dataset']]
 SPECTRE_TEST_CASE("Unit.IO.H5.read_data_error", "[Unit][IO][H5]") {
   ERROR_TEST();
@@ -587,7 +576,11 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeFile1D", "[Unit][IO][H5]") {
   CHECK(std::vector<std::string>{"[0][0]"} ==
         h5::get_group_names(file_id, "/"));
   CHECK(h5::contains_attribute(file_id, "/[0][0]", "Extents"));
-  CHECK(3.8 == h5::get_time(file_id, "/[0][0]"));
+  CHECK(3.8 ==
+        h5::read_value_attribute<double>(
+            h5::detail::OpenGroup{file_id, "/[0][0]", h5::AccessType::ReadOnly}
+                .id(),
+            "Time"));
   h5::detail::OpenGroup group(file_id, "/[0][0]", h5::AccessType::ReadOnly);
   CHECK(extents == h5::read_extents<1>(group.id(), "Extents"));
   CHECK((DataVector{0., 1., 2.}) == h5::read_data(group.id(), "x-coord"));
@@ -625,7 +618,11 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeFile2D", "[Unit][IO][H5]") {
   CHECK(std::vector<std::string>{"[0][0]"} ==
         h5::get_group_names(file_id, "/"));
   CHECK(h5::contains_attribute(file_id, "/[0][0]", "Extents"));
-  CHECK(3.8 == h5::get_time(file_id, "/[0][0]"));
+  CHECK(3.8 ==
+        h5::read_value_attribute<double>(
+            h5::detail::OpenGroup{file_id, "/[0][0]", h5::AccessType::ReadOnly}
+                .id(),
+            "Time"));
   h5::detail::OpenGroup group(file_id, "/[0][0]", h5::AccessType::ReadOnly);
   CHECK(extents == h5::read_extents<dim>(group.id(), "Extents"));
   CHECK(get<0>(grid_coords) == h5::read_data(group.id(), "x-coord"));
@@ -668,7 +665,11 @@ SPECTRE_TEST_CASE("Unit.IO.H5.VolumeFile3D", "[Unit][IO][H5]") {
   CHECK(std::vector<std::string>{"[0][0]"} ==
         h5::get_group_names(file_id, "/"));
   CHECK(h5::contains_attribute(file_id, "/[0][0]", "Extents"));
-  CHECK(3.8 == h5::get_time(file_id, "/[0][0]"));
+  CHECK(3.8 ==
+        h5::read_value_attribute<double>(
+            h5::detail::OpenGroup{file_id, "/[0][0]", h5::AccessType::ReadOnly}
+                .id(),
+            "Time"));
   h5::detail::OpenGroup group(file_id, "/[0][0]", h5::AccessType::ReadOnly);
   CHECK(extents == h5::read_extents<dim>(group.id(), "Extents"));
   CHECK(get<0>(grid_coords) == h5::read_data(group.id(), "x-coord"));

--- a/tests/Unit/Utilities/Test_Algorithm.cpp
+++ b/tests/Unit/Utilities/Test_Algorithm.cpp
@@ -4,11 +4,13 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <iterator>
+#include <vector>
 
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/Array.hpp"  // IWYU pragma: associated
 #include "Utilities/Numeric.hpp"
 
+namespace {
 constexpr bool check_swap() noexcept {
   int x = 4;
   int y = 444;
@@ -56,6 +58,7 @@ constexpr bool check_next_permutation() noexcept {
   cpp17::array<size_t, size> expected{{1, 2, 4, 6, 5, 3}};
   return a == expected;
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
   // Check the functions at runtime
@@ -73,4 +76,50 @@ SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
                 "Failed test Unit.Utilities.Algorithm");
   static_assert(check_next_permutation(),
                 "Failed test Unit.Utilities.Algorithm");
+
+  // Test wrappers around STL algorithms
+  CHECK(alg::all_of(std::vector<int>{1, 1, 1, 1},
+                    [](const int t) { return t == 1; }));
+  CHECK_FALSE(alg::all_of(std::vector<int>{1, 2, 1, 1},
+                          [](const int t) { return t == 1; }));
+  CHECK_FALSE(alg::all_of(std::vector<int>{2, 1, 1, 1},
+                          [](const int t) { return t == 1; }));
+  CHECK_FALSE(alg::all_of(std::vector<int>{1, 1, 1, 2},
+                          [](const int t) { return t == 1; }));
+  CHECK(alg::any_of(std::vector<int>{4, 2, 1, 3},
+                    [](const int t) { return t == 1; }));
+  CHECK_FALSE(alg::any_of(std::vector<int>{4, 2, -1, 3},
+                          [](const int t) { return t == 1; }));
+  CHECK(alg::none_of(std::vector<int>{4, 2, -1, 3},
+                     [](const int t) { return t == 1; }));
+  CHECK_FALSE(alg::none_of(std::vector<int>{4, 2, 1, 3},
+                           [](const int t) { return t == 1; }));
+  CHECK_FALSE(alg::none_of(std::vector<int>{1, 2, -1, 3},
+                           [](const int t) { return t == 1; }));
+  CHECK_FALSE(alg::none_of(std::vector<int>{4, 2, -1, 1},
+                           [](const int t) { return t == 1; }));
+  const std::vector<int> a{1, 2, 3, 4};
+  CHECK(alg::find(a, 3) == a.begin() + 2);
+  CHECK(alg::find(a, 5) == a.end());
+  CHECK(alg::found(a, 3));
+  CHECK_FALSE(alg::found(a, 5));
+
+  CHECK(alg::find_if(a, [](const int t) { return t > 3; }) == a.end() - 1);
+  CHECK(alg::find_if(a, [](const int t) { return t < 0; }) == a.end());
+  CHECK(alg::found_if(a, [](const int t) { return t > 3; }));
+  CHECK_FALSE(alg::found_if(a, [](const int t) { return t < 0; }));
+
+  CHECK(alg::find_if_not(a, [](const int t) { return t < 3; }) == a.end() - 2);
+  CHECK(alg::find_if_not(a, [](const int t) { return t < 8; }) == a.end());
+  CHECK(alg::found_if_not(a, [](const int t) { return t < 3; }));
+  CHECK_FALSE(alg::found_if_not(a, [](const int t) { return t < 8; }));
+
+  int count = 0;
+  alg::for_each(std::vector<size_t>{1, 7, 234, 987, 32},
+                [&count](const size_t value) {
+                  if (value > 100) {
+                    count++;
+                  }
+                });
+  CHECK(count == 2);
 }


### PR DESCRIPTION
## Proposed changes

**Note:** Does not depend on #954 

- Adds various HDF5 related helper functions
- Removes specific helper functions and uses the added generic ones instead.
- There are still missing noexcept, factoring in/out of detail namespaces, etc. in the H5 code that needs to be done, but I will clean this up in a later PR since the whole H5 code helper code could use an overhaul.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
