### PR TITLE
Simplify reductions

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -966,17 +966,15 @@ temporal identifier, and the second is the data to be sent.
 
 Finally, there are reduction actions which are used when reducing data over an
 array. For example, you may want to know the sum of a `int` from every
-element in the array. You can do this by using Charm++'s built-in reduction
-function for summing `int`s as follows:
+element in the array. You can do this as follows:
 
 \snippet Test_AlgorithmReduction.cpp contribute_to_reduction_example
 
 This reduces over the parallel component
 `ArrayParallelComponent<Metavariables>`, reduces to the parallel component
 `SingletonParallelComponent<Metavariables>`, and calls the action
-`ProcessReducedSumOfInts` after the reduction has been performed. The
-`CkReduction::sum_int` argument tells Charm++ that you want to sum integers
-instead of some other type or operation. The reduction action is:
+`ProcessReducedSumOfInts` after the reduction has been performed. The reduction
+action is:
 
 \snippet Test_AlgorithmReduction.cpp reduce_sum_int_action
 
@@ -993,10 +991,18 @@ layer on top of Charm++.
 Custom reductions require one additional step to calling
 `contribute_to_reduction`, which is writing a reduction function to reduce the
 custom data. We provide a generic type that can be used in custom reductions,
-`Parallel::ReductionData`, which takes as template parameters the types it
-holds, similar to `std::tuple`. An example of a custom reduction function is:
-
-\snippet Test_AlgorithmReduction.cpp custom_reduce_function
+`Parallel::ReductionData`, which takes a series of `Parallel::ReductionDatum` as
+template parameters and `ReductionDatum::value_type`s as the arguments to the
+constructor. Each `ReductionDatum` takes up to four template parameters (two
+are required). The first is the type of data to reduce, and the second is a
+binary invokable that is called at each step of the reduction to combine two
+messages. The last two template parameters are used after the reduction has
+completed. The third parameter is an n-ary invokable that is called once the
+reduction is complete, whose first argument is the result of the reduction. The
+additional arguments can be any `ReductionDatum::value_type` in the
+`ReductionData` that are before the current one. The fourth template parameter
+of `ReductionDatum` is used to specify which data should be passed. It is a
+`std::index_sequence` indexing into the `ReductionData`.
 
 The action that is invoked with the result of the reduction is:
 

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -411,10 +411,9 @@ void AlgorithmImpl<ParallelComponent, ChareType, Metavariables,
         "no sense for a reduction.");
   }
   performing_action_ = true;
-  Algorithm_detail::simple_action_visitor<Action, InitialDataBox>(
-      box_, inboxes_, *const_global_cache_,
-      static_cast<const array_index&>(array_index_), actions_list{},
-      std::add_pointer_t<ParallelComponent>{}, std::forward<Arg>(arg));
+  arg.finalize();
+  forward_tuple_to_action<Action>(std::move(arg.data()),
+                                  std::make_index_sequence<Arg::pack_size()>{});
   performing_action_ = false;
   unlock(&node_lock_);
 }

--- a/src/Parallel/Reduction.hpp
+++ b/src/Parallel/Reduction.hpp
@@ -9,36 +9,82 @@
 #include "Parallel/CharmRegistration.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 namespace Parallel {
