### PR TITLE
Update Minmod limiter to work with limiter actions

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LIBRARY_SOURCES
     OrientationMap.cpp
     SegmentId.cpp
     Side.cpp
+    SizeOfElement.cpp
     )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Domain/SizeOfElement.cpp
+++ b/src/Domain/SizeOfElement.cpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/SizeOfElement.hpp"
+
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Mesh.hpp"  // IWYU pragma: keep
+#include "Domain/Side.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/StdArrayHelpers.hpp"  // IWYU pragma: keep
+
+template <size_t VolumeDim>
+std::array<double, VolumeDim> size_of_element(
+    const Mesh<VolumeDim>& mesh,
+    const tnsr::I<DataVector, VolumeDim>& inertial_coords) noexcept {
+  ASSERT(mesh.quadrature() ==
+             make_array<VolumeDim>(Spectral::Quadrature::GaussLobatto),
+         "Implementation assumes that grid points extend to the faces of the\n"
+         "element, but not sure if this is true for quadrature: "
+             << mesh.quadrature());
+  auto result = make_array<VolumeDim>(0.0);
+  // inertial-coord vector between lower face center and upper face center
+  auto center_to_center = make_array<VolumeDim>(0.0);
+  for (size_t logical_dim = 0; logical_dim < VolumeDim; ++logical_dim) {
+    for (size_t inertial_dim = 0; inertial_dim < VolumeDim; ++inertial_dim) {
+      const double center_upper = mean_value_on_boundary(
+          inertial_coords.get(inertial_dim), mesh, logical_dim, Side::Upper);
+      const double center_lower = mean_value_on_boundary(
+          inertial_coords.get(inertial_dim), mesh, logical_dim, Side::Lower);
+      center_to_center.at(inertial_dim) = center_upper - center_lower;
+    }
+    result.at(logical_dim) = magnitude(center_to_center);
+  }
+  return result;
+}
+
+// Explicit instantiations
+template std::array<double, 1> size_of_element(
+    const Mesh<1>&, const tnsr::I<DataVector, 1>&) noexcept;
+template std::array<double, 2> size_of_element(
+    const Mesh<2>&, const tnsr::I<DataVector, 2>&) noexcept;
+template std::array<double, 3> size_of_element(
+    const Mesh<3>&, const tnsr::I<DataVector, 3>&) noexcept;

