### PR TITLE
Rename variables_tags to variables_tag for consistency.

### DIFF
--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Hll.hpp
@@ -67,7 +67,7 @@ template <typename System>
 struct Hll {
  private:
   using char_speeds_tag = typename System::char_speeds_tag;
-  using variables_tags = typename System::variables_tags;
+  using variables_tag = typename System::variables_tag;
 
  public:
   /// The minimum signal velocity bounding
@@ -86,13 +86,13 @@ struct Hll {
 
   using package_tags =
       tmpl::push_back<tmpl::append<db::split_tag<db::add_tag_prefix<
-                                       ::Tags::NormalDotFlux, variables_tags>>,
-                                   db::split_tag<variables_tags>>,
+                                       ::Tags::NormalDotFlux, variables_tag>>,
+                                   db::split_tag<variables_tag>>,
                       MinSignalSpeed, MaxSignalSpeed>;
 
   using argument_tags = tmpl::append<
-      db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux, variables_tags>>,
-      db::split_tag<variables_tags>, char_speeds_tag>;
+      db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux, variables_tag>>,
+      db::split_tag<variables_tag>, char_speeds_tag>;
 
  private:
   template <typename VariablesTagList, typename NormalDoFluxTagList>
@@ -200,19 +200,19 @@ struct Hll {
   template <class... Args>
   void package_data(const Args&... args) const noexcept {
     package_data_helper<
-        db::split_tag<variables_tags>,
+        db::split_tag<variables_tag>,
         db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux,
-                                         variables_tags>>>::function(args...);
+                                         variables_tag>>>::function(args...);
   }
 
   template <class... Args>
   void operator()(const Args&... args) const noexcept {
     call_operator_helper<
         db::split_tag<
-            db::add_tag_prefix<::Tags::NormalDotNumericalFlux, variables_tags>>,
-        db::split_tag<variables_tags>,
+            db::add_tag_prefix<::Tags::NormalDotNumericalFlux, variables_tag>>,
+        db::split_tag<variables_tag>,
         db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux,
-                                         variables_tags>>>::function(args...);
+                                         variables_tag>>>::function(args...);
   }
 };
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp
@@ -43,7 +43,7 @@ template <typename System>
 struct LocalLaxFriedrichs {
  private:
   using char_speeds_tag = typename System::char_speeds_tag;
-  using variables_tags = typename System::variables_tags;
+  using variables_tag = typename System::variables_tag;
 
  public:
   // The maximum characteristic speed modulus on one side of the interface.
@@ -54,13 +54,13 @@ struct LocalLaxFriedrichs {
 
   using package_tags =
       tmpl::push_back<tmpl::append<db::split_tag<db::add_tag_prefix<
-                                       ::Tags::NormalDotFlux, variables_tags>>,
-                                   db::split_tag<variables_tags>>,
+                                       ::Tags::NormalDotFlux, variables_tag>>,
+                                   db::split_tag<variables_tag>>,
                       MaxAbsCharSpeed>;
 
   using argument_tags = tmpl::append<
-      db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux, variables_tags>>,
-      db::split_tag<variables_tags>, char_speeds_tag>;
+      db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux, variables_tag>>,
+      db::split_tag<variables_tag>, char_speeds_tag>;
 
  private:
   template <typename VariablesTagList, typename NormalDoFluxTagList>
@@ -153,19 +153,19 @@ struct LocalLaxFriedrichs {
   template <class... Args>
   void package_data(const Args&... args) const noexcept {
     package_data_helper<
-        db::split_tag<variables_tags>,
+        db::split_tag<variables_tag>,
         db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux,
-                                         variables_tags>>>::function(args...);
+                                         variables_tag>>>::function(args...);
   }
 
   template <class... Args>
   void operator()(const Args&... args) const noexcept {
     call_operator_helper<
         db::split_tag<
-            db::add_tag_prefix<::Tags::NormalDotNumericalFlux, variables_tags>>,
-        db::split_tag<variables_tags>,
+            db::add_tag_prefix<::Tags::NormalDotNumericalFlux, variables_tag>>,
+        db::split_tag<variables_tag>,
         db::split_tag<db::add_tag_prefix<::Tags::NormalDotFlux,
-                                         variables_tags>>>::function(args...);
+                                         variables_tag>>>::function(args...);
   }
 };
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/TestHelpers.hpp
@@ -71,7 +71,7 @@ std::array<DataVector, (Dim + 1) * (Dim + 1)> characteristic_speeds(
 template <size_t Dim>
 struct System {
   static constexpr size_t volume_dim = Dim;
-  using variables_tags =
+  using variables_tag =
       ::Tags::Variables<tmpl::list<Tags::Variable1, Tags::Variable2<Dim>,
                                    Tags::Variable3<Dim>, Tags::Variable4<Dim>>>;
   using char_speeds_tag = Tags::CharacteristicSpeeds<Dim>;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_Hll.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_Hll.cpp
@@ -32,7 +32,7 @@ void test_hll_flux_tags() noexcept {
       cpp17::is_same_v<typename hll_flux::argument_tags,
                        tmpl::push_back<tmpl::append<
                            TestHelpers::NumericalFluxes::n_dot_f_tags<Dim>,
-                           db::split_tag<typename system::variables_tags>,
+                           db::split_tag<typename system::variables_tag>,
                            typename system::char_speeds_tag>>>,
       "Failed testing dg::NumericalFluxes::Hll::argument_tags");
 
@@ -41,7 +41,7 @@ void test_hll_flux_tags() noexcept {
           typename hll_flux::package_tags,
           tmpl::push_back<
               tmpl::append<TestHelpers::NumericalFluxes::n_dot_f_tags<Dim>,
-                           db::split_tag<typename system::variables_tags>>,
+                           db::split_tag<typename system::variables_tag>>,
               typename hll_flux::MinSignalSpeed,
               typename hll_flux::MaxSignalSpeed>>,
       "Failed testing dg::NumericalFluxes::Hll::package_tags");

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_LocalLaxFriedrichs.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/Test_LocalLaxFriedrichs.cpp
@@ -32,7 +32,7 @@ void test_llf_flux_tags() noexcept {
       cpp17::is_same_v<typename llf_flux::argument_tags,
                        tmpl::push_back<tmpl::append<
                            TestHelpers::NumericalFluxes::n_dot_f_tags<Dim>,
-                           db::split_tag<typename system::variables_tags>,
+                           db::split_tag<typename system::variables_tag>,
                            typename system::char_speeds_tag>>>,
       "Failed testing dg::NumericalFluxes::LocalLaxFriedrichs::argument_tags");
 
@@ -41,7 +41,7 @@ void test_llf_flux_tags() noexcept {
           typename llf_flux::package_tags,
           tmpl::push_back<
               tmpl::append<TestHelpers::NumericalFluxes::n_dot_f_tags<Dim>,
-                           db::split_tag<typename system::variables_tags>>,
+                           db::split_tag<typename system::variables_tag>>,
               typename llf_flux::MaxAbsCharSpeed>>,
       "Failed testing dg::NumericalFluxes::LocalLaxFriedrichs::package_tags");
 }


### PR DESCRIPTION
## Proposed changes

Rename `variables_tags` to `variables_tag` to be consistent with other uses of `varaiables_tag`

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
