### PR TITLE
Include ElementIndex.hpp in ElementId.hpp

### DIFF
--- a/src/Domain/ElementId.hpp
+++ b/src/Domain/ElementId.hpp
@@ -12,13 +12,12 @@
 #include <iosfwd>
 #include <limits>
 
+#include "Domain/ElementIndex.hpp" // IWYU pragma: keep
 #include "Domain/SegmentId.hpp"
 #include "Domain/Side.hpp"
 #include "Utilities/MakeArray.hpp"
 
 /// \cond
-template <size_t>
-class ElementIndex;
 namespace Parallel {
 template <class>
 class ArrayIndex;


### PR DESCRIPTION
## Proposed changes

Include ElementIndex.hpp in ElementId.hpp, to avoid compile errors when using create_element().

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->