### PR TITLE
Fix unused variables and H5 error check

### DIFF
--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -188,7 +188,7 @@ std::vector<T> read_rank1_attribute(const hid_t group_id,
     CHECK_H5(datatype_id, "Failed to get datatype from attribute " << name);
     const hid_t datatype = H5Tget_native_type(datatype_id, H5T_DIR_DESCEND);
     const auto size = H5Tget_size(datatype);
-    if (UNLIKELY(sizeof(h5_type<T>()) != size)) {
+    if (UNLIKELY(sizeof(T) != size)) {
       ERROR("The read HDF5 type of the attribute ("
             << datatype
             << ") has a different size than the type we are reading. The "

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -72,9 +72,6 @@ void run_events_and_triggers(const EventsAndTriggersType& events_and_triggers,
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
       {serialize_and_deserialize(events_and_triggers)},
       std::move(dist_objects)};
-  auto& box = runner.template algorithms<my_component>()
-                  .at(0)
-                  .template get_databox<db::DataBox<tmpl::list<>>>();
 
   runner.next_action<component>(0);
 

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -218,10 +218,7 @@ SPECTRE_TEST_CASE("Unit.IO.H5.Dat", "[Unit][IO][H5]") {
   std::vector<std::string> legend{"Time", "Error L2", "Error L1", "Error"};
 
   h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
-  {
-    auto& error_file =
-        my_file.insert<h5::Dat>("/L2_errors", legend, version_number);
-  }
+  my_file.insert<h5::Dat>("/L2_errors", legend, version_number);
   // pass bad values to make sure the original ones aren't overridden.
   auto evil_legend = legend;
   evil_legend.emplace_back("Uh oh");


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
