### PR TITLE
Block redundant updates in Averager

### DIFF
--- a/src/ControlSystem/Averager.cpp
+++ b/src/ControlSystem/Averager.cpp
@@ -86,6 +86,13 @@ void Averager<DerivOrder>::update(const double time, const DataVector& raw_q,
     tau_k_ = averaged_values_.get()[0];
   }
 
+  // Do not allow updates at or before last update time
+  if (not times_.empty() and time <= last_time_updated()) {
+    ERROR("The specified time t=" << time << " is at or before the last time "
+                                             "updated, t_update="
+                                  << last_time_updated() << ".");
+  }
+
   // update deques
   times_.emplace_front(time);
   raw_qs_.emplace_front(raw_q);

--- a/tests/Unit/ControlSystem/Test_Averager.cpp
+++ b/tests/Unit/ControlSystem/Test_Averager.cpp
@@ -146,7 +146,7 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Averager.Functionality",
 
   Averager<deriv_order> averager(0.5, false);
 
-  // test the have_sufficient_data function:
+  // test the validity of data functionality
   // data not valid yet
   CHECK_FALSE(static_cast<bool>(averager(t)));
   // first update
@@ -177,6 +177,26 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.Averager.Functionality",
   // clear the averager, which should make the data no longer valid
   averager.clear();
   CHECK_FALSE(static_cast<bool>(averager(t)));
+}
+
+// [[OutputRegex, at or before the last time]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.Averager.BadUpdateTwice",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  Averager<2> averager(0.5, false);
+
+  averager.update(0.5, {0.0}, {0.1});
+  averager.update(0.5, {0.0}, {0.1});
+}
+
+// [[OutputRegex, at or before the last time]]
+SPECTRE_TEST_CASE("Unit.ControlSystem.Averager.BadUpdatePast",
+                  "[ControlSystem][Unit]") {
+  ERROR_TEST();
+  Averager<2> averager(0.5, false);
+
+  averager.update(0.5, {0.0}, {0.1});
+  averager.update(0.3, {0.0}, {0.1});
 }
 
 // [[OutputRegex, The number of components in the raw_q provided \(2\) does]]


### PR DESCRIPTION
## Proposed changes

The FunctionOfTimeUpdater may redundantly call the Averager 
update function more than once at a given time. This results in an 
fpe, due to the attempted numerical differentiation with delta_t = 0. 
This fix allows for calls to the update at any time, but refuses to 
update if we already have, or if an attempt is made to update at 
a previous time -- this keeps the Averager in a 'valid' state.

### Types of changes:

- [1/2] Bugfix
- [1/2] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
