### PR TITLE
Volume observer pr4

### DIFF
--- a/cmake/SetupCharmAlgorithm.py
+++ b/cmake/SetupCharmAlgorithm.py
@@ -45,6 +45,15 @@ def create_interface_file(args):
               "    entry void perform_algorithm();\n" \
               "\n" % (args['algorithm_name'], args['algorithm_name'])
 
+    if (args['algorithm_type'] == "nodegroup"):
+        ci_str += "    template <typename Action, typenameLDOTLDOTLDOT Args>\n" \
+            "    entry void threaded_action(\n" \
+            "               std::tuple<COMPUTE_VARIADIC_ARGS>& args);\n" \
+            "\n" \
+            "    template <typename Action>\n" \
+            "    entry void threaded_action();\n" \
+            "\n"
+
     # A bug in Charm++ prevents entry methods with default argument values.
     # The workaround is to have two entry methods and default the argument in
     # the AlgorithmImpl member function.

--- a/src/Evolution/Executables/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Executables/ScalarWave/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBS_TO_LINK
     CoordinateMaps
     DiscontinuousGalerkin
     DomainCreators
+    IO
     Informer
     LinearOperators
     MathFunctions

--- a/src/Evolution/Systems/ScalarWave/Actions.hpp
+++ b/src/Evolution/Systems/ScalarWave/Actions.hpp
@@ -1,0 +1,115 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "IO/Observer/Actions.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/VolumeActions.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace ScalarWave {
+/// %Actions specific to scalar wave evolutions.
+namespace Actions {
+/*!
+ * \brief Temporary action for observing volume (and in the future, reduction)
+ * data
+ *
+ * A few notes:
+ * - Observation frequency is currently hard-coded and must manually be updated.
+ *   Look for `time_by_timestep_value` to update.
+ * - Writes the solution and error in \f$\Psi, \Pi\f$, and \f$\Phi_i\f$ to disk.
+ */
+struct Observe {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            size_t Dim, typename ActionList, typename ParallelComponent>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ElementIndex<Dim>& array_index,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const auto& time = db::get<Tags::Time>(box);
+    // Note: this currently assumes a constant time step that is a power of ten.
+    const size_t time_by_timestep_value = static_cast<size_t>(
+        std::round(time.value() / db::get<Tags::TimeStep>(box).value()));
+
+    const std::string element_name = MakeString{} << ElementId<Dim>(array_index)
+                                                  << '/';
+    // We hard-code the writing frequency to large time values to avoid breaking
+    // the tests.
+    if (time_by_timestep_value % 1000 == 0 and time_by_timestep_value > 0) {
+      const auto& extents = db::get<Tags::Mesh<Dim>>(box).extents();
+      // Retrieve the tensors and compute the solution error.
+      const auto& psi = db::get<ScalarWave::Psi>(box);
+      const auto& pi = db::get<ScalarWave::Pi>(box);
+      const auto& phi = db::get<ScalarWave::Phi<Dim>>(box);
+      const auto& inertial_coordinates =
+          db::get<Tags::Coordinates<Dim, Frame::Inertial>>(box);
+
+      // Compute the error in the solution, and generate tensor component list.
+      using Vars = typename Metavariables::system::variables_tag::type;
+      using solution_tag = OptionTags::AnalyticSolutionBase;
+      const auto exact_solution = Parallel::get<solution_tag>(cache).variables(
+          inertial_coordinates, time.value(), typename Vars::tags_list{});
+
+      // Remove tensor types, only storing individual components.
+      std::vector<TensorComponent> components;
+      components.reserve(3 * Dim + 4);
+
+      components.emplace_back(element_name + ScalarWave::Psi::name(),
+                              psi.get());
+      DataVector error =
+          tuples::get<ScalarWave::Psi>(exact_solution).get() - psi.get();
+      components.emplace_back(element_name + "Error" + ScalarWave::Psi::name(),
+                              error);
+      components.emplace_back(element_name + ScalarWave::Pi::name(), pi.get());
+      error = tuples::get<ScalarWave::Pi>(exact_solution).get() - pi.get();
+      components.emplace_back(element_name + "Error" + ScalarWave::Pi::name(),
+                              error);
+      for (size_t d = 0; d < Dim; ++d) {
+        const std::string component_suffix =
+            d == 0 ? "_x" : d == 1 ? "_y" : "_z";
+        components.emplace_back(
+            element_name + ScalarWave::Phi<Dim>::name() + component_suffix,
+            phi.get(d));
+
+        error = tuples::get<ScalarWave::Phi<Dim>>(exact_solution).get(d) -
+                phi.get(d);
+        components.emplace_back(element_name + "Error" +
+                                    ScalarWave::Phi<Dim>::name() +
+                                    component_suffix,
+                                error);
+        components.emplace_back(
+            element_name + Tags::Coordinates<Dim, Frame::Inertial>::name() +
+                component_suffix,
+            inertial_coordinates.get(d));
+      }
+
+      // Send data to observer
+      auto& local_volume_observer =
+          *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+               cache)
+               .ckLocalBranch();
+      Parallel::simple_action<observers::Actions::ContributeVolumeData>(
+          local_volume_observer, observers::ObservationId(time),
+          observers::ArrayComponentId(
+              std::add_pointer_t<ParallelComponent>{nullptr},
+              Parallel::ArrayIndex<ElementIndex<Dim>>(array_index)),
+          std::move(components), extents);
+    }
+    return std::forward_as_tuple(std::move(box));
+  }
+};
+}  // namespace Actions
+}  // namespace ScalarWave

