### PR TITLE
Wrap GrMhd functions in structs

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Equations.hpp
@@ -62,17 +62,17 @@ struct ComputeDuDt {
       Pi, Phi<Dim>, Tags::deriv<Psi, tmpl::size_t<Dim>, Frame::Inertial>,
       Tags::deriv<Pi, tmpl::size_t<Dim>, Frame::Inertial>,
       Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
-      gr::Tags::Lapse<Dim, Frame::Inertial, DataVector>,
+      gr::Tags::Lapse<DataVector>,
       gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
-      Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataVector>,
-                  tmpl::size_t<Dim>, Frame::Inertial>,
+      Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<Dim>,
+                  Frame::Inertial>,
       Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
                   tmpl::size_t<Dim>, Frame::Inertial>,
       gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>,
       gr::Tags::TraceSpatialChristoffelSecondKind<Dim, Frame::Inertial,
                                                   DataVector>,
-      gr::Tags::TraceExtrinsicCurvature<Dim, Frame::Inertial, DataVector>,
-      ConstraintGamma1, ConstraintGamma2>;
+      gr::Tags::TraceExtrinsicCurvature<DataVector>, ConstraintGamma1,
+      ConstraintGamma2>;
 
   static void apply(
       gsl::not_null<Scalar<DataVector>*> dt_pi,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -48,7 +48,7 @@ struct ComputeDuDt {
                  Tags::deriv<Pi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
                  Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
                  ConstraintGamma0, ConstraintGamma1, ConstraintGamma2,
-                 GaugeH<Dim>, SpacetimeDerivGaugeH<Dim>, gr::Tags::Lapse<Dim>,
+                 GaugeH<Dim>, SpacetimeDerivGaugeH<Dim>, gr::Tags::Lapse<>,
                  gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
                  gr::Tags::InverseSpacetimeMetric<Dim>,
                  gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim>,
@@ -112,7 +112,7 @@ struct ComputeNormalDotFluxes {
  public:
   using argument_tags =
       tmpl::list<gr::Tags::SpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>,
-                 ConstraintGamma1, ConstraintGamma2, gr::Tags::Lapse<Dim>,
+                 ConstraintGamma1, ConstraintGamma2, gr::Tags::Lapse<>,
                  gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>>;
 
   static void apply(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.cpp
@@ -9,7 +9,10 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -20,7 +23,7 @@
 namespace grmhd {
 namespace ValenciaDivClean {
 
-void conservative_from_primitive(
+void ConservativeFromPrimitive::apply(
     const gsl::not_null<Scalar<DataVector>*> tilde_d,
     const gsl::not_null<Scalar<DataVector>*> tilde_tau,
     const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp
@@ -4,13 +4,23 @@
 #pragma once
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
 
+// IWYU pragma: no_include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+// IWYU pragma: no_include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
+// IWYU pragma: no_include "PointwiseFunctions/Hydro/Tags.hpp"
+
+/// \cond
 namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
 
 class DataVector;
+/// \endcond
 
 // IWYU pragma: no_forward_declare Tensor
 
@@ -48,21 +58,40 @@ namespace ValenciaDivClean {
  *  W^2 \left[ \rho \left( \epsilon + v^2
  * \frac{W}{W + 1} \right) + p v^2 \right] .\f]
  */
-void conservative_from_primitive(
-    gsl::not_null<Scalar<DataVector>*> tilde_d,
-    gsl::not_null<Scalar<DataVector>*> tilde_tau,
-    gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
-    gsl::not_null<Scalar<DataVector>*> tilde_phi,
-    const Scalar<DataVector>& rest_mass_density,
-    const Scalar<DataVector>& specific_internal_energy,
-    const Scalar<DataVector>& specific_enthalpy,
-    const Scalar<DataVector>& pressure,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
-    const Scalar<DataVector>& lorentz_factor,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
-    const Scalar<DataVector>& divergence_cleaning_field) noexcept;
+struct ConservativeFromPrimitive {
+  using return_tags = tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
+                                 grmhd::ValenciaDivClean::Tags::TildeTau,
+                                 grmhd::ValenciaDivClean::Tags::TildeS<>,
+                                 grmhd::ValenciaDivClean::Tags::TildeB<>,
+                                 grmhd::ValenciaDivClean::Tags::TildePhi>;
+
+  using argument_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                 hydro::Tags::SpecificInternalEnergy<DataVector>,
+                 hydro::Tags::SpecificEnthalpy<DataVector>,
+                 hydro::Tags::Pressure<DataVector>,
+                 hydro::Tags::SpatialVelocity<DataVector, 3>,
+                 hydro::Tags::LorentzFactor<DataVector>,
+                 hydro::Tags::MagneticField<DataVector, 3>,
+                 gr::Tags::SqrtDetSpatialMetric<>, gr::Tags::SpatialMetric<3>,
+                 hydro::Tags::DivergenceCleaningField<DataVector>>;
+
+  static void apply(
+      gsl::not_null<Scalar<DataVector>*> tilde_d,
+      gsl::not_null<Scalar<DataVector>*> tilde_tau,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> tilde_s,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_b,
+      gsl::not_null<Scalar<DataVector>*> tilde_phi,
+      const Scalar<DataVector>& rest_mass_density,
+      const Scalar<DataVector>& specific_internal_energy,
+      const Scalar<DataVector>& specific_enthalpy,
+      const Scalar<DataVector>& pressure,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+      const Scalar<DataVector>& lorentz_factor,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+      const Scalar<DataVector>& divergence_cleaning_field) noexcept;
+};
 }  // namespace ValenciaDivClean
 }  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.cpp
@@ -9,7 +9,10 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -20,7 +23,7 @@
 namespace grmhd {
 namespace ValenciaDivClean {
 
-void fluxes(
+void ComputeFluxes::apply(
     const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
     const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
         tilde_tau_flux,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
@@ -4,6 +4,14 @@
 #pragma once
 
 #include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+// IWYU pragma: no_include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
+// IWYU pragma: no_include "PointwiseFunctions/Hydro/Tags.hpp"
 
 /// \cond
 namespace gsl {
@@ -12,6 +20,11 @@ class not_null;
 }  // namespace gsl
 
 class DataVector;
+
+namespace Tags {
+template <typename>
+struct Fluxes;
+}  // namespace Tags
 /// \endcond
 
 // IWYU pragma: no_forward_declare Tensor
@@ -45,23 +58,45 @@ namespace ValenciaDivClean {
  * \f$p\f$ is the fluid pressure, and \f$p_m = \frac{1}{2} \left[ \left( B^n v_n
  * \right)^2 + B^n B_n / W^2 \right]\f$ is the magnetic pressure.
  */
-void fluxes(
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_tau_flux,
-    gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
-    gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_phi_flux,
-    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
-    const Scalar<DataVector>& tilde_phi, const Scalar<DataVector>& lapse,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
-    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataVector>& pressure,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
-    const Scalar<DataVector>& lorentz_factor,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field) noexcept;
+struct ComputeFluxes {
+  using return_tags =
+      tmpl::list<::Tags::Fluxes<grmhd::ValenciaDivClean::Tags::TildeD>,
+                 ::Tags::Fluxes<grmhd::ValenciaDivClean::Tags::TildeTau>,
+                 ::Tags::Fluxes<grmhd::ValenciaDivClean::Tags::TildeS<>>,
+                 ::Tags::Fluxes<grmhd::ValenciaDivClean::Tags::TildeB<>>,
+                 ::Tags::Fluxes<grmhd::ValenciaDivClean::Tags::TildePhi>>;
+
+  using argument_tags =
+      tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
+                 grmhd::ValenciaDivClean::Tags::TildeTau,
+                 grmhd::ValenciaDivClean::Tags::TildeS<>,
+                 grmhd::ValenciaDivClean::Tags::TildeB<>,
+                 grmhd::ValenciaDivClean::Tags::TildePhi, gr::Tags::Lapse<>,
+                 gr::Tags::Shift<3>, gr::Tags::SqrtDetSpatialMetric<>,
+                 gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>,
+                 hydro::Tags::Pressure<DataVector>,
+                 hydro::Tags::SpatialVelocity<DataVector, 3>,
+                 hydro::Tags::LorentzFactor<DataVector>,
+                 hydro::Tags::MagneticField<DataVector, 3>>;
+
+  static void apply(
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_d_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_tau_flux,
+      gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> tilde_s_flux,
+      gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> tilde_b_flux,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> tilde_phi_flux,
+      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+      const Scalar<DataVector>& tilde_phi, const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& shift,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+      const Scalar<DataVector>& pressure,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+      const Scalar<DataVector>& lorentz_factor,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field) noexcept;
+};
 }  // namespace ValenciaDivClean
 }  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.cpp
@@ -11,8 +11,11 @@
 #include "ErrorHandling/Error.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/EquationsOfState/SpecificEnthalpy.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"  // IWYU pragma: keep
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -27,24 +30,26 @@ namespace grmhd {
 namespace ValenciaDivClean {
 
 template <typename PrimitiveRecoveryScheme, size_t ThermodynamicDim>
-void primitive_from_conservative(
-    gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-    gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
-    gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
-    gsl::not_null<Scalar<DataVector>*> lorentz_factor,
-    gsl::not_null<Scalar<DataVector>*> pressure,
-    gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
-    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
-    const Scalar<DataVector>& tilde_phi,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
-    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-        equation_of_state) noexcept {
+void PrimitiveFromConservative<PrimitiveRecoveryScheme, ThermodynamicDim>::
+    apply(
+        gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+        gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+        gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+            spatial_velocity,
+        gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
+        gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+        gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+        gsl::not_null<Scalar<DataVector>*> pressure,
+        gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+        const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+        const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+        const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+        const Scalar<DataVector>& tilde_phi,
+        const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+        const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+        const Scalar<DataVector>& sqrt_det_spatial_metric,
+        const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+            equation_of_state) noexcept {
   get(*divergence_cleaning_field) =
       get(tilde_phi) / get(sqrt_det_spatial_metric);
   for (size_t i = 0; i < 3; ++i) {
@@ -116,27 +121,9 @@ void primitive_from_conservative(
 #define RECOVERY(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define THERMODIM(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATION(_, data)                                                \
-  template void grmhd::ValenciaDivClean::primitive_from_conservative<         \
-      RECOVERY(data), THERMODIM(data)>(                                       \
-      gsl::not_null<Scalar<DataVector>*> rest_mass_density,                   \
-      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,            \
-      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>                 \
-          spatial_velocity,                                                   \
-      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field, \
-      gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,           \
-      gsl::not_null<Scalar<DataVector>*> lorentz_factor,                      \
-      gsl::not_null<Scalar<DataVector>*> pressure,                            \
-      gsl::not_null<Scalar<DataVector>*> specific_enthalpy,                   \
-      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau, \
-      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,                 \
-      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,                 \
-      const Scalar<DataVector>& tilde_phi,                                    \
-      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,         \
-      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,     \
-      const Scalar<DataVector>& sqrt_det_spatial_metric,                      \
-      const EquationsOfState::EquationOfState<true, THERMODIM(data)>&         \
-          equation_of_state) noexcept;
+#define INSTANTIATION(_, data)                                        \
+  template struct grmhd::ValenciaDivClean::PrimitiveFromConservative< \
+      RECOVERY(data), THERMODIM(data)>;
 
 GENERATE_INSTANTIATIONS(
     INSTANTIATION,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
@@ -6,7 +6,15 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+// IWYU pragma: no_include "PointwiseFunctions/GeneralRelativity/GrTags.hpp"
+// IWYU pragma: no_include "PointwiseFunctions/Hydro/Tags.hpp"
 
 /// \cond
 namespace gsl {
@@ -34,23 +42,45 @@ namespace ValenciaDivClean {
  * compares several inversion methods.
  */
 template <typename PrimitiveRecoveryScheme, size_t ThermodynamicDim>
-void primitive_from_conservative(
-    gsl::not_null<Scalar<DataVector>*> rest_mass_density,
-    gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
-    gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
-    gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
-    gsl::not_null<Scalar<DataVector>*> lorentz_factor,
-    gsl::not_null<Scalar<DataVector>*> pressure,
-    gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
-    const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
-    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
-    const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
-    const Scalar<DataVector>& tilde_phi,
-    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
-    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
-    const Scalar<DataVector>& sqrt_det_spatial_metric,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
-        equation_of_state) noexcept;
+struct PrimitiveFromConservative {
+  using return_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                 hydro::Tags::SpecificInternalEnergy<DataVector>,
+                 hydro::Tags::SpatialVelocity<DataVector, 3>,
+                 hydro::Tags::MagneticField<DataVector, 3>,
+                 hydro::Tags::DivergenceCleaningField<DataVector>,
+                 hydro::Tags::LorentzFactor<DataVector>,
+                 hydro::Tags::Pressure<DataVector>,
+                 hydro::Tags::SpecificEnthalpy<DataVector>>;
+
+  using argument_tags =
+      tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
+                 grmhd::ValenciaDivClean::Tags::TildeTau,
+                 grmhd::ValenciaDivClean::Tags::TildeS<>,
+                 grmhd::ValenciaDivClean::Tags::TildeB<>,
+                 grmhd::ValenciaDivClean::Tags::TildePhi,
+                 gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>,
+                 gr::Tags::SqrtDetSpatialMetric<>,
+                 hydro::Tags::EquationOfState<true, ThermodynamicDim>>;
+
+  static void apply(
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
+      gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+      gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+      gsl::not_null<Scalar<DataVector>*> pressure,
+      gsl::not_null<Scalar<DataVector>*> specific_enthalpy,
+      const Scalar<DataVector>& tilde_d, const Scalar<DataVector>& tilde_tau,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
+      const Scalar<DataVector>& tilde_phi,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+          equation_of_state) noexcept;
+};
 }  // namespace ValenciaDivClean
 }  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"
 
 class DataVector;
 
@@ -30,14 +31,14 @@ struct TildeTau : db::SimpleTag {
 };
 
 /// The densitized momentum density \f${\tilde S_i}\f$
-template <typename Fr = Frame::Inertial>
+template <typename Fr>
 struct TildeS : db::SimpleTag {
   using type = tnsr::i<DataVector, 3, Fr>;
   static std::string name() noexcept { return Frame::prefix<Fr>() + "TildeS"; }
 };
 
 /// The densitized magnetic field \f${\tilde B^i}\f$
-template <typename Fr = Frame::Inertial>
+template <typename Fr>
 struct TildeB : db::SimpleTag {
   using type = tnsr::I<DataVector, 3, Fr>;
   static std::string name() noexcept { return Frame::prefix<Fr>() + "TildeB"; }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp
@@ -1,0 +1,26 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+
+/// \cond
+class DataVector;
+
+namespace grmhd {
+namespace ValenciaDivClean {
+namespace Tags {
+struct TildeD;
+struct TildeTau;
+template <typename Fr = Frame::Inertial>
+struct TildeS;
+template <typename Fr = Frame::Inertial>
+struct TildeB;
+struct TildePhi;
+}  // namespace Tags
+}  // namespace ValenciaDivClean
+}  // namespace grmhd
+/// \endcond

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -407,7 +407,7 @@ template Index<3> read_extents<3>(const hid_t group_id,
   template std::vector<TYPE(DATA)> read_rank1_attribute<TYPE(DATA)>( \
       const hid_t group_id, const std::string& name) noexcept;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double, uint32_t, uint64_t, int))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, unsigned int, unsigned long, int))
 
 #undef INSTANTIATE
 #undef TYPE

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.cpp
@@ -180,8 +180,7 @@ KerrSchild::variables(const tnsr::I<DataType, 3>& x, const double /*t*/,
   const DataType lapse_squared = 1.0 / (1.0 + 2.0 * H * square(null_vector_0));
 
   auto result = make_with_value<tuples::TaggedTuple<
-      gr::Tags::Lapse<3, Frame::Inertial, DataType>,
-      Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, DataType>>,
+      gr::Tags::Lapse<DataType>, Tags::dt<gr::Tags::Lapse<DataType>>,
       DerivLapse<DataType>, gr::Tags::Shift<3, Frame::Inertial, DataType>,
       Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataType>>,
       DerivShift<DataType>,
@@ -189,14 +188,12 @@ KerrSchild::variables(const tnsr::I<DataType, 3>& x, const double /*t*/,
       Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>,
       DerivSpatialMetric<DataType>>>(x, 0.0);
 
-  get(get<gr::Tags::Lapse<3, Frame::Inertial, DataType>>(result)) =
-      sqrt(lapse_squared);
+  get(get<gr::Tags::Lapse<DataType>>(result)) = sqrt(lapse_squared);
 
   {
-    const DataType temp =
-        -square(null_vector_0) *
-        get(get<gr::Tags::Lapse<3, Frame::Inertial, DataType>>(result)) *
-        lapse_squared;
+    const DataType temp = -square(null_vector_0) *
+                          get(get<gr::Tags::Lapse<DataType>>(result)) *
+                          lapse_squared;
     for (size_t i = 0; i < 3; ++i) {
       get<DerivLapse<DataType>>(result).get(i) = temp * deriv_H.get(i);
     }

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/KerrSchild.hpp
@@ -241,8 +241,8 @@ class KerrSchild {
   ~KerrSchild() = default;
 
   template <typename DataType>
-  using DerivLapse = Tags::deriv<gr::Tags::Lapse<3, Frame::Inertial, DataType>,
-                                 tmpl::size_t<3>, Frame::Inertial>;
+  using DerivLapse =
+      Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<3>, Frame::Inertial>;
   template <typename DataType>
   using DerivShift = Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataType>,
                                  tmpl::size_t<3>, Frame::Inertial>;
@@ -252,8 +252,7 @@ class KerrSchild {
                   tmpl::size_t<3>, Frame::Inertial>;
   template <typename DataType>
   using tags = tmpl::list<
-      gr::Tags::Lapse<3, Frame::Inertial, DataType>,
-      Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, DataType>>,
+      gr::Tags::Lapse<DataType>, Tags::dt<gr::Tags::Lapse<DataType>>,
       DerivLapse<DataType>, gr::Tags::Shift<3, Frame::Inertial, DataType>,
       Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataType>>,
       DerivShift<DataType>,

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.cpp
@@ -9,38 +9,35 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+// IWYU pragma: no_forward_declare Tags::deriv
+
 namespace EinsteinSolutions {
 
 template <size_t Dim>
 template <typename DataType>
-tuples::TaggedTuple<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>
-Minkowski<Dim>::variables(
+tuples::TaggedTuple<gr::Tags::Lapse<DataType>> Minkowski<Dim>::variables(
     const tnsr::I<DataType, Dim>& x, double /*t*/,
-    tmpl::list<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>> /*meta*/) const
-    noexcept {
+    tmpl::list<gr::Tags::Lapse<DataType>> /*meta*/) const noexcept {
   return {Scalar<DataType>(make_with_value<DataType>(x, 1.))};
 }
 
 template <size_t Dim>
 template <typename DataType>
-tuples::TaggedTuple<Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>>
+tuples::TaggedTuple<Tags::dt<gr::Tags::Lapse<DataType>>>
 Minkowski<Dim>::variables(
     const tnsr::I<DataType, Dim>& x, double /*t*/,
-    tmpl::list<
-        Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>> /*meta*/)
-    const noexcept {
+    tmpl::list<Tags::dt<gr::Tags::Lapse<DataType>>> /*meta*/) const noexcept {
   return {Scalar<DataType>(make_with_value<DataType>(x, 0.))};
 }
 
 template <size_t Dim>
 template <typename DataType>
-tuples::TaggedTuple<Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
-                                tmpl::size_t<Dim>, Frame::Inertial>>
+tuples::TaggedTuple<
+    Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<Dim>, Frame::Inertial>>
 Minkowski<Dim>::variables(
     const tnsr::I<DataType, Dim>& x, double /*t*/,
-    tmpl::list<Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
-                           tmpl::size_t<Dim>, Frame::Inertial>> /*meta*/) const
-    noexcept {
+    tmpl::list<Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<Dim>,
+                           Frame::Inertial>> /*meta*/) const noexcept {
   return {make_with_value<tnsr::i<DataType, Dim>>(x, 0.)};
 }
 
@@ -145,23 +142,21 @@ Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
 
 template <size_t Dim>
 template <typename DataType>
-tuples::TaggedTuple<
-    gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, DataType>>
-Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
-                          tmpl::list<gr::Tags::SqrtDetSpatialMetric<
-                              Dim, Frame::Inertial, DataType>> /*meta*/) const
+tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DataType>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>> /*meta*/) const
     noexcept {
   return {make_with_value<Scalar<DataType>>(x, 1.)};
 }
 
 template <size_t Dim>
 template <typename DataType>
-tuples::TaggedTuple<
-    Tags::dt<gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, DataType>>>
-Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
-                          tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<
-                              Dim, Frame::Inertial, DataType>>> /*meta*/) const
-    noexcept {
+tuples::TaggedTuple<Tags::dt<gr::Tags::SqrtDetSpatialMetric<DataType>>>
+Minkowski<Dim>::variables(
+    const tnsr::I<DataType, Dim>& x, double /*t*/,
+    tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<DataType>>> /*meta*/)
+    const noexcept {
   return {make_with_value<Scalar<DataType>>(x, 0.)};
 }
 } // namespace EinsteinSolutions
@@ -171,28 +166,22 @@ Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
 #define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                                   \
-  template tuples::TaggedTuple<                                                \
-      gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>>                \
+  template tuples::TaggedTuple<gr::Tags::Lapse<DTYPE(data)>>                   \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<gr::Tags::Lapse<DTYPE(data)>> /*meta*/) const noexcept;       \
+  template tuples::TaggedTuple<Tags::dt<gr::Tags::Lapse<DTYPE(data)>>>         \
+  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
+      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
+      tmpl::list<Tags::dt<gr::Tags::Lapse<DTYPE(data)>>> /*meta*/)             \
+      const noexcept;                                                          \
+  template tuples::TaggedTuple<Tags::deriv<                                    \
+      gr::Tags::Lapse<DTYPE(data)>, tmpl::size_t<DIM(data)>, Frame::Inertial>> \
   EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
       const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
       tmpl::list<                                                              \
-          gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>> /*meta*/)  \
-      const noexcept;                                                          \
-  template tuples::TaggedTuple<                                                \
-      Tags::dt<gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>>>      \
-  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
-      tmpl::list<Tags::dt<                                                     \
-          gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>>> /*meta*/) \
-      const noexcept;                                                          \
-  template tuples::TaggedTuple<                                                \
-      Tags::deriv<gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>,    \
-                  tmpl::size_t<DIM(data)>, Frame::Inertial>>                   \
-  EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
-      const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
-      tmpl::list<Tags::deriv<                                                  \
-          gr::Tags::Lapse<DIM(data), Frame::Inertial, DTYPE(data)>,            \
-          tmpl::size_t<DIM(data)>, Frame::Inertial>> /*meta*/) const noexcept; \
+          Tags::deriv<gr::Tags::Lapse<DTYPE(data)>, tmpl::size_t<DIM(data)>,   \
+                      Frame::Inertial>> /*meta*/) const noexcept;              \
   template tuples::TaggedTuple<                                                \
       gr::Tags::Shift<DIM(data), Frame::Inertial, DTYPE(data)>>                \
   EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
@@ -251,19 +240,18 @@ Minkowski<Dim>::variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
       tmpl::list<gr::Tags::ExtrinsicCurvature<DIM(data), Frame::Inertial,      \
                                               DTYPE(data)>> /*meta*/)          \
       const noexcept;                                                          \
-  template tuples::TaggedTuple<                                                \
-      gr::Tags::SqrtDetSpatialMetric<DIM(data), Frame::Inertial, DTYPE(data)>> \
+  template tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DTYPE(data)>>    \
   EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
       const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
-      tmpl::list<gr::Tags::SqrtDetSpatialMetric<DIM(data), Frame::Inertial,    \
-                                                DTYPE(data)>> /*meta*/)        \
+      tmpl::list<gr::Tags::SqrtDetSpatialMetric<DTYPE(data)>> /*meta*/)        \
       const noexcept;                                                          \
-  template tuples::TaggedTuple<Tags::dt<gr::Tags::SqrtDetSpatialMetric<        \
-      DIM(data), Frame::Inertial, DTYPE(data)>>>                               \
+  template tuples::TaggedTuple<                                                \
+      Tags::dt<gr::Tags::SqrtDetSpatialMetric<DTYPE(data)>>>                   \
   EinsteinSolutions::Minkowski<DIM(data)>::variables(                          \
       const tnsr::I<DTYPE(data), DIM(data)>& x, double /*t*/,                  \
-      tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<                      \
-          DIM(data), Frame::Inertial, DTYPE(data)>>> /*meta*/) const noexcept;
+      tmpl::list<                                                              \
+          Tags::dt<gr::Tags::SqrtDetSpatialMetric<DTYPE(data)>>> /*meta*/)     \
+      const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector))
 

--- a/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Minkowski.hpp
@@ -12,6 +12,8 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
+// IWYU pragma: no_forward_declare Tags::deriv
+
 /// \cond
 namespace PUP {
 class er;
@@ -45,9 +47,8 @@ class Minkowski {
   ~Minkowski() = default;
 
   template <typename DataType>
-  using DerivLapse =
-      Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
-                  tmpl::size_t<Dim>, Frame::Inertial>;
+  using DerivLapse = Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<Dim>,
+                                 Frame::Inertial>;
   template <typename DataType>
   using DerivShift =
       Tags::deriv<gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
@@ -58,8 +59,7 @@ class Minkowski {
                   tmpl::size_t<Dim>, Frame::Inertial>;
   template <typename DataType>
   using tags = tmpl::list<
-      gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
-      Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>,
+      gr::Tags::Lapse<DataType>, Tags::dt<gr::Tags::Lapse<DataType>>,
       DerivLapse<DataType>, gr::Tags::Shift<Dim, Frame::Inertial, DataType>,
       Tags::dt<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>,
       DerivShift<DataType>,
@@ -76,29 +76,21 @@ class Minkowski {
   }
 
   template <typename DataType>
-  tuples::TaggedTuple<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>
-  variables(
+  tuples::TaggedTuple<gr::Tags::Lapse<DataType>> variables(
       const tnsr::I<DataType, Dim>& x, double t,
-      tmpl::list<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>> /*meta*/)
-      const noexcept;
+      tmpl::list<gr::Tags::Lapse<DataType>> /*meta*/) const noexcept;
 
   template <typename DataType>
-  tuples::TaggedTuple<Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>>
-  variables(
+  tuples::TaggedTuple<Tags::dt<gr::Tags::Lapse<DataType>>> variables(
       const tnsr::I<DataType, Dim>& x, double t,
-      tmpl::list<
-          Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>>> /*meta*/)
-      const noexcept;
+      tmpl::list<Tags::dt<gr::Tags::Lapse<DataType>>> /*meta*/) const noexcept;
 
   template <typename DataType>
-  tuples::TaggedTuple<
-      Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
-                  tmpl::size_t<Dim>, Frame::Inertial>>
-  variables(
-      const tnsr::I<DataType, Dim>& x, double t,
-      tmpl::list<Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, DataType>,
-                             tmpl::size_t<Dim>, Frame::Inertial>> /*meta*/)
-      const noexcept;
+  tuples::TaggedTuple<Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<Dim>,
+                                  Frame::Inertial>>
+  variables(const tnsr::I<DataType, Dim>& x, double t,
+            tmpl::list<Tags::deriv<gr::Tags::Lapse<DataType>, tmpl::size_t<Dim>,
+                                   Frame::Inertial>> /*meta*/) const noexcept;
 
   template <typename DataType>
   tuples::TaggedTuple<gr::Tags::Shift<Dim, Frame::Inertial, DataType>>
@@ -167,19 +159,17 @@ class Minkowski {
       noexcept;
 
   template <typename DataType>
-  tuples::TaggedTuple<
-      gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, DataType>>
-  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
-            tmpl::list<gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial,
-                                                      DataType>> /*meta*/) const
+  tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DataType>> variables(
+      const tnsr::I<DataType, Dim>& x, double /*t*/,
+      tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>> /*meta*/) const
       noexcept;
 
   template <typename DataType>
-  tuples::TaggedTuple<
-      Tags::dt<gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, DataType>>>
-  variables(const tnsr::I<DataType, Dim>& x, double /*t*/,
-            tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<
-                Dim, Frame::Inertial, DataType>>> /*meta*/) const noexcept;
+  tuples::TaggedTuple<Tags::dt<gr::Tags::SqrtDetSpatialMetric<DataType>>>
+  variables(
+      const tnsr::I<DataType, Dim>& x, double /*t*/,
+      tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<DataType>>> /*meta*/)
+      const noexcept;
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT

--- a/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTags.hpp
@@ -32,7 +32,7 @@ struct InverseSpatialMetric : db::SimpleTag {
   using type = tnsr::II<DataType, Dim, Frame>;
   static std::string name() noexcept { return "InverseSpatialMetric"; }
 };
-template <size_t Dim, typename Frame, typename DataType>
+template <typename DataType>
 struct SqrtDetSpatialMetric : db::SimpleTag {
   using type = Scalar<DataType>;
   static std::string name() noexcept { return "SqrtDetSpatialMetric"; }
@@ -42,7 +42,7 @@ struct Shift : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Frame>;
   static std::string name() noexcept { return "Shift"; }
 };
-template <size_t Dim, typename Frame, typename DataType>
+template <typename DataType>
 struct Lapse : db::SimpleTag {
   using type = Scalar<DataType>;
   static std::string name() noexcept { return "Lapse"; }
@@ -92,7 +92,7 @@ struct ExtrinsicCurvature : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
   static std::string name() noexcept { return "ExtrinsicCurvature"; }
 };
-template <size_t Dim, typename Frame, typename DataType>
+template <typename DataType>
 struct TraceExtrinsicCurvature : db::SimpleTag {
   using type = Scalar<DataType>;
   static std::string name() noexcept { return "TraceExtrinsicCurvature"; }

--- a/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/GrTagsDeclarations.hpp
@@ -24,13 +24,12 @@ struct SpatialMetric;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct InverseSpatialMetric;
-template <size_t Dim, typename Frame, typename DataType>
+template <typename DataType = DataVector>
 struct SqrtDetSpatialMetric;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct Shift;
-template <size_t Dim, typename Frame = Frame::Inertial,
-          typename DataType = DataVector>
+template <typename DataType = DataVector>
 struct Lapse;
 
 template <size_t Dim, typename Frame = Frame::Inertial,
@@ -57,8 +56,7 @@ struct TraceSpatialChristoffelSecondKind;
 template <size_t Dim, typename Frame = Frame::Inertial,
           typename DataType = DataVector>
 struct ExtrinsicCurvature;
-template <size_t Dim, typename Frame = Frame::Inertial,
-          typename DataType = DataVector>
+template <typename DataType = DataVector>
 struct TraceExtrinsicCurvature;
 }  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -8,6 +8,8 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 
 /// \ingroup EvolutionSystemsGroup
 /// \brief Items related to hydrodynamic systems.
@@ -25,7 +27,7 @@ struct AlfvenSpeedSquared : db::SimpleTag {
 /// The magnetic field \f$b^\mu = u_\nu F^{\mu \nu}\f$ measured by an observer
 /// comoving with the fluid with 4-velocity \f$u_\nu\f$ where \f$F^{\mu \nu}\f$
 /// is the Faraday tensor.
-template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+template <typename DataType, size_t Dim, typename Fr>
 struct ComovingMagneticField : db::SimpleTag {
   using type = tnsr::A<DataType, Dim, Fr>;
   static std::string name() noexcept {
@@ -40,6 +42,14 @@ struct DivergenceCleaningField : db::SimpleTag {
   static std::string name() noexcept { return "DivergenceCleaningField"; }
 };
 
+/// The equation of state
+template <bool IsRelativistic, size_t ThermodynamicDim>
+struct EquationOfState : db::SimpleTag {
+  using type = std::unique_ptr<
+      EquationsOfState::EquationOfState<IsRelativistic, ThermodynamicDim>>;
+  static std::string name() noexcept { return "EquationOfState"; }
+};
+
 /// The Lorentz factor \f$W\f$.
 template <typename DataType>
 struct LorentzFactor : db::SimpleTag {
@@ -50,7 +60,7 @@ struct LorentzFactor : db::SimpleTag {
 /// The magnetic field \f$B^i = n_\mu F^{i \mu}\f$ measured by an Eulerian
 /// observer, where \f$n_\mu\f$ is the normal to the spatial hypersurface and
 /// \f$F^{\mu \nu}\f$ is the Faraday tensor.
-template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+template <typename DataType, size_t Dim, typename Fr>
 struct MagneticField : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Fr>;
   static std::string name() noexcept {
@@ -87,7 +97,7 @@ struct SoundSpeedSquared : db::SimpleTag {
 };
 
 /// The spatial velocity \f$v^i\f$.
-template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+template <typename DataType, size_t Dim, typename Fr>
 struct SpatialVelocity : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Fr>;
   static std::string name() noexcept {
@@ -96,7 +106,7 @@ struct SpatialVelocity : db::SimpleTag {
 };
 
 /// The spatial velocity one-form \f$v_i\f$.
-template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+template <typename DataType, size_t Dim, typename Fr>
 struct SpatialVelocityOneForm : db::SimpleTag {
   using type = tnsr::i<DataType, Dim, Fr>;
   static std::string name() noexcept {

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+
+/// \cond
+class DataVector;
+
+namespace hydro {
+namespace Tags {
+
+template <typename DataType>
+struct AlfvenSpeedSquared;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct ComovingMagneticField;
+template <typename DataType>
+struct DivergenceCleaningField;
+template <bool IsRelativistic, size_t ThermodynamicDim>
+struct EquationOfState;
+template <typename DataType>
+struct LorentzFactor;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct MagneticField;
+template <typename DataType>
+struct MagneticPressure;
+template <typename DataType>
+struct Pressure;
+template <typename DataType>
+struct RestMassDensity;
+template <typename DataType>
+struct SoundSpeedSquared;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct SpatialVelocity;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct SpatialVelocityOneForm;
+template <typename DataType>
+struct SpatialVelocitySquared;
+template <typename DataType>
+struct SpecificEnthalpy;
+template <typename DataType>
+struct SpecificInternalEnergy;
+}  // namespace Tags
+}  // namespace hydro
+/// \endcond

--- a/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
+++ b/tests/Unit/ApparentHorizons/Test_FastFlow.cpp
@@ -33,6 +33,8 @@
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+// IWYU pragma: no_forward_declare Tags::deriv
+
 namespace {
 
 FastFlow::Status do_iteration(
@@ -69,7 +71,7 @@ FastFlow::Status do_iteration(
     const auto status_and_info = flow->iterate_horizon_finder<Frame::Inertial>(
         strahlkorper, inverse_spatial_metric,
         gr::extrinsic_curvature(
-            get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
+            get<gr::Tags::Lapse<DataVector>>(vars),
             get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
             get<EinsteinSolutions::KerrSchild::DerivShift<DataVector>>(vars),
             spatial_metric,

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -32,6 +32,7 @@
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp"
 
+// IWYU pragma: no_forward_declare Tags::deriv
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
@@ -84,7 +85,7 @@ void test_expansion(const Solution& solution,
   const auto residual = StrahlkorperGr::expansion(
       grad_unit_normal_one_form, inverse_surface_metric,
       gr::extrinsic_curvature(
-          get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
+          get<gr::Tags::Lapse<DataVector>>(vars),
           get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
           get<Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
                           tmpl::size_t<3>, Frame::Inertial>>(vars),
@@ -325,7 +326,7 @@ void test_spin_function(const Solution& solution,
       get<Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                       tmpl::size_t<3>, Frame::Inertial>>(vars);
   const auto& extrinsic_curvature = gr::extrinsic_curvature(
-      get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
+      get<gr::Tags::Lapse<DataVector>>(vars),
       get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
       get<Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
                       tmpl::size_t<3>, Frame::Inertial>>(vars),
@@ -398,7 +399,7 @@ void test_dimensionful_spin_magnitude(
       get<Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                       tmpl::size_t<3>, Frame::Inertial>>(vars);
   const auto& extrinsic_curvature = gr::extrinsic_curvature(
-      get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
+      get<gr::Tags::Lapse<DataVector>>(vars),
       get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
       get<Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
                       tmpl::size_t<3>, Frame::Inertial>>(vars),
@@ -483,7 +484,7 @@ void test_spin_vector(
       get<Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
                       tmpl::size_t<3>, Frame::Inertial>>(vars);
   const auto& extrinsic_curvature = gr::extrinsic_curvature(
-      get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars),
+      get<gr::Tags::Lapse<DataVector>>(vars),
       get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(vars),
       get<Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
                       tmpl::size_t<3>, Frame::Inertial>>(vars),

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_ConservativeFromPrimitive.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_ConservativeFromPrimitive.cpp
@@ -18,7 +18,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.ConservativeFromPrimitive",
       "Evolution/Systems/GrMhd/ValenciaDivClean"};
 
   pypp::check_with_random_values<1>(
-      &grmhd::ValenciaDivClean::conservative_from_primitive, "TestFunctions",
+      &grmhd::ValenciaDivClean::ConservativeFromPrimitive::apply,
+      "TestFunctions",
       {"tilde_d", "tilde_tau", "tilde_s", "tilde_b", "tilde_phi"},
       {{{0.0, 1.0}}}, DataVector{5});
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Fluxes.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Fluxes.cpp
@@ -17,7 +17,7 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Fluxes", "[Unit][GrMhd]") {
       "Evolution/Systems/GrMhd/ValenciaDivClean"};
 
   pypp::check_with_random_values<1>(
-      &grmhd::ValenciaDivClean::fluxes, "TestFunctions",
+      &grmhd::ValenciaDivClean::ComputeFluxes::apply, "TestFunctions",
       {"tilde_d_flux", "tilde_tau_flux", "tilde_s_flux", "tilde_b_flux",
        "tilde_phi_flux"},
       {{{0.0, 1.0}}}, DataVector{5});

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
@@ -198,7 +198,7 @@ void test_primitive_from_conservative(
   tnsr::I<DataVector, 3> tilde_b(number_of_points);
   Scalar<DataVector> tilde_phi(number_of_points);
 
-  grmhd::ValenciaDivClean::conservative_from_primitive(
+  grmhd::ValenciaDivClean::ConservativeFromPrimitive::apply(
       make_not_null(&tilde_d), make_not_null(&tilde_tau),
       make_not_null(&tilde_s), make_not_null(&tilde_b),
       make_not_null(&tilde_phi), expected_rest_mass_density,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_PrimitiveFromConservative.cpp
@@ -215,15 +215,19 @@ void test_primitive_from_conservative(
   Scalar<DataVector> lorentz_factor(number_of_points);
   Scalar<DataVector> pressure(number_of_points);
   Scalar<DataVector> specific_enthalpy(number_of_points);
-  grmhd::ValenciaDivClean::primitive_from_conservative<PrimitiveRecoveryScheme,
-                                                       ThermodynamicDim>(
-      make_not_null(&rest_mass_density),
-      make_not_null(&specific_internal_energy),
-      make_not_null(&spatial_velocity), make_not_null(&magnetic_field),
-      make_not_null(&divergence_cleaning_field), make_not_null(&lorentz_factor),
-      make_not_null(&pressure), make_not_null(&specific_enthalpy), tilde_d,
-      tilde_tau, tilde_s, tilde_b, tilde_phi, spatial_metric,
-      inv_spatial_metric, sqrt_det_spatial_metric, equation_of_state);
+  grmhd::ValenciaDivClean::PrimitiveFromConservative<
+      PrimitiveRecoveryScheme,
+      ThermodynamicDim>::apply(make_not_null(&rest_mass_density),
+                               make_not_null(&specific_internal_energy),
+                               make_not_null(&spatial_velocity),
+                               make_not_null(&magnetic_field),
+                               make_not_null(&divergence_cleaning_field),
+                               make_not_null(&lorentz_factor),
+                               make_not_null(&pressure),
+                               make_not_null(&specific_enthalpy), tilde_d,
+                               tilde_tau, tilde_s, tilde_b, tilde_phi,
+                               spatial_metric, inv_spatial_metric,
+                               sqrt_det_spatial_metric, equation_of_state);
 
   Approx larger_approx =
       Approx::custom().epsilon(std::numeric_limits<double>::epsilon() * 1.e7);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_KerrSchild.cpp
@@ -5,10 +5,10 @@
 
 #include <algorithm>
 #include <array>
-#include <cmath>
 #include <cstddef>
 #include <limits>
 #include <string>
+#include <type_traits>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -26,6 +26,8 @@
 #include "tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp"
 #include "tests/Unit/PointwiseFunctions/GeneralRelativity/GrTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tags::deriv
 
 namespace {
 
@@ -71,9 +73,8 @@ void test_schwarzschild(const DataType& used_for_size) noexcept {
 
   const auto vars =
       solution.variables(x, t, EinsteinSolutions::KerrSchild::tags<DataType>{});
-  const auto& lapse = get<gr::Tags::Lapse<3, Frame::Inertial, DataType>>(vars);
-  const auto& dt_lapse =
-      get<Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, DataType>>>(vars);
+  const auto& lapse = get<gr::Tags::Lapse<DataType>>(vars);
+  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<DataType>>>(vars);
   const auto& d_lapse =
       get<EinsteinSolutions::KerrSchild::DerivLapse<DataType>>(vars);
   const auto& shift = get<gr::Tags::Shift<3, Frame::Inertial, DataType>>(vars);
@@ -196,9 +197,8 @@ void test_double_vs_datavector() noexcept {
 
   const auto vars1 =
       solution.variables(x1, t, EinsteinSolutions::KerrSchild::tags<double>{});
-  const auto& lapse1 = get<gr::Tags::Lapse<3, Frame::Inertial, double>>(vars1);
-  const auto& dt_lapse1 =
-      get<Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, double>>>(vars1);
+  const auto& lapse1 = get<gr::Tags::Lapse<double>>(vars1);
+  const auto& dt_lapse1 = get<Tags::dt<gr::Tags::Lapse<double>>>(vars1);
   const auto& d_lapse1 =
       get<EinsteinSolutions::KerrSchild::DerivLapse<double>>(vars1);
   const auto& shift1 = get<gr::Tags::Shift<3, Frame::Inertial, double>>(vars1);
@@ -215,10 +215,8 @@ void test_double_vs_datavector() noexcept {
 
   const auto vars2 = solution.variables(
       x2, t, EinsteinSolutions::KerrSchild::tags<DataVector>{});
-  const auto& lapse2 =
-      get<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>(vars2);
-  const auto& dt_lapse2 =
-      get<Tags::dt<gr::Tags::Lapse<3, Frame::Inertial, DataVector>>>(vars2);
+  const auto& lapse2 = get<gr::Tags::Lapse<DataVector>>(vars2);
+  const auto& dt_lapse2 = get<Tags::dt<gr::Tags::Lapse<DataVector>>>(vars2);
   const auto& d_lapse2 =
       get<EinsteinSolutions::KerrSchild::DerivLapse<DataVector>>(vars2);
   const auto& shift2 =

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_Minkowski.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/Test_Minkowski.cpp
@@ -17,6 +17,8 @@
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+// IWYU pragma: no_forward_declare Tags::deriv
+
 namespace {
 template <size_t Dim, typename T>
 void test_minkowski(const T& value) {
@@ -28,19 +30,16 @@ void test_minkowski(const T& value) {
   const auto one = make_with_value<T>(value, 1.);
   const auto zero = make_with_value<T>(value, 0.);
 
-  const auto lapse =
-      get<gr::Tags::Lapse<Dim, Frame::Inertial, T>>(minkowski.variables(
-          x, t, tmpl::list<gr::Tags::Lapse<Dim, Frame::Inertial, T>>{}));
-  const auto dt_lapse = get<Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, T>>>(
-      minkowski.variables(
-          x, t,
-          tmpl::list<Tags::dt<gr::Tags::Lapse<Dim, Frame::Inertial, T>>>{}));
-  const auto d_lapse = get<Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, T>,
-                                       tmpl::size_t<Dim>, Frame::Inertial>>(
-      minkowski.variables(
-          x, t,
-          tmpl::list<Tags::deriv<gr::Tags::Lapse<Dim, Frame::Inertial, T>,
-                                 tmpl::size_t<Dim>, Frame::Inertial>>{}));
+  const auto lapse = get<gr::Tags::Lapse<T>>(
+      minkowski.variables(x, t, tmpl::list<gr::Tags::Lapse<T>>{}));
+  const auto dt_lapse = get<Tags::dt<gr::Tags::Lapse<T>>>(
+      minkowski.variables(x, t, tmpl::list<Tags::dt<gr::Tags::Lapse<T>>>{}));
+  const auto d_lapse =
+      get<Tags::deriv<gr::Tags::Lapse<T>, tmpl::size_t<Dim>, Frame::Inertial>>(
+          minkowski.variables(
+              x, t,
+              tmpl::list<Tags::deriv<gr::Tags::Lapse<T>, tmpl::size_t<Dim>,
+                                     Frame::Inertial>>{}));
   const auto shift =
       get<gr::Tags::Shift<Dim, Frame::Inertial, T>>(minkowski.variables(
           x, t, tmpl::list<gr::Tags::Shift<Dim, Frame::Inertial, T>>{}));
@@ -83,18 +82,11 @@ void test_minkowski(const T& value) {
       minkowski.variables(
           x, t,
           tmpl::list<gr::Tags::ExtrinsicCurvature<Dim, Frame::Inertial, T>>{}));
-  const auto det_g =
-      get<gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, T>>(
-          minkowski.variables(
-              x, t,
-              tmpl::list<
-                  gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, T>>{}));
+  const auto det_g = get<gr::Tags::SqrtDetSpatialMetric<T>>(minkowski.variables(
+      x, t, tmpl::list<gr::Tags::SqrtDetSpatialMetric<T>>{}));
   const auto dt_det_g =
-      get<Tags::dt<gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, T>>>(
-          minkowski.variables(
-              x, t,
-              tmpl::list<Tags::dt<
-                  gr::Tags::SqrtDetSpatialMetric<Dim, Frame::Inertial, T>>>{}));
+      get<Tags::dt<gr::Tags::SqrtDetSpatialMetric<T>>>(minkowski.variables(
+          x, t, tmpl::list<Tags::dt<gr::Tags::SqrtDetSpatialMetric<T>>>{}));
 
   CHECK(lapse.get() == one);
   CHECK(dt_lapse.get() == zero);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/EinsteinSolutions/VerifyEinsteinSolution.hpp
@@ -81,8 +81,8 @@ void verify_time_independent_einstein_solution(
   // Evaluate analytic solution
   const auto vars =
       solution.variables(x, t, typename Solution::template tags<DataVector>{});
-  const auto& lapse = get<gr::Tags::Lapse<3>>(vars);
-  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<3>>>(vars);
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<>>>(vars);
   const auto& d_lapse =
       get<typename Solution::template DerivLapse<DataVector>>(vars);
   const auto& shift = get<gr::Tags::Shift<3>>(vars);

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -21,6 +21,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
         "Logical_ComovingMagneticField");
   CHECK(hydro::Tags::DivergenceCleaningField<DataVector>::name() ==
         "DivergenceCleaningField");
+  CHECK(hydro::Tags::EquationOfState<true, 2>::name() == "EquationOfState");
   CHECK(hydro::Tags::LorentzFactor<DataVector>::name() == "LorentzFactor");
   CHECK(hydro::Tags::MagneticField<DataVector, 3, Frame::Inertial>::name() ==
         "MagneticField");


### PR DESCRIPTION
## Proposed changes

- Remove Dim and Frame template parameters for GrTags of Scalars
- Add TagsDeclarations for Hydro/Tags and GrMhd/ValenciaDivClean/Tags
- Add tag for EquationOfState
- Wrap GrMhd functions in structs


### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
