### PR TITLE
Add swap_type tensor metafunction

### DIFF
--- a/src/DataStructures/Tensor/Metafunctions.hpp
+++ b/src/DataStructures/Tensor/Metafunctions.hpp
@@ -111,4 +111,12 @@ template <typename Tensor>
 using remove_first_index =
     ::Tensor<typename Tensor::type, tmpl::pop_front<typename Tensor::symmetry>,
              tmpl::pop_front<typename Tensor::index_list>>;
+
+/// \ingroup TensorGroup
+/// \brief Swap the data type of a tensor for a new type
+/// \tparam NewType the new data type
+/// \tparam Tensor the tensor from which to keep symmetry and index information
+template <typename NewType, typename Tensor>
+using swap_type =
+    ::Tensor<NewType, typename Tensor::symmetry, typename Tensor::index_list>;
 }  // namespace TensorMetafunctions

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Element.hpp"  // IWYU pragma: keep
 #include "ErrorHandling/Assert.hpp"
@@ -77,10 +78,6 @@ bool limit_one_tensor(
     const tnsr::I<double, VolumeDim>& element_size,
     const std::unordered_map<Direction<VolumeDim>, tnsr::I<double, VolumeDim>>&
         neighbor_sizes) noexcept;
-
-template <typename TensorType>
-using tensor_double_from = Tensor<double, typename TensorType::symmetry,
-                                  typename TensorType::index_list>;
 }  // namespace Minmod_detail
 
 namespace SlopeLimiters {
@@ -201,8 +198,8 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   /// \param tensors The tensors to be averaged and packaged.
   /// \param mesh The mesh on which the tensor values are measured.
   void data_for_neighbors(
-      const gsl::not_null<std::add_pointer_t<
-          Minmod_detail::tensor_double_from<db::item_type<Tags>>>>... means,
+      const gsl::not_null<std::add_pointer_t<TensorMetafunctions::swap_type<
+          double, db::item_type<Tags>>>>... means,
       const db::item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh) const
       noexcept {
     const auto wrap_compute_mean = [&mesh](const auto& mean,
@@ -243,9 +240,10 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   ///   test cases with very clean initial data.
   bool apply(
       const gsl::not_null<std::add_pointer_t<db::item_type<Tags>>>... tensors,
-      const std::unordered_map<Direction<VolumeDim>,
-                               Minmod_detail::tensor_double_from<
-                                   db::item_type<Tags>>>&... neighbor_tensors,
+      const std::unordered_map<
+          Direction<VolumeDim>,
+          TensorMetafunctions::swap_type<
+              double, db::item_type<Tags>>>&... neighbor_tensors,
       const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
       const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
       const tnsr::I<double, VolumeDim>& element_size,

--- a/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
+++ b/tests/Unit/DataStructures/Tensor/Test_Tensor.cpp
@@ -189,6 +189,12 @@ static_assert(
         SpatialIndex<3, UpLo::Up, Frame::Inertial>>,
     "Failed testing check_index_symmetry");
 
+// Test swap_type
+static_assert(
+    cpp17::is_same_v<tnsr::ij<double, 3>, TensorMetafunctions::swap_type<
+                                              double, tnsr::ij<DataVector, 3>>>,
+    "Failed testing swap_type");
+
 static_assert(not cpp17::is_constructible_v<
                   Tensor<double, Symmetry<>, tmpl::list<>>, tmpl::list<>>,
               "Tensor construction failed to be SFINAE friendly");


### PR DESCRIPTION
Swap type from `Tensor<DataType1, blah>` to `Tensor<DataType2, blah>`.

Promotes (to a publicly usable metafunction) and generalizes (to arbitrary data types) a helper function from the Minmod code.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