--- a/src/IO/Observer/Actions.hpp
+++ b/src/IO/Observer/Actions.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Index.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/Tags.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -21,9 +21,7 @@ namespace Actions {
 struct Initialize {
   using simple_tags =
       db::AddSimpleTags<Tags::NumberOfEvents, Tags::ReductionArrayComponentIds,
-                        Tags::VolumeArrayComponentIds, Tags::TensorData,
-                        Tags::ReductionDataLock, Tags::VolumeDataLock,
-                        Tags::ReductionFileLock, Tags::VolumeFileLock>;
+                        Tags::VolumeArrayComponentIds, Tags::TensorData>;
   using compute_tags = db::AddComputeTags<>;
 
   using return_tag_list = tmpl::append<simple_tags, compute_tags>;
@@ -40,8 +38,32 @@ struct Initialize {
         db::item_type<Tags::NumberOfEvents>{},
         db::item_type<Tags::ReductionArrayComponentIds>{},
         db::item_type<Tags::VolumeArrayComponentIds>{},
+        db::item_type<Tags::TensorData>{}));
+  }
+};
+
+/*!
+ * \brief Initializes the DataBox of the observer parallel component that writes
+ * to disk.
+ */
+struct InitializeWriter {
+  using simple_tags =
+      db::AddSimpleTags<Tags::TensorData, Tags::ReductionFileLock,
+                        Tags::VolumeFileLock>;
+  using compute_tags = db::AddComputeTags<>;
+
+  using return_tag_list = tmpl::append<simple_tags, compute_tags>;
+
+  template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    return std::make_tuple(db::create<simple_tags>(
         db::item_type<Tags::TensorData>{}, Parallel::create_lock(),
-        Parallel::create_lock(), Parallel::create_lock(),
         Parallel::create_lock()));
   }
 };

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -48,8 +48,8 @@ struct Initialize {
  */
 struct InitializeWriter {
   using simple_tags =
-      db::AddSimpleTags<Tags::TensorData, Tags::ReductionFileLock,
-                        Tags::VolumeFileLock>;
+      db::AddSimpleTags<Tags::TensorData, Tags::VolumeObserversContributed,
+                        Tags::ReductionFileLock, Tags::VolumeFileLock>;
   using compute_tags = db::AddComputeTags<>;
 
   using return_tag_list = tmpl::append<simple_tags, compute_tags>;
@@ -63,8 +63,9 @@ struct InitializeWriter {
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     return std::make_tuple(db::create<simple_tags>(
-        db::item_type<Tags::TensorData>{}, Parallel::create_lock(),
-        Parallel::create_lock()));
+        db::item_type<Tags::TensorData>{},
+        db::item_type<Tags::VolumeObserversContributed>{},
+        Parallel::create_lock(), Parallel::create_lock()));
   }
 };
 }  // namespace Actions

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "AlgorithmGroup.hpp"
 #include "AlgorithmNodegroup.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/Initialize.hpp"
@@ -12,12 +13,16 @@
 namespace observers {
 /*!
  * \ingroup ObserversGroup
- * \brief The nodegroup parallel component that is responsible for reducing data
- * to be observed and for writing data to disk.
+ * \brief The group parallel component that is responsible for reducing data
+ * to be observed.
+ *
+ * Once the data from all elements on the processing element (usually a core)
+ * has been collected, it is copied (not sent over the network) to the local
+ * nodegroup parallel component, `ObserverWriter`, for writing to disk.
  */
 template <class Metavariables>
 struct Observer {
-  using chare_type = Parallel::Algorithms::Nodegroup;
+  using chare_type = Parallel::Algorithms::Group;
   using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using action_list = tmpl::list<>;
@@ -40,4 +45,33 @@ struct Observer {
           Metavariables>& /*global_cache*/) noexcept {}
 };
 
+/*!
+ * \ingroup ObserversGroup
+ * \brief The nodegroup parallel component that is responsible for writing data
+ * to disk.
+ */
+template <class Metavariables>
+struct ObserverWriter {
+  using chare_type = Parallel::Algorithms::Nodegroup;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using metavariables = Metavariables;
+  using action_list = tmpl::list<>;
+
+  using initial_databox = db::compute_databox_type<
+      typename Actions::InitializeWriter::return_tag_list>;
+
+  using options = tmpl::list<>;
+
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    Parallel::simple_action<Actions::InitializeWriter>(
+        Parallel::get_parallel_component<ObserverWriter>(local_cache));
+  }
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase /*next_phase*/,
+      Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*global_cache*/) noexcept {}
+};
 }  // namespace observers

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -34,7 +34,7 @@ struct Observer {
         Parallel::get_parallel_component<Observer>(local_cache));
   }
 
