### PR TITLE
ssize_t cleanup

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/LagrangePolynomial.hpp
+++ b/src/NumericalAlgorithms/Interpolation/LagrangePolynomial.hpp
@@ -35,11 +35,11 @@ template <typename Iterator>
 double lagrange_polynomial(size_t j, double x,
                            const Iterator& control_points_begin,
                            const Iterator& control_points_end) {
-  ASSERT(j < static_cast<size_t>(std::distance(control_points_begin,
-                                               control_points_end)),
+  const auto j_diff =
+      static_cast<typename std::iterator_traits<Iterator>::difference_type>(j);
+  ASSERT(j_diff < std::distance(control_points_begin, control_points_end),
          "Polynomial number out of range " << j << " > "
          << (std::distance(control_points_begin, control_points_end) - 1));
-  return lagrange_polynomial(std::next(control_points_begin,
-                                       static_cast<ssize_t>(j)),
+  return lagrange_polynomial(std::next(control_points_begin, j_diff),
                              x, control_points_begin, control_points_end);
 }

--- a/src/Time/History.hpp
+++ b/src/Time/History.hpp
@@ -59,7 +59,9 @@ class History {
   /// HistoryIterator::value() and HistoryIterator::derivative().
   //@{
   const_iterator begin() const noexcept {
-    return data_.begin() + static_cast<ssize_t>(first_needed_entry_);
+    return data_.begin() +
+           static_cast<typename decltype(data_.begin())::difference_type>(
+               first_needed_entry_);
   }
   const_iterator end() const noexcept { return data_.end(); }
   const_iterator cbegin() const noexcept { return begin(); }
@@ -74,7 +76,7 @@ class History {
   /// through HistoryIterator methods.
   //@{
   const_reference operator[](size_type n) const noexcept {
-    return *(begin() + static_cast<ssize_t>(n));
+    return *(begin() + static_cast<difference_type>(n));
   }
 
   const_reference front() const noexcept { return *begin(); }
@@ -202,8 +204,11 @@ inline void History<Vars, DerivVars>::mark_unneeded(
 
 template <typename Vars, typename DerivVars>
 inline void History<Vars, DerivVars>::shrink_to_fit() noexcept {
-  data_.erase(data_.begin(),
-              data_.begin() + static_cast<ssize_t>(first_needed_entry_));
+  data_.erase(
+      data_.begin(),
+      data_.begin() +
+          static_cast<typename decltype(data_.begin())::difference_type>(
+              first_needed_entry_));
   first_needed_entry_ = 0;
 }
 

--- a/src/Time/StepControllers/SplitRemaining.hpp
+++ b/src/Time/StepControllers/SplitRemaining.hpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <pup.h>
 
 #include "Options/Options.hpp"
@@ -43,8 +44,8 @@ class SplitRemaining : public StepController {
     const Time goal =
         desired_step > 0 ? time.slab().end() : time.slab().start();
     const TimeDelta remaining = goal - time;
-    const ssize_t steps = static_cast<ssize_t>(
-        std::max(std::ceil(remaining.value() / desired_step), 1.));
+    const auto steps = std::max(
+        static_cast<int32_t>(std::ceil(remaining.value() / desired_step)), 1);
 
     return remaining / steps;
   }

--- a/src/Time/Time.hpp
+++ b/src/Time/Time.hpp
@@ -23,8 +23,6 @@ class er;
 class TimeDelta;
 /// \endcond
 
-// IWYU pragma: no_include <sys/types.h>
-
 /// \ingroup TimeGroup
 ///
 /// The time in a simulation.  Times can be safely compared for exact

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -285,7 +285,10 @@ void test_initialize_element(
     const SystemAnalyticSolution solution{};
     double past_t = start_time;
     for (size_t i = history.size(); i > 0; --i) {
-      const auto entry = history.begin() + static_cast<ssize_t>(i - 1);
+      const auto entry =
+          history.begin() +
+          static_cast<
+              typename std::decay_t<decltype(history)>::difference_type>(i - 1);
       past_t -= dt;
 
       CHECK(entry->value() == past_t);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_LagrangePolynomial.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_LagrangePolynomial.cpp
@@ -5,7 +5,6 @@
 
 #include <array>
 #include <cstddef>
-#include <sys/types.h>
 
 #include "NumericalAlgorithms/Interpolation/LagrangePolynomial.hpp"
 #include "Utilities/Gsl.hpp"
@@ -19,7 +18,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.LagrangePolynomial",
       CHECK(lagrange_polynomial(j, gsl::at(control, i),
                                 control.begin(), control.end())
             == approx(i == j ? 1. : 0.));
-      CHECK(lagrange_polynomial(control.begin() + static_cast<ssize_t>(j),
+      CHECK(lagrange_polynomial(control.begin() + static_cast<ptrdiff_t>(j),
                                 gsl::at(control, i),
                                 control.begin(),
                                 control.end()) ==

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <initializer_list>  // IWYU pragma: keep
 #include <memory>
 #include <string>
@@ -155,7 +156,7 @@ void test_actions(const size_t order, const bool forward_in_time) noexcept {
           0, ActionTesting::MockDistributedObject<component>{
                  db::create<component::simple_tags, component::compute_tags>(
                      initial_value, 0., db::item_type<history_tag>{}, TimeId{},
-                     TimeId(forward_in_time, 1 - static_cast<ssize_t>(order),
+                     TimeId(forward_in_time, 1 - static_cast<int64_t>(order),
                             initial_time),
                      initial_time_step)});
   MockRuntimeSystem runner{
@@ -256,7 +257,7 @@ double error_in_step(const size_t order, const double step) noexcept {
           0, ActionTesting::MockDistributedObject<component>{
                  db::create<component::simple_tags, component::compute_tags>(
                      initial_value, 0., db::item_type<history_tag>{}, TimeId{},
-                     TimeId(forward_in_time, 1 - static_cast<ssize_t>(order),
+                     TimeId(forward_in_time, 1 - static_cast<int64_t>(order),
                             initial_time),
                      initial_time_step)});
   MockRuntimeSystem runner{

--- a/tests/Unit/Time/Test_History.cpp
+++ b/tests/Unit/Time/Test_History.cpp
@@ -83,7 +83,7 @@ void check_history_state(const HistoryType& hist) noexcept {
     auto it = hist.begin();
     for (size_t i = 0; i < hist.size(); ++i, ++it) {
       CHECK(*it == hist[i]);
-      const auto entry_num = static_cast<ssize_t>(i) - 1;
+      const auto entry_num = static_cast<double>(i) - 1.0;
       CHECK((*it).value() == entry_num);
       CHECK(it->value() == entry_num);
       CHECK(it.value() == entry_num);
@@ -149,7 +149,7 @@ SPECTRE_TEST_CASE("Unit.Time.History", "[Unit][Time]") {
     auto it = history.begin();
     for (size_t i = 0; i < 2; ++i, ++it) {
       CHECK(*it == history[i]);
-      const auto entry_num = static_cast<ssize_t>(i) + 1;
+      const auto entry_num = static_cast<double>(i) + 1.0;
       CHECK((*it).value() == entry_num);
       CHECK(it->value() == entry_num);
       CHECK(it.value() == entry_num);
@@ -175,7 +175,7 @@ size_t check_boundary_state(gsl::not_null<BoundaryHistoryType*> hist) noexcept {
   {
     auto it = hist->local_begin();
     for (size_t i = 0; i < hist->local_size(); ++i, ++it) {
-      const auto entry_num = static_cast<ssize_t>(i) - 1;
+      const auto entry_num = static_cast<double>(i) - 1.0;
       CHECK((*it).value() == entry_num);
       CHECK(it->value() == entry_num);
     }
@@ -186,7 +186,7 @@ size_t check_boundary_state(gsl::not_null<BoundaryHistoryType*> hist) noexcept {
   {
     auto it = hist->remote_begin();
     for (size_t i = 0; i < hist->remote_size(); ++i, ++it) {
-      const auto entry_num = static_cast<ssize_t>(i) - 2;
+      const auto entry_num = static_cast<double>(i) - 2.0;
       CHECK((*it).value() == entry_num);
       CHECK(it->value() == entry_num);
     }
@@ -271,7 +271,7 @@ SPECTRE_TEST_CASE("Unit.Time.BoundaryHistory", "[Unit][Time]") {
   {
     auto it = history.local_begin();
     for (size_t i = 0; i < history.local_size(); ++i, ++it) {
-      const auto entry_num = static_cast<ssize_t>(i) + 1;
+      const auto entry_num = static_cast<double>(i) + 1.0;
       CHECK((*it).value() == entry_num);
       CHECK(it->value() == entry_num);
     }
@@ -285,7 +285,7 @@ SPECTRE_TEST_CASE("Unit.Time.BoundaryHistory", "[Unit][Time]") {
   {
     auto it = history.remote_begin();
     for (size_t i = 0; i < history.remote_size(); ++i, ++it) {
-      const auto entry_num = static_cast<ssize_t>(i);
+      const auto entry_num = static_cast<double>(i);
       CHECK((*it).value() == entry_num);
       CHECK(it->value() == entry_num);
     }

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <deque>
 
 #include "ErrorHandling/Assert.hpp"
@@ -270,7 +271,7 @@ void do_lts_test(const std::array<TimeDelta, 2>& dt) noexcept {
   {
     const Slab init_slab = slab.advance_towards(-dt[0]);
 
-    for (ssize_t step = 1; step <= 3; ++step) {
+    for (int32_t step = 1; step <= 3; ++step) {
       {
         const Time now = t - step * dt[0].with_slab(init_slab);
         history.local_insert_initial(make_time_id(now),
@@ -374,7 +375,7 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Boundary.Variable",
     const TimeDelta init_dt = init_slab.duration() / 4;
 
     // clang-tidy misfeature: warns about boost internals here
-    for (ssize_t step = 1; step <= 3; ++step) {  // NOLINT
+    for (int32_t step = 1; step <= 3; ++step) {  // NOLINT
       // clang-tidy misfeature: warns about boost internals here
       const Time now = t - step * init_dt;  // NOLINT
       history.local_insert_initial(make_time_id(now),


### PR DESCRIPTION
As discussed in [#1003](https://github.com/sxs-collaboration/spectre/pull/1003#discussion_r221186604), `ssize_t` is usually not the correct type for iterators and indexing and similar.  This replaces the `ssize_t`s with more appropriate types everywhere except in BarycentricRational.?pp, which is a relatively complicated case in code I am not very familiar with.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
