### PR TITLE
Performance of partial derivatives, Variables and fix perf bug with subitems

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -704,14 +704,15 @@ template <typename ParentTag, typename... Subtags>
 SPECTRE_ALWAYS_INLINE constexpr void
 DataBox<tmpl::list<Tags...>>::add_sub_compute_item_tags_to_box(
     tmpl::list<Subtags...> /*meta*/) noexcept {
-  const auto helper = [lazy_function =
-                           get_deferred<ParentTag>()](auto tag) noexcept {
+  const auto helper = [lazy_function = get_deferred<ParentTag>()](
+                          auto tag) noexcept->decltype(auto) {
     return Subitems<tmpl::list<Tags...>, ParentTag>::
         template create_compute_item<decltype(tag)>(lazy_function.get());
   };
   EXPAND_PACK_LEFT_TO_RIGHT(
       (get_deferred<Subtags>() =
-           make_deferred<db::item_type<Subtags>>(helper, Subtags{})));
+           make_deferred_for_subitem<decltype(helper(Subtags{}))>(helper,
+                                                                  Subtags{})));
 }
 
 namespace DataBox_detail {

--- a/src/DataStructures/DataBox/Deferred.hpp
+++ b/src/DataStructures/DataBox/Deferred.hpp
@@ -23,13 +23,13 @@ class Deferred;
 
 namespace Deferred_detail {
 template <typename T>
-decltype(auto) retrieve_from_deferred(const T& t) {
+decltype(auto) retrieve_from_deferred(const T& t) noexcept {
   return t;
 }
 
 template <typename T, typename MakeConstReference>
 decltype(auto) retrieve_from_deferred(
-    const Deferred<T, MakeConstReference>& t) {
+    const Deferred<T, MakeConstReference>& t) noexcept {
   return t.get();
 }
 
@@ -54,8 +54,8 @@ class assoc_state {
   assoc_state& operator=(const assoc_state& /*rhs*/) = delete;
   assoc_state(assoc_state&& /*rhs*/) = delete;
   assoc_state& operator=(assoc_state&& /*rhs*/) = delete;
-  virtual const Rt& get() const = 0;
-  virtual Rt& mutate() = 0;
+  virtual const Rt& get() const noexcept = 0;
+  virtual Rt& mutate() noexcept = 0;
   virtual void reset() noexcept = 0;
   // clang-tidy: no non-const references
   virtual void pack_unpack_lazy_function(PUP::er& p) noexcept = 0;  // NOLINT
@@ -67,11 +67,11 @@ class assoc_state {
 template <typename Rt>
 class simple_assoc_state : public assoc_state<Rt> {
  public:
-  explicit simple_assoc_state(Rt t) : t_(std::move(t)) {}
+  explicit simple_assoc_state(Rt t) noexcept;
 
-  const Rt& get() const override { return t_; }
+  const Rt& get() const noexcept override { return t_; }
 
-  Rt& mutate() override { return t_; }
+  Rt& mutate() noexcept override { return t_; }
 
   void reset() noexcept override { ERROR("Cannot reset a simple_assoc_state"); }
 
@@ -80,9 +80,7 @@ class simple_assoc_state : public assoc_state<Rt> {
     ERROR("Cannot send a Deferred that's not a lazily evaluated function");
   }
 
-  bool evaluated() const noexcept override {
-    return true;
-  }
+  bool evaluated() const noexcept override { return true; }
 
   boost::shared_ptr<assoc_state<Rt>> deep_copy() const noexcept override {
     return deep_copy_impl();
@@ -102,24 +100,25 @@ class simple_assoc_state : public assoc_state<Rt> {
         "Cannot create a copy of a DataBox (e.g. using db::create_copy) that "
         "holds a non-copyable simple item. The item type is '"
         << pretty_type::get_name<T>() << "'.");
-    return nullptr;
   }
 
   Rt t_;
 };
 
+template <typename Rt>
+simple_assoc_state<Rt>::simple_assoc_state(Rt t) noexcept : t_(std::move(t)) {}
+
 template <typename Rt, typename Fp, typename... Args>
 class deferred_assoc_state : public assoc_state<Rt> {
  public:
-  explicit deferred_assoc_state(Fp f, Args... args)
-      : func_(std::move(f)), args_(std::make_tuple(std::move(args)...)) {}
+  explicit deferred_assoc_state(Fp f, Args... args) noexcept;
   deferred_assoc_state(const deferred_assoc_state& /*rhs*/) = delete;
   deferred_assoc_state& operator=(const deferred_assoc_state& /*rhs*/) = delete;
   deferred_assoc_state(deferred_assoc_state&& /*rhs*/) = delete;
   deferred_assoc_state& operator=(deferred_assoc_state&& /*rhs*/) = delete;
   ~deferred_assoc_state() override = default;
 
-  const Rt& get() const override {
+  const Rt& get() const noexcept override {
     if (not evaluated_) {
       apply(std::make_index_sequence<sizeof...(Args)>{});
       evaluated_ = true;
@@ -127,10 +126,7 @@ class deferred_assoc_state : public assoc_state<Rt> {
     return t_;
   }
 
-  Rt& mutate() override {
-    ERROR("Cannot mutate a computed Deferred");
-    return t_;
-  }
+  Rt& mutate() noexcept override { ERROR("Cannot mutate a computed Deferred"); }
 
   void reset() noexcept override { evaluated_ = false; }
 
@@ -147,16 +143,13 @@ class deferred_assoc_state : public assoc_state<Rt> {
     }
   }
 
-  bool evaluated() const noexcept override {
-    return evaluated_;
-  }
+  bool evaluated() const noexcept override { return evaluated_; }
 
   boost::shared_ptr<assoc_state<Rt>> deep_copy() const noexcept override {
     ERROR(
         "Have not yet implemented a deep_copy for deferred_assoc_state. It's "
         "not at all clear if this is even possible because it is incorrect to "
         "assume that the args_ have not changed.");
-    return nullptr;
   }
 
  private:
@@ -171,7 +164,7 @@ class deferred_assoc_state : public assoc_state<Rt> {
                 tt::is_callable_v<std::decay_t<Fp>,
                                   remove_deferred_t<std::decay_t<Args>>...>)> =
           nullptr>
-  void apply(std::integer_sequence<size_t, Is...> /*meta*/) const {
+  void apply(std::integer_sequence<size_t, Is...> /*meta*/) const noexcept {
     t_ = std::move(func_(retrieve_from_deferred(std::get<Is>(args_))...));
   }
 
@@ -181,10 +174,15 @@ class deferred_assoc_state : public assoc_state<Rt> {
                 tt::is_callable_v<
                     std::decay_t<Fp>, gsl::not_null<std::add_pointer_t<Rt>>,
                     remove_deferred_t<std::decay_t<Args>>...>)> = nullptr>
-  void apply(std::integer_sequence<size_t, Is...> /*meta*/) const {
+  void apply(std::integer_sequence<size_t, Is...> /*meta*/) const noexcept {
     func_(make_not_null(&t_), retrieve_from_deferred(std::get<Is>(args_))...);
   }
 };
+
+template <typename Rt, typename Fp, typename... Args>
+deferred_assoc_state<Rt, Fp, Args...>::deferred_assoc_state(
+    Fp f, Args... args) noexcept
+    : func_(std::move(f)), args_(std::make_tuple(std::move(args)...)) {}
 
 // Specialization to handle functions that return a `const Rt&`. We treat the
 // return value as pointer to the data we actually want to have visible to us
@@ -200,24 +198,21 @@ class deferred_assoc_state : public assoc_state<Rt> {
 template <typename Rt, typename Fp, typename... Args>
 class deferred_assoc_state<const Rt&, Fp, Args...> : public assoc_state<Rt> {
  public:
-  explicit deferred_assoc_state(Fp f, Args... args) noexcept
-      : func_(std::move(f)), args_(std::make_tuple(std::move(args)...)) {}
+  explicit deferred_assoc_state(Fp f, Args... args) noexcept;
   deferred_assoc_state(const deferred_assoc_state& /*rhs*/) = delete;
   deferred_assoc_state& operator=(const deferred_assoc_state& /*rhs*/) = delete;
   deferred_assoc_state(deferred_assoc_state&& /*rhs*/) = delete;
   deferred_assoc_state& operator=(deferred_assoc_state&& /*rhs*/) = delete;
   ~deferred_assoc_state() override = default;
 
-  const Rt& get() const override {
+  const Rt& get() const noexcept override {
     if (not t_) {
       apply(std::make_index_sequence<sizeof...(Args)>{});
     }
     return *t_;
   }
 
-  Rt& mutate() override {
-    ERROR("Cannot mutate a compute tag.");
-  }
+  Rt& mutate() noexcept override { ERROR("Cannot mutate a compute tag."); }
 
   void reset() noexcept override { t_ = nullptr; }
 
@@ -236,7 +231,6 @@ class deferred_assoc_state<const Rt&, Fp, Args...> : public assoc_state<Rt> {
         "Have not yet implemented a deep_copy for deferred_assoc_state. It's "
         "not at all clear if this is even possible because it is incorrect to "
         "assume that the args_ have not changed.");
-    return nullptr;
   }
 
  private:
@@ -249,6 +243,11 @@ class deferred_assoc_state<const Rt&, Fp, Args...> : public assoc_state<Rt> {
     t_ = &(func_(retrieve_from_deferred(std::get<Is>(args_))...));
   }
 };
+
+template <typename Rt, typename Fp, typename... Args>
+deferred_assoc_state<const Rt&, Fp, Args...>::deferred_assoc_state(
+    Fp f, Args... args) noexcept
+    : func_(std::move(f)), args_(std::make_tuple(std::move(args)...)) {}
 }  // namespace Deferred_detail
 
 /*!
@@ -302,9 +301,9 @@ class Deferred {
   Deferred& operator=(Deferred&&) = default;
   ~Deferred() = default;
 
-  constexpr const value_type& get() const { return state_->get(); }
+  constexpr const value_type& get() const noexcept { return state_->get(); }
 
-  constexpr value_type& mutate() { return state_->mutate(); }
+  constexpr value_type& mutate() noexcept { return state_->mutate(); }
 
   // clang-tidy: no non-const references
   void pack_unpack_lazy_function(PUP::er& p) noexcept {  // NOLINT
@@ -315,14 +314,12 @@ class Deferred {
 
   void reset() noexcept { state_->reset(); }
 
-  Deferred deep_copy() const noexcept {
-    return Deferred{state_->deep_copy()};
-  }
+  Deferred deep_copy() const noexcept { return Deferred{state_->deep_copy()}; }
 
   explicit Deferred(
       boost::shared_ptr<Deferred_detail::assoc_state<tmpl::conditional_t<
-          MakeConstReference::value, const value_type&, value_type>>>&& state)
-      : state_(std::move(state)) {}
+          MakeConstReference::value, const value_type&, value_type>>>&&
+          state) noexcept;
 
  private:
   boost::shared_ptr<Deferred_detail::assoc_state<tmpl::conditional_t<
@@ -331,19 +328,22 @@ class Deferred {
 
   // clang-tidy: redundant declaration
   template <typename Rt1, typename Fp, typename... Args>
-  friend Deferred<Rt1> make_deferred(Fp f, Args&&... args);  // NOLINT
-
-  // clang-tidy: redundant declaration
-  template <typename Rt1, typename Fp, typename... Args>
   friend void update_deferred_args(  // NOLINT
       gsl::not_null<Deferred<Rt1>*> deferred, Fp /*f used for type deduction*/,
-      Args&&... args);
+      Args&&... args) noexcept;
 
   // clang-tidy: redundant declaration
   template <typename Rt1, typename Fp, typename... Args>
   friend void update_deferred_args(  // NOLINT
-      gsl::not_null<Deferred<Rt1>*> deferred, Args&&... args);
+      gsl::not_null<Deferred<Rt1>*> deferred, Args&&... args) noexcept;
 };
+
+template <typename Rt, typename MakeConstReference>
+Deferred<Rt, MakeConstReference>::Deferred(
+    boost::shared_ptr<Deferred_detail::assoc_state<tmpl::conditional_t<
+        MakeConstReference::value, const value_type&, value_type>>>&&
+        state) noexcept
+    : state_(std::move(state)) {}
 
 /*!
  * \ingroup DataBoxGroup
@@ -378,7 +378,7 @@ class Deferred {
  * @return Deferred object that will lazily evaluate the function
  */
 template <typename Rt, typename Fp, typename... Args>
-Deferred<Rt> make_deferred(Fp f, Args&&... args) {
+Deferred<Rt> make_deferred(Fp f, Args&&... args) noexcept {
   return Deferred<Rt>(boost::make_shared<Deferred_detail::deferred_assoc_state<
                           Rt, std::decay_t<Fp>, std::decay_t<Args>...>>(
       f, std::forward<Args>(args)...));
@@ -433,13 +433,14 @@ auto make_deferred_for_subitem(Fp&& f, Args&&... args) noexcept {
  */
 template <typename Rt, typename Fp, typename... Args>
 void update_deferred_args(const gsl::not_null<Deferred<Rt>*> deferred,
-                          Fp /*f used for type deduction*/, Args&&... args) {
+                          Fp /*f used for type deduction*/,
+                          Args&&... args) noexcept {
   update_deferred_args<Rt, Fp>(deferred, std::forward<Args>(args)...);
 }
 
 template <typename Rt, typename Fp, typename... Args>
 void update_deferred_args(const gsl::not_null<Deferred<Rt>*> deferred,
-                          Args&&... args) {
+                          Args&&... args) noexcept {
   auto* ptr = dynamic_cast<Deferred_detail::deferred_assoc_state<
       Rt, std::decay_t<Fp>, std::decay_t<Args>...>*>(deferred->state_.get());
   if (ptr == nullptr) {

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -320,6 +320,21 @@ class Tensor<X, Symm, IndexList<Indices...>> {
   // @}
 
   // @{
+  /// Get the storage index of the tensor index. Should only be used when
+  /// optimizing code in which computing the storage index is a bottleneck.
+  template <typename... N>
+  SPECTRE_ALWAYS_INLINE static constexpr size_t get_storage_index(
+      const N... args) noexcept {
+    return structure::get_storage_index(args...);
+  }
+  template <typename I>
+  SPECTRE_ALWAYS_INLINE static constexpr size_t get_storage_index(
+      const std::array<I, sizeof...(Indices)>& tensor_index) noexcept {
+    return structure::get_storage_index(tensor_index);
+  }
+  // @}
+
+  // @{
   /// Given an iterator or storage index, get the multiplicity of an index
   ///
   /// \see TensorMetafunctions::compute_multiplicity

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -823,7 +823,7 @@ struct Subitems<TagList, Tag,
   }
 
   template <typename Subtag>
-  static item_type<Subtag> create_compute_item(
+  static const item_type<Subtag>& create_compute_item(
       const item_type<Tag>& parent_value) noexcept {
     return get<Subtag>(parent_value);
   }

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -70,6 +71,19 @@ class Variables;
  * Prefix tags can also be stored and their format is:
  *
  * \snippet Test_Variables.cpp prefix_variables_tag
+ *
+ * #### Design Decisions
+ *
+ * The `Variables` class is designed to hold several different `Tensor`s
+ * performing one memory allocation for all the `Tensor`s. The advantage is that
+ * memory allocations are quite expensive, especially in a parallel environment.
+ *
+ * `Variables` stores the data it owns in a `std::unique_ptr<double[],
+ * decltype(&free)>` instead of a `std::vector` because allocating the
+ * `unique_ptr` with `malloc` allows us to avoid initializing the memory
+ * completely in release mode when no value is passed to the constructor.
+ * Additionally, if the macro `SPECTRE_NAN_INIT` is defined, initialization with
+ * `NaN`s is done even in release mode.
  */
 template <typename... Tags>
 class Variables<tmpl::list<Tags...>> {
@@ -78,6 +92,10 @@ class Variables<tmpl::list<Tags...>> {
   using allocator_type = std::allocator<value_type>;
   using size_type = size_t;
   using difference_type = std::ptrdiff_t;
+  static constexpr auto transpose_flag = blaze::defaultTransposeFlag;
+  using pointer_type =
+      PointerVector<double, blaze::unaligned, blaze::unpadded, transpose_flag,
+                    blaze::DynamicVector<double, transpose_flag>>;
 
   /// A typelist of the Tags whose variables are held
   using tags_list = tmpl::list<Tags...>;
@@ -110,9 +128,9 @@ class Variables<tmpl::list<Tags...>> {
   /// Default construct an empty Variables class, Charm++ needs this
   Variables() noexcept;
 
-  explicit Variables(
-      size_t number_of_grid_points,
-      double value = std::numeric_limits<double>::signaling_NaN()) noexcept;
+  explicit Variables(size_t number_of_grid_points) noexcept;
+
+  Variables(size_t number_of_grid_points, double value) noexcept;
 
   Variables(Variables&& rhs) noexcept = default;
   Variables& operator=(Variables&& rhs) noexcept;
@@ -150,11 +168,12 @@ class Variables<tmpl::list<Tags...>> {
   ~Variables() noexcept = default;
   /// \endcond
 
+  // @{
   /// Initialize a Variables to the state it would have after calling
   /// the constructor with the same arguments.
-  void initialize(
-      size_t number_of_grid_points,
-      double value = std::numeric_limits<double>::signaling_NaN()) noexcept;
+  void initialize(size_t number_of_grid_points) noexcept;
+  void initialize(size_t number_of_grid_points, double value) noexcept;
+  // @}
 
   constexpr SPECTRE_ALWAYS_INLINE size_t number_of_grid_points() const
       noexcept {
@@ -365,14 +384,13 @@ class Variables<tmpl::list<Tags...>> {
   template <class FriendTags>
   friend class Variables;
 
-  std::vector<double, allocator_type> variable_data_impl_;
-  // variable_data_ is only used to plug into the Blaze expression templates
-  PointerVector<double, blaze::unaligned, blaze::unpadded,
-                blaze::defaultTransposeFlag,
-                blaze::DynamicVector<double, blaze::defaultTransposeFlag>>
-      variable_data_;
+  std::unique_ptr<double[], decltype(&free)> variable_data_impl_{nullptr,
+                                                                 &free};
   size_t size_ = 0;
   size_t number_of_grid_points_ = 0;
+
+  // variable_data_ is only used to plug into the Blaze expression templates
+  pointer_type variable_data_;
   tuples::TaggedTuple<Tags...> reference_variable_data_;
 };
 
@@ -391,6 +409,12 @@ Variables<tmpl::list<Tags...>>::Variables() noexcept {
 }
 
 template <typename... Tags>
+Variables<tmpl::list<Tags...>>::Variables(
+    const size_t number_of_grid_points) noexcept {
+  initialize(number_of_grid_points);
+}
+
+template <typename... Tags>
 Variables<tmpl::list<Tags...>>::Variables(const size_t number_of_grid_points,
                                           const double value) noexcept {
   initialize(number_of_grid_points, value);
@@ -398,24 +422,55 @@ Variables<tmpl::list<Tags...>>::Variables(const size_t number_of_grid_points,
 
 template <typename... Tags>
 void Variables<tmpl::list<Tags...>>::initialize(
-    const size_t number_of_grid_points, const double value) noexcept {
-  variable_data_impl_.assign(
-      number_of_grid_points * number_of_independent_components, value);
-  variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
+    const size_t number_of_grid_points) noexcept {
   size_ = number_of_grid_points * number_of_independent_components;
-  number_of_grid_points_ = number_of_grid_points;
-  add_reference_variable_data(tmpl::list<Tags...>{});
+  if (size_ > 0) {
+    // clang-tidy: cppcoreguidelines-no-malloc
+    variable_data_impl_.reset(static_cast<double*>(
+        malloc(number_of_grid_points *  // NOLINT
+               number_of_independent_components * sizeof(double))));
+    number_of_grid_points_ = number_of_grid_points;
+#if defined(SPECTRE_DEBUG) || defined(SPECTRE_NAN_INIT)
+    std::fill(variable_data_impl_.get(), variable_data_impl_.get() + size_,
+              std::numeric_limits<double>::signaling_NaN());
+#endif  // SPECTRE_DEBUG
+    variable_data_.reset(variable_data_impl_.get(), size_);
+    add_reference_variable_data(tmpl::list<Tags...>{});
+  }
+}
+
+template <typename... Tags>
+void Variables<tmpl::list<Tags...>>::initialize(
+    const size_t number_of_grid_points, const double value) noexcept {
+  size_ = number_of_grid_points * number_of_independent_components;
+  if (size_ > 0) {
+    // clang-tidy: cppcoreguidelines-no-malloc
+    variable_data_impl_.reset(static_cast<double*>(
+        malloc(number_of_grid_points *  // NOLINT
+               number_of_independent_components * sizeof(double))));
+    number_of_grid_points_ = number_of_grid_points;
+    std::fill(variable_data_impl_.get(), variable_data_impl_.get() + size_,
+              value);
+    variable_data_.reset(variable_data_impl_.get(), size_);
+    add_reference_variable_data(tmpl::list<Tags...>{});
+  }
 }
 
 /// \cond HIDDEN_SYMBOLS
 template <typename... Tags>
 Variables<tmpl::list<Tags...>>::Variables(
     const Variables<tmpl::list<Tags...>>& rhs) noexcept
-    : variable_data_impl_(rhs.variable_data_impl_),
-      variable_data_(variable_data_impl_.data(), variable_data_impl_.size()),
-      size_(rhs.size_),
-      number_of_grid_points_(rhs.number_of_grid_points()) {
-  add_reference_variable_data(tmpl::list<Tags...>{});
+    : size_(rhs.size_), number_of_grid_points_(rhs.number_of_grid_points()) {
+  if (size_ > 0) {
+    // clang-tidy: cppcoreguidelines-no-malloc
+    variable_data_impl_.reset(
+        static_cast<double*>(malloc(size_ * sizeof(double))));  // NOLINT
+    variable_data_.reset(variable_data_impl_.get(), size_);
+    add_reference_variable_data(tmpl::list<Tags...>{});
+    variable_data_ =
+        static_cast<const blaze::Vector<pointer_type, transpose_flag>&>(
+            rhs.variable_data_);
+  }
 }
 
 template <typename... Tags>
@@ -424,11 +479,22 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   if (&rhs == this) {
     return *this;
   }
-  variable_data_impl_ = rhs.variable_data_impl_;
-  variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
   size_ = rhs.size_;
-  number_of_grid_points_ = rhs.number_of_grid_points();
-  add_reference_variable_data(tmpl::list<Tags...>{});
+  if (number_of_grid_points_ != rhs.number_of_grid_points()) {
+    number_of_grid_points_ = rhs.number_of_grid_points();
+    if (size_ > 0) {
+      // clang-tidy: cppcoreguidelines-no-malloc
+      variable_data_impl_.reset(
+          static_cast<double*>(malloc(size_ * sizeof(double))));  // NOLINT
+      variable_data_.reset(variable_data_impl_.get(), size_);
+      add_reference_variable_data(tmpl::list<Tags...>{});
+    }
+  }
+  if (size_ > 0) {
+    variable_data_ =
+        static_cast<const blaze::Vector<pointer_type, transpose_flag>&>(
+            rhs.variable_data_);
+  }
   return *this;
 }
 
@@ -439,9 +505,9 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
     return *this;
   }
   variable_data_impl_ = std::move(rhs.variable_data_impl_);
-  variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
   size_ = rhs.size_;
   number_of_grid_points_ = std::move(rhs.number_of_grid_points_);
+  variable_data_.reset(variable_data_impl_.get(), size());
   add_reference_variable_data(tmpl::list<Tags...>{});
   return *this;
 }
@@ -452,11 +518,17 @@ template <typename... WrappedTags, Requires<tmpl2::flat_all_v<cpp17::is_same_v<
                                        db::remove_all_prefixes<Tags>>...>>>
 Variables<tmpl::list<Tags...>>::Variables(
     const Variables<tmpl::list<WrappedTags...>>& rhs) noexcept
-    : variable_data_impl_(rhs.variable_data_impl_),
-      variable_data_(variable_data_impl_.data(), variable_data_impl_.size()),
-      size_(rhs.size_),
-      number_of_grid_points_(rhs.number_of_grid_points()) {
-  add_reference_variable_data(tmpl::list<Tags...>{});
+    : size_(rhs.size_), number_of_grid_points_(rhs.number_of_grid_points()) {
+  if (size_ > 0) {
+    // clang-tidy: cppcoreguidelines-no-malloc
+    variable_data_impl_.reset(
+        static_cast<double*>(malloc(size_ * sizeof(double))));  // NOLINT
+    variable_data_.reset(variable_data_impl_.get(), size_);
+    variable_data_ =
+        static_cast<const blaze::Vector<pointer_type, transpose_flag>&>(
+            rhs.variable_data_);
+    add_reference_variable_data(tmpl::list<Tags...>{});
+  }
 }
 
 template <typename... Tags>
@@ -465,11 +537,20 @@ template <typename... WrappedTags, Requires<tmpl2::flat_all_v<cpp17::is_same_v<
                                        db::remove_all_prefixes<Tags>>...>>>
 Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
     const Variables<tmpl::list<WrappedTags...>>& rhs) noexcept {
-  variable_data_impl_ = rhs.variable_data_impl_;
-  variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
   size_ = rhs.size_;
-  number_of_grid_points_ = rhs.number_of_grid_points();
-  add_reference_variable_data(tmpl::list<Tags...>{});
+  if (number_of_grid_points_ != rhs.number_of_grid_points()) {
+    number_of_grid_points_ = rhs.number_of_grid_points();
+    if (size_ > 0) {
+      // clang-tidy: cppcoreguidelines-no-malloc
+      variable_data_impl_.reset(
+          static_cast<double*>(malloc(size_ * sizeof(double))));  // NOLINT
+      variable_data_.reset(variable_data_impl_.get(), size_);
+      add_reference_variable_data(tmpl::list<Tags...>{});
+    }
+  }
+  variable_data_ =
+      static_cast<const blaze::Vector<pointer_type, transpose_flag>&>(
+          rhs.variable_data_);
   return *this;
 }
 
@@ -481,9 +562,9 @@ template <typename... WrappedTags,
 Variables<tmpl::list<Tags...>>::Variables(
     Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept
     : variable_data_impl_(std::move(rhs.variable_data_impl_)),
-      variable_data_(std::move(rhs.variable_data_)),
       size_(rhs.size()),
       number_of_grid_points_(rhs.number_of_grid_points()),
+      variable_data_(variable_data_impl_.get(), size_),
       reference_variable_data_(std::move(rhs.reference_variable_data_)) {}
 
 template <typename... Tags>
@@ -493,23 +574,26 @@ template <typename... WrappedTags, Requires<tmpl2::flat_all_v<cpp17::is_same_v<
 Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
     Variables<tmpl::list<WrappedTags...>>&& rhs) noexcept {
   variable_data_impl_ = std::move(rhs.variable_data_impl_);
-  variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
   size_ = rhs.size_;
   number_of_grid_points_ = std::move(rhs.number_of_grid_points_);
+  variable_data_.reset(variable_data_impl_.get(), size());
   add_reference_variable_data(tmpl::list<Tags...>{});
   return *this;
 }
 
 template <typename... Tags>
 void Variables<tmpl::list<Tags...>>::pup(PUP::er& p) noexcept {
-  p | variable_data_impl_;
   p | size_;
   p | number_of_grid_points_;
   if (p.isUnpacking()) {
-    variable_data_.reset(variable_data_impl_.data(),
-                         variable_data_impl_.size());
+    // clang-tidy: cppcoreguidelines-no-malloc
+    variable_data_impl_.reset(static_cast<double*>(
+        malloc(number_of_grid_points_ *  // NOLINT
+               number_of_independent_components * sizeof(double))));
+    variable_data_.reset(variable_data_impl_.get(), size());
     add_reference_variable_data(tmpl::list<Tags...>{});
   }
+  PUParray(p, variable_data_impl_.get(), size_);
 }
 /// \endcond
 
@@ -544,12 +628,10 @@ template <typename... Tags>
 template <typename VT, bool VF>
 Variables<tmpl::list<Tags...>>::Variables(
     const blaze::Vector<VT, VF>& expression) noexcept
-    : variable_data_impl_((~expression).size()),
-      variable_data_(variable_data_impl_.data(), variable_data_impl_.size()),
-      size_((~expression).size()),
+    : size_((~expression).size()),
       number_of_grid_points_(size_ / number_of_independent_components) {
+  initialize(number_of_grid_points_);
   variable_data_ = expression;
-  add_reference_variable_data(tmpl::list<Tags...>{});
 }
 
 /// \cond
@@ -557,12 +639,12 @@ template <typename... Tags>
 template <typename VT, bool VF>
 Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
     const blaze::Vector<VT, VF>& expression) noexcept {
-  size_ = (~expression).size();
-  number_of_grid_points_ = size_ / number_of_independent_components;
-  variable_data_impl_.resize(size_);
-  variable_data_.reset(variable_data_impl_.data(), variable_data_impl_.size());
+  if (size_ != (~expression).size()) {
+    size_ = (~expression).size();
+    number_of_grid_points_ = size_ / number_of_independent_components;
+    initialize(number_of_grid_points_);
+  }
   variable_data_ = expression;
-  add_reference_variable_data(tmpl::list<Tags...>{});
   return *this;
 }
 /// \endcond

--- a/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
@@ -284,7 +284,7 @@ struct InitializeElement {
               bool IsConservative = LocalSystem::is_conservative>
     struct ComputeTags {
       using type = db::AddComputeTags<
-          Tags::Time, Tags::ComputeDeriv<
+          Tags::Time, Tags::DerivCompute<
                           variables_tag,
                           Tags::InverseJacobian<Tags::ElementMap<Dim>,
                                                 Tags::LogicalCoordinates<Dim>>,

--- a/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
@@ -295,7 +295,7 @@ struct InitializeElement {
     struct ComputeTags<LocalSystem, true> {
       using type = db::AddComputeTags<
           Tags::Time,
-          Tags::ComputeDiv<
+          Tags::DivCompute<
               db::add_tag_prefix<Tags::Flux, variables_tag, tmpl::size_t<Dim>,
                                  Frame::Inertial>,
               Tags::InverseJacobian<Tags::ElementMap<Dim>,

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -72,7 +72,7 @@ struct Evolution {
   struct ComputeTags<LocalSystem, true> {
     using type = db::AddComputeTags<
         Tags::Time,
-        Tags::ComputeDiv<db::add_tag_prefix<Tags::Flux, variables_tag,
+        Tags::DivCompute<db::add_tag_prefix<Tags::Flux, variables_tag,
                                             tmpl::size_t<dim>, Frame::Inertial>,
                          Tags::InverseJacobian<Tags::ElementMap<dim>,
                                                Tags::LogicalCoordinates<dim>>>>;

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -62,7 +62,7 @@ struct Evolution {
   struct ComputeTags {
     using type = db::AddComputeTags<
         Tags::Time,
-        Tags::ComputeDeriv<variables_tag,
+        Tags::DerivCompute<variables_tag,
                            Tags::InverseJacobian<Tags::ElementMap<dim>,
                                                  Tags::LogicalCoordinates<dim>>,
                            typename System::gradients_tags>>;

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -35,7 +35,7 @@ struct Mesh;
 ///
 /// \snippet Test_Divergence.cpp divergence_name
 ///
-/// \see Tags::ComputeDiv
+/// \see Tags::DivCompute
 template <typename Tag, typename = std::nullptr_t>
 struct div;
 
@@ -77,7 +77,7 @@ namespace Tags {
 ///
 /// This tag inherits from `db::add_prefix_tag<Tags::div, Tag>`.
 template <typename Tag, typename InverseJacobianTag>
-struct ComputeDiv : db::add_tag_prefix<div, Tag>, db::ComputeTag {
+struct DivCompute : db::add_tag_prefix<div, Tag>, db::ComputeTag {
  private:
   using inv_jac_indices =
       typename db::item_type<InverseJacobianTag>::index_list;

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -39,7 +39,7 @@ struct Variables;
  * \tparam Dim The volume dim as a type (e.g. `tmpl::size_t<Dim>`)
  * \tparam Frame The frame of the derivative index
  *
- * \see Tags::ComputeDeriv
+ * \see Tags::DerivCompute
  */
 template <typename Tag, typename Dim, typename Frame, typename = std::nullptr_t>
 struct deriv;
@@ -147,7 +147,7 @@ namespace Tags {
  */
 template <typename VariablesTag, typename InverseJacobianTag,
           typename DerivTags = typename db::item_type<VariablesTag>::tags_list>
-struct ComputeDeriv
+struct DerivCompute
     : db::add_tag_prefix<
           deriv, db::variables_tag_with_tags_list<VariablesTag, DerivTags>,
           tmpl::size_t<tmpl::back<

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -7,25 +7,216 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Mesh.hpp"
 #include "NumericalAlgorithms/LinearOperators/Transpose.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Blas.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
 namespace partial_derivatives_detail {
 template <size_t Dim, typename VariableTags, typename DerivativeTags>
 struct LogicalImpl;
+
+// This routine has been optimized to perform really well. The following
+// describes what optimizations were made.
+//
+// - The `partial_derivatives` functions below have an overload where the
+//   logical derivatives may be passed in instead of being computed. In the
+//   overloads where the logical derivatives are not passed in they must be
+//   computed. However, it is more efficient to allocate the memory for the
+//   logical partial derivatives with respect to each coordinate at once. This
+//   requires the `partial_derivatives_impl` to accept raw pointers to doubles
+//   for the logical derivatives so it can be used for all overloads.
+//
+// - The resultant Variables `du` is a not_null pointer so that mutating compute
+//   items can be supported.
+//
+// - The storage indices into the inverse Jacobian are precomputed to avoid
+//   having to recompute them for each tensor component of `u`.
+//
+// - The DataVectors lhs and logical_du are non-owning DataVectors to be able to
+//   plug into the optimized expression templates. This requires a `const_cast`
+//   even though we will never change the `double*`.
+//
+// - Loop over every Tensor component in the variables by incrementing a raw
+//   pointer to the contiguous data (vs. looping over each Tensor in the
+//   variables with a tmpl::for_each then iterating over each component of this
+//   Tensor).
+//
+// - We factor out the `logical_deriv_index == 0` case so that we do not need to
+//   zero the memory in `du` before the computation.
+template <typename DerivativeTags, size_t Dim, typename DerivativeFrame>
+void partial_derivatives_impl(
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        Tags::deriv, DerivativeTags, tmpl::size_t<Dim>, DerivativeFrame>>*>
+        du,
+    const std::array<const double*, Dim>& logical_partial_derivatives_of_u,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
+        inverse_jacobian) noexcept {
+  constexpr size_t number_of_independent_components =
+      Variables<DerivativeTags>::number_of_independent_components;
+  double* pdu = du->data();
+  const size_t num_grid_points = du->number_of_grid_points();
+  DataVector lhs{}, logical_du{};
+
+  std::array<std::array<size_t, Dim>, Dim> indices{};
+  for (size_t deriv_index = 0; deriv_index < Dim; ++deriv_index) {
+    for (size_t d = 0; d < Dim; ++d) {
+      gsl::at(gsl::at(indices, d), deriv_index) =
+          InverseJacobian<DataVector, Dim, Frame::Logical,
+                          DerivativeFrame>::get_storage_index(d, deriv_index);
+    }
+  }
+
+  for (size_t component_index = 0;
+       component_index < number_of_independent_components; ++component_index) {
+    for (size_t deriv_index = 0; deriv_index < Dim; ++deriv_index) {
+      lhs.set_data_ref(pdu, num_grid_points);
+      // clang-tidy: const cast is fine since we won't modify the data and we
+      // need it to easily hook into the expression templates.
+      logical_du.set_data_ref(
+          const_cast<double*>(  // NOLINT
+              gsl::at(logical_partial_derivatives_of_u, 0)) +  // NOLINT
+              component_index * num_grid_points,
+          num_grid_points);
+      lhs = (*(inverse_jacobian.begin() + gsl::at(indices[0], deriv_index))) *
+            logical_du;
+      for (size_t logical_deriv_index = 1; logical_deriv_index < Dim;
+           ++logical_deriv_index) {
+        // clang-tidy: const cast is fine since we won't modify the data and we
+        // need it to easily hook into the expression templates.
+        logical_du.set_data_ref(const_cast<double*>(  // NOLINT
+                                    gsl::at(logical_partial_derivatives_of_u,
+                                            logical_deriv_index)) +  // NOLINT
+                                    component_index * num_grid_points,
+                                num_grid_points);
+        lhs +=
+            (*(inverse_jacobian.begin() +
+               gsl::at(gsl::at(indices, logical_deriv_index), deriv_index))) *
+            logical_du;
+      }
+      // clang-tidy: no pointer arithmetic
+      pdu += num_grid_points;  // NOLINT
+    }
+  }
+}
 }  // namespace partial_derivatives_detail
+
+template <typename DerivativeTags, typename VariableTags, size_t Dim>
+void logical_partial_derivatives(
+    const gsl::not_null<std::array<Variables<DerivativeTags>, Dim>*>
+        logical_partial_derivatives_of_u,
+    const Variables<VariableTags>& u, const Mesh<Dim>& mesh) noexcept {
+  if (UNLIKELY((*logical_partial_derivatives_of_u)[0].number_of_grid_points() !=
+               u.number_of_grid_points())) {
+    for (auto& deriv : *logical_partial_derivatives_of_u) {
+      deriv.initialize(u.number_of_grid_points());
+    }
+  }
+  std::array<double*, Dim> deriv_pointers{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(deriv_pointers, i) =
+        gsl::at(*logical_partial_derivatives_of_u, i).data();
+  }
+  if (Dim == 1) {
+    Variables<DerivativeTags>* temp = nullptr;
+    partial_derivatives_detail::LogicalImpl<Dim, VariableTags, DerivativeTags>::
+        apply(make_not_null(&deriv_pointers), temp, u, mesh);
+    return;
+  }
+  Variables<DerivativeTags> temp(u.number_of_grid_points());
+  partial_derivatives_detail::LogicalImpl<
+      Dim, VariableTags, DerivativeTags>::apply(make_not_null(&deriv_pointers),
+                                                &temp, u, mesh);
+}
 
 template <typename DerivativeTags, typename VariableTags, size_t Dim>
 std::array<Variables<DerivativeTags>, Dim> logical_partial_derivatives(
     const Variables<VariableTags>& u, const Mesh<Dim>& mesh) noexcept {
-  return partial_derivatives_detail::LogicalImpl<
-      Dim, VariableTags, DerivativeTags>::apply(u, mesh);
+  auto logical_partial_derivatives_of_u =
+      make_array<Dim>(Variables<DerivativeTags>(u.number_of_grid_points()));
+  logical_partial_derivatives<DerivativeTags>(
+      make_not_null(&logical_partial_derivatives_of_u), u, mesh);
+  return logical_partial_derivatives_of_u;
+}
+
+template <typename DerivativeTags, size_t Dim, typename DerivativeFrame>
+void partial_derivatives(
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        Tags::deriv, DerivativeTags, tmpl::size_t<Dim>, DerivativeFrame>>*>
+        du,
+    const std::array<Variables<DerivativeTags>, Dim>&
+        logical_partial_derivatives_of_u,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
+        inverse_jacobian) noexcept {
+  auto& partial_derivatives_of_u = *du;
+  // For mutating compute items we must set the size.
+  if (UNLIKELY(partial_derivatives_of_u.number_of_grid_points() !=
+               logical_partial_derivatives_of_u[0].number_of_grid_points())) {
+    partial_derivatives_of_u.initialize(
+        logical_partial_derivatives_of_u[0].number_of_grid_points());
+  }
+
+  std::array<const double*, Dim> logical_derivs{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(logical_derivs, i) =
+        gsl::at(logical_partial_derivatives_of_u, i).data();
+  }
+  partial_derivatives_detail::partial_derivatives_impl<DerivativeTags>(
+      make_not_null(&partial_derivatives_of_u), logical_derivs,
+      inverse_jacobian);
+}
+
+template <typename DerivativeTags, typename VariableTags, size_t Dim,
+          typename DerivativeFrame>
+void partial_derivatives(
+    const gsl::not_null<Variables<db::wrap_tags_in<
+        Tags::deriv, DerivativeTags, tmpl::size_t<Dim>, DerivativeFrame>>*>
+        du,
+    const Variables<VariableTags>& u, const Mesh<Dim>& mesh,
+    const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
+        inverse_jacobian) noexcept {
+  auto& partial_derivatives_of_u = *du;
+  // For mutating compute items we must set the size.
+  if (UNLIKELY(partial_derivatives_of_u.number_of_grid_points() !=
+               mesh.number_of_grid_points())) {
+    partial_derivatives_of_u.initialize(mesh.number_of_grid_points());
+  }
+
+  // Using malloc instead of new is faster because we do not need to zero the
+  // data.
+  // clang-tidy: cppcoreguidelines-no-malloc
+  std::unique_ptr<double[], decltype(&free)> logical_derivs_data(
+      static_cast<double*>(
+          malloc(Dim * u.number_of_grid_points() *  // NOLINT
+                 Variables<DerivativeTags>::number_of_independent_components *
+                 sizeof(double))),
+      &free);
+  std::array<double*, Dim> logical_derivs{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(logical_derivs, i) =
+        &(logical_derivs_data
+              [i * u.number_of_grid_points() *
+               Variables<DerivativeTags>::number_of_independent_components]);
+  }
+  partial_derivatives_detail::LogicalImpl<
+      Dim, VariableTags, DerivativeTags>::apply(make_not_null(&logical_derivs),
+                                                &partial_derivatives_of_u, u,
+                                                mesh);
+
+  std::array<const double*, Dim> const_logical_derivs{};
+  for (size_t i = 0; i < Dim; ++i) {
+    gsl::at(const_logical_derivs, i) = gsl::at(logical_derivs, i);
+  }
+  partial_derivatives_detail::partial_derivatives_impl<DerivativeTags>(
+      make_not_null(&partial_derivatives_of_u), const_logical_derivs,
+      inverse_jacobian);
 }
 
 template <typename DerivativeTags, typename VariableTags, size_t Dim,
@@ -36,36 +227,11 @@ partial_derivatives(
     const Variables<VariableTags>& u, const Mesh<Dim>& mesh,
     const InverseJacobian<DataVector, Dim, Frame::Logical, DerivativeFrame>&
         inverse_jacobian) noexcept {
-  const auto logical_partial_derivatives_of_u =
-      logical_partial_derivatives<DerivativeTags>(u, mesh);
-
   Variables<db::wrap_tags_in<Tags::deriv, DerivativeTags, tmpl::size_t<Dim>,
                              DerivativeFrame>>
-      partial_derivatives_of_u(u.number_of_grid_points(), 0.0);
-
-  tmpl::for_each<DerivativeTags>([
-    &partial_derivatives_of_u, &inverse_jacobian,
-    &logical_partial_derivatives_of_u
-  ](auto tag) noexcept {
-    using Tag = tmpl::type_from<decltype(tag)>;
-    using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<Dim>, DerivativeFrame>;
-    auto& partial_derivatives_of_variable =
-        get<DerivativeTag>(partial_derivatives_of_u);
-    for (auto it = partial_derivatives_of_variable.begin();
-         it != partial_derivatives_of_variable.end(); ++it) {
-      const auto deriv_indices =
-          partial_derivatives_of_variable.get_tensor_index(it);
-      const size_t deriv_index = deriv_indices[0];
-      const auto tensor_indices =
-          all_but_specified_element_of(deriv_indices, 0);
-      for (size_t d = 0; d < Dim; ++d) {
-        *it += inverse_jacobian.get(d, deriv_index) *
-               get<Tag>(gsl::at(logical_partial_derivatives_of_u, d))
-                   .get(tensor_indices);
-      }
-    }
-  });
-
+      partial_derivatives_of_u(u.number_of_grid_points());
+  partial_derivatives<DerivativeTags>(make_not_null(&partial_derivatives_of_u),
+                                      u, mesh, inverse_jacobian);
   return partial_derivatives_of_u;
 }
 
@@ -73,108 +239,117 @@ namespace partial_derivatives_detail {
 template <typename VariableTags, typename DerivativeTags>
 struct LogicalImpl<1, VariableTags, DerivativeTags> {
   static constexpr const size_t Dim = 1;
-  static auto apply(const Variables<VariableTags>& u,
+  template <typename T>
+  static void apply(const gsl::not_null<std::array<double*, Dim>*> logical_du,
+                    Variables<T>* /*unused_in_1d*/,
+                    const Variables<VariableTags>& u,
                     const Mesh<Dim>& mesh) noexcept {
-    auto logical_partial_derivatives_of_u = make_array<Dim>(
-        Variables<DerivativeTags>(u.number_of_grid_points(), 0.0));
+    auto& logical_partial_derivatives_of_u = *logical_du;
+    const size_t deriv_size =
+        Variables<DerivativeTags>::number_of_independent_components *
+        u.number_of_grid_points();
     const Matrix& differentiation_matrix_xi =
         Spectral::differentiation_matrix(mesh.slice_through(0));
-    dgemm_<true>('N', 'N', mesh.extents(0),
-                 logical_partial_derivatives_of_u[0].size() / mesh.extents(0),
+    dgemm_<true>('N', 'N', mesh.extents(0), deriv_size / mesh.extents(0),
                  mesh.extents(0), 1.0, differentiation_matrix_xi.data(),
                  mesh.extents(0), u.data(), mesh.extents(0), 0.0,
-                 logical_partial_derivatives_of_u[0].data(), mesh.extents(0));
-
-    return logical_partial_derivatives_of_u;
+                 logical_partial_derivatives_of_u[0], mesh.extents(0));
   }
 };
 
 template <typename VariableTags, typename DerivativeTags>
 struct LogicalImpl<2, VariableTags, DerivativeTags> {
   static constexpr size_t Dim = 2;
-  static auto apply(const Variables<VariableTags>& u,
+  template <typename T>
+  static void apply(const gsl::not_null<std::array<double*, Dim>*> logical_du,
+                    Variables<T>* const partial_u_wrt_eta,
+                    const Variables<VariableTags>& u,
                     const Mesh<2>& mesh) noexcept {
-    auto logical_partial_derivatives_of_u =
-        make_array<Dim>(Variables<DerivativeTags>(u.number_of_grid_points()));
+    static_assert(
+        Variables<DerivativeTags>::number_of_independent_components <=
+            Variables<T>::number_of_independent_components,
+        "Temporary buffer in logical partial derivatives is too small");
+    auto& logical_partial_derivatives_of_u = *logical_du;
+    const size_t deriv_size =
+        Variables<DerivativeTags>::number_of_independent_components *
+        u.number_of_grid_points();
     const Matrix& differentiation_matrix_xi =
         Spectral::differentiation_matrix(mesh.slice_through(0));
-    const size_t num_components_times_xi_slices =
-        logical_partial_derivatives_of_u[0].size() / mesh.extents(0);
+    const size_t num_components_times_xi_slices = deriv_size / mesh.extents(0);
     dgemm_<true>('N', 'N', mesh.extents(0), num_components_times_xi_slices,
                  mesh.extents(0), 1.0, differentiation_matrix_xi.data(),
                  mesh.extents(0), u.data(), mesh.extents(0), 0.0,
-                 logical_partial_derivatives_of_u[0].data(), mesh.extents(0));
+                 logical_partial_derivatives_of_u[0], mesh.extents(0));
 
     const auto u_eta_fastest =
         transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
             u, mesh.extents(0), num_components_times_xi_slices);
-    Variables<DerivativeTags> partial_u_wrt_eta(u.number_of_grid_points());
     const Matrix& differentiation_matrix_eta =
         Spectral::differentiation_matrix(mesh.slice_through(1));
-    const size_t num_components_times_eta_slices =
-        logical_partial_derivatives_of_u[1].size() / mesh.extents(1);
+    const size_t num_components_times_eta_slices = deriv_size / mesh.extents(1);
     dgemm_<true>('N', 'N', mesh.extents(1), num_components_times_eta_slices,
                  mesh.extents(1), 1.0, differentiation_matrix_eta.data(),
                  mesh.extents(1), u_eta_fastest.data(), mesh.extents(1), 0.0,
-                 partial_u_wrt_eta.data(), mesh.extents(1));
-    transpose(make_not_null(&logical_partial_derivatives_of_u[1]),
-              partial_u_wrt_eta, num_components_times_xi_slices,
-              mesh.extents(0));
-
-    return logical_partial_derivatives_of_u;
+                 partial_u_wrt_eta->data(), mesh.extents(1));
+    raw_transpose(make_not_null(logical_partial_derivatives_of_u[1]),
+                  partial_u_wrt_eta->data(), num_components_times_xi_slices,
+                  mesh.extents(0));
   }
 };
 
 template <typename VariableTags, typename DerivativeTags>
 struct LogicalImpl<3, VariableTags, DerivativeTags> {
   static constexpr size_t Dim = 3;
-  static auto apply(const Variables<VariableTags>& u,
+  template <class T>
+  static void apply(const gsl::not_null<std::array<double*, Dim>*> logical_du,
+                    Variables<T>* const partial_u_wrt_eta_or_zeta,
+                    const Variables<VariableTags>& u,
                     const Mesh<3>& mesh) noexcept {
-    auto logical_partial_derivatives_of_u =
-        make_array<Dim>(Variables<DerivativeTags>(u.number_of_grid_points()));
+    static_assert(
+        Variables<DerivativeTags>::number_of_independent_components <=
+            Variables<T>::number_of_independent_components,
+        "Temporary buffer in logical partial derivatives is too small");
+    auto& logical_partial_derivatives_of_u = *logical_du;
     const Matrix& differentiation_matrix_xi =
         Spectral::differentiation_matrix(mesh.slice_through(0));
-    const size_t num_components_times_xi_slices =
-        logical_partial_derivatives_of_u[0].size() / mesh.extents(0);
+    const size_t deriv_size =
+        Variables<DerivativeTags>::number_of_independent_components *
+        u.number_of_grid_points();
+    const size_t num_components_times_xi_slices = deriv_size / mesh.extents(0);
     dgemm_<true>('N', 'N', mesh.extents(0), num_components_times_xi_slices,
                  mesh.extents(0), 1.0, differentiation_matrix_xi.data(),
                  mesh.extents(0), u.data(), mesh.extents(0), 0.0,
-                 logical_partial_derivatives_of_u[0].data(), mesh.extents(0));
+                 logical_partial_derivatives_of_u[0], mesh.extents(0));
 
     auto u_eta_or_zeta_fastest =
         transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
             u, mesh.extents(0), num_components_times_xi_slices);
-    Variables<DerivativeTags> partial_u_wrt_eta_or_zeta(
-        u.number_of_grid_points());
     const Matrix& differentiation_matrix_eta =
         Spectral::differentiation_matrix(mesh.slice_through(1));
-    const size_t num_components_times_eta_slices =
-        logical_partial_derivatives_of_u[1].size() / mesh.extents(1);
+    const size_t num_components_times_eta_slices = deriv_size / mesh.extents(1);
     dgemm_<true>('N', 'N', mesh.extents(1), num_components_times_eta_slices,
                  mesh.extents(1), 1.0, differentiation_matrix_eta.data(),
                  mesh.extents(1), u_eta_or_zeta_fastest.data(), mesh.extents(1),
-                 0.0, partial_u_wrt_eta_or_zeta.data(), mesh.extents(1));
-    transpose(make_not_null(&logical_partial_derivatives_of_u[1]),
-              partial_u_wrt_eta_or_zeta, num_components_times_xi_slices,
-              mesh.extents(0));
+                 0.0, partial_u_wrt_eta_or_zeta->data(), mesh.extents(1));
+    raw_transpose(make_not_null(logical_partial_derivatives_of_u[1]),
+                  partial_u_wrt_eta_or_zeta->data(),
+                  num_components_times_xi_slices, mesh.extents(0));
 
     const size_t chunk_size = mesh.extents(0) * mesh.extents(1);
-    const size_t number_of_chunks =
-        logical_partial_derivatives_of_u[1].size() / chunk_size;
+    const size_t number_of_chunks = deriv_size / chunk_size;
     transpose(make_not_null(&u_eta_or_zeta_fastest), u, chunk_size,
               number_of_chunks);
     const Matrix& differentiation_matrix_zeta =
         Spectral::differentiation_matrix(mesh.slice_through(2));
     const size_t num_components_times_zeta_slices =
-        logical_partial_derivatives_of_u[2].size() / mesh.extents(2);
+        deriv_size / mesh.extents(2);
     dgemm_<true>('N', 'N', mesh.extents(2), num_components_times_zeta_slices,
                  mesh.extents(2), 1.0, differentiation_matrix_zeta.data(),
                  mesh.extents(2), u_eta_or_zeta_fastest.data(), mesh.extents(2),
-                 0.0, partial_u_wrt_eta_or_zeta.data(), mesh.extents(2));
-    transpose(make_not_null(&logical_partial_derivatives_of_u[2]),
-              partial_u_wrt_eta_or_zeta, number_of_chunks, chunk_size);
-
-    return logical_partial_derivatives_of_u;
+                 0.0, partial_u_wrt_eta_or_zeta->data(), mesh.extents(2));
+    raw_transpose(make_not_null(logical_partial_derivatives_of_u[2]),
+                  partial_u_wrt_eta_or_zeta->data(), number_of_chunks,
+                  chunk_size);
   }
 };
 }  // namespace partial_derivatives_detail

--- a/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Transpose.hpp
@@ -22,11 +22,14 @@
 // would make non-intuitive choices of the return-by-pointer version
 // below over this function.
 template <typename T>
-void raw_transpose(const gsl::not_null<T*> result,
-                   const T* const data, const size_t chunk_size,
+void raw_transpose(const gsl::not_null<T*> result, const T* const data,
+                   const size_t chunk_size,
                    const size_t number_of_chunks) noexcept {
-  for (size_t j = 0; j < number_of_chunks; ++j) {
-    for (size_t i = 0; i < chunk_size; ++i) {
+  // The i outside loop order is faster, but that could be architecture
+  // dependent and so may need updating in the future. Changing this made the
+  // logical derivatives in 3D with 50 variables 20% faster.
+  for (size_t i = 0; i < chunk_size; ++i) {
+    for (size_t j = 0; j < number_of_chunks; ++j) {
       // clang-tidy: pointer arithmetic
       result.get()[j + number_of_chunks * i] =  // NOLINT
           data[i + chunk_size * j];             // NOLINT

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -165,7 +165,7 @@ struct TestConservativeOrNonconservativeParts {
     using system = typename Metavariables::system;
     constexpr size_t dim = system::volume_dim;
 
-    CHECK(box_contains<Tags::ComputeDeriv<
+    CHECK(box_contains<Tags::DerivCompute<
               typename system::variables_tag,
               Tags::InverseJacobian<Tags::ElementMap<dim>,
                                     Tags::LogicalCoordinates<dim>>,

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -191,7 +191,7 @@ struct TestConservativeOrNonconservativeParts<true> {
     CHECK(db::get<db::add_tag_prefix<Tags::Source, variables_tag>>(*box)
               .number_of_grid_points() == number_of_grid_points);
 
-    CHECK(box_contains<Tags::ComputeDiv<
+    CHECK(box_contains<Tags::DivCompute<
               db::add_tag_prefix<Tags::Flux, variables_tag, tmpl::size_t<dim>,
                                  Frame::Inertial>,
               Tags::InverseJacobian<Tags::ElementMap<dim>,

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -235,8 +235,8 @@ void test_divergence_compute_item(
   auto box =
       db::create<db::AddSimpleTags<Tags::Mesh<Dim>, flux_tag, map_tag>,
                  db::AddComputeTags<Tags::LogicalCoordinates<Dim>, inv_jac_tag,
-                                    Tags::ComputeDiv<flux_tag, inv_jac_tag>>>(
-      mesh, fluxes, coordinate_map);
+                                    Tags::DivCompute<flux_tag, inv_jac_tag>>>(
+          mesh, fluxes, coordinate_map);
 
   const auto& div_fluxes =
       db::get<Tags::div<Tags::Variables<div_tags>>>(box);

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -32,6 +32,7 @@
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 // IWYU pragma: no_forward_declare Tags::deriv
+// IWYU pragma: no_forward_declare Variables
 
 namespace {
 
@@ -127,17 +128,21 @@ void test_logical_partial_derivatives_1d(const Mesh<1>& mesh) {
       }
     }
 
-    const auto du = logical_partial_derivatives<GradientTags>(u, mesh);
-
-    for (size_t n = 0;
-         n < Variables<GradientTags>::number_of_independent_components; ++n) {
-      for (size_t s = 0; s < number_of_grid_points; ++s) {
-        const double expected =
-            (0 == a ? 0.0 : a * (n + 1) * pow(xi[s], a - 1));
-        CHECK(du[0].data()[s + n * number_of_grid_points]  // NOLINT
-              == approx(expected));
+    const auto helper = [&](const auto& du) noexcept {
+      for (size_t n = 0;
+           n < Variables<GradientTags>::number_of_independent_components; ++n) {
+        for (size_t s = 0; s < number_of_grid_points; ++s) {
+          const double expected =
+              (0 == a ? 0.0 : a * (n + 1) * pow(xi[s], a - 1));
+          CHECK(du[0].data()[s + n * number_of_grid_points]  // NOLINT
+                == approx(expected));
+        }
       }
-    }
+    };
+    helper(logical_partial_derivatives<GradientTags>(u, mesh));
+    std::array<Variables<GradientTags>, 1> du{};
+    logical_partial_derivatives(make_not_null(&du), u, mesh);
+    helper(du);
   }
 }
 
@@ -156,27 +161,32 @@ void test_logical_partial_derivatives_2d(const Mesh<2>& mesh) {
     }
   }
 
-  const auto du = logical_partial_derivatives<GradientTags>(u, mesh);
-
-  for (size_t n = 0;
-       n < Variables<GradientTags>::number_of_independent_components; ++n) {
-    for (IndexIterator<2> ii(mesh.extents()); ii; ++ii) {
-      const double expected_dxi =
-          (0 == a
-               ? 0.0
-               : a * (n + 1) * pow(xi[ii()[0]], a - 1) * pow(eta[ii()[1]], b));
-      const double expected_deta = (0 == b ? 0.0
-                                           : b * (n + 1) * pow(xi[ii()[0]], a) *
-                                                 pow(eta[ii()[1]], b - 1));
-      // clang-tidy: pointer arithmetic
-      CHECK(du[0].data()[ii.collapsed_index() +         // NOLINT
-                         n * number_of_grid_points] ==  // NOLINT
-            approx(expected_dxi));
-      CHECK(du[1].data()[ii.collapsed_index() +         // NOLINT
-                         n * number_of_grid_points] ==  // NOLINT
-            approx(expected_deta));
+  const auto helper = [&](const auto& du) noexcept {
+    for (size_t n = 0;
+         n < Variables<GradientTags>::number_of_independent_components; ++n) {
+      for (IndexIterator<2> ii(mesh.extents()); ii; ++ii) {
+        const double expected_dxi =
+            (0 == a ? 0.0
+                    : a * (n + 1) * pow(xi[ii()[0]], a - 1) *
+                          pow(eta[ii()[1]], b));
+        const double expected_deta =
+            (0 == b ? 0.0
+                    : b * (n + 1) * pow(xi[ii()[0]], a) *
+                          pow(eta[ii()[1]], b - 1));
+        // clang-tidy: pointer arithmetic
+        CHECK(du[0].data()[ii.collapsed_index() +         // NOLINT
+                           n * number_of_grid_points] ==  // NOLINT
+              approx(expected_dxi));
+        CHECK(du[1].data()[ii.collapsed_index() +         // NOLINT
+                           n * number_of_grid_points] ==  // NOLINT
+              approx(expected_deta));
+      }
     }
-  }
+  };
+  helper(logical_partial_derivatives<GradientTags>(u, mesh));
+  std::array<Variables<GradientTags>, 2> du{};
+  logical_partial_derivatives(make_not_null(&du), u, mesh);
+  helper(du);
 }
 
 template <typename VariableTags, typename GradientTags = VariableTags>
@@ -197,35 +207,39 @@ void test_logical_partial_derivatives_3d(const Mesh<3>& mesh) {
     }
   }
 
-  const auto du = logical_partial_derivatives<GradientTags>(u, mesh);
-
-  for (size_t n = 0;
-       n < Variables<GradientTags>::number_of_independent_components; ++n) {
-    for (IndexIterator<3> ii(mesh.extents()); ii; ++ii) {
-      const double expected_dxi =
-          (0 == a ? 0.0
-                  : a * (n + 1) * pow(xi[ii()[0]], a - 1) *
-                        pow(eta[ii()[1]], b) * pow(zeta[ii()[2]], c));
-      const double expected_deta =
-          (0 == b ? 0.0
-                  : b * (n + 1) * pow(xi[ii()[0]], a) *
-                        pow(eta[ii()[1]], b - 1) * pow(zeta[ii()[2]], c));
-      const double expected_dzeta =
-          (0 == c ? 0.0
-                  : c * (n + 1) * pow(xi[ii()[0]], a) * pow(eta[ii()[1]], b) *
-                        pow(zeta[ii()[2]], c - 1));
-      // clang-tidy: pointer arithmetic
-      CHECK(du[0].data()[ii.collapsed_index() +         // NOLINT
-                         n * number_of_grid_points] ==  // NOLINT
-            approx(expected_dxi));
-      CHECK(du[1].data()[ii.collapsed_index() +         // NOLINT
-                         n * number_of_grid_points] ==  // NOLINT
-            approx(expected_deta));
-      CHECK(du[2].data()[ii.collapsed_index() +         // NOLINT
-                         n * number_of_grid_points] ==  // NOLINT
-            approx(expected_dzeta));
+  const auto helper = [&](const auto& du) noexcept {
+    for (size_t n = 0;
+         n < Variables<GradientTags>::number_of_independent_components; ++n) {
+      for (IndexIterator<3> ii(mesh.extents()); ii; ++ii) {
+        const double expected_dxi =
+            (0 == a ? 0.0
+                    : a * (n + 1) * pow(xi[ii()[0]], a - 1) *
+                          pow(eta[ii()[1]], b) * pow(zeta[ii()[2]], c));
+        const double expected_deta =
+            (0 == b ? 0.0
+                    : b * (n + 1) * pow(xi[ii()[0]], a) *
+                          pow(eta[ii()[1]], b - 1) * pow(zeta[ii()[2]], c));
+        const double expected_dzeta =
+            (0 == c ? 0.0
+                    : c * (n + 1) * pow(xi[ii()[0]], a) * pow(eta[ii()[1]], b) *
+                          pow(zeta[ii()[2]], c - 1));
+        // clang-tidy: pointer arithmetic
+        CHECK(du[0].data()[ii.collapsed_index() +         // NOLINT
+                           n * number_of_grid_points] ==  // NOLINT
+              approx(expected_dxi));
+        CHECK(du[1].data()[ii.collapsed_index() +         // NOLINT
+                           n * number_of_grid_points] ==  // NOLINT
+              approx(expected_deta));
+        CHECK(du[2].data()[ii.collapsed_index() +         // NOLINT
+                           n * number_of_grid_points] ==  // NOLINT
+              approx(expected_dzeta));
+      }
     }
-  }
+  };
+  helper(logical_partial_derivatives<GradientTags>(u, mesh));
+  std::array<Variables<GradientTags>, 3> du{};
+  logical_partial_derivatives(make_not_null(&du), u, mesh);
+  helper(du);
 }
 
 template <typename VariableTags, typename GradientTags = VariableTags>
@@ -253,13 +267,25 @@ void test_partial_derivatives_1d(const Mesh<1>& mesh) {
       get<DerivativeTag>(expected_du) = Tag::df({{a}}, x);
     });
 
-    const auto du =
-        partial_derivatives<GradientTags>(u, mesh, inverse_jacobian);
+    const auto helper = [&](const auto& du) noexcept {
+      for (size_t n = 0; n < du.size(); ++n) {
+        CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
+        CHECK(du.data()[n] == approx(expected_du.data()[n]));   // NOLINT
+      }
+    };
+    helper(partial_derivatives<GradientTags>(u, mesh, inverse_jacobian));
+    using vars_type =
+        decltype(partial_derivatives<GradientTags>(u, mesh, inverse_jacobian));
+    vars_type du{};
+    partial_derivatives<GradientTags>(make_not_null(&du), u, mesh,
+                                      inverse_jacobian);
+    helper(du);
 
-    for (size_t n = 0; n < du.size(); ++n) {
-      CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
-      CHECK(du.data()[n] == approx(expected_du.data()[n]));   // NOLINT
-    }
+    vars_type du_with_logical{};
+    partial_derivatives<GradientTags>(
+        make_not_null(&du_with_logical),
+        logical_partial_derivatives<GradientTags>(u, mesh), inverse_jacobian);
+    helper(du_with_logical);
   }
 }
 
@@ -294,14 +320,26 @@ void test_partial_derivatives_2d(const Mesh<2>& mesh) {
         get<DerivativeTag>(expected_du) = Tag::df({{a, b}}, x);
       });
 
-      const auto du =
-          partial_derivatives<GradientTags>(u, mesh, inverse_jacobian);
+      const auto helper = [&](const auto& du) noexcept {
+        for (size_t n = 0; n < du.size(); ++n) {
+          CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
+          CHECK(du.data()[n] ==                                   // NOLINT
+                approx(expected_du.data()[n]).epsilon(1.e-13));   // NOLINT
+        }
+      };
+      helper(partial_derivatives<GradientTags>(u, mesh, inverse_jacobian));
+      using vars_type = decltype(
+          partial_derivatives<GradientTags>(u, mesh, inverse_jacobian));
+      vars_type du{};
+      partial_derivatives<GradientTags>(make_not_null(&du), u, mesh,
+                                        inverse_jacobian);
+      helper(du);
 
-      for (size_t n = 0; n < du.size(); ++n) {
-        CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
-        CHECK(du.data()[n] ==                                   // NOLINT
-              approx(expected_du.data()[n]).epsilon(1.e-13));   // NOLINT
-      }
+      vars_type du_with_logical{};
+      partial_derivatives<GradientTags>(
+          make_not_null(&du_with_logical),
+          logical_partial_derivatives<GradientTags>(u, mesh), inverse_jacobian);
+      helper(du_with_logical);
     }
   }
 }
@@ -342,14 +380,27 @@ void test_partial_derivatives_3d(const Mesh<3>& mesh) {
           get<DerivativeTag>(expected_du) = Tag::df({{a, b, c}}, x);
         });
 
-        const auto du =
-            partial_derivatives<GradientTags>(u, mesh, inverse_jacobian);
+        const auto helper = [&](const auto& du) noexcept {
+          for (size_t n = 0; n < du.size(); ++n) {
+            CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
+            CHECK(du.data()[n] ==                                   // NOLINT
+                  approx(expected_du.data()[n]).epsilon(1.e-11));
+          }
+        };
+        helper(partial_derivatives<GradientTags>(u, mesh, inverse_jacobian));
+        using vars_type = decltype(
+            partial_derivatives<GradientTags>(u, mesh, inverse_jacobian));
+        vars_type du{};
+        partial_derivatives<GradientTags>(make_not_null(&du), u, mesh,
+                                          inverse_jacobian);
+        helper(du);
 
-        for (size_t n = 0; n < du.size(); ++n) {
-          CAPTURE_PRECISE(du.data()[n] - expected_du.data()[n]);  // NOLINT
-          CHECK(du.data()[n] ==                                   // NOLINT
-                approx(expected_du.data()[n]).epsilon(1.e-11));
-        }
+        vars_type du_with_logical{};
+        partial_derivatives<GradientTags>(
+            make_not_null(&du_with_logical),
+            logical_partial_derivatives<GradientTags>(u, mesh),
+            inverse_jacobian);
+        helper(du_with_logical);
       }
     }
   }

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -489,12 +489,11 @@ void test_partial_derivatives_compute_item(
   using map_tag = MapTag<std::decay_t<decltype(map)>>;
   using inv_jac_tag =
       Tags::InverseJacobian<map_tag, Tags::LogicalCoordinates<Dim>>;
-  using deriv_tag = Tags::ComputeDeriv<Tags::Variables<vars_tags>,
-                                      inv_jac_tag>;
+  using deriv_tag = Tags::DerivCompute<Tags::Variables<vars_tags>, inv_jac_tag>;
   using prefixed_variables_tag =
       db::add_tag_prefix<SomePrefix, Tags::Variables<vars_tags>>;
   using deriv_prefixed_tag =
-      Tags::ComputeDeriv<prefixed_variables_tag, inv_jac_tag,
+      Tags::DerivCompute<prefixed_variables_tag, inv_jac_tag,
                          tmpl::list<SomePrefix<Var1<Dim>>>>;
 
   const std::array<size_t, Dim> array_to_functions{extents_array -


### PR DESCRIPTION
## Proposed changes

- Make partial derivs up to 2x faster (for small meshes) and provide mutating overloads (no mutating compute item yet)
- Allow bypassing operator new's default initialization in Variables by using `malloc` and only initialize values in debug more or explicitly requested
- Allow Subitems to return by `const&` (fixes a bug where for compute items returning variables the unpacking would be incorrect in terms of an allocation and copy was done instead of aliasing)
- Rename `ComputeDeriv` -> `DerivCompute` and `ComputeDiv` -> `DivCompute`. I prefer this because when we have simple + compute tags we can alphabetize things and still have them be next to each other. 

Commit order:
1. Make Variables use unique_ptr for memory
2. Expose the storage index through Tensor
3. Speed up the partial derivatives calculation
4. Allow Subitem compute items to return by const&
5. Clean up Deferred and noexcept
6. Rename ComputeDeriv to DerivCompute
7. Rename ComputeDiv to DivCompute

Breaks:
- Name of `ComputeDeriv` and of `ComputeDiv`

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
