### PR TITLE
Change wheeler env to use python 3.6.5

### DIFF
--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -26,7 +26,6 @@ spectre_unload_modules() {
     module unload git/2.8.4
     module unload llvm/5.0.1
     module unload charm/6.8.0-smp
-    module unload python/anaconda2-4.1.1
 }
 
 spectre_load_modules() {
@@ -48,7 +47,6 @@ spectre_load_modules() {
     module load git/2.8.4
     module load llvm/5.0.1
     module load charm/6.8.0-smp
-    module load python/anaconda2-4.1.1
 }
 
 spectre_run_cmake() {

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -26,7 +26,6 @@ spectre_unload_modules() {
     module unload git/2.8.4
     module unload lcov/1.13
     module unload charm/6.8.0-smp
-    module unload python/anaconda2-4.1.1
 }
 
 spectre_load_modules() {
@@ -48,7 +47,6 @@ spectre_load_modules() {
     module load git/2.8.4
     module load lcov/1.13
     module load charm/6.8.0-smp
-    module load python/anaconda2-4.1.1
 }
 
 spectre_run_cmake() {


### PR DESCRIPTION
## Proposed changes

The wheeler environment uses python 2.4 via anaconda, so I switched it to use 3.6.5 instead. (Gabe was hitting some issues with tests failing)

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
