### PR TITLE
Fix documentation failure on Travis

### DIFF
--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -3,7 +3,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-# Setup lmod and spack to load dependencies
+# Load what we need from `/root/.bashrc`
 . /etc/profile.d/lmod.sh
 export PATH=$PATH:/work/spack/bin
 . /work/spack/share/spack/setup-env.sh
@@ -15,6 +15,7 @@ spack load gsl
 spack load libxsmm
 spack load pkg-config
 spack load yaml-cpp
+export PATH=$PATH:/work/texlive/bin/x86_64-linux
 
 ccache -z
 


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
