### PR TITLE
Reduction observers

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/DgElementArray.hpp
@@ -107,7 +107,7 @@ struct DgElementArray {
       // at specific times.
       const size_t fake_temporal_id = 0;
       Parallel::simple_action<observers::Actions::RegisterWithObservers<
-          observers::TypeOfObservation::Volume>>(
+          observers::TypeOfObservation::ReductionAndVolume>>(
           Parallel::get_parallel_component<DgElementArray>(local_cache),
           fake_temporal_id);
     }

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -32,6 +32,7 @@
 #include "Time/Actions/UpdateU.hpp"                // IWYU pragma: keep
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Functional.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -59,6 +60,13 @@ struct EvolutionMetavars {
   // metavariables
   using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
   using domain_creator_tag = OptionTags::DomainCreator<Dim, Frame::Inertial>;
+
+  using Redum = Parallel::ReductionDatum<double, funcl::Plus<>,
+                                         funcl::Sqrt<funcl::Divides<>>,
+                                         std::index_sequence<1>>;
+  using reduction_data_tags = tmpl::list<observers::Tags::ReductionData<
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<size_t, funcl::Plus<>>, Redum, Redum>>;
 
   using component_list = tmpl::list<
       observers::Observer<EvolutionMetavars>,

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -49,7 +49,7 @@ struct Initialize {
 struct InitializeWriter {
   using simple_tags =
       db::AddSimpleTags<Tags::TensorData, Tags::VolumeObserversContributed,
-                        Tags::ReductionFileLock, Tags::VolumeFileLock>;
+                        Tags::H5FileLock>;
   using compute_tags = db::AddComputeTags<>;
 
   using return_tag_list = tmpl::append<simple_tags, compute_tags>;
@@ -65,7 +65,7 @@ struct InitializeWriter {
     return std::make_tuple(db::create<simple_tags>(
         db::item_type<Tags::TensorData>{},
         db::item_type<Tags::VolumeObserversContributed>{},
-        Parallel::create_lock(), Parallel::create_lock()));
+        Parallel::create_lock()));
   }
 };
 }  // namespace Actions

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -15,30 +15,50 @@
 
 namespace observers {
 namespace Actions {
+namespace detail {
+template <class Tag>
+using reduction_data_to_reduction_names = typename Tag::names_tag;
+}  // namespace detail
 /*!
  * \brief Initializes the DataBox on the observer parallel component
  */
+template <class Metavariables>
 struct Initialize {
-  using simple_tags =
+  using simple_tags = tmpl::append<
       db::AddSimpleTags<Tags::NumberOfEvents, Tags::ReductionArrayComponentIds,
-                        Tags::VolumeArrayComponentIds, Tags::TensorData>;
+                        Tags::VolumeArrayComponentIds, Tags::TensorData,
+                        Tags::ReductionObserversContributed>,
+      typename Metavariables::reduction_data_tags,
+      tmpl::transform<
+          typename Metavariables::reduction_data_tags,
+          tmpl::bind<detail::reduction_data_to_reduction_names, tmpl::_1>>>;
   using compute_tags = db::AddComputeTags<>;
 
   using return_tag_list = tmpl::append<simple_tags, compute_tags>;
 
-  template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
-            typename ActionList, typename ParallelComponent>
+  template <typename... InboxTags, typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
   static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
+    return helper(typename Metavariables::reduction_data_tags{});
+  }
+
+ private:
+  template <typename... ReductionTags>
+  static auto helper(tmpl::list<ReductionTags...> /*meta*/) noexcept {
     return std::make_tuple(db::create<simple_tags>(
         db::item_type<Tags::NumberOfEvents>{},
         db::item_type<Tags::ReductionArrayComponentIds>{},
         db::item_type<Tags::VolumeArrayComponentIds>{},
-        db::item_type<Tags::TensorData>{}));
+        db::item_type<Tags::TensorData>{},
+        db::item_type<Tags::ReductionObserversContributed>{},
+        db::item_type<ReductionTags>{}...,
+        db::item_type<
+            detail::reduction_data_to_reduction_names<ReductionTags>>{}...));
   }
 };
 
@@ -46,26 +66,40 @@ struct Initialize {
  * \brief Initializes the DataBox of the observer parallel component that writes
  * to disk.
  */
+template <class Metavariables>
 struct InitializeWriter {
-  using simple_tags =
+  using simple_tags = tmpl::append<
       db::AddSimpleTags<Tags::TensorData, Tags::VolumeObserversContributed,
-                        Tags::H5FileLock>;
+                        Tags::ReductionObserversContributed, Tags::H5FileLock>,
+      typename Metavariables::reduction_data_tags,
+      tmpl::transform<
+          typename Metavariables::reduction_data_tags,
+          tmpl::bind<detail::reduction_data_to_reduction_names, tmpl::_1>>>;
   using compute_tags = db::AddComputeTags<>;
 
   using return_tag_list = tmpl::append<simple_tags, compute_tags>;
 
-  template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
-            typename ActionList, typename ParallelComponent>
+  template <typename... InboxTags, typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
   static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
+    return helper(typename Metavariables::reduction_data_tags{});
+  }
+
+ private:
+  template <typename... ReductionTags>
+  static auto helper(tmpl::list<ReductionTags...> /*meta*/) noexcept {
     return std::make_tuple(db::create<simple_tags>(
         db::item_type<Tags::TensorData>{},
         db::item_type<Tags::VolumeObserversContributed>{},
-        Parallel::create_lock()));
+        db::item_type<Tags::ReductionObserversContributed>{},
+        Parallel::create_lock(), db::item_type<ReductionTags>{}...,
+        db::item_type<
+            detail::reduction_data_to_reduction_names<ReductionTags>>{}...));
   }
 };
 }  // namespace Actions

