### PR TITLE
Add some of the helper commits from DirectionMap PR

### DIFF
--- a/cmake/SetupSciPy.cmake
+++ b/cmake/SetupSciPy.cmake
@@ -1,7 +1,7 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-find_package(SciPy)
+find_package(SciPy REQUIRED)
 
 message(STATUS "SciPy incl: " ${SCIPY_INCLUDE_DIRS})
 message(STATUS "SciPy vers: " ${SCIPY_VERSION})

--- a/src/DataStructures/DataVector.cpp
+++ b/src/DataStructures/DataVector.cpp
@@ -5,8 +5,9 @@
 
 #include <algorithm>
 #include <pup.h>
+#include <utility>  // IWYU pragma: keep
 
-#include "Utilities/StdHelpers.hpp"
+#include "Utilities/PrintHelpers.hpp"
 
 DataVector::DataVector(const size_t size, const double value) noexcept
     : owned_data_(size, value) {
@@ -94,8 +95,7 @@ void DataVector::pup(PUP::er& p) noexcept {  // NOLINT
 }
 
 std::ostream& operator<<(std::ostream& os, const DataVector& d) {
-  // This function is inside the detail namespace StdHelpers.hpp
-  StdHelpers_detail::print_helper(os, d.begin(), d.end());
+  sequence_print_helper(os, d.begin(), d.end());
   return os;
 }
 

--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -6,6 +6,7 @@
 #include <pup.h>  // IWYU pragma: keep
 
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
 
 namespace Frame {
 struct Grid;
@@ -19,7 +20,7 @@ Block<VolumeDim, TargetFrame>::Block(
         map,
     const size_t id,
     std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>
-        neighbors)
+        neighbors) noexcept
     : map_(std::move(map)), id_(id), neighbors_(std::move(neighbors)) {
   // Loop over Directions to search which Directions were not set to neighbors_,
   // set these Directions to external_boundaries_.
@@ -31,7 +32,7 @@ Block<VolumeDim, TargetFrame>::Block(
 }
 
 template <size_t VolumeDim, typename TargetFrame>
-void Block<VolumeDim, TargetFrame>::pup(PUP::er& p) {
+void Block<VolumeDim, TargetFrame>::pup(PUP::er& p) noexcept {
   p | map_;
   p | id_;
   p | neighbors_;
@@ -40,10 +41,10 @@ void Block<VolumeDim, TargetFrame>::pup(PUP::er& p) {
 
 template <size_t VolumeDim, typename TargetFrame>
 std::ostream& operator<<(std::ostream& os,
-                         const Block<VolumeDim, TargetFrame>& block) {
+                         const Block<VolumeDim, TargetFrame>& block) noexcept {
   os << "Block " << block.id() << ":\n";
-  os << "Neighbors: " << block.neighbors() << "\n";
-  os << "External boundaries: " << block.external_boundaries() << "\n";
+  os << "Neighbors: " << block.neighbors() << '\n';
+  os << "External boundaries: " << block.external_boundaries() << '\n';
   return os;
 }
 
@@ -61,48 +62,23 @@ bool operator!=(const Block<VolumeDim, TargetFrame>& lhs,
   return not(lhs == rhs);
 }
 
-template class Block<1, Frame::Grid>;
-template class Block<2, Frame::Grid>;
-template class Block<3, Frame::Grid>;
-template class Block<1, Frame::Inertial>;
-template class Block<2, Frame::Inertial>;
-template class Block<3, Frame::Inertial>;
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define GET_FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-template std::ostream& operator<<(std::ostream& os,
-                                  const Block<1, Frame::Grid>& block);
-template std::ostream& operator<<(std::ostream& os,
-                                  const Block<2, Frame::Grid>& block);
-template std::ostream& operator<<(std::ostream& os,
-                                  const Block<3, Frame::Grid>& block);
-template std::ostream& operator<<(std::ostream& os,
-                                  const Block<1, Frame::Inertial>& block);
-template std::ostream& operator<<(std::ostream& os,
-                                  const Block<2, Frame::Inertial>& block);
-template std::ostream& operator<<(std::ostream& os,
-                                  const Block<3, Frame::Inertial>& block);
+#define INSTANTIATION(r, data)                                               \
+  template class Block<GET_DIM(data), GET_FRAME(data)>;                      \
+  template std::ostream& operator<<(                                         \
+      std::ostream& os, const Block<GET_DIM(data), GET_FRAME(data)>& block); \
+  template bool operator==(                                                  \
+      const Block<GET_DIM(data), GET_FRAME(data)>& lhs,                      \
+      const Block<GET_DIM(data), GET_FRAME(data)>& rhs) noexcept;            \
+  template bool operator!=(                                                  \
+      const Block<GET_DIM(data), GET_FRAME(data)>& lhs,                      \
+      const Block<GET_DIM(data), GET_FRAME(data)>& rhs) noexcept;
 
-template bool operator==(const Block<1, Frame::Grid>& lhs,
-                         const Block<1, Frame::Grid>& rhs) noexcept;
-template bool operator==(const Block<2, Frame::Grid>& lhs,
-                         const Block<2, Frame::Grid>& rhs) noexcept;
-template bool operator==(const Block<3, Frame::Grid>& lhs,
-                         const Block<3, Frame::Grid>& rhs) noexcept;
-template bool operator==(const Block<1, Frame::Inertial>& lhs,
-                         const Block<1, Frame::Inertial>& rhs) noexcept;
-template bool operator==(const Block<2, Frame::Inertial>& lhs,
-                         const Block<2, Frame::Inertial>& rhs) noexcept;
-template bool operator==(const Block<3, Frame::Inertial>& lhs,
-                         const Block<3, Frame::Inertial>& rhs) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
+                        (Frame::Grid, Frame::Inertial))
 
-template bool operator!=(const Block<1, Frame::Grid>& lhs,
-                         const Block<1, Frame::Grid>& rhs) noexcept;
-template bool operator!=(const Block<2, Frame::Grid>& lhs,
-                         const Block<2, Frame::Grid>& rhs) noexcept;
-template bool operator!=(const Block<3, Frame::Grid>& lhs,
-                         const Block<3, Frame::Grid>& rhs) noexcept;
-template bool operator!=(const Block<1, Frame::Inertial>& lhs,
-                         const Block<1, Frame::Inertial>& rhs) noexcept;
-template bool operator!=(const Block<2, Frame::Inertial>& lhs,
-                         const Block<2, Frame::Inertial>& rhs) noexcept;
-template bool operator!=(const Block<3, Frame::Inertial>& lhs,
-                         const Block<3, Frame::Inertial>& rhs) noexcept;
+#undef GET_DIM
+#undef GET_FRAME
+#undef INSTANTIATION

--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -42,11 +42,7 @@ template <size_t VolumeDim, typename TargetFrame>
 std::ostream& operator<<(std::ostream& os,
                          const Block<VolumeDim, TargetFrame>& block) {
   os << "Block " << block.id() << ":\n";
-  os << "Neighbors:\n";
-  for (const auto& direction_to_neighbors : block.neighbors()) {
-    os << direction_to_neighbors.first << ": " << direction_to_neighbors.second
-       << "\n";
-  }
+  os << "Neighbors: " << block.neighbors() << "\n";
   os << "External boundaries: " << block.external_boundaries() << "\n";
   return os;
 }

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -49,7 +49,7 @@ class Block {
             CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>&& map,
         size_t id,
         std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>
-            neighbors);
+            neighbors) noexcept;
 
   Block() = default;
   ~Block() = default;
@@ -81,7 +81,7 @@ class Block {
   }
 
   /// Serialization for Charm++
-  void pup(PUP::er& p);  // NOLINT
+  void pup(PUP::er& p) noexcept;  // NOLINT
 
  private:
   std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>
@@ -93,7 +93,7 @@ class Block {
 
 template <size_t VolumeDim, typename TargetFrame>
 std::ostream& operator<<(std::ostream& os,
-                         const Block<VolumeDim, TargetFrame>& block);
+                         const Block<VolumeDim, TargetFrame>& block) noexcept;
 
 template <size_t VolumeDim, typename TargetFrame>
 bool operator==(const Block<VolumeDim, TargetFrame>& lhs,

--- a/src/Domain/BlockId.hpp
+++ b/src/Domain/BlockId.hpp
@@ -7,9 +7,11 @@
 #include <ostream>
 #include <pup.h>
 
+/// \cond
 namespace PUP {
 class er;
 }  // namespace PUP
+/// \endcond
 
 namespace domain {
 /*!

--- a/src/Domain/BlockNeighbor.cpp
+++ b/src/Domain/BlockNeighbor.cpp
@@ -5,20 +5,22 @@
 
 #include <ostream>
 
+#include "Utilities/GenerateInstantiations.hpp"
+
 template <size_t VolumeDim>
-BlockNeighbor<VolumeDim>::BlockNeighbor(size_t id,
-                                        OrientationMap<VolumeDim> orientation)
+BlockNeighbor<VolumeDim>::BlockNeighbor(
+    size_t id, OrientationMap<VolumeDim> orientation) noexcept
     : id_(id), orientation_(std::move(orientation)) {}
 
 template <size_t VolumeDim>
-void BlockNeighbor<VolumeDim>::pup(PUP::er& p) {
+void BlockNeighbor<VolumeDim>::pup(PUP::er& p) noexcept {
   p | id_;
   p | orientation_;
 }
 
 template <size_t VolumeDim>
-std::ostream& operator<<(std::ostream& os,
-                         const BlockNeighbor<VolumeDim>& block_neighbor) {
+std::ostream& operator<<(
+    std::ostream& os, const BlockNeighbor<VolumeDim>& block_neighbor) noexcept {
   os << "Id = " << block_neighbor.id()
      << "; orientation = " << block_neighbor.orientation();
   return os;
@@ -36,25 +38,18 @@ bool operator!=(const BlockNeighbor<VolumeDim>& lhs,
   return not(lhs == rhs);
 }
 
-// Explicit instantiations
-template class BlockNeighbor<1>;
-template class BlockNeighbor<2>;
-template class BlockNeighbor<3>;
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-template std::ostream& operator<<(std::ostream&, const BlockNeighbor<1>&);
-template std::ostream& operator<<(std::ostream&, const BlockNeighbor<2>&);
-template std::ostream& operator<<(std::ostream&, const BlockNeighbor<3>&);
+#define INSTANTIATION(r, data)                                                \
+  template class BlockNeighbor<GET_DIM(data)>;                                \
+  template std::ostream& operator<<(                                          \
+      std::ostream& os, const BlockNeighbor<GET_DIM(data)>& block);           \
+  template bool operator==(const BlockNeighbor<GET_DIM(data)>& lhs,           \
+                           const BlockNeighbor<GET_DIM(data)>& rhs) noexcept; \
+  template bool operator!=(const BlockNeighbor<GET_DIM(data)>& lhs,           \
+                           const BlockNeighbor<GET_DIM(data)>& rhs) noexcept;
 
-template bool operator==(const BlockNeighbor<1>& lhs,
-                         const BlockNeighbor<1>& rhs);
-template bool operator==(const BlockNeighbor<2>& lhs,
-                         const BlockNeighbor<2>& rhs);
-template bool operator==(const BlockNeighbor<3>& lhs,
-                         const BlockNeighbor<3>& rhs);
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
-template bool operator!=(const BlockNeighbor<1>& lhs,
-                         const BlockNeighbor<1>& rhs);
-template bool operator!=(const BlockNeighbor<2>& lhs,
-                         const BlockNeighbor<2>& rhs);
-template bool operator!=(const BlockNeighbor<3>& lhs,
-                         const BlockNeighbor<3>& rhs);
+#undef GET_DIM
+#undef INSTANTIATION

--- a/src/Domain/BlockNeighbor.hpp
+++ b/src/Domain/BlockNeighbor.hpp
@@ -11,9 +11,11 @@
 
 #include "Domain/OrientationMap.hpp"
 
+/// \cond
 namespace PUP {
 class er;
 }  // namespace PUP
+/// \endcond
 
 /// \ingroup ComputationalDomainGroup
 /// Information about the neighbor of a Block in a particular direction.
@@ -28,7 +30,7 @@ class BlockNeighbor {
   ///
   /// \param id the Id of the neighbor.
   /// \param orientation the OrientationMap of the neighbor.
-  BlockNeighbor(size_t id, OrientationMap<VolumeDim> orientation);
+  BlockNeighbor(size_t id, OrientationMap<VolumeDim> orientation) noexcept;
   ~BlockNeighbor() = default;
   BlockNeighbor(const BlockNeighbor<VolumeDim>& neighbor) = default;
   BlockNeighbor(BlockNeighbor<VolumeDim>&&) noexcept = default;
@@ -44,7 +46,7 @@ class BlockNeighbor {
   }
 
   // Serialization for Charm++
-  void pup(PUP::er& p);  // NOLINT
+  void pup(PUP::er& p) noexcept;  // NOLINT
 
  private:
   size_t id_{0};
@@ -53,8 +55,8 @@ class BlockNeighbor {
 
 /// Output operator for BlockNeighbor.
 template <size_t VolumeDim>
-std::ostream& operator<<(std::ostream& os,
-                         const BlockNeighbor<VolumeDim>& block_neighbor);
+std::ostream& operator<<(
+    std::ostream& os, const BlockNeighbor<VolumeDim>& block_neighbor) noexcept;
 
 template <size_t VolumeDim>
 bool operator==(const BlockNeighbor<VolumeDim>& lhs,

--- a/src/Domain/Direction.cpp
+++ b/src/Domain/Direction.cpp
@@ -7,7 +7,9 @@
 
 #include "ErrorHandling/Assert.hpp"
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
 
+/// \cond
 template <size_t VolumeDim>
 void Direction<VolumeDim>::pup(PUP::er& p) noexcept {
   p | axis_;
@@ -23,7 +25,6 @@ Direction<1>::Direction(const size_t dimension, const Side side) noexcept {
   side_ = side;
 }
 
-/// \cond NEVER
 template <>
 Direction<2>::Direction(const size_t dimension, const Side side) noexcept {
   ASSERT(0 == dimension or 1 == dimension,
@@ -49,11 +50,10 @@ Direction<3>::Direction(const size_t dimension, const Side side) noexcept {
   }
   side_ = side;
 }
-/// \endcond
 
 template <size_t VolumeDim>
 std::ostream& operator<<(std::ostream& os,
-                         const Direction<VolumeDim>& direction) {
+                         const Direction<VolumeDim>& direction) noexcept {
   if (-1.0 == direction.sign()) {
     os << "-";
   } else {
@@ -63,12 +63,15 @@ std::ostream& operator<<(std::ostream& os,
   return os;
 }
 
-template std::ostream& operator<<(std::ostream&, const Direction<1>&);
-template std::ostream& operator<<(std::ostream&, const Direction<2>&);
-template std::ostream& operator<<(std::ostream&, const Direction<3>&);
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-/// \cond
-template void Direction<1>::pup(PUP::er&) noexcept;
-template void Direction<2>::pup(PUP::er&) noexcept;
-template void Direction<3>::pup(PUP::er&) noexcept;
+#define INSTANTIATION(r, data)                                                 \
+  template std::ostream& operator<<(std::ostream&,                             \
+                                    const Direction<GET_DIM(data)>&) noexcept; \
+  template void Direction<GET_DIM(data)>::pup(PUP::er&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef GET_DIM
+#undef INSTANTIATION
 /// \endcond

--- a/src/Domain/Direction.hpp
+++ b/src/Domain/Direction.hpp
@@ -78,7 +78,7 @@ class Direction {
 /// Output operator for a Direction.
 template <size_t VolumeDim>
 std::ostream& operator<<(std::ostream& os,
-                         const Direction<VolumeDim>& direction);
+                         const Direction<VolumeDim>& direction) noexcept;
 
 //##############################################################################
 // INLINE DEFINITIONS
@@ -173,14 +173,14 @@ inline const std::array<Direction<3>, 6>& Direction<3>::all_directions()
 /// \endcond
 
 template <size_t VolumeDim>
-inline bool operator==(const Direction<VolumeDim>& lhs,
-                       const Direction<VolumeDim>& rhs) {
+bool operator==(const Direction<VolumeDim>& lhs,
+                const Direction<VolumeDim>& rhs) noexcept {
   return lhs.dimension() == rhs.dimension() and lhs.sign() == rhs.sign();
 }
 
 template <size_t VolumeDim>
-inline bool operator!=(const Direction<VolumeDim>& lhs,
-                       const Direction<VolumeDim>& rhs) {
+bool operator!=(const Direction<VolumeDim>& lhs,
+                const Direction<VolumeDim>& rhs) noexcept {
   return not(lhs == rhs);
 }
 

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -22,7 +22,7 @@ struct Logical;
 
 template <size_t VolumeDim, typename TargetFrame>
 Domain<VolumeDim, TargetFrame>::Domain(
-    std::vector<Block<VolumeDim, TargetFrame>> blocks)
+    std::vector<Block<VolumeDim, TargetFrame>> blocks) noexcept
     : blocks_(std::move(blocks)) {}
 
 template <size_t VolumeDim, typename TargetFrame>
@@ -32,7 +32,7 @@ Domain<VolumeDim, TargetFrame>::Domain(
         maps,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    const std::vector<PairOfFaces>& identifications) {
+    const std::vector<PairOfFaces>& identifications) noexcept {
   ASSERT(maps.size() == corners_of_all_blocks.size(),
          "Must pass same number of maps as block corner sets.");
   std::vector<
@@ -62,17 +62,17 @@ bool operator!=(const Domain<VolumeDim, TargetFrame>& lhs,
 
 template <size_t VolumeDim, typename TargetFrame>
 std::ostream& operator<<(std::ostream& os,
-                         const Domain<VolumeDim, TargetFrame>& d) {
+                         const Domain<VolumeDim, TargetFrame>& d) noexcept {
   const auto& blocks = d.blocks();
   os << "Domain with " << blocks.size() << " blocks:\n";
   for (const auto& block : blocks) {
-    os << block << "\n";
+    os << block << '\n';
   }
   return os;
 }
 
 template <size_t VolumeDim, typename TargetFrame>
-void Domain<VolumeDim, TargetFrame>::pup(PUP::er& p) {
+void Domain<VolumeDim, TargetFrame>::pup(PUP::er& p) noexcept {
   p | blocks_;
 }
 

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -35,7 +35,7 @@ class CoordinateMapBase;
 template <size_t VolumeDim, typename TargetFrame>
 class Domain {
  public:
-  explicit Domain(std::vector<Block<VolumeDim, TargetFrame>> blocks);
+  explicit Domain(std::vector<Block<VolumeDim, TargetFrame>> blocks) noexcept;
 
   /*!
    * Create a Domain using a corner numbering scheme to encode the Orientations,
@@ -59,9 +59,9 @@ class Domain {
              maps,
          const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
              corners_of_all_blocks,
-         const std::vector<PairOfFaces>& identifications = {});
+         const std::vector<PairOfFaces>& identifications = {}) noexcept;
 
-  Domain() = default;
+  Domain() noexcept = default;
   ~Domain() = default;
   Domain(const Domain&) = delete;
   Domain(Domain&&) = default;
@@ -70,12 +70,12 @@ class Domain {
   Domain<VolumeDim, TargetFrame>& operator=(Domain<VolumeDim, TargetFrame>&&) =
       default;
 
-  const std::vector<Block<VolumeDim, TargetFrame>>& blocks() const {
+  const std::vector<Block<VolumeDim, TargetFrame>>& blocks() const noexcept {
     return blocks_;
   }
 
   //clang-tidy: google-runtime-references
-  void pup(PUP::er& p); //NOLINT
+  void pup(PUP::er& p) noexcept;  // NOLINT
 
  private:
   std::vector<Block<VolumeDim, TargetFrame>> blocks_{};
@@ -91,4 +91,4 @@ bool operator!=(const Domain<VolumeDim, TargetFrame>& lhs,
 
 template <size_t VolumeDim, typename TargetFrame>
 std::ostream& operator<<(std::ostream& os,
-                         const Domain<VolumeDim, TargetFrame>& d);
+                         const Domain<VolumeDim, TargetFrame>& d) noexcept;

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -52,7 +52,7 @@ void set_internal_boundaries(
         corners_of_all_blocks,
     gsl::not_null<std::vector<
         std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
-        neighbors_of_all_blocks);
+        neighbors_of_all_blocks) noexcept;
 
 /// \ingroup ComputationalDomainGroup
 /// Sets up additional BlockNeighbors corresponding to any
@@ -65,7 +65,7 @@ void set_identified_boundaries(
         corners_of_all_blocks,
     gsl::not_null<std::vector<
         std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
-        neighbors_of_all_blocks);
+        neighbors_of_all_blocks) noexcept;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief The corners for a rectilinear domain made of n-cubes.
@@ -216,6 +216,7 @@ template <size_t VolumeDim>
 class VolumeCornerIterator {
  public:
   VolumeCornerIterator() noexcept { setup_from_local_corner_number(); }
+
   explicit VolumeCornerIterator(size_t initial_local_corner_number) noexcept
       : local_corner_number_(initial_local_corner_number) {
     setup_from_local_corner_number();
@@ -229,16 +230,20 @@ class VolumeCornerIterator {
             collapsed_index(block_index, global_corner_extents)),
         global_corner_index_(block_index),
         global_corner_extents_(global_corner_extents) {}
+
   void operator++() noexcept {
     ++local_corner_number_;
     setup_from_local_corner_number();
   }
+
   explicit operator bool() const noexcept {
     return local_corner_number_ < two_to_the(VolumeDim);
   }
+
   const size_t& local_corner_number() const noexcept {
     return local_corner_number_;
   }
+
   size_t global_corner_number() const noexcept {
     std::array<size_t, VolumeDim> new_indices{};
     for (size_t i = 0; i < VolumeDim; i++) {
@@ -249,19 +254,24 @@ class VolumeCornerIterator {
     const Index<VolumeDim> interior_multi_index(new_indices);
     return collapsed_index(interior_multi_index, global_corner_extents_);
   }
+
   const std::array<Side, VolumeDim>& operator()() const noexcept {
     return array_sides_;
   }
+
   const std::array<Side, VolumeDim>& operator*() const noexcept {
     return array_sides_;
   }
+
   const std::array<double, VolumeDim>& coords_of_corner() const noexcept {
     return coords_of_corner_;
   }
+
   const std::array<Direction<VolumeDim>, VolumeDim>& directions_of_corner()
       const noexcept {
     return array_directions_;
   }
+
   void setup_from_local_corner_number() noexcept {
     for (size_t i = 0; i < VolumeDim; i++) {
       gsl::at(coords_of_corner_, i) =
@@ -291,6 +301,7 @@ template <size_t VolumeDim>
 class FaceCornerIterator {
  public:
   explicit FaceCornerIterator(Direction<VolumeDim> direction) noexcept;
+
   void operator++() noexcept {
     face_index_++;
     do {
@@ -301,18 +312,22 @@ class FaceCornerIterator {
       corner_[i] = 2 * static_cast<int>(get_nth_bit(index_, i)) - 1;
     }
   }
+
   explicit operator bool() const noexcept {
     return face_index_ < two_to_the(VolumeDim - 1);
   }
+
   tnsr::I<double, VolumeDim, Frame::Logical> operator()() const noexcept {
     return corner_;
   }
+
   tnsr::I<double, VolumeDim, Frame::Logical> operator*() const noexcept {
     return corner_;
   }
 
   // Returns the value used to construct the logical corner.
   size_t volume_index() const noexcept { return index_; }
+
   // Returns the number of times operator++ has been called.
   size_t face_index() const noexcept { return face_index_; }
 

--- a/src/Domain/Element.cpp
+++ b/src/Domain/Element.cpp
@@ -7,6 +7,7 @@
 #include <pup.h>  // IWYU pragma: keep
 
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 
 template <size_t VolumeDim>
@@ -63,18 +64,18 @@ std::ostream& operator<<(std::ostream& os,
   return os;
 }
 
-template class Element<1>;
-template class Element<2>;
-template class Element<3>;
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-template bool operator==(const Element<1>&, const Element<1>&) noexcept;
-template bool operator==(const Element<2>&, const Element<2>&) noexcept;
-template bool operator==(const Element<3>&, const Element<3>&) noexcept;
+#define INSTANTIATION(r, data)                                      \
+  template class Element<GET_DIM(data)>;                            \
+  template bool operator==(const Element<GET_DIM(data)>&,           \
+                           const Element<GET_DIM(data)>&) noexcept; \
+  template bool operator!=(const Element<GET_DIM(data)>&,           \
+                           const Element<GET_DIM(data)>&) noexcept; \
+  template std::ostream& operator<<(std::ostream&,                  \
+                                    const Element<GET_DIM(data)>&) noexcept;
 
-template bool operator!=(const Element<1>&, const Element<1>&) noexcept;
-template bool operator!=(const Element<2>&, const Element<2>&) noexcept;
-template bool operator!=(const Element<3>&, const Element<3>&) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
-template std::ostream& operator<<(std::ostream&, const Element<1>&) noexcept;
-template std::ostream& operator<<(std::ostream&, const Element<2>&) noexcept;
-template std::ostream& operator<<(std::ostream&, const Element<3>&) noexcept;
+#undef GET_DIM
+#undef INSTANTIATION

--- a/src/Domain/ElementId.hpp
+++ b/src/Domain/ElementId.hpp
@@ -48,7 +48,8 @@ class ElementId {
 
   /// Conversion operator needed to index `proxy`s using `ElementId`
   // clang-tidy: mark explicit, we want implicit conversion
-  operator Parallel::ArrayIndex<ElementIndex<VolumeDim>>() const;  // NOLINT
+  operator Parallel::ArrayIndex<ElementIndex<VolumeDim>>() const  // NOLINT
+      noexcept;
 
   /// Create an arbitrary ElementId.
   ElementId(size_t block_id,
@@ -75,7 +76,8 @@ class ElementId {
 
 /// Output operator for ElementId.
 template <size_t VolumeDim>
-std::ostream& operator<<(std::ostream& os, const ElementId<VolumeDim>& id);
+std::ostream& operator<<(std::ostream& os,
+                         const ElementId<VolumeDim>& id) noexcept;
 
 /// Equivalence operator for ElementId.
 template <size_t VolumeDim>

--- a/src/Domain/ElementIndex.cpp
+++ b/src/Domain/ElementIndex.cpp
@@ -11,6 +11,7 @@
 #include "Domain/ElementId.hpp"  // IWYU pragma: keep
 #include "Domain/SegmentId.hpp"
 #include "ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
 SegmentIndex::SegmentIndex(size_t block_id,
@@ -92,38 +93,22 @@ std::ostream& operator<<(std::ostream& s,
   return s;
 }
 
-template struct ElementIndex<1>;
-template struct ElementIndex<2>;
-template struct ElementIndex<3>;
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-template bool operator==(const ElementIndex<1>& a,
-                         const ElementIndex<1>& b) noexcept;
-template bool operator==(const ElementIndex<2>& a,
-                         const ElementIndex<2>& b) noexcept;
-template bool operator==(const ElementIndex<3>& a,
-                         const ElementIndex<3>& b) noexcept;
+#define INSTANTIATION(r, data)                                             \
+  template struct ElementIndex<GET_DIM(data)>;                             \
+  template bool operator==(const ElementIndex<GET_DIM(data)>& a,           \
+                           const ElementIndex<GET_DIM(data)>& b) noexcept; \
+  template bool operator!=(const ElementIndex<GET_DIM(data)>& a,           \
+                           const ElementIndex<GET_DIM(data)>& b) noexcept; \
+  template size_t hash_value(                                              \
+      const ElementIndex<GET_DIM(data)>& index) noexcept;                  \
+  template size_t std::hash<ElementIndex<GET_DIM(data)>>::operator()(      \
+      const ElementIndex<GET_DIM(data)>& x) const noexcept;                \
+  template std::ostream& operator<<(                                       \
+      std::ostream& s, const ElementIndex<GET_DIM(data)>& index) noexcept;
 
-template bool operator!=(const ElementIndex<1>& a,
-                         const ElementIndex<1>& b) noexcept;
-template bool operator!=(const ElementIndex<2>& a,
-                         const ElementIndex<2>& b) noexcept;
-template bool operator!=(const ElementIndex<3>& a,
-                         const ElementIndex<3>& b) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
-template size_t hash_value(const ElementIndex<1>& index) noexcept;
-template size_t hash_value(const ElementIndex<2>& index) noexcept;
-template size_t hash_value(const ElementIndex<3>& index) noexcept;
-
-template size_t std::hash<ElementIndex<1>>::operator()(
-    const ElementIndex<1>& x) const noexcept;
-template size_t std::hash<ElementIndex<2>>::operator()(
-    const ElementIndex<2>& x) const noexcept;
-template size_t std::hash<ElementIndex<3>>::operator()(
-    const ElementIndex<3>& x) const noexcept;
-
-template std::ostream& operator<<(std::ostream& s,
-                                  const ElementIndex<1>& index) noexcept;
-template std::ostream& operator<<(std::ostream& s,
-                                  const ElementIndex<2>& index) noexcept;
-template std::ostream& operator<<(std::ostream& s,
-                                  const ElementIndex<3>& index) noexcept;
+#undef GET_DIM
+#undef INSTANTIATION

--- a/src/Domain/ElementIndex.hpp
+++ b/src/Domain/ElementIndex.hpp
@@ -32,7 +32,7 @@ static_assert(two_to_the(refinement_bits) >= max_refinement_level,
 
 class SegmentIndex {
  public:
-  SegmentIndex() = default;
+  SegmentIndex() noexcept = default;
   SegmentIndex(size_t block_id, const SegmentId& segment_id) noexcept;
   size_t block_id() const noexcept { return block_id_; }
   size_t index() const noexcept { return index_; }

--- a/src/Domain/ElementMap.cpp
+++ b/src/Domain/ElementMap.cpp
@@ -6,6 +6,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"  // IWYU pragma: keep
 #include "Domain/Side.hpp"
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
 
 /// \cond
 template <size_t Dim, typename TargetFrame>
@@ -63,11 +64,17 @@ void ElementMap<Dim, TargetFrame>::pup(PUP::er& p) noexcept {
   p | inverse_jacobian_;
 }
 
-template class ElementMap<1, Frame::Inertial>;
-template class ElementMap<2, Frame::Inertial>;
-template class ElementMap<3, Frame::Inertial>;
 // For dual frame evolutions the ElementMap only goes to the grid frame
-template class ElementMap<1, Frame::Grid>;
-template class ElementMap<2, Frame::Grid>;
-template class ElementMap<3, Frame::Grid>;
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define GET_FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(r, data) \
+  template class ElementMap<GET_DIM(data), GET_FRAME(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
+                        (Frame::Inertial, Frame::Grid))
+
+#undef GET_DIM
+#undef GET_FRAME
+#undef INSTANTIATION
 /// \endcond

--- a/src/Domain/InitialElementIds.cpp
+++ b/src/Domain/InitialElementIds.cpp
@@ -8,6 +8,7 @@
 #include "Domain/ElementId.hpp"
 #include "Domain/SegmentId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeArray.hpp"
 
 template <>
@@ -78,12 +79,15 @@ std::vector<ElementId<VolumeDim>> initial_element_ids(
   return element_ids;
 }
 
-template std::vector<ElementId<1>> initial_element_ids<1>(
-    const std::vector<std::array<size_t, 1>>&
-        initial_refinement_levels) noexcept;
-template std::vector<ElementId<2>> initial_element_ids<2>(
-    const std::vector<std::array<size_t, 2>>&
-        initial_refinement_levels) noexcept;
-template std::vector<ElementId<3>> initial_element_ids<3>(
-    const std::vector<std::array<size_t, 3>>&
-        initial_refinement_levels) noexcept;
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                              \
+  template std::vector<ElementId<GET_DIM(data)>>            \
+  initial_element_ids<GET_DIM(data)>(                       \
+      const std::vector<std::array<size_t, GET_DIM(data)>>& \
+          initial_refinement_levels) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef GET_DIM
+#undef INSTANTIATION

--- a/src/Domain/Neighbors.cpp
+++ b/src/Domain/Neighbors.cpp
@@ -8,23 +8,25 @@
 
 #include "Domain/ElementId.hpp"      // IWYU pragma: keep
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
 
 template <size_t VolumeDim>
 Neighbors<VolumeDim>::Neighbors(std::unordered_set<ElementId<VolumeDim>> ids,
-                                OrientationMap<VolumeDim> orientation)
+                                OrientationMap<VolumeDim> orientation) noexcept
     : ids_(std::move(ids)), orientation_(std::move(orientation)) {}
 
 template <size_t VolumeDim>
 void Neighbors<VolumeDim>::add_ids(
-    const std::unordered_set<ElementId<VolumeDim>>& additional_ids) {
+    const std::unordered_set<ElementId<VolumeDim>>& additional_ids) noexcept {
   for (const auto& id : additional_ids) {
     ids_.insert(id);
   }
 }
 
 template <size_t VolumeDim>
-std::ostream& operator<<(std::ostream& os, const Neighbors<VolumeDim>& n) {
+std::ostream& operator<<(std::ostream& os,
+                         const Neighbors<VolumeDim>& n) noexcept {
   os << "Ids = " << n.ids() << "; orientation = " << n.orientation();
   return os;
 }
@@ -47,19 +49,18 @@ void Neighbors<VolumeDim>::pup(PUP::er& p) noexcept {
   p | orientation_;
 }
 
-// Explicit instantiations
-template class Neighbors<1>;
-template class Neighbors<2>;
-template class Neighbors<3>;
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-template std::ostream& operator<<(std::ostream&, const Neighbors<1>&);
-template std::ostream& operator<<(std::ostream&, const Neighbors<2>&);
-template std::ostream& operator<<(std::ostream&, const Neighbors<3>&);
+#define INSTANTIATION(r, data)                                            \
+  template class Neighbors<GET_DIM(data)>;                                \
+  template std::ostream& operator<<(                                      \
+      std::ostream& os, const Neighbors<GET_DIM(data)>& block) noexcept;  \
+  template bool operator==(const Neighbors<GET_DIM(data)>& lhs,           \
+                           const Neighbors<GET_DIM(data)>& rhs) noexcept; \
+  template bool operator!=(const Neighbors<GET_DIM(data)>& lhs,           \
+                           const Neighbors<GET_DIM(data)>& rhs) noexcept;
 
-template bool operator==(const Neighbors<1>&, const Neighbors<1>&) noexcept;
-template bool operator==(const Neighbors<2>&, const Neighbors<2>&) noexcept;
-template bool operator==(const Neighbors<3>&, const Neighbors<3>&) noexcept;
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 
-template bool operator!=(const Neighbors<1>&, const Neighbors<1>&) noexcept;
-template bool operator!=(const Neighbors<2>&, const Neighbors<2>&) noexcept;
-template bool operator!=(const Neighbors<3>&, const Neighbors<3>&) noexcept;
+#undef GET_DIM
+#undef INSTANTIATION

--- a/src/Domain/Neighbors.hpp
+++ b/src/Domain/Neighbors.hpp
@@ -32,7 +32,7 @@ class Neighbors {
   /// \param ids the ids of the neighbors.
   /// \param orientation the OrientationMap of the neighbors.
   Neighbors(std::unordered_set<ElementId<VolumeDim>> ids,
-            OrientationMap<VolumeDim> orientation);
+            OrientationMap<VolumeDim> orientation) noexcept;
 
   /// Default constructor for Charm++ serialization.
   Neighbors() = default;
@@ -58,7 +58,8 @@ class Neighbors {
 
   /// Add ids of neighbors.
   /// Adding an existing neighbor is allowed.
-  void add_ids(const std::unordered_set<ElementId<VolumeDim>>& additional_ids);
+  void add_ids(
+      const std::unordered_set<ElementId<VolumeDim>>& additional_ids) noexcept;
 
   /// Serialization for Charm++
   void pup(PUP::er& p) noexcept;  // NOLINT
@@ -66,31 +67,31 @@ class Neighbors {
   /// The number of neighbors
   size_t size() const noexcept { return ids_.size(); }
 
-  typename std::unordered_set<ElementId<VolumeDim>>::iterator begin() {
+  typename std::unordered_set<ElementId<VolumeDim>>::iterator begin() noexcept {
     return ids_.begin();
   }
 
-  typename std::unordered_set<ElementId<VolumeDim>>::iterator end() {
+  typename std::unordered_set<ElementId<VolumeDim>>::iterator end() noexcept {
     return ids_.end();
   }
 
   typename std::unordered_set<ElementId<VolumeDim>>::const_iterator begin()
-      const {
+      const noexcept {
     return ids_.begin();
   }
 
-  typename std::unordered_set<ElementId<VolumeDim>>::const_iterator end()
-      const {
+  typename std::unordered_set<ElementId<VolumeDim>>::const_iterator end() const
+      noexcept {
     return ids_.end();
   }
 
   typename std::unordered_set<ElementId<VolumeDim>>::const_iterator cbegin()
-      const {
+      const noexcept {
     return ids_.begin();
   }
 
-  typename std::unordered_set<ElementId<VolumeDim>>::const_iterator cend()
-      const {
+  typename std::unordered_set<ElementId<VolumeDim>>::const_iterator cend() const
+      noexcept {
     return ids_.end();
   }
 
@@ -101,7 +102,8 @@ class Neighbors {
 
 /// Output operator for Neighborss.
 template <size_t VolumeDim>
-std::ostream& operator<<(std::ostream& os, const Neighbors<VolumeDim>& n);
+std::ostream& operator<<(std::ostream& os,
+                         const Neighbors<VolumeDim>& n) noexcept;
 
 template <size_t VolumeDim>
 bool operator==(const Neighbors<VolumeDim>& lhs,

--- a/src/Domain/OrientationMap.cpp
+++ b/src/Domain/OrientationMap.cpp
@@ -23,7 +23,7 @@ std::set<size_t> set_of_dimensions(
 }  // namespace
 
 template <size_t VolumeDim>
-OrientationMap<VolumeDim>::OrientationMap() {
+OrientationMap<VolumeDim>::OrientationMap() noexcept {
   for (size_t j = 0; j < VolumeDim; j++) {
     gsl::at(mapped_directions_, j) = Direction<VolumeDim>(j, Side::Upper);
   }
@@ -31,7 +31,7 @@ OrientationMap<VolumeDim>::OrientationMap() {
 
 template <size_t VolumeDim>
 OrientationMap<VolumeDim>::OrientationMap(
-    std::array<Direction<VolumeDim>, VolumeDim> mapped_directions)
+    std::array<Direction<VolumeDim>, VolumeDim> mapped_directions) noexcept
     : mapped_directions_(std::move(mapped_directions)) {
   for (size_t j = 0; j < VolumeDim; j++) {
     if (gsl::at(mapped_directions_, j).dimension() != j or
@@ -46,7 +46,8 @@ OrientationMap<VolumeDim>::OrientationMap(
 template <size_t VolumeDim>
 OrientationMap<VolumeDim>::OrientationMap(
     const std::array<Direction<VolumeDim>, VolumeDim>& directions_in_host,
-    const std::array<Direction<VolumeDim>, VolumeDim>& directions_in_neighbor) {
+    const std::array<Direction<VolumeDim>, VolumeDim>&
+        directions_in_neighbor) noexcept {
   for (size_t j = 0; j < VolumeDim; j++) {
     gsl::at(mapped_directions_, gsl::at(directions_in_host, j).dimension()) =
         (gsl::at(directions_in_host, j).side() == Side::Upper
@@ -102,14 +103,14 @@ void OrientationMap<VolumeDim>::pup(PUP::er& p) noexcept {
 
 template <>
 std::ostream& operator<<(std::ostream& os,
-                         const OrientationMap<1>& orientation) {
+                         const OrientationMap<1>& orientation) noexcept {
   os << "(" << orientation(Direction<1>::upper_xi()) << ")";
   return os;
 }
 
 template <>
 std::ostream& operator<<(std::ostream& os,
-                         const OrientationMap<2>& orientation) {
+                         const OrientationMap<2>& orientation) noexcept {
   os << "(" << orientation(Direction<2>::upper_xi()) << ", "
      << orientation(Direction<2>::upper_eta()) << ")";
   return os;
@@ -117,7 +118,7 @@ std::ostream& operator<<(std::ostream& os,
 
 template <>
 std::ostream& operator<<(std::ostream& os,
-                         const OrientationMap<3>& orientation) {
+                         const OrientationMap<3>& orientation) noexcept {
   os << "(" << orientation(Direction<3>::upper_xi()) << ", "
      << orientation(Direction<3>::upper_eta()) << ", "
      << orientation(Direction<3>::upper_zeta()) << ")";

--- a/src/Domain/OrientationMap.hpp
+++ b/src/Domain/OrientationMap.hpp
@@ -34,13 +34,13 @@ class OrientationMap {
  public:
   /// The default orientation is the identity map on directions.
   /// The bool `is_aligned_` is correspondingly set to `true`.
-  OrientationMap();
+  OrientationMap() noexcept;
   explicit OrientationMap(
-      std::array<Direction<VolumeDim>, VolumeDim> mapped_directions);
+      std::array<Direction<VolumeDim>, VolumeDim> mapped_directions) noexcept;
   OrientationMap(
       const std::array<Direction<VolumeDim>, VolumeDim>& directions_in_host,
       const std::array<Direction<VolumeDim>, VolumeDim>&
-          directions_in_neighbor);
+          directions_in_neighbor) noexcept;
   ~OrientationMap() = default;
   OrientationMap(const OrientationMap&) = default;
   OrientationMap& operator=(const OrientationMap&) = default;
@@ -99,7 +99,7 @@ class OrientationMap {
 /// Output operator for OrientationMap.
 template <size_t VolumeDim>
 std::ostream& operator<<(std::ostream& os,
-                         const OrientationMap<VolumeDim>& orientation);
+                         const OrientationMap<VolumeDim>& orientation) noexcept;
 
 template <size_t VolumeDim>
 bool operator!=(const OrientationMap<VolumeDim>& lhs,

--- a/src/Domain/SegmentId.cpp
+++ b/src/Domain/SegmentId.cpp
@@ -7,7 +7,7 @@
 #include <ostream>
 #include <pup.h>
 
-SegmentId::SegmentId(const size_t refinement_level, const size_t index)
+SegmentId::SegmentId(const size_t refinement_level, const size_t index) noexcept
     : refinement_level_(refinement_level), index_(index) {
   ASSERT(index < two_to_the(refinement_level),
          "index = " << index << ", refinement_level = " << refinement_level);
@@ -18,7 +18,7 @@ void SegmentId::pup(PUP::er& p) noexcept {
   p | index_;
 }
 
-std::ostream& operator<<(std::ostream& os, const SegmentId& id) {
+std::ostream& operator<<(std::ostream& os, const SegmentId& id) noexcept {
   os << 'L' << id.refinement_level() << 'I' << id.index();
   return os;
 }

--- a/src/Domain/SegmentId.hpp
+++ b/src/Domain/SegmentId.hpp
@@ -57,7 +57,7 @@ class SegmentId {
   SegmentId& operator=(const SegmentId& segment_id) noexcept = default;
   SegmentId& operator=(SegmentId&& segment_id) noexcept = default;
 
-  SegmentId(size_t refinement_level, size_t index);
+  SegmentId(size_t refinement_level, size_t index) noexcept;
 
   constexpr size_t refinement_level() const noexcept {
     return refinement_level_;
@@ -101,7 +101,7 @@ class SegmentId {
 };
 
 /// Output operator for SegmentId.
-std::ostream& operator<<(std::ostream& os, const SegmentId& id);
+std::ostream& operator<<(std::ostream& os, const SegmentId& id) noexcept;
 
 /// Equivalence operator for SegmentId.
 bool operator==(const SegmentId& lhs, const SegmentId& rhs) noexcept;

--- a/src/Domain/Side.cpp
+++ b/src/Domain/Side.cpp
@@ -6,7 +6,7 @@
 
 #include <ostream>
 
-std::ostream& operator<<(std::ostream& os, const Side& side) {
+std::ostream& operator<<(std::ostream& os, const Side& side) noexcept {
   switch (side) {
     case Side::Lower:
       os << "Lower";

--- a/src/Domain/Side.hpp
+++ b/src/Domain/Side.hpp
@@ -22,4 +22,4 @@ constexpr inline Side opposite(const Side side) {
 }
 
 /// Output operator for a Side.
-std::ostream& operator<<(std::ostream& os, const Side& side);
+std::ostream& operator<<(std::ostream& os, const Side& side) noexcept;

--- a/src/Domain/SizeOfElement.cpp
+++ b/src/Domain/SizeOfElement.cpp
@@ -10,6 +10,7 @@
 #include "ErrorHandling/Assert.hpp"
 #include "NumericalAlgorithms/LinearOperators/MeanValue.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/StdArrayHelpers.hpp"  // IWYU pragma: keep
 
@@ -39,9 +40,14 @@ std::array<double, VolumeDim> size_of_element(
 }
 
 // Explicit instantiations
-template std::array<double, 1> size_of_element(
-    const Mesh<1>&, const tnsr::I<DataVector, 1>&) noexcept;
-template std::array<double, 2> size_of_element(
-    const Mesh<2>&, const tnsr::I<DataVector, 2>&) noexcept;
-template std::array<double, 3> size_of_element(
-    const Mesh<3>&, const tnsr::I<DataVector, 3>&) noexcept;
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                \
+  template std::array<double, GET_DIM(data)> size_of_element( \
+      const Mesh<GET_DIM(data)>&,                             \
+      const tnsr::I<DataVector, GET_DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef GET_DIM
+#undef INSTANTIATION

--- a/src/Time/StepControllers/StepController.hpp
+++ b/src/Time/StepControllers/StepController.hpp
@@ -9,6 +9,7 @@
 #include <pup.h>
 
 #include "Parallel/CharmPupable.hpp"
+#include "Parallel/PupStlCpp11.hpp"
 #include "Time/Time.hpp"
 #include "Utilities/TMPL.hpp"
 

--- a/src/Utilities/PrintHelpers.hpp
+++ b/src/Utilities/PrintHelpers.hpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Applies the function f(out, it) to each item from begin to
+ * end, separated by commas and surrounded by parens.
+ */
+template <typename ForwardIt, typename Func>
+void sequence_print_helper(std::ostream& out, ForwardIt&& begin,
+                           ForwardIt&& end, Func f) noexcept {
+  out << "(";
+  if (begin != end) {
+    while (true) {
+      f(out, begin++);
+      if (begin == end) {
+        break;
+      }
+      out << ",";
+    }
+  }
+  out << ")";
+}
+
+/*!
+ * \ingroup UtilitiesGroup
+ * \brief Prints all the items as a comma separated list surrounded by parens.
+ */
+template <typename ForwardIt>
+void sequence_print_helper(std::ostream& out, ForwardIt&& begin,
+                           ForwardIt&& end) noexcept {
+  sequence_print_helper(
+      out, std::forward<ForwardIt>(begin), std::forward<ForwardIt>(end),
+      [](std::ostream& os, const ForwardIt& it) noexcept { os << *it; });
+}
+
+//@{
+/*!
+ * \ingroup UtilitiesGroup
+ * Like sequence_print_helper, but sorts the string representations.
+ */
+template <typename ForwardIt, typename Func>
+void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
+                            ForwardIt&& end, Func f) noexcept {
+  std::vector<std::string> entries;
+  while (begin != end) {
+    std::ostringstream ss;
+    f(ss, begin++);
+    entries.push_back(ss.str());
+  }
+  std::sort(entries.begin(), entries.end());
+  sequence_print_helper(out, entries.begin(), entries.end());
+}
+
+template <typename ForwardIt>
+void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
+                            ForwardIt&& end) noexcept {
+  unordered_print_helper(
+      out, std::forward<ForwardIt>(begin), std::forward<ForwardIt>(end),
+      [](std::ostream& os, const ForwardIt& it) noexcept { os << *it; });
+}
+//@}

--- a/src/Utilities/StdHelpers.hpp
+++ b/src/Utilities/StdHelpers.hpp
@@ -6,80 +6,29 @@
 
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <chrono>
+#include <cstdio>
 #include <ctime>
 #include <deque>
-#include <iterator>
 #include <list>
 #include <map>
 #include <memory>
-#include <numeric>
 #include <set>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
-#include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/PrintHelpers.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/StlStreamDeclarations.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 namespace StdHelpers_detail {
-// applies the function f(out, it) to each item from begin to end, separated
-// by commas and surrounded by parens
-template <typename ForwardIt, typename Func>
-inline void print_helper(std::ostream& out, ForwardIt&& begin, ForwardIt&& end,
-                         Func f) {
-  out << "(";
-  if (begin != end) {
-    while (true) {
-      f(out, begin++);
-      if (begin == end) {
-        break;
-      }
-      out << ",";
-    }
-  }
-  out << ")";
-}
-
-// prints all the items as a comma separated list surrounded by parens
-template <typename ForwardIt>
-inline void print_helper(std::ostream& out, ForwardIt&& begin,
-                         ForwardIt&& end) {
-  print_helper(out, std::forward<ForwardIt>(begin),
-               std::forward<ForwardIt>(end),
-               [](std::ostream& os, const ForwardIt& it) { os << *it; });
-}
-
-// Like print_helper, but sorts the string representations
-template <typename ForwardIt, typename Func>
-inline void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
-                                   ForwardIt&& end, Func f) {
-  std::vector<std::string> entries;
-  while (begin != end) {
-    std::ostringstream ss;
-    f(ss, begin++);
-    entries.push_back(ss.str());
-  }
-  std::sort(entries.begin(), entries.end());
-  print_helper(out, entries.begin(), entries.end());
-}
-
-template <typename ForwardIt>
-inline void unordered_print_helper(std::ostream& out, ForwardIt&& begin,
-                                   ForwardIt&& end) {
-  unordered_print_helper(
-      out, std::forward<ForwardIt>(begin), std::forward<ForwardIt>(end),
-      [](std::ostream& os, const ForwardIt& it) { os << *it; });
-}
-
 // Helper classes for operator<< for tuples
 template <size_t N>
 struct TuplePrinter {
@@ -116,7 +65,7 @@ struct TuplePrinter<0> {
  */
 template <typename T>
 inline std::ostream& operator<<(std::ostream& os, const std::list<T>& v) {
-  StdHelpers_detail::print_helper(os, std::begin(v), std::end(v));
+  sequence_print_helper(os, std::begin(v), std::end(v));
   return os;
 }
 
@@ -126,7 +75,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::list<T>& v) {
  */
 template <typename T>
 inline std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
-  StdHelpers_detail::print_helper(os, std::begin(v), std::end(v));
+  sequence_print_helper(os, std::begin(v), std::end(v));
   return os;
 }
 
@@ -136,7 +85,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
  */
 template <typename T>
 inline std::ostream& operator<<(std::ostream& os, const std::deque<T>& v) {
-  StdHelpers_detail::print_helper(os, std::begin(v), std::end(v));
+  sequence_print_helper(os, std::begin(v), std::end(v));
   return os;
 }
 
@@ -146,7 +95,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::deque<T>& v) {
  */
 template <typename T, size_t N>
 inline std::ostream& operator<<(std::ostream& os, const std::array<T, N>& a) {
-  StdHelpers_detail::print_helper(os, begin(a), end(a));
+  sequence_print_helper(os, begin(a), end(a));
   return os;
 }
 
@@ -170,7 +119,7 @@ inline std::ostream& operator<<(std::ostream& os,
 template <typename K, typename V, typename H>
 inline std::ostream& operator<<(std::ostream& os,
                                 const std::unordered_map<K, V, H>& m) {
-  StdHelpers_detail::unordered_print_helper(
+  unordered_print_helper(
       os, begin(m), end(m),
       [](std::ostream& out,
          typename std::unordered_map<K, V, H>::const_iterator it) {
@@ -185,7 +134,7 @@ inline std::ostream& operator<<(std::ostream& os,
  */
 template <typename K, typename V, typename C>
 inline std::ostream& operator<<(std::ostream& os, const std::map<K, V, C>& m) {
-  StdHelpers_detail::print_helper(
+  sequence_print_helper(
       os, begin(m), end(m),
       [](std::ostream& out, typename std::map<K, V, C>::const_iterator it) {
         out << "[" << it->first << "," << it->second << "]";
@@ -200,7 +149,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::map<K, V, C>& m) {
 template <typename T>
 inline std::ostream& operator<<(std::ostream& os,
                                 const std::unordered_set<T>& v) {
-  StdHelpers_detail::unordered_print_helper(os, std::begin(v), std::end(v));
+  unordered_print_helper(os, std::begin(v), std::end(v));
   return os;
 }
 
@@ -210,7 +159,7 @@ inline std::ostream& operator<<(std::ostream& os,
  */
 template <typename T, typename C>
 inline std::ostream& operator<<(std::ostream& os, const std::set<T, C>& v) {
-  StdHelpers_detail::print_helper(os, std::begin(v), std::end(v));
+  sequence_print_helper(os, std::begin(v), std::end(v));
   return os;
 }
 
@@ -248,7 +197,7 @@ inline std::ostream& operator<<(std::ostream& os, const std::pair<T, U>& t) {
 template <typename K, typename V, typename H>
 inline std::string keys_of(const std::unordered_map<K, V, H>& m) {
   std::ostringstream os;
-  StdHelpers_detail::unordered_print_helper(
+  unordered_print_helper(
       os, begin(m), end(m),
       [](std::ostream& out,
          typename std::unordered_map<K, V, H>::const_iterator it) {
@@ -264,7 +213,7 @@ inline std::string keys_of(const std::unordered_map<K, V, H>& m) {
 template <typename K, typename V, typename C>
 inline std::string keys_of(const std::map<K, V, C>& m) {
   std::ostringstream os;
-  StdHelpers_detail::print_helper(
+  sequence_print_helper(
       os, begin(m), end(m),
       [](std::ostream& out, typename std::map<K, V, C>::const_iterator it) {
         out << it->first;

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -93,9 +93,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Block.Neighbors", "[Domain][Unit]") {
   // Test output:
   CHECK(get_output(block) ==
         "Block 3:\n"
-        "Neighbors:\n"
-        "-1: Id = 2; orientation = (-0, +1)\n"
-        "+0: Id = 1; orientation = (+0, +1)\n"
+        "Neighbors: "
+        "([+0,Id = 1; orientation = (+0, +1)],"
+        "[-1,Id = 2; orientation = (-0, +1)])\n"
         "External boundaries: (+1,-0)\n");
 
   // Test comparison:

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -97,16 +97,9 @@ void test_1d_domains() {
         Domain<1, Frame::Inertial>{std::move(vector_of_blocks)},
         expected_neighbors, expected_boundaries, expected_maps);
 
-    CHECK(get_output(domain) ==
-          "Domain with 2 blocks:\n"
-          "Block 0:\n"
-          "Neighbors:\n"
-          "+0: Id = 1; orientation = (-0)\n"
-          "External boundaries: (-0)\n\n"
-          "Block 1:\n"
-          "Neighbors:\n"
-          "+0: Id = 0; orientation = (-0)\n"
-          "External boundaries: (-0)\n\n");
+    CHECK(get_output(domain) == "Domain with 2 blocks:\n" +
+                                    get_output(domain.blocks()[0]) + "\n" +
+                                    get_output(domain.blocks()[1]) + "\n");
   }
 
   {

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -195,8 +195,8 @@ void test_reverse_iterators(Container& c) {
  * \brief Function to test comparison operators.  Pass values with
  * less < greater.
  */
-template <typename T>
-void check_cmp(const T& less, const T& greater) {
+template <typename T, typename U>
+void check_cmp(const T& less, const U& greater) {
   CHECK(less == less);
   CHECK_FALSE(less == greater);
   CHECK(less != greater);


### PR DESCRIPTION
## Proposed changes

- Add some of the helper commits from #745 
- Clean up various parts of `Domain/*` files. missing `noexcept`, use `GENERATE_INSTANTATIONS`, use `alg::*` instead of `std::*` in `DomainHelpers.cpp` where possible (still need to write wrappers for some algorithms).

The domain clean up will make namespacing that stuff much easier :)

### Types of changes:

- [x] Code cleanup
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