-  static void execute_next_global_actions(
+  static void execute_next_phase(
       const typename Metavariables::Phase /*next_phase*/,
       Parallel::CProxy_ConstGlobalCache<
           Metavariables>& /*global_cache*/) noexcept {}

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -7,6 +7,7 @@
 #include "AlgorithmNodegroup.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 
@@ -23,7 +24,7 @@ namespace observers {
 template <class Metavariables>
 struct Observer {
   using chare_type = Parallel::Algorithms::Group;
-  using const_global_cache_tag_list = tmpl::list<>;
+  using const_global_cache_tag_list = tmpl::list<OptionTags::VolumeFileName>;
   using metavariables = Metavariables;
   using action_list = tmpl::list<>;
 
@@ -53,7 +54,7 @@ struct Observer {
 template <class Metavariables>
 struct ObserverWriter {
   using chare_type = Parallel::Algorithms::Nodegroup;
-  using const_global_cache_tag_list = tmpl::list<>;
+  using const_global_cache_tag_list = tmpl::list<OptionTags::VolumeFileName>;
   using metavariables = Metavariables;
   using action_list = tmpl::list<>;
 

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -15,6 +15,7 @@
 #include "DataStructures/Tensor/TensorData.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/ObservationId.hpp"
+#include "Options/Options.hpp"
 
 namespace observers {
 /// \ingroup ObserversGroup
@@ -50,16 +51,11 @@ struct TensorData : db::SimpleTag {
                                             ExtentsAndTensorVolumeData>>;
 };
 
-/// Node lock used when needing a lock for volume data.
-struct VolumeDataLock : db::SimpleTag {
-  static std::string name() noexcept { return "VolumeDataLock"; }
-  using type = CmiNodeLock;
-};
-
-/// Node lock used when needing a lock for reduction data.
-struct ReductionDataLock : db::SimpleTag {
-  static std::string name() noexcept { return "ReductionDataLock"; }
-  using type = CmiNodeLock;
+/// The number of observer components that have contributed data at the
+/// observation ids.
+struct VolumeObserversContributed : db::SimpleTag {
+  static std::string name() noexcept { return "VolumeObserversContributed"; }
+  using type = std::unordered_map<observers::ObservationId, size_t>;
 };
 
 /// Node lock used when needing to lock the H5 file on disk.
@@ -74,4 +70,15 @@ struct ReductionFileLock : db::SimpleTag {
   using type = CmiNodeLock;
 };
 }  // namespace Tags
+
+namespace OptionTags {
+/// \ingroup ObserversGroup
+/// The name of the H5 file on disk to which all volume data is written.
+struct VolumeFileName {
+  using type = std::string;
+  static constexpr OptionString help = {
+      "Name of the volume data file without extension"};
+  static type default_value() noexcept { return "./VolumeData"; }
+};
+}  // namespace OptionTags
 }  // namespace observers

--- a/src/IO/Observer/TypeOfObservation.hpp
+++ b/src/IO/Observer/TypeOfObservation.hpp
@@ -5,6 +5,8 @@
 
 #include <iosfwd>
 
+#include "Utilities/TypeTraits.hpp"
+
 namespace observers {
 /*!
  * \ingroup ObserversGroup
@@ -23,4 +25,21 @@ enum class TypeOfObservation {
 };
 
 std::ostream& operator<<(std::ostream& os, const TypeOfObservation& t) noexcept;
+
+// @{
+/// Inherits off of `std::true_type` if `T` has a member variable
+/// `RegisterWithObserver`
+template <class T, class = cpp17::void_t<>>
+struct has_register_with_observer : std::false_type {};
+
+/// \cond
+template <class T>
+struct has_register_with_observer<
+    T, cpp17::void_t<decltype(T::RegisterWithObserver)>> : std::true_type {};
+/// \endcond
+
+template <class T>
+constexpr bool has_register_with_observer_v =
+    has_register_with_observer<T>::value;
+// @}
 }  // namespace observers

--- a/src/IO/Observer/VolumeActions.hpp
+++ b/src/IO/Observer/VolumeActions.hpp
@@ -1,0 +1,227 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace observers {
+namespace ThreadedActions {
+/// \cond
+struct WriteVolumeData;
+/// \endcond
+}  // namespace ThreadedActions
+
+namespace Actions {
+/// \cond
+struct ContributeVolumeDataToWriter;
+/// \endcond
+
+/*!
+ * \ingroup ObserverGroup
+ * \brief Send volume tensor data to the observer.
+ *
+ * \warning  Currently this action can only be called once per `observation_id`
+ * per `array_component_id`. Calling it more often is undefined behavior and may
+ * result in incomplete data being written and/or memory leaks. The reason is
+ * that we do not register the number of times a component with an ID at a
+ * specific observation id will call the observer. However, this will be a
+ * feature implemented in the future.
+ */
+struct ContributeVolumeData {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, size_t Dim,
+            Requires<sizeof...(DbTags) != 0> = nullptr>
+    static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const observers::ObservationId& observation_id,
+                    const observers::ArrayComponentId& array_component_id,
+                    std::vector<TensorComponent>&& in_received_tensor_data,
+                    const Index<Dim>& received_extents) noexcept {
+    db::mutate<Tags::TensorData>(
+        make_not_null(&box),
+        [
+          &cache, &observation_id, &array_component_id, &received_extents,
+          received_tensor_data = std::move(in_received_tensor_data)
+        ](const gsl::not_null<db::item_type<Tags::TensorData>*> volume_data,
+          const std::unordered_set<ArrayComponentId>&
+              volume_component_ids) mutable noexcept {
+          if (volume_data->count(observation_id) == 0 or
+              volume_data->at(observation_id).count(array_component_id) == 0) {
+            std::vector<size_t> extents(received_extents.begin(),
+                                        received_extents.end());
+            volume_data->operator[](observation_id)
+                .emplace(
+                    array_component_id,
+                    ExtentsAndTensorVolumeData(
+                        std::move(extents), std::move(received_tensor_data)));
+          } else {
+            auto& current_data =
+                volume_data->at(observation_id).at(array_component_id);
+            ASSERT(
+                alg::equal(current_data.extents, received_extents),
+                "The extents from the same volume component at a specific "
+                "observation should always be the same. For example, the "
+                "extents of a dG element should be the same for all calls to "
+                "ContributeVolumeData that occur at the same time.");
+            current_data.tensor_components.insert(
+                current_data.tensor_components.end(),
+                std::make_move_iterator(received_tensor_data.begin()),
+                std::make_move_iterator(received_tensor_data.end()));
+          }
+
+          // Check if we have received all "volume" data from the registered
+          // elements. If so we copy it to the nodegroup volume writer.
+          if (volume_data->at(observation_id).size() ==
+              volume_component_ids.size()) {
+            auto& local_writer = *Parallel::get_parallel_component<
+                                      ObserverWriter<Metavariables>>(cache)
+                                      .ckLocalBranch();
+            Parallel::simple_action<ContributeVolumeDataToWriter>(
+                local_writer, observation_id,
+                std::move((*volume_data)[observation_id]));
+            volume_data->erase(observation_id);
+          }
+        },
+        db::get<Tags::VolumeArrayComponentIds>(box));
+  }
+};
+
+/*!
+ * \ingroup ObserverGroup
+ * \brief Move data to the observer writer for writing to disk.
+ */
+struct ContributeVolumeDataToWriter {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<sizeof...(DbTags) != 0> = nullptr>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const observers::ObservationId& observation_id,
+                    std::unordered_map<observers::ArrayComponentId,
+                                       ExtentsAndTensorVolumeData>&&
+                        in_volume_data) noexcept {
+    db::mutate<Tags::TensorData, Tags::VolumeObserversContributed>(
+        make_not_null(&box),
+        [&cache, &observation_id, in_volume_data = std::move(in_volume_data) ](
+            const gsl::not_null<std::unordered_map<
+                observers::ObservationId,
+                std::unordered_map<observers::ArrayComponentId,
+                                   ExtentsAndTensorVolumeData>>*>
+                volume_data,
+            const gsl::not_null<
+                std::unordered_map<observers::ObservationId, size_t>*>
+                volume_observers_contributed) mutable noexcept {
+          if (volume_data->count(observation_id) == 0) {
+            volume_data->operator[](observation_id) = std::move(in_volume_data);
+            (*volume_observers_contributed)[observation_id] = 1;
+          } else {
+            auto& current_data = volume_data->at(observation_id);
+            current_data.insert(std::make_move_iterator(in_volume_data.begin()),
+                                std::make_move_iterator(in_volume_data.end()));
+            (*volume_observers_contributed)[observation_id]++;
+          }
+          // Check if we have received all "volume" data from the Observer
+          // group. If so we write to disk.
+          const auto procs_on_node =
+              static_cast<size_t>(Parallel::procs_on_node(Parallel::my_node()));
+          if (volume_observers_contributed->at(observation_id) ==
+              procs_on_node) {
+            Parallel::threaded_action<ThreadedActions::WriteVolumeData>(
+                Parallel::get_parallel_component<ObserverWriter<Metavariables>>(
+                    cache)[static_cast<size_t>(Parallel::my_node())],
+                observation_id);
+            volume_observers_contributed->erase(observation_id);
+          }
+        });
+  }
+};
+}  // namespace Actions
+
+namespace ThreadedActions {
+/*!
+ * \ingroup ObserverGroup
+ * \brief Writes volume data at the `observation_id` to disk.
+ */
+struct WriteVolumeData {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<sizeof...(DbTags) != 0> = nullptr>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const gsl::not_null<CmiNodeLock*> node_lock,
+                    const observers::ObservationId& observation_id) noexcept {
+    // Get data from the DataBox in a thread-safe manner
+    Parallel::lock(node_lock);
+    std::unordered_map<observers::ArrayComponentId, ExtentsAndTensorVolumeData>
+        volume_data{};
+    CmiNodeLock file_lock;
+    db::mutate<Tags::VolumeFileLock, Tags::TensorData>(
+        make_not_null(&box),
+        [&observation_id, &file_lock, &volume_data ](
+            const gsl::not_null<CmiNodeLock*> in_file_lock,
+            const gsl::not_null<db::item_type<Tags::TensorData>*>
+                in_volume_data) noexcept {
+          volume_data = std::move((*in_volume_data)[observation_id]);
+          in_volume_data->erase(observation_id);
+          file_lock = *in_file_lock;
+        });
+    Parallel::unlock(node_lock);
+
+    // Write to file. We use a separate node lock because writing can be very
+    // time consuming (it's network dependent, depends on how full the disks
+    // are, what other users are doing, etc.) and we want to be able to continue
+    // to work on the nodegroup while we are writing data to disk.
+    Parallel::lock(&file_lock);
+    const auto& file_prefix = Parallel::get<OptionTags::VolumeFileName>(cache);
+    h5::H5File<h5::AccessType::ReadWrite> h5file(
+        file_prefix + std::to_string(Parallel::my_node()) + ".h5", true);
+    constexpr size_t version_number = 0;
+    auto& volume_file =
+        h5file.try_insert<h5::VolumeData>("/element_data", version_number);
+    for (const auto& id_and_tensor_data_for_grid : volume_data) {
+      const auto& extents_and_tensors = id_and_tensor_data_for_grid.second;
+      volume_file.insert_tensor_data(
+          observation_id.hash(), observation_id.value(), extents_and_tensors);
+    }
+    Parallel::unlock(&file_lock);
+  }
+};
+}  // namespace ThreadedActions
+}  // namespace observers

--- a/src/Parallel/Invoke.hpp
+++ b/src/Parallel/Invoke.hpp
@@ -53,13 +53,22 @@ void simple_action(Proxy&& proxy, Arg0&& arg0, Args&&... args) noexcept {
 }
 // @}
 
+// @{
 /*!
  * \ingroup ParallelGroup
  * \brief Invoke a threaded action on `proxy`, where the proxy must be a
  * nodegroup.
  */
-template <typename Action, typename Proxy, typename... Args>
-void threaded_action(Proxy&& proxy, Args&&... args) noexcept {
-  proxy.template threaded_action<Action>(std::forward<Args>(args)...);
+template <typename Action, typename Proxy>
+void threaded_action(Proxy&& proxy) noexcept {
+  proxy.template threaded_action<Action>();
 }
+
+template <typename Action, typename Proxy, typename Arg0, typename... Args>
+void threaded_action(Proxy&& proxy, Arg0&& arg0, Args&&... args) noexcept {
+  proxy.template threaded_action<Action>(
+      std::tuple<std::decay_t<Arg0>, std::decay_t<Args>...>(
+          std::forward<Arg0>(arg0), std::forward<Args>(args)...));
+}
+// @}
 }  // namespace Parallel

--- a/src/Utilities/Algorithm.hpp
+++ b/src/Utilities/Algorithm.hpp
@@ -225,4 +225,24 @@ decltype(auto) for_each(const Container& c, UnaryFunction&& f) {
   using std::end;
   return std::for_each(begin(c), end(c), std::forward<UnaryFunction>(f));
 }
+
+/// Convenience wrapper around std::equal, assumes containers `lhs` has at least
+/// as many elements as `rhs`.
+template <class Container, class Container2>
+decltype(auto) equal(const Container& lhs, const Container2& rhs) {
+  using std::begin;
+  using std::end;
+  return std::equal(begin(lhs), end(lhs), begin(rhs));
+}
+
+/// Convenience wrapper around std::equal, assumes containers `lhs` has at least
+/// as many elements as `rhs`.
+template <class Container, class Container2, class BinaryPredicate>
+decltype(auto) equal(const Container& lhs, const Container2& rhs,
+                     BinaryPredicate&& p) {
+  using std::begin;
+  using std::end;
+  return std::equal(begin(lhs), end(lhs), begin(rhs),
+                    std::forward<BinaryPredicate>(p));
+}
 }  // namespace alg

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -30,3 +30,5 @@ TimeStepper:
     TargetOrder: 3
 
 NumericalFluxParams:
