### PR TITLE
Fixes to limiter for use in executables

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -39,5 +39,6 @@ target_link_libraries(
   INTERFACE CoordinateMaps
   INTERFACE DataStructures
   INTERFACE ErrorHandling
+  INTERFACE LinearOperators
   INTERFACE Spectral
   )

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -8,3 +8,10 @@ set(LIBRARY_SOURCES
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
+
+target_link_libraries(
+  ${LIBRARY}
+  INTERFACE DataStructures
+  INTERFACE Domain
+  INTERFACE LinearOperators
+  )

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/LimiterActions.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/LimiterActions.hpp
@@ -67,7 +67,7 @@ namespace Actions {
 /// \see SendDataForLimiter
 template <typename Metavariables>
 struct Limit {
-  using const_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<typename Metavariables::limiter>;
 
   static_assert(
       not Metavariables::local_time_stepping,
@@ -156,7 +156,7 @@ struct Limit {
 /// \see ApplyLimiter
 template <typename Metavariables>
 struct SendData {
-  using const_global_cache_tags = tmpl::list<>;
+  using const_global_cache_tags = tmpl::list<typename Metavariables::limiter>;
   using limiter_comm_tag =
       SlopeLimiters::Tags::LimiterCommunicationTag<Metavariables>;
 

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -225,6 +225,12 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
     tuples::TaggedTuple<Minmod_detail::to_tensor_double<Tags>...> means_;
     std::array<double, VolumeDim> element_size_ =
         make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN());
+
+    // clang-tidy: google-runtime-references
+    void pup(PUP::er& p) noexcept {  // NOLINT
+      p | means_;
+      p | element_size_;
+    }
   };
 
   using package_argument_tags = tmpl::list<Tags..., ::Tags::Mesh<VolumeDim>,

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Tags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Tags.hpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Options/Options.hpp"
+
+namespace OptionTags {
+/*!
+ * \ingroup OptionTagsGroup
+ * \brief The global cache tag that retrieves the parameters for the slope
+ * limiter from the input file
+ */
+template <typename SlopeLimiterType>
+struct SlopeLimiterParams {
+  static constexpr OptionString help = "The options for the slope limiter";
+  using type = SlopeLimiterType;
+};
+}  // namespace OptionTags


### PR DESCRIPTION
## Proposed changes

Small fixes needed to use limiters in an executable

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

