### PR TITLE
Add Dirichlet Boundary Conditions

### DIFF
--- a/src/Domain/ElementId.cpp
+++ b/src/Domain/ElementId.cpp
@@ -4,6 +4,7 @@
 #include "Domain/ElementId.hpp"
 
 #include <boost/functional/hash.hpp>
+#include <limits>
 #include <ostream>
 
 #include "Domain/ElementIndex.hpp"
@@ -65,6 +66,16 @@ template <size_t VolumeDim>
 void ElementId<VolumeDim>::pup(PUP::er& p) noexcept {
   p | block_id_;
   p | segment_ids_;
+}
+
+template <size_t VolumeDim>
+ElementId<VolumeDim> ElementId<VolumeDim>::external_boundary_id() noexcept {
+  // To ensure that this does not correspond to an actual element, we set the
+  // block id to be much larger than the possible number of blocks.
+  // We use half of the maximum possible value in case the id of an actual block
+  // underflows to the maximum.
+  return ElementId<VolumeDim>(std::numeric_limits<size_t>::max() / 2,
+                              make_array<VolumeDim>(SegmentId(0, 0)));
 }
 
 template <size_t VolumeDim>

--- a/src/Domain/ElementId.hpp
+++ b/src/Domain/ElementId.hpp
@@ -68,6 +68,10 @@ class ElementId {
   /// Serialization for Charm++
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  /// Returns an ElementId meant for identifying data on external boundaries,
+  /// which should never correspond to the Id of an actual element.
+  static ElementId<VolumeDim> external_boundary_id() noexcept;
+
  private:
   size_t block_id_ = std::numeric_limits<size_t>::max();
   std::array<SegmentId, VolumeDim> segment_ids_ =

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <string>
 
@@ -68,5 +69,46 @@ struct UnnormalizedFaceNormal : db::ComputeTag {
       tmpl::list<Mesh<VolumeDim - 1>, ElementMap<VolumeDim, Frame>,
                  Direction<VolumeDim>>;
   using volume_tags = tmpl::list<ElementMap<VolumeDim, Frame>>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// Specialisation of UnnormalizedFaceNormal for the external boundaries which
+/// inverts the normals. Since ExternalBoundariesDirections are meant to
+/// represent ghost elements, the normals should correspond to the normals in
+/// said element, which are inverted with respect to the current element.
+template <size_t VolumeDim, typename Frame>
+struct InterfaceComputeItem<Tags::BoundaryDirectionsExterior<VolumeDim>,
+                            UnnormalizedFaceNormal<VolumeDim, Frame>>
+    : db::PrefixTag,
+      db::ComputeTag,
+      Tags::Interface<Tags::BoundaryDirectionsExterior<VolumeDim>,
+                      Tags::UnnormalizedFaceNormal<VolumeDim, Frame>> {
+  using dirs = BoundaryDirectionsExterior<VolumeDim>;
+
+  static std::string name() noexcept {
+    return "BoundaryDirectionsExterior<UnnormalizedFaceNormal>";
+  }
+
+  static auto function(
+      const db::item_type<Tags::Interface<dirs, Mesh<VolumeDim - 1>>>& meshes,
+      const db::item_type<Tags::ElementMap<VolumeDim, Frame>>& map) noexcept {
+    std::unordered_map<::Direction<VolumeDim>,
+                       tnsr::i<DataVector, VolumeDim, Frame>>
+        normals{};
+    for (const auto& direction_and_mesh : meshes) {
+      const auto& direction = direction_and_mesh.first;
+      const auto& mesh = direction_and_mesh.second;
+      auto internal_face_normal =
+          unnormalized_face_normal(mesh, map, direction);
+      std::transform(internal_face_normal.begin(), internal_face_normal.end(),
+                     internal_face_normal.begin(), std::negate<>());
+      normals[direction] = std::move(internal_face_normal);
+    }
+    return normals;
+  }
+
+  using argument_tags = tmpl::list<Tags::Interface<dirs, Mesh<VolumeDim - 1>>,
+                                   Tags::ElementMap<VolumeDim, Frame>>;
 };
 }  // namespace Tags

--- a/src/Domain/LogicalCoordinates.hpp
+++ b/src/Domain/LogicalCoordinates.hpp
@@ -10,10 +10,15 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "Domain/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+namespace Tags {
+template<size_t Dim>
+struct Mesh;
+template <size_t, typename>
+struct Coordinates;
+}  // namespace Tags
 template <size_t Dim>
 class Mesh;
 class DataVector;

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -166,6 +166,20 @@ struct BoundaryDirectionsInterior : db::ComputeTag {
   }
 };
 
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// The set of directions which correspond to external boundaries. To be used
+/// to represent data which exists on the exterior side of the external boundary
+/// faces.
+template <size_t VolumeDim>
+struct BoundaryDirectionsExterior : db::ComputeTag {
+  static std::string name() noexcept { return "BoundaryDirectionsExterior"; }
+  using argument_tags = tmpl::list<Element<VolumeDim>>;
+  static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
+    return element.external_boundaries();
+  }
+};
+
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -21,6 +21,7 @@
 #include "Domain/Element.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/IndexToSliceAt.hpp"
+#include "Domain/LogicalCoordinates.hpp"  // IWYU pragma: keep
 #include "Domain/Mesh.hpp"
 #include "Domain/Side.hpp"
 #include "Options/Options.hpp"
@@ -32,10 +33,6 @@
 
 /// \cond
 class DataVector;
