### PR TITLE
Add function apply_tuple_combinations

### DIFF
--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_SliceIterator.cpp
   Test_StripeIterator.cpp
   Test_Variables.cpp
+  Test_VectorImplHelper.cpp
   )
 
 add_subdirectory(DataBox)

--- a/tests/Unit/DataStructures/Test_VectorImplHelper.cpp
+++ b/tests/Unit/DataStructures/Test_VectorImplHelper.cpp
@@ -34,6 +34,13 @@ SPECTRE_TEST_CASE("Unit.Utilities.VectorImplHelpers.ApplyTupleCombinations",
 
 SPECTRE_TEST_CASE("Unit.DataStructures.VectorImplHelpers.TupleHelpers",
                   "[Utilities][Unit]") {
+  auto test_tup = std::make_tuple(5.5, std::complex<int>{2, 3}, 'c');
+  CHECK(TestHelpers::VectorImpl::remove_nth<0>(test_tup) ==
+        std::make_tuple(std::complex<int>{2, 3}, 'c'));
+  CHECK(TestHelpers::VectorImpl::remove_nth<1>(test_tup) ==
+        std::make_tuple(5.5, 'c'));
+  CHECK(TestHelpers::VectorImpl::remove_nth<2>(test_tup) ==
+        std::make_tuple(5.5, std::complex<int>{2, 3}));
   const auto addr_test_tup =
       TestHelpers::VectorImpl::addressof(make_not_null(&test_tup));
   CHECK(addr_test_tup == std::make_tuple(&std::get<0>(test_tup),

--- a/tests/Unit/DataStructures/Test_VectorImplHelper.cpp
+++ b/tests/Unit/DataStructures/Test_VectorImplHelper.cpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <tuple>
+
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/DataStructures/Test_VectorImplHelper.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.VectorImplHelpers.ApplyTupleCombinations",
+                  "[Utilities][Unit]") {
+  // for more generic applications, with lambdas:
+  /// [tuple_combos_lambda]
+  const int zero = 0;
+  const double one = 1.2;  // for general lambda, 1.2 casts to 1
+  const std::complex<double> two{2.5, 5.0};  // for lambda, real and casts to 2
+  std::array<std::array<bool, 3>, 3> checklist {{{{false, false, false}},
+                                                 {{false, false, false}},
+                                                 {{false, false, false}}}};
+  const auto lambda_tuple = std::make_tuple(zero, one, two);
+  TestHelpers::VectorImpl::apply_tuple_combinations<2>(
+      lambda_tuple, [&checklist](auto x, auto y) noexcept {
+        gsl::at(gsl::at(checklist, static_cast<size_t>(std::real(x))),
+                static_cast<size_t>(std::real(y))) = true;
+        CHECK(std::imag(x) + std::real(y) >= 0);
+      });
+  CHECK(checklist == std::array<std::array<bool, 3>, 3>{
+          {{{true, true, true}}, {{true, true, true}}, {{true, true, true}}}});
+  /// [tuple_combos_lambda]
+}

--- a/tests/Unit/DataStructures/Test_VectorImplHelper.cpp
+++ b/tests/Unit/DataStructures/Test_VectorImplHelper.cpp
@@ -31,3 +31,12 @@ SPECTRE_TEST_CASE("Unit.Utilities.VectorImplHelpers.ApplyTupleCombinations",
           {{{true, true, true}}, {{true, true, true}}, {{true, true, true}}}});
   /// [tuple_combos_lambda]
 }
+
+SPECTRE_TEST_CASE("Unit.DataStructures.VectorImplHelpers.TupleHelpers",
+                  "[Utilities][Unit]") {
+  const auto addr_test_tup =
+      TestHelpers::VectorImpl::addressof(make_not_null(&test_tup));
+  CHECK(addr_test_tup == std::make_tuple(&std::get<0>(test_tup),
+                                         &std::get<1>(test_tup),
+                                         &std::get<2>(test_tup)));
+}

--- a/tests/Unit/DataStructures/Test_VectorImplHelper.hpp
+++ b/tests/Unit/DataStructures/Test_VectorImplHelper.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>  // IWYU pragma: keep
 #include <tuple>
 #include <utility>
 
@@ -60,5 +61,23 @@ constexpr inline void apply_tuple_combinations(
   });
 }
 // @}
+
+namespace detail {
+template <typename... ValueTypes, size_t... Is>
+auto addressof_impl(gsl::not_null<std::tuple<ValueTypes...>*> preset,
+                    std::index_sequence<Is...> /*meta*/) noexcept {
+  return std::make_tuple(std::addressof(std::get<Is>(*preset))...);
+}
+}  // namespace detail
+
+/*!
+ * \brief given a pointer to a tuple, returns a tuple filled with pointers to
+ * the given tuple's elements
+ */
+template <typename... ValueTypes>
+auto addressof(gsl::not_null<std::tuple<ValueTypes...>*> preset) noexcept {
+  return detail::addressof_impl(
+      preset, std::make_index_sequence<sizeof...(ValueTypes)>());
+}
 }  // namespace VectorImpl
 }  // namespace TestHelpers