--- a/src/IO/Observer/ObservationId.cpp
+++ b/src/IO/Observer/ObservationId.cpp
@@ -3,6 +3,7 @@
 
 #include "IO/Observer/ObservationId.hpp"
 
+#include <ostream>
 #include <pup.h>
 
 namespace observers {
@@ -17,5 +18,9 @@ bool operator==(const ObservationId& lhs, const ObservationId& rhs) noexcept {
 
 bool operator!=(const ObservationId& lhs, const ObservationId& rhs) noexcept {
   return not(lhs == rhs);
+}
+
+std::ostream& operator<<(std::ostream& os, const ObservationId& t) noexcept {
+  return os << '(' << t.hash() << ',' << t.value() << ')';
 }
 }  // namespace observers

--- a/src/IO/Observer/ObservationId.hpp
+++ b/src/IO/Observer/ObservationId.hpp
@@ -6,6 +6,7 @@
 #include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <functional>
+#include <iosfwd>
 #include <string>
 
 #include "Utilities/PrettyType.hpp"
@@ -72,6 +73,8 @@ ObservationId::ObservationId(const Id& t) noexcept
 
 bool operator==(const ObservationId& lhs, const ObservationId& rhs) noexcept;
 bool operator!=(const ObservationId& lhs, const ObservationId& rhs) noexcept;
+
+std::ostream& operator<<(std::ostream& os, const ObservationId& t) noexcept;
 }  // namespace observers
 
 namespace std {

--- a/src/IO/Observer/ObserverComponent.hpp
+++ b/src/IO/Observer/ObserverComponent.hpp
@@ -24,19 +24,19 @@ namespace observers {
 template <class Metavariables>
 struct Observer {
   using chare_type = Parallel::Algorithms::Group;
-  using const_global_cache_tag_list = tmpl::list<OptionTags::VolumeFileName>;
+  using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using action_list = tmpl::list<>;
 
-  using initial_databox =
-      db::compute_databox_type<typename Actions::Initialize::return_tag_list>;
+  using initial_databox = db::compute_databox_type<
+      typename Actions::Initialize<Metavariables>::return_tag_list>;
 
   using options = tmpl::list<>;
 
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
     auto& local_cache = *(global_cache.ckLocalBranch());
-    Parallel::simple_action<Actions::Initialize>(
+    Parallel::simple_action<Actions::Initialize<Metavariables>>(
         Parallel::get_parallel_component<Observer>(local_cache));
   }
 
@@ -54,19 +54,20 @@ struct Observer {
 template <class Metavariables>
 struct ObserverWriter {
   using chare_type = Parallel::Algorithms::Nodegroup;
-  using const_global_cache_tag_list = tmpl::list<OptionTags::VolumeFileName>;
+  using const_global_cache_tag_list =
+      tmpl::list<OptionTags::ReductionFileName, OptionTags::VolumeFileName>;
   using metavariables = Metavariables;
   using action_list = tmpl::list<>;
 
   using initial_databox = db::compute_databox_type<
-      typename Actions::InitializeWriter::return_tag_list>;
+      typename Actions::InitializeWriter<Metavariables>::return_tag_list>;
 
   using options = tmpl::list<>;
 
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
     auto& local_cache = *(global_cache.ckLocalBranch());
-    Parallel::simple_action<Actions::InitializeWriter>(
+    Parallel::simple_action<Actions::InitializeWriter<Metavariables>>(
         Parallel::get_parallel_component<ObserverWriter>(local_cache));
   }
 

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -1,0 +1,264 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/NodeLock.hpp"
+#include "Parallel/Printf.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeString.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace observers {
+namespace ThreadedActions {
+/// \cond
+struct WriteReductionData;
+/// \endcond
+}  // namespace ThreadedActions
+
+namespace Actions {
+/// \cond
+struct ContributeReductionDataToWriter;
+/// \endcond
+
+/*!
+ * \ingroup ObserverGroup
+ * \brief Send reduction data to the observer group.
+ *
+ * Once everything at a specific `ObservationId` has been contributed to the
+ * reduction, the groups reduce to their local nodegroup.
+ */
+struct ContributeReductionData {
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, typename... Ts,
+            Requires<sizeof...(DbTags) != 0> = nullptr>
+  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const observers::ObservationId& observation_id,
+                    const std::vector<std::string>& reduction_names,
+                    Parallel::ReductionData<Ts...>&& reduction_data) noexcept {
+    db::mutate<Tags::ReductionData<Ts...>, Tags::ReductionDataNames<Ts...>,
+               Tags::ReductionObserversContributed>(
+        make_not_null(&box),
+        [
+          &observation_id, reduction_data = std::move(reduction_data),
+          &reduction_names, &cache
+        ](const gsl::not_null<std::unordered_map<
+              ObservationId, Parallel::ReductionData<Ts...>>*>
+              reduction_data_map,
+          const gsl::not_null<
+              std::unordered_map<ObservationId, std::vector<std::string>>*>
+              reduction_names_map,
+          const gsl::not_null<
+              std::unordered_map<observers::ObservationId, size_t>*>
+              reduction_observers_contributed,
+          const std::unordered_set<ArrayComponentId>&
+              reduction_component_ids) mutable noexcept {
+          auto& contribute_count =
+              (*reduction_observers_contributed)[observation_id];
+          if (reduction_data_map->count(observation_id) == 0) {
+            reduction_data_map->emplace(observation_id,
+                                        std::move(reduction_data));
+            reduction_names_map->emplace(observation_id, reduction_names);
+            contribute_count = 1;
+          } else {
+            ASSERT(
+                reduction_names_map->at(observation_id) == reduction_names,
+                "Reduction names differ at ObservationId "
+                    << observation_id
+                    << " with the expected names being "
+                    // Use MakeString to get around ADL for STL stream operators
+                    // (MakeString is in global namespace).
+                    << (MakeString{} << reduction_names_map->at(observation_id)
+                                     << " and the received names being "
+                                     << reduction_names));
+            reduction_data_map->operator[](observation_id)
+                .combine(std::move(reduction_data));
+            contribute_count++;
+          }
+
+          // Check if we have received all reduction data from the registered
+          // elements. If so, we reduce to the local ObserverWriter nodegroup.
+          if (contribute_count == reduction_component_ids.size()) {
+            const auto node_id = Parallel::my_node();
+            auto& local_writer = *Parallel::get_parallel_component<
+                                      ObserverWriter<Metavariables>>(cache)
+                                      .ckLocalBranch();
+            Parallel::threaded_action<ThreadedActions::WriteReductionData>(
+                local_writer, observation_id,
+                node_id == 0 ? std::move((*reduction_names_map)[observation_id])
+                             : std::vector<std::string>{},
+                std::move((*reduction_data_map)[observation_id]));
+            reduction_data_map->erase(observation_id);
+            reduction_names_map->erase(observation_id);
+            reduction_observers_contributed->erase(observation_id);
+          }
+        },
+        db::get<Tags::ReductionArrayComponentIds>(box));
+  }
+};
+}  // namespace Actions
+
+namespace ThreadedActions {
+/*!
+ * \ingroup ObserverGroup
+ * \brief Collect the reduction data from the Observer group on the
+ * ObserverWriter nodegroup before sending to node 0 for writing to disk.
+ *
+ * \note This action is also used for writing on node 0.
+ */
+struct WriteReductionData {
+ private:
+  template <typename... Ts, size_t... Is>
+  static void write_data(std::vector<std::string>&& legend,
+                         std::tuple<Ts...>&& data,
+                         const std::string& file_prefix,
+                         std::index_sequence<Is...> /*meta*/) noexcept {
+    static_assert(sizeof...(Ts) > 0,
+                  "Must be reducing at least one piece of data");
+    std::vector<double> data_to_append{
+        static_cast<double>(std::get<Is>(data))...};
+
+    h5::H5File<h5::AccessType::ReadWrite> h5file(file_prefix + ".h5", true);
+    constexpr size_t version_number = 0;
+    auto& time_series_file = h5file.try_insert<h5::Dat>(
+        "/element_data", std::move(legend), version_number);
+    time_series_file.append(data_to_append);
+  }
+
+ public:
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, typename... ReductionDatums,
+            Requires<sizeof...(DbTags) != 0> = nullptr>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const gsl::not_null<CmiNodeLock*> node_lock,
+                    const observers::ObservationId& observation_id,
+                    std::vector<std::string>&& reduction_names,
+                    Parallel::ReductionData<ReductionDatums...>&&
+                        in_reduction_data) noexcept {
+    CmiNodeLock file_lock;
+    bool write_to_disk = false;
+    std::vector<std::string> legend{};
+    Parallel::lock(node_lock);
+    db::mutate<Tags::ReductionData<ReductionDatums...>,
+               Tags::ReductionDataNames<ReductionDatums...>,
+               Tags::ReductionObserversContributed, Tags::H5FileLock>(
+        make_not_null(&box),
+        [
+          &cache, &file_lock, &in_reduction_data, &legend, &observation_id,
+          &reduction_names, &write_to_disk
+        ](const gsl::not_null<
+              db::item_type<Tags::ReductionData<ReductionDatums...>>*>
+              reduction_data,
+          const gsl::not_null<
+              std::unordered_map<ObservationId, std::vector<std::string>>*>
+              reduction_names_map,
+          const gsl::not_null<
+              std::unordered_map<observers::ObservationId, size_t>*>
+              reduction_observers_contributed,
+          const gsl::not_null<CmiNodeLock*> reduction_file_lock) noexcept {
+          auto& contribute_count =
+              (*reduction_observers_contributed)[observation_id];
+          const auto node_id = Parallel::my_node();
+          const auto number_of_nodes =
+              static_cast<size_t>(Parallel::number_of_nodes());
+          const auto procs_on_node =
+              static_cast<size_t>(Parallel::procs_on_node(node_id));
+
+          if (node_id == 0 and not reduction_names.empty()) {
+            reduction_names_map->emplace(observation_id,
+                                         std::move(reduction_names));
+          }
+
+          if (UNLIKELY(procs_on_node == 1 and number_of_nodes == 1)) {
+            write_to_disk = true;
+            file_lock = *reduction_file_lock;
+            legend = std::move(reduction_names_map->operator[](observation_id));
+            reduction_names_map->erase(observation_id);
+          } else if (reduction_data->count(observation_id) == 0) {
+            reduction_data->operator[](observation_id) =
+                std::move(in_reduction_data);
+            contribute_count = 1;
+          } else if (contribute_count ==
+                     (procs_on_node - 1) + (number_of_nodes - 1)) {
+            ASSERT(node_id == 0,
+                   "Should only receive additional reduction data on node 0 "
+                   "but received it on node "
+                       << node_id);
+            // On node 0 we are collecting data from all other nodes so we
+            // should get procs_on_node data from the group on our node plus
+            // (number_of_nodes - 1) contributions from other nodes.
+            in_reduction_data.combine(
+                std::move(reduction_data->operator[](observation_id)));
+            reduction_data->erase(observation_id);
+            reduction_observers_contributed->erase(observation_id);
+            write_to_disk = true;
+            file_lock = *reduction_file_lock;
+            legend = std::move(reduction_names_map->operator[](observation_id));
+            reduction_names_map->erase(observation_id);
+          } else {
+            reduction_data->at(observation_id)
+                .combine(std::move(in_reduction_data));
+            contribute_count++;
+          }
+
+          // Check if we have received all reduction data from the Observer
+          // group. If so we reduce to node 0 for writing to disk.
+          if (node_id != 0 and reduction_observers_contributed->at(
+                                   observation_id) == procs_on_node) {
+            Parallel::threaded_action<WriteReductionData>(
+                Parallel::get_parallel_component<ObserverWriter<Metavariables>>(
+                    cache)[0],
+                observation_id, std::vector<std::string>{},
+                std::move(reduction_data->operator[](observation_id)));
+            reduction_observers_contributed->erase(observation_id);
+            reduction_data->erase(observation_id);
+          }
+        });
+    Parallel::unlock(node_lock);
+
+    if (write_to_disk) {
+      Parallel::lock(&file_lock);
+      in_reduction_data.finalize();
+      WriteReductionData::write_data(
+          std::move(legend), std::move(in_reduction_data.data()),
+          Parallel::get<OptionTags::ReductionFileName>(cache),
+          std::make_index_sequence<sizeof...(ReductionDatums)>{});
+      Parallel::unlock(&file_lock);
+    }
+  }
+};
+}  // namespace ThreadedActions
+}  // namespace observers

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -97,15 +97,13 @@ struct ReductionObserversContributed : db::SimpleTag {
   using type = std::unordered_map<observers::ObservationId, size_t>;
 };
 
-/// Node lock used when needing to lock the H5 file on disk.
-struct VolumeFileLock : db::SimpleTag {
-  static std::string name() noexcept { return "VolumeFileLock"; }
-  using type = CmiNodeLock;
-};
-
-/// Node lock used when needing to lock the H5 file on disk.
-struct ReductionFileLock : db::SimpleTag {
-  static std::string name() noexcept { return "ReductionFileLock"; }
+/// Node lock used when needing to read/write to H5 files on disk.
+///
+/// The reason for only having one lock for all files is that we currently don't
+/// require a thread-safe HDF5 installation. In the future we will need to
+/// experiment with different HDF5 configurations.
+struct H5FileLock : db::SimpleTag {
+  static std::string name() noexcept { return "H5FileLock"; }
   using type = CmiNodeLock;
 };
 }  // namespace Tags

--- a/src/Parallel/Reduction.hpp
+++ b/src/Parallel/Reduction.hpp
@@ -78,6 +78,8 @@ template <class... Ts, class... InvokeCombines, class... InvokeFinals,
           class... InvokeFinalExtraArgsIndices>
 struct ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
                                     InvokeFinalExtraArgsIndices>...> {
+  static_assert(sizeof...(Ts) > 0,
+                "Must be reducing at least one piece of data.");
   static constexpr size_t pack_size() noexcept { return sizeof...(Ts); }
 
   explicit ReductionData(

--- a/src/Parallel/Reduction.hpp
+++ b/src/Parallel/Reduction.hpp
@@ -101,13 +101,15 @@ struct ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
   static CkReductionMsg* combine(int number_of_messages,
                                  CkReductionMsg** msgs) noexcept;
 
-  void combine(ReductionData&& t) noexcept {
+  ReductionData& combine(ReductionData&& t) noexcept {
     ReductionData::combine_helper(this, std::move(t),
                                   std::make_index_sequence<sizeof...(Ts)>{});
+    return *this;
   }
 
-  void finalize() noexcept {
+  ReductionData& finalize() noexcept {
     invoke_final_loop_over_tuple(std::make_index_sequence<sizeof...(Ts)>{});
+    return *this;
   }
 
   /// \cond

--- a/src/Utilities/Functional.hpp
+++ b/src/Utilities/Functional.hpp
@@ -7,6 +7,9 @@
 #include <cstddef>
 #include <tuple>
 
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/StaticAssert.hpp"
+
 /*!
  * \ingroup UtilitiesGroup
  * \brief Higher order function objects similar to `std::plus`, etc.
@@ -59,6 +62,21 @@ struct Identity;
     }                                                                   \
   };                                                                    \
   /** \endcond*/
+
+/// Functional that asserts the first and second arguments are equal and returns
+/// the first argument.
+template <class C = Identity>
+struct AssertEqual : Functional<2> {
+  template <class T>
+  const T& operator()(const T& t0, const T& t1) noexcept {
+    DEBUG_STATIC_ASSERT(
+        C::arity == 1,
+        "The arity of the functional passed to AssertEqual must be 1");
+    ASSERT(t0 == t1, "Values are not equal in funcl::AssertEqual "
+                         << t0 << " and " << t1);
+    return C{}(t0);
+  }
+};
 
 /// Functional for dividing two objects
 MAKE_BINARY_OPERATOR(Divides, /)

--- a/src/Utilities/MakeString.hpp
+++ b/src/Utilities/MakeString.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <ostream>
 #include <sstream>
 #include <string>
 
@@ -41,3 +42,8 @@ class MakeString {
  private:
   std::stringstream stream_{};
 };
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const MakeString& t) noexcept {
+  return os << std::string{t};
+}

--- a/tests/Unit/IO/CMakeLists.txt
+++ b/tests/Unit/IO/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Observers/Test_RegisterElements.cpp
   Observers/Test_Tags.cpp
   Observers/Test_ObservationId.cpp
+  Observers/Test_ReductionObserver.cpp
   Observers/Test_TypeOfObservation.cpp
   Observers/Test_VolumeObserver.cpp
   Test_H5.cpp

--- a/tests/Unit/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/IO/Observers/ObserverHelpers.hpp
@@ -30,12 +30,13 @@ struct observer_component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list =
-      tmpl::list<observers::OptionTags::VolumeFileName>;
+  using const_global_cache_tag_list = tmpl::list<>;
   using action_list = tmpl::list<>;
   using component_being_mocked = observers::Observer<Metavariables>;
-  using simple_tags = observers::Actions::Initialize::simple_tags;
-  using compute_tags = observers::Actions::Initialize::compute_tags;
+  using simple_tags =
+      typename observers::Actions::Initialize<Metavariables>::simple_tags;
+  using compute_tags =
+      typename observers::Actions::Initialize<Metavariables>::compute_tags;
   using initial_databox =
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
 };
@@ -45,11 +46,15 @@ struct observer_writer_component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
+  using const_global_cache_tag_list =
+      tmpl::list<observers::OptionTags::ReductionFileName,
+                 observers::OptionTags::VolumeFileName>;
   using action_list = tmpl::list<>;
   using component_being_mocked = observers::ObserverWriter<Metavariables>;
-  using simple_tags = observers::Actions::InitializeWriter::simple_tags;
-  using compute_tags = observers::Actions::InitializeWriter::compute_tags;
+  using simple_tags =
+      typename observers::Actions::InitializeWriter<Metavariables>::simple_tags;
+  using compute_tags = typename observers::Actions::InitializeWriter<
+      Metavariables>::compute_tags;
   using initial_databox =
       db::compute_databox_type<tmpl::append<simple_tags, compute_tags>>;
 };
@@ -60,6 +65,13 @@ struct Metavariables {
                                     observer_component<Metavariables>,
                                     observer_writer_component<Metavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
+
+  using Redum = Parallel::ReductionDatum<double, funcl::Plus<>,
+                                         funcl::Sqrt<funcl::Divides<>>,
+                                         std::index_sequence<1>>;
+  using reduction_data_tags = tmpl::list<observers::Tags::ReductionData<
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<size_t, funcl::Plus<>>, Redum, Redum>>;
 
   enum class Phase { Initialize, Exit };
 };

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -26,12 +26,13 @@ struct observer_component {
   using const_global_cache_tag_list = tmpl::list<>;
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
-      typename observers::Actions::Initialize::return_tag_list>;
+      typename observers::Actions::Initialize<Metavariables>::return_tag_list>;
 };
 
 struct Metavariables {
   using component_list = tmpl::list<observer_component<Metavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
+  using reduction_data_tags = tmpl::list<>;
 
   enum class Phase { Initialize, Exit };
 };
@@ -52,7 +53,8 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Initialize", "[Unit][Observers]") {
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
       {}, std::move(dist_objects)};
 
-  runner.simple_action<obs_component, observers::Actions::Initialize>(0);
+  runner.simple_action<obs_component,
+                       observers::Actions::Initialize<Metavariables>>(0);
   const auto& observer_box =
       runner.template algorithms<obs_component>()
           .at(0)

--- a/tests/Unit/IO/Observers/Test_ObservationId.cpp
+++ b/tests/Unit/IO/Observers/Test_ObservationId.cpp
@@ -5,10 +5,13 @@
 
 #include <cstddef>
 #include <functional>
+#include <string>
 
 #include "IO/Observer/ObservationId.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/MakeString.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
 namespace observer_testing_detail {
@@ -56,6 +59,9 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ObservationId", "[Unit][Observers]") {
   CHECK(time0.hash() != time1.hash());
   CHECK(time0.value() == 0.0);
   CHECK(time1.value() == 0.5);
+
+  CHECK(get_output(id0) == std::string(MakeString{} << '(' << id0.hash() << ','
+                                                    << id0.value() << ')'));
 
   // Test PUP
   test_serialization(id0);

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -1,0 +1,170 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/Matrix.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "IO/H5/AccessType.hpp"
+#include "IO/H5/Dat.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Initialize.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ReductionActions.hpp"   // IWYU pragma: keep
+#include "IO/Observer/Tags.hpp"               // IWYU pragma: keep
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/IO/Observers/ObserverHelpers.hpp"
+
+// NOLINTNEXTLINE(google-build-using-namespace)
+using namespace TestObservers_detail;
+
+SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
+  using TupleOfMockDistributedObjects =
+      typename ActionTesting::MockRuntimeSystem<
+          Metavariables>::TupleOfMockDistributedObjects;
+  using obs_component = observer_component<Metavariables>;
+  using obs_writer = observer_writer_component<Metavariables>;
+  using element_comp = element_component<Metavariables>;
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using ObserverMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          obs_component>;
+  using WriterMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          obs_writer>;
+  using ElementMockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          element_comp>;
+  TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<ObserverMockDistributedObjectsTag>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<obs_component>{});
+  tuples::get<WriterMockDistributedObjectsTag>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<obs_writer>{});
+
+  // Specific IDs have no significance, just need different IDs.
+  const std::vector<ElementId<2>> element_ids{{1, {{{1, 0}, {1, 0}}}},
+                                              {1, {{{1, 1}, {1, 0}}}},
+                                              {1, {{{1, 0}, {2, 3}}}},
+                                              {1, {{{1, 0}, {5, 4}}}},
+                                              {0, {{{1, 0}, {1, 0}}}}};
+  for (const auto& id : element_ids) {
+    tuples::get<ElementMockDistributedObjectsTag>(dist_objects)
+        .emplace(ElementIndex<2>{id},
+                 ActionTesting::MockDistributedObject<element_comp>{});
+  }
+
+  tuples::TaggedTuple<observers::OptionTags::ReductionFileName,
+                      observers::OptionTags::VolumeFileName>
+      cache_data{};
+  const auto& output_file_prefix =
+      tuples::get<observers::OptionTags::ReductionFileName>(cache_data) =
+          "./Unit.IO.Observers.ReductionObserver";
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{
+      cache_data, std::move(dist_objects)};
+
+  runner.simple_action<obs_component,
+                       observers::Actions::Initialize<Metavariables>>(0);
+  runner.simple_action<obs_writer,
+                       observers::Actions::InitializeWriter<Metavariables>>(0);
+
+  // Register elements
+  for (const auto& id : element_ids) {
+    runner.simple_action<element_comp,
+                         observers::Actions::RegisterWithObservers<
+                             observers::TypeOfObservation::Reduction>>(id, 0);
+    // Invoke the simple_action RegisterSenderWithSelf that was called on the
+    // observer component by the RegisterWithObservers action.
+    runner.invoke_queued_simple_action<obs_component>(0);
+  }
+
+  const std::string h5_file_name = output_file_prefix + ".h5";
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+
+  using Redum = Parallel::ReductionDatum<double, funcl::Plus<>,
+                                         funcl::Sqrt<funcl::Divides<>>,
+                                         std::index_sequence<1>>;
+  using ReData = Parallel::ReductionData<
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<size_t, funcl::Plus<>>, Redum, Redum>;
+  const auto make_fake_reduction_data = [](
+      const observers::ArrayComponentId& id, const double time) noexcept {
+    const auto hashed_id =
+        static_cast<double>(std::hash<observers::ArrayComponentId>{}(id));
+    constexpr size_t number_of_grid_points = 4;
+    const double error0 = 1.0e-10 * hashed_id + time;
+    const double error1 = 1.0e-12 * hashed_id + 2 * time;
+    return ReData{time, number_of_grid_points, error0, error1};
+  };
+
+  const TimeId time(3);
+  const std::vector<std::string> legend{"Time", "NumberOfPoints", "Error0",
+                                        "Error1"};
+  // Test passing reduction data.
+  for (const auto& id : element_ids) {
+    const observers::ArrayComponentId array_id(
+        std::add_pointer_t<element_comp>{nullptr},
+        Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{id}});
+
+    auto reduction_data_fakes =
+        make_fake_reduction_data(array_id, time.value());
+    runner.simple_action<obs_component,
+                         observers::Actions::ContributeReductionData>(
+        0, observers::ObservationId(time), legend,
+        std::move(reduction_data_fakes));
+  }
+  // Invke the threaded action 'WriteReductionData' to write reduction data to
+  // disk.
+  runner.invoke_queued_threaded_action<obs_writer>(0);
+
+  // Check that the H5 file was written correctly.
+  {
+    const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);
+    const auto& dat_file = file.get<h5::Dat>("/element_data");
+    const Matrix written_data = dat_file.get_data();
+    const auto& written_legend = dat_file.get_legend();
+    CHECK(written_legend == legend);
+    const auto expected =
+        alg::accumulate(
+            element_ids, ReData(time.value(), 0, 0.0, 0.0),
+            [&time, &make_fake_reduction_data ](
+                ReData state, const ElementId<2>& id) noexcept {
+              const observers::ArrayComponentId array_id(
+                  std::add_pointer_t<element_comp>{nullptr},
+                  Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{id}});
+              return state.combine(
+                  make_fake_reduction_data(array_id, time.value()));
+            })
+            .finalize()
+            .data();
+    CHECK(std::get<0>(expected) == written_data(0, 0));
+    CHECK(std::get<1>(expected) == written_data(0, 1));
+    CHECK(std::get<2>(expected) == written_data(0, 2));
+    CHECK(std::get<3>(expected) == written_data(0, 3));
+  }
+
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+}

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -69,8 +69,10 @@ void check_observer_registration() {
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
       {}, std::move(dist_objects)};
 
