### PR TITLE
Remove template parameters from Algorithm

### DIFF
--- a/cmake/SetupCharmAlgorithm.py
+++ b/cmake/SetupCharmAlgorithm.py
@@ -18,7 +18,6 @@ def create_interface_file(args):
              "  include \"Parallel/ConstGlobalCache.decl.h\";\n" \
              "\n" \
              "  template <typename ParallelComponent,\n" \
-             "            typename OrderedActionsList,\n" \
              "            typename SpectreArrayIndex>\n" % args['algorithm_name']
     # The chare type needs to be checked
     if args['algorithm_type'] == "array":
@@ -109,31 +108,23 @@ def create_header_file(args):
         "namespace Algorithms {\n" \
         "struct %s {\n" \
         "  template <typename ParallelComponent,\n" \
-        "            typename OrderedActionsList,\n" \
         "            typename SpectreArrayIndex>\n" \
         "  using cproxy = CProxy_Algorithm%s<ParallelComponent,\n" \
-        "                           OrderedActionsList,\n" \
         "                           SpectreArrayIndex>;\n" \
         "\n" \
         "  template <typename ParallelComponent,\n" \
-        "            typename OrderedActionsList,\n" \
         "            typename SpectreArrayIndex>\n" \
         "  using cbase = CBase_Algorithm%s<ParallelComponent,\n" \
-        "                          OrderedActionsList,\n" \
         "                          SpectreArrayIndex>;\n" \
         "\n" \
         "  template <typename ParallelComponent,\n" \
-        "            typename OrderedActionsList,\n" \
         "            typename SpectreArrayIndex>\n" \
         "  using algorithm_type = Algorithm%s<ParallelComponent,\n" \
-        "                             OrderedActionsList,\n" \
         "                             SpectreArrayIndex>;\n" \
         "\n" \
         "  template <typename ParallelComponent,\n" \
-        "            typename OrderedActionsList,\n" \
         "            typename SpectreArrayIndex>\n" \
         "  using ckindex = CkIndex_Algorithm%s<ParallelComponent,\n" \
-        "                             OrderedActionsList,\n" \
         "                             SpectreArrayIndex>;\n" \
         "};\n" \
         "}  // namespace Algorithms\n" \
@@ -144,20 +135,18 @@ def create_header_file(args):
     # Write Algorithm class
     header_str += \
         "template <typename ParallelComponent,\n" \
-        "          typename OrderedActionsList,\n" \
         "          typename SpectreArrayIndex>\n" \
         "class Algorithm%s\n" \
         "    : public CBase_Algorithm%s<ParallelComponent, \n" \
-        "                      OrderedActionsList,\n" \
         "                      SpectreArrayIndex>,\n" \
         "      public Parallel::AlgorithmImpl<ParallelComponent,\n" \
-        "                                     OrderedActionsList,\n" \
-        "                                     SpectreArrayIndex> {\n" \
+        "                       typename ParallelComponent::action_list,\n" \
+        "                       SpectreArrayIndex> {\n" \
         "  using algorithm = Parallel::Algorithms::%s;\n" \
         " public:\n" \
         "  using Parallel::AlgorithmImpl<ParallelComponent,\n" \
-        "                                OrderedActionsList,\n" \
-        "                                SpectreArrayIndex>::AlgorithmImpl;\n" \
+        "                  typename ParallelComponent::action_list,\n" \
+        "                  SpectreArrayIndex>::AlgorithmImpl;\n" \
         "};\n\n" % (args['algorithm_name'],
                     args['algorithm_name'], args['algorithm_name'])
     # Write include of the def file, but including only the template definitions

--- a/cmake/SetupCharmAlgorithm.py
+++ b/cmake/SetupCharmAlgorithm.py
@@ -17,8 +17,7 @@ def create_interface_file(args):
              "  include \"Utilities/TaggedTuple.hpp\";\n" \
              "  include \"Parallel/ConstGlobalCache.decl.h\";\n" \
              "\n" \
-             "  template <typename ParallelComponent, " \
-             "typename Metavariables, \n" \
+             "  template <typename ParallelComponent,\n" \
              "            typename OrderedActionsList,\n" \
              "            typename SpectreArrayIndex>\n" % args['algorithm_name']
     # The chare type needs to be checked
@@ -29,7 +28,8 @@ def create_interface_file(args):
 
     ci_str += " Algorithm%s {\n" \
               "    entry Algorithm%s(" \
