### PR TITLE
Small fixes in GrTags, including adding SpatialChristoffelSecondKind.

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
 
 class DataVector;
 

--- a/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
@@ -59,6 +59,11 @@ struct SpacetimeChristoffelSecondKind : db::SimpleTag {
   static std::string name() noexcept { return "SpactimeChristoffelSecondKind"; }
 };
 template <size_t Dim, typename Frame, typename DataType>
+struct SpatialChristoffelSecondKind : db::SimpleTag {
+  using type = tnsr::Ijj<DataType, Dim, Frame>;
+  static std::string name() noexcept { return "SpatialChristoffelSecondKind"; }
+};
+template <size_t Dim, typename Frame, typename DataType>
 struct SpacetimeNormalOneForm : db::SimpleTag {
   using type = tnsr::a<DataType, Dim, Frame>;
   static std::string name() noexcept { return "SpacetimeNormalOneForm"; }

--- a/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
@@ -41,6 +41,9 @@ template <size_t Dim, typename Frame = Frame::Inertial,
 struct SpacetimeChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
+struct SpatialChristoffelSecondKind;
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct SpacetimeNormalOneForm;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
@@ -48,11 +51,14 @@ struct SpacetimeNormalVector;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct TraceSpacetimeChristoffelFirstKind;
-template <size_t Dim, typename Frame, typename DataType>
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct TraceSpatialChristoffelSecondKind;
-template <size_t Dim, typename Frame, typename DataType>
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct ExtrinsicCurvature;
-template <size_t Dim, typename Frame, typename DataType>
+template <size_t Dim, typename Frame = Frame::Inertial,
+          typename DataType = DataVector>
 struct TraceExtrinsicCurvature;
 }  // namespace Tags
 }  // namespace gr


### PR DESCRIPTION
## Proposed changes

Add SpatialChristoffelSecondKind to GrTags, and also make other
things in GrTags consistent.

(This used to be part of the horizon finder PR but it is really independent so I pulled it out)

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