-  runner.simple_action<obs_component, observers::Actions::Initialize>(0);
-  runner.simple_action<obs_writer, observers::Actions::InitializeWriter>(0);
+  runner.simple_action<obs_component,
+                       observers::Actions::Initialize<Metavariables>>(0);
+  runner.simple_action<obs_writer,
+                       observers::Actions::InitializeWriter<Metavariables>>(0);
   // Test initial state
   const auto& observer_box =
       runner.template algorithms<obs_component>()

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -16,8 +16,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
   CHECK(VolumeArrayComponentIds::name() == "VolumeArrayComponentIds");
   CHECK(TensorData::name() == "TensorData");
   CHECK(VolumeObserversContributed::name() == "VolumeObserversContributed");
-  CHECK(VolumeFileLock::name() == "VolumeFileLock");
-  CHECK(ReductionFileLock::name() == "ReductionFileLock");
+  CHECK(H5FileLock::name() == "H5FileLock");
   CHECK(ReductionData<double>::name() == "ReductionData");
   CHECK(ReductionDataNames<double>::name() == "ReductionDataNames");
   CHECK(NumberOfNodesContributedToReduction::name() ==

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "IO/Observer/Tags.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 namespace observers {
 namespace Tags {
@@ -17,6 +18,20 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
   CHECK(VolumeObserversContributed::name() == "VolumeObserversContributed");
   CHECK(VolumeFileLock::name() == "VolumeFileLock");
   CHECK(ReductionFileLock::name() == "ReductionFileLock");
+  CHECK(ReductionData<double>::name() == "ReductionData");
+  CHECK(ReductionDataNames<double>::name() == "ReductionDataNames");
+  CHECK(NumberOfNodesContributedToReduction::name() ==
+        "NumberOfNodesContributedToReduction");
+  CHECK(ReductionObserversContributed::name() ==
+        "ReductionObserversContributed");
+  static_assert(
+      cpp17::is_same_v<typename ReductionData<double, int, char>::names_tag,
+                       ReductionDataNames<double, int, char>>,
+      "Failed testing Observers tags");
+  static_assert(
+      cpp17::is_same_v<typename ReductionDataNames<double, int, char>::data_tag,
+                       ReductionData<double, int, char>>,
+      "Failed testing Observers tags");
 }
 }  // namespace Tags
 }  // namespace observers

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -146,58 +146,62 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
             /* get<0> = index of dimensions */
             std::get<0>(volume_data_fakes));
   }
