### PR TITLE
SetupIwyu.cmake now checks if clang compiler is used

### DIFF
--- a/cmake/SetupIwyu.cmake
+++ b/cmake/SetupIwyu.cmake
@@ -52,35 +52,41 @@ function(add_iwyu_tool_targets IWYU_TOOL)
 endfunction(add_iwyu_tool_targets IWYU_TOOL)
 
 if(NOT ${USE_PCH})
-  set(IWYU_REQUIRED_VERSION 0.9)
-  find_program(IWYU_BINARY include-what-you-use)
-  find_program(IWYU_TOOL iwyu_tool.py)
-  if("${IWYU_TOOL}" STREQUAL "IWYU_TOOL-NOTFOUND")
-    message(STATUS "Could not find include-what-you-use iwyu_tool.py")
-  else("${IWYU_TOOL}" STREQUAL "IWYU_TOOL-NOTFOUND")
-    # Parse IWYU version
-    execute_process(
-      COMMAND ${IWYU_BINARY} --version
-      OUTPUT_VARIABLE IWYU_VERSION_STRING
-      )
-    string(
-      REPLACE "include-what-you-use " ""
-      IWYU_VERSION_STRING "${IWYU_VERSION_STRING}")
-    string(FIND ${IWYU_VERSION_STRING} " " IWYU_VERSION_END)
-    string(SUBSTRING ${IWYU_VERSION_STRING} 0 ${IWYU_VERSION_END} IWYU_VERSION)
-    if(${IWYU_VERSION} VERSION_LESS ${IWYU_REQUIRED_VERSION})
-      message(STATUS
-        "include-what-you-use version must be ${IWYU_REQUIRED_VERSION} "
-        "but found ${IWYU_VERSION}")
-      set(IWYU_TOOL "IWYU_TOOL-NOTFOUND")
-    else(${IWYU_VERSION} VERSION_LESS ${IWYU_REQUIRED_VERSION})
-      message(STATUS "iwyu include-what-you-use: ${IWYU_BINARY}")
-      message(STATUS "iwyu iwyu_tool.py: ${IWYU_TOOL}")
-      message(STATUS "iwyu vers: ${IWYU_VERSION}")
-      add_iwyu_tool_targets(${IWYU_TOOL})
-    endif(${IWYU_VERSION} VERSION_LESS ${IWYU_REQUIRED_VERSION})
-  endif("${IWYU_TOOL}" STREQUAL "IWYU_TOOL-NOTFOUND")
-else()
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(IWYU_REQUIRED_VERSION 0.9)
+    find_program(IWYU_BINARY include-what-you-use)
+    find_program(IWYU_TOOL iwyu_tool.py)
+    if("${IWYU_TOOL}" STREQUAL "IWYU_TOOL-NOTFOUND")
+      message(STATUS "Could not find include-what-you-use iwyu_tool.py")
+    else("${IWYU_TOOL}" STREQUAL "IWYU_TOOL-NOTFOUND")
+      # Parse IWYU version
+      execute_process(
+        COMMAND ${IWYU_BINARY} --version
+        OUTPUT_VARIABLE IWYU_VERSION_STRING
+        )
+      string(
+        REPLACE "include-what-you-use " ""
+        IWYU_VERSION_STRING "${IWYU_VERSION_STRING}")
+      string(FIND ${IWYU_VERSION_STRING} " " IWYU_VERSION_END)
+      string(SUBSTRING ${IWYU_VERSION_STRING} 0 ${IWYU_VERSION_END} IWYU_VERSION)
+      if(${IWYU_VERSION} VERSION_LESS ${IWYU_REQUIRED_VERSION})
+        message(STATUS
+          "include-what-you-use version must be ${IWYU_REQUIRED_VERSION} "
+          "but found ${IWYU_VERSION}")
+        set(IWYU_TOOL "IWYU_TOOL-NOTFOUND")
+      else(${IWYU_VERSION} VERSION_LESS ${IWYU_REQUIRED_VERSION})
+        message(STATUS "iwyu include-what-you-use: ${IWYU_BINARY}")
+        message(STATUS "iwyu iwyu_tool.py: ${IWYU_TOOL}")
+        message(STATUS "iwyu vers: ${IWYU_VERSION}")
+        add_iwyu_tool_targets(${IWYU_TOOL})
+      endif(${IWYU_VERSION} VERSION_LESS ${IWYU_REQUIRED_VERSION})
+    endif("${IWYU_TOOL}" STREQUAL "IWYU_TOOL-NOTFOUND")
+  else(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(STATUS
+      "iwyu: Cannot use include-what-you-use without clang compiler. "
+      "Compile with clang to use iwyu.")
+  endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+else(NOT ${USE_PCH})
   message(STATUS
     "iwyu: Cannot use include-what-you-use with precompiled header. "
     "Pass USE_PCH=OFF to CMake to disable the precompiled header.")


### PR DESCRIPTION
## Proposed changes

- now cmake only configures IWYU when clang is used for compiling
- fixes #824

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