-              "Parallel::CProxy_ConstGlobalCache<Metavariables>);\n" \
+              "Parallel::CProxy_ConstGlobalCache<\n" \
+              "                      METAVARIABLES_FROM_COMPONENT>);\n" \
               "\n" \
               "    template <typename Action, typenameLDOTLDOTLDOT Args>\n" \
               "    entry void simple_action(\n" \
@@ -108,33 +108,33 @@ def create_header_file(args):
         "namespace Parallel {\n" \
         "namespace Algorithms {\n" \
         "struct %s {\n" \
-        "  template <typename ParallelComponent, typename Metavariables,\n" \
+        "  template <typename ParallelComponent,\n" \
         "            typename OrderedActionsList,\n" \
         "            typename SpectreArrayIndex>\n" \
         "  using cproxy = CProxy_Algorithm%s<ParallelComponent,\n" \
-        "                           Metavariables, OrderedActionsList,\n" \
+        "                           OrderedActionsList,\n" \
         "                           SpectreArrayIndex>;\n" \
         "\n" \
-        "  template <typename ParallelComponent, typename Metavariables,\n" \
+        "  template <typename ParallelComponent,\n" \
         "            typename OrderedActionsList,\n" \
         "            typename SpectreArrayIndex>\n" \
         "  using cbase = CBase_Algorithm%s<ParallelComponent,\n" \
-        "                          Metavariables, OrderedActionsList,\n" \
+        "                          OrderedActionsList,\n" \
         "                          SpectreArrayIndex>;\n" \
         "\n" \
-        "  template <typename ParallelComponent, typename Metavariables,\n" \
+        "  template <typename ParallelComponent,\n" \
         "            typename OrderedActionsList,\n" \
         "            typename SpectreArrayIndex>\n" \
         "  using algorithm_type = Algorithm%s<ParallelComponent,\n" \
-        "                             Metavariables, OrderedActionsList,\n" \
+        "                             OrderedActionsList,\n" \
         "                             SpectreArrayIndex>;\n" \
         "\n" \
-        "  template <typename ParallelComponent, typename Metavariables,\n" \
+        "  template <typename ParallelComponent,\n" \
         "            typename OrderedActionsList,\n" \
         "            typename SpectreArrayIndex>\n" \
         "  using ckindex = CkIndex_Algorithm%s<ParallelComponent,\n" \
-        "                             Metavariables, OrderedActionsList,\n" \
-        "                              SpectreArrayIndex>;\n" \
+        "                             OrderedActionsList,\n" \
+        "                             SpectreArrayIndex>;\n" \
         "};\n" \
         "}  // namespace Algorithms\n" \
         "}  // namespace Parallel\n\n" % \
@@ -143,22 +143,20 @@ def create_header_file(args):
          args['algorithm_name'])
     # Write Algorithm class
     header_str += \
-        "template <typename ParallelComponent, typename Metavariables,\n" \
+        "template <typename ParallelComponent,\n" \
         "          typename OrderedActionsList,\n" \
         "          typename SpectreArrayIndex>\n" \
         "class Algorithm%s\n" \
         "    : public CBase_Algorithm%s<ParallelComponent, \n" \
-        "                      Metavariables, OrderedActionsList,\n" \
+        "                      OrderedActionsList,\n" \
         "                      SpectreArrayIndex>,\n" \
         "      public Parallel::AlgorithmImpl<ParallelComponent,\n" \
         "                                     Parallel::Algorithms::%s,\n" \
-        "                                     Metavariables,\n" \
         "                                     OrderedActionsList,\n" \
         "                                     SpectreArrayIndex> {\n" \
         "  using algorithm = Parallel::Algorithms::%s;\n" \
         " public:\n" \
         "  using Parallel::AlgorithmImpl<ParallelComponent,algorithm,\n" \
