### PR TITLE
Add InterpolationTarget and InitializeInterpolationTarget.

### DIFF
--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -48,6 +48,15 @@ struct DomainCreator {
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
+/// The ::Domain.
+template <size_t VolumeDim, typename Frame>
+struct Domain : db::SimpleTag {
+  static std::string name() noexcept { return "Domain"; }
+  using type = ::Domain<VolumeDim, Frame>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
 /// The ::Element associated with the DataBox
 template <size_t VolumeDim>
 struct Element : db::SimpleTag {

--- a/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace intrp {
+
+/// Holds Actions for Interpolator and InterpolationTarget.
+namespace Actions {
+
+/// \ingroup ActionsGroup
+/// \brief Initializes an InterpolationTarget
+///
+/// Uses: nothing
+///
+/// DataBox changes:
+/// - Adds:
+///   - `Tags::IndicesOfFilledInterpPoints`
+///   - `Tags::TemporalIds<Metavariables>`
+///   - `::Tags::Domain<`VolumeDim`, Frame>`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+/// - Removes: nothing
+/// - Modifies: nothing
+///
+/// For requirements on InterpolationTargetTag, see InterpolationTarget
+template <typename InterpolationTargetTag>
+struct InitializeInterpolationTarget {
+  /// For requirements on Metavariables, see InterpolationTarget
+  template <typename Metavariables, size_t VolumeDim, typename Frame>
+  using return_tag_list = tmpl::list<
+      Tags::IndicesOfFilledInterpPoints, Tags::TemporalIds<Metavariables>,
+      ::Tags::Domain<VolumeDim, Frame>,
+      ::Tags::Variables<
+          typename InterpolationTargetTag::vars_to_interpolate_to_target>>;
+  template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent, size_t VolumeDim,
+            typename Frame>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    Domain<VolumeDim, Frame>&& domain) noexcept {
+    return std::make_tuple(db::create<db::get_items<return_tag_list<
+                               Metavariables, VolumeDim, Frame>>>(
+        db::item_type<Tags::IndicesOfFilledInterpPoints>{},
+        db::item_type<Tags::TemporalIds<Metavariables>>{}, std::move(domain),
+        db::item_type<::Tags::Variables<typename InterpolationTargetTag::
+                                            vars_to_interpolate_to_target>>{}));
+  }
+};
+
+}  // namespace Actions
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/DomainCreator.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace intrp {
+namespace Actions {
+template <typename InterpolationTargetTag>
+struct InitializeInterpolationTarget;
+}  // namespace Actions
+}  // namespace intrp
+/// \endcond
+
+namespace intrp {
+
+/// \brief ParallelComponent representing a set of points to be interpolated
+/// to and a function to call upon interpolation to those points.
+///
+/// Each InterpolationTarget will communicate with the `Interpolator`.
+///
+/// `InterpolationTargetTag` must contain the following type aliases:
+/// - vars_to_interpolate_to_target: a `tmpl::list` of tags describing
+///                                  variables to interpolate.  Will be used
+///                                  to construct a `Variables`.
+/// - compute_items_on_source:       a `tmpl::list` of compute items that uses
+///                                  `Metavariables::interpolator_source_vars`
+///                                  as input and computes the `Variables`
+///                                  defined by `vars_to_interpolate_to_target`.
+/// - compute_items_on_target:       a `tmpl::list` of compute items that uses
+///                                 `vars_to_interpolate_to_target` as input.
+/// - compute_target_points:         a `simple_action` of `InterpolationTarget`
+///                                  that computes the target points and
+///                                  sends them to `Interpolators`.
+///                                  It takes a `temporal_id` as an extra
+///                                  argument.
+/// - post_interpolation_callback:   a struct with a function
+///```
+///       static void apply(const DataBox<DbTags>&,
+///                         const intrp::ConstGlobalCache<Metavariables>&,
+///                         const Metavariables::temporal_id&) noexcept;
+///```
+///                                  that will be called when interpolation
+///                                  is complete. `DbTags` includes everything
+///                                  in `vars_to_interpolate_to_target`
+///                                  and `compute_items_on_target`.
+///
+/// `Metavariables` must contain the following type aliases:
+/// - interpolator_source_vars:   a `tmpl::list` of tags that define a
+///                               `Variables` sent from all `Element`s
+///                               to the local `Interpolator`.
+/// - interpolation_target_tags:  a `tmpl::list` of all
+///                               `InterpolationTargetTag`s.
+/// - temporal_id:                the type held by ::intrp::Tags::TemporalIds.
+template <class Metavariables, typename InterpolationTargetTag,
+          size_t VolumeDim, typename Frame>
+struct InterpolationTarget {
+  using chare_type = ::Parallel::Algorithms::Singleton;
+  using metavariables = Metavariables;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename Actions::InitializeInterpolationTarget<InterpolationTargetTag>::
+          template return_tag_list<Metavariables, VolumeDim, Frame>>;
+  using options = tmpl::list<::OptionTags::DomainCreator<VolumeDim, Frame>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<metavariables>& global_cache,
+      std::unique_ptr<DomainCreator<VolumeDim, Frame>> domain_creator) noexcept;
+  static void execute_next_phase(
+      typename metavariables::Phase /*next_phase*/,
+      const Parallel::CProxy_ConstGlobalCache<metavariables>&
+      /*global_cache*/) noexcept {}
+};
+
+template <class Metavariables, typename InterpolationTargetTag>
+template <size_t VolumeDim, typename Frame>
+void InterpolationTarget<Metavariables, InterpolationTargetTag>::initialize(
+    Parallel::CProxy_ConstGlobalCache<metavariables>& global_cache,
+    std::unique_ptr<DomainCreator<VolumeDim, Frame>> domain_creator) noexcept {
+  auto& my_proxy = Parallel::get_parallel_component<InterpolationTarget>(
+      *(global_cache.ckLocalBranch()));
+  Parallel::simple_action<
+      Actions::InitializeInterpolationTarget<InterpolationTargetTag>>(
+      my_proxy, domain_creator->create_domain());
+}
+
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <string>
+#include <unordered_set>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+
+/// \cond
+template <size_t Dim, typename Frame>
+class Domain;
+/// \endcond
+
+namespace intrp {
+
+/// Tags for items held in the DataBox of InterpolationTarget or Interpolator.
+namespace Tags {
+
+/// Keeps track of which points have been filled with interpolated data.
+struct IndicesOfFilledInterpPoints : db::SimpleTag {
+  static std::string name() noexcept { return "IndicesOfFilledInterpPoints"; }
+  using type = std::unordered_set<size_t>;
+};
+
+/// TemporalIds on which to interpolate.
+template <typename Metavariables>
+struct TemporalIds : db::SimpleTag {
+  using type = std::deque<typename Metavariables::temporal_id>;
+  static std::string name() noexcept { return "TemporalIds"; }
+};
+
+}  // namespace Tags
+}  // namespace intrp

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -24,6 +24,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Domain/Tags.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/MakeVector.hpp"
@@ -34,6 +35,8 @@
 namespace {
 void test_1d_domains() {
   {
+    CHECK(Tags::Domain<1, Frame::Logical>::name() == "Domain");
+    CHECK(Tags::Domain<1, Frame::Inertial>::name() == "Domain");
     PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
                                          CoordinateMaps::Affine>));
 
@@ -195,6 +198,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear1D1", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear2D", "[Domain][Unit]") {
+  CHECK(Tags::Domain<2, Frame::Inertial>::name() == "Domain");
   const OrientationMap<2> half_turn{std::array<Direction<2>, 2>{
       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}};
   const OrientationMap<2> quarter_turn_cw{std::array<Direction<2>, 2>{
@@ -239,6 +243,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear2D", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear3D", "[Domain][Unit]") {
+  CHECK(Tags::Domain<3, Frame::Inertial>::name() == "Domain");
   const OrientationMap<3> aligned{};
   const OrientationMap<3> quarter_turn_cw_xi{std::array<Direction<3>, 3>{
       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_NumericalInterpolation")
 
 set(LIBRARY_SOURCES
   Test_BarycentricRational.cpp
+  Test_InitializeInterpolationTarget.cpp
   Test_IrregularInterpolant.cpp
   Test_LagrangePolynomial.cpp
   )

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -1,0 +1,114 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <deque>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/Shell.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+/// \cond
+class DataVector;
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+namespace Tags {
+template <size_t Dim, typename Frame>
+struct Domain;
+}  // namespace Tags
+/// \endcond
+
+namespace {
+
+template <typename Metavariables, typename InterpolationTargetTag>
+struct mock_interpolation_target {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename ::intrp::Actions::InitializeInterpolationTarget<
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
+                                                            ::Frame::Inertial>>;
+};
+
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::Lapse<DataVector>>;
+  };
+  using temporal_id = Time;
+
+  using component_list = tmpl::list<
+      mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialize, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.Initialize",
+                  "[Unit]") {
+  using metavars = MockMetavariables;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  using TupleOfMockDistributedObjects =
+      MockRuntimeSystem::TupleOfMockDistributedObjects;
+  TupleOfMockDistributedObjects dist_objects{};
+  using MockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolation_target<metavars, metavars::InterpolationTargetA>>;
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
+      .emplace(0,
+               ActionTesting::MockDistributedObject<mock_interpolation_target<
+                   metavars, metavars::InterpolationTargetA>>{});
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
+
+  const auto domain_creator =
+      DomainCreators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+
+  runner.simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
+      ::intrp::Actions::InitializeInterpolationTarget<
+          metavars::InterpolationTargetA>>(0, domain_creator.create_domain());
+
+  const auto& box =
+      runner
+          .template algorithms<mock_interpolation_target<
+              metavars, metavars::InterpolationTargetA>>()
+          .at(0)
+          .template get_databox<typename mock_interpolation_target<
+              metavars, metavars::InterpolationTargetA>::initial_databox>();
+
+  CHECK(db::get<::intrp::Tags::IndicesOfFilledInterpPoints>(box).empty());
+  CHECK(db::get<::intrp::Tags::TemporalIds<metavars>>(box).empty());
+
+  CHECK(db::get<::Tags::Domain<3, Frame::Inertial>>(box) ==
+        domain_creator.create_domain());
+
+  const auto test_vars = db::item_type<
+      ::Tags::Variables<tmpl::list<gr::Tags::Lapse<DataVector>>>>{};
+  CHECK(db::get<::Tags::Variables<typename metavars::InterpolationTargetA::
+                                      vars_to_interpolate_to_target>>(box) ==
+        test_vars);
+
+  CHECK(::intrp::Tags::IndicesOfFilledInterpPoints::name() ==
+        "IndicesOfFilledInterpPoints");
+  CHECK(::intrp::Tags::TemporalIds<metavars>::name() == "TemporalIds");
+}
+
+}  // namespace


### PR DESCRIPTION
This is one of several PRs that will implement parallel interpolation.
Each InterpolationTarget will be able to tell the Interpolator which points
to interpolate to, and then will have a callback function that will
be called on those interpolated points.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
