### PR TITLE
Make Travis fail on doxygen warnings

### DIFF
--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -44,7 +44,7 @@ fi
 # can search the file for warnings
 if [ ${BUILD_DOC} ]; then
     make doc | tee doxygen.log
-    ! grep 'warning' ./doxygen.log
+    grep 'warning' ./doxygen.log && exit 1
 fi
 
 # Build the code and run tests


### PR DESCRIPTION
`bash -e` only causes failures under some circumstances.  Most of the
exceptions make obvious sense (the test in an "if", for example), but
one odd one is commands being inverted with a "!".

Fixes #987

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
