### PR TITLE
Charm++ Projections Support

### DIFF
--- a/cmake/SetupCharmModuleFunctions.cmake
+++ b/cmake/SetupCharmModuleFunctions.cmake
@@ -104,6 +104,9 @@ function(generate_algorithms_impl ALGORITHM_NAME ALGORITHM_TYPE ALGORITHM_DIR)
   # First block:
   # Move into user class from charm for receive_data, allowing perfect
   # forwarding
+  # The string for the variadic "simple_action" is non-temporary on purpose.
+  # For charm projectionsnot we need either a constant string or a string
+  # that is not freed by the program.
   #
   # Second block:
   # Handle entry methods that take a variadic std::tuple. Charm++ cannot
@@ -118,7 +121,7 @@ function(generate_algorithms_impl ALGORITHM_NAME ALGORITHM_TYPE ALGORITHM_DIR)
      \
      && perl -pi -e 's/LDOTLDOTLDOT/.../g' Algorithm${ALGORITHM_NAME}.def.h \
      && perl -pi -e 's/LDOTLDOTLDOT/.../g' Algorithm${ALGORITHM_NAME}.decl.h \
-     && perl -pi -e 's/\(\\\"simple_action\\\(const\\s+std::tuple<\\s*\)COMPUTE_VARIADIC_ARGS\(\\s*>\\s*&args\\\)\\\"\)/std::string\(std::string\(\\1\"\) + Parallel::charmxx::get_template_parameters_as_string<Args...>\(\) + std::string\(\"\\2\)\).c_str\(\)/g' Algorithm${ALGORITHM_NAME}.def.h \
+     && perl -pi -e 's/\(\\\"simple_action\\\(const\\s+std::tuple<\\s*\)COMPUTE_VARIADIC_ARGS\(\\s*>\\s*&args\\\)\\\"\)/\(::new std::string\(std::string\(\\1\"\) + Parallel::charmxx::get_template_parameters_as_string<Args...>\(\) + std::string\(\"\\2\)\)\)->c_str\(\)/g' Algorithm${ALGORITHM_NAME}.def.h \
      && perl -pi -e 's/COMPUTE_VARIADIC_ARGS/Args.../g' \
              Algorithm${ALGORITHM_NAME}.def.h \
      && perl -pi -e 's/COMPUTE_VARIADIC_ARGS/Args.../g' \

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -23,6 +23,7 @@
 // IWYU pragma: no_include "Parallel/Algorithm.hpp"
 #include "Parallel/AlgorithmMetafunctions.hpp"
 #include "Parallel/CharmRegistration.hpp"
