### PR TITLE
Add generalized harmonic 3-index constraint

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY GeneralizedHarmonic)
 
 set(LIBRARY_SOURCES
+    Constraints.cpp
     Equations.cpp
     )
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace GeneralizedHarmonic {
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::iaa<DataType, SpatialDim, Frame> three_index_constraint(
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_spacetime_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  auto constraint =
+      make_with_value<tnsr::iaa<DataType, SpatialDim, Frame>>(phi, 0.0);
+  three_index_constraint<SpatialDim, Frame, DataType>(&constraint,
+                                                      d_spacetime_metric, phi);
+  return constraint;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void three_index_constraint(
+    gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_spacetime_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  // Declare iterators for d_spacetime_metric and phi outside the for loop,
+  // because they are const but constraint is not
+  auto d_spacetime_metric_it = d_spacetime_metric.begin(), phi_it = phi.begin();
+
+  for (auto constraint_it = (*constraint).begin();
+       constraint_it != (*constraint).end();
+       ++constraint_it, (void)++d_spacetime_metric_it, (void)++phi_it) {
+    *constraint_it = *d_spacetime_metric_it - *phi_it;
+  }
+}
+}  // namespace GeneralizedHarmonic
+
+// Explicit Instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                               \
+  template tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>                  \
+  GeneralizedHarmonic::three_index_constraint(                             \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>&                \
+          d_spacetime_metric,                                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept; \
+  template void GeneralizedHarmonic::three_index_constraint(               \
+      gsl::not_null<tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>*>       \
+          constraint,                                                      \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>&                \
+          d_spacetime_metric,                                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE
+/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -1,0 +1,40 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+///\file
+/// Defines functions to calculate the generalized harmonic constraints
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace GeneralizedHarmonic {
+// @{
+/*!
+ * \brief Computes the generalized-harmonic 3-index constraint.
+ *
+ * \details Computes the generalized-harmonic 3-index constraint,
+ * \f$C_{iab} = \partial_i\psi_{ab} - \Phi_{iab},\f$ which is
+ * given by Eq. (26) of http://arXiv.org/abs/gr-qc/0512093v3
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::iaa<DataType, SpatialDim, Frame> three_index_constraint(
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_spacetime_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void three_index_constraint(
+    gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_spacetime_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+// @}
+}  // namespace GeneralizedHarmonic

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_GeneralizedHarmonic")
 
 set(LIBRARY_SOURCES
+  Test_Constraints.cpp
   Test_DuDt.cpp
   Test_Fluxes.cpp
   )

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -1,0 +1,63 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+
+namespace {
+template <size_t SpatialDim, typename Frame, typename DataType>
+void test_three_index_constraint(const DataType& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::iaa<DataType, SpatialDim, Frame> (*)(
+          const tnsr::iaa<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&)>(
+          &GeneralizedHarmonic::three_index_constraint<SpatialDim, Frame,
+                                                       DataType>),
+      "numpy", "subtract", {{{-10.0, 10.0}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.ThreeIndexConstraint",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GeneralizedHarmonic/"};
+
+  test_three_index_constraint<1, Frame::Grid, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_three_index_constraint<1, Frame::Inertial, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_three_index_constraint<1, Frame::Grid, double>(
+      std::numeric_limits<double>::signaling_NaN());
+  test_three_index_constraint<1, Frame::Inertial, double>(
+      std::numeric_limits<double>::signaling_NaN());
+
+  test_three_index_constraint<2, Frame::Grid, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_three_index_constraint<2, Frame::Inertial, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_three_index_constraint<2, Frame::Grid, double>(
+      std::numeric_limits<double>::signaling_NaN());
+  test_three_index_constraint<2, Frame::Inertial, double>(
+      std::numeric_limits<double>::signaling_NaN());
+
+  test_three_index_constraint<3, Frame::Grid, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_three_index_constraint<3, Frame::Inertial, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_three_index_constraint<3, Frame::Grid, double>(
+      std::numeric_limits<double>::signaling_NaN());
+  test_three_index_constraint<3, Frame::Inertial, double>(
+      std::numeric_limits<double>::signaling_NaN());
+}


### PR DESCRIPTION
## Proposed changes

Begin adding generalized harmonic constraint equations, starting with the one that's the most straightforward, the 3-index constraint.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