+/// \cond
+template <class... Ts>
+struct ReductionData;
+/// \endcond
+
+namespace detail {
 /*!
  * \ingroup ParallelGroup
- * \brief Used for reducing heterogeneous collection of types in a single
- * reduction call
- *
- * For each `ReductionData` you must write a custom reducer to reduce the data.
- * Here is an example of such a function:
- *
- * \snippet Test_AlgorithmReduction.cpp custom_reduce_function
- *
- * A variable number of `CkReductionMsg*`s are passed to the reducer, and so it
- * is necessary to loop over each message, contributing the data into a new
- * `ReductionData` (called `reduced` in the above example). The
- * `Parallel::get()` function is used to retrieve elements from the
- * `ReductionData` in a manner that is completely analogous to retrieving
- * elements from a `std::tuple` using `std::get`. Once the new `ReductionData`
- * has been filled, a new `CkReductionMsg*` must be returned using
- * `Parallel::new_reduction_msg()`.
+ * \brief Convert a `ReductionData` to a `CkReductionMsg`. Used in custom
+ * reducers.
  */
 template <class... Ts>
-struct ReductionData {
-  template <class Arg0, class... Args,
-            Requires<not cpp17::is_same_v<std::decay_t<Arg0>, ReductionData>> =
-                nullptr>
-  explicit ReductionData(Arg0&& arg0, Args&&... args)
-      : data(std::forward<Arg0>(arg0), std::forward<Args>(args)...) {}
+CkReductionMsg* new_reduction_msg(
+    ReductionData<Ts...>& reduction_data) noexcept {
+  return CkReductionMsg::buildNew(static_cast<int>(reduction_data.size()),
+                                  reduction_data.packed().get());
+}
+}  // namespace detail
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief The data to be reduced, and invokables to be called whenever two
+ * reduction messages are combined and after the reduction has been completed.
+ *
+ * `InvokeCombine` is a binary invokable that maps `(T current_state, T element)
+ * -> T`, where the `current_state` is the result of reductions so far. The
+ * `InvokeFinal` is an n-ary that takes as its first argument a `T
+ * result_of_reduction` and is invoked once after the reduction is completed.
+ * The additional arguments correspond to the resultant data of earlier
+ * `ReductionDatum` template parameters in the `ReductionData`, and are
+ * identified via the `InvokeFinalExtraArgsIndices`, which must be a
+ * `std::index_sequence`. Specifically, say you want the third
+ * `ReductionDatum`'s `InvokeFinal` to be passed the first `ReductionDatum` then
+ * `std::index_sequence<0>` would be passed for `InvokeFinalExtraArgsIndices`.
+ * Here is an example of computing the RMS error of the evolved variables `u`
+ * and `v`:
+ *
+ * \snippet Test_AlgorithmReduction.cpp contribute_to_rms_reduction
+ *
+ * with the receiving action:
+ *
+ * \snippet Test_AlgorithmReduction.cpp reduce_rms_action
+ */
+template <class T, class InvokeCombine, class InvokeFinal = funcl::Identity,
+          class InvokeFinalExtraArgsIndices = std::index_sequence<>>
+struct ReductionDatum {
+  using value_type = T;
+  using invoke_combine = InvokeCombine;
+  using invoke_final = InvokeFinal;
+  using invoke_final_extra_args_indices = InvokeFinalExtraArgsIndices;
+  T value;
+};
+
+/*!
+ * \ingroup ParallelGroup
+ * \brief Used for reducing a possibly heterogeneous collection of types in a
+ * single reduction call
+ */
+template <class... Ts, class... InvokeCombines, class... InvokeFinals,
+          class... InvokeFinalExtraArgsIndices>
+struct ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                                    InvokeFinalExtraArgsIndices>...> {
+  static constexpr size_t pack_size() noexcept { return sizeof...(Ts); }
+
+  explicit ReductionData(
+      ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                     InvokeFinalExtraArgsIndices>... args) noexcept;
+
+  explicit ReductionData(Ts... args) noexcept;
 
   ReductionData() = default;
   ReductionData(const ReductionData& /*rhs*/) = default;
@@ -52,185 +98,156 @@ struct ReductionData {
     creator | *this;
   }
 
+  static CkReductionMsg* combine(int number_of_messages,
+                                 CkReductionMsg** msgs) noexcept;
+
+  void combine(ReductionData&& t) noexcept {
+    ReductionData::combine_helper(this, std::move(t),
+                                  std::make_index_sequence<sizeof...(Ts)>{});
+  }
+
+  void finalize() noexcept {
+    invoke_final_loop_over_tuple(std::make_index_sequence<sizeof...(Ts)>{});
+  }
+
   /// \cond
   // clang-tidy: non-const reference
-  void pup(PUP::er& p) noexcept { p | data; }  // NOLINT
+  void pup(PUP::er& p) noexcept { p | data_; }  // NOLINT
 
   std::unique_ptr<char[]> packed() noexcept;
 
   size_t size() noexcept;
 
- private:
-  // clang-tidy: false positive redundant declaration
-  template <size_t Index, class... Us>
-  friend auto get(ReductionData<Us...>& reduction_data) noexcept  // NOLINT
-      -> decltype(std::get<Index>(reduction_data.data));
-  // clang-tidy: false positive redundant declaration
-  template <size_t Index, class... Us>
-  friend auto get(  // NOLINT
-      const ReductionData<Us...>& reduction_data) noexcept
-      -> decltype(std::get<Index>(reduction_data.data));
-  // clang-tidy: false positive redundant declaration
-  template <size_t Index, class... Us>
-  friend auto get(ReductionData<Us...>&& reduction_data) noexcept  // NOLINT
-      -> decltype(std::get<Index>(reduction_data.data));
-  // clang-tidy: false positive redundant declaration
-  template <size_t Index, class... Us>
-  friend auto get(  // NOLINT
-      const ReductionData<Us...>&& reduction_data) noexcept
-      -> decltype(std::get<Index>(reduction_data.data));
+  const std::tuple<Ts...>& data() const noexcept { return data_; }
 
-  std::tuple<Ts...> data;
+  std::tuple<Ts...>& data() noexcept { return data_; }
+
+ private:
+  template <size_t... Is>
+  static void combine_helper(gsl::not_null<ReductionData*> reduced,
+                             ReductionData&& current,
+                             std::index_sequence<Is...> /*meta*/) noexcept;
+
+  template <size_t I, class InvokeFinal, size_t... Js>
+  void invoke_final_helper(std::index_sequence<Js...> /*meta*/) noexcept;
+
+  template <size_t... Is>
+  void invoke_final_loop_over_tuple(
+      std::index_sequence<Is...> /*meta*/) noexcept;
+
+  std::tuple<Ts...> data_;
   /// \endcond
 };
 
 /// \cond
-template <class... Ts>
-std::unique_ptr<char[]> ReductionData<Ts...>::packed() noexcept {
+template <class... Ts, class... InvokeCombines, class... InvokeFinals,
+          class... InvokeFinalExtraArgsIndices>
+ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                             InvokeFinalExtraArgsIndices>...>::
+    ReductionData(ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                                 InvokeFinalExtraArgsIndices>... args) noexcept
+    : data_(std::move(args.value)...) {}
+
+template <class... Ts, class... InvokeCombines, class... InvokeFinals,
+          class... InvokeFinalExtraArgsIndices>
+ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                             InvokeFinalExtraArgsIndices>...>::
+    ReductionData(Ts... args) noexcept
+    : data_(std::move(args)...) {}
+
+template <class... Ts, class... InvokeCombines, class... InvokeFinals,
+          class... InvokeFinalExtraArgsIndices>
+CkReductionMsg* ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                                             InvokeFinalExtraArgsIndices>...>::
+    combine(const int number_of_messages,
+            CkReductionMsg** const msgs) noexcept {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  ReductionData reduced(msgs[0]);
+  for (int msg_id = 1; msg_id < number_of_messages; ++msg_id) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    ReductionData current(msgs[msg_id]);
+    ReductionData::combine_helper(&reduced, std::move(current),
+                                  std::make_index_sequence<sizeof...(Ts)>{});
+  }
+  return detail::new_reduction_msg(reduced);
+}
+
+template <class... Ts, class... InvokeCombines, class... InvokeFinals,
+          class... InvokeFinalExtraArgsIndices>
+std::unique_ptr<char[]> ReductionData<
+    ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                   InvokeFinalExtraArgsIndices>...>::packed() noexcept {
   auto result = std::make_unique<char[]>(size());
   PUP::toMem packer(result.get());
   packer | *this;
   return result;
 }
 
-template <class... Ts>
-size_t ReductionData<Ts...>::size() noexcept {
+template <class... Ts, class... InvokeCombines, class... InvokeFinals,
+          class... InvokeFinalExtraArgsIndices>
+size_t
+ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                             InvokeFinalExtraArgsIndices>...>::size() noexcept {
   PUP::sizer size_pup;
   size_pup | *this;
   return size_pup.size();
 }
+
+template <class... Ts, class... InvokeCombines, class... InvokeFinals,
+          class... InvokeFinalExtraArgsIndices>
+template <size_t... Is>
+void ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                                  InvokeFinalExtraArgsIndices>...>::
+    combine_helper(const gsl::not_null<ReductionData*> reduced,
+                   ReductionData&& current,
+                   std::index_sequence<Is...> /*meta*/) noexcept {
+  EXPAND_PACK_LEFT_TO_RIGHT((std::get<Is>(reduced->data_) = InvokeCombines{}(
+                                 std::move(std::get<Is>(reduced->data_)),
+                                 std::move(std::get<Is>(current.data_)))));
+}
+
+template <class... Ts, class... InvokeCombines, class... InvokeFinals,
+          class... InvokeFinalExtraArgsIndices>
+template <size_t I, class InvokeFinal, size_t... Js>
+void ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                                  InvokeFinalExtraArgsIndices>...>::
+    invoke_final_helper(std::index_sequence<Js...> /*meta*/) noexcept {
+  std::get<I>(data_) = InvokeFinal{}(std::move(std::get<I>(data_)),
+                                     cpp17::as_const(std::get<Js>(data_))...);
+}
+
+template <class... Ts, class... InvokeCombines, class... InvokeFinals,
+          class... InvokeFinalExtraArgsIndices>
+template <size_t... Is>
+void ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                                  InvokeFinalExtraArgsIndices>...>::
+    invoke_final_loop_over_tuple(std::index_sequence<Is...> /*meta*/) noexcept {
+  EXPAND_PACK_LEFT_TO_RIGHT(
+      invoke_final_helper<Is, InvokeFinals>(InvokeFinalExtraArgsIndices{}));
+}
 /// \endcond
-
-/*!
- * \ingroup ParallelGroup
- * \brief Retrieve the `Index`th element from a `ReductionData<Ts...>`, similar
- * to `std::get` for `std::tuple`s
- *
- * \note Also available for rvalue and const references
- */
-template <size_t Index, class... Us>
-auto get(ReductionData<Us...>& reduction_data) noexcept
-    -> decltype(std::get<Index>(reduction_data.data)) {
-  return std::get<Index>(reduction_data.data);
-}
-/// \cond
-template <size_t Index, class... Us>
-auto get(const ReductionData<Us...>& reduction_data) noexcept
-    -> decltype(std::get<Index>(reduction_data.data)) {
-  return std::get<Index>(reduction_data.data);
-}
-template <size_t Index, class... Us>
-auto get(ReductionData<Us...>&& reduction_data) noexcept
-    -> decltype(std::get<Index>(reduction_data.data)) {
-  return std::get<Index>(reduction_data.data);
-}
-template <size_t Index, class... Us>
-auto get(const ReductionData<Us...>&& reduction_data) noexcept
-    -> decltype(std::get<Index>(reduction_data.data)) {
-  return std::get<Index>(reduction_data.data);
-}
-/// \endcond
-
-namespace Parallel_detail {
-template <class T, class = cpp17::void_t<>>
-struct is_custom_reduction_type : std::false_type {};
-
-template <class T>
-struct is_custom_reduction_type<
-    T,
-    cpp17::void_t<
-        Requires<cpp17::is_same_v<std::unique_ptr<char[]>,
-                                  decltype(std::declval<T>().packed())>>,
-        decltype(std::declval<T>().pup(std::declval<PUP::er&>())),
-        Requires<cpp17::is_same_v<size_t, decltype(std::declval<T>().size())>>,
-        Requires<std::is_constructible<T, CkReductionMsg* const>::value>>>
-    : std::true_type {};
-
-template <class T>
-constexpr bool is_custom_reduction_type_v = is_custom_reduction_type<T>::value;
-}  // namespace Parallel_detail
 
 /*!
  * \ingroup ParallelGroup
  * \brief Perform a reduction from the `sender_component` (typically your own
  * parallel component) to the `target_component`, performing the `Action` upon
  * receiving the reduction.
- *
- * A Charm++ reducer specifying what type of reduction is to be done must also
- * be passed (see
- * [here](http://charm.cs.illinois.edu/manuals/html/charm++/manual.html)).
- *
- * \example
- * Built-in Charm++ reductions are supported as:
- * \snippet Test_AlgorithmReduction.cpp contribute_to_reduction_example
  */
-template <
-    class Action, class ReductionType, class SenderProxy, class TargetProxy,
-    Requires<not Parallel_detail::is_custom_reduction_type_v<ReductionType>> =
-        nullptr>
-void contribute_to_reduction(const ReductionType& reduction_data,
-                             const SenderProxy& sender_component,
-                             const TargetProxy& target_component,
-                             CkReduction::reducerType reducer) noexcept {
-  CkCallback callback(
-      TargetProxy::index_t::template redn_wrapper_reduction_action<
-          Action, std::decay_t<ReductionType>>(nullptr),
-      target_component);
-  sender_component.ckLocal()->contribute(sizeof(reduction_data),
-                                         &reduction_data, reducer, callback);
-}
-
-/*!
- * \ingroup ParallelGroup
- * \brief Perform a reduction from the `sender_component` (typically your own
- * parallel component) to the `target_component`, performing the `Action` upon
- * receiving the reduction.
- *
- * The template parameter `F` is a function pointer to the custom reduction
- * function.
- *
- * \example
- * Let's say you want to perform a custom reduction on an
- * `int`, `std::unordered_map<std::string, int>`, and `std::vector<int>`. You
- * would then write a custom reduction function like the following:
- * \snippet Test_AlgorithmReduction.cpp custom_reduce_function
- * To have an array element contribute to the reduction you must call the
- * `contribute_to_reduction` as follows:
- * \snippet Test_AlgorithmReduction.cpp custom_contribute_to_reduction_example
- *
- * \note Registration of the reduction function with Charm++ will be handled
- * automatically so ignore that portion of the Charm++ manual.
- */
-template <Parallel::charmxx::ReducerFunctions F, class Action,
-          class ReductionType, class SenderProxy, class TargetProxy>
-void contribute_to_reduction(ReductionType&& reduction_data,
+template <class Action, class SenderProxy, class TargetProxy, class... Ts>
+void contribute_to_reduction(ReductionData<Ts...> reduction_data,
                              const SenderProxy& sender_component,
                              const TargetProxy& target_component) noexcept {
-  (void)Parallel::charmxx::RegisterReducerFunction<F>::registrar;
+  (void)Parallel::charmxx::RegisterReducerFunction<
+      &ReductionData<Ts...>::combine>::registrar;
   CkCallback callback(
       TargetProxy::index_t::template redn_wrapper_reduction_action<
-          Action, std::decay_t<ReductionType>>(nullptr),
+          Action, std::decay_t<ReductionData<Ts...>>>(nullptr),
       target_component);
   sender_component.ckLocal()->contribute(
       static_cast<int>(reduction_data.size()), reduction_data.packed().get(),
       Parallel::charmxx::charm_reducer_functions.at(
-          std::hash<Parallel::charmxx::ReducerFunctions>{}(F)),
+          std::hash<Parallel::charmxx::ReducerFunctions>{}(
+              &ReductionData<Ts...>::combine)),
       callback);
-}
-
-/*!
- * \ingroup ParallelGroup
- * \brief Convert a `ReductionData` to a `CkReductionMsg`. Used in custom
- * reducers.
- *
- * \example
- * See the return statement of:
- * \snippet Test_AlgorithmReduction.cpp custom_reduce_function
- */
-template <class... Ts>
-CkReductionMsg* new_reduction_msg(
-    ReductionData<Ts...>& reduction_data) noexcept {
-  return CkReductionMsg::buildNew(static_cast<int>(reduction_data.size()),
-                                  reduction_data.packed().get());
 }
 }  // namespace Parallel

--- a/src/Utilities/Numeric.hpp
+++ b/src/Utilities/Numeric.hpp
@@ -1,6 +1,10 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
+
 #pragma once
+
+#include <iterator>
+#include <numeric>
 
 #include "Utilities/Gsl.hpp"
 
@@ -33,3 +37,24 @@ constexpr T accumulate(InputIt first, InputIt last, T init) {
   return init;
 }
 }  // namespace cpp2b