-  // Invoke the simple_action RegisterSenderWithSelf that was called on the
-  // observer component by the RegisterWithObservers action.
+  // Invoke the simple action 'ContributeVolumeDataToWriter' to move the volume
+  // data to the Writer parallel component.
   runner.invoke_queued_simple_action<obs_writer>(0);
+  // Invoke the threaded action 'WriteVolumeData' to write the data to disk.
   runner.invoke_queued_threaded_action<obs_writer>(0);
 
   // Check that the H5 file was written correctly.
-  h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
-  auto& volume_file = my_file.get<h5::VolumeData>("/element_data");
+  {
+    h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
+    auto& volume_file = my_file.get<h5::VolumeData>("/element_data");
 
-  const auto temporal_id = observers::ObservationId(TimeId(3)).hash();
-  CHECK(volume_file.list_observation_ids() == std::vector<size_t>{temporal_id});
-  const auto grids = volume_file.list_grids(temporal_id);
-  const std::vector<std::string> expected_grids(
-      boost::make_transform_iterator(element_ids.begin(),
-                                     get_output<ElementId<2>>),
-      boost::make_transform_iterator(element_ids.end(),
-                                     get_output<ElementId<2>>));
-  REQUIRE(alg::all_of(grids, [&expected_grids](const std::string& name) {
-    return alg::found(expected_grids, name);
-  }));
-  REQUIRE(alg::all_of(expected_grids, [&grids](const std::string& name) {
-    return alg::found(grids, name);
-  }));
+    const auto temporal_id = observers::ObservationId(TimeId(3)).hash();
+    CHECK(volume_file.list_observation_ids() ==
+          std::vector<size_t>{temporal_id});
+    const auto grids = volume_file.list_grids(temporal_id);
+    const std::vector<std::string> expected_grids(
+        boost::make_transform_iterator(element_ids.begin(),
+                                       get_output<ElementId<2>>),
+        boost::make_transform_iterator(element_ids.end(),
+                                       get_output<ElementId<2>>));
+    REQUIRE(alg::all_of(grids, [&expected_grids](const std::string& name) {
+      return alg::found(expected_grids, name);
+    }));
+    REQUIRE(alg::all_of(expected_grids, [&grids](const std::string& name) {
+      return alg::found(grids, name);
+    }));
 
-  for (const auto& element_id : element_ids) {
-    const std::string grid_name = MakeString{} << element_id;
-    const auto tensor_names =
-        volume_file.list_tensor_components(temporal_id, grid_name);
-    const std::vector<std::string> expected_tensor_names{
-        "T_x", "T_y", "S_xx", "S_yy", "S_xy", "S_yx"};
-    CAPTURE(element_id);
-    CAPTURE(tensor_names);
-    CAPTURE(expected_tensor_names);
-    REQUIRE(alg::all_of(tensor_names,
-                        [&expected_tensor_names](const std::string& name) {
-                          return alg::found(expected_tensor_names, name);
-                        }));
-    REQUIRE(alg::all_of(expected_tensor_names,
-                        [&tensor_names](const std::string& name) {
-                          return alg::found(tensor_names, name);
-                        }));
-    const observers::ArrayComponentId array_id(
-        std::add_pointer_t<element_comp>{nullptr},
-        Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{element_id}});
-    const auto volume_data_fakes = make_fake_volume_data(array_id, "");
-    CHECK(std::vector<size_t>{std::get<0>(volume_data_fakes)[0],
-                              std::get<0>(volume_data_fakes)[1]} ==
-          volume_file.get_extents(temporal_id, grid_name));
-    for (const auto& tensor_component : std::get<1>(volume_data_fakes)) {
-      CHECK(tensor_component.data ==
-            volume_file.get_tensor_component(temporal_id, grid_name,
-                                             tensor_component.name));
+    for (const auto& element_id : element_ids) {
+      const std::string grid_name = MakeString{} << element_id;
+      const auto tensor_names =
+          volume_file.list_tensor_components(temporal_id, grid_name);
+      const std::vector<std::string> expected_tensor_names{
+          "T_x", "T_y", "S_xx", "S_yy", "S_xy", "S_yx"};
+      CAPTURE(element_id);
+      CAPTURE(tensor_names);
+      CAPTURE(expected_tensor_names);
+      REQUIRE(alg::all_of(tensor_names,
+                          [&expected_tensor_names](const std::string& name) {
+                            return alg::found(expected_tensor_names, name);
+                          }));
+      REQUIRE(alg::all_of(expected_tensor_names,
+                          [&tensor_names](const std::string& name) {
+                            return alg::found(tensor_names, name);
+                          }));
+      const observers::ArrayComponentId array_id(
+          std::add_pointer_t<element_comp>{nullptr},
+          Parallel::ArrayIndex<ElementIndex<2>>{ElementIndex<2>{element_id}});
+      const auto volume_data_fakes = make_fake_volume_data(array_id, "");
+      CHECK(std::vector<size_t>{std::get<0>(volume_data_fakes)[0],
+                                std::get<0>(volume_data_fakes)[1]} ==
+            volume_file.get_extents(temporal_id, grid_name));
+      for (const auto& tensor_component : std::get<1>(volume_data_fakes)) {
+        CHECK(tensor_component.data ==
+              volume_file.get_tensor_component(temporal_id, grid_name,
+                                               tensor_component.name));
+      }
     }
   }
   if (file_system::check_if_file_exists(h5_file_name)) {

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -76,15 +76,19 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
                  ActionTesting::MockDistributedObject<element_comp>{});
   }
 