+
+VolumeFileName: "./ScalarWave1DPeriodic"

--- a/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
@@ -30,3 +30,5 @@ TimeStepper:
     TargetOrder: 3
 
 NumericalFluxParams:
+
+VolumeFileName: "./ScalarWave2DPeriodic"

--- a/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
@@ -30,3 +30,5 @@ TimeStepper:
     TargetOrder: 3
 
 NumericalFluxParams:
+
+VolumeFileName: "./ScalarWave3DPeriodic"

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -62,14 +62,14 @@ ACTION_TESTING_CHECK_MOCK_ACTION_LIST(threaded_actions);
 template <typename Component>
 class MockDistributedObject {
  private:
-  class InvokeSimpleActionBase {
+  class InvokeActionBase {
    public:
-    InvokeSimpleActionBase() = default;
-    InvokeSimpleActionBase(const InvokeSimpleActionBase&) = default;
-    InvokeSimpleActionBase& operator=(const InvokeSimpleActionBase&) = default;
-    InvokeSimpleActionBase(InvokeSimpleActionBase&&) = default;
-    InvokeSimpleActionBase& operator=(InvokeSimpleActionBase&&) = default;
-    virtual ~InvokeSimpleActionBase() = default;
+    InvokeActionBase() = default;
+    InvokeActionBase(const InvokeActionBase&) = default;
+    InvokeActionBase& operator=(const InvokeActionBase&) = default;
+    InvokeActionBase(InvokeActionBase&&) = default;
+    InvokeActionBase& operator=(InvokeActionBase&&) = default;
+    virtual ~InvokeActionBase() = default;
     virtual void invoke_action() noexcept = 0;
   };
 
@@ -80,7 +80,7 @@ class MockDistributedObject {
   // - This prevents possible stack overflows
   // - Allows better introspection and control over the Actions' behavior
   template <typename Action, typename... Args>
-  class InvokeSimpleAction : public InvokeSimpleActionBase {
+  class InvokeSimpleAction : public InvokeActionBase {
    public:
     InvokeSimpleAction(MockDistributedObject* local_alg,
                        std::tuple<Args...> args)
@@ -118,7 +118,7 @@ class MockDistributedObject {
   };
 
   template <typename Action, typename... Args>
-  class InvokeThreadedAction : public InvokeSimpleActionBase {
+  class InvokeThreadedAction : public InvokeActionBase {
    public:
     InvokeThreadedAction(MockDistributedObject* local_alg,
                        std::tuple<Args...> args)
@@ -378,8 +378,8 @@ class MockDistributedObject {
   tuples::tagged_tuple_from_typelist<
       Parallel::get_inbox_tags<typename Component::action_list>>* inboxes_{
       nullptr};
-  std::deque<std::unique_ptr<InvokeSimpleActionBase>> simple_action_queue_;
-  std::deque<std::unique_ptr<InvokeSimpleActionBase>> threaded_action_queue_;
+  std::deque<std::unique_ptr<InvokeActionBase>> simple_action_queue_;
+  std::deque<std::unique_ptr<InvokeActionBase>> threaded_action_queue_;
   CmiNodeLock node_lock_ = Parallel::create_lock();
 };
 

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Observers/Test_Tags.cpp
   Observers/Test_ObservationId.cpp
   Observers/Test_TypeOfObservation.cpp
+  Observers/Test_VolumeObserver.cpp
   Test_H5.cpp
   Test_VolumeData.cpp
   )

--- a/tests/Unit/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/IO/Observers/ObserverHelpers.hpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <functional>
+
+#include "Domain/ElementIndex.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace TestObservers_detail {
+using ElementIndexType = ElementIndex<2>;
+
+template <typename Metavariables>
+struct element_component {
+  using component_being_mocked = void;  // Not needed
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndexType;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::DataBox<tmpl::list<>>;
+};
+
+template <typename Metavariables>
+struct observer_component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using component_being_mocked = observers::Observer<Metavariables>;
+  using simple_tags = observers::Actions::Initialize::simple_tags;
+  using compute_tags = observers::Actions::Initialize::compute_tags;
+  using initial_databox =
+      db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<element_component<Metavariables>,
+                                    observer_component<Metavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  enum class Phase { Initialize, Exit };
+};
+
+class TimeId {
+ public:
+  explicit TimeId(const size_t value) : value_(value) {}
+  size_t value() const { return value_; }
+
+ private:
+  size_t value_;
+};
+inline size_t hash_value(const TimeId& id) noexcept { return id.value(); }
+}  // namespace TestObservers_detail
+
+namespace std {
+template <>
+struct hash<TestObservers_detail::TimeId> {
+  size_t operator()(const TestObservers_detail::TimeId& id) const noexcept {
+    return id.value();
+  }
+};
+}  // namespace std

--- a/tests/Unit/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/IO/Observers/ObserverHelpers.hpp
@@ -30,7 +30,8 @@ struct observer_component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
+  using const_global_cache_tag_list =
+      tmpl::list<observers::OptionTags::VolumeFileName>;
   using action_list = tmpl::list<>;
   using component_being_mocked = observers::Observer<Metavariables>;
   using simple_tags = observers::Actions::Initialize::simple_tags;

--- a/tests/Unit/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/IO/Observers/ObserverHelpers.hpp
@@ -39,9 +39,25 @@ struct observer_component {
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
 };
 
+template <typename Metavariables>
+struct observer_writer_component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+  using simple_tags = observers::Actions::InitializeWriter::simple_tags;
+  using compute_tags = observers::Actions::InitializeWriter::compute_tags;
+  using initial_databox =
+      db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
+};
+
+
 struct Metavariables {
   using component_list = tmpl::list<element_component<Metavariables>,
-                                    observer_component<Metavariables>>;
+                                    observer_component<Metavariables>,
+                                    observer_writer_component<Metavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
 
   enum class Phase { Initialize, Exit };

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -35,18 +35,24 @@ void check_observer_registration() {
       typename ActionTesting::MockRuntimeSystem<
           Metavariables>::TupleOfMockDistributedObjects;
   using obs_component = observer_component<Metavariables>;
+  using obs_writer = observer_writer_component<Metavariables>;
   using element_comp = element_component<Metavariables>;
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
   using ObserverMockDistributedObjectsTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<
           obs_component>;
+  using WriterMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          obs_writer>;
   using ElementMockDistributedObjectsTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<
           element_comp>;
   TupleOfMockDistributedObjects dist_objects{};
   tuples::get<ObserverMockDistributedObjectsTag>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
+  tuples::get<WriterMockDistributedObjectsTag>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<obs_writer>{});
 
   // Specific IDs have no significance, just need different IDs.
   const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
@@ -64,6 +70,7 @@ void check_observer_registration() {
       {}, std::move(dist_objects)};
 
   runner.simple_action<obs_component, observers::Actions::Initialize>(0);
+  runner.simple_action<obs_writer, observers::Actions::InitializeWriter>(0);
   // Test initial state
   const auto& observer_box =
       runner.template algorithms<obs_component>()

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -21,45 +21,13 @@
 #include "IO/Observer/Tags.hpp"               // IWYU pragma: keep
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/ArrayIndex.hpp"
-#include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/IO/Observers/ObserverHelpers.hpp"
 
 namespace {
-using ElementIndexType = ElementIndex<2>;
-
-template <typename Metavariables>
-struct element_component {
-  using component_being_mocked = void;  // Not needed
-  using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
-  using array_index = ElementIndexType;
-  using const_global_cache_tag_list = tmpl::list<>;
-  using action_list = tmpl::list<>;
-  using initial_databox = db::DataBox<tmpl::list<>>;
-};
-
-template <typename Metavariables>
-struct observer_component {
-  using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
-  using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
-  using action_list = tmpl::list<>;
-  using component_being_mocked = observers::Observer<Metavariables>;
-  using simple_tags = observers::Actions::Initialize::simple_tags;
-  using compute_tags = observers::Actions::Initialize::compute_tags;
-  using initial_databox =
-      db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
-};
-
-struct Metavariables {
-  using component_list = tmpl::list<element_component<Metavariables>,
-                                    observer_component<Metavariables>>;
-  using const_global_cache_tag_list = tmpl::list<>;
-
-  enum class Phase { Initialize, Exit };
-};
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace TestObservers_detail;
 
 template <observers::TypeOfObservation TypeOfObservation>
 void check_observer_registration() {
@@ -147,7 +115,7 @@ void check_observer_registration() {
   }
 }
 
-SPECTRE_TEST_CASE("Unit.IO.Observers.RegisterElements", "[Unit]") {
+SPECTRE_TEST_CASE("Unit.IO.Observers.RegisterElements", "[Unit][Observers]") {
   SECTION("Register as requiring reduction observer support") {
     check_observer_registration<observers::TypeOfObservation::Reduction>();
   }

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -14,8 +14,9 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
   CHECK(ReductionArrayComponentIds::name() == "ReductionArrayComponentIds");
   CHECK(VolumeArrayComponentIds::name() == "VolumeArrayComponentIds");
   CHECK(TensorData::name() == "TensorData");
-  CHECK(VolumeDataLock::name() == "VolumeDataLock");
-  CHECK(ReductionDataLock::name() == "ReductionDataLock");
+  CHECK(VolumeObserversContributed::name() == "VolumeObserversContributed");
+  CHECK(VolumeFileLock::name() == "VolumeFileLock");
+  CHECK(ReductionFileLock::name() == "ReductionFileLock");
 }
 }  // namespace Tags
 }  // namespace observers

--- a/tests/Unit/IO/Observers/Test_TypeOfObservation.cpp
+++ b/tests/Unit/IO/Observers/Test_TypeOfObservation.cpp
@@ -8,6 +8,16 @@
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "Utilities/GetOutput.hpp"
 
+namespace {
+enum class Phases0 { A, B, RegisterWithObserver };
+enum class Phases1 { A, B, C };
+
+static_assert(observers::has_register_with_observer_v<Phases0>,
+              "Failed testing observers::has_register_with_observers");
+static_assert(not observers::has_register_with_observer_v<Phases1>,
+              "Failed testing observers::has_register_with_observers");
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.IO.Observers.TypeOfObservation", "[Unit][Observers]") {
   using observers::TypeOfObservation;
   CHECK(get_output(TypeOfObservation::Reduction) == "Reduction");

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -1,0 +1,212 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <boost/iterator/transform_iterator.hpp>
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Initialize.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/Tags.hpp"               // IWYU pragma: keep
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "IO/Observer/VolumeActions.hpp"  // IWYU pragma: keep
+#include "Parallel/ArrayIndex.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/IO/Observers/ObserverHelpers.hpp"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace TestObservers_detail;
+
+SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
+  using TupleOfMockDistributedObjects =
+      typename ActionTesting::MockRuntimeSystem<
+          Metavariables>::TupleOfMockDistributedObjects;
+  using obs_component = observer_component<Metavariables>;
+  using obs_writer = observer_writer_component<Metavariables>;
+  using element_comp = element_component<Metavariables>;
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using ObserverMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          obs_component>;
+  using WriterMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          obs_writer>;
+  using ElementMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          element_comp>;
+  TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<ObserverMockDistributedObjectsTag>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
+  tuples::get<WriterMockDistributedObjectsTag>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<obs_writer>{});
+
+  // Specific IDs have no significance, just need different IDs.
+  const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
+                                              {1, {{{1, 1}, {1, 0}}}},
+                                              {1, {{{1, 0}, {2, 3}}}},
+                                              {1, {{{1, 0}, {5, 4}}}},
+                                              {0, {{{1, 0}, {1, 0}}}}};
+  for (const auto& id : element_ids) {
+    tuples::get<ElementMockDistributedObjectsTag>(dist_objects)
+        .emplace(ElementIndex<2>{id},
+                 ActionTesting::MockDistributedObject<element_comp>{});
+  }
+
+  tuples::TaggedTuple<observers::OptionTags::VolumeFileName> cache_data{};
+  const auto& output_file_prefix =
+      tuples::get<observers::OptionTags::VolumeFileName>(cache_data) =
+          "./Unit.IO.Observers.VolumeObserver";
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      cache_data, std::move(dist_objects)};
+
+  runner.simple_action<obs_component, observers::Actions::Initialize>(0);
+  runner.simple_action<obs_writer, observers::Actions::InitializeWriter>(0);
+  // Test initial state
+  const auto& observer_box =
+      runner.template algorithms<obs_component>()
+          .at(0)
+          .template get_databox<typename obs_component::initial_databox>();
+
+  // Register elements
+  for (const auto& id : element_ids) {
+    runner
+        .simple_action<element_comp, observers::Actions::RegisterWithObservers<
+                                         observers::TypeOfObservation::Volume>>(
+            id, 0);
+    // Invoke the simple_action RegisterSenderWithSelf that was called on the
+    // observer component by the RegisterWithObservers action.
+    runner.invoke_queued_simple_action<obs_component>(0);
+  }
+
+  const std::string h5_file_name = output_file_prefix + "0.h5";
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+
+  const auto make_fake_volume_data = [](const observers::ArrayComponentId& id,
+                                        const std::string& element_name) {
+    const auto hashed_id =
+        static_cast<double>(std::hash<observers::ArrayComponentId>{}(id));
+    std::vector<TensorComponent> data(6);
+    data[0] = TensorComponent(element_name + "T_x"s,
+                              DataVector{0.5 * hashed_id, 1.0 * hashed_id,
+                                         3.0 * hashed_id, -2.0 * hashed_id});
+    data[1] = TensorComponent(element_name + "T_y"s,
+                              DataVector{-0.5 * hashed_id, -1.0 * hashed_id,
+                                         -3.0 * hashed_id, 2.0 * hashed_id});
+
+    data[2] = TensorComponent(element_name + "S_xx"s,
+                              DataVector{10.5 * hashed_id, 11.0 * hashed_id,
+                                         13.0 * hashed_id, -22.0 * hashed_id});
+    data[3] = TensorComponent(element_name + "S_xy"s,
+                              DataVector{10.5 * hashed_id, -11.0 * hashed_id,
+                                         -13.0 * hashed_id, -22.0 * hashed_id});
+    data[4] = TensorComponent(element_name + "S_yx"s,
+                              DataVector{-10.5 * hashed_id, 11.0 * hashed_id,
+                                         13.0 * hashed_id, 22.0 * hashed_id});
+    data[5] = TensorComponent(element_name + "S_yy"s,
+                              DataVector{-10.5 * hashed_id, -11.0 * hashed_id,
+                                         -13.0 * hashed_id, 22.0 * hashed_id});
+
+    return std::make_tuple(Index<2>{2, 2}, std::move(data));
+  };
+
+  // Test passing volume data...
+  for (const auto& id : element_ids) {
+    const observers::ArrayComponentId array_id(
+        std::add_pointer_t<element_comp>{nullptr},
+        Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{id}});
+
+    auto volume_data_fakes =
+        make_fake_volume_data(array_id, MakeString{} << id << '/');
+    runner
+        .simple_action<obs_component, observers::Actions::ContributeVolumeData>(
+            0, observers::ObservationId(TimeId(3)), array_id,
+            /* get<1> = volume tensor data */
+            std::move(std::get<1>(volume_data_fakes)),
+            /* get<0> = index of dimensions */
+            std::get<0>(volume_data_fakes));
+  }
+  // Invoke the simple_action RegisterSenderWithSelf that was called on the
+  // observer component by the RegisterWithObservers action.
+  runner.invoke_queued_simple_action<obs_writer>(0);
+  runner.invoke_queued_threaded_action<obs_writer>(0);
+
+  // Check that the H5 file was written correctly.
+  h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
+  auto& volume_file = my_file.get<h5::VolumeData>("/element_data");
+
+  const auto temporal_id = observers::ObservationId(TimeId(3)).hash();
+  CHECK(volume_file.list_observation_ids() == std::vector<size_t>{temporal_id});
+  const auto grids = volume_file.list_grids(temporal_id);
+  const std::vector<std::string> expected_grids(
+      boost::make_transform_iterator(element_ids.begin(),
+                                     get_output<ElementId<2>>),
+      boost::make_transform_iterator(element_ids.end(),
+                                     get_output<ElementId<2>>));
+  REQUIRE(alg::all_of(grids, [&expected_grids](const std::string& name) {
+    return alg::found(expected_grids, name);
+  }));
+  REQUIRE(alg::all_of(expected_grids, [&grids](const std::string& name) {
+    return alg::found(grids, name);
+  }));
+
+  for (const auto& element_id : element_ids) {
+    const std::string grid_name = MakeString{} << element_id;
+    const auto tensor_names =
+        volume_file.list_tensor_components(temporal_id, grid_name);
+    const std::vector<std::string> expected_tensor_names{
+        "T_x", "T_y", "S_xx", "S_yy", "S_xy", "S_yx"};
+    CAPTURE(element_id);
+    CAPTURE(tensor_names);
+    CAPTURE(expected_tensor_names);
+    REQUIRE(alg::all_of(tensor_names,
+                        [&expected_tensor_names](const std::string& name) {
+                          return alg::found(expected_tensor_names, name);
+                        }));
+    REQUIRE(alg::all_of(expected_tensor_names,
+                        [&tensor_names](const std::string& name) {
+                          return alg::found(tensor_names, name);
+                        }));
+    const observers::ArrayComponentId array_id(
+        std::add_pointer_t<element_comp>{nullptr},
+        Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{element_id}});
+    const auto volume_data_fakes = make_fake_volume_data(array_id, "");
+    CHECK(std::vector<size_t>{std::get<0>(volume_data_fakes)[0],
+                              std::get<0>(volume_data_fakes)[1]} ==
+          volume_file.get_extents(temporal_id, grid_name));
+    for (const auto& tensor_component : std::get<1>(volume_data_fakes)) {
+      CHECK(tensor_component.data ==
+            volume_file.get_tensor_component(temporal_id, grid_name,
+                                             tensor_component.name));
+    }
+  }
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+}