--- a/tests/Unit/DataStructures/Test_VectorImplHelper.hpp
+++ b/tests/Unit/DataStructures/Test_VectorImplHelper.hpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/Tuple.hpp"
+
+namespace TestHelpers {
+namespace VectorImpl {
+// @{
+/*!
+ * \brief Perform a function over combinatoric subsets of a `std::tuple`
+ *
+ * \details
+ * If given a function object, the apply_tuple_combinations function will
+ * apply the function to all ordered combinations. For instance, if the tuple
+ * contains elements (a,b,c) and the function f accepts two arguments it will be
+ * executed on all nine combinations of the three possible
+ * arguments. Importantly, the function f must then be invokable for all such
+ * argument combinations.
+ *
+ * \tparam ArgLength the number of arguments taken by the invokable. In the
+ * case where `function` is an object or closure whose call operator is
+ * overloaded or a template it is not possible to determine the number of
+ * arguments using a type trait. One common use case would be a generic
+ * lambda. For this reason it is necessary to explicitly specify the number of
+ * arguments to the invokable.
+ *
+ * \param set - the tuple for which you'd like to execute every combination
+ *
+ * \param function - The a callable, which is called on the combinations of the
+ * tuple
+ *
+ * \param args - a set of partially assembled arguments passed recursively. Some
+ * arguments can be passed in by the using code, in which case those are kept at
+ * the end of the argument list and the combinations are prependend.
+ */
+template <size_t ArgLength, typename T, typename... Elements, typename... Args,
+          Requires<sizeof...(Args) == ArgLength> = nullptr>
+constexpr inline void apply_tuple_combinations(
+    const std::tuple<Elements...>& set, const T& function,
+    const Args&... args) noexcept {
+  (void)
+      set;  // so it is used, can be documented, and causes no compiler warnings
+  function(args...);
+}
+
+template <size_t ArgLength, typename T, typename... Elements, typename... Args,
+          Requires<(ArgLength > sizeof...(Args))> = nullptr>
+constexpr inline void apply_tuple_combinations(
+    const std::tuple<Elements...>& set, const T& function,
+    const Args&... args) noexcept {
+  tuple_fold(set, [&function, &set, &args...](const auto& x) noexcept {
+      apply_tuple_combinations<ArgLength>(set, function, x, args...);
+  });
+}
+// @}
+}  // namespace VectorImpl
+}  // namespace TestHelpers

--- a/tests/Unit/DataStructures/Test_VectorImplHelper.hpp
+++ b/tests/Unit/DataStructures/Test_VectorImplHelper.hpp
@@ -68,6 +68,13 @@ auto addressof_impl(gsl::not_null<std::tuple<ValueTypes...>*> preset,
                     std::index_sequence<Is...> /*meta*/) noexcept {
   return std::make_tuple(std::addressof(std::get<Is>(*preset))...);
 }
+
+template <size_t N, typename... ValueTypes, size_t... Is1, size_t... Is2>
+auto remove_nth_impl(const std::tuple<ValueTypes...>& tup,
+                     std::index_sequence<Is1...> /*meta*/,
+                     std::index_sequence<Is2...> /*meta*/) noexcept {
+  return std::make_tuple(std::get<Is1>(tup)..., std::get<N + Is2 + 1>(tup)...);
+}
 }  // namespace detail
 
 /*!
@@ -78,6 +85,20 @@ template <typename... ValueTypes>
 auto addressof(gsl::not_null<std::tuple<ValueTypes...>*> preset) noexcept {
   return detail::addressof_impl(
       preset, std::make_index_sequence<sizeof...(ValueTypes)>());
+}
+
+/*!
+ * \brief given a tuple, returns a tuple with the specified element removed
+ *
+ * \tparam N the element to remove
+ *
+ * \param tup the tuple from which to remove the element
+ */
+template <size_t N, typename... ValueTypes>
+auto remove_nth(const std::tuple<ValueTypes...>& tup) noexcept {
+  return detail::remove_nth_impl<N>(
+      tup, std::make_index_sequence<N>(),
+      std::make_index_sequence<sizeof...(ValueTypes) - N - 1>());
 }
 }  // namespace VectorImpl
 }  // namespace TestHelpers


### PR DESCRIPTION
## Proposed changes

Given a tuple with of length N and a function which takes m<N arguments, this
function expands to the N^m calls of the function on every combination of the
tuple elements of length m (including, for instance, the first element repeated
m times).

Two varieties provided - one which takes a std::function and infers the
argument set length, and one which requires the argument length to be specified
as a template parameter and can take any callable - so can be used with
lambdas (for which the argument length does not seem to be easily inferred.

Tests and use cases provided in `Test_Tuple.cpp`

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

Similar functions can be made for other combinatoric constructs without too much effort. Happy to add them if they seem desirable.