### PR TITLE
Silence clang7 self-assignment warnings in tests

### DIFF
--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -160,7 +160,14 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
   CHECK(get_output(empty_vars) == "Variables is empty!");
 
   // Check self-assignment
+#if defined(__clang__) && __clang_major__ > 6
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif  // defined(__clang__) && __clang_major__ > 6
   v = v;
+#if defined(__clang__) && __clang_major__ > 6
+#pragma GCC diagnostic pop
+#endif  // defined(__clang__) && __clang_major__ > 6
   CHECK(v == v2);
 
   CHECK(

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -84,8 +84,15 @@ void test_copy_semantics(const T& a) {
   // constructor
   const T c(a);  // NOLINT
   CHECK(c == a);
+#if defined(__clang__) && __clang_major__ > 6
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+#endif  // defined(__clang__) && __clang_major__ > 6
   // clang-tidy: self-assignment
   b = b;  // NOLINT
+#if defined(__clang__) && __clang_major__ > 6
+#pragma GCC diagnostic pop
+#endif  // defined(__clang__) && __clang_major__ > 6
   CHECK(b == a);
 }
 


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