--- a/tests/Unit/Utilities/Test_Algorithm.cpp
+++ b/tests/Unit/Utilities/Test_Algorithm.cpp
@@ -122,4 +122,17 @@ SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
                   }
                 });
   CHECK(count == 2);
+
+  // Test alg::equal
+  CHECK(alg::equal(std::vector<int>{1, -7, 8, 9},
+                   std::array<int, 4>{{1, -7, 8, 9}}));
+  CHECK_FALSE(alg::equal(std::vector<int>{1, 7, 8, 9},
+                         std::array<int, 4>{{1, -7, 8, 9}}));
+
+  CHECK(alg::equal(
+      std::vector<int>{1, -7, 8, 9}, std::array<int, 4>{{-1, 7, -8, -9}},
+      [](const int lhs, const int rhs) noexcept { return lhs == -rhs; }));
+  CHECK_FALSE(alg::equal(
+      std::vector<int>{1, -7, 8, 9}, std::array<int, 4>{{-1, -7, -8, -9}},
+      [](const int lhs, const int rhs) noexcept { return lhs == -rhs; }));
 }


### PR DESCRIPTION
## Proposed changes

Adds volume observers that currently require a system-specific action. Once we have time (December-ish) we will need to go back and use the events and triggers infrastructure to properly handle observers in a more system-agnostic method.

Commit order is:
1. Add convenience wrapper around std::equal
2. Add support for calling threaded actions remotely
3. Add support for threaded_actions to mocking framework
4. Rename InvokeSimpleActionBase to InvokeActionBase
5. Factor out code from Test_RegisterElements
6. Fix name of execute_next_phase in observer component
7. Add ObserverWriter component
8. Add actions for observing volume data
9. Add trait observers::has_register_with_observer
10. Add support for registering with observers to DgElementArray
11. Add action for observing scalar wave solution and error.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