+
+namespace alg {
+/// Convenience wrapper around std::accumulate, returns
+/// `std::accumulate(begin(c), end(c), init)`.
+template <class Container, class T>
+decltype(auto) accumulate(const Container& c, T init) {
+  using std::begin;
+  using std::end;
+  return std::accumulate(begin(c), end(c), std::move(init));
+}
+
+/// Convenience wrapper around std::accumulate, returns
+/// `std::accumulate(begin(c), end(c), init, f)`.
+template <class Container, class T, class BinaryFunction>
+decltype(auto) accumulate(const Container& c, T init, BinaryFunction&& f) {
+  using std::begin;
+  using std::end;
+  return std::accumulate(begin(c), end(c), std::move(init),
+                         std::forward<BinaryFunction>(f));
+}
+}  // namespace alg

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -5,7 +5,10 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <cstddef>
+#include <ostream>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -15,8 +18,8 @@
 #include "AlgorithmArray.hpp"
 #include "AlgorithmSingleton.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "ErrorHandling/Error.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
-#include "Parallel/Abort.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/InitializationFunctions.hpp"
@@ -24,6 +27,8 @@
 #include "Parallel/Main.hpp"
 #include "Parallel/Reduction.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/Functional.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -32,45 +37,12 @@ template <typename TagsList>
 class DataBox;
 }  // namespace db
 struct TestMetavariables;
