### PR TITLE
Add support for Block orientations in Minmod and limiter actions

### DIFF
--- a/src/Domain/OrientationMap.cpp
+++ b/src/Domain/OrientationMap.cpp
@@ -64,7 +64,7 @@ OrientationMap<VolumeDim>::OrientationMap(
 
 template <size_t VolumeDim>
 std::array<SegmentId, VolumeDim> OrientationMap<VolumeDim>::operator()(
-    const std::array<SegmentId, VolumeDim>& segmentIds) const {
+    const std::array<SegmentId, VolumeDim>& segmentIds) const noexcept {
   std::array<SegmentId, VolumeDim> result = segmentIds;
   for (size_t d = 0; d < VolumeDim; d++) {
     gsl::at(result, gsl::at(mapped_directions_, d).dimension()) =

--- a/src/Domain/OrientationMap.cpp
+++ b/src/Domain/OrientationMap.cpp
@@ -76,6 +76,14 @@ std::array<SegmentId, VolumeDim> OrientationMap<VolumeDim>::operator()(
 }
 
 template <size_t VolumeDim>
+Mesh<VolumeDim> OrientationMap<VolumeDim>::operator()(
+    const Mesh<VolumeDim>& mesh) const noexcept {
+  return Mesh<VolumeDim>(this->permute_from_neighbor(mesh.extents().indices()),
+                         this->permute_from_neighbor(mesh.basis()),
+                         this->permute_from_neighbor(mesh.quadrature()));
+}
+
+template <size_t VolumeDim>
 OrientationMap<VolumeDim> OrientationMap<VolumeDim>::inverse_map() const
     noexcept {
   std::array<Direction<VolumeDim>, VolumeDim> result;

--- a/src/Domain/OrientationMap.hpp
+++ b/src/Domain/OrientationMap.hpp
@@ -57,7 +57,8 @@ class OrientationMap {
   }
 
   /// The corresponding direction in the neighbor.
-  Direction<VolumeDim> operator()(const Direction<VolumeDim>& direction) const {
+  Direction<VolumeDim> operator()(const Direction<VolumeDim>& direction) const
+      noexcept {
     return direction.side() == Side::Upper
                ? gsl::at(mapped_directions_, direction.dimension())
                : gsl::at(mapped_directions_, direction.dimension()).opposite();
@@ -65,7 +66,7 @@ class OrientationMap {
 
   /// The corresponding SegmentIds in the neighbor.
   std::array<SegmentId, VolumeDim> operator()(
-      const std::array<SegmentId, VolumeDim>& segmentIds) const;
+      const std::array<SegmentId, VolumeDim>& segmentIds) const noexcept;
 
   /// An array whose elements are permuted such that
   /// `result[d] = array_in_neighbor[this->operator()(d)]`

--- a/src/Domain/OrientationMap.hpp
+++ b/src/Domain/OrientationMap.hpp
@@ -7,14 +7,13 @@
 #include <cstddef>
 #include <iosfwd>
 
-
 #include "Domain/Direction.hpp"
-#include "Domain/SegmentId.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/SegmentId.hpp"  // IWYU pragma: keep
 #include "Domain/Side.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TypeTraits.hpp"
 
-class SegmentId;
 namespace PUP {
 class er;
 }  // namespace PUP
@@ -67,6 +66,9 @@ class OrientationMap {
   /// The corresponding SegmentIds in the neighbor.
   std::array<SegmentId, VolumeDim> operator()(
       const std::array<SegmentId, VolumeDim>& segmentIds) const noexcept;
+
+  /// The corresponding Mesh in the neighbor
+  Mesh<VolumeDim> operator()(const Mesh<VolumeDim>& mesh) const noexcept;
 
   /// An array whose elements are permuted such that
   /// `result[d] = array_in_neighbor[this->operator()(d)]`

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/LimiterActions.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/LimiterActions.hpp
@@ -46,7 +46,6 @@ namespace Actions {
 /// \brief Receive limiter data from neighbors, then apply limiter.
 ///
 /// Currently, is not tested for support of:
-/// - Blocks with differing Orientations
 /// - h-refinement
 /// Currently, does not support:
 /// - Local time-stepping
@@ -135,7 +134,6 @@ struct Limit {
 /// \brief Send local data needed for limiting.
 ///
 /// Currently, is not tested for support of:
-/// - Blocks with differing Orientations
 /// - h-refinement
 /// Currently, does not support:
 /// - Local time-stepping
@@ -196,11 +194,12 @@ struct SendData {
           typename Metavariables::limiter::type::package_argument_tags;
       const auto packaged_data = db::apply<argument_tags>(
           [&limiter](const auto&... args) noexcept {
+            // Note: orientation is received as last element of pack `args`
             typename Metavariables::limiter::type::PackagedData pack{};
             limiter.package_data(make_not_null(&pack), args...);
             return pack;
           },
-          box);
+          box, orientation);
 
       for (const auto& neighbor : neighbors_in_direction) {
         Parallel::receive_data<limiter_comm_tag>(

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -242,10 +242,12 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   /// \param mesh The mesh on which the tensor values are measured.
   /// \param element_size The size of the element in inertial coordinates, along
   ///        each dimension of logical coordinates.
+  /// \param orientation_map The orientation of the neighbor
   void package_data(const gsl::not_null<PackagedData*>& packaged_data,
                     const db::item_type<Tags>&... tensors,
                     const Mesh<VolumeDim>& mesh,
-                    const std::array<double, VolumeDim>& element_size) const
+                    const std::array<double, VolumeDim>& element_size,
+                    const OrientationMap<VolumeDim>& /*orientation_map*/) const
       noexcept {
     const auto wrap_compute_means =
         [&mesh, &packaged_data ](auto tag, const auto& tensor) noexcept {

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -247,18 +247,22 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
                     const db::item_type<Tags>&... tensors,
                     const Mesh<VolumeDim>& mesh,
                     const std::array<double, VolumeDim>& element_size,
-                    const OrientationMap<VolumeDim>& /*orientation_map*/) const
+                    const OrientationMap<VolumeDim>& orientation_map) const
       noexcept {
     const auto wrap_compute_means =
         [&mesh, &packaged_data ](auto tag, const auto& tensor) noexcept {
       for (size_t i = 0; i < tensor.size(); ++i) {
+        // Compute the mean using the local orientation of the tensor and mesh:
+        // this avoids the work of reorienting the tensor while giving the same
+        // result.
         get<Minmod_detail::to_tensor_double<decltype(tag)>>(
             packaged_data->means_)[i] = mean_value(tensor[i], mesh);
       }
       return '0';
     };
     expand_pack(wrap_compute_means(Tags{}, tensors)...);
-    packaged_data->element_size_ = element_size;
+    packaged_data->element_size_ =
+        orientation_map.permute_from_neighbor(element_size);
   }
 
   using limit_tags = tmpl::list<Tags...>;

--- a/tests/Unit/Domain/Test_OrientationMap.cpp
+++ b/tests/Unit/Domain/Test_OrientationMap.cpp
@@ -36,7 +36,7 @@ void test_1d() {
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}});
   CHECK_FALSE(custom2.is_aligned());
 
-  // Test if OrientationMap can encode a 1D parallel/ antiparallel.
+  // Test if OrientationMap can encode a 1D parallel/antiparallel.
   std::array<Direction<1>, 1> block1_directions{{Direction<1>::upper_xi()}};
   std::array<Direction<1>, 1> block2_directions{{Direction<1>::lower_xi()}};
   OrientationMap<1> parallel_orientation(block1_directions, block1_directions);
@@ -47,13 +47,14 @@ void test_1d() {
   CHECK(parallel_orientation(segment_ids) == segment_ids);
   CHECK(antiparallel_orientation(segment_ids) ==
         expected_antiparallel_segment_ids);
-  CHECK(get_output(parallel_orientation) == "(+0)");
-  CHECK(get_output(antiparallel_orientation) == "(-0)");
   CHECK(std::array<int, 1>{{1}} ==
         parallel_orientation.permute_from_neighbor(std::array<int, 1>{{1}}));
   CHECK(
       std::array<int, 1>{{1}} ==
       antiparallel_orientation.permute_from_neighbor(std::array<int, 1>{{1}}));
+
+  CHECK(get_output(parallel_orientation) == "(+0)");
+  CHECK(get_output(antiparallel_orientation) == "(-0)");
 
   // Test comparison:
   CHECK(custom1 != custom2);
@@ -127,6 +128,11 @@ void test_2d() {
   std::array<SegmentId, 2> expected_pos_eta_neg_xi_segment_ids{
       {SegmentId(3, 5), SegmentId(2, 2)}};
 
+  CHECK_FALSE(rotated2d_neg_eta_pos_xi.is_aligned());
+  CHECK_FALSE(rotated2d_neg_xi_neg_eta.is_aligned());
+  CHECK_FALSE(rotated2d_pos_eta_neg_xi.is_aligned());
+  CHECK(rotated2d_pos_xi_pos_eta.is_aligned());
+
   // Check mapped(size_t dimension) function
   CHECK(rotated2d_neg_xi_neg_eta(0) == 0);
   CHECK(rotated2d_neg_xi_neg_eta(1) == 1);
@@ -135,7 +141,7 @@ void test_2d() {
   CHECK(rotated2d_pos_eta_neg_xi(0) == 1);
   CHECK(rotated2d_pos_eta_neg_xi(1) == 0);
 
-  // Check mapped(Direction<2> direction function)
+  // Check mapped(Direction<2> direction) function
   CHECK(rotated2d_neg_xi_neg_eta(upper_xi) == lower_xi);
   CHECK(rotated2d_neg_xi_neg_eta(upper_eta) == lower_eta);
   CHECK(rotated2d_neg_xi_neg_eta(lower_xi) == upper_xi);
@@ -157,11 +163,8 @@ void test_2d() {
         expected_neg_xi_neg_eta_segment_ids);
   CHECK(rotated2d_pos_eta_neg_xi(segment_ids) ==
         expected_pos_eta_neg_xi_segment_ids);
-  CHECK_FALSE(rotated2d_neg_eta_pos_xi.is_aligned());
-  CHECK_FALSE(rotated2d_neg_xi_neg_eta.is_aligned());
-  CHECK_FALSE(rotated2d_pos_eta_neg_xi.is_aligned());
-  CHECK(rotated2d_pos_xi_pos_eta.is_aligned());
 
+  // Check permute_from_neighbor(std::array<T, 2> array)
   const std::array<int, 2> input_array{{1, -3}};
   const std::array<int, 2> flipped_array{{-3, 1}};
   CHECK(rotated2d_neg_xi_neg_eta.permute_from_neighbor(input_array) ==
@@ -172,7 +175,7 @@ void test_2d() {
         flipped_array);
 
   // The naming convention used in this test:
-  //"neg_eta_pos_xi" means that -1 in the host maps to +0,
+  // "neg_eta_pos_xi" means that -1 in the host maps to +0,
   // and that +0 in the host maps to +1, in the neighbor.
   // For the output operator, the directions that correspond
   // to the +0 and +1 directions in the host are outputted.
@@ -351,18 +354,18 @@ SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.AllOrientations",
                  ? gsl::at(original_point, map_i()(d))
                  : -1.0 * gsl::at(original_point, map_i()(d))));
     }
+  }
+  for (OrientationMapIterator<3> map_i{}; map_i; ++map_i) {
+    const std::array<double, 3> original_point{{0.5, -2.0, 1.5}};
+    const std::array<double, 3> new_point =
+        discrete_rotation(map_i(), original_point);
+    for (size_t d = 0; d < 3; d++) {
+      CHECK(gsl::at(new_point, d) ==
+            (map_i()(Direction<3>{d, Side::Upper}).side() == Side::Upper
+                 ? gsl::at(original_point, map_i()(d))
+                 : -1.0 * gsl::at(original_point, map_i()(d))));
     }
-    for (OrientationMapIterator<3> map_i{}; map_i; ++map_i) {
-      const std::array<double, 3> original_point{{0.5, -2.0, 1.5}};
-      const std::array<double, 3> new_point =
-          discrete_rotation(map_i(), original_point);
-      for (size_t d = 0; d < 3; d++) {
-        CHECK(gsl::at(new_point, d) ==
-              (map_i()(Direction<3>{d, Side::Upper}).side() == Side::Upper
-                   ? gsl::at(original_point, map_i()(d))
-                   : -1.0 * gsl::at(original_point, map_i()(d))));
-      }
-    }
+  }
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DiscreteRotation.Rotation", "[Domain][Unit]") {

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -761,7 +761,7 @@ void test_package_data_work(
       VolumeDim, tmpl::list<scalar, vector<VolumeDim>>>::PackagedData
       packaged_data{};
   minmod.package_data(make_not_null(&packaged_data), input_scalar,
-                      modified_vector, mesh, element_size);
+                      modified_vector, mesh, element_size, {});
 
   // Should not normally look inside package, but we do so here for testing.
   double lhs =

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -745,7 +745,8 @@ void test_package_data_work(
     const tnsr::I<DataVector, VolumeDim>& input_vector,
     const Mesh<VolumeDim>& mesh,
     const tnsr::I<DataVector, VolumeDim, Frame::Logical>& logical_coords,
-    const std::array<double, VolumeDim>& element_size) noexcept {
+    const std::array<double, VolumeDim>& element_size,
+    const OrientationMap<VolumeDim>& orientation_map) noexcept {
   // To streamline the testing of the op() function, the test sets up
   // identical data for all components of input_vector. To better test the
   // package_data function, we first modify the input so the data
@@ -760,10 +761,12 @@ void test_package_data_work(
   typename SlopeLimiters::Minmod<
       VolumeDim, tmpl::list<scalar, vector<VolumeDim>>>::PackagedData
       packaged_data{};
+
+  // First we test package_data with an identity orientation_map
   minmod.package_data(make_not_null(&packaged_data), input_scalar,
                       modified_vector, mesh, element_size, {});
 
-  // Should not normally look inside package, but we do so here for testing.
+  // Should not normally look inside the package, but we do so here for testing.
   double lhs =
       get(get<Minmod_detail::to_tensor_double<scalar>>(packaged_data.means_));
   CHECK(lhs == approx(mean_value(get(input_scalar), mesh)));
@@ -774,6 +777,20 @@ void test_package_data_work(
     CHECK(lhs == approx(mean_value(modified_vector.get(d), mesh)));
   }
   CHECK(packaged_data.element_size_ == element_size);
+
+  // Then we test with a reorientation, as if sending the data to another Block
+  minmod.package_data(make_not_null(&packaged_data), input_scalar,
+                      modified_vector, mesh, element_size, orientation_map);
+  lhs = get(get<Minmod_detail::to_tensor_double<scalar>>(packaged_data.means_));
+  CHECK(lhs == approx(mean_value(get(input_scalar), mesh)));
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    lhs = get<Minmod_detail::to_tensor_double<vector<VolumeDim>>>(
+              packaged_data.means_)
+              .get(d);
+    CHECK(lhs == approx(mean_value(modified_vector.get(d), mesh)));
+  }
+  CHECK(packaged_data.element_size_ ==
+        orientation_map.permute_from_neighbor(element_size));
 }
 
 // Helper function for testing Minmod::op()
@@ -851,8 +868,10 @@ SPECTRE_TEST_CASE(
   const auto input_scalar = scalar::type{data};
   const auto input_vector = vector<1>::type{data};
 
+  const OrientationMap<1> test_reorientation(
+      std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}});
   test_package_data_work(input_scalar, input_vector, mesh, logical_coords,
-                         element_size);
+                         element_size, test_reorientation);
 
   // b. Generate neighbor data for the scalar and vector Tensors.
   std::unordered_map<
@@ -917,8 +936,10 @@ SPECTRE_TEST_CASE(
   const auto input_scalar = scalar::type{data};
   const auto input_vector = vector<2>::type{data};
 
+  const OrientationMap<2> test_reorientation(std::array<Direction<2>, 2>{
+      {Direction<2>::lower_eta(), Direction<2>::upper_xi()}});
   test_package_data_work(input_scalar, input_vector, mesh, logical_coords,
-                         element_size);
+                         element_size, test_reorientation);
 
   // b. Generate neighbor data for the scalar and vector Tensors.
   std::unordered_map<
@@ -1023,8 +1044,11 @@ SPECTRE_TEST_CASE(
   const auto input_scalar = scalar::type{data};
   const auto input_vector = vector<3>::type{data};
 
+  const OrientationMap<3> test_reorientation(std::array<Direction<3>, 3>{
+      {Direction<3>::lower_eta(), Direction<3>::upper_xi(),
+       Direction<3>::lower_zeta()}});
   test_package_data_work(input_scalar, input_vector, mesh, logical_coords,
-                         element_size);
+                         element_size, test_reorientation);
 
   // b. Generate neighbor data for the scalar and vector Tensors.
   std::unordered_map<


### PR DESCRIPTION
## Proposed changes

* Enable `OrientationMap` to re-orient a `Mesh`. This may need discussion: is `OrientationMap` the correct place to put this function? (i.e., do we want `OrientationMap` to depend on `Mesh`?) Alternatives might be in `Mesh`, in a new "MeshHelpers", or similar.
* Enable limiter actions to pass an `OrientationMap` to the limiter's `package_data` function.
* Use `OrientationMap` in `Minmod::package_data` to re-orient the element's size data.

- [x] Depends on #999. 

Order of new commits:
1. Clean up whitespace and ordering in OrientationMap test
2. Enable OrientationMap to reorient a Mesh
3. Support orientations in limiter actions
4. Support orientations in Minmod


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