+#include "Parallel/Info.hpp"
 #include "Parallel/NodeLock.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/SimpleActionVisitation.hpp"

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -133,6 +133,11 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<ActionsPack...>> {
   using metavariables = typename ParallelComponent::metavariables;
   /// List of Actions in the order they will be executed
   using actions_list = tmpl::list<ActionsPack...>;
+#ifdef SPECTRE_CHARM_PROJECTIONS
+  /// List of Actions traced for profiling; at the moment this contains all
+  /// Actions
+  using trace_actions_list = actions_list;
+#endif
   /// List off all the Tags that can be received into the Inbox
   using inbox_tags_list = Parallel::get_inbox_tags<actions_list>;
   /// The type of the object used to identify the element of the array, group
@@ -538,7 +543,8 @@ constexpr bool AlgorithmImpl<ParallelComponent, tmpl::list<ActionsPack...>>::
 #ifdef SPECTRE_CHARM_PROJECTIONS
     traceUserBracketEvent(SPECTRE_CHARM_NON_ACTION_WALLTIME_EVENT_ID,
                           non_action_time_start_, Parallel::wall_time());
-    double start_time = detail::start_trace_action<this_action>();
+    double start_time =
+        Parallel::start_trace_action<this_action, trace_actions_list>();
 #endif
     performing_action_ = true;
     algorithm_step_++;
@@ -571,7 +577,7 @@ constexpr bool AlgorithmImpl<ParallelComponent, tmpl::list<ActionsPack...>>::
 
     performing_action_ = false;
 #ifdef SPECTRE_CHARM_PROJECTIONS
-    detail::stop_trace_action<this_action>(start_time);
+    Parallel::stop_trace_action<this_action, trace_actions_list>(start_time);
     non_action_time_start_ = Parallel::wall_time();
 #endif
     // Wrap counter if necessary

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -27,6 +27,7 @@
 #include "Parallel/NodeLock.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/SimpleActionVisitation.hpp"
+#include "Parallel/TraceActions.hpp"
 #include "Parallel/TypeTraits.hpp"
 #include "Utilities/BoostHelpers.hpp"
 #include "Utilities/ForceInline.hpp"

--- a/src/Parallel/CharmRegistration.hpp
+++ b/src/Parallel/CharmRegistration.hpp
@@ -129,7 +129,10 @@ struct RegisterParallelComponent : RegistrationHelper {
       return;  // LCOV_EXCL_LINE
     }
     done_registration = true;
-    ckindex::__register(get_template_parameters_as_string<algorithm>().c_str(),
+
+    // note: non-temporary string is on purpose, not freed string is
+    // necessary for projections output
+    ckindex::__register((::new std::string(name()))->c_str(),
                         sizeof(algorithm));
   }
 
@@ -177,8 +180,10 @@ struct RegisterChare : RegistrationHelper {
       return;  // LCOV_EXCL_LINE
     }
     done_registration = true;
-    CkIndex::__register(get_template_parameters_as_string<Chare>().c_str(),
-                        sizeof(Chare));
+
+    // note: non-temporary string is on purpose, not freed string is
+    // necessary for projections output
+    CkIndex::__register((::new std::string(name()))->c_str(), sizeof(Chare));
   }
 
   bool is_registering_chare() const noexcept override { return true; }

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -20,6 +20,7 @@
 #include "Parallel/Exit.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Printf.hpp"
+#include "Parallel/TraceRegister.hpp"
 #include "Parallel/TypeTraits.hpp"
 #include "Utilities/Overloader.hpp"
 #include "Utilities/TMPL.hpp"
@@ -291,8 +292,15 @@ void Main<Metavariables>::initialize() noexcept {
         [this](auto... opts) {
           ParallelComponent::initialize(const_global_cache_proxy_,
                                         std::move(opts)...);
+
+#ifdef SPECTRE_CHARM_PROJECTIONS
+          // register the events that are traced for projections
+          using trace_actions_list = typename ParallelComponent::action_list;
+          Parallel::register_events_to_trace<trace_actions_list>();
+#endif
         });
   });
+
   CkStartQD(CkCallback(CkIndex_Main<Metavariables>::execute_next_phase(),
                        this->thisProxy));
 }

--- a/src/Parallel/TraceActions.hpp
+++ b/src/Parallel/TraceActions.hpp
@@ -12,13 +12,10 @@
 
 //#include "Utilities/Papi.hpp"
 
-//#include "Parallel/Algorithm.hpp"
 #include "Parallel/Info.hpp"
 #include "Utilities/TMPL.hpp"
 
