### PR TITLE
Allow adding referencing compute tags DataBox

### DIFF
--- a/tests/Unit/Parallel/CMakeLists.txt
+++ b/tests/Unit/Parallel/CMakeLists.txt
@@ -118,6 +118,7 @@ add_algorithm_test("AlgorithmNodelock" "")
 # Tests that do not require their own Chare setup and can work with the
 # unit tests
 set(PARALLEL_TESTS
+  Parallel/Test_ConstGlobalCacheDataBox.cpp
   Parallel/Test_GotoAction.cpp
   Parallel/Test_Parallel.cpp
   Parallel/Test_ParallelComponentHelpers.cpp

--- a/tests/Unit/Parallel/Test_ConstGlobalCacheDataBox.cpp
+++ b/tests/Unit/Parallel/Test_ConstGlobalCacheDataBox.cpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Parallel {
+namespace OptionTags {
+struct IntegerList : db::BaseTag {
+  using type = std::array<int, 3>;
+  static constexpr OptionString help = {"Help"};
+};
+
+struct UniquePtrIntegerList : db::BaseTag {
+  using type = std::unique_ptr<std::array<int, 3>>;
+  static constexpr OptionString help = {"Help"};
+};
+}  // namespace OptionTags
+
+namespace {
+struct Metavars {
+  using const_global_cache_tag_list =
+      tmpl::list<OptionTags::IntegerList, OptionTags::UniquePtrIntegerList>;
+  using component_list = tmpl::list<>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Parallel.ConstGlobalCacheDataBox", "[Unit][Parallel]") {
+  tuples::TaggedTuple<OptionTags::IntegerList, OptionTags::UniquePtrIntegerList>
+      tuple{};
+  tuples::get<OptionTags::IntegerList>(tuple) = std::array<int, 3>{{-1, 3, 7}};
+  tuples::get<OptionTags::UniquePtrIntegerList>(tuple) =
+      std::make_unique<std::array<int, 3>>(std::array<int, 3>{{1, 5, -8}});
+  ConstGlobalCache<Metavars> cache{std::move(tuple)};
+  auto box = db::create<
+      db::AddSimpleTags<Tags::ConstGlobalCacheImpl<Metavars>>,
+      db::AddComputeTags<
+          Tags::FromConstGlobalCache<OptionTags::IntegerList>,
+          Tags::FromConstGlobalCache<OptionTags::UniquePtrIntegerList>>>(
+      &cpp17::as_const(cache));
+  CHECK(db::get<Tags::ConstGlobalCache>(box) == &cache);
+  CHECK(std::array<int, 3>{{-1, 3, 7}} ==
+        db::get<OptionTags::IntegerList>(box));
+  CHECK(std::array<int, 3>{{1, 5, -8}} ==
+        db::get<OptionTags::UniquePtrIntegerList>(box));
+  CHECK(&Parallel::get<OptionTags::IntegerList>(cache) ==
+        &db::get<OptionTags::IntegerList>(box));
+  CHECK(&Parallel::get<OptionTags::UniquePtrIntegerList>(cache) ==
+        &db::get<OptionTags::UniquePtrIntegerList>(box));
+
+  tuples::TaggedTuple<OptionTags::IntegerList, OptionTags::UniquePtrIntegerList>
+      tuple2{};
+  tuples::get<OptionTags::IntegerList>(tuple2) =
+      std::array<int, 3>{{10, -3, 700}};
+  tuples::get<OptionTags::UniquePtrIntegerList>(tuple2) =
+      std::make_unique<std::array<int, 3>>(std::array<int, 3>{{100, -7, -300}});
+  ConstGlobalCache<Metavars> cache2{std::move(tuple2)};
+  db::mutate<Tags::ConstGlobalCache>(
+      make_not_null(&box),
+      [&cache2](
+          const gsl::not_null<const Parallel::ConstGlobalCache<Metavars>**> t) {
+        *t = std::addressof(cache2);
+      });
+
+  CHECK(db::get<Tags::ConstGlobalCache>(box) == &cache2);
+  CHECK(std::array<int, 3>{{10, -3, 700}} ==
+        db::get<OptionTags::IntegerList>(box));
+  CHECK(std::array<int, 3>{{100, -7, -300}} ==
+        db::get<OptionTags::UniquePtrIntegerList>(box));
+  CHECK(&Parallel::get<OptionTags::IntegerList>(cache2) ==
+        &db::get<OptionTags::IntegerList>(box));
+  CHECK(&Parallel::get<OptionTags::UniquePtrIntegerList>(cache2) ==
+        &db::get<OptionTags::UniquePtrIntegerList>(box));
+
+  CHECK(Tags::FromConstGlobalCache<OptionTags::IntegerList>::name() ==
+        "FromConstGlobalCache(IntegerList)");
+  CHECK(Tags::FromConstGlobalCache<OptionTags::UniquePtrIntegerList>::name() ==
+        "FromConstGlobalCache(UniquePtrIntegerList)");
+}
+}  // namespace Parallel


### PR DESCRIPTION
## Proposed changes

The use case for this is storing a pointer to the ConstGlobalCache, and then
having compute tags that are used to retrieve things stored in the
ConstGlobalCache using the base tag mechanism (OptionTags will be pure base
tags).

This doesn't add anything from the GlobalCache to the evolution DataBox, but adds the ability to do them to the DataBox. The `OptionTags` that we want to be able to retrieve from the DataBox will need to inherit from `db::BaseTag`.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
