### PR TITLE
Ignore *.pyc files in CheckFiles.sh

### DIFF
--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -47,6 +47,7 @@ if ! find \
      ! -path "./docs/*" \
      ! -path "./build*" \
      ! -path '*/__pycache__/*' \
+     ! -name '*.pyc' \
      ! -path "*.idea/*" \
      ! -name '*~' \
      ! -name "*.patch" \


### PR DESCRIPTION
They don't appear on Travis, but can on user machines where the repo
has been used.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