-using the_trace_actions_list = actions_list;
-
-namespace detail {
+namespace Parallel {
 // @{
 /*!
  * \ingroup Profiling
@@ -33,19 +30,18 @@ namespace detail {
  * `read_events` and then recorded into Charm++ user stats (supported from
  * Charm++ v6.8.0 and newer) for analysis.
  */
+template <typename Action, typename ActionList,
+          Requires<tmpl::list_contains_v<ActionList, Action>> = nullptr>
+void stop_trace_action(const double start_time) {
+  static_assert(tmpl::size<ActionList>::value <
+                    SPECTRE_CHARM_NON_ACTION_WALLTIME_EVENT_ID,
+                "Cannot have more than "
+                "SPECTRE_CHARM_NON_ACTION_WALLTIME_EVENT_ID Actions to trace");
+  traceUserBracketEvent(tmpl::index_of<ActionList, Action>::value, start_time,
+                        Parallel::wall_time());
 
-template <
-    typename Action,
-    Requires<tmpl::found<the_trace_actions_list,
-                         tmpl::bind<std::is_same, tmpl::_1, Action>> =
-                 nullptr> void stop_trace_action(const double start_time) {
-  static_assert(tmpl::size<the_trace_actions_list>::value < 1000,
-                "Cannot have more than 1000 Actions to trace");
-  traceUserBracketEvent(tmpl::index_of<the_trace_actions_list, Action>::value,
-                        start_time, Parallel::wall_time());
 #ifdef SPECTRE_PAPI_COUNTERS
-  const auto action_number =
-      tmpl::index_of<the_trace_actions_list, Action>::value;
+  const auto action_number = tmpl::index_of<ActionList, Action>::value;
   std::array<long long, papi_event_names.size()> read_events;
   long long ret = PAPI_OK;
   if ((ret = PAPI_stop_counters(read_events.data(), read_events.size())) !=
@@ -61,11 +57,8 @@ template <
 }
 
 /// \cond HIDDEN_SYMBOLS
-template <
-    typename Action,
-    Requires<not tmpl::found<the_trace_actions_list,
-                             tmpl::bind<std::is_same, tmpl::_1, Action>>> =
-        nullptr>
+template <typename Action, typename ActionList,
+          Requires<not tmpl::list_contains_v<ActionList, Action>> = nullptr>
 constexpr void stop_trace_action(const double /*start_time*/) {}
 /// \endcond
 // @}
@@ -81,21 +74,19 @@ constexpr void stop_trace_action(const double /*start_time*/) {}
  * not an available hardware PMU, or the counters were already started once and
  * not stopped before this call.
  */
-template <typename Action>
+template <typename Action, typename ActionList,
+          Requires<tmpl::list_contains_v<ActionList, Action>> = nullptr>
 double start_trace_action() {
 #ifdef SPECTRE_PAPI_COUNTERS
-  if (tmpl::found<the_trace_actions_list,
-                  tmpl::bind<std::is_same, Action, tmpl::_1>>::value) {
-    long long ret = PAPI_OK;
-    if (UNLIKELY((ret = PAPI_start_counters(
-                      papi_event_ids.data(),
-                      static_cast<int>(papi_event_ids.size()))) != PAPI_OK)) {
-      ERROR("PAPI failed to start counters: "
-            << PAPI_strerror(ret) << "\npapi_event_ids: " << papi_event_ids);
-    }
+  long long ret = PAPI_OK;
+  if (UNLIKELY((ret = PAPI_start_counters(
+                    papi_event_ids.data(),
+                    static_cast<int>(papi_event_ids.size()))) != PAPI_OK)) {
+    ERROR("PAPI failed to start counters: "
+          << PAPI_strerror(ret) << "\npapi_event_ids: " << papi_event_ids);
   }
 #endif  // defined(SPECTRE_PAPI_COUNTERS)
   return Parallel::wall_time();
 }
-}  // namespace detail
+}  // namespace Parallel
 #endif  // defined(SPECTRE_CHARM_PROJECTIONS)

--- a/src/Parallel/TraceActions.hpp
+++ b/src/Parallel/TraceActions.hpp
@@ -1,0 +1,101 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines functions for tracing Actions
+
+#pragma once
+
+#ifdef SPECTRE_CHARM_PROJECTIONS
+
+#include <charm++.h>
+
+//#include "Utilities/Papi.hpp"
+
+//#include "Parallel/Algorithm.hpp"
+#include "Parallel/Info.hpp"
+#include "Utilities/TMPL.hpp"
+
+using the_trace_actions_list = actions_list;
+
+namespace detail {
+// @{
+/*!
+ * \ingroup Profiling
+ * \brief Called after an Action to record the time it took to execute and any
+ * PAPI counters
+ *
+ * A Charm++ bracketed user event is recorded for the particular Action given
+ * the `start_time`. The `start_time` should be the return value of
+ * `start_trace_action` called before the Action executed. If any PAPI counters
+ * should be recorded then the counters are stopped, causing an ERROR if there
+ * are problems stopping the counters. The values of the counters are read into
+ * `read_events` and then recorded into Charm++ user stats (supported from
+ * Charm++ v6.8.0 and newer) for analysis.
+ */
+
+template <
+    typename Action,
+    Requires<tmpl::found<the_trace_actions_list,
+                         tmpl::bind<std::is_same, tmpl::_1, Action>> =
+                 nullptr> void stop_trace_action(const double start_time) {
+  static_assert(tmpl::size<the_trace_actions_list>::value < 1000,
+                "Cannot have more than 1000 Actions to trace");
+  traceUserBracketEvent(tmpl::index_of<the_trace_actions_list, Action>::value,
+                        start_time, Parallel::wall_time());
+#ifdef SPECTRE_PAPI_COUNTERS
+  const auto action_number =
+      tmpl::index_of<the_trace_actions_list, Action>::value;
+  std::array<long long, papi_event_names.size()> read_events;
+  long long ret = PAPI_OK;
+  if ((ret = PAPI_stop_counters(read_events.data(), read_events.size())) !=
+      PAPI_OK) {
+    ERROR("PAPI failed to stop and read counts: " << PAPI_strerror(ret));
+  }
+  for (size_t i = 0; i < read_events.size(); ++i) {
+    updateStat(
+        charm_papi_events_offset + i + action_number * read_events.size(),
+        read_events[i]);
+  }
+#endif  // defined(SPECTRE_PAPI_COUNTERS)
+}
+
+/// \cond HIDDEN_SYMBOLS
+template <
+    typename Action,
+    Requires<not tmpl::found<the_trace_actions_list,
+                             tmpl::bind<std::is_same, tmpl::_1, Action>>> =
+        nullptr>
+constexpr void stop_trace_action(const double /*start_time*/) {}
+/// \endcond
+// @}
+
+/*!
+ * \ingroup Profiling
+ * \brief Start tracing an Action, returns the walltime of the call
+ *
+ * Checks if the Action `Action` is in the `ActionList` and
+ * if so attempts to start PAPI counters if requested. An error occurs if the
+ * counters were unable to start for any reason, included is an error message.
+ * Typically the `Invalid arguments` means either one of the `papi_event_ids` is
+ * not an available hardware PMU, or the counters were already started once and
+ * not stopped before this call.
+ */
+template <typename Action>
+double start_trace_action() {
+#ifdef SPECTRE_PAPI_COUNTERS
+  if (tmpl::found<the_trace_actions_list,
+                  tmpl::bind<std::is_same, Action, tmpl::_1>>::value) {
+    long long ret = PAPI_OK;
+    if (UNLIKELY((ret = PAPI_start_counters(
+                      papi_event_ids.data(),
+                      static_cast<int>(papi_event_ids.size()))) != PAPI_OK)) {
+      ERROR("PAPI failed to start counters: "
+            << PAPI_strerror(ret) << "\npapi_event_ids: " << papi_event_ids);
+    }
+  }
+#endif  // defined(SPECTRE_PAPI_COUNTERS)
+  return Parallel::wall_time();
+}
+}  // namespace detail
+#endif  // defined(SPECTRE_CHARM_PROJECTIONS)

--- a/src/Parallel/TraceRegister.hpp
+++ b/src/Parallel/TraceRegister.hpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+/// \file
+/// Defines functions to register Actions for tracing
+
+#pragma once
+
+#include <charm++.h>
+#include <cstring>
+
+#include "Parallel/CharmRegistration.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Parallel {
+#ifdef SPECTRE_CHARM_PROJECTIONS
+// Nothing to do for empty ActionList
+template <typename ActionList, typename TotalSize = tmpl::size<ActionList>,
+          Requires<(tmpl::size<ActionList>::value == 0)> = nullptr>
+constexpr SPECTRE_ALWAYS_INLINE void register_charm_trace_user_event() {}
+
+// Non-Empty ActionList
+// Register events recursively
+template <typename ActionList, typename TotalSize = tmpl::size<ActionList>,
+          Requires<(tmpl::size<ActionList>::value > 0)> = nullptr>
+void register_charm_trace_user_event() {
+  const auto action_number = TotalSize::value - tmpl::size<ActionList>::value;
+
+  // note: eventstr is not temporary and not freed on purpose, because we need
+  // either a constant string or a dynamically allocated string that is NOT
+  // freed by the program
+  std::string* eventstr =
+      new std::string(Parallel::charmxx::get_template_parameters_as_string<
+                      tmpl::front<ActionList>>());
+  traceRegisterUserEvent(eventstr->c_str(), action_number);
+#ifdef SPECTRE_PAPI_COUNTERS
+  for (size_t i = 0; i < papi_event_names.size(); ++i) {
+    // Note: the pointer char* named "buffer" is freed by Charm++ internally
+    char* buffer =
+        new char[std::strlen(papi_event_names[i]) +
+                 std::strlen(tmpl::front<ActionList>::event_name) + 3];
+    // Stats are named "Action::event_name + '_' + papi_event_names"
+    std::strcpy(buffer, tmpl::front<ActionList>::event_name);
+    buffer[std::strlen(tmpl::front<ActionList>::event_name)] = '_';
+    std::strcpy(&buffer[std::strlen(tmpl::front<ActionList>::event_name)] + 1,
+                papi_event_names[i]);
+    // charm_papi_events_offset is defined in Utilities/Papi.hpp and is what
+    // will be an inline variable in C++17 (it has no external linkage). It is
+    // used to ensure an offset from zero of the user stat options.
+    traceRegisterUserStat(buffer, charm_papi_events_offset + i +
+                                      action_number * papi_event_names.size());
+  }
+#endif  // defined(SPECTRE_PAPI_COUNTERS)
+  register_charm_trace_user_event<tmpl::pop_front<ActionList>, TotalSize>();
+}
+
+// User stats are not supported for Charm++ versions before v6.8.0, so we check
+// if the function exists, otherwise don't add them
+#ifdef SPECTRE_PROJECTIONS_USER_STATS
+void register_specified_user_stats() {
+  for (size_t i = 0; i < user_stat_names.size(); ++i) {
+    traceRegisterUserStat(user_stat_names[i], projections_user_stat_offset + i);
+  }
+}
+#else   // defined(SPECTRE_PROJECTIONS_USER_STATS)
+constexpr SPECTRE_ALWAYS_INLINE void register_specified_user_stats() {}
+#endif  // defined(SPECTRE_PROJECTIONS_USER_STATS)
+
+template <typename ActionList>
+inline void register_events_to_trace() {
+  // PAPI not yet ported, hence commented out
+  // init_papi_for_parallel Parallel::init_papi_for_parallel();
+  Parallel::register_charm_trace_user_event<ActionList>();
+  traceRegisterUserEvent("Non-action time",
+                         SPECTRE_CHARM_NON_ACTION_WALLTIME_EVENT_ID);
+#ifdef SPECTRE_CHARM_RECEIVE_MAP_DATA_EVENT_ID
+  traceRegisterUserEvent("Receive Map Data",
+                         SPECTRE_CHARM_RECEIVE_MAP_DATA_EVENT_ID);
+#endif  // defined(SPECTRE_CHARM_RECEIVE_MAP_DATA_EVENT_ID)
+  // Register additional user-specified stats
+  register_specified_user_stats();
+}
+#else   // defined(SPECTRE_CHARM_PROJECTIONS)
+constexpr SPECTRE_ALWAYS_INLINE void register_events_to_trace() {}
+#endif  // defined(SPECTRE_CHARM_PROJECTIONS)
+}  // namespace Parallel


### PR DESCRIPTION
## Proposed changes

- Bring back support for profiling with charm++ projections
- addresses  #925

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

- The new files src/Parallel/TraceActions.hpp and src/Parallel/TraceRegister.hpp have been ported from the old bitbucket repository. 
- The previous registration routines created dangling pointers inside of charm, which lead to faulty output files used by projections. When registering chares or user events charm wants either a constant string or a string that is NOT freed by the program. This creates some memory leak, but since the registration takes only place once at the beginning it seems to be a small issue.
- cmake code has been changed. The auto generated files must be rebuild to generate correct projections output.
- The PAPI support hasn't been ported yet and the PAPI related code is untested
- The documentation on profiling must be updated.
- At the moment all actions in the actions_list are traced.
- There are no unit tests yet for this part of the code. 