### PR TITLE
Build some of the test libraries in stage0 on travis

### DIFF
--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -54,7 +54,7 @@ if [ -z "${RUN_CLANG_TIDY}" ] \
     && [ -z "${RUN_IWYU}" ] \
     && [ -z "${BUILD_DOC}" ]; then
     if [[ ${TRAVIS_BUILD_STAGE_NAME} = "Build libraries" ]]; then
-        make libs -j2
+        make libs test-libs-stage1 -j2
     fi
 
     if [[ ${TRAVIS_BUILD_STAGE_NAME} = \

--- a/.travis/MacOsBuild.sh
+++ b/.travis/MacOsBuild.sh
@@ -54,7 +54,7 @@ cmake -D CHARM_ROOT=$DEP_CACHE/charm-${CHARM_VERSION} \
 make module_All
 
 if [[ ${TRAVIS_BUILD_STAGE_NAME} = "Build libraries" ]]; then
-    make libs -j2
+    make libs test-libs-stage1 -j2
 fi
 
 if [[ ${TRAVIS_BUILD_STAGE_NAME} = \


### PR DESCRIPTION
## Proposed changes

Builds most of the test libs in the first stage of travis to avoid timeouts.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
