### PR TITLE
Don't let YAML exceptions escape the option parser

### DIFF
--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -304,7 +304,7 @@ class Options {
   std::string parsing_help(const YAML::Node& options) const noexcept;
 
   /// Error message when failed to parse an input file.
-  [[noreturn]] void parser_error(const YAML::ParserException& e) const noexcept;
+  [[noreturn]] void parser_error(const YAML::Exception& e) const noexcept;
 
   std::string help_text_{};
   OptionContext context_{};
@@ -338,10 +338,10 @@ void Options<OptionList>::parse_file(const std::string& file_name) noexcept {
   context_.append("In " + file_name);
   try {
     parse(YAML::LoadFile(file_name));
-  } catch (const YAML::ParserException& e) {
-    parser_error(e);
   } catch (YAML::BadFile& /*e*/) {
     ERROR("Could not open the input file " << file_name);
+  } catch (const YAML::Exception& e) {
+    parser_error(e);
   }
 }
 
@@ -350,7 +350,7 @@ void Options<OptionList>::parse(const std::string& options) noexcept {
   context_.append("In string");
   try {
     parse(YAML::Load(options));
-  } catch (YAML::ParserException& e) {
+  } catch (YAML::Exception& e) {
     parser_error(e);
   }
 }
@@ -533,7 +533,7 @@ std::string Options<OptionList>::parsing_help(
 
 template <typename OptionList>
 [[noreturn]] void Options<OptionList>::parser_error(
-    const YAML::ParserException& e) const noexcept {
+    const YAML::Exception& e) const noexcept {
   auto context = context_;
   context.line = e.mark.line;
   context.column = e.mark.column;

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -723,3 +723,11 @@ SPECTRE_TEST_CASE("Unit.Options.Format.UnorderedMap.Error", "[Unit][Options]") {
   opts.parse("FormatUnorderedMap: X");
   opts.get<FormatUnorderedMap>();
 }
+
+// [[OutputRegex, At line 3 column 1:.Unable to correctly parse the
+// input file because of a syntax error]]
+SPECTRE_TEST_CASE("Unit.Options.bad_colon", "[Unit][Options]") {
+  ERROR_TEST();
+  Options<tmpl::list<>> opts("");
+  opts.parse("\n\n:");
+}


### PR DESCRIPTION
If the name of a specified option was empty converting it to a string
would fail with a BadConversion exception in the initial parse pass,
which I thought could only generate ParserExceptions.  Now we just
catch everything.

We still print out the parsing error message, which I think is not
technically correct because the input is valid YAML, but it's clearly
not a valid input file so this should be OK.

Fixes #887

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