-template <class Metavariables>
-struct SingletonParallelComponent;
 
 // The reason we use a 46 element array is that on Wheeler, the SXS
 // supercomputer at Caltech, there are 23 worker threads per node and we want to
 // be able to test on two nodes to make sure multinode communication is working
 // correctly.
 static constexpr int number_of_1d_array_elements = 46;
-
-/// [custom_reduce_function]
-CkReductionMsg* reduce_reduction_data(const int number_of_messages,
-                                      CkReductionMsg** const msgs) noexcept {
-  // clang-tidy: do not use pointer arithmetic
-  Parallel::ReductionData<int, std::unordered_map<std::string, int>,
-                          std::vector<int>>
-      reduced(msgs[0]);  // NOLINT
-  for (int msg_id = 1; msg_id < number_of_messages; ++msg_id) {
-    // clang-tidy: do not use pointer arithmetic
-    Parallel::ReductionData<int, std::unordered_map<std::string, int>,
-                            std::vector<int>>
-        current(msgs[msg_id]);  // NOLINT
-    if (Parallel::get<0>(current) != Parallel::get<0>(reduced)) {
-      Parallel::abort("Tried to reduce from different iteration values.");
-    }
-    // compute maximum of each value in an unordered_map
-    for (const auto& string_double : Parallel::get<1>(current)) {
-      if (string_double.second >
-          Parallel::get<1>(reduced)[string_double.first]) {
-        Parallel::get<1>(reduced)[string_double.first] = string_double.second;
-      }
-    }
-    // compute sum of each element in a vector
-    for (size_t i = 0; i < Parallel::get<2>(current).size(); ++i) {
-      Parallel::get<2>(reduced)[i] += Parallel::get<2>(current)[i];
-    }
-  }
-  return Parallel::new_reduction_msg(reduced);
-}
-/// [custom_reduce_function]
 
 /// [reduce_sum_int_action]
 struct ProcessReducedSumOfInts {
@@ -91,7 +63,8 @@ struct ProcessReducedSumOfInts {
 };
 /// [reduce_sum_int_action]
 
-struct ProcessReducedSumOfDoubles {
+/// [reduce_rms_action]
+struct ProcessErrorNorms {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
@@ -101,62 +74,43 @@ struct ProcessReducedSumOfDoubles {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/,
-                    const double& value) noexcept {
-    static_assert(
-        cpp17::is_same_v<ParallelComponent,
-                         SingletonParallelComponent<TestMetavariables>>,
-        "The ParallelComponent is not deduced to be the right type");
-    SPECTRE_PARALLEL_REQUIRE(approx(13.4 * number_of_1d_array_elements) ==
-                             value);
+                    const int points,
+                    const double error_u,
+                    const double error_v) noexcept {
+    SPECTRE_PARALLEL_REQUIRE(number_of_1d_array_elements * 3 == points);
+    SPECTRE_PARALLEL_REQUIRE(equal_within_roundoff(
+        error_u, sqrt(number_of_1d_array_elements * square(1.0e-3) / points)));
+    SPECTRE_PARALLEL_REQUIRE(equal_within_roundoff(
+        error_v, sqrt(number_of_1d_array_elements * square(1.0e-4) / points)));
   }
 };
-
-struct ProcessReducedProductOfDoubles {
-  template <typename DbTags, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent>
-  static void apply(db::DataBox<DbTags>& /*box*/,
-                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/,
-                    const double& value) noexcept {
-    static_assert(
-        cpp17::is_same_v<ParallelComponent,
-                         SingletonParallelComponent<TestMetavariables>>,
-        "The ParallelComponent is not deduced to be the right type");
-    SPECTRE_PARALLEL_REQUIRE(approx(pow<number_of_1d_array_elements>(13.4)) ==
-                             value);
-  }
-};
+/// [reduce_rms_action]
 
 /// [custom_reduction_action]
 struct ProcessCustomReductionAction {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
-  static void apply(
-      db::DataBox<DbTags>& /*box*/,
-      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/,
-      const Parallel::ReductionData<int, std::unordered_map<std::string, int>,
-                                    std::vector<int>>&
-          value) noexcept {
-    SPECTRE_PARALLEL_REQUIRE(Parallel::get<0>(value) == 10);
-    SPECTRE_PARALLEL_REQUIRE(Parallel::get<1>(value).at("unity") ==
+  static void apply(db::DataBox<DbTags>& /*box*/,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/, int reduced_int,
+                    std::unordered_map<std::string, int> reduced_map,
+                    std::vector<int>&& reduced_vector) noexcept {
+    SPECTRE_PARALLEL_REQUIRE(reduced_int == 10);
+    SPECTRE_PARALLEL_REQUIRE(reduced_map.at("unity") ==
                              number_of_1d_array_elements - 1);
-    SPECTRE_PARALLEL_REQUIRE(Parallel::get<1>(value).at("double") ==
+    SPECTRE_PARALLEL_REQUIRE(reduced_map.at("double") ==
                              2 * number_of_1d_array_elements - 2);
-    SPECTRE_PARALLEL_REQUIRE(Parallel::get<1>(value).at("negative") == 0);
+    SPECTRE_PARALLEL_REQUIRE(reduced_map.at("negative") == 0);
     SPECTRE_PARALLEL_REQUIRE(
-        Parallel::get<2>(value) ==
-        (std::vector<int>{
-            number_of_1d_array_elements * (number_of_1d_array_elements - 1) / 2,
-            number_of_1d_array_elements * 10,
-            -8 * number_of_1d_array_elements}));
+        reduced_vector ==
+        (std::vector<int>{-reduced_int * number_of_1d_array_elements *
+                              (number_of_1d_array_elements - 1) / 2,
+                          -reduced_int * number_of_1d_array_elements * 10,
+                          8 * reduced_int * number_of_1d_array_elements}));
   }
 };
 /// [custom_reduction_action]
@@ -194,7 +148,6 @@ struct ArrayReduce {
     static_assert(cpp17::is_same_v<ParallelComponent,
                                    ArrayParallelComponent<TestMetavariables>>,
                   "The ParallelComponent is not deduced to be the right type");
-    int my_send_int = array_index;
     const auto& my_proxy =
         Parallel::get_parallel_component<ArrayParallelComponent<Metavariables>>(
             cache)[array_index];
@@ -204,39 +157,87 @@ struct ArrayReduce {
     const auto& singleton_proxy = Parallel::get_parallel_component<
         SingletonParallelComponent<Metavariables>>(cache);
     /// [contribute_to_reduction_example]
+    Parallel::ReductionData<Parallel::ReductionDatum<int, funcl::Plus<>>>
+        my_send_int{array_index};
     Parallel::contribute_to_reduction<ProcessReducedSumOfInts>(
-        my_send_int, my_proxy, singleton_proxy, CkReduction::sum_int);
+        my_send_int, my_proxy, singleton_proxy);
     /// [contribute_to_reduction_example]
     /// [contribute_to_broadcast_reduction]
     Parallel::contribute_to_reduction<ProcessReducedSumOfInts>(
-        my_send_int, my_proxy, array_proxy, CkReduction::sum_int);
+        my_send_int, my_proxy, array_proxy);
     /// [contribute_to_broadcast_reduction]
 
-    double my_send_double = 13.4;
-    Parallel::contribute_to_reduction<ProcessReducedSumOfDoubles>(
-        my_send_double, my_proxy, singleton_proxy, CkReduction::sum_double);
-
-    Parallel::contribute_to_reduction<ProcessReducedProductOfDoubles>(
-        my_send_double, my_proxy, singleton_proxy, CkReduction::product_double);
+    /// [contribute_to_rms_reduction]
+    using RmsRed = Parallel::ReductionDatum<double, funcl::Plus<>,
+                                            funcl::Sqrt<funcl::Divides<>>,
+                                            std::index_sequence<0>>;
+    Parallel::ReductionData<Parallel::ReductionDatum<size_t, funcl::Plus<>>,
+                            RmsRed, RmsRed>
+        error_reduction{3, square(1.0e-3), square(1.0e-4)};
+    Parallel::contribute_to_reduction<ProcessErrorNorms>(error_reduction,
+                                                         my_proxy, array_proxy);
+    /// [contribute_to_rms_reduction]
 
     /// [custom_contribute_to_reduction_example]
     std::unordered_map<std::string, int> my_send_map;
     my_send_map["unity"] = array_index;
     my_send_map["double"] = 2 * array_index;
     my_send_map["negative"] = -array_index;
-    Parallel::contribute_to_reduction<&reduce_reduction_data,
-                                      ProcessCustomReductionAction>(
-        Parallel::ReductionData<int, std::unordered_map<std::string, int>,
-                                std::vector<int>>{
-            10, my_send_map, std::vector<int>{array_index, 10, -8}},
+    struct {
+      int operator()(const int time_state, const int time) noexcept {
+        if (time_state != time) {
+          ERROR("Tried to reduce from different iteration values "
+                << time_state << " and " << time);
+        }
+        return time_state;
+      }
+    } check_times_equal;
+    struct {
+      std::unordered_map<std::string, int> operator()(
+          std::unordered_map<std::string, int> state,
+          const std::unordered_map<std::string, int>& element) noexcept {
+        for (const auto& string_int : element) {
+          if (string_int.second > state.at(string_int.first)) {
+            state[string_int.first] = string_int.second;
+          }
+        }
+        return state;
+      }
+    } map_combine;
+    struct {
+      std::vector<int> operator()(std::vector<int> state,
+                                  const std::vector<int>& element) noexcept {
+        for (size_t i = 0; i < state.size(); ++i) {
+          state[i] += element[i];
+        }
+        return state;
+      }
+
+    } vector_combine;
+    struct {
+      std::vector<int> operator()(std::vector<int> data,
+                                  const int& first_reduction) {
+        std::transform(data.begin(), data.end(), data.begin(),
+                       [&first_reduction](const int t) {
+                         return -1 * t * first_reduction;
+                       });
+        return data;
+      }
+    } vector_finalize;
+    using ReductionType = Parallel::ReductionData<
+        Parallel::ReductionDatum<int, decltype(check_times_equal)>,
+        Parallel::ReductionDatum<std::unordered_map<std::string, int>,
+                                 decltype(map_combine)>,
+        Parallel::ReductionDatum<std::vector<int>, decltype(vector_combine),
+                                 decltype(vector_finalize),
+                                 std::index_sequence<0>>>;
+    Parallel::contribute_to_reduction<ProcessCustomReductionAction>(
+        ReductionType{10, my_send_map, std::vector<int>{array_index, 10, -8}},
         my_proxy, singleton_proxy);
     /// [custom_contribute_to_reduction_example]
     /// [custom_contribute_to_broadcast_reduction]
-    Parallel::contribute_to_reduction<&reduce_reduction_data,
-                                      ProcessCustomReductionAction>(
-        Parallel::ReductionData<int, std::unordered_map<std::string, int>,
-                                std::vector<int>>{
-            10, my_send_map, std::vector<int>{array_index, 10, -8}},
+    Parallel::contribute_to_reduction<ProcessCustomReductionAction>(
+        ReductionType{10, my_send_map, std::vector<int>{array_index, 10, -8}},
         my_proxy, array_proxy);
     /// [custom_contribute_to_broadcast_reduction]
 

--- a/tests/Unit/Utilities/Test_Numeric.cpp
+++ b/tests/Unit/Utilities/Test_Numeric.cpp
@@ -32,4 +32,13 @@ SPECTRE_TEST_CASE("Unit.Utilities.Numeric", "[Unit][Utilities]") {
   // Check the functions at compile time
   static_assert(check_iota(), "Failed test Unit.Utilities.Numeric");
   static_assert(check_accumulate(), "Failed test Unit.Utilities.Numeric");
+
+  // Check STL wrappers
+  CHECK(alg::accumulate(std::array<int, 3>{{1, -3, 7}}, 4) == 9);
+  CHECK(alg::accumulate(std::array<int, 3>{{1, -3, 7}}, 4,
+                        std::multiplies<>{}) == -84);
+  CHECK(alg::accumulate(std::array<int, 3>{{1, -3, 7}},
+                        4, [](const int state, const int element) noexcept {
+                          return state * element;
+                        }) == -84);
 }


### PR DESCRIPTION
## Proposed changes

- Simplify the way reductions work by removing the necessity for users of reductions to interact with Charm++ directly. Also adds the ability to provide a function object to be invoked after the reduction is completed but before the data is passed to the action.

Order of commits:
1. Add wrapper around std::accumulate
2. Simplify the way reductions work

Depends on:
- [x] #997 
- [x] #985 (dependency could be removed)

Breaks:
- Reductions. Completely.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