--- a/src/Domain/SizeOfElement.hpp
+++ b/src/Domain/SizeOfElement.hpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t VolumeDim>
+class Mesh;
+namespace Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+template <size_t VolumeDim>
+struct Mesh;
+}  // namespace Tags
+/// \endcond
+
+/*!
+ * \ingroup ComputationalDomainGroup
+ * \brief Compute the inertial-coordinate size of an element along each of its
+ * logical directions.
+ *
+ * For each logical direction, compute the mean position (in inertial
+ * coordinates) of the element's lower and upper faces in that direction.
+ * This is done by simply averaging the coordinates of the face grid points.
+ * The size of the element along this logical direction is then the distance
+ * between the mean positions of the lower and upper faces.
+ * Note that for curved elements, this is an approximate measurement of size.
+ *
+ * \details
+ * Because this quantity is defined in terms of specific coordinates, it is
+ * not well represented by a `Tensor`, so we use a `std::array`.
+ */
+template <size_t VolumeDim>
+std::array<double, VolumeDim> size_of_element(
+    const Mesh<VolumeDim>& mesh,
+    const tnsr::I<DataVector, VolumeDim>& inertial_coords) noexcept;
+
+namespace Tags {
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// The inertial-coordinate size of an element along each of its logical
+/// directions.
+template <size_t VolumeDim>
+struct SizeOfElement : db::ComputeTag {
+  static std::string name() noexcept { return "SizeOfElement"; }
+  using argument_tags =
+      tmpl::list<Tags::Mesh<VolumeDim>,
+                 Tags::Coordinates<VolumeDim, Frame::Inertial>>;
+  static constexpr auto function = size_of_element<VolumeDim>;
+};
+}  // namespace Tags

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
@@ -51,7 +51,7 @@ bool limit_one_tensor(
     const SlopeLimiters::MinmodType& minmod_type, const double tvbm_constant,
     const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
-    const tnsr::I<double, VolumeDim>& element_size,
+    const std::array<double, VolumeDim>& element_size,
     const std::unordered_map<
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
         gsl::not_null<const double*>,
@@ -59,7 +59,7 @@ bool limit_one_tensor(
         neighbor_tensor_begin,
     const std::unordered_map<
         std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
-        tnsr::I<double, VolumeDim>,
+        std::array<double, VolumeDim>,
         boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_sizes) noexcept {
   // True if the mesh is linear-order in every direction
@@ -68,7 +68,7 @@ bool limit_one_tensor(
   const double tvbm_scale = [&tvbm_constant, &element_size ]() noexcept {
     double max_h_sqr = 0.0;
     for (size_t d = 0; d < VolumeDim; ++d) {
-      max_h_sqr = std::max(max_h_sqr, square(element_size.get(d)));
+      max_h_sqr = std::max(max_h_sqr, square(gsl::at(element_size, d)));
     }
     return tvbm_constant * max_h_sqr;
   }
@@ -111,8 +111,8 @@ bool limit_one_tensor(
         // Note that this is not "by the book" Minmod, but an attempt to
         // generalize Minmod to work on non-uniform grids.
         const double distance_factor =
-            0.5 *
-            (1.0 + neighbor_sizes.at(dir_key).get(dim) / element_size.get(dim));
+            0.5 * (1.0 + gsl::at(neighbor_sizes.at(dir_key), dim) /
+                             gsl::at(element_size, dim));
         const double neighbor_mean =
             // clang-tidy: do not use pointer arithmetic
             *(neighbor_tensor_begin.at(dir_key).get() + iter_offset);  // NOLINT
@@ -206,34 +206,34 @@ template bool limit_one_tensor<1>(
     const gsl::not_null<DataVector*>, const gsl::not_null<DataVector*>,
     const SlopeLimiters::MinmodType&, const double, const Element<1>&,
     const Mesh<1>&, const tnsr::I<DataVector, 1, Frame::Logical>&,
-    const tnsr::I<double, 1>&,
+    const std::array<double, 1>&,
     const std::unordered_map<
         std::pair<Direction<1>, ElementId<1>>, gsl::not_null<const double*>,
         boost::hash<std::pair<Direction<1>, ElementId<1>>>>&,
     const std::unordered_map<
-        std::pair<Direction<1>, ElementId<1>>, tnsr::I<double, 1>,
+        std::pair<Direction<1>, ElementId<1>>, std::array<double, 1>,
         boost::hash<std::pair<Direction<1>, ElementId<1>>>>&) noexcept;
 template bool limit_one_tensor<2>(
     const gsl::not_null<DataVector*>, const gsl::not_null<DataVector*>,
     const SlopeLimiters::MinmodType&, const double, const Element<2>&,
     const Mesh<2>&, const tnsr::I<DataVector, 2, Frame::Logical>&,
-    const tnsr::I<double, 2>&,
+    const std::array<double, 2>&,
     const std::unordered_map<
         std::pair<Direction<2>, ElementId<2>>, gsl::not_null<const double*>,
         boost::hash<std::pair<Direction<2>, ElementId<2>>>>&,
     const std::unordered_map<
-        std::pair<Direction<2>, ElementId<2>>, tnsr::I<double, 2>,
+        std::pair<Direction<2>, ElementId<2>>, std::array<double, 2>,
         boost::hash<std::pair<Direction<2>, ElementId<2>>>>&) noexcept;
 template bool limit_one_tensor<3>(
     const gsl::not_null<DataVector*>, const gsl::not_null<DataVector*>,
     const SlopeLimiters::MinmodType&, const double, const Element<3>&,
     const Mesh<3>&, const tnsr::I<DataVector, 3, Frame::Logical>&,
-    const tnsr::I<double, 3>&,
+    const std::array<double, 3>&,
     const std::unordered_map<
         std::pair<Direction<3>, ElementId<3>>, gsl::not_null<const double*>,
         boost::hash<std::pair<Direction<3>, ElementId<3>>>>&,
     const std::unordered_map<
-        std::pair<Direction<3>, ElementId<3>>, tnsr::I<double, 3>,
+        std::pair<Direction<3>, ElementId<3>>, std::array<double, 3>,
         boost::hash<std::pair<Direction<3>, ElementId<3>>>>&) noexcept;
 }  // namespace Minmod_detail
 

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
@@ -48,13 +48,13 @@ template <size_t VolumeDim>
 bool limit_one_tensor(
     const gsl::not_null<DataVector*> tensor_begin,
     const gsl::not_null<DataVector*> tensor_end,
-    const std::unordered_map<Direction<VolumeDim>,
-                             gsl::not_null<const double*>>&
-        neighbor_tensor_begin,
     const SlopeLimiters::MinmodType& minmod_type, const double tvbm_constant,
     const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
     const tnsr::I<double, VolumeDim>& element_size,
+    const std::unordered_map<Direction<VolumeDim>,
+                             gsl::not_null<const double*>>&
+        neighbor_tensor_begin,
     const std::unordered_map<Direction<VolumeDim>, tnsr::I<double, VolumeDim>>&
         neighbor_sizes) noexcept {
   // True if the mesh is linear-order in every direction
@@ -89,6 +89,9 @@ bool limit_one_tensor(
       const auto dir = Direction<VolumeDim>(dim, side);
       const bool has_neighbors = (externals.find(dir) == externals.end());
       if (has_neighbors) {
+        const auto& neighbor_ids = element.neighbors().at(dir).ids();
+        ASSERT(neighbor_ids.size() == 1,
+               "Minmod does not yet support h-refinment");
         // Compute an effective element-center-to-neighbor-center distance
         // that accounts for the possibility of different refinement levels
         // or discontinuous maps (e.g., at Block boundaries). Treated naively,
@@ -194,24 +197,24 @@ bool limit_one_tensor(
 // Explicit instantiations
 template bool limit_one_tensor<1>(
     const gsl::not_null<DataVector*>, const gsl::not_null<DataVector*>,
-    const std::unordered_map<Direction<1>, gsl::not_null<const double*>>&,
     const SlopeLimiters::MinmodType&, const double, const Element<1>&,
     const Mesh<1>&, const tnsr::I<DataVector, 1, Frame::Logical>&,
     const tnsr::I<double, 1>&,
+    const std::unordered_map<Direction<1>, gsl::not_null<const double*>>&,
     const std::unordered_map<Direction<1>, tnsr::I<double, 1>>&) noexcept;
 template bool limit_one_tensor<2>(
     const gsl::not_null<DataVector*>, const gsl::not_null<DataVector*>,
-    const std::unordered_map<Direction<2>, gsl::not_null<const double*>>&,
     const SlopeLimiters::MinmodType&, const double, const Element<2>&,
     const Mesh<2>&, const tnsr::I<DataVector, 2, Frame::Logical>&,
     const tnsr::I<double, 2>&,
+    const std::unordered_map<Direction<2>, gsl::not_null<const double*>>&,
     const std::unordered_map<Direction<2>, tnsr::I<double, 2>>&) noexcept;
 template bool limit_one_tensor<3>(
     const gsl::not_null<DataVector*>, const gsl::not_null<DataVector*>,
-    const std::unordered_map<Direction<3>, gsl::not_null<const double*>>&,
     const SlopeLimiters::MinmodType&, const double, const Element<3>&,
     const Mesh<3>&, const tnsr::I<DataVector, 3, Frame::Logical>&,
     const tnsr::I<double, 3>&,
+    const std::unordered_map<Direction<3>, gsl::not_null<const double*>>&,
     const std::unordered_map<Direction<3>, tnsr::I<double, 3>>&) noexcept;
 }  // namespace Minmod_detail
 

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -41,6 +41,17 @@ namespace SlopeLimiters {
 template <size_t VolumeDim, typename TagsToLimit>
 class Minmod;
 }  // namespace SlopeLimiters
+
+namespace Tags {
+template <size_t Dim, typename Frame>
+struct Coordinates;
+template <size_t VolumeDim>
+struct Element;
+template <size_t VolumeDim>
+struct Mesh;
+template <size_t VolumeDim>
+struct SizeOfElement;
+}  // namespace Tags
 /// \endcond
 
 namespace SlopeLimiters {
@@ -216,6 +227,9 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
         make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN());
   };
 
+  using package_argument_tags = tmpl::list<Tags..., ::Tags::Mesh<VolumeDim>,
+                                           ::Tags::SizeOfElement<VolumeDim>>;
+
   /// \brief Package data for sending to neighbor elements.
   ///
   /// The following quantities are stored in `PackagedData` and communicated
@@ -244,6 +258,12 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
     expand_pack(wrap_compute_means(Tags{}, tensors)...);
     packaged_data->element_size_ = element_size;
   }
+
+  using limit_tags = tmpl::list<Tags...>;
+  using limit_argument_tags =
+      tmpl::list<::Tags::Element<VolumeDim>, ::Tags::Mesh<VolumeDim>,
+                 ::Tags::Coordinates<VolumeDim, Frame::Logical>,
+                 ::Tags::SizeOfElement<VolumeDim>>;
 
   /// \brief Limits the solution on the element.
   ///

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <boost/functional/hash.hpp>  // IWYU pragma: keep
 #include <cstddef>
 #include <limits>
 #include <string>
@@ -26,6 +27,8 @@
 class DataVector;
 template <size_t VolumeDim>
 class Direction;
+template <size_t VolumeDim>
+class ElementId;
 template <size_t>
 class Mesh;
 
@@ -76,10 +79,15 @@ bool limit_one_tensor(
     const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
     const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
     const tnsr::I<double, VolumeDim>& element_size,
-    const std::unordered_map<Direction<VolumeDim>,
-                             gsl::not_null<const double*>>&
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+        gsl::not_null<const double*>,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_tensor_begin,
-    const std::unordered_map<Direction<VolumeDim>, tnsr::I<double, VolumeDim>>&
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+        tnsr::I<double, VolumeDim>,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
         neighbor_sizes) noexcept;
 
 template <typename Tag>
@@ -267,7 +275,9 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
       const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
       const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
       const tnsr::I<double, VolumeDim>& element_size,
-      const std::unordered_map<Direction<VolumeDim>, PackagedData>&
+      const std::unordered_map<
+          std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+          boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
           neighbor_data) const noexcept {
     bool limiter_activated = false;
     const auto wrap_limit_one_tensor = [
@@ -286,7 +296,10 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
       const auto tensor_begin = make_not_null(tensor->begin());
       const auto tensor_end = make_not_null(tensor->end());
       const auto neighbor_tensor_begin = [&neighbor_data]() noexcept {
-        std::unordered_map<Direction<VolumeDim>, gsl::not_null<const double*>>
+        std::unordered_map<
+            std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+            gsl::not_null<const double*>,
+            boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
             result;
         for (const auto& neighbor_and_data : neighbor_data) {
           result.insert(std::make_pair(
@@ -299,7 +312,10 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
       }
       ();
       const auto neighbor_sizes = [&neighbor_data]() noexcept {
-        std::unordered_map<Direction<VolumeDim>, tnsr::I<double, VolumeDim>>
+        std::unordered_map<
+            std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>,
+            tnsr::I<double, VolumeDim>,
+            boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>
             result;
         for (const auto& neighbor_and_data : neighbor_data) {
           result.insert(std::make_pair(neighbor_and_data.first,

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIBRARY_SOURCES
   Test_OrientationMap.cpp
   Test_SegmentId.cpp
   Test_Side.cpp
+  Test_SizeOfElement.cpp
   )
 
 add_subdirectory(Amr)

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/Rotation.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Domain/SizeOfElement.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+tnsr::I<DataVector, 2> make_inertial_coords_2d(const Mesh<2>& mesh) noexcept {
+  using Affine = CoordinateMaps::Affine;
+  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  const auto map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
+      CoordinateMaps::DiscreteRotation<2>(
+          OrientationMap<2>{std::array<Direction<2>, 2>{
+              {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
+  return map(logical_coordinates(mesh));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.SizeOfElement", "[Domain][Unit]") {
+  SECTION("1D") {
+    const auto mesh = Mesh<1>(4, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto);
+    const auto coords = [&mesh]() {
+      const auto map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
+      return map(logical_coordinates(mesh));
+    }();
+    const auto size = size_of_element(mesh, coords);
+    const auto size_expected = make_array<1>(0.9);
+    CHECK_ITERABLE_APPROX(size, size_expected);
+  }
+
+  SECTION("2D") {
+    const auto mesh = Mesh<2>({{4, 5}}, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto);
+    const auto coords = make_inertial_coords_2d(mesh);
+    const auto size = size_of_element(mesh, coords);
+    const auto size_expected = make_array(0.1, 1.7);
+    CHECK_ITERABLE_APPROX(size, size_expected);
+  }
+
+  SECTION("3D") {
+    const auto mesh = Mesh<3>({{4, 5, 6}}, Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto);
+    const auto coords = [&mesh]() {
+      using Affine = CoordinateMaps::Affine;
+      using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+      const auto map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
+                   Affine(-1.0, 1.0, 12.0, 12.5)},
+          CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
+      return map(logical_coordinates(mesh));
+    }();
+    const auto size = size_of_element(mesh, coords);
+    const auto size_expected = make_array(0.1, 1.7, 0.5);
+    CHECK_ITERABLE_APPROX(size, size_expected);
+  }
+
+  SECTION("ComputeTag") {
+    auto mesh = Mesh<2>({{4, 5}}, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto);
+    auto coords = make_inertial_coords_2d(mesh);
+    const auto box = db::create<
+        db::AddSimpleTags<Tags::Mesh<2>, Tags::Coordinates<2, Frame::Inertial>>,
+        db::AddComputeTags<Tags::SizeOfElement<2>>>(mesh, std::move(coords));
+
+    const auto size_compute_item = db::get<Tags::SizeOfElement<2>>(box);
+    const auto size_expected = make_array(0.1, 1.7);
+    CHECK_ITERABLE_APPROX(size_compute_item, size_expected);
+  }
+}

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_SlopeLimiters")
 
 set(LIBRARY_SOURCES
   Test_LimiterActions.cpp
+  Test_LimiterActionsWithMinmod.cpp
   Test_Minmod.cpp
   )
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_LimiterActionsWithMinmod.cpp
@@ -1,0 +1,135 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <boost/functional/hash.hpp>  // IWYU pragma: keep
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/SizeOfElement.hpp"  // IWYU pragma: keep
+#include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/LimiterActions.hpp"  // IWYU pragma: keep
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace {
+struct TemporalId : db::SimpleTag {
+  static std::string name() noexcept { return "TemporalId"; }
+  using type = int;
+};
+
+struct Var : db::SimpleTag {
+  static std::string name() noexcept { return "Var"; }
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr const size_t volume_dim = Dim;
+  using variables_tag = Tags::Variables<tmpl::list<Var>>;
+};
+
+struct LimiterTag {
+  using type = SlopeLimiters::Minmod<2, tmpl::list<Var>>;
+};
+
+template <size_t Dim, typename Metavariables>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<Dim>;
+  using const_global_cache_tag_list = tmpl::list<LimiterTag>;
+  using action_list =
+      tmpl::list<SlopeLimiters::Actions::SendData<Metavariables>,
+                 SlopeLimiters::Actions::Limit<Metavariables>>;
+  using simple_tags =
+      db::AddSimpleTags<TemporalId, Tags::Mesh<Dim>, Tags::Element<Dim>,
+                        Tags::ElementMap<Dim>,
+                        Tags::Coordinates<Dim, Frame::Logical>,
+                        Tags::Coordinates<Dim, Frame::Inertial>, Var>;
+  using compute_tags = db::AddComputeTags<Tags::SizeOfElement<Dim>>;
+  using initial_databox =
+      db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using component_list = tmpl::list<component<Dim, Metavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using limiter = LimiterTag;
+  using system = System<Dim>;
+  using temporal_id = TemporalId;
+  static constexpr bool local_time_stepping = false;
+};
+}  // namespace
+
+// This test checks that the Minmod limiter's interfaces and type aliases
+// succesfully integrate with the limiter actions. It does this by compiling
+// together the Minmod limiter and the actions, then making calls to the
+// SendData and the Limit actions. No checks are performed here that the limiter
+// and/or actions produce correct output: that is done in other tests.
+SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.LimiterActions.Minmod",
+                  "[Unit][NumericalAlgorithms][Actions]") {
+  using metavariables = Metavariables<2>;
+  using my_component = component<2, metavariables>;
+
+  const Mesh<2> mesh{3, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const ElementId<2> self_id(1, {{{2, 0}, {1, 0}}});
+  const Element<2> element(self_id, {});
+
+  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
+  const CoordinateMaps::Affine eta_map{-1., 1., 7., 3.};
+  auto map = ElementMap<2, Frame::Inertial>(
+      self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+                   CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                                  CoordinateMaps::Affine>(
+                       xi_map, eta_map)));
+
+  auto logical_coords = logical_coordinates(mesh);
+  auto inertial_coords = map(logical_coords);
+  auto var = Scalar<DataVector>(mesh.number_of_grid_points(), 1234.);
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<my_component>;
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
+      .emplace(
+          self_id,
+          db::create<my_component::simple_tags, my_component::compute_tags>(
+              0, mesh, element, std::move(map), std::move(logical_coords),
+              std::move(inertial_coords), std::move(var)));
+
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      SlopeLimiters::Minmod<2, tmpl::list<Var>>(
+          SlopeLimiters::MinmodType::LambdaPi1),
+      std::move(dist_objects)};
+
+  // SendData
+  runner.next_action<my_component>(self_id);
+  CHECK(runner.is_ready<my_component>(self_id));
+  // Limit
+  runner.next_action<my_component>(self_id);
+}

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -29,6 +29,7 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -141,7 +142,7 @@ Element<3> make_element() noexcept {
 // Values of left_id, right_id based on make_element<1> above.
 auto make_neighbor_packaged_data(
     const double left, const double right,
-    const tnsr::I<double, 1>& local_size_for_neighbor_size) noexcept {
+    const std::array<double, 1>& local_size_for_neighbor_size) noexcept {
   constexpr size_t left_id = 1;
   constexpr size_t right_id = 2;
   return std::unordered_map<
@@ -171,18 +172,18 @@ auto make_neighbor_packaged_data(const double left, const double right,
       std::make_pair(
           std::make_pair(Direction<1>::lower_xi(), ElementId<1>(left_id)),
           SlopeLimiters::Minmod<1, tmpl::list<scalar>>::PackagedData{
-              Scalar<double>(left), tnsr::I<double, 1>(left_size)}),
+              Scalar<double>(left), make_array<1>(left_size)}),
       std::make_pair(
           std::make_pair(Direction<1>::upper_xi(), ElementId<1>(right_id)),
           SlopeLimiters::Minmod<1, tmpl::list<scalar>>::PackagedData{
-              Scalar<double>(right), tnsr::I<double, 1>(right_size)})};
+              Scalar<double>(right), make_array<1>(right_size)})};
 }
 
 void test_limiter_activates_work(
     const SlopeLimiters::Minmod<1, tmpl::list<scalar>>& minmod,
     const scalar::type& input, const Element<1>& element, const Mesh<1>& mesh,
     const tnsr::I<DataVector, 1, Frame::Logical>& logical_coords,
-    const tnsr::I<double, 1>& element_size,
+    const std::array<double, 1>& element_size,
     const std::unordered_map<
         std::pair<Direction<1>, ElementId<1>>,
         SlopeLimiters::Minmod<1, tmpl::list<scalar>>::PackagedData,
@@ -206,7 +207,7 @@ void test_limiter_does_not_activate_work(
     const SlopeLimiters::Minmod<1, tmpl::list<scalar>>& minmod,
     const scalar::type& input, const Element<1>& element, const Mesh<1>& mesh,
     const tnsr::I<DataVector, 1, Frame::Logical>& logical_coords,
-    const tnsr::I<double, 1>& element_size,
+    const std::array<double, 1>& element_size,
     const std::unordered_map<
         std::pair<Direction<1>, ElementId<1>>,
         SlopeLimiters::Minmod<1, tmpl::list<scalar>>::PackagedData,
@@ -254,7 +255,7 @@ void test_limiter_action_on_constant_function(
   const double value = 0.3;
   const auto input =
       make_with_value<scalar::type>(get<0>(logical_coords), value);
-  const auto element_size = tnsr::I<double, 1>{1.2};
+  const auto element_size = make_array<1>(1.2);
   for (const double left : {-0.4, value, 1.2}) {
     for (const double right : {0.2, value, 0.9}) {
       test_limiter_does_not_activate_work(
@@ -273,7 +274,7 @@ void test_limiter_action_on_linear_function(
   const auto mesh = Mesh<1>(number_of_grid_points, Spectral::Basis::Legendre,
                             Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
-  const auto element_size = tnsr::I<double, 1>{2.0};
+  const auto element_size = make_array<1>(2.0);
 
   const auto test_limiter_activates =
       [&minmod, &element, &mesh, &logical_coords, &element_size ](
@@ -359,7 +360,7 @@ void test_limiter_action_on_quadratic_function(
   const auto mesh = Mesh<1>(number_of_grid_points, Spectral::Basis::Legendre,
                             Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
-  const auto element_size = tnsr::I<double, 1>{2.0};
+  const auto element_size = make_array<1>(2.0);
 
   const auto test_limiter_activates =
       [&minmod, &element, &mesh, &logical_coords, &element_size ](
@@ -430,7 +431,7 @@ void test_limiter_action_with_tvbm_correction(
   const auto mesh = Mesh<1>(number_of_grid_points, Spectral::Basis::Legendre,
                             Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
-  const auto element_size = tnsr::I<double, 1>{2.0};
+  const auto element_size = make_array<1>(2.0);
 
   const auto test_limiter_activates =
       [&element, &mesh, &logical_coords, &element_size ](
@@ -487,7 +488,7 @@ void test_lambda_pin_troubled_cell_tvbm_correction(
   const auto mesh = Mesh<1>(number_of_grid_points, Spectral::Basis::Legendre,
                             Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
-  const auto element_size = tnsr::I<double, 1>{2.0};
+  const auto element_size = make_array<1>(2.0);
 
   const auto test_limiter_activates =
       [&element, &mesh, &logical_coords, &element_size ](
@@ -554,7 +555,7 @@ void test_limiter_action_at_boundary(
   const auto mesh = Mesh<1>(number_of_grid_points, Spectral::Basis::Legendre,
                             Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
-  const auto element_size = tnsr::I<double, 1>{2.0};
+  const auto element_size = make_array<1>(2.0);
 
   const auto func = [](
       const tnsr::I<DataVector, 1, Frame::Logical>& coords) noexcept {
@@ -603,7 +604,7 @@ void test_limiter_action_with_different_size_neighbor(
                             Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
   const double dx = 1.0;
-  const auto element_size = tnsr::I<double, 1>{dx};
+  const auto element_size = make_array<1>(dx);
 
   const auto test_limiter_activates =
       [&minmod, &element, &mesh, &logical_coords, &element_size ](
@@ -744,7 +745,7 @@ void test_package_data_work(
     const tnsr::I<DataVector, VolumeDim>& input_vector,
     const Mesh<VolumeDim>& mesh,
     const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
-    const tnsr::I<double, VolumeDim>& element_size) noexcept {
+    const std::array<double, VolumeDim>& element_size) noexcept {
   // To streamline the testing of the op() function, the test sets up
   // identical data for all components of input_vector. To better test the
   // package_data function, we first modify the input so the data
@@ -788,7 +789,7 @@ void test_work(
         neighbor_data,
     const Mesh<VolumeDim>& mesh,
     const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
-    const tnsr::I<double, VolumeDim>& element_size,
+    const std::array<double, VolumeDim>& element_size,
     const std::array<double, VolumeDim>& target_scalar_slope,
     const std::array<std::array<double, VolumeDim>, VolumeDim>&
         target_vector_slope) noexcept {
@@ -838,7 +839,7 @@ SPECTRE_TEST_CASE(
   const auto mesh =
       Mesh<1>(3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
-  const auto element_size = tnsr::I<double, 1>{{{0.5}}};
+  const auto element_size = make_array<1>(0.5);
   const auto true_slope = std::array<double, 1>{{2.0}};
   const auto func = [&true_slope](
       const tnsr::I<DataVector, 1, Frame::Logical>& coords) noexcept {
@@ -902,7 +903,7 @@ SPECTRE_TEST_CASE(
       Mesh<2>(std::array<size_t, 2>{{3, 3}}, Spectral::Basis::Legendre,
               Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
-  const auto element_size = tnsr::I<double, 2>{{{0.5, 1.0}}};
+  const auto element_size = make_array(0.5, 1.0);
   const auto true_slope = std::array<double, 2>{{2.0, -3.0}};
   const auto& func = [&true_slope](
       const tnsr::I<DataVector, 2, Frame::Logical>& coords) noexcept {
@@ -1007,7 +1008,7 @@ SPECTRE_TEST_CASE(
       Mesh<3>(std::array<size_t, 3>{{3, 3, 4}}, Spectral::Basis::Legendre,
               Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
-  const auto element_size = tnsr::I<double, 3>{{{0.5, 1.0, 0.8}}};
+  const auto element_size = make_array(0.5, 1.0, 0.8);
   const auto true_slope = std::array<double, 3>{{2.0, -3.0, 1.0}};
   const auto func = [&true_slope](
       const tnsr::I<DataVector, 3, Frame::Logical>& coords) noexcept {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -95,7 +95,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.Minmod.Serialization",
 namespace {
 template <size_t VolumeDim>
 Neighbors<VolumeDim> make_neighbor_with_id(const size_t id) noexcept {
-  return {std::unordered_set<ElementId<VolumeDim>>{id},
+  return {std::unordered_set<ElementId<VolumeDim>>{ElementId<VolumeDim>(id)},
           OrientationMap<VolumeDim>{}};
 }
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -137,65 +137,46 @@ Element<3> make_element() noexcept {
           {Direction<3>::upper_zeta(), make_neighbor_with_id<3>(6)}}};
 }
 
-std::unordered_map<Direction<1>, Scalar<double>> make_neighbor_means(
-    const double left, const double right) noexcept {
-  return std::unordered_map<Direction<1>, Scalar<double>>{
-      {Direction<1>::lower_xi(), Scalar<double>(left)},
-      {Direction<1>::upper_xi(), Scalar<double>(right)}};
+std::unordered_map<Direction<1>,
+                   SlopeLimiters::Minmod<1, tmpl::list<scalar>>::PackagedData>
+make_neighbor_packaged_data(
+    const double left, const double right,
+    const tnsr::I<double, 1>& local_size_for_neighbor_size) noexcept {
+  return std::unordered_map<
+      Direction<1>, SlopeLimiters::Minmod<1, tmpl::list<scalar>>::PackagedData>{
+      {Direction<1>::lower_xi(),
+       {Scalar<double>(left), local_size_for_neighbor_size}},
+      {Direction<1>::upper_xi(),
+       {Scalar<double>(right), local_size_for_neighbor_size}}};
 }
 
-// Set neighbor sizes to local size, corresponding to uniform elements.
-template <size_t VolumeDim>
-std::unordered_map<Direction<VolumeDim>, tnsr::I<double, VolumeDim>>
-make_neighbor_sizes_from_local_size(
-    const tnsr::I<double, VolumeDim>& local_size) noexcept;
-
-template <>
-std::unordered_map<Direction<1>, tnsr::I<double, 1>>
-make_neighbor_sizes_from_local_size(
-    const tnsr::I<double, 1>& local_size) noexcept {
-  return std::unordered_map<Direction<1>, tnsr::I<double, 1>>{
-      {Direction<1>::lower_xi(), local_size},
-      {Direction<1>::upper_xi(), local_size}};
-}
-
-template <>
-std::unordered_map<Direction<2>, tnsr::I<double, 2>>
-make_neighbor_sizes_from_local_size(
-    const tnsr::I<double, 2>& local_size) noexcept {
-  return std::unordered_map<Direction<2>, tnsr::I<double, 2>>{
-      {Direction<2>::lower_xi(), local_size},
-      {Direction<2>::upper_xi(), local_size},
-      {Direction<2>::lower_eta(), local_size},
-      {Direction<2>::upper_eta(), local_size}};
-}
-
-template <>
-std::unordered_map<Direction<3>, tnsr::I<double, 3>>
-make_neighbor_sizes_from_local_size(
-    const tnsr::I<double, 3>& local_size) noexcept {
-  return std::unordered_map<Direction<3>, tnsr::I<double, 3>>{
-      {Direction<3>::lower_xi(), local_size},
-      {Direction<3>::upper_xi(), local_size},
-      {Direction<3>::lower_eta(), local_size},
-      {Direction<3>::upper_eta(), local_size},
-      {Direction<3>::lower_zeta(), local_size},
-      {Direction<3>::upper_zeta(), local_size}};
+std::unordered_map<Direction<1>,
+                   SlopeLimiters::Minmod<1, tmpl::list<scalar>>::PackagedData>
+make_neighbor_packaged_data(const double left, const double right,
+                            const double left_size,
+                            const double right_size) noexcept {
+  return std::unordered_map<
+      Direction<1>, SlopeLimiters::Minmod<1, tmpl::list<scalar>>::PackagedData>{
+      {Direction<1>::lower_xi(),
+       {Scalar<double>(left), tnsr::I<double, 1>(left_size)}},
+      {Direction<1>::upper_xi(),
+       {Scalar<double>(right), tnsr::I<double, 1>(right_size)}}};
 }
 
 void test_limiter_activates_work(
     const SlopeLimiters::Minmod<1, tmpl::list<scalar>>& minmod,
-    const scalar::type& input,
-    const std::unordered_map<Direction<1>, Scalar<double>>& neighbor_means,
-    const Element<1>& element, const Mesh<1>& mesh,
+    const scalar::type& input, const Element<1>& element, const Mesh<1>& mesh,
     const tnsr::I<DataVector, 1, Frame::Logical>& logical_coords,
     const tnsr::I<double, 1>& element_size,
-    const std::unordered_map<Direction<1>, tnsr::I<double, 1>>& neighbor_sizes,
+    const std::unordered_map<
+        Direction<1>,
+        SlopeLimiters::Minmod<1, tmpl::list<scalar>>::PackagedData>&
+        neighbor_data,
     const double expected_slope) noexcept {
   auto input_to_limit = input;
   const bool limiter_activated =
-      minmod.apply(make_not_null(&input_to_limit), neighbor_means, element,
-                   mesh, logical_coords, element_size, neighbor_sizes);
+      minmod(make_not_null(&input_to_limit), element, mesh, logical_coords,
+             element_size, neighbor_data);
   CHECK(limiter_activated);
   const scalar::type expected_output = [&logical_coords, &mesh ](
       const scalar::type& in, const double slope) noexcept {
@@ -208,17 +189,17 @@ void test_limiter_activates_work(
 
 void test_limiter_does_not_activate_work(
     const SlopeLimiters::Minmod<1, tmpl::list<scalar>>& minmod,
-    const scalar::type& input,
-    const std::unordered_map<Direction<1>, Scalar<double>>& neighbor_means,
-    const Element<1>& element, const Mesh<1>& mesh,
+    const scalar::type& input, const Element<1>& element, const Mesh<1>& mesh,
     const tnsr::I<DataVector, 1, Frame::Logical>& logical_coords,
     const tnsr::I<double, 1>& element_size,
-    const std::unordered_map<Direction<1>, tnsr::I<double, 1>>&
-        neighbor_sizes) noexcept {
+    const std::unordered_map<
+        Direction<1>,
+        SlopeLimiters::Minmod<1, tmpl::list<scalar>>::PackagedData>&
+        neighbor_data) noexcept {
   auto input_to_limit = input;
   const bool limiter_activated =
-      minmod.apply(make_not_null(&input_to_limit), neighbor_means, element,
-                   mesh, logical_coords, element_size, neighbor_sizes);
+      minmod(make_not_null(&input_to_limit), element, mesh, logical_coords,
+             element_size, neighbor_data);
   // The limiter can report an activation even if the solution was not modified.
   // This occurs when a pure-linear solution is represented on a higher-than-
   // linear order grid, so that the limiter's linearizing step doesn't actually
@@ -258,12 +239,11 @@ void test_limiter_action_on_constant_function(
   const auto input =
       make_with_value<scalar::type>(get<0>(logical_coords), value);
   const auto element_size = tnsr::I<double, 1>{1.2};
-  const auto neighbor_sizes = make_neighbor_sizes_from_local_size(element_size);
   for (const double left : {-0.4, value, 1.2}) {
     for (const double right : {0.2, value, 0.9}) {
       test_limiter_does_not_activate_work(
-          minmod, input, make_neighbor_means(left, right), element, mesh,
-          logical_coords, element_size, neighbor_sizes);
+          minmod, input, element, mesh, logical_coords, element_size,
+          make_neighbor_packaged_data(left, right, element_size));
     }
   }
 }
@@ -278,27 +258,22 @@ void test_limiter_action_on_linear_function(
                             Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
   const auto element_size = tnsr::I<double, 1>{2.0};
-  const auto neighbor_sizes = make_neighbor_sizes_from_local_size(element_size);
 
   const auto test_limiter_activates =
-      [
-        &minmod, &element, &mesh, &logical_coords, &element_size,
-        &neighbor_sizes
-      ](const scalar::type& local_input, const double left, const double right,
-        const double expected_slope) noexcept {
+      [&minmod, &element, &mesh, &logical_coords, &element_size ](
+          const scalar::type& local_input, const double left,
+          const double right, const double expected_slope) noexcept {
     test_limiter_activates_work(
-        minmod, local_input, make_neighbor_means(left, right), element, mesh,
-        logical_coords, element_size, neighbor_sizes, expected_slope);
+        minmod, local_input, element, mesh, logical_coords, element_size,
+        make_neighbor_packaged_data(left, right, element_size), expected_slope);
   };
   const auto test_limiter_does_not_activate =
-      [
-        &minmod, &element, &mesh, &logical_coords, &element_size,
-        &neighbor_sizes
-      ](const scalar::type& local_input, const double left,
-        const double right) noexcept {
+      [&minmod, &element, &mesh, &logical_coords, &element_size ](
+          const scalar::type& local_input, const double left,
+          const double right) noexcept {
     test_limiter_does_not_activate_work(
-        minmod, local_input, make_neighbor_means(left, right), element, mesh,
-        logical_coords, element_size, neighbor_sizes);
+        minmod, local_input, element, mesh, logical_coords, element_size,
+        make_neighbor_packaged_data(left, right, element_size));
   };
 
   // With a MUSCL limiter, the largest allowed slope is half as big as for a
@@ -369,27 +344,22 @@ void test_limiter_action_on_quadratic_function(
                             Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
   const auto element_size = tnsr::I<double, 1>{2.0};
-  const auto neighbor_sizes = make_neighbor_sizes_from_local_size(element_size);
 
   const auto test_limiter_activates =
-      [
-        &minmod, &element, &mesh, &logical_coords, &element_size,
-        &neighbor_sizes
-      ](const scalar::type& local_input, const double left, const double right,
-        const double expected_slope) noexcept {
+      [&minmod, &element, &mesh, &logical_coords, &element_size ](
+          const scalar::type& local_input, const double left,
+          const double right, const double expected_slope) noexcept {
     test_limiter_activates_work(
-        minmod, local_input, make_neighbor_means(left, right), element, mesh,
-        logical_coords, element_size, neighbor_sizes, expected_slope);
+        minmod, local_input, element, mesh, logical_coords, element_size,
+        make_neighbor_packaged_data(left, right, element_size), expected_slope);
   };
   const auto test_limiter_does_not_activate =
-      [
-        &minmod, &element, &mesh, &logical_coords, &element_size,
-        &neighbor_sizes
-      ](const scalar::type& local_input, const double left,
-        const double right) noexcept {
+      [&minmod, &element, &mesh, &logical_coords, &element_size ](
+          const scalar::type& local_input, const double left,
+          const double right) noexcept {
     test_limiter_does_not_activate_work(
-        minmod, local_input, make_neighbor_means(left, right), element, mesh,
-        logical_coords, element_size, neighbor_sizes);
+        minmod, local_input, element, mesh, logical_coords, element_size,
+        make_neighbor_packaged_data(left, right, element_size));
   };
 
   const double muscl_slope_factor =
@@ -445,25 +415,24 @@ void test_limiter_action_with_tvbm_correction(
                             Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
   const auto element_size = tnsr::I<double, 1>{2.0};
-  const auto neighbor_sizes = make_neighbor_sizes_from_local_size(element_size);
 
   const auto test_limiter_activates =
-      [&element, &mesh, &logical_coords, &element_size, &neighbor_sizes ](
+      [&element, &mesh, &logical_coords, &element_size ](
           const SlopeLimiters::Minmod<1, tmpl::list<scalar>>& minmod,
           const scalar::type& local_input, const double left,
           const double right, const double expected_slope) noexcept {
     test_limiter_activates_work(
-        minmod, local_input, make_neighbor_means(left, right), element, mesh,
-        logical_coords, element_size, neighbor_sizes, expected_slope);
+        minmod, local_input, element, mesh, logical_coords, element_size,
+        make_neighbor_packaged_data(left, right, element_size), expected_slope);
   };
   const auto test_limiter_does_not_activate =
-      [&element, &mesh, &logical_coords, &element_size, &neighbor_sizes ](
+      [&element, &mesh, &logical_coords, &element_size ](
           const SlopeLimiters::Minmod<1, tmpl::list<scalar>>& minmod,
           const scalar::type& local_input, const double left,
           const double right) noexcept {
     test_limiter_does_not_activate_work(
-        minmod, local_input, make_neighbor_means(left, right), element, mesh,
-        logical_coords, element_size, neighbor_sizes);
+        minmod, local_input, element, mesh, logical_coords, element_size,
+        make_neighbor_packaged_data(left, right, element_size));
   };
 
   // Make other limiters of same type but with different TBVM constants.
@@ -503,25 +472,24 @@ void test_lambda_pin_troubled_cell_tvbm_correction(
                             Spectral::Quadrature::GaussLobatto);
   const auto logical_coords = logical_coordinates(mesh);
   const auto element_size = tnsr::I<double, 1>{2.0};
-  const auto neighbor_sizes = make_neighbor_sizes_from_local_size(element_size);
 
   const auto test_limiter_activates =
-      [&element, &mesh, &logical_coords, &element_size, &neighbor_sizes ](
+      [&element, &mesh, &logical_coords, &element_size ](
           const SlopeLimiters::Minmod<1, tmpl::list<scalar>>& minmod,
           const scalar::type& local_input, const double left,
           const double right, const double expected_slope) noexcept {
     test_limiter_activates_work(
-        minmod, local_input, make_neighbor_means(left, right), element, mesh,
-        logical_coords, element_size, neighbor_sizes, expected_slope);
+        minmod, local_input, element, mesh, logical_coords, element_size,
+        make_neighbor_packaged_data(left, right, element_size), expected_slope);
   };
   const auto test_limiter_does_not_activate =
-      [&element, &mesh, &logical_coords, &element_size, &neighbor_sizes ](
+      [&element, &mesh, &logical_coords, &element_size ](
           const SlopeLimiters::Minmod<1, tmpl::list<scalar>>& minmod,
           const scalar::type& local_input, const double left,
           const double right) noexcept {
     test_limiter_does_not_activate_work(
-        minmod, local_input, make_neighbor_means(left, right), element, mesh,
-        logical_coords, element_size, neighbor_sizes);
+        minmod, local_input, element, mesh, logical_coords, element_size,
+        make_neighbor_packaged_data(left, right, element_size));
   };
 
   const auto pi_n = SlopeLimiters::MinmodType::LambdaPiN;
@@ -579,25 +547,29 @@ void test_limiter_action_at_boundary(
   const auto input = scalar::type(func(logical_coords));
 
   // Test with element that has external lower-xi boundary
+  // Neighbor on upper-xi side has ElementId == 2
   const auto element_at_lower_xi_boundary = Element<1>{
       ElementId<1>{0}, Element<1>::Neighbors_t{{Direction<1>::upper_xi(),
                                                 make_neighbor_with_id<1>(2)}}};
   for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
     test_limiter_activates_work(
-        minmod, input, {{Direction<1>::upper_xi(), Scalar<double>{neighbor}}},
-        element_at_lower_xi_boundary, mesh, logical_coords, element_size,
-        {{Direction<1>::upper_xi(), element_size}}, 0.0);
+        minmod, input, element_at_lower_xi_boundary, mesh, logical_coords,
+        element_size,
+        {{Direction<1>::upper_xi(), {Scalar<double>{neighbor}, element_size}}},
+        0.0);
   }
 
   // Test with element that has external upper-xi boundary
+  // Neighbor on lower-xi side has ElementId == 1
   const auto element_at_upper_xi_boundary = Element<1>{
       ElementId<1>{0}, Element<1>::Neighbors_t{{Direction<1>::lower_xi(),
                                                 make_neighbor_with_id<1>(1)}}};
   for (const double neighbor : {-1.3, 3.6, 4.8, 13.2}) {
     test_limiter_activates_work(
-        minmod, input, {{Direction<1>::lower_xi(), Scalar<double>{neighbor}}},
-        element_at_upper_xi_boundary, mesh, logical_coords, element_size,
-        {{Direction<1>::lower_xi(), element_size}}, 0.0);
+        minmod, input, element_at_upper_xi_boundary, mesh, logical_coords,
+        element_size,
+        {{Direction<1>::lower_xi(), {Scalar<double>{neighbor}, element_size}}},
+        0.0);
   }
 }
 
@@ -616,29 +588,21 @@ void test_limiter_action_with_different_size_neighbor(
   const auto test_limiter_activates =
       [&minmod, &element, &mesh, &logical_coords, &element_size ](
           const scalar::type& local_input, const double left,
-          const double right,
-          const std::unordered_map<Direction<1>, tnsr::I<double, 1>>&
-              neighbor_sizes,
+          const double right, const double left_size, const double right_size,
           const double expected_slope) noexcept {
     test_limiter_activates_work(
-        minmod, local_input, make_neighbor_means(left, right), element, mesh,
-        logical_coords, element_size, neighbor_sizes, expected_slope);
+        minmod, local_input, element, mesh, logical_coords, element_size,
+        make_neighbor_packaged_data(left, right, left_size, right_size),
+        expected_slope);
   };
   const auto test_limiter_does_not_activate =
       [&minmod, &element, &mesh, &logical_coords, &element_size ](
           const scalar::type& local_input, const double left,
-          const double right,
-          const std::unordered_map<Direction<1>, tnsr::I<double, 1>>&
-              neighbor_sizes) noexcept {
+          const double right, const double left_size,
+          const double right_size) noexcept {
     test_limiter_does_not_activate_work(
-        minmod, local_input, make_neighbor_means(left, right), element, mesh,
-        logical_coords, element_size, neighbor_sizes);
-  };
-  const auto make_neighbor_sizes = [](const double left,
-                                      const double right) noexcept {
-    return std::unordered_map<Direction<1>, tnsr::I<double, 1>>{
-        {Direction<1>::lower_xi(), tnsr::I<double, 1>(left)},
-        {Direction<1>::upper_xi(), tnsr::I<double, 1>(right)}};
+        minmod, local_input, element, mesh, logical_coords, element_size,
+        make_neighbor_packaged_data(left, right, left_size, right_size));
   };
 
   const double muscl_slope_factor =
@@ -652,31 +616,28 @@ void test_limiter_action_with_different_size_neighbor(
   const auto input = scalar::type(func(logical_coords));
 
   // Establish baseline using evenly-sized elements
-  test_limiter_does_not_activate(
-      input, 0.8 - eps, 3.2 + eps,
-      make_neighbor_sizes_from_local_size(element_size));
+  test_limiter_does_not_activate(input, 0.8 - eps, 3.2 + eps, dx, dx);
 
-  const auto larger_right = make_neighbor_sizes(dx, 2.0 * dx);
+  const double larger = 2.0 * dx;
+  const double smaller = 0.5 * dx;
+
   // Larger neighbor with same mean => true reduction in slope => trigger
-  test_limiter_activates(input, 0.8 - eps, 3.2, larger_right,
+  test_limiter_activates(input, 0.8 - eps, 3.2, dx, larger,
                          0.8 * muscl_slope_factor);
   // Larger neighbor with larger mean => same slope => no trigger
-  test_limiter_does_not_activate(input, 0.8 - eps, 3.8 + eps, larger_right);
+  test_limiter_does_not_activate(input, 0.8 - eps, 3.8 + eps, dx, larger);
 
-  const auto smaller_right = make_neighbor_sizes(dx, 0.5 * dx);
   // Smaller neighbor with same mean => increased slope => no trigger
-  test_limiter_does_not_activate(input, 0.8 - eps, 3.2 + eps, smaller_right);
+  test_limiter_does_not_activate(input, 0.8 - eps, 3.2 + eps, dx, smaller);
   // Smaller neighbor with lower mean => same slope => no trigger
-  test_limiter_does_not_activate(input, 0.8 - eps, 2.9 + eps, smaller_right);
+  test_limiter_does_not_activate(input, 0.8 - eps, 2.9 + eps, dx, smaller);
 
-  const auto larger_left = make_neighbor_sizes(2.0 * dx, dx);
-  test_limiter_activates(input, 0.8, 3.2 + eps, larger_left,
+  test_limiter_activates(input, 0.8, 3.2 + eps, larger, dx,
                          0.8 * muscl_slope_factor);
-  test_limiter_does_not_activate(input, 0.2 - eps, 3.2 + eps, larger_left);
+  test_limiter_does_not_activate(input, 0.2 - eps, 3.2 + eps, larger, dx);
 
-  const auto smaller_left = make_neighbor_sizes(0.5 * dx, dx);
-  test_limiter_does_not_activate(input, 0.8 - eps, 3.2 + eps, smaller_left);
-  test_limiter_does_not_activate(input, 1.1 - eps, 3.2 + eps, smaller_left);
+  test_limiter_does_not_activate(input, 0.8 - eps, 3.2 + eps, smaller, dx);
+  test_limiter_does_not_activate(input, 1.1 - eps, 3.2 + eps, smaller, dx);
 }
 }  // namespace
 
@@ -764,7 +725,7 @@ void test_package_data_work(
     const Mesh<VolumeDim>& mesh,
     const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
     const tnsr::I<double, VolumeDim>& element_size) noexcept {
-  // To streamline the testing of the apply function, the test sets up
+  // To streamline the testing of the op() function, the test sets up
   // identical data for all components of input_vector. To better test the
   // package_data function, we first modify the input so the data
   // aren't all identical:
@@ -794,39 +755,33 @@ void test_package_data_work(
   CHECK(packaged_data.element_size_ == element_size);
 }
 
-// Helper function for testing Minmod::apply()
+// Helper function for testing Minmod::op()
 template <size_t VolumeDim>
-void test_apply_work(
+void test_work(
     const Scalar<DataVector>& input_scalar,
-    const std::unordered_map<Direction<VolumeDim>, Scalar<double>>&
-        neighbor_scalars,
-    const std::array<double, VolumeDim>& target_scalar_slope,
     const tnsr::I<DataVector, VolumeDim>& input_vector,
-    const std::unordered_map<Direction<VolumeDim>, tnsr::I<double, VolumeDim>>&
-        neighbor_vectors,
-    const std::array<std::array<double, VolumeDim>, VolumeDim>&
-        target_vector_slope,
+    const std::unordered_map<
+        Direction<VolumeDim>,
+        typename SlopeLimiters::Minmod<
+            VolumeDim, tmpl::list<scalar, vector<VolumeDim>>>::PackagedData>&
+        neighbor_data,
     const Mesh<VolumeDim>& mesh,
     const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
-    const tnsr::I<double, VolumeDim>& element_size) noexcept {
+    const tnsr::I<double, VolumeDim>& element_size,
+    const std::array<double, VolumeDim>& target_scalar_slope,
+    const std::array<std::array<double, VolumeDim>, VolumeDim>&
+        target_vector_slope) noexcept {
   auto scalar_to_limit = input_scalar;
   auto vector_to_limit = input_vector;
 
   const auto element = make_element<VolumeDim>();
-  const auto neighbor_sizes = make_neighbor_sizes_from_local_size(element_size);
   const SlopeLimiters::Minmod<VolumeDim, tmpl::list<scalar, vector<VolumeDim>>>
       minmod(SlopeLimiters::MinmodType::LambdaPi1);
-  const bool limiter_activated = minmod.apply(
-      make_not_null(&scalar_to_limit), make_not_null(&vector_to_limit),
-      neighbor_scalars, neighbor_vectors, element, mesh, logical_coords,
-      element_size, neighbor_sizes);
+  const bool limiter_activated =
+      minmod(make_not_null(&scalar_to_limit), make_not_null(&vector_to_limit),
+             element, mesh, logical_coords, element_size, neighbor_data);
 
   CHECK(limiter_activated);
-
-  CAPTURE(input_scalar);
-  CAPTURE(scalar_to_limit);
-  CAPTURE(neighbor_scalars);
-  CAPTURE(target_scalar_slope);
 
   const auto expected_limiter_output = [&logical_coords, &mesh ](
       const DataVector& input,
@@ -837,8 +792,6 @@ void test_apply_work(
     }
     return result;
   };
-
-  CAPTURE(expected_limiter_output(get(input_scalar), target_scalar_slope));
 
   CHECK_ITERABLE_APPROX(
       get(scalar_to_limit),
@@ -857,7 +810,7 @@ SPECTRE_TEST_CASE(
     "[SlopeLimiters][Unit]") {
   // The goals of this test are,
   // 1. check Minmod::package_data
-  // 2. check that Minmod::apply limits different tensors independently
+  // 2. check that Minmod::op() limits different tensors independently
   // See comments in the 3D test for full details.
   //
   // a. Generate data to fill all tensor components.
@@ -880,29 +833,34 @@ SPECTRE_TEST_CASE(
                          element_size);
 
   // b. Generate neighbor data for the scalar and vector Tensors.
+  std::unordered_map<
+      Direction<1>,
+      SlopeLimiters::Minmod<1, tmpl::list<scalar, vector<1>>>::PackagedData>
+      neighbor_data{};
+  neighbor_data[Direction<1>::lower_xi()].element_size_ = element_size;
+  neighbor_data[Direction<1>::upper_xi()].element_size_ = element_size;
+
   // The scalar we treat as a shock: we want the slope to be reduced
   const auto target_scalar_slope = std::array<double, 1>{{1.2}};
-  const auto neighbor_scalars =
-      std::unordered_map<Direction<1>, Scalar<double>>{
-          {Direction<1>::lower_xi(),
-           Scalar<double>(mean - target_scalar_slope[0])},
-          {Direction<1>::upper_xi(),
-           Scalar<double>(mean + target_scalar_slope[0])},
-      };
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<1>::lower_xi()].means_) =
+      Scalar<double>(mean - target_scalar_slope[0]);
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<1>::upper_xi()].means_) =
+      Scalar<double>(mean + target_scalar_slope[0]);
 
   // The vector x-component we treat as a smooth function: no limiter action
   const auto target_vector_slope =
       std::array<std::array<double, 1>, 1>{{true_slope}};
-  const auto neighbor_vectors =
-      std::unordered_map<Direction<1>, tnsr::I<double, 1>>{
-          {Direction<1>::lower_xi(),
-           tnsr::I<double, 1>{{{mean - 2.0 * true_slope[0]}}}},
-          {Direction<1>::upper_xi(),
-           tnsr::I<double, 1>{{{mean + 2.0 * true_slope[0]}}}}};
+  get<Minmod_detail::to_tensor_double<vector<1>>>(
+      neighbor_data[Direction<1>::lower_xi()].means_) =
+      tnsr::I<double, 1>(mean - 2.0 * true_slope[0]);
+  get<Minmod_detail::to_tensor_double<vector<1>>>(
+      neighbor_data[Direction<1>::upper_xi()].means_) =
+      tnsr::I<double, 1>(mean + 2.0 * true_slope[0]);
 
-  test_apply_work(input_scalar, neighbor_scalars, target_scalar_slope,
-                  input_vector, neighbor_vectors, target_vector_slope, mesh,
-                  logical_coords, element_size);
+  test_work(input_scalar, input_vector, neighbor_data, mesh, logical_coords,
+            element_size, target_scalar_slope, target_vector_slope);
 }
 
 SPECTRE_TEST_CASE(
@@ -910,8 +868,8 @@ SPECTRE_TEST_CASE(
     "[SlopeLimiters][Unit]") {
   // The goals of this test are,
   // 1. check Minmod::package_data
-  // 2. check that Minmod::apply limits different tensors independently
-  // 3. check that Minmod::apply limits different dimensions independently
+  // 2. check that Minmod::op() limits different tensors independently
+  // 3. check that Minmod::op() limits different dimensions independently
   // See comments in the 3D test for full details.
   //
   // a. Generate data to fill all tensor components.
@@ -937,18 +895,33 @@ SPECTRE_TEST_CASE(
                          element_size);
 
   // b. Generate neighbor data for the scalar and vector Tensors.
+  std::unordered_map<
+      Direction<2>,
+      SlopeLimiters::Minmod<2, tmpl::list<scalar, vector<2>>>::PackagedData>
+      neighbor_data{};
+  neighbor_data[Direction<2>::lower_xi()].element_size_ = element_size;
+  neighbor_data[Direction<2>::upper_xi()].element_size_ = element_size;
+  neighbor_data[Direction<2>::lower_eta()].element_size_ = element_size;
+  neighbor_data[Direction<2>::upper_eta()].element_size_ = element_size;
+
   // The scalar we treat as a 3D shock: we want each slope to be reduced
   const auto target_scalar_slope = std::array<double, 2>{{1.2, -2.2}};
   const auto neighbor_scalar_func = [&mean, &target_scalar_slope](
                                         const size_t dim, const int sign) {
     return Scalar<double>(mean + sign * gsl::at(target_scalar_slope, dim));
   };
-  const auto neighbor_scalars =
-      std::unordered_map<Direction<2>, Scalar<double>>{
-          {Direction<2>::lower_xi(), neighbor_scalar_func(0, -1)},
-          {Direction<2>::upper_xi(), neighbor_scalar_func(0, 1)},
-          {Direction<2>::lower_eta(), neighbor_scalar_func(1, -1)},
-          {Direction<2>::upper_eta(), neighbor_scalar_func(1, 1)}};
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<2>::lower_xi()].means_) =
+      neighbor_scalar_func(0, -1);
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<2>::upper_xi()].means_) =
+      neighbor_scalar_func(0, 1);
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<2>::lower_eta()].means_) =
+      neighbor_scalar_func(1, -1);
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<2>::upper_eta()].means_) =
+      neighbor_scalar_func(1, 1);
 
   // The vector we treat differently in each component, to check the limiter
   // acts independently on each:
@@ -969,16 +942,21 @@ SPECTRE_TEST_CASE(
         {{mean + sign * gsl::at(neighbor_vector_slope[0], dim),
           mean + sign * gsl::at(neighbor_vector_slope[1], dim)}}};
   };
-  const auto neighbor_vectors =
-      std::unordered_map<Direction<2>, tnsr::I<double, 2>>{
-          {Direction<2>::lower_xi(), neighbor_vector_func(0, -1)},
-          {Direction<2>::upper_xi(), neighbor_vector_func(0, 1)},
-          {Direction<2>::lower_eta(), neighbor_vector_func(1, -1)},
-          {Direction<2>::upper_eta(), neighbor_vector_func(1, 1)}};
+  get<Minmod_detail::to_tensor_double<vector<2>>>(
+      neighbor_data[Direction<2>::lower_xi()].means_) =
+      neighbor_vector_func(0, -1);
+  get<Minmod_detail::to_tensor_double<vector<2>>>(
+      neighbor_data[Direction<2>::upper_xi()].means_) =
+      neighbor_vector_func(0, 1);
+  get<Minmod_detail::to_tensor_double<vector<2>>>(
+      neighbor_data[Direction<2>::lower_eta()].means_) =
+      neighbor_vector_func(1, -1);
+  get<Minmod_detail::to_tensor_double<vector<2>>>(
+      neighbor_data[Direction<2>::upper_eta()].means_) =
+      neighbor_vector_func(1, 1);
 
-  test_apply_work(input_scalar, neighbor_scalars, target_scalar_slope,
-                  input_vector, neighbor_vectors, target_vector_slope, mesh,
-                  logical_coords, element_size);
+  test_work(input_scalar, input_vector, neighbor_data, mesh, logical_coords,
+            element_size, target_scalar_slope, target_vector_slope);
 }
 
 SPECTRE_TEST_CASE(
@@ -986,14 +964,14 @@ SPECTRE_TEST_CASE(
     "[SlopeLimiters][Unit]") {
   // The goals of this test are,
   // 1. check Minmod::package_data
-  // 2. check that Minmod::apply limits different tensors independently
-  // 3. check that Minmod::apply limits different dimensions independently
+  // 2. check that Minmod::op() limits different tensors independently
+  // 3. check that Minmod::op() limits different dimensions independently
   //
   // The steps taken to meet these goals are:
   // a. set up values in two Tensor<DataVector>s, one scalar and one vector,
   //    then test that Minmod::package_data has correct output
   // b. set up neighbor values for these two tensors, then test that
-  //    Minmod::apply has correct output
+  //    Minmod::op() has correct output
   //
   // These steps are detailed through the test.
   //
@@ -1025,6 +1003,17 @@ SPECTRE_TEST_CASE(
                          element_size);
 
   // b. Generate neighbor data for the scalar and vector Tensors.
+  std::unordered_map<
+      Direction<3>,
+      SlopeLimiters::Minmod<3, tmpl::list<scalar, vector<3>>>::PackagedData>
+      neighbor_data{};
+  neighbor_data[Direction<3>::lower_xi()].element_size_ = element_size;
+  neighbor_data[Direction<3>::upper_xi()].element_size_ = element_size;
+  neighbor_data[Direction<3>::lower_eta()].element_size_ = element_size;
+  neighbor_data[Direction<3>::upper_eta()].element_size_ = element_size;
+  neighbor_data[Direction<3>::lower_zeta()].element_size_ = element_size;
+  neighbor_data[Direction<3>::upper_zeta()].element_size_ = element_size;
+
   // The scalar we treat as a 3D shock: we want each slope to be reduced
   const auto target_scalar_slope = std::array<double, 3>{{1.2, -2.2, 0.1}};
   // This function generates the desired neighbor mean value by extrapolating
@@ -1038,14 +1027,24 @@ SPECTRE_TEST_CASE(
     // because the center-to-center distance to the neighbor element is 2.0:
     return Scalar<double>(mean + sign * gsl::at(target_scalar_slope, dim));
   };
-  const auto neighbor_scalars =
-      std::unordered_map<Direction<3>, Scalar<double>>{
-          {Direction<3>::lower_xi(), neighbor_scalar_func(0, -1)},
-          {Direction<3>::upper_xi(), neighbor_scalar_func(0, 1)},
-          {Direction<3>::lower_eta(), neighbor_scalar_func(1, -1)},
-          {Direction<3>::upper_eta(), neighbor_scalar_func(1, 1)},
-          {Direction<3>::lower_zeta(), neighbor_scalar_func(2, -1)},
-          {Direction<3>::upper_zeta(), neighbor_scalar_func(2, 1)}};
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<3>::lower_xi()].means_) =
+      neighbor_scalar_func(0, -1);
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<3>::upper_xi()].means_) =
+      neighbor_scalar_func(0, 1);
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<3>::lower_eta()].means_) =
+      neighbor_scalar_func(1, -1);
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<3>::upper_eta()].means_) =
+      neighbor_scalar_func(1, 1);
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<3>::lower_zeta()].means_) =
+      neighbor_scalar_func(2, -1);
+  get<Minmod_detail::to_tensor_double<scalar>>(
+      neighbor_data[Direction<3>::upper_zeta()].means_) =
+      neighbor_scalar_func(2, 1);
 
   // The vector we treat differently in each component, to verify that the
   // limiter acts independently on each:
@@ -1075,16 +1074,25 @@ SPECTRE_TEST_CASE(
           mean + sign * gsl::at(neighbor_vector_slope[1], dim),
           mean - 1.1 - dim - sign}}};  // arbitrary, but smaller than mean
   };
-  const auto neighbor_vectors =
-      std::unordered_map<Direction<3>, tnsr::I<double, 3>>{
-          {Direction<3>::lower_xi(), neighbor_vector_func(0, -1)},
-          {Direction<3>::upper_xi(), neighbor_vector_func(0, 1)},
-          {Direction<3>::lower_eta(), neighbor_vector_func(1, -1)},
-          {Direction<3>::upper_eta(), neighbor_vector_func(1, 1)},
-          {Direction<3>::lower_zeta(), neighbor_vector_func(2, -1)},
-          {Direction<3>::upper_zeta(), neighbor_vector_func(2, 1)}};
+  get<Minmod_detail::to_tensor_double<vector<3>>>(
+      neighbor_data[Direction<3>::lower_xi()].means_) =
+      neighbor_vector_func(0, -1);
+  get<Minmod_detail::to_tensor_double<vector<3>>>(
+      neighbor_data[Direction<3>::upper_xi()].means_) =
+      neighbor_vector_func(0, 1);
+  get<Minmod_detail::to_tensor_double<vector<3>>>(
+      neighbor_data[Direction<3>::lower_eta()].means_) =
+      neighbor_vector_func(1, -1);
+  get<Minmod_detail::to_tensor_double<vector<3>>>(
+      neighbor_data[Direction<3>::upper_eta()].means_) =
+      neighbor_vector_func(1, 1);
+  get<Minmod_detail::to_tensor_double<vector<3>>>(
+      neighbor_data[Direction<3>::lower_zeta()].means_) =
+      neighbor_vector_func(2, -1);
+  get<Minmod_detail::to_tensor_double<vector<3>>>(
+      neighbor_data[Direction<3>::upper_zeta()].means_) =
+      neighbor_vector_func(2, 1);
 
-  test_apply_work(input_scalar, neighbor_scalars, target_scalar_slope,
-                  input_vector, neighbor_vectors, target_vector_slope, mesh,
-                  logical_coords, element_size);
+  test_work(input_scalar, input_vector, neighbor_data, mesh, logical_coords,
+            element_size, target_scalar_slope, target_vector_slope);
 }


### PR DESCRIPTION
## Proposed changes

Updates the interface of Minmod to match the interfaces expected by the SendData and Limit actions (these were added in PR #963). This mostly involves reordering and repacking arguments.

Adds a test that Minmod can be compiled together with the limiter actions.

Commit order:
  1. Fix incorrect ElementIds in Minmod test
  2. Clean up type aliases in LimiterActions test
  3. Rewrite Minmod's packaging function
  4. Rewrite Minmod's operator()
  5. Index Minmod neighbor data by pair<Direction, ElementId>
  6. Add size_of_element and test
  7. Update Minmod to match size_of_element return type
  8. Add limiter action type aliases to Minmod
  9. Add test that compiles limiter actions with Minmod

[Edited to update commit order]

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).