### PR TITLE
add functors for standard and blaze math functions

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -156,7 +156,10 @@ ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 
 # Macros we actually want to expand during preprocessing
-EXPAND_AS_DEFINED      = MAKE_BINARY_OPERATOR
+EXPAND_AS_DEFINED      = MAKE_BINARY_FUNCTIONAL \
+                         MAKE_BINARY_INPLACE_OPERATOR \
+                         MAKE_BINARY_OPERATOR \
+                         MAKE_UNARY_FUNCTIONAL
 
 EXPAND_ONLY_PREDEF     = YES
 

--- a/src/Utilities/Functional.hpp
+++ b/src/Utilities/Functional.hpp
@@ -9,12 +9,40 @@
 
 #include "ErrorHandling/Assert.hpp"
 #include "ErrorHandling/StaticAssert.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Math.hpp"
 
 /*!
  * \ingroup UtilitiesGroup
  * \brief Higher order function objects similar to `std::plus`, etc.
+ *
+ * \details
+ * These chaining function objects can be used to represent highly general
+ * mathematical operations
+ * 1. as types, which can be passed around in template arguments, and
+ * 2. such that any time they can be evaluated at compile time, they will be.
+ *
+ * As an illustrative example, consider the definition of a general sinusoid
+ * function object type :
+ * \snippet Utilities/Test_Functional.cpp using_sinusoid
+ * which then gives a type which when instantiated and evaluated will give the
+ * answer \f$ a\times\sin(b + c \times d)\f$ from calling `Sinusoid{}(a,b,c,d)`
+ *
+ * As a more creative example, we can take advantage of literals to make, for
+ * instance, distributions. Let's make a Gaussian with mean at 5.0 and unity
+ * variance
+ * \snippet Utilities/Test_Functional.cpp using_gaussian
+ *
+ * This gives us a function object whose call operator takes one argument that
+ * gives the value of the desired Gaussian distribution \f$ e^{-(x - 5.0)^2}
+ * \f$
  */
 namespace funcl {
+// using for overload resolution with blaze
+using std::conj;
+using std::imag;
+using std::real;
+
 /// \cond
 template <size_t Arity>
 struct Functional {
@@ -32,7 +60,87 @@ struct Functional {
 struct Identity;
 /// \endcond
 
+/// Functional that asserts that the function object `C` applied to the first
+/// and second arguments are equal and returns the function object C applied to
+/// the first argument
+template <class C = Identity>
+struct AssertEqual : Functional<2> {
+  template <class T>
+  const T& operator()(const T& t0, const T& t1) noexcept {
+    DEBUG_STATIC_ASSERT(
+        C::arity == 1,
+        "The arity of the functional passed to AssertEqual must be 1");
+    ASSERT(C{}(t0) == C{}(t1), "Values are not equal in funcl::AssertEqual "
+           << C{}(t0) << " and " << C{}(t1));
+    return C{}(t0);
+  }
+};
+
+#define MAKE_BINARY_FUNCTIONAL(NAME, OPERATOR)                                 \
+  /** Functional for computing `OPERATOR` from two objects */                  \
+  template <class C0 = Identity, class C1 = C0>                                \
+  struct NAME : Functional<C0::arity + C1::arity> {                            \
+    using base = Functional<C0::arity + C1::arity>;                            \
+    template <class... Ts>                                                     \
+    constexpr auto operator()(const Ts&... ts) noexcept {                      \
+      return OPERATOR(                                                         \
+          base::template helper<C0, 0>(std::tuple<const Ts&...>(ts...),        \
+                                       std::make_index_sequence<C0::arity>{}), \
+          base::template helper<C1, C0::arity>(                                \
+              std::tuple<const Ts&...>(ts...),                                 \
+              std::make_index_sequence<C1::arity>{}));                         \
+    }                                                                          \
+  };                                                                           \
+  /** \cond */                                                                 \
+  template <class C1>                                                          \
+  struct NAME<Identity, C1> : Functional<1 + C1::arity> {                      \
+    template <class T0, class... Ts>                                           \
+    constexpr auto operator()(const T0& t0, const Ts&... ts) noexcept {        \
+      return OPERATOR(t0, C1{}(ts...));                                        \
+    }                                                                          \
+  };                                                                           \
+  template <>                                                                  \
+  struct NAME<Identity, Identity> : Functional<2> {                            \
+    template <class T0, class T1>                                              \
+    constexpr auto operator()(const T0& t0, const T1& t1) noexcept {           \
+      return OPERATOR(t0, t1);                                                 \
+    }                                                                          \
+  } /** \endcond */
+
+#define MAKE_BINARY_INPLACE_OPERATOR(NAME, OPERATOR)                        \
+  /** Functional for computing `OPERATOR` of two objects */                 \
+  template <class C0 = Identity, class C1 = C0>                             \
+  struct NAME : Functional<C0::arity + C1::arity> {                         \
+    using base = Functional<C0::arity + C1::arity>;                         \
+    template <class... Ts>                                                  \
+    constexpr decltype(auto) operator()(Ts&... ts) noexcept {               \
+      return base::template helper<C0, 0>(                                  \
+          std::tuple<const Ts&...>(ts...),                                  \
+          std::make_index_sequence<C0::arity>{})                            \
+          OPERATOR base::template helper<C1, C0::arity>(                    \
+              std::tuple<const Ts&...>(ts...),                              \
+              std::make_index_sequence<C1::arity>{});                       \
+    }                                                                       \
+  };                                                                        \
+  /** \cond */                                                              \
+  template <class C1>                                                       \
+  struct NAME<Identity, C1> : Functional<1 + C1::arity> {                   \
+    template <class T0, class... Ts>                                        \
+    constexpr decltype(auto) operator()(T0& t0, const Ts&... ts) noexcept { \
+      return t0 OPERATOR C1{}(ts...);                                       \
+    }                                                                       \
+  };                                                                        \
+  template <>                                                               \
+  struct NAME<Identity, Identity> : Functional<2> {                         \
+    static constexpr size_t arity = 2;                                      \
+    template <class T0, class T1>                                           \
+    constexpr decltype(auto) operator()(T0& t0, const T1& t1) noexcept {    \
+      return t0 OPERATOR t1;                                                \
+    }                                                                       \
+  } /** \endcond */
+
 #define MAKE_BINARY_OPERATOR(NAME, OPERATOR)                            \
+  /** Functional for computing `OPERATOR` of two objects */             \
   template <class C0 = Identity, class C1 = C0>                         \
   struct NAME : Functional<C0::arity + C1::arity> {                     \
     using base = Functional<C0::arity + C1::arity>;                     \
@@ -56,36 +164,46 @@ struct Identity;
   };                                                                    \
   template <>                                                           \
   struct NAME<Identity, Identity> : Functional<2> {                     \
+    static constexpr size_t arity = 2;                                  \
     template <class T0, class T1>                                       \
     constexpr auto operator()(const T0& t0, const T1& t1) noexcept {    \
       return t0 OPERATOR t1;                                            \
     }                                                                   \
-  };                                                                    \
-  /** \endcond*/
+  } /** \endcond */
 
-/// Functional that asserts the first and second arguments are equal and returns
-/// the first argument.
-template <class C = Identity>
-struct AssertEqual : Functional<2> {
-  template <class T>
-  const T& operator()(const T& t0, const T& t1) noexcept {
-    DEBUG_STATIC_ASSERT(
-        C::arity == 1,
-        "The arity of the functional passed to AssertEqual must be 1");
-    ASSERT(t0 == t1, "Values are not equal in funcl::AssertEqual "
-                         << t0 << " and " << t1);
-    return C{}(t0);
+#define MAKE_LITERAL_VAL(NAME, VAL)          \
+  /** Functional literal for `VAL` */        \
+  struct Literal##NAME : Functional<0> {     \
+    constexpr double operator()() noexcept { \
+      return static_cast<double>(VAL);       \
+    }                                        \
   }
-};
 
-/// Functional for dividing two objects
-MAKE_BINARY_OPERATOR(Divides, /)
+#define MAKE_UNARY_FUNCTIONAL(NAME, OPERATOR)             \
+  /** Functional for computing `OPERATOR` on an object */ \
+  template <typename C0 = Identity>                       \
+  struct NAME;                                            \
+  /** \cond */                                            \
+  template <typename C0>                                  \
+  struct NAME : Functional<C0::arity> {                   \
+    template <class... Ts>                                \
+    constexpr auto operator()(const Ts&... ts) noexcept { \
+      return OPERATOR(C0{}(ts...));                       \
+    }                                                     \
+  };                                                      \
+  template <>                                             \
+  struct NAME<Identity> : Functional<1> {                 \
+    template <class T0>                                   \
+    constexpr auto operator()(const T0& t0) noexcept {    \
+      return OPERATOR(t0);                                \
+    }                                                     \
+  } /** \endcond */
 
 /// Functional to retrieve the `ArgumentIndex`th argument
 template <size_t Arity, size_t ArgumentIndex = 0, class C = Identity>
 struct GetArgument : Functional<Arity> {
   template <class... Ts>
-  constexpr auto operator()(const Ts&... ts) noexcept {
+  constexpr decltype(auto) operator()(const Ts&... ts) noexcept {
     static_assert(Arity == sizeof...(Ts),
                   "The arity passed to GetArgument must be the same as the "
                   "actually arity of the function.");
@@ -96,38 +214,63 @@ struct GetArgument : Functional<Arity> {
 /// The identity higher order function object
 struct Identity : Functional<1> {
   template <class T>
-  constexpr const T& operator()(const T& t) noexcept {
+  SPECTRE_ALWAYS_INLINE constexpr const T& operator()(const T& t) noexcept {
     return t;
   }
 };
 
-/// Functional for subtracting two objects
-MAKE_BINARY_OPERATOR(Minus, -)
-
-/// Functional for multiplying two objects
-MAKE_BINARY_OPERATOR(Multiplies, *)
-
-/// Functional for negating an object
-template <class C = Identity>
-struct Negate : Functional<C::arity> {
-  template <class... Ts>
-  constexpr auto operator()(const Ts&... ts) noexcept {
-    return -C{}(ts...);
-  }
+template <int val, typename Type = double>
+struct Literal : Functional<0> {
+  constexpr Type operator()() noexcept { return static_cast<Type>(val); }
 };
 
-/// Functional for adding two objects
-MAKE_BINARY_OPERATOR(Plus, +)
+MAKE_BINARY_INPLACE_OPERATOR(DivAssign, /=);
+MAKE_BINARY_INPLACE_OPERATOR(MinusAssign, -=);
+MAKE_BINARY_INPLACE_OPERATOR(MultAssign, *=);
+MAKE_BINARY_INPLACE_OPERATOR(PlusAssign, +=);
 
-/// Functional for taking the square root of a quantity
-template <class C = Identity>
-struct Sqrt : Functional<C::arity> {
-  template <class... Ts>
-  constexpr auto operator()(const Ts&... ts) noexcept {
-    using std::sqrt;
-    return sqrt(C{}(ts...));
-  }
-};
+MAKE_BINARY_OPERATOR(Divides, /);
+MAKE_BINARY_OPERATOR(Minus, -);
+MAKE_BINARY_OPERATOR(Multiplies, *);
+MAKE_BINARY_OPERATOR(Plus, +);
+
+MAKE_BINARY_FUNCTIONAL(Atan2, atan2);
+MAKE_BINARY_FUNCTIONAL(Hypot, hypot);
+MAKE_BINARY_FUNCTIONAL(Pow, pow);
+
+MAKE_LITERAL_VAL(Pi, M_PI);
+MAKE_LITERAL_VAL(E, M_E);
+
+MAKE_UNARY_FUNCTIONAL(Abs, abs);
+MAKE_UNARY_FUNCTIONAL(Acos, acos);
+MAKE_UNARY_FUNCTIONAL(Acosh, acosh);
+MAKE_UNARY_FUNCTIONAL(Asin, asin);
+MAKE_UNARY_FUNCTIONAL(Asinh, asinh);
+MAKE_UNARY_FUNCTIONAL(Atan, atan);
+MAKE_UNARY_FUNCTIONAL(Atanh, atanh);
+MAKE_UNARY_FUNCTIONAL(Cbrt, cbrt);
+MAKE_UNARY_FUNCTIONAL(Conj, conj);
+MAKE_UNARY_FUNCTIONAL(Cos, cos);
+MAKE_UNARY_FUNCTIONAL(Cosh, cosh);
+MAKE_UNARY_FUNCTIONAL(Erf, erf);
+MAKE_UNARY_FUNCTIONAL(Exp, exp);
+MAKE_UNARY_FUNCTIONAL(Exp2, exp2);
+MAKE_UNARY_FUNCTIONAL(Exp10, exp10);
+MAKE_UNARY_FUNCTIONAL(Fabs, fabs);
+MAKE_UNARY_FUNCTIONAL(Imag, imag);
+MAKE_UNARY_FUNCTIONAL(InvCbrt, invcbrt);
+MAKE_UNARY_FUNCTIONAL(InvSqrt, invsqrt);
+MAKE_UNARY_FUNCTIONAL(Log, log);
+MAKE_UNARY_FUNCTIONAL(Log10, log10);
+MAKE_UNARY_FUNCTIONAL(Log2, log2);
+MAKE_UNARY_FUNCTIONAL(Real, real);
+MAKE_UNARY_FUNCTIONAL(Sin, sin);
+MAKE_UNARY_FUNCTIONAL(Sinh, sinh);
+MAKE_UNARY_FUNCTIONAL(Sqrt, sqrt);
+MAKE_UNARY_FUNCTIONAL(StepFunction, step_function);
+MAKE_UNARY_FUNCTIONAL(Tan, tan);
+MAKE_UNARY_FUNCTIONAL(Tanh, tanh);
+MAKE_UNARY_FUNCTIONAL(Negate, -);
 
 /// Function for squaring a quantity
 template <class C = Identity>
@@ -139,5 +282,8 @@ struct Square : Functional<C::arity> {
   }
 };
 
+#undef MAKE_BINARY_FUNCTIONAL
+#undef MAKE_BINARY_INPLACE_OPERATOR
 #undef MAKE_BINARY_OPERATOR
+#undef MAKE_UNARY_FUNCTIONAL
 }  // namespace funcl

--- a/src/Utilities/Math.hpp
+++ b/src/Utilities/Math.hpp
@@ -5,10 +5,12 @@
 
 #include <cmath>
 #include <numeric>
+#include <type_traits>
 #include <vector>
 
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 /*!
@@ -44,4 +46,30 @@ T evaluate_polynomial(const std::vector<U>& coeffs, const T& x) noexcept {
   return std::accumulate(
       coeffs.rbegin(), coeffs.rend(), make_with_value<T>(x, 0.),
       [&x](const T& state, const U& element) { return state * x + element; });
+}
+
+/// \ingroup UtilitiesGroup
+
+/// \brief Defines the Heaviside step function \f$\Theta\f$ for arithmetic
+/// types.  \f$\Theta(0) = 1\f$.
+template <typename T, Requires<std::is_arithmetic<T>::value> = nullptr>
+constexpr T step_function(const T& arg) noexcept {
+  return static_cast<T>((arg >= static_cast<T>(0)) ? 1 : 0);
+}
+
+/// \ingroup UtilitiesGroup
+/// \brief Defines the inverse square-root (\f$1/\sqrt{x}\f$) for arithmetic
+/// and complex types
+template <typename T, Requires<std::is_arithmetic<T>::value or
+                               tt::is_a_v<std::complex, T>> = nullptr>
+auto invsqrt(const T& arg) noexcept {
+  return static_cast<T>(1.0) / sqrt(arg);
+}
+
+/// \ingroup UtilitiesGroup
+/// \brief Defines the inverse cube-root (\f$1/\sqrt[3]{x}\f$) for arithmetic
+/// types
+template <typename T, Requires<std::is_arithmetic<T>::value> = nullptr>
+auto invcbrt(const T& arg) noexcept {
+  return static_cast<T>(1.0) / cbrt(arg);
 }

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -26,6 +26,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "Utilities/NoSuchType.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/StlStreamDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
@@ -348,6 +349,10 @@ constexpr bool is_unsigned_v = std::is_unsigned<T>::value;
 /// \ingroup TypeTraitsGroup
 template <class T>
 constexpr bool is_floating_point_v = std::is_floating_point<T>::value;
+
+/// \ingroup TypeTraitsGroup
+template <class T>
+constexpr bool is_integral_v = std::is_integral<T>::value;
 
 /// \ingroup TypeTraitsGroup
 template <class T>
@@ -1358,6 +1363,30 @@ struct remove_cvref_wrap {
 
 template <typename T>
 using remove_cvref_wrap_t = typename remove_cvref_wrap<T>::type;
+// @}
+
+// @{
+/// \ingroup TypeTraitsGroup
+/// \brief Extracts the fundamental type for a container
+///
+/// \details  Designates a type alias `get_fundamental_type::type`
+///  as `T` when `T` itself is an appropriate fundamental type, and the
+/// contained type of a container which specifies a `value_type`.
+///
+/// `get_fundamental_type_t<T>` is provided as a type alias to
+/// `type` from `get_fundamental_type<T>`
+template <typename T, typename Enable = cpp17::void_t<>>
+struct get_fundamental_type {
+  using type = tmpl::conditional_t<cpp17::is_fundamental_v<T>, T, NoSuchType>;
+};
+/// \cond
+template <typename T>
+struct get_fundamental_type<T, cpp17::void_t<typename T::value_type>> {
+  using type = typename get_fundamental_type<typename T::value_type>::type;
+};
+/// \endcond
+template <typename T>
+using get_fundamental_type_t = typename get_fundamental_type<T>::type;
 // @}
 
 namespace tt_detail {

--- a/tests/Unit/Utilities/Test_Functional.cpp
+++ b/tests/Unit/Utilities/Test_Functional.cpp
@@ -3,21 +3,195 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <cmath>
+#include <array>
+#include <cmath>  // IWYU pragma: keep
+#include <complex>
+#include <cstddef>
+#include <random>
+#include <tuple>
+#include <utility>
 
 #include "ErrorHandling/Error.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"  // IWYU pragma: keep
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 namespace funcl {
+using std::imag;
+using std::real;
+// clang-tidy : suppress warning from no-paren on macro parameter, macro doesn't
+// work when it's in parens. Same for all subsequent macros.
+#define MAKE_UNARY_TEST(STRUCTNAME, FUNC)                                  \
+  struct TestFuncEval##STRUCTNAME {                                        \
+    template <typename T, typename DistT, typename UniformGen>             \
+    void operator()(UniformGen gen, UniformCustomDistribution<DistT> dist, \
+                    T /*meta*/) noexcept {                                 \
+      auto val = make_with_random_values<typename T::type>(                \
+          make_not_null(&gen), make_not_null(&dist));                      \
+      CHECK(STRUCTNAME<>{}(val) == FUNC(val)); /*NOLINT*/                  \
+    }                                                                      \
+  }
+
+#define MAKE_BINARY_TEST(STRUCTNAME, FUNC)                                   \
+  struct TestFuncEval##STRUCTNAME {                                          \
+    template <typename T1, typename T2, typename DistT1, typename DistT2,    \
+              typename UniformGen>                                           \
+    void operator()(UniformGen gen, UniformCustomDistribution<DistT1> dist1, \
+                    UniformCustomDistribution<DistT2> dist2, T1 /*meta*/,    \
+                    T2 /*meta*/) noexcept {                                  \
+      auto val1 = make_with_random_values<typename T1::type>(                \
+          make_not_null(&gen), make_not_null(&dist1));                       \
+      auto val2 = make_with_random_values<typename T2::type>(                \
+          make_not_null(&gen), make_not_null(&dist2));                       \
+      CHECK(STRUCTNAME<>{}(val1, val2) == FUNC(val1, val2)); /*NOLINT*/      \
+    }                                                                        \
+  }
+
+#define MAKE_BINARY_OP_TEST(STRUCTNAME, OP)                                  \
+  struct TestFuncEval##STRUCTNAME {                                          \
+    template <typename T1, typename T2, typename DistT1, typename DistT2,    \
+              typename UniformGen>                                           \
+    void operator()(UniformGen gen, UniformCustomDistribution<DistT1> dist1, \
+                    UniformCustomDistribution<DistT2> dist2, T1 /*meta*/,    \
+                    T2 /*meta*/) noexcept {                                  \
+      auto val1 = make_with_random_values<typename T1::type>(                \
+          make_not_null(&gen), make_not_null(&dist1));                       \
+      auto val2 = make_with_random_values<typename T2::type>(                \
+          make_not_null(&gen), make_not_null(&dist2));                       \
+      CHECK(STRUCTNAME<>{}(val1, val2) == val1 OP val2); /*NOLINT*/          \
+    }                                                                        \
+  }
+
+#define MAKE_BINARY_INPLACE_TEST(STRUCTNAME, OP, TESTOP)                       \
+  struct TestFuncEval##STRUCTNAME {                                            \
+    template <typename T1, typename T2, typename DistT1, typename DistT2,      \
+              typename UniformGen,                                             \
+              Requires<cpp17::is_same_v<                                       \
+                  typename T1::type,                                           \
+                  decltype(std::declval<typename T1::type>() TESTOP            \
+                               std::declval<typename T2::type>())>> = nullptr> \
+    void operator()(UniformGen gen, UniformCustomDistribution<DistT1> dist1,   \
+                    UniformCustomDistribution<DistT2> dist2, T1 /*meta*/,      \
+                    T2 /*meta*/) noexcept {                                    \
+      auto val1 = make_with_random_values<typename T1::type>(                  \
+          make_not_null(&gen), make_not_null(&dist1));                         \
+      auto val2 = make_with_random_values<typename T2::type>(                  \
+          make_not_null(&gen), make_not_null(&dist2));                         \
+      auto val1_copy = val1;                                                   \
+      auto result = val1_copy TESTOP val2;                                     \
+      STRUCTNAME<>{}(val1, val2); /*NOLINT*/                                   \
+      CHECK(val1 == result);                                                   \
+    }                                                                          \
+    /* SFINAE to avoid testing illegal combinations like */                    \
+    /* double += complex<double> in addition to vise-versa. */                 \
+    /* Below no-op happens when inplace cannot be called. */                   \
+    template <typename T1, typename T2, typename DistT1, typename DistT2,      \
+              typename UniformGen,                                             \
+              Requires<not cpp17::is_same_v<                                   \
+                  typename T1::type,                                           \
+                  decltype(std::declval<typename T1::type>() TESTOP            \
+                               std::declval<typename T2::type>())>> = nullptr> \
+    void operator()(UniformGen /*gen*/,                                        \
+                    UniformCustomDistribution<DistT1> /*dist1*/,               \
+                    UniformCustomDistribution<DistT2> /*dist2*/, T1 /*meta*/,  \
+                    T2 /*meta*/) noexcept {}                                   \
+  }
+
 namespace {
-void test_assert_equal() {
-  CHECK(AssertEqual<>{}(7, 7) == 7);
+
+MAKE_UNARY_TEST(Abs, abs);
+MAKE_UNARY_TEST(Acos, acos);
+MAKE_UNARY_TEST(Acosh, acosh);
+MAKE_UNARY_TEST(Asin, asin);
+MAKE_UNARY_TEST(Asinh, asinh);
+MAKE_UNARY_TEST(Atan, atan);
+MAKE_UNARY_TEST(Atanh, atanh);
+MAKE_UNARY_TEST(Cbrt, cbrt);
+MAKE_UNARY_TEST(Cos, cos);
+MAKE_UNARY_TEST(Cosh, cosh);
+MAKE_UNARY_TEST(Erf, erf);
+MAKE_UNARY_TEST(Exp, exp);
+MAKE_UNARY_TEST(Exp10, exp10);
+MAKE_UNARY_TEST(Exp2, exp2);
+MAKE_UNARY_TEST(Fabs, fabs);
+MAKE_UNARY_TEST(Imag, imag);
+MAKE_UNARY_TEST(InvCbrt, invcbrt);
+MAKE_UNARY_TEST(InvSqrt, invsqrt);
+MAKE_UNARY_TEST(Log, log);
+MAKE_UNARY_TEST(Log10, log10);
+MAKE_UNARY_TEST(Log2, log2);
+MAKE_UNARY_TEST(Real, real);
+MAKE_UNARY_TEST(Sin, sin);
+MAKE_UNARY_TEST(Sinh, sinh);
+MAKE_UNARY_TEST(StepFunction, step_function);
+MAKE_UNARY_TEST(Square, square);
+MAKE_UNARY_TEST(Sqrt, sqrt);
+MAKE_UNARY_TEST(Tan, tan);
+MAKE_UNARY_TEST(Tanh, tanh);
+
+MAKE_BINARY_TEST(Atan2, atan2);
+MAKE_BINARY_TEST(Hypot, hypot);
+MAKE_BINARY_TEST(Pow, pow);
+
+MAKE_BINARY_OP_TEST(Divides, /);
+MAKE_BINARY_OP_TEST(Minus, -);
+MAKE_BINARY_OP_TEST(Multiplies, *);
+MAKE_BINARY_OP_TEST(Plus, +);
+
+MAKE_BINARY_INPLACE_TEST(DivAssign, /=, /);
+MAKE_BINARY_INPLACE_TEST(MinusAssign, -=, -);
+MAKE_BINARY_INPLACE_TEST(MultAssign, *=, *);
+MAKE_BINARY_INPLACE_TEST(PlusAssign, +=, +);
+
+using RealTypeList = tmpl::list<float, double, int, long>;
+using AllTypeList = tmpl::list<float, double, std::complex<double>>;
+using DoubleSet = tmpl::list<double, std::complex<double>>;
+
+using Bound = std::array<double, 2>;
+
+template <typename ValType, typename Gen, typename Dist>
+ValType expandable_random_val(Gen& gen, Dist& dist, size_t /*meta*/) noexcept {
+  return make_with_random_values<ValType>(make_not_null(&gen),
+                                          make_not_null(&dist));
 }
-void test_divides() {
-  CHECK(Divides<>{}(1, -2) == 0);
-  CHECK(Divides<>{}(1, -2.0) == -0.5);
+
+template <typename C, typename ValType, typename Func, typename Gen,
+          size_t... Is>
+void test_functional_against_function(
+    const Func func, Gen& gen, const Bound& bounds,
+    const std::index_sequence<Is...> /*meta*/) noexcept {
+  static_assert(sizeof...(Is) == C::arity,
+                "test was passed incorrect number of arguments");
+  UniformCustomDistribution<typename tt::get_fundamental_type_t<ValType>> dist{
+      bounds};
+  [&func](auto... arg) noexcept {
+    if (cpp17::is_same_v<ValType,
+                         typename tt::get_fundamental_type_t<ValType>>) {
+      CHECK_ITERABLE_APPROX(C{}(arg...), func(arg...));
+    } else {
+      CHECK(C{}(arg...) == func(arg...));
+    }
+  }(expandable_random_val<ValType>(gen, dist, Is)...);
 }
-void test_get_argument() {
+
+/// [using_sinusoid]
+using Sinusoid = funcl::Multiplies<
+    funcl::Identity,
+    funcl::Sin<funcl::Plus<funcl::Identity, funcl::Multiplies<>>>>;
+///[using_sinusoid]
+
+/// [using_gaussian]
+using GaussianExp =
+    funcl::Negate<funcl::Square<funcl::Minus<Identity, Literal<5, double>>>>;
+using Gaussian = funcl::Exp<GaussianExp>;
+/// [using_gaussian]
+
+void test_get_argument() noexcept {
   CHECK(GetArgument<1>{}(-2) == -2);
   CHECK(GetArgument<1, 0>{}(-2) == -2);
   CHECK(GetArgument<2, 0>{}(-2, 1) == -2);
@@ -26,57 +200,219 @@ void test_get_argument() {
   CHECK(GetArgument<3, 1>{}(-2, 8, -10) == 8);
   CHECK(GetArgument<3, 2>{}(-2, 8, -10) == -10);
 }
-void test_identity() {
-  CHECK(Identity{}(-2) == -2);
-  CHECK(Identity{}(-2.0) == -2.0);
-}
-void test_minus() {
-  CHECK(Minus<>{}(1, -2) == 3);
-  CHECK(Minus<>{}(1, -2.0) == 3.0);
-}
-void test_multiplies() {
-  CHECK(Multiplies<>{}(1, -2) == -2);
-  CHECK(Multiplies<>{}(1, -2.0) == -2.0);
-}
-void test_negate() {
-  CHECK(Negate<>{}(10) == -10);
-  CHECK(Negate<>{}(-10.0) == 10.0);
-}
-void test_plus() {
-  CHECK(Plus<>{}(1, -2) == -1);
-  CHECK(Plus<>{}(1, -2.0) == -1.0);
-}
-void test_sqrt() {
-  CHECK(Sqrt<>{}(3.0) == sqrt(3.0));
-}
-void test_square() {
-  CHECK(Square<>{}(3.0) == 9.0);
-  CHECK(Square<>{}(-3.0) == 9.0);
+
+void test_assert_equal() noexcept { CHECK(AssertEqual<>{}(7, 7) == 7); }
+
+template <typename Gen>
+void test_functional_combinations(Gen& gen) noexcept {
+  const Bound generic{{-50.0, 50.0}};
+
+  test_functional_against_function<Plus<Minus<>, Identity>, double>(
+      [](const auto& x, const auto& y, const auto& z) { return (x - y) + z; },
+      gen, generic, std::make_index_sequence<3>());
+  test_functional_against_function<Sinusoid, double>(
+      [](const auto& w, const auto& x, const auto& y, const auto& z) {
+        return w * sin(x + y * z);
+      },
+      gen, generic, std::make_index_sequence<4>());
+  test_functional_against_function<Multiplies<Plus<Plus<>, Plus<>>, Identity>,
+                                   double>(
+      [](const auto& x1, const auto& x2, const auto& x3, const auto& x4,
+         const auto& x5) { return x5 * (x1 + x2 + x3 + x4); },
+      gen, generic, std::make_index_sequence<5>());
+  test_functional_against_function<
+      Minus<Plus<Identity, Multiplies<>>, Identity>, double>(
+      [](const auto& x1, const auto& x2, const auto& x3, const auto& x4) {
+        return (x1 + (x2 * x3)) - x4;
+      },
+      gen, generic, std::make_index_sequence<4>());
+  test_functional_against_function<Plus<Negate<>, Identity>, double>(
+      [](const auto& x, const auto& y) { return (y - x); }, gen, generic,
+      std::make_index_sequence<2>());
+  test_functional_against_function<Negate<Plus<>>, double>(
+      [](const auto& x, const auto& y) { return -(y + x); }, gen, generic,
+      std::make_index_sequence<2>());
+  test_functional_against_function<Negate<Plus<Identity, Negate<>>>, double>(
+      [](const auto& x, const auto& y) { return -(x - y); }, gen, generic,
+      std::make_index_sequence<2>());
+  test_functional_against_function<Gaussian, double>(
+      [](const auto& x) { return exp(-(x - 5.0) * (x - 5.0)); }, gen, generic,
+      std::make_index_sequence<1>());
+  test_functional_against_function<Negate<Plus<Literal<3>, Negate<>>>, double>(
+      [](const auto& y) { return -(3.0 - y); }, gen, generic,
+      std::make_index_sequence<1>());
 }
 
-void test_composition() {
-  CHECK(Plus<Negate<>>{}(2.0, 7.0) == -9.0);
-  CHECK(Plus<Negate<>, Identity>{}(2.0, 7.0) == 5.0);
-  CHECK(Negate<Plus<>>{}(2.0, 7.0) == -9.0);
-  CHECK(Multiplies<Plus<Plus<>, Plus<>>, Identity>{}(1, 2, 3, 4, 5) == 50);
-  CHECK(Minus<Plus<Identity, Multiplies<>>, Identity>{}(1, 2, 3, 4) == 3);
-  CHECK(Negate<Plus<Identity, Negate<>>>{}(2.0, 7.0) == 5.0);
-  CHECK(Plus<Identity, Multiplies<>>{}(1, 2, 3) == 7);
+template <typename Gen>
+void test_generic_unaries(Gen& gen) noexcept {
+  const Bound generic{{-50.0, 50.0}};
+  const Bound gt_one{{1.0, 100.0}};
+  const Bound mone_one{{-1.0, 1.0}};
+  const Bound positive{{.001, 100.0}};
+
+  auto generic_unaries =
+      std::make_tuple(std::make_tuple(TestFuncEvalAbs{}, generic),
+                      std::make_tuple(TestFuncEvalAcos{}, mone_one),
+                      std::make_tuple(TestFuncEvalAcosh{}, gt_one),
+                      std::make_tuple(TestFuncEvalAsin{}, mone_one),
+                      std::make_tuple(TestFuncEvalAsinh{}, generic),
+                      std::make_tuple(TestFuncEvalAtan{}, generic),
+                      std::make_tuple(TestFuncEvalAtanh{}, mone_one),
+                      std::make_tuple(TestFuncEvalCos{}, generic),
+                      std::make_tuple(TestFuncEvalCosh{}, generic),
+                      std::make_tuple(TestFuncEvalExp{}, generic),
+                      std::make_tuple(TestFuncEvalImag{}, generic),
+                      std::make_tuple(TestFuncEvalInvSqrt{}, positive),
+                      std::make_tuple(TestFuncEvalLog{}, positive),
+                      std::make_tuple(TestFuncEvalReal{}, generic),
+                      std::make_tuple(TestFuncEvalSin{}, generic),
+                      std::make_tuple(TestFuncEvalSinh{}, generic),
+                      std::make_tuple(TestFuncEvalSqrt{}, positive),
+                      std::make_tuple(TestFuncEvalSquare{}, generic),
+                      std::make_tuple(TestFuncEvalTan{}, generic),
+                      std::make_tuple(TestFuncEvalTanh{}, generic));
+
+  tmpl::for_each<AllTypeList>([&gen, &generic_unaries ](auto x) noexcept {
+    using DistType =
+        typename tt::get_fundamental_type_t<typename decltype(x)::type>;
+    tmpl::for_each<tmpl::make_sequence<std::integral_constant<size_t, 0>, 20,
+                                       tmpl::next<tmpl::_1>>>([
+      &gen, &x, &generic_unaries
+    ](auto index) noexcept {
+      auto& tup = std::get<decltype(index)::type::value>(generic_unaries);
+      std::get<0>(tup)(
+          gen, UniformCustomDistribution<DistType>{std::get<Bound>(tup)}, x);
+    });
+  });
 }
 
-SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Unit][Utilities]") {
+template <typename Gen>
+void test_floating_point_functions(Gen& gen) noexcept {
+  const Bound generic{{-50.0, 50.0}};
+  const Bound gt_one{{1.0, 100.0}};
+  const Bound positive{{.001, 100.0}};
+  const Bound small{{0.1, 5.0}};
+
+  auto floating_unaries =
+      std::make_tuple(std::make_tuple(TestFuncEvalLog10{}, positive));
+
+  auto just_floating_binaries =
+      std::make_tuple(std::make_tuple(TestFuncEvalPow{}, small));
+
+  auto generic_binaries =
+      std::make_tuple(std::make_tuple(TestFuncEvalDivides{}, gt_one),
+                      std::make_tuple(TestFuncEvalMinus{}, generic),
+                      std::make_tuple(TestFuncEvalMultiplies{}, generic),
+                      std::make_tuple(TestFuncEvalPlus{}, generic),
+                      std::make_tuple(TestFuncEvalDivAssign{}, gt_one),
+                      std::make_tuple(TestFuncEvalMultAssign{}, generic),
+                      std::make_tuple(TestFuncEvalMinusAssign{}, generic),
+                      std::make_tuple(TestFuncEvalPlusAssign{}, generic));
+
+  auto floating_binaries =
+      std::tuple_cat(generic_binaries, just_floating_binaries);
+
+  tmpl::for_each<DoubleSet>([&gen, &floating_unaries,
+                             &floating_binaries ](auto x) noexcept {
+    using DistType1 =
+        typename tt::get_fundamental_type_t<typename decltype(x)::type>;
+    tmpl::for_each<tmpl::make_sequence<std::integral_constant<size_t, 0>, 1,
+                                       tmpl::next<tmpl::_1>>>([
+      &gen, &x, &floating_unaries
+    ](auto index) noexcept {
+      auto& tup = std::get<decltype(index)::type::value>(floating_unaries);
+      std::get<0>(tup)(
+          gen, UniformCustomDistribution<DistType1>{std::get<Bound>(tup)}, x);
+    });
+    tmpl::for_each<DoubleSet>([&gen, &floating_binaries, &x ](auto y) noexcept {
+      using DistType2 =
+          typename tt::get_fundamental_type_t<typename decltype(y)::type>;
+      tmpl::for_each<tmpl::make_sequence<std::integral_constant<size_t, 0>, 9,
+                                         tmpl::next<tmpl::_1>>>([
+        &gen, &x, &y, &floating_binaries
+      ](auto index) noexcept {
+        auto& tup = std::get<decltype(index)::type::value>(floating_binaries);
+        std::get<0>(tup)(
+            gen, UniformCustomDistribution<DistType1>{std::get<Bound>(tup)},
+            UniformCustomDistribution<DistType2>{std::get<Bound>(tup)}, x, y);
+      });
+    });
+  });
+}
+
+template <typename Gen>
+void test_real_functions(Gen& gen) noexcept {
+  const Bound generic{{-50.0, 50.0}};
+  const Bound gt_one{{1.0, 100.0}};
+  const Bound positive{{.001, 100.0}};
+  const Bound small{{0.1, 5.0}};
+
+  auto generic_binaries =
+      std::make_tuple(std::make_tuple(TestFuncEvalDivides{}, gt_one),
+                      std::make_tuple(TestFuncEvalMinus{}, generic),
+                      std::make_tuple(TestFuncEvalMultiplies{}, generic),
+                      std::make_tuple(TestFuncEvalPlus{}, generic),
+                      std::make_tuple(TestFuncEvalDivAssign{}, gt_one),
+                      std::make_tuple(TestFuncEvalMultAssign{}, generic),
+                      std::make_tuple(TestFuncEvalMinusAssign{}, generic),
+                      std::make_tuple(TestFuncEvalPlusAssign{}, generic));
+
+  auto just_real_binaries =
+      std::make_tuple(std::make_tuple(TestFuncEvalAtan2{}, generic),
+                      std::make_tuple(TestFuncEvalHypot{}, generic));
+
+  auto real_unaries =
+      std::make_tuple(std::make_tuple(TestFuncEvalCbrt{}, positive),
+                      std::make_tuple(TestFuncEvalErf{}, generic),
+                      std::make_tuple(TestFuncEvalExp10{}, small),
+                      std::make_tuple(TestFuncEvalExp2{}, small),
+                      std::make_tuple(TestFuncEvalFabs{}, generic),
+                      std::make_tuple(TestFuncEvalInvCbrt{}, gt_one),
+                      std::make_tuple(TestFuncEvalLog2{}, gt_one),
+                      std::make_tuple(TestFuncEvalStepFunction{}, generic));
+
+  auto real_binaries = std::tuple_cat(just_real_binaries, generic_binaries);
+
+  tmpl::for_each<RealTypeList>([&gen, &real_binaries,
+                                &real_unaries ](auto x) noexcept {
+    using DistType1 =
+        typename tt::get_fundamental_type_t<typename decltype(x)::type>;
+    tmpl::for_each<tmpl::make_sequence<std::integral_constant<size_t, 0>, 8,
+                                       tmpl::next<tmpl::_1>>>(
+        [&gen, &x, &real_unaries ](auto index) noexcept {
+          auto& tup = std::get<decltype(index)::type::value>(real_unaries);
+          std::get<0>(tup)(
+              gen, UniformCustomDistribution<DistType1>{std::get<Bound>(tup)},
+              x);
+        });
+
+    tmpl::for_each<RealTypeList>([&gen, &real_binaries, &x ](auto y) noexcept {
+      using DistType2 =
+          typename tt::get_fundamental_type_t<typename decltype(y)::type>;
+      tmpl::for_each<tmpl::make_sequence<std::integral_constant<size_t, 0>, 10,
+                                         tmpl::next<tmpl::_1>>>([
+        &gen, &x, &y, &real_binaries
+      ](auto index) noexcept {
+        auto& tup = std::get<decltype(index)::type::value>(real_binaries);
+        std::get<0>(tup)(
+            gen, UniformCustomDistribution<DistType1>(std::get<Bound>(tup)),
+            UniformCustomDistribution<DistType2>(std::get<Bound>(tup)), x, y);
+      });
+    });
+  });
+}
+
+SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Utilities][Unit]") {
+  std::random_device r;
+  const auto seed = r();
+  INFO("Seed (individual functionals) is: " << seed);
+  std::mt19937 generator(seed);
+  test_generic_unaries(generator);
+  test_floating_point_functions(generator);
+  test_real_functions(generator);
+  test_functional_combinations(generator);
   test_assert_equal();
-  test_divides();
   test_get_argument();
-  test_identity();
-  test_minus();
-  test_multiplies();
-  test_negate();
-  test_plus();
-  test_sqrt();
-  test_square();
-
-  test_composition();
 }
 
 // [[OutputRegex, Values are not equal in funcl::AssertEqual 7 and 8]]
@@ -88,5 +424,9 @@ SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Unit][Utilities]") {
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+#undef MAKE_UNARY_TEST
+#undef MAKE_BINARY_TEST
+#undef MAKE_BINARY_OP_TEST
+#undef MAKE_BINARY_INPLACE_TEST
 }  // namespace
 }  // namespace funcl

--- a/tests/Unit/Utilities/Test_Math.cpp
+++ b/tests/Unit/Utilities/Test_Math.cpp
@@ -3,6 +3,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <cmath>
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
@@ -29,5 +30,17 @@ SPECTRE_TEST_CASE("Unit.Utilities.Math", "[Unit][Utilities]") {
     CHECK_ITERABLE_APPROX(
         evaluate_polynomial(poly_variable_coeffs, DataVector({0., 0.5, 1.})),
         DataVector({1., 1., 3.}));
+  }
+
+  SECTION("Test inverse roots and step_function") {
+    CHECK(step_function(1.0) == 1.0);
+    CHECK(step_function(0.5) == 1.0);
+    CHECK(step_function(-10) == 0);
+    CHECK(step_function(0.0) == 1.0);
+    CHECK(step_function(0) == 1);
+    CHECK(invsqrt(4.0) == 0.5);
+    CHECK(invsqrt(10) == 1.0 / sqrt(10));
+    CHECK(approx(invcbrt(27.0)) == (1 / 3.0));
+    CHECK(approx(invcbrt(1.0 / 64.0)) == 4.0);
   }
 }

--- a/tests/Unit/Utilities/Test_TypeTraits.cpp
+++ b/tests/Unit/Utilities/Test_TypeTraits.cpp
@@ -2,6 +2,7 @@
 // See LICENSE.txt for details.
 
 #include <array>
+#include <complex>
 #include <cstddef>
 #include <deque>
 #include <forward_list>
@@ -692,6 +693,20 @@ static_assert(
         int>,
     "Failed testing remove_cvref_wrap");
 /// [remove_cvref_wrap]
+
+/// [get_fundamental_type]
+static_assert(
+    cpp17::is_same_v<
+        typename tt::get_fundamental_type<std::array<double, 2>>::type, double>,
+    "Failed testing get_fundamental_type");
+static_assert(
+    cpp17::is_same_v<
+        typename tt::get_fundamental_type_t<std::vector<std::complex<int>>>,
+        int>,
+    "Failed testing get_fundamental_type");
+static_assert(cpp17::is_same_v<typename tt::get_fundamental_type_t<int>, int>,
+              "Failed testing get_fundamental_type");
+/// [get_fundamental_type]
 
 namespace {
 // The name syntax is ReturnType_NumberOfArgs_Counter


### PR DESCRIPTION
## Proposed changes

Put into `Utilities/Functional.hpp` are macros for unary, binary, and binary assign operators such
that functors can easily be generated from a function argument. This is then used to define
functors associated with all supported operations on `DataVectors`. For convenience in writing type-generic code, step_function, invsqrt, and invcbrt are defined for primitives.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