-        "                                Metavariables,\n" \
         "                                OrderedActionsList,\n" \
         "                                SpectreArrayIndex>::AlgorithmImpl;\n" \
         "};\n\n" % (args['algorithm_name'], args['algorithm_name'],

--- a/cmake/SetupCharmAlgorithm.py
+++ b/cmake/SetupCharmAlgorithm.py
@@ -140,13 +140,12 @@ def create_header_file(args):
         "    : public CBase_Algorithm%s<ParallelComponent, \n" \
         "                      SpectreArrayIndex>,\n" \
         "      public Parallel::AlgorithmImpl<ParallelComponent,\n" \
-        "                       typename ParallelComponent::action_list,\n" \
-        "                       SpectreArrayIndex> {\n" \
+        "                       typename ParallelComponent::action_list> {\n" \
         "  using algorithm = Parallel::Algorithms::%s;\n" \
         " public:\n" \
         "  using Parallel::AlgorithmImpl<ParallelComponent,\n" \
-        "                  typename ParallelComponent::action_list,\n" \
-        "                  SpectreArrayIndex>::AlgorithmImpl;\n" \
+        "                  typename ParallelComponent::action_list\n" \
+        "                  >::AlgorithmImpl;\n" \
         "};\n\n" % (args['algorithm_name'],
                     args['algorithm_name'], args['algorithm_name'])
     # Write include of the def file, but including only the template definitions

--- a/cmake/SetupCharmAlgorithm.py
+++ b/cmake/SetupCharmAlgorithm.py
@@ -151,15 +151,14 @@ def create_header_file(args):
         "                      OrderedActionsList,\n" \
         "                      SpectreArrayIndex>,\n" \
         "      public Parallel::AlgorithmImpl<ParallelComponent,\n" \
-        "                                     Parallel::Algorithms::%s,\n" \
         "                                     OrderedActionsList,\n" \
         "                                     SpectreArrayIndex> {\n" \
         "  using algorithm = Parallel::Algorithms::%s;\n" \
         " public:\n" \
-        "  using Parallel::AlgorithmImpl<ParallelComponent,algorithm,\n" \
+        "  using Parallel::AlgorithmImpl<ParallelComponent,\n" \
         "                                OrderedActionsList,\n" \
         "                                SpectreArrayIndex>::AlgorithmImpl;\n" \
-        "};\n\n" % (args['algorithm_name'], args['algorithm_name'],
+        "};\n\n" % (args['algorithm_name'],
                     args['algorithm_name'], args['algorithm_name'])
     # Write include of the def file, but including only the template definitions
     header_str += "#define CK_TEMPLATES_ONLY\n" \

--- a/cmake/SetupCharmAlgorithm.py
+++ b/cmake/SetupCharmAlgorithm.py
@@ -20,8 +20,7 @@ def create_interface_file(args):
              "  template <typename ParallelComponent, " \
              "typename Metavariables, \n" \
              "            typename OrderedActionsList,\n" \
-             "            typename SpectreArrayIndex, \n" \
-             "typename InitialDataBox>\n" % args['algorithm_name']
+             "            typename SpectreArrayIndex>\n" % args['algorithm_name']
     # The chare type needs to be checked
     if args['algorithm_type'] == "array":
         ci_str += "  array [SpectreArrayIndex]"
@@ -111,33 +110,31 @@ def create_header_file(args):
         "struct %s {\n" \
         "  template <typename ParallelComponent, typename Metavariables,\n" \
         "            typename OrderedActionsList,\n" \
-        "            typename SpectreArrayIndex, typename InitialDataBox>\n" \
+        "            typename SpectreArrayIndex>\n" \
         "  using cproxy = CProxy_Algorithm%s<ParallelComponent,\n" \
         "                           Metavariables, OrderedActionsList,\n" \
-        "                           SpectreArrayIndex,\n" \
-        "                           InitialDataBox>;\n" \
+        "                           SpectreArrayIndex>;\n" \
         "\n" \
         "  template <typename ParallelComponent, typename Metavariables,\n" \
         "            typename OrderedActionsList,\n" \
-        "            typename SpectreArrayIndex, typename InitialDataBox>\n" \
+        "            typename SpectreArrayIndex>\n" \
         "  using cbase = CBase_Algorithm%s<ParallelComponent,\n" \
         "                          Metavariables, OrderedActionsList,\n" \
-        "                          SpectreArrayIndex,\n" \
-        "                          InitialDataBox>;\n" \
+        "                          SpectreArrayIndex>;\n" \
         "\n" \
         "  template <typename ParallelComponent, typename Metavariables,\n" \
         "            typename OrderedActionsList,\n" \
-        "            typename SpectreArrayIndex, typename InitialDataBox>\n" \
+        "            typename SpectreArrayIndex>\n" \
         "  using algorithm_type = Algorithm%s<ParallelComponent,\n" \
         "                             Metavariables, OrderedActionsList,\n" \
-        "                             SpectreArrayIndex, InitialDataBox>;\n" \
+        "                             SpectreArrayIndex>;\n" \
         "\n" \
         "  template <typename ParallelComponent, typename Metavariables,\n" \
         "            typename OrderedActionsList,\n" \
-        "            typename SpectreArrayIndex, typename InitialDataBox>\n" \
+        "            typename SpectreArrayIndex>\n" \
         "  using ckindex = CkIndex_Algorithm%s<ParallelComponent,\n" \
         "                             Metavariables, OrderedActionsList,\n" \
-        "                              SpectreArrayIndex, InitialDataBox>;\n" \
+        "                              SpectreArrayIndex>;\n" \
         "};\n" \
         "}  // namespace Algorithms\n" \
         "}  // namespace Parallel\n\n" % \
@@ -148,25 +145,22 @@ def create_header_file(args):
     header_str += \
         "template <typename ParallelComponent, typename Metavariables,\n" \
         "          typename OrderedActionsList,\n" \
-        "          typename SpectreArrayIndex, typename InitialDataBox>\n" \
+        "          typename SpectreArrayIndex>\n" \
         "class Algorithm%s\n" \
         "    : public CBase_Algorithm%s<ParallelComponent, \n" \
         "                      Metavariables, OrderedActionsList,\n" \
-        "                      SpectreArrayIndex,\n" \
-        "                      InitialDataBox>,\n" \
+        "                      SpectreArrayIndex>,\n" \
         "      public Parallel::AlgorithmImpl<ParallelComponent,\n" \
         "                                     Parallel::Algorithms::%s,\n" \
         "                                     Metavariables,\n" \
         "                                     OrderedActionsList,\n" \
-        "                                     SpectreArrayIndex,\n" \
-        "                                     InitialDataBox> {\n" \
+        "                                     SpectreArrayIndex> {\n" \
         "  using algorithm = Parallel::Algorithms::%s;\n" \
         " public:\n" \
         "  using Parallel::AlgorithmImpl<ParallelComponent,algorithm,\n" \
         "                                Metavariables,\n" \
         "                                OrderedActionsList,\n" \
-        "                                SpectreArrayIndex,\n" \
-        "                                InitialDataBox>::AlgorithmImpl;\n" \
+        "                                SpectreArrayIndex>::AlgorithmImpl;\n" \
         "};\n\n" % (args['algorithm_name'], args['algorithm_name'],
                     args['algorithm_name'], args['algorithm_name'])
     # Write include of the def file, but including only the template definitions

--- a/cmake/SetupCharmModuleFunctions.cmake
+++ b/cmake/SetupCharmModuleFunctions.cmake
@@ -127,6 +127,10 @@ function(generate_algorithms_impl ALGORITHM_NAME ALGORITHM_TYPE ALGORITHM_DIR)
              Algorithm${ALGORITHM_NAME}.def.h \
      && perl -pi -e 's/<\\s*Action, Args\\s*>/<Action, Args...>/g' \
              Algorithm${ALGORITHM_NAME}.decl.h \
+     && perl -pi -e 's/METAVARIABLES_FROM_COMPONENT/typename ParallelComponent::metavariables/g' \
+             Algorithm${ALGORITHM_NAME}.def.h \
+     && perl -pi -e 's/METAVARIABLES_FROM_COMPONENT/typename ParallelComponent::metavariables/g' \
+             Algorithm${ALGORITHM_NAME}.decl.h \
      \
      \
      && perl -pi -e 's/\(\\s*impl_obj->template\\s+simple_action<\\s*Action\)\\s*>\\\(args/\\1>\(std::move\(args\)/g' Algorithm${ALGORITHM_NAME}.def.h \

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -143,12 +143,10 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<ActionsPack...>, ArrayIndex> {
   using chare_type = typename ParallelComponent::chare_type;
   /// The Charm++ proxy object type
   using cproxy_type =
-      typename chare_type::template cproxy<ParallelComponent, actions_list,
-                                           array_index>;
+      typename chare_type::template cproxy<ParallelComponent, array_index>;
   /// The Charm++ base object type
   using cbase_type =
-      typename chare_type::template cbase<ParallelComponent, actions_list,
-                                          array_index>;
+      typename chare_type::template cbase<ParallelComponent, array_index>;
   /// \cond
   // The types held by the boost::variant, box_
   using databox_types = Algorithm_detail::build_action_return_typelist<
@@ -266,7 +264,7 @@ class AlgorithmImpl<ParallelComponent, tmpl::list<ActionsPack...>, ArrayIndex> {
     // down cast to the algorithm_type, so that the `thisIndex` method can be
     // called, which is defined in the CBase class
     array_index_ = static_cast<typename chare_type::template algorithm_type<
-        ParallelComponent, tmpl::list<ActionsPack...>, ArrayIndex>&>(*this)
+        ParallelComponent, ArrayIndex>&>(*this)
                        .thisIndex;
   }
 
@@ -481,9 +479,9 @@ constexpr void AlgorithmImpl<ParallelComponent, tmpl::list<ActionsPack...>,
   non_action_time_start_ = Parallel::wall_time();
 #endif
   lock(&node_lock_);
-  while (sizeof...(ActionsPack) > 0 and not get_terminate() and
+  while (tmpl::size<actions_list>::value > 0 and not get_terminate() and
          iterate_over_actions(
-             std::make_index_sequence<sizeof...(ActionsPack)>{})) {
+             std::make_index_sequence<tmpl::size<actions_list>::value>{})) {
   }
   unlock(&node_lock_);
 #ifdef SPECTRE_CHARM_PROJECTIONS
@@ -587,7 +585,7 @@ AlgorithmImpl<ParallelComponent, tmpl::list<ActionsPack...>, ArrayIndex>::
     non_action_time_start_ = Parallel::wall_time();
 #endif
     // Wrap counter if necessary
-    if (algorithm_step_ >= sizeof...(ActionsPack)) {
+    if (algorithm_step_ >= tmpl::size<actions_list>::value) {
       algorithm_step_ = 0;
     }
   };

--- a/src/Parallel/CharmRegistration.hpp
+++ b/src/Parallel/CharmRegistration.hpp
@@ -110,7 +110,7 @@ template <typename ParallelComponent>
 struct RegisterParallelComponent : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::action_list,
+      ParallelComponent,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using ckindex = typename charm_type::ckindex;
   using algorithm = typename charm_type::algorithm;
@@ -200,7 +200,7 @@ template <typename ParallelComponent, typename Action, typename... Args>
 struct RegisterSimpleAction : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::action_list,
+      ParallelComponent,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
@@ -235,7 +235,7 @@ template <typename ParallelComponent, typename Action>
 struct RegisterSimpleAction<ParallelComponent, Action> : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::action_list,
+      ParallelComponent,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
@@ -276,7 +276,7 @@ template <typename ParallelComponent, typename Action, typename... Args>
 struct RegisterThreadedAction : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::action_list,
+      ParallelComponent,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
@@ -311,7 +311,7 @@ template <typename ParallelComponent, typename Action>
 struct RegisterThreadedAction<ParallelComponent, Action> : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::action_list,
+      ParallelComponent,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
@@ -378,7 +378,7 @@ template <typename ParallelComponent, typename ReceiveTag>
 struct RegisterReceiveData : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::action_list,
+      ParallelComponent,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
@@ -439,7 +439,7 @@ template <typename ParallelComponent, typename Action, typename ReductionType>
 struct RegisterReductionAction : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::action_list,
+      ParallelComponent,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;

--- a/src/Parallel/CharmRegistration.hpp
+++ b/src/Parallel/CharmRegistration.hpp
@@ -112,8 +112,7 @@ struct RegisterParallelComponent : RegistrationHelper {
   using charm_type = charm_types_with_parameters<
       ParallelComponent, typename ParallelComponent::metavariables,
       typename ParallelComponent::action_list,
-      typename get_array_index<chare_type>::template f<ParallelComponent>,
-      typename ParallelComponent::initial_databox>;
+      typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using ckindex = typename charm_type::ckindex;
   using algorithm = typename charm_type::algorithm;
 
@@ -204,8 +203,7 @@ struct RegisterSimpleAction : RegistrationHelper {
   using charm_type = charm_types_with_parameters<
       ParallelComponent, typename ParallelComponent::metavariables,
       typename ParallelComponent::action_list,
-      typename get_array_index<chare_type>::template f<ParallelComponent>,
-      typename ParallelComponent::initial_databox>;
+      typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
   using algorithm = typename charm_type::algorithm;
@@ -241,8 +239,7 @@ struct RegisterSimpleAction<ParallelComponent, Action> : RegistrationHelper {
   using charm_type = charm_types_with_parameters<
       ParallelComponent, typename ParallelComponent::metavariables,
       typename ParallelComponent::action_list,
-      typename get_array_index<chare_type>::template f<ParallelComponent>,
-      typename ParallelComponent::initial_databox>;
+      typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
   using algorithm = typename charm_type::algorithm;
@@ -284,8 +281,7 @@ struct RegisterThreadedAction : RegistrationHelper {
   using charm_type = charm_types_with_parameters<
       ParallelComponent, typename ParallelComponent::metavariables,
       typename ParallelComponent::action_list,
-      typename get_array_index<chare_type>::template f<ParallelComponent>,
-      typename ParallelComponent::initial_databox>;
+      typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
   using algorithm = typename charm_type::algorithm;
@@ -321,8 +317,7 @@ struct RegisterThreadedAction<ParallelComponent, Action> : RegistrationHelper {
   using charm_type = charm_types_with_parameters<
       ParallelComponent, typename ParallelComponent::metavariables,
       typename ParallelComponent::action_list,
-      typename get_array_index<chare_type>::template f<ParallelComponent>,
-      typename ParallelComponent::initial_databox>;
+      typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
   using algorithm = typename charm_type::algorithm;
@@ -390,8 +385,7 @@ struct RegisterReceiveData : RegistrationHelper {
   using charm_type = charm_types_with_parameters<
       ParallelComponent, typename ParallelComponent::metavariables,
       typename ParallelComponent::action_list,
-      typename get_array_index<chare_type>::template f<ParallelComponent>,
-      typename ParallelComponent::initial_databox>;
+      typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
   using algorithm = typename charm_type::algorithm;
@@ -453,8 +447,7 @@ struct RegisterReductionAction : RegistrationHelper {
   using charm_type = charm_types_with_parameters<
       ParallelComponent, typename ParallelComponent::metavariables,
       typename ParallelComponent::action_list,
-      typename get_array_index<chare_type>::template f<ParallelComponent>,
-      typename ParallelComponent::initial_databox>;
+      typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
   using algorithm = typename charm_type::algorithm;

--- a/src/Parallel/CharmRegistration.hpp
+++ b/src/Parallel/CharmRegistration.hpp
@@ -110,8 +110,7 @@ template <typename ParallelComponent>
 struct RegisterParallelComponent : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::metavariables,
-      typename ParallelComponent::action_list,
+      ParallelComponent, typename ParallelComponent::action_list,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using ckindex = typename charm_type::ckindex;
   using algorithm = typename charm_type::algorithm;
@@ -201,8 +200,7 @@ template <typename ParallelComponent, typename Action, typename... Args>
 struct RegisterSimpleAction : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::metavariables,
-      typename ParallelComponent::action_list,
+      ParallelComponent, typename ParallelComponent::action_list,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
@@ -237,8 +235,7 @@ template <typename ParallelComponent, typename Action>
 struct RegisterSimpleAction<ParallelComponent, Action> : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::metavariables,
-      typename ParallelComponent::action_list,
+      ParallelComponent, typename ParallelComponent::action_list,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
@@ -279,8 +276,7 @@ template <typename ParallelComponent, typename Action, typename... Args>
 struct RegisterThreadedAction : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::metavariables,
-      typename ParallelComponent::action_list,
+      ParallelComponent, typename ParallelComponent::action_list,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
@@ -315,8 +311,7 @@ template <typename ParallelComponent, typename Action>
 struct RegisterThreadedAction<ParallelComponent, Action> : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::metavariables,
-      typename ParallelComponent::action_list,
+      ParallelComponent, typename ParallelComponent::action_list,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
@@ -383,8 +378,7 @@ template <typename ParallelComponent, typename ReceiveTag>
 struct RegisterReceiveData : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::metavariables,
-      typename ParallelComponent::action_list,
+      ParallelComponent, typename ParallelComponent::action_list,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;
@@ -445,8 +439,7 @@ template <typename ParallelComponent, typename Action, typename ReductionType>
 struct RegisterReductionAction : RegistrationHelper {
   using chare_type = typename ParallelComponent::chare_type;
   using charm_type = charm_types_with_parameters<
-      ParallelComponent, typename ParallelComponent::metavariables,
-      typename ParallelComponent::action_list,
+      ParallelComponent, typename ParallelComponent::action_list,
       typename get_array_index<chare_type>::template f<ParallelComponent>>;
   using cproxy = typename charm_type::cproxy;
   using ckindex = typename charm_type::ckindex;

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -109,16 +109,14 @@ struct get_array_index<Parallel::Algorithms::Nodegroup> {
 template <typename ParallelComponent>
 using proxy_from_parallel_component =
     typename ParallelComponent::chare_type::template cproxy<
-        ParallelComponent, typename ParallelComponent::metavariables,
-        typename ParallelComponent::action_list,
+        ParallelComponent, typename ParallelComponent::action_list,
         typename get_array_index<typename ParallelComponent::chare_type>::
             template f<ParallelComponent>>;
 
 template <typename ParallelComponent>
 using index_from_parallel_component =
     typename ParallelComponent::chare_type::template ckindex<
-        ParallelComponent, typename ParallelComponent::metavariables,
-        typename ParallelComponent::action_list,
+        ParallelComponent, typename ParallelComponent::action_list,
         typename get_array_index<typename ParallelComponent::chare_type>::
             template f<ParallelComponent>>;
 

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -109,14 +109,14 @@ struct get_array_index<Parallel::Algorithms::Nodegroup> {
 template <typename ParallelComponent>
 using proxy_from_parallel_component =
     typename ParallelComponent::chare_type::template cproxy<
-        ParallelComponent, typename ParallelComponent::action_list,
+        ParallelComponent,
         typename get_array_index<typename ParallelComponent::chare_type>::
             template f<ParallelComponent>>;
 
 template <typename ParallelComponent>
 using index_from_parallel_component =
     typename ParallelComponent::chare_type::template ckindex<
-        ParallelComponent, typename ParallelComponent::action_list,
+        ParallelComponent,
         typename get_array_index<typename ParallelComponent::chare_type>::
             template f<ParallelComponent>>;
 

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -112,8 +112,7 @@ using proxy_from_parallel_component =
         ParallelComponent, typename ParallelComponent::metavariables,
         typename ParallelComponent::action_list,
         typename get_array_index<typename ParallelComponent::chare_type>::
-            template f<ParallelComponent>,
-        typename ParallelComponent::initial_databox>;
+            template f<ParallelComponent>>;
 
 template <typename ParallelComponent>
 using index_from_parallel_component =
@@ -121,8 +120,7 @@ using index_from_parallel_component =
         ParallelComponent, typename ParallelComponent::metavariables,
         typename ParallelComponent::action_list,
         typename get_array_index<typename ParallelComponent::chare_type>::
-            template f<ParallelComponent>,
-        typename ParallelComponent::initial_databox>;
+            template f<ParallelComponent>>;
 
 template <class ParallelComponent, class... Args>
 struct charm_types_with_parameters {

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -693,7 +693,7 @@ class MockProxy {
 /// A mock class for the CMake-generated `Parallel::Algorithms::Array`
 struct MockArrayChare {
   template <typename Component, typename Metavariables, typename ActionList,
-            typename Index, typename InitialDataBox>
+            typename Index>
   using cproxy =
       ActionTesting_detail::MockProxy<Component, Index,
                                       Parallel::get_inbox_tags<ActionList>>;

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -692,8 +692,7 @@ class MockProxy {
 
 /// A mock class for the CMake-generated `Parallel::Algorithms::Array`
 struct MockArrayChare {
-  template <typename Component, typename Metavariables, typename ActionList,
-            typename Index>
+  template <typename Component, typename ActionList, typename Index>
   using cproxy =
       ActionTesting_detail::MockProxy<Component, Index,
                                       Parallel::get_inbox_tags<ActionList>>;

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -692,10 +692,10 @@ class MockProxy {
 
 /// A mock class for the CMake-generated `Parallel::Algorithms::Array`
 struct MockArrayChare {
-  template <typename Component, typename ActionList, typename Index>
-  using cproxy =
-      ActionTesting_detail::MockProxy<Component, Index,
-                                      Parallel::get_inbox_tags<ActionList>>;
+  template <typename Component, typename Index>
+  using cproxy = ActionTesting_detail::MockProxy<
+      Component, Index,
+      Parallel::get_inbox_tags<typename Component::action_list>>;
 };
 }  // namespace ActionTesting
 

--- a/tests/Unit/Parallel/Test_TypeTraits.cpp
+++ b/tests/Unit/Parallel/Test_TypeTraits.cpp
@@ -24,19 +24,27 @@ class NonpupableClass {};
 
 struct MV {};
 
-struct SingletonParallelComponent {};
-struct ArrayParallelComponent {};
-struct GroupParallelComponent {};
-struct NodegroupParallelComponent {};
+struct SingletonParallelComponent {
+  using metavariables = MV;
+};
+struct ArrayParallelComponent {
+  using metavariables = MV;
+};
+struct GroupParallelComponent {
+  using metavariables = MV;
+};
+struct NodegroupParallelComponent {
+  using metavariables = MV;
+};
 
-using singleton_proxy = CProxy_AlgorithmSingleton<SingletonParallelComponent,
-                                                  MV, tmpl::list<>, int>;
+using singleton_proxy =
+    CProxy_AlgorithmSingleton<SingletonParallelComponent, tmpl::list<>, int>;
 using array_proxy =
-    CProxy_AlgorithmArray<ArrayParallelComponent, MV, tmpl::list<>, int>;
+    CProxy_AlgorithmArray<ArrayParallelComponent, tmpl::list<>, int>;
 using group_proxy =
-    CProxy_AlgorithmGroup<ArrayParallelComponent, MV, tmpl::list<>, int>;
+    CProxy_AlgorithmGroup<ArrayParallelComponent, tmpl::list<>, int>;
 using nodegroup_proxy =
-    CProxy_AlgorithmNodegroup<ArrayParallelComponent, MV, tmpl::list<>, int>;
+    CProxy_AlgorithmNodegroup<ArrayParallelComponent, tmpl::list<>, int>;
 }  // namespace
 
 static_assert(Parallel::is_array_proxy<array_proxy>::value,

--- a/tests/Unit/Parallel/Test_TypeTraits.cpp
+++ b/tests/Unit/Parallel/Test_TypeTraits.cpp
@@ -13,10 +13,6 @@
 namespace PUP {
 class er;
 }  // namespace PUP
-namespace db {
-template <typename TagsList>
-class DataBox;
-}  // namespace db
 
 namespace {
 class PupableClass {
@@ -33,18 +29,14 @@ struct ArrayParallelComponent {};
 struct GroupParallelComponent {};
 struct NodegroupParallelComponent {};
 
-using singleton_proxy =
-    CProxy_AlgorithmSingleton<SingletonParallelComponent, MV, tmpl::list<>, int,
-                              db::DataBox<tmpl::list<>>>;
+using singleton_proxy = CProxy_AlgorithmSingleton<SingletonParallelComponent,
+                                                  MV, tmpl::list<>, int>;
 using array_proxy =
-    CProxy_AlgorithmArray<ArrayParallelComponent, MV, tmpl::list<>, int,
-                          db::DataBox<tmpl::list<>>>;
+    CProxy_AlgorithmArray<ArrayParallelComponent, MV, tmpl::list<>, int>;
 using group_proxy =
-    CProxy_AlgorithmGroup<ArrayParallelComponent, MV, tmpl::list<>, int,
-                          db::DataBox<tmpl::list<>>>;
+    CProxy_AlgorithmGroup<ArrayParallelComponent, MV, tmpl::list<>, int>;
 using nodegroup_proxy =
-    CProxy_AlgorithmNodegroup<ArrayParallelComponent, MV, tmpl::list<>, int,
-                              db::DataBox<tmpl::list<>>>;
+    CProxy_AlgorithmNodegroup<ArrayParallelComponent, MV, tmpl::list<>, int>;
 }  // namespace
 
 static_assert(Parallel::is_array_proxy<array_proxy>::value,

--- a/tests/Unit/Parallel/Test_TypeTraits.cpp
+++ b/tests/Unit/Parallel/Test_TypeTraits.cpp
@@ -8,7 +8,6 @@
 #include "AlgorithmNodegroup.hpp"
 #include "AlgorithmSingleton.hpp"
 #include "Parallel/TypeTraits.hpp"
-#include "Utilities/TMPL.hpp"
 
 namespace PUP {
 class er;
@@ -38,13 +37,10 @@ struct NodegroupParallelComponent {
 };
 
 using singleton_proxy =
-    CProxy_AlgorithmSingleton<SingletonParallelComponent, tmpl::list<>, int>;
-using array_proxy =
-    CProxy_AlgorithmArray<ArrayParallelComponent, tmpl::list<>, int>;
-using group_proxy =
-    CProxy_AlgorithmGroup<ArrayParallelComponent, tmpl::list<>, int>;
-using nodegroup_proxy =
-    CProxy_AlgorithmNodegroup<ArrayParallelComponent, tmpl::list<>, int>;
+    CProxy_AlgorithmSingleton<SingletonParallelComponent, int>;
+using array_proxy = CProxy_AlgorithmArray<ArrayParallelComponent, int>;
+using group_proxy = CProxy_AlgorithmGroup<ArrayParallelComponent, int>;
+using nodegroup_proxy = CProxy_AlgorithmNodegroup<ArrayParallelComponent, int>;
 }  // namespace
 
 static_assert(Parallel::is_array_proxy<array_proxy>::value,


### PR DESCRIPTION
## Proposed changes

Removes a lot of the template parameters from AlgorithmImpl and the Charm++ code. The Charm++ code I believe is now at the least number of template parameters it can be within our pattern (it may be possible to get rid of the `SpectreArrayIndex`, but this would require some careful thought and experimentation). The `AlgorithmImpl` in the future will also need to get rid of `ActionList` since we will have one of these per phase. This PR is a first step towards:
- phase-dependent action lists
- Automatically adding the global cache tags into the DataBox.

To achieve adding the cache tags to the DataBox we will need to no longer have `initial_databox` inside the component, but we should instead specify the initial action. The AlgorithmImpl can then grab the `return_tag_list` from the initialize action to set the initial DataBox type. This is required because of eager evaluation of type aliases causing a circular dependency when creating the `tag_list` inside DataBox.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