-  tuples::TaggedTuple<observers::OptionTags::VolumeFileName> cache_data{};
+  tuples::TaggedTuple<observers::OptionTags::ReductionFileName,
+                      observers::OptionTags::VolumeFileName>
+      cache_data{};
   const auto& output_file_prefix =
       tuples::get<observers::OptionTags::VolumeFileName>(cache_data) =
           "./Unit.IO.Observers.VolumeObserver";
   ActionTesting::MockRuntimeSystem<Metavariables> runner{
       cache_data, std::move(dist_objects)};
 
-  runner.simple_action<obs_component, observers::Actions::Initialize>(0);
-  runner.simple_action<obs_writer, observers::Actions::InitializeWriter>(0);
+  runner.simple_action<obs_component,
+                       observers::Actions::Initialize<Metavariables>>(0);
+  runner.simple_action<obs_writer,
+                       observers::Actions::InitializeWriter<Metavariables>>(0);
 
   // Register elements
   for (const auto& id : element_ids) {

--- a/tests/Unit/Utilities/Test_Functional.cpp
+++ b/tests/Unit/Utilities/Test_Functional.cpp
@@ -5,10 +5,14 @@
 
 #include <cmath>
 
+#include "ErrorHandling/Error.hpp"
 #include "Utilities/Functional.hpp"
 
 namespace funcl {
 namespace {
+void test_assert_equal() {
+  CHECK(AssertEqual<>{}(7, 7) == 7);
+}
 void test_divides() {
   CHECK(Divides<>{}(1, -2) == 0);
   CHECK(Divides<>{}(1, -2.0) == -0.5);
@@ -61,6 +65,7 @@ void test_composition() {
 }
 
 SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Unit][Utilities]") {
+  test_assert_equal();
   test_divides();
   test_get_argument();
   test_identity();
@@ -72,6 +77,16 @@ SPECTRE_TEST_CASE("Unit.Utilities.Functional", "[Unit][Utilities]") {
   test_square();
 
   test_composition();
+}
+
+// [[OutputRegex, Values are not equal in funcl::AssertEqual 7 and 8]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Utilities.Functional.AssertEqual",
+                               "[Unit][Utilities]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  AssertEqual<>{}(7, 8);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
 }
 }  // namespace
 }  // namespace funcl