-namespace Tags {
-template<size_t Dim>
-struct LogicalCoordinates;
-} // namespace Tags
 /// \endcond
 
 namespace OptionTags {

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -32,6 +32,10 @@
 
 /// \cond
 class DataVector;
+namespace Tags {
+template<size_t Dim>
+struct LogicalCoordinates;
+} // namespace Tags
 /// \endcond
 
 namespace OptionTags {
@@ -335,6 +339,27 @@ struct InterfaceMesh : db::ComputeTag, Tags::Mesh<VolumeDim - 1> {
   using base = Tags::Mesh<VolumeDim - 1>;
   using argument_tags = tmpl::list<Direction<VolumeDim>, Mesh<VolumeDim>>;
   using volume_tags = tmpl::list<Mesh<VolumeDim>>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationDomainGroup
+/// Computes the coordinates in the frame `Frame` on the faces defined by
+/// `Direction`. Intended to be prefixed by a `Tags::InterfaceComputeItem` to
+/// define the directions on which to compute the coordinates.
+template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
+struct BoundaryCoordinates : db::ComputeTag,
+                             Tags::Coordinates<VolumeDim, Frame> {
+  static constexpr auto function(
+      const ::Direction<VolumeDim> &direction,
+      const ::Mesh<VolumeDim - 1> &interface_mesh,
+      const ::ElementMap<VolumeDim, Frame> &map) noexcept {
+    return map(interface_logical_coordinates(interface_mesh, direction));
+  }
+  static std::string name() noexcept { return "BoundaryCoordinates"; }
+  using base = Tags::Coordinates<VolumeDim, Frame>;
+  using argument_tags = tmpl::list<Direction<VolumeDim>, Mesh<VolumeDim - 1>,
+                                   ElementMap<VolumeDim, Frame>>;
+  using volume_tags = tmpl::list<ElementMap<VolumeDim, Frame>>;
 };
 
 // Virtual inheritance is used here to prevent a compiler warning: Derived class

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -154,10 +154,12 @@ struct InternalDirections : db::ComputeTag {
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
-/// The set of directions which correspond to external boundaries
+/// The set of directions which correspond to external boundaries.
+/// Used for representing data on the interior side of the external boundary
+/// faces.
 template <size_t VolumeDim>
-struct BoundaryDirections : db::ComputeTag {
-  static std::string name() noexcept { return "BoundaryDirections"; }
+struct BoundaryDirectionsInterior : db::ComputeTag {
+  static std::string name() noexcept { return "BoundaryDirectionsInterior"; }
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
     return element.external_boundaries();

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -18,6 +18,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesGlobalTimeStepping.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/GotoAction.hpp"  // IWYU pragma: keep
@@ -56,6 +57,7 @@ struct EvolutionMetavars {
   static constexpr bool local_time_stepping = true;
   using analytic_solution_tag =
       OptionTags::AnalyticSolution<Burgers::Solutions::Linear>;
+  using boundary_condition_tag = analytic_solution_tag;
   using normal_dot_numerical_flux =
       OptionTags::NumericalFluxParams<Burgers::LocalLaxFriedrichsFlux>;
   using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
@@ -70,6 +72,8 @@ struct EvolutionMetavars {
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeVolumeDuDt,
+      dg::Actions::ImposeDirichletBoundaryConditions<
+          EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyBoundaryFluxesGlobalTimeStepping>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -20,6 +20,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesGlobalTimeStepping.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -55,6 +56,7 @@ struct EvolutionMetavars {
   static constexpr bool local_time_stepping = false;
   using analytic_solution_tag =
       OptionTags::AnalyticSolution<ScalarWave::Solutions::PlaneWave<Dim>>;
+  using boundary_condition_tag = analytic_solution_tag;
   using normal_dot_numerical_flux =
       OptionTags::NumericalFluxParams<ScalarWave::UpwindFlux<Dim>>;
   // A tmpl::list of tags to be added to the ConstGlobalCache by the
@@ -78,6 +80,8 @@ struct EvolutionMetavars {
                      Actions::FinalTime, Actions::ComputeVolumeDuDt,
                      dg::Actions::ComputeNonconservativeBoundaryFluxes,
                      dg::Actions::SendDataForFluxes<EvolutionMetavars>,
+                     dg::Actions::ImposeDirichletBoundaryConditions<
+                                      EvolutionMetavars>,
                      dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
                      dg::Actions::ApplyBoundaryFluxesGlobalTimeStepping,
                      Actions::RecordTimeStepperData, Actions::UpdateU>>>;

--- a/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
@@ -160,8 +160,12 @@ struct DiscontinuousGalerkin {
         Tags::InterfaceComputeItem<Tags::InternalDirections<dim>, Tag>;
 
     template <typename Tag>
-    using boundary_compute_tag =
-        Tags::InterfaceComputeItem<Tags::BoundaryDirections<dim>, Tag>;
+    using boundary_interior_compute_tag =
+        Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<dim>, Tag>;
+
+    template <typename Tag>
+    using boundary_exterior_compute_tag =
+        Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>, Tag>;
 
     using char_speed_tag = typename LocalSystem::char_speeds_tag;
 
@@ -174,10 +178,16 @@ struct DiscontinuousGalerkin {
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
         interface_compute_tag<char_speed_tag>,
         Tags::Slice<
-            Tags::BoundaryDirections<dim>,
+            Tags::BoundaryDirectionsInterior<dim>,
             db::add_tag_prefix<Tags::Flux, typename LocalSystem::variables_tag,
                                tmpl::size_t<dim>, Frame::Inertial>>,
-        boundary_compute_tag<Tags::ComputeNormalDotFlux<
+        boundary_interior_compute_tag<Tags::ComputeNormalDotFlux<
+            typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
+        Tags::Slice<Tags::BoundaryDirectionsExterior<dim>,
+                    db::add_tag_prefix<Tags::Flux,
+                                       typename LocalSystem::variables_tag,
+                                       tmpl::size_t<dim>, Frame::Inertial>>,
+        boundary_exterior_compute_tag<Tags::ComputeNormalDotFlux<
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>>;
 
     template <typename TagsList>

--- a/src/Evolution/Initialization/Interface.hpp
+++ b/src/Evolution/Initialization/Interface.hpp
@@ -19,7 +19,8 @@ namespace Initialization {
 /// DataBox changes:
 /// - Adds:
 ///   * `face_tags<Tags::InternalDirections<Dim>>`
-///   * `face_tags<Tags::BoundaryDirections<Dim>>`
+///   * `face_tags<Tags::BoundaryDirectionsInterior<Dim>>`
+///   * `face_tags<Tags::BoundaryDirectionsExterior<Dim>>`
 ///
 /// - For face_tags:
 ///   * `Tags::InterfaceComputeItem<Directions, Tags::Direction<Dim>>`
@@ -37,7 +38,9 @@ namespace Initialization {
 template <typename System>
 struct Interface {
   static constexpr size_t dim = System::volume_dim;
-  using simple_tags = db::AddSimpleTags<>;
+  using simple_tags =
+      db::AddSimpleTags<Tags::Interface<Tags::BoundaryDirectionsExterior<dim>,
+                                        typename System::variables_tag>>;
 
   template <typename Directions>
   using face_tags = tmpl::list<
@@ -53,13 +56,47 @@ struct Interface {
       Tags::InterfaceComputeItem<
           Directions, Tags::Normalized<Tags::UnnormalizedFaceNormal<dim>>>>;
 
-  using compute_tags = tmpl::append<face_tags<Tags::InternalDirections<dim>>,
-                                    face_tags<Tags::BoundaryDirections<dim>>>;
+  using ext_tags = tmpl::list<
+      Tags::BoundaryDirectionsExterior<dim>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::Direction<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::InterfaceMesh<dim>>,
+      Tags::Slice<Tags::BoundaryDirectionsExterior<dim>,
+                  typename System::spacetime_variables_tag>,
+      Tags::Slice<Tags::BoundaryDirectionsExterior<dim>,
+                  typename System::primitive_variables_tag>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::BoundaryCoordinates<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::UnnormalizedFaceNormal<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 typename System::template magnitude_tag<
+                                     Tags::UnnormalizedFaceNormal<dim>>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          Tags::Normalized<Tags::UnnormalizedFaceNormal<dim>>>>;
+
+  using compute_tags =
+      tmpl::append<face_tags<Tags::InternalDirections<dim>>,
+                   face_tags<Tags::BoundaryDirectionsInterior<dim>>, ext_tags>;
 
   template <typename TagsList>
   static auto initialize(db::DataBox<TagsList>&& box) noexcept {
+    const auto& mesh = db::get<Tags::Mesh<dim>>(box);
+    std::unordered_map<Direction<dim>,
+                       db::item_type<typename System::variables_tag>>
+        external_boundary_vars{};
+
+    for (const auto& direction :
+         db::get<Tags::Element<dim>>(box).external_boundaries()) {
+      external_boundary_vars[direction] =
+          db::item_type<typename System::variables_tag>{
+              mesh.slice_away(direction.dimension()).number_of_grid_points()};
+    }
+
     return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
-        std::move(box));
+        std::move(box), std::move(external_boundary_vars));
   }
 };
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -1,0 +1,164 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Tags.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/InterfaceActionHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace Tags {
+template <typename Tag>
+struct Magnitude;
+}  // namespace Tags
+// IWYU pragma: no_forward_declare db::DataBox
+/// \endcond
+
+namespace dg {
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief Packages data on external boundaries for calculating numerical flux.
+/// Computes contributions on the interior side from the volume, and imposes
+/// Dirichlet boundary conditions on the exterior side.
+///
+/// With:
+/// - Boundary<Tag> =
+///   Tags::Interface<Tags::BoundaryDirections<volume_dim>, Tag>
+/// - External<Tag> =
+///   Tags::Interface<Tags::ExternalBoundaryDirections<volume_dim>, Tag>
+///
+/// Uses:
+/// - ConstGlobalCache:
+///   - Metavariables::normal_dot_numerical_flux
+///   - Metavariables::boundary_condition
+/// - DataBox:
+///   - Tags::Element<volume_dim>
+///   - Boundary<Tags listed in
+///               Metavariables::normal_dot_numerical_flux::type::argument_tags>
+///   - External<Tags listed in
+///               Metavariables::normal_dot_numerical_flux::type::argument_tags>
+///   - Boundary<Tags::Mesh<volume_dim - 1>>
+///   - External<Tags::Mesh<volume_dim - 1>>
+///   - Boundary<Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>,
+///   - External<Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>,
+///   - Boundary<Tags::BoundaryCoordinates<volume_dim>>,
+///   - Metavariables::temporal_id
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///      - Tags::VariablesBoundaryData
+///      - External<typename system::variables_tag>
+///
+/// \see ReceiveDataForFluxes
+template <typename Metavariables>
+struct ImposeDirichletBoundaryConditions {
+  using const_global_cache_tags =
+      tmpl::list<typename Metavariables::normal_dot_numerical_flux,
+                 typename Metavariables::boundary_condition_tag>;
+
+  template <typename DbTags, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<DbTags>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    using system = typename Metavariables::system;
+
+    static_assert(
+        system::is_conservative or
+            cpp17::is_same_v<typename Metavariables::analytic_solution_tag,
+                             typename Metavariables::boundary_condition_tag>,
+        "Only analytic boundary conditions, or dirichlet boundary conditions "
+        "for conservative systems are implemented");
+
+    constexpr size_t volume_dim = system::volume_dim;
+
+    const auto& normal_dot_numerical_flux_computer =
+        get<typename Metavariables::normal_dot_numerical_flux>(cache);
+
+    const auto& element = db::get<Tags::Element<volume_dim>>(box);
+    const auto& temporal_id = db::get<typename Metavariables::temporal_id>(box);
+
+    const double time = db::get<Tags::Time>(box).value();
+
+    const auto& boundary_coords = db::get<
+        Tags::Interface<Tags::BoundaryDirectionsExterior<volume_dim>,
+                        Tags::Coordinates<volume_dim, Frame::Inertial>>>(box);
+
+    const auto& boundary_condition =
+        get<typename Metavariables::boundary_condition_tag>(cache);
+
+    // Apply the boundary condition
+    db::mutate_apply<
+        tmpl::list<Tags::Interface<Tags::BoundaryDirectionsExterior<volume_dim>,
+                                   typename system::variables_tag>>,
+        tmpl::list<>>(
+        [&boundary_condition, &time, &boundary_coords](
+            const gsl::not_null<db::item_type<
+                Tags::Interface<Tags::BoundaryDirectionsExterior<volume_dim>,
+                                typename system::variables_tag>>*>
+                external_bdry_vars) noexcept {
+          for (auto& external_direction_and_vars : *external_bdry_vars) {
+            auto& direction = external_direction_and_vars.first;
+            auto& vars = external_direction_and_vars.second;
+            vars.assign_subset(boundary_condition.variables(
+                boundary_coords.at(direction), time,
+                typename system::variables_tag::type::tags_list{}));
+          }
+        },
+        make_not_null(&box));
+
+    for (const auto& direction : element.external_boundaries()) {
+      const auto mortar_id = std::make_pair(
+          direction, ElementId<volume_dim>::external_boundary_id());
+
+      auto interior_data = DgActions_detail::compute_local_mortar_data(
+          box, direction, normal_dot_numerical_flux_computer,
+          Tags::BoundaryDirectionsInterior<volume_dim>{}, Metavariables{});
+
+      auto exterior_data = DgActions_detail::compute_packaged_data(
+          box, direction, normal_dot_numerical_flux_computer,
+          Tags::BoundaryDirectionsExterior<volume_dim>{}, Metavariables{});
+
+      db::mutate<Tags::VariablesBoundaryData>(
+          make_not_null(&box),
+          [&mortar_id, &temporal_id, &interior_data, &exterior_data ](
+              const gsl::not_null<
+                  db::item_type<Tags::VariablesBoundaryData, DbTags>*>
+                  mortar_data) noexcept {
+            mortar_data->at(mortar_id).local_insert(temporal_id,
+                                                    std::move(interior_data));
+            mortar_data->at(mortar_id).remote_insert(
+                temporal_id, std::move(exterior_data));
+          });
+    }
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace dg

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/InterfaceActionHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/InterfaceActionHelpers.hpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+
+namespace DgActions_detail {
+template<typename Metavariables, typename DataBoxType, typename DirectionsTag,
+    typename NumericalFlux>
+auto compute_packaged_data(
+    const DataBoxType &box,
+    const Direction<Metavariables::system::volume_dim> &direction,
+    const NumericalFlux &normal_dot_numerical_flux_computer,
+    const DirectionsTag /*meta*/, const Metavariables /*meta*/) noexcept {
+  constexpr size_t volume_dim = Metavariables::system::volume_dim;
+
+  using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
+
+  using package_arguments =
+  typename Metavariables::normal_dot_numerical_flux::type::argument_tags;
+
+  const auto &face_mesh =
+      db::get<Tags::Interface<DirectionsTag, Tags::Mesh<volume_dim - 1>>>(box)
+          .at(direction);
+
+  const auto packaged_data = db::apply<tmpl::transform<
+      package_arguments, tmpl::bind<Tags::Interface, DirectionsTag, tmpl::_1>>>(
+      [&face_mesh, &direction,
+          &normal_dot_numerical_flux_computer](const auto &... args) noexcept {
+        typename flux_comm_types::PackagedData ret(
+            face_mesh.number_of_grid_points(), 0.0);
+        normal_dot_numerical_flux_computer.package_data(make_not_null(&ret),
+                                                        args.at(direction)...);
+        return ret;
+      },
+      box);
+
+  return packaged_data;
+}
+
+template <typename Metavariables, typename DataBoxType, typename DirectionsTag,
+          typename NumericalFlux>
+auto compute_local_mortar_data(
+    const DataBoxType& box,
+    const Direction<Metavariables::system::volume_dim>& direction,
+    const NumericalFlux& normal_dot_numerical_flux_computer,
+    const DirectionsTag /*meta*/, const Metavariables /*meta*/) noexcept {
+  constexpr size_t volume_dim = Metavariables::system::volume_dim;
+
+  using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
+
+  using normal_dot_fluxes_tag =
+  Tags::Interface<DirectionsTag,
+                  typename flux_comm_types::normal_dot_fluxes_tag>;
+
+  const auto &face_mesh =
+      db::get<Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>,
+                              Tags::Mesh<volume_dim - 1>>>(box)
+          .at(direction);
+
+  const auto packaged_data =
+      compute_packaged_data(box, direction, normal_dot_numerical_flux_computer,
+                            DirectionsTag{}, Metavariables{});
+
+  typename flux_comm_types::LocalData interface_data{};
+  interface_data.magnitude_of_face_normal = db::get<Tags::Interface<
+      DirectionsTag,
+      Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>>(box)
+      .at(direction);
+
+  interface_data.mortar_data.initialize(face_mesh.number_of_grid_points());
+  interface_data.mortar_data.assign_subset(packaged_data);
+
+  if (tmpl::size<typename flux_comm_types::LocalMortarData::tags_list>::value !=
+      tmpl::size<typename flux_comm_types::PackagedData::tags_list>::value) {
+    // The local fluxes were not (all) included in the packaged
+    // data, so we need to add them to the mortar data
+    // explicitly.
+    const auto &normal_dot_fluxes =
+        db::get<normal_dot_fluxes_tag>(box).at(direction);
+    interface_data.mortar_data.assign_subset(normal_dot_fluxes);
+  }
+
+  return interface_data;
+}
+}  // namespace DgActions_detail

--- a/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Tags.hpp
@@ -12,6 +12,10 @@ namespace OptionTags {
 struct AnalyticSolutionBase {};
 
 /// \ingroup OptionTagsGroup
+/// Base tag with which to retrieve the BoundaryConditionType
+struct BoundaryConditionBase {};
+
+/// \ingroup OptionTagsGroup
 /// The analytic solution, with the type of the analytic solution set as the
 /// template parameter
 template <typename SolutionType>
@@ -19,5 +23,12 @@ struct AnalyticSolution : AnalyticSolutionBase {
   static constexpr OptionString help =
       "Analytic solution used for the initial data and errors";
   using type = SolutionType;
+};
+/// \ingroup OptionTagsGroup
+/// The boundary condition to be applied at all external boundaries.
+template <typename BoundaryConditionType>
+struct BoundaryCondition : BoundaryConditionBase {
+  static constexpr OptionString help = "Boundary condition to be used";
+  using type = BoundaryConditionType;
 };
 }  // namespace OptionTags

--- a/tests/Unit/Domain/Test_ElementId.cpp
+++ b/tests/Unit/Domain/Test_ElementId.cpp
@@ -58,6 +58,11 @@ SPECTRE_TEST_CASE("Unit.Domain.ElementId", "[Domain][Unit]") {
 
   // Test output operator:
   CHECK(get_output(block_2_3d) == "[B2,(L2I3,L1I0,L1I1)]");
+
+  CHECK(ElementId<3>::external_boundary_id().block_id() ==
+        std::numeric_limits<size_t>::max() / 2);
+  CHECK(ElementId<3>::external_boundary_id().segment_ids() ==
+        make_array<3>(SegmentId(0, 0)));
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.ElementId.ElementIndexConversion",

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -102,10 +102,12 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
   constexpr size_t dim = 3;
   using internal_directions = Tags::InternalDirections<dim>;
   using boundary_directions_interior = Tags::BoundaryDirectionsInterior<dim>;
+  using boundary_directions_exterior = Tags::BoundaryDirectionsExterior<dim>;
   using templated_directions = TestTags::TemplatedDirections<int>;
 
   CHECK(internal_directions::name() == "InternalDirections");
   CHECK(boundary_directions_interior::name() == "BoundaryDirectionsInterior");
+  CHECK(boundary_directions_exterior::name() == "BoundaryDirectionsExterior");
 
   Element<dim> element{ElementId<3>(0),
                        {{Direction<dim>::lower_xi(), {}},
@@ -151,7 +153,8 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
           Tags::InterfaceComputeItem<boundary_directions_interior,
                                      TestTags::Negate<TestTags::Double>>,
           Tags::InterfaceComputeItem<boundary_directions_interior,
-                                     TestTags::ComplexComputeItem<dim>>>(
+                                     TestTags::ComplexComputeItem<dim>>,
+          boundary_directions_exterior>>(
       std::move(element), 5,
       std::unordered_map<Direction<dim>, double>{
           {Direction<dim>::lower_xi(), 1.5},
@@ -179,12 +182,8 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
               {Direction<dim>::upper_xi(), Direction<dim>::upper_xi()},
               {Direction<dim>::upper_zeta(), Direction<dim>::upper_zeta()}}));
 
-      CHECK(
-      (get<Tags::Interface<boundary_directions, Tags::Direction<dim>>>(box)) ==
-      (std::unordered_map<Direction<dim>, Direction<dim>>{
-              {Direction<dim>::upper_eta(), Direction<dim>::upper_eta()},
-              {Direction<dim>::lower_eta(), Direction<dim>::lower_eta()},
-              {Direction<dim>::lower_zeta(), Direction<dim>::lower_zeta()}}));
+  CHECK(get<Tags::BoundaryDirectionsInterior<dim>>(box) ==
+        get<Tags::BoundaryDirectionsExterior<dim>>(box));
 
     CHECK(get<TestTags::Negate<TestTags::Int>>(box) == -5);
 

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -101,11 +101,11 @@ struct TemplatedDirections : db::SimpleTag {
 SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
   constexpr size_t dim = 3;
   using internal_directions = Tags::InternalDirections<dim>;
-  using boundary_directions = Tags::BoundaryDirections<dim>;
+  using boundary_directions_interior = Tags::BoundaryDirectionsInterior<dim>;
   using templated_directions = TestTags::TemplatedDirections<int>;
 
   CHECK(internal_directions::name() == "InternalDirections");
-  CHECK(boundary_directions::name() == "BoundaryDirections");
+  CHECK(boundary_directions_interior::name() == "BoundaryDirectionsInterior");
 
   Element<dim> element{ElementId<3>(0),
                        {{Direction<dim>::lower_xi(), {}},
@@ -124,10 +124,10 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
       db::AddSimpleTags<
           Tags::Element<dim>, TestTags::Int,
           Tags::Interface<internal_directions, TestTags::Double>,
-          Tags::Interface<boundary_directions, TestTags::Double>,
+          Tags::Interface<boundary_directions_interior, TestTags::Double>,
           TestTags::NoCopy<1>,
           Tags::Interface<internal_directions, TestTags::NoCopy<2>>,
-          Tags::Interface<boundary_directions, TestTags::NoCopy<2>>,
+          Tags::Interface<boundary_directions_interior, TestTags::NoCopy<2>>,
           templated_directions,
           Tags::Interface<templated_directions, TestTags::Double>>,
       db::AddComputeTags<
@@ -143,13 +143,15 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
                                      Tags::Direction<dim>>,
           Tags::InterfaceComputeItem<templated_directions,
                                      TestTags::Negate<TestTags::Double>>,
-          boundary_directions,
-          Tags::InterfaceComputeItem<boundary_directions, Tags::Direction<dim>>,
-          Tags::InterfaceComputeItem<boundary_directions, TestTags::AddThree>,
-          Tags::InterfaceComputeItem<boundary_directions,
+          boundary_directions_interior,
+          Tags::InterfaceComputeItem<boundary_directions_interior,
+                                     Tags::Direction<dim>>,
+          Tags::InterfaceComputeItem<boundary_directions_interior,
+                                     TestTags::AddThree>,
+          Tags::InterfaceComputeItem<boundary_directions_interior,
                                      TestTags::Negate<TestTags::Double>>,
-          Tags::InterfaceComputeItem<boundary_directions,
-                                     TestTags::ComplexComputeItem<dim>>>>(
+          Tags::InterfaceComputeItem<boundary_directions_interior,
+                                     TestTags::ComplexComputeItem<dim>>>(
       std::move(element), 5,
       std::unordered_map<Direction<dim>, double>{
           {Direction<dim>::lower_xi(), 1.5},
@@ -165,17 +167,17 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
       std::unordered_map<Direction<dim>, double>{
           {Direction<dim>::upper_xi(), 4.5}});
 
-    CHECK(get<Tags::BoundaryDirections<dim>>(box) ==
+    CHECK(get<Tags::BoundaryDirectionsInterior<dim>>(box) ==
           std::unordered_set<Direction<dim>>{Direction<dim>::lower_eta(),
                                              Direction<dim>::upper_eta(),
                                              Direction<dim>::lower_zeta()});
 
-    CHECK(
-      (get<Tags::Interface<internal_directions, Tags::Direction<dim>>>(box)) ==
-      (std::unordered_map<Direction<dim>, Direction<dim>>{
-            {Direction<dim>::lower_xi(), Direction<dim>::lower_xi()},
-            {Direction<dim>::upper_xi(), Direction<dim>::upper_xi()},
-            {Direction<dim>::upper_zeta(), Direction<dim>::upper_zeta()}}));
+    CHECK((get<Tags::Interface<internal_directions, Tags::Direction<dim>>>(
+              box)) ==
+          (std::unordered_map<Direction<dim>, Direction<dim>>{
+              {Direction<dim>::lower_xi(), Direction<dim>::lower_xi()},
+              {Direction<dim>::upper_xi(), Direction<dim>::upper_xi()},
+              {Direction<dim>::upper_zeta(), Direction<dim>::upper_zeta()}}));
 
       CHECK(
       (get<Tags::Interface<boundary_directions, Tags::Direction<dim>>>(box)) ==
@@ -197,7 +199,7 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
               {Direction<dim>::upper_xi(), -2.5},
               {Direction<dim>::upper_zeta(), -3.5}}));
 
-    CHECK((get<Tags::Interface<boundary_directions,
+    CHECK((get<Tags::Interface<boundary_directions_interior,
                                TestTags::Negate<TestTags::Double>>>(box)) ==
           (std::unordered_map<Direction<dim>, double>{
               {Direction<dim>::lower_eta(), -10.5},
@@ -210,20 +212,20 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
               {Direction<dim>::upper_xi(), 8},
               {Direction<dim>::upper_zeta(), 8}}));
 
-    CHECK((get<Tags::Interface<boundary_directions, TestTags::Int>>(box)) ==
-          (std::unordered_map<Direction<dim>, int>{
-              {Direction<dim>::lower_eta(), 8},
-              {Direction<dim>::upper_eta(), 8},
-              {Direction<dim>::lower_zeta(), 8}}));
+    CHECK((get<Tags::Interface<boundary_directions_interior, TestTags::Int>>(
+              box)) == (std::unordered_map<Direction<dim>, int>{
+                           {Direction<dim>::lower_eta(), 8},
+                           {Direction<dim>::upper_eta(), 8},
+                           {Direction<dim>::lower_zeta(), 8}}));
 
-      CHECK((get<Tags::Interface<internal_directions,
-                                 TestTags::ComplexComputeItem<dim>>>(box)) ==
-            (std::unordered_map<Direction<dim>, std::pair<int, double>>{
-                {Direction<dim>::lower_xi(), {5, 1.5}},
-                {Direction<dim>::upper_xi(), {5, 2.5}},
-                {Direction<dim>::upper_zeta(), {5, 3.5}}}));
+    CHECK((get<Tags::Interface<internal_directions,
+                               TestTags::ComplexComputeItem<dim>>>(box)) ==
+          (std::unordered_map<Direction<dim>, std::pair<int, double>>{
+              {Direction<dim>::lower_xi(), {5, 1.5}},
+              {Direction<dim>::upper_xi(), {5, 2.5}},
+              {Direction<dim>::upper_zeta(), {5, 3.5}}}));
 
-    CHECK((get<Tags::Interface<boundary_directions,
+    CHECK((get<Tags::Interface<boundary_directions_interior,
                                TestTags::ComplexComputeItem<dim>>>(box)) ==
           (std::unordered_map<Direction<dim>, std::pair<int, double>>{
               {Direction<dim>::lower_eta(), {5, 10.5}},

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -8,5 +8,6 @@ set(LIBRARY_SOURCES
   Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
   Actions/Test_FluxCommunication.cpp
   Actions/Test_FluxCommunicationLts.cpp
+  Actions/Test_ImposeBoundaryConditions.cpp
   PARENT_SCOPE
   )

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -1,0 +1,491 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+// IWYU pragma: no_include <boost/functional/hash/extensions.hpp>
+#include <cstddef>
+#include <functional>
+#include <initializer_list>  // IWYU pragma: keep
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+// IWYU pragma: no_include "DataStructures/VariablesHelpers.hpp"  // for Variables
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+// IWYU pragma: no_include "NumericalAlgorithms/DiscontinuousGalerkin/SimpleBoundaryData.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+// IWYU pragma: no_include "Parallel/PupStlCpp11.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+// IWYU pragma: no_forward_declare dg::Actions::ImposeDirichletBoundaryConditions
+// IWYU pragma: no_forward_declare dg::Actions::ReceiveDataForFluxes
+
+namespace {
+constexpr size_t Dim = 2;
+
+using TemporalId = Tags::TimeId;
+
+struct Var : db::SimpleTag {
+  static std::string name() noexcept { return "Var"; }
+  using type = Scalar<DataVector>;
+};
+
+struct OtherData : db::SimpleTag {
+  static std::string name() noexcept { return "OtherData"; }
+  using type = Scalar<DataVector>;
+};
+
+class NumericalFlux {
+ public:
+  struct ExtraData : db::SimpleTag {
+    static std::string name() noexcept { return "ExtraTag"; }
+    using type = tnsr::I<DataVector, 1>;
+  };
+
+  using package_tags = tmpl::list<ExtraData, Var>;
+
+  using argument_tags =
+      tmpl::list<Tags::NormalDotFlux<Var>, OtherData,
+                 Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>;
+  void package_data(const gsl::not_null<Variables<package_tags>*> packaged_data,
+                    const Scalar<DataVector>& var_flux,
+                    const Scalar<DataVector>& other_data,
+                    const tnsr::i<DataVector, Dim, Frame::Inertial>&
+                        interface_unit_normal) const noexcept {
+    get(get<Var>(*packaged_data)) = 10. * get(var_flux);
+    get<0>(get<ExtraData>(*packaged_data)) =
+        get(other_data) + 2. * get<0>(interface_unit_normal) +
+        3. * get<1>(interface_unit_normal);
+  }
+
+  // void operator()(...) is unused
+
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+struct NumericalFluxTag {
+  using type = NumericalFlux;
+};
+
+struct BoundaryCondition {
+  tuples::TaggedTuple<Var> variables(const tnsr::I<DataVector, Dim>& /*x*/,
+                                     double /*t*/,
+                                     tmpl::list<Var> /*meta*/) const noexcept {
+    return tuples::TaggedTuple<Var>{Scalar<DataVector>{{{{30., 40., 50.}}}}};
+  }
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+struct BoundaryConditionTag {
+  using type = BoundaryCondition;
+};
+
+struct System {
+  static constexpr const size_t volume_dim = Dim;
+  static constexpr bool is_conservative = true;
+
+  using variables_tag = Tags::Variables<tmpl::list<Var>>;
+
+  template <typename Tag>
+  using magnitude_tag = Tags::EuclideanMagnitude<Tag>;
+};
+
+template <typename Tag>
+using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
+template <typename Tag>
+using interface_compute_tag =
+    Tags::InterfaceComputeItem<Tags::InternalDirections<Dim>, Tag>;
+
+template <typename Tag>
+using boundary_tag =
+    Tags::Interface<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
+template <typename Tag>
+using boundary_compute_tag =
+    Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
+
+template <typename Tag>
+using external_boundary_tag =
+    Tags::Interface<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
+template <typename Tag>
+using external_boundary_compute_tag =
+    Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
+
+template <typename FluxCommTypes>
+using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;
+template <typename FluxCommTypes>
+using LocalMortarData = typename FluxCommTypes::LocalMortarData;
+template <typename FluxCommTypes>
+using PackagedData = typename FluxCommTypes::PackagedData;
+template <typename FluxCommTypes>
+using normal_dot_fluxes_tag =
+    interface_tag<typename FluxCommTypes::normal_dot_fluxes_tag>;
+template <typename FluxCommTypes>
+using bdry_normal_dot_fluxes_tag =
+    boundary_tag<typename FluxCommTypes::normal_dot_fluxes_tag>;
+template <typename FluxCommTypes>
+using external_bdry_normal_dot_fluxes_tag =
+    external_boundary_tag<typename FluxCommTypes::normal_dot_fluxes_tag>;
+
+using bdry_vars_tag = boundary_tag<Tags::Variables<tmpl::list<Var>>>;
+using external_bdry_vars_tag =
+    external_boundary_tag<Tags::Variables<tmpl::list<Var>>>;
+
+template <typename FluxCommTypes>
+using fluxes_tag = typename FluxCommTypes::FluxesTag;
+
+using other_data_tag = interface_tag<Tags::Variables<tmpl::list<OtherData>>>;
+using bdry_other_data_tag =
+    boundary_tag<Tags::Variables<tmpl::list<OtherData>>>;
+using external_bdry_other_data_tag =
+    external_boundary_tag<Tags::Variables<tmpl::list<OtherData>>>;
+using mortar_next_temporal_ids_tag = Tags::Mortars<Tags::Next<TemporalId>, Dim>;
+using mortar_meshes_tag = Tags::Mortars<Tags::Mesh<Dim - 1>, Dim>;
+using mortar_sizes_tag = Tags::Mortars<Tags::MortarSize<Dim - 1>, Dim>;
+
+template <typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<Dim>;
+  using const_global_cache_tag_list =
+      tmpl::list<NumericalFluxTag, BoundaryConditionTag>;
+  using action_list =
+      tmpl::list<dg::Actions::ImposeDirichletBoundaryConditions<Metavariables>,
+                 dg::Actions::ReceiveDataForFluxes<Metavariables>>;
+  using flux_comm_types = dg::FluxCommunicationTypes<Metavariables>;
+
+  using simple_tags = db::AddSimpleTags<
+      TemporalId, Tags::Next<TemporalId>, Tags::Mesh<Dim>, Tags::Element<Dim>,
+      Tags::ElementMap<Dim>, bdry_normal_dot_fluxes_tag<flux_comm_types>,
+      bdry_other_data_tag, external_bdry_normal_dot_fluxes_tag<flux_comm_types>,
+      external_bdry_other_data_tag, external_bdry_vars_tag,
+      mortar_data_tag<flux_comm_types>, mortar_next_temporal_ids_tag,
+      mortar_meshes_tag, mortar_sizes_tag>;
+
+  using compute_tags = db::AddComputeTags<
+      Tags::Time, Tags::BoundaryDirectionsInterior<Dim>,
+      boundary_compute_tag<Tags::Direction<Dim>>,
+      boundary_compute_tag<Tags::InterfaceMesh<Dim>>,
+      boundary_compute_tag<Tags::UnnormalizedFaceNormal<Dim>>,
+      boundary_compute_tag<
+          Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+      boundary_compute_tag<Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>,
+      Tags::BoundaryDirectionsExterior<Dim>,
+      external_boundary_compute_tag<Tags::Direction<Dim>>,
+      external_boundary_compute_tag<Tags::InterfaceMesh<Dim>>,
+      external_boundary_compute_tag<Tags::BoundaryCoordinates<Dim>>,
+      external_boundary_compute_tag<Tags::UnnormalizedFaceNormal<Dim>>,
+      external_boundary_compute_tag<
+          Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+      external_boundary_compute_tag<
+          Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+
+  using initial_databox =
+      db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
+};
+
+struct Metavariables {
+  using system = System;
+  using component_list = tmpl::list<component<Metavariables>>;
+  using temporal_id = TemporalId;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  using normal_dot_numerical_flux = NumericalFluxTag;
+  using boundary_condition_tag = BoundaryConditionTag;
+  using analytic_solution_tag = boundary_condition_tag;
+};
+
+template <typename Component>
+using compute_items = typename Component::compute_tags;
+
+using flux_comm_types = typename component<Metavariables>::flux_comm_types;
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.BoundaryConditions",
+                  "[Unit][NumericalAlgorithms][Actions]") {
+  using metavariables = Metavariables;
+  using my_component = component<metavariables>;
+  const Mesh<2> mesh{3, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+
+  //      xi      Block       +- xi
+  //      |     0   |   1     |
+  // eta -+ +-------+-+-+---+ eta
+  //        |       |X| |   |
+  //        |       +-+-+   |
+  //        |       | | |   |
+  //        +-------+-+-+---+
+  // We run the actions on the indicated element.
+  const ElementId<2> self_id(1, {{{2, 0}, {1, 0}}});
+  const ElementId<2> west_id(0);
+  const ElementId<2> east_id(1, {{{2, 1}, {1, 0}}});
+  const ElementId<2> south_id(1, {{{2, 0}, {1, 1}}});
+
+  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
+  const CoordinateMaps::Affine eta_map{-1., 1., 7., 3.};
+
+  const auto coordmap =
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                         CoordinateMaps::Affine>(xi_map,
+                                                                 eta_map));
+
+  const auto external_directions = {Direction<2>::lower_eta(),
+                                    Direction<2>::upper_xi()};
+
+  const auto external_mortar_ids = {
+      std::make_pair(Direction<2>::lower_eta(),
+                     ElementId<2>::external_boundary_id()),
+      std::make_pair(Direction<2>::upper_xi(),
+                     ElementId<2>::external_boundary_id())};
+
+  const struct {
+    std::unordered_map<Direction<2>, Scalar<DataVector>> bdry_fluxes;
+    std::unordered_map<Direction<2>, Scalar<DataVector>> bdry_other_data;
+    std::unordered_map<Direction<2>, Scalar<DataVector>> external_bdry_fluxes;
+    std::unordered_map<Direction<2>, Scalar<DataVector>>
+        external_bdry_other_data;
+    std::unordered_map<Direction<2>, Scalar<DataVector>> external_bdry_vars;
+  } data{{{Direction<2>::lower_eta(), Scalar<DataVector>{{{{1., 2., 3.}}}}},
+          {Direction<2>::upper_xi(), Scalar<DataVector>{{{{21., 22., 23.}}}}}},
+         {{Direction<2>::lower_eta(), Scalar<DataVector>{{{{4., 5., 6.}}}}},
+          {Direction<2>::upper_xi(), Scalar<DataVector>{{{{24., 25., 26.}}}}}},
+         {{Direction<2>::lower_eta(), Scalar<DataVector>{{{{7., 8., 9.}}}}},
+          {Direction<2>::upper_xi(), Scalar<DataVector>{{{{27., 28., 29.}}}}}},
+         {{Direction<2>::lower_eta(), Scalar<DataVector>{{{{10., 11., 12.}}}}},
+          {Direction<2>::upper_xi(), Scalar<DataVector>{{{{30., 31., 32.}}}}}},
+         {{Direction<2>::lower_eta(), Scalar<DataVector>{{{{13., 14., 15.}}}}},
+          {Direction<2>::upper_xi(), Scalar<DataVector>{{{{33., 34., 35.}}}}}}};
+
+  auto start_box = [
+    &mesh, &self_id, &west_id, &south_id, &coordmap, &data,
+    &external_directions, &external_mortar_ids
+  ]() noexcept {
+    const Element<2> element(self_id,
+                             {{Direction<2>::lower_xi(), {{west_id}, {}}},
+                              {Direction<2>::upper_eta(), {{south_id}, {}}}});
+
+    auto map = ElementMap<2, Frame::Inertial>(self_id, coordmap->get_clone());
+
+    db::item_type<normal_dot_fluxes_tag<flux_comm_types>>
+        bdry_normal_dot_fluxes;
+    for (const auto& direction : external_directions) {
+      auto& flux_vars = bdry_normal_dot_fluxes[direction];
+      flux_vars.initialize(3);
+      get<Tags::NormalDotFlux<Var>>(flux_vars) = data.bdry_fluxes.at(direction);
+    }
+
+    db::item_type<other_data_tag> bdry_other_data;
+    for (const auto& direction : external_directions) {
+      auto& other_data_vars = bdry_other_data[direction];
+      other_data_vars.initialize(3);
+      get<OtherData>(other_data_vars) = data.bdry_other_data.at(direction);
+    }
+
+    db::item_type<normal_dot_fluxes_tag<flux_comm_types>>
+        external_bdry_normal_dot_fluxes;
+    for (const auto& direction : external_directions) {
+      auto& flux_vars = external_bdry_normal_dot_fluxes[direction];
+      flux_vars.initialize(3);
+      get<Tags::NormalDotFlux<Var>>(flux_vars) =
+          data.external_bdry_fluxes.at(direction);
+    }
+
+    db::item_type<other_data_tag> external_bdry_other_data;
+    for (const auto& direction : external_directions) {
+      auto& other_data_vars = external_bdry_other_data[direction];
+      other_data_vars.initialize(3);
+      get<OtherData>(other_data_vars) =
+          data.external_bdry_other_data.at(direction);
+    }
+
+    db::item_type<external_bdry_vars_tag> external_bdry_vars;
+    for (const auto& direction : external_directions) {
+      auto& vars = external_bdry_vars[direction];
+      vars.initialize(3);
+      get<Var>(vars) = data.external_bdry_vars.at(direction);
+    }
+
+    const Slab slab(1.2, 3.4);
+    const Time start = slab.start();
+    const Time end = slab.end();
+
+    TimeId initial_time(true, 4, start);
+    TimeId next_time(true, 4, end);
+
+    db::item_type<mortar_data_tag<flux_comm_types>> mortar_history{};
+    db::item_type<mortar_next_temporal_ids_tag> mortar_next_temporal_ids{};
+    db::item_type<mortar_meshes_tag> mortar_meshes{};
+    db::item_type<mortar_sizes_tag> mortar_sizes{};
+    for (const auto& mortar_id : external_mortar_ids) {
+      mortar_history.insert({mortar_id, {}});
+      mortar_next_temporal_ids.insert({mortar_id, initial_time});
+      mortar_meshes.insert({mortar_id, mesh.slice_away(0)});
+      mortar_sizes.insert({mortar_id, {{Spectral::MortarSize::Full}}});
+    }
+
+    return db::create<
+        db::AddSimpleTags<
+            TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
+            Tags::ElementMap<2>, bdry_normal_dot_fluxes_tag<flux_comm_types>,
+            bdry_other_data_tag,
+            external_bdry_normal_dot_fluxes_tag<flux_comm_types>,
+            external_bdry_other_data_tag, external_bdry_vars_tag,
+            mortar_data_tag<flux_comm_types>, mortar_next_temporal_ids_tag,
+            mortar_meshes_tag, mortar_sizes_tag>,
+        compute_items<my_component>>(
+        initial_time, next_time, mesh, element, std::move(map),
+        std::move(bdry_normal_dot_fluxes), std::move(bdry_other_data),
+        std::move(external_bdry_normal_dot_fluxes),
+        std::move(external_bdry_other_data), std::move(external_bdry_vars),
+        std::move(mortar_history), std::move(mortar_next_temporal_ids),
+        std::move(mortar_meshes), std::move(mortar_sizes));
+  }
+  ();
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
+      .emplace(self_id, std::move(start_box));
+
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      {NumericalFlux{}, BoundaryCondition{}}, std::move(dist_objects)};
+
+  using initial_databox_type = db::compute_databox_type<tmpl::append<
+      db::AddSimpleTags<
+          TemporalId, Tags::Next<TemporalId>, Tags::Mesh<2>, Tags::Element<2>,
+          Tags::ElementMap<2>, bdry_normal_dot_fluxes_tag<flux_comm_types>,
+          bdry_other_data_tag,
+          external_bdry_normal_dot_fluxes_tag<flux_comm_types>,
+          external_bdry_other_data_tag, external_bdry_vars_tag,
+          mortar_data_tag<flux_comm_types>, mortar_next_temporal_ids_tag,
+          mortar_meshes_tag, mortar_sizes_tag>,
+      compute_items<my_component>>>;
+
+  runner.next_action<my_component>(self_id);
+
+  CHECK(runner.is_ready<my_component>(self_id));
+
+  // Check that BC's were indeed applied.
+  const auto& external_vars =
+      db::get<external_bdry_vars_tag>(runner.algorithms<my_component>()
+                                          .at(self_id)
+                                          .get_databox<initial_databox_type>());
+
+  db::item_type<external_bdry_vars_tag> expected_vars{};
+  for (const auto& direction : external_directions) {
+    expected_vars[direction].initialize(3);
+  }
+  get<Var>(expected_vars[Direction<2>::lower_eta()]) =
+      Scalar<DataVector>({{{30., 40., 50.}}});
+  get<Var>(expected_vars[Direction<2>::upper_xi()]) =
+      Scalar<DataVector>({{{30., 40., 50.}}});
+  CHECK(external_vars == expected_vars);
+
+  // ReceiveDataForFluxes
+  runner.next_action<my_component>(self_id);
+  const auto& self_box = runner.algorithms<my_component>()
+                             .at(self_id)
+                             .get_databox<initial_databox_type>();
+
+  auto mortar_history = serialize_and_deserialize(
+      db::get<mortar_data_tag<flux_comm_types>>(self_box));
+  CHECK(mortar_history.size() == 2);
+  const auto check_mortar = [&mortar_history](
+      const std::pair<Direction<2>, ElementId<2>>& mortar_id,
+      const Scalar<DataVector>& local_flux,
+      const Scalar<DataVector>& remote_flux,
+      const Scalar<DataVector>& local_other,
+      const Scalar<DataVector>& remote_other,
+      const tnsr::i<DataVector, 2>& local_normal,
+      const tnsr::i<DataVector, 2>& remote_normal) noexcept {
+    LocalMortarData<flux_comm_types> local_mortar_data(3);
+    get<Tags::NormalDotFlux<Var>>(local_mortar_data) = local_flux;
+    const auto magnitude_local_normal = magnitude(local_normal);
+    auto normalized_local_normal = local_normal;
+    for (auto& x : normalized_local_normal) {
+      x /= get(magnitude_local_normal);
+    }
+    PackagedData<flux_comm_types> local_packaged(3);
+    NumericalFlux{}.package_data(&local_packaged, local_flux, local_other,
+                                 normalized_local_normal);
+    local_mortar_data.assign_subset(local_packaged);
+
+    const auto magnitude_remote_normal = magnitude(remote_normal);
+    auto normalized_remote_normal = remote_normal;
+    for (auto& x : normalized_remote_normal) {
+      x /= get(magnitude_remote_normal);
+    }
+    PackagedData<flux_comm_types> remote_packaged(3);
+    NumericalFlux{}.package_data(&remote_packaged, remote_flux, remote_other,
+                                 normalized_remote_normal);
+
+    const auto result = mortar_history.at(mortar_id).extract();
+
+    CHECK(result.first.mortar_data == local_mortar_data);
+    CHECK(result.first.magnitude_of_face_normal == magnitude_local_normal);
+    CHECK(result.second == remote_packaged);
+  };
+
+  check_mortar(
+      std::make_pair(Direction<2>::lower_eta(),
+                     ElementId<2>::external_boundary_id()),
+      data.bdry_fluxes.at(Direction<2>::lower_eta()),
+      data.external_bdry_fluxes.at(Direction<2>::lower_eta()),
+      data.bdry_other_data.at(Direction<2>::lower_eta()),
+      data.external_bdry_other_data.at(Direction<2>::lower_eta()),
+      tnsr::i<DataVector, 2>{{{DataVector{3, 0.0}, DataVector{3, 1.0}}}},
+      tnsr::i<DataVector, 2>{{{DataVector{3, 0.0}, DataVector{3, -1.0}}}});
+
+  check_mortar(
+      std::make_pair(Direction<2>::upper_xi(),
+                     ElementId<2>::external_boundary_id()),
+      data.bdry_fluxes.at(Direction<2>::upper_xi()),
+      data.external_bdry_fluxes.at(Direction<2>::upper_xi()),
+      data.bdry_other_data.at(Direction<2>::upper_xi()),
+      data.external_bdry_other_data.at(Direction<2>::upper_xi()),
+      tnsr::i<DataVector, 2>{{{DataVector{3, 2.0}, DataVector{3, 0.0}}}},
+      tnsr::i<DataVector, 2>{{{DataVector{3, -2.0}, DataVector{3, 0.0}}}});
+}


### PR DESCRIPTION
## Proposed changes

- Adds another directions tag `ExternalBoundaryDirections` which is used to prefix Tags which hold data on the exterior side of the external boundaries. This is a bad name to distinguish from `BoundaryDirections` which is meant for the interior side. I'm open to suggestions, perhaps `BoundaryDirectionsInteriorSide` and `BoundaryDirectionsExteriorSide`?

- Specialises FaceNormal to flip the normal for these external directions, since they're meant to correspond to the opposite side of a "ghost" element. 

- First pass at boundary conditions: Enables analytic boundary conditions for any system, and Dirichlet for conservative systems. A single boundary condition will be applied for all boundaries. Basically, the `BoundaryConditionTag` must have the same interface as an `AnalyticSolutionTag`, and must return all of the evolved variables at a given `x` and `t`. The reason this won't work for something like ScalarWave is that Dirichlet conditions for such systems only apply to a subset of the evolved variables, (only psi; pi and phi are no-ops which means they have to be set to the interior values) whereas for conservative systems they apply to all of the evolved variables, so it's the same interface as an analytic solution. 

- ImposeDirichletBoundaryConditions action: Similar to SendDataForFluxes. For the mortar data, interior data is set the same as `local_data` in SendDataForFluxes, and exterior data is set by the boundary conditions, which is then put into the mortar data with a `remote_insert`. The mortar ids for the remote data is just set to the element's id itself. In ReceiveDataForFluxes, I had to alter the `is_ready` function to not wait for data from `mortar_id`s with the same id as the element. 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