--- a/tests/Unit/Utilities/Test_MakeString.cpp
+++ b/tests/Unit/Utilities/Test_MakeString.cpp
@@ -15,5 +15,7 @@ SPECTRE_TEST_CASE("Unit.Utilities.MakeString", "[Unit][Utilities]") {
   std::array<int, 3> arr{{2, 3, 4}};
   const std::string t = MakeString{} << "Test" << 2 << arr << "Done";
   /// [make_string]
-  CHECK(t == "Test2" + get_output(arr) + "Done");
+  const std::string expected = "Test2" + get_output(arr) + "Done";
+  CHECK(t == expected);
+  CHECK(get_output(MakeString{} << "Test" << 2 << arr << "Done") == expected);
 }


### PR DESCRIPTION
## Proposed changes

Adds the ability to do observations that are reductions over the entire domain. In the future we will add facilities for doing reductions over only some blocks as well.

This is the only PR for reduction observers since it can piggy-back on a lot of the volume observer infrastructure and already in-place H5 IO of Dat files.

Commit order:
1. Add reduction observers
2. Properly close H5 file in Test_VolumeObserver
3. ReductionData finalize and combine return *this
4. Add funcl::AssertEqual
5. Switch to single file lock
6. Add tags for reductions
7. Add stream operator for MakeString with std::ostream
8. Add stream operator for ObservationId

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
