### PR TITLE
Add FixedHashMap class

### DIFF
--- a/src/DataStructures/FixedHashMap.hpp
+++ b/src/DataStructures/FixedHashMap.hpp
@@ -1,0 +1,601 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/none.hpp>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <iterator>
+#include <pup.h>
+#include <pup_stl.h>
+#include <type_traits>
+
+#include "ErrorHandling/Assert.hpp"
+#include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/BoostHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/PrintHelpers.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/// \cond
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+class FixedHashMapIterator;
+/// \endcond
+
+namespace FixedHashMap_detail {
+template <typename T, typename = cpp17::void_t<>>
+struct has_is_perfect_member : std::false_type {};
+
+template <typename T>
+struct has_is_perfect_member<T,
+                             cpp17::void_t<decltype(T::template is_perfect<0>)>>
+    : std::true_type {};
+
+template <typename T>
+constexpr bool has_is_perfect_member_v = has_is_perfect_member<T>::value;
+
+template <class T, size_t MaxSize,
+          bool HasIsPerfect = has_is_perfect_member_v<T>>
+constexpr bool is_perfect = T::template is_perfect<MaxSize>;
+
+template <class T, size_t MaxSize>
+constexpr bool is_perfect<T, MaxSize, false> = false;
+}  // namespace FixedHashMap_detail
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief A hash table with a compile-time specified maximum size and ability to
+ * efficiently handle perfect hashes.
+ *
+ * There are a few requirements on the types passed to `FixedHashMap`. These
+ * are:
+ * - `Key` is CopyConstructible for copy and move semantics, as well as
+ *   serialization
+ * - `ValueType` is MoveConstructible
+ * - If `Hash` is a perfect hash for some values of `MaxSize` then in order to
+ *   use the perfect hashing improvements `Hash` must have a member variable
+ *   template `is_perfect` that takes as its only template parameter a `size_t`
+ *   equal to `MaxSize`. A perfect hash must map each `Key` to `[0, MaxSize)`
+ *   uniquely.
+ * - Keys are distinct.
+ *
+ * The interface is similar to std::unordered_map, so see the documentation for
+ * that for details.
+ *
+ * #### Implementation Details
+ *
+ * - Uses linear probing for non-perfect hashes.
+ * - The hash `Hash` is assumed to be a perfect hash for `MaxSize` if
+ *   `Hash::template is_perfect<MaxSize>` is true.
+ */
+template <size_t MaxSize, class Key, class ValueType,
+          class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>>
+class FixedHashMap {
+  static constexpr bool hash_is_perfect =
+      FixedHashMap_detail::is_perfect<Hash, MaxSize>;
+
+ public:
+  using key_type = Key;
+  using mapped_type = ValueType;
+  using value_type = std::pair<const key_type, mapped_type>;
+  using size_type = size_t;
+  using difference_type = ptrdiff_t;
+  using hasher = Hash;
+  using key_equal = KeyEqual;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using iterator =
+      FixedHashMapIterator<MaxSize, key_type, value_type, hasher, key_equal>;
+  using const_iterator =
+      FixedHashMapIterator<MaxSize, key_type, const value_type, hasher,
+                           key_equal>;
+
+  FixedHashMap() = default;
+  FixedHashMap(std::initializer_list<value_type> init) noexcept;
+  FixedHashMap(const FixedHashMap&) = default;
+  FixedHashMap& operator=(const FixedHashMap& other) noexcept(
+      noexcept(std::is_nothrow_copy_constructible<value_type>::value));
+  FixedHashMap(FixedHashMap&&) = default;
+  FixedHashMap& operator=(FixedHashMap&& other) noexcept;
+  ~FixedHashMap() = default;
+
+  iterator begin() noexcept { return unconst(cbegin()); }
+  const_iterator begin() const noexcept {
+    return const_iterator(data_.begin(), data_.end());
+  }
+  const_iterator cbegin() const noexcept { return begin(); }
+
+  iterator end() noexcept { return unconst(cend()); }
+  const_iterator end() const noexcept {
+    return const_iterator(data_.end(), data_.end());
+  }
+  const_iterator cend() const noexcept { return end(); }
+
+  bool empty() const noexcept { return size_ == 0; }
+  size_t size() const noexcept { return size_; }
+
+  void clear() noexcept;
+
+  // @{
+  /// Inserts the element if it does not exists.
+  std::pair<iterator, bool> insert(const value_type& value) noexcept {
+    return insert(value_type(value));
+  }
+  std::pair<iterator, bool> insert(value_type&& value) noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return insert_or_assign_impl<false>(const_cast<key_type&&>(value.first),
+                                        std::move(value.second));
+  }
+  template <typename... Args>
+  std::pair<iterator, bool> emplace(Args&&... args) noexcept {
+    return insert(value_type(std::forward<Args>(args)...));
+  }
+  // @}
+  // @{
+  /// Inserts the element if it does not exists, otherwise assigns to it the new
+  /// value.
+  template <class M>
+  std::pair<iterator, bool> insert_or_assign(const key_type& key,
+                                             M&& obj) noexcept {
+    return insert_or_assign(key_type{key}, std::forward<M>(obj));
+  }
+  template <class M>
+  std::pair<iterator, bool> insert_or_assign(key_type&& key, M&& obj) noexcept {
+    return insert_or_assign_impl<true>(std::move(key), std::forward<M>(obj));
+  }
+  // @}
+
+  iterator erase(const const_iterator& pos) noexcept;
+  size_t erase(const key_type& key) noexcept;
+
+  mapped_type& at(const key_type& key);
+  const mapped_type& at(const key_type& key) const;
+  mapped_type& operator[](const key_type& key) noexcept;
+
+  size_t count(const key_type& key) const noexcept;
+  iterator find(const key_type& key) noexcept {
+    return unconst(cpp17::as_const(*this).find(key));
+  }
+  const_iterator find(const key_type& key) const noexcept {
+    auto it = get_data_entry(key);
+    return it != data_.end() and is_set(*it) ? const_iterator(&*it, data_.end())
+                                             : end();
+  }
+
+  /// Check if `key` is in the map
+  bool contains(const key_type& key) const noexcept {
+    return find(key) != end();
+  }
+
+  /// Get key equal function object
+  key_equal key_eq() const noexcept { return key_equal{}; }
+  /// Get hash function object
+  hasher hash_function() const noexcept { return hasher{}; }
+
+  void pup(PUP::er& p) noexcept {  // NOLINT(google-runtime-references)
+    p | data_;
+    p | size_;
+  }
+
+ private:
+  template <size_t FMaxSize, class FKey, class FValueType, class FHash,
+            class FKeyEqual>
+  // NOLINTNEXTLINE(readability-redundant-declaration) false positive
+  friend bool operator==(
+      const FixedHashMap<FMaxSize, FKey, FValueType, FHash, FKeyEqual>& a,
+      const FixedHashMap<FMaxSize, FKey, FValueType, FHash, FKeyEqual>&
+          b) noexcept;
+
+  template <bool Assign, class M>
+  std::pair<iterator, bool> insert_or_assign_impl(key_type&& key,
+                                                  M&& obj) noexcept;
+
+  using storage_type = std::array<boost::optional<value_type>, MaxSize>;
+
+  SPECTRE_ALWAYS_INLINE size_type hash(const key_type& key) const noexcept {
+    return hash_is_perfect ? Hash{}(key) : Hash{}(key) % MaxSize;
+  }
+
+  template <bool IsInserting>
+  typename storage_type::iterator get_data_entry(const Key& key) noexcept;
+
+  typename storage_type::const_iterator get_data_entry(const Key& key) const
+      noexcept {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return const_cast<FixedHashMap&>(*this).get_data_entry<false>(key);
+  }
+
+  iterator unconst(const const_iterator& it) noexcept {
+    return iterator(&it.get_optional() - data_.begin() + data_.begin(),
+                    data_.end());
+  }
+
+  SPECTRE_ALWAYS_INLINE static bool is_set(
+      const boost::optional<value_type>& opt) noexcept {
+    return static_cast<bool>(opt);
+  }
+
+  storage_type data_{};
+  size_t size_ = 0;
+};
+
+/// \cond HIDDEN_SYMBOLS
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+class FixedHashMapIterator {
+ public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = std::remove_const_t<ValueType>;
+  using difference_type = ptrdiff_t;
+  using pointer = ValueType*;
+  using reference = ValueType&;
+
+  FixedHashMapIterator() = default;
+
+  /// Implicit conversion from mutable to const iterator.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  operator FixedHashMapIterator<MaxSize, Key, const ValueType, Hash, KeyEqual>()
+      const noexcept {
+    return {entry_, end_};
+  }
+
+  reference operator*() const noexcept {
+    ASSERT(entry_ != nullptr, "Invalid FixedHashMapIterator");
+    ASSERT(is_set(*entry_),
+           "FixedHashMapIterator points to an invalid value in the map.");
+    // deference pointer, then dereference boost::optional
+    return **entry_;
+  }
+  pointer operator->() const noexcept {
+    ASSERT(entry_ != nullptr, "Invalid FixedHashMapIterator");
+    ASSERT(is_set(*entry_),
+           "FixedHashMapIterator points to an invalid value in the map.");
+    return entry_->get_ptr();
+  }
+
+  FixedHashMapIterator& operator++() noexcept;
+  // clang-tidy wants this to return a const object.  Returning const
+  // objects is very strange, and as of June 2018 clang-tidy's
+  // explanation for the lint is a dead link.
+  FixedHashMapIterator operator++(int) noexcept;  // NOLINT(cert-dcl21-cpp)
+
+ private:
+  friend class FixedHashMap<MaxSize, Key, typename value_type::second_type,
+                            Hash, KeyEqual>;
+  friend class FixedHashMapIterator<MaxSize, Key, value_type, Hash, KeyEqual>;
+
+  friend bool operator==(const FixedHashMapIterator& a,
+                         const FixedHashMapIterator& b) noexcept {
+    return a.entry_ == b.entry_;
+  }
+  friend bool operator<(const FixedHashMapIterator& a,
+                        const FixedHashMapIterator& b) noexcept {
+    return a.entry_ < b.entry_;
+  }
+
+  // The rest of the comparison operators don't need access to the
+  // class internals, but they need to be instantiated for each
+  // instantiation of the class.
+  friend bool operator!=(const FixedHashMapIterator& a,
+                         const FixedHashMapIterator& b) noexcept {
+    return not(a == b);
+  }
+  friend bool operator>(const FixedHashMapIterator& a,
+                        const FixedHashMapIterator& b) noexcept {
+    return b < a;
+  }
+  friend bool operator<=(const FixedHashMapIterator& a,
+                         const FixedHashMapIterator& b) noexcept {
+    return not(b < a);
+  }
+  friend bool operator>=(const FixedHashMapIterator& a,
+                         const FixedHashMapIterator& b) noexcept {
+    return not(a < b);
+  }
+
+  using map_optional_type = boost::optional<std::remove_const_t<ValueType>>;
+  using optional_type =
+      std::conditional_t<std::is_const<ValueType>::value,
+                         const map_optional_type, map_optional_type>;
+
+  SPECTRE_ALWAYS_INLINE static bool is_set(const optional_type& opt) noexcept {
+    return static_cast<bool>(opt);
+  }
+
+  FixedHashMapIterator(optional_type* const entry,
+                       optional_type* const end) noexcept
+      : entry_(entry), end_(end) {
+    if (entry_ != end_ and not*entry_) {
+      operator++();
+    }
+  }
+
+  optional_type& get_optional() const { return *entry_; }
+
+  optional_type* entry_{nullptr};
+  optional_type* end_{nullptr};
+};
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+FixedHashMapIterator<MaxSize, Key, ValueType, Hash, KeyEqual>&
+FixedHashMapIterator<MaxSize, Key, ValueType, Hash, KeyEqual>::
+operator++() noexcept {
+  ASSERT(entry_ != end_,
+         "Tried to increment an end iterator, which is undefined behavior.");
+  // Move to next element, which might not be the next element in the std::array
+  do {
+    ++entry_;  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  } while (entry_ < end_ and not is_set(*entry_));
+  return *this;
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+// NOLINTNEXTLINE(cert-dcl21-cpp) see declaration
+FixedHashMapIterator<MaxSize, Key, ValueType, Hash, KeyEqual>
+FixedHashMapIterator<MaxSize, Key, ValueType, Hash, KeyEqual>::operator++(
+    int) noexcept {
+  const auto ret = *this;
+  operator++();
+  return ret;
+}
+/// \endcond
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>&
+FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::operator=(
+    const FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>&
+        other) noexcept(noexcept(std::
+                                     is_nothrow_copy_constructible<
+                                         value_type>::value)) {
+  if (this == &other) {
+    return *this;
+  }
+  clear();
+  size_ = other.size_;
+  for (size_t i = 0; i < data_.size(); ++i) {
+    const auto& other_optional = gsl::at(other.data_, i);
+    if (is_set(other_optional)) {
+      // The boost::optionals cannot be assigned to because they
+      // contain the map keys, which are const, so we have to replace
+      // the contents instead, since that counts as a destroy +
+      // initialize.
+      gsl::at(data_, i).emplace(*other_optional);
+    }
+  }
+  return *this;
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>&
+FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::operator=(
+    FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+  clear();
+  size_ = other.size_;
+  for (size_t i = 0; i < data_.size(); ++i) {
+    auto& other_optional = gsl::at(other.data_, i);
+    if (is_set(other_optional)) {
+      // The boost::optionals cannot be assigned to because they
+      // contain the map keys, which are const, so we have to replace
+      // the contents instead, since that counts as a destroy +
+      // initialize.
+      gsl::at(data_, i).emplace(std::move(*other_optional));
+    }
+  }
+  return *this;
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::FixedHashMap(
+    std::initializer_list<value_type> init) noexcept {
+  // size_ is set by calling insert
+  for (const auto& entry : init) {
+    insert(entry);
+  }
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+void FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::clear() noexcept {
+  for (auto& entry : data_) {
+    entry = boost::none;
+  }
+  size_ = 0;
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+template <bool Assign, class M>
+auto FixedHashMap<MaxSize, Key, ValueType, Hash,
+                  KeyEqual>::insert_or_assign_impl(key_type&& key,
+                                                   M&& obj) noexcept
+    -> std::pair<iterator, bool> {
+  auto data_it = get_data_entry<true>(key);
+  if (UNLIKELY(data_it == data_.end())) {
+    ERROR("Unable to insert element into FixedHashMap of maximum size "
+          << MaxSize << " because it is full. If the current size (" << size_
+          << ") is not equal to the maximum size then please file an issue "
+             "with the code you used to produce this error. "
+          << (hash_is_perfect ? " If a perfect hash is used and it hashes to "
+                                "past the last element stored, then this "
+                                "error may also be triggered."
+                              : ""));
+  }
+  // data_it points to either the existing element or a new bucket to place the
+  // element.
+  const auto is_new_entry = not is_set(*data_it);
+  if (is_new_entry or Assign) {
+    if (is_new_entry) {
+      ++size_;
+    }
+    data_it->emplace(std::move(key), std::forward<M>(obj));
+  }
+  return std::make_pair(iterator{data_it, data_.end()}, is_new_entry);
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::erase(
+    const const_iterator& pos) noexcept -> iterator {
+  auto next_it = &(unconst(pos).get_optional());
+  --size_;
+  *next_it = boost::none;
+  // pos now points to an unset entry, advance to next valid one
+  do {
+    ++next_it;
+    if (next_it == data_.end()) {
+      next_it = data_.begin();
+    }
+    if (is_set(*next_it)) {
+      return {next_it, data_.end()};
+    }
+  } while (next_it != &pos.get_optional());
+  return end();
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+size_t FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::erase(
+    const key_type& key) noexcept {
+  auto it = get_data_entry<false>(key);
+  if (it == data_.end() or not is_set(*it)) {
+    return 0;
+  }
+  *it = boost::none;
+  --size_;
+  return 1;
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::at(
+    const key_type& key) -> mapped_type& {
+  auto it = get_data_entry<false>(key);
+  if (it == data_.end() or not is_set(*it)) {
+    throw std::out_of_range(get_output(key) + " not in FixedHashMap");
+  }
+  return (**it).second;
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::at(
+    const key_type& key) const -> const mapped_type& {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  return const_cast<FixedHashMap&>(*this).at(key);
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::operator[](
+    const key_type& key) noexcept -> mapped_type& {
+  auto it = get_data_entry<true>(key);
+  if (it == data_.end()) {
+    ERROR("Unable to insert element into FixedHashMap of maximum size "
+          << MaxSize << " because it is full. If the current size (" << size_
+          << ") is not equal to the maximum size then please file an issue "
+             "with the code you used to produce this error. "
+          << (hash_is_perfect ? " If a perfect hash is used and it hashes to "
+                                "past the last element stored, then this "
+                                "error may also be triggered."
+                              : ""));
+  }
+  if (not is_set(*it)) {
+    ++size_;
+    it->emplace(key, mapped_type{});
+  }
+  return (**it).second;
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+size_t FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::count(
+    const key_type& key) const noexcept {
+  const auto it = get_data_entry(key);
+  return it == data_.end() or not is_set(*it) ? 0 : 1;
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+template <bool IsInserting>
+auto FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>::get_data_entry(
+    const Key& key) noexcept -> typename storage_type::iterator {
+  const auto hashed_key = hash(key);
+  auto it = data_.begin() + hashed_key;
+  if (not hash_is_perfect) {
+    // First search for an existing key.
+    while (not is_set(*it) or (**it).first != key) {
+      if (++it == data_.end()) {
+        it = data_.begin();
+      }
+      if (UNLIKELY(it == data_.begin() + hashed_key)) {
+        // not found, return end iterator to storage_type
+        it = data_.end();
+        break;
+      }
+    }
+    // If we are inserting an element but couldn't find an existing key, then
+    // find the first available bucket.
+    if (IsInserting and it == data_.end()) {
+      it = data_.begin() + hashed_key;
+      while (is_set(*it)) {
+        if (++it == data_.end()) {
+          it = data_.begin();
+        }
+        if (UNLIKELY(it == data_.begin() + hashed_key)) {
+          // could not find any open bucket
+          return data_.end();
+        }
+      }
+    }
+  }
+  return it;
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+bool operator==(
+    const FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>& a,
+    const FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>& b) noexcept {
+  return a.size_ == b.size_ and a.data_ == b.data_;
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+bool operator!=(
+    const FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>& a,
+    const FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>& b) noexcept {
+  return not(a == b);
+}
+
+template <size_t MaxSize, class Key, class ValueType, class Hash,
+          class KeyEqual>
+std::ostream& operator<<(
+    std::ostream& os,
+    const FixedHashMap<MaxSize, Key, ValueType, Hash, KeyEqual>& m) noexcept {
+  unordered_print_helper(
+      os, std::begin(m), std::end(m),
+      [](std::ostream & out,
+         typename FixedHashMap<MaxSize, Key, ValueType, Hash,
+                               KeyEqual>::const_iterator it) noexcept {
+        out << "[" << it->first << "," << it->second << "]";
+      });
+  return os;
+}

--- a/src/Domain/Direction.hpp
+++ b/src/Domain/Direction.hpp
@@ -197,3 +197,16 @@ struct hash<Direction<VolumeDim>> {
   }
 };
 }  // namespace std
+
+/// \ingroup ComputationalDomainGroup
+/// Provides a perfect hash if the size of the hash table is `2 * Dim`. To take
+/// advantage of this, use the `FixedHashMap` class.
+template <size_t Dim>
+struct DirectionHash {
+  template <size_t MaxSize>
+  static constexpr bool is_perfect = MaxSize == 2 * Dim;
+
+  size_t operator()(const Direction<Dim>& t) noexcept {
+    return 2 * t.dimension() + (t.side() == Side::Upper ? 1 : 0);
+  }
+};

--- a/src/Utilities/BoostHelpers.hpp
+++ b/src/Utilities/BoostHelpers.hpp
@@ -69,19 +69,21 @@ char pup_helper(int& index, PUP::er& p, boost::variant<Ts...>& var,  // NOLINT
 }
 }  // namespace BoostVariant_detail
 
+namespace PUP {
 template <class... Ts>
-void pup(PUP::er& p, boost::variant<Ts...>& var) {  // NOLINT
+void pup(er& p, boost::variant<Ts...>& var) noexcept {  // NOLINT
   int index = 0;
   int send_index = var.which();
   p | send_index;
   (void)std::initializer_list<char>{
-      BoostVariant_detail::pup_helper<Ts>(index, p, var, send_index)...};
+      ::BoostVariant_detail::pup_helper<Ts>(index, p, var, send_index)...};
 }
 
 template <typename... Ts>
-inline void operator|(PUP::er& p, boost::variant<Ts...>& d) {  // NOLINT
+inline void operator|(er& p, boost::variant<Ts...>& d) noexcept {  // NOLINT
   pup(p, d);
 }
+}  // namespace PUP
 
 /*!
  * \ingroup UtilitiesGroup
@@ -98,8 +100,9 @@ std::string type_of_current_state(
   // clang-format on
 }
 
+namespace PUP {
 template <class T>
-void pup(PUP::er& p, boost::optional<T>& var) {  // NOLINT
+void pup(er& p, boost::optional<T>& var) noexcept {  // NOLINT
   bool has_data = var != boost::none;
   p | has_data;
   if (has_data) {
@@ -113,6 +116,7 @@ void pup(PUP::er& p, boost::optional<T>& var) {  // NOLINT
 }
 
 template <typename T>
-inline void operator|(PUP::er& p, boost::optional<T>& var) {  // NOLINT
+inline void operator|(er& p, boost::optional<T>& var) noexcept {  // NOLINT
   pup(p, var);
 }
+}  // namespace PUP

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_DataVector.cpp
   Test_DenseMatrix.cpp
   Test_DenseVector.cpp
+  Test_FixedHashMap.cpp
   Test_GeneralIndexIterator.cpp
   Test_IdPair.cpp
   Test_Index.cpp

--- a/tests/Unit/DataStructures/Test_FixedHashMap.cpp
+++ b/tests/Unit/DataStructures/Test_FixedHashMap.cpp
@@ -1,0 +1,555 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <initializer_list>
+#include <iterator>
+#include <ostream>
+#include <pup.h>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/FixedHashMap.hpp"
+#include "Domain/Direction.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Overloader.hpp"
+#include "Utilities/StdHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+template <size_t Dim>
+void check_single_element_map_with_direction(
+    const Direction<Dim>& direction) noexcept {
+  FixedHashMap<2 * Dim, Direction<Dim>, std::pair<double, NonCopyable>,
+               DirectionHash<Dim>>
+      map;
+
+  map.emplace(direction, std::make_pair(1.5, NonCopyable{}));
+  const typename decltype(map)::value_type entry(
+      cpp17::as_const(direction), std::make_pair(1.5, NonCopyable{}));
+
+  const auto& const_map = map;
+
+  test_iterators(map);
+  check_cmp(const_map.begin(), const_map.end());
+  check_cmp(map.begin(), map.end());
+  check_cmp(map.cbegin(), map.end());
+  check_cmp(map.begin(), map.cend());
+
+  CHECK(not const_map.empty());
+  CHECK(const_map.size() == 1);
+
+  CHECK(const_map.count(direction) == 1);
+  CHECK(const_map.count(direction.opposite()) == 0);
+
+  CHECK(const_map.find(direction) == const_map.begin());
+  CHECK(const_map.find(direction.opposite()) == const_map.end());
+
+  CHECK(*const_map.begin() == entry);
+  CHECK(&const_map.at(direction) == &const_map.begin()->second);
+
+  auto it = map.begin();
+  CHECK(*it == entry);
+  CHECK(it.operator->() == &*it);
+  auto it2 = it;
+  CHECK(*it++ == entry);
+  CHECK(it != it2);
+  CHECK(*it2 == entry);
+  CHECK(it == map.end());
+  CHECK(++it2 == map.end());
+  CHECK(it2 == map.end());
+}
+
+template <size_t MaxSize>
+void test_direction_key() {
+  for (const auto& direction : Direction<2>::all_directions()) {
+    check_single_element_map_with_direction(direction);
+  }
+
+  FixedHashMap<MaxSize, Direction<2>, double, DirectionHash<2>> map;
+
+  CHECK(map.empty());
+  CHECK(map.size() == 0);  // NOLINT(readability-container-size-empty)
+
+  CHECK(map.begin() == cpp17::as_const(map).begin());
+  CHECK(map.begin() == cpp17::as_const(map).cbegin());
+  CHECK(map.end() == cpp17::as_const(map).end());
+  CHECK(map.end() == cpp17::as_const(map).cend());
+  CHECK(map.begin() == map.end());
+
+  const auto dir1 = Direction<2>::lower_eta();
+  const auto dir2 = Direction<2>::upper_xi();
+  const auto dir3 = Direction<2>::lower_xi();
+  {
+    CHECK(map.count(dir1) == 0);
+    const auto result = map.emplace(dir1, 1.);
+    CHECK(result.second);
+    CHECK(result.first == map.find(dir1));
+    CHECK(map.count(dir1) == 1);
+  }
+  CHECK(not map.empty());
+  CHECK(map.size() == 1);
+  {
+    CHECK(map.count(dir2) == 0);
+    const auto result = map.insert(std::make_pair(dir2, 2.));
+    CHECK(result.second);
+    CHECK(result.first == map.find(dir2));
+    CHECK(map.count(dir2) == 1);
+  }
+  CHECK(not map.empty());
+  CHECK(map.size() == 2);
+  {
+    const auto result = map.insert(std::make_pair(dir2, 3.));
+    CHECK(not result.second);
+    CHECK(result.first == map.find(dir2));
+    CHECK(map.count(dir2) == 1);
+  }
+  CHECK(map.size() == 2);
+  {
+    const auto result = map.emplace(dir1, 4.);
+    CHECK(not result.second);
+    CHECK(result.first == map.find(dir1));
+    CHECK(map.count(dir1) == 1);
+  }
+  CHECK(map.size() == 2);
+  CHECK(cpp17::as_const(map).at(dir1) == 1.);
+  CHECK(cpp17::as_const(map).at(dir2) == 2.);
+  map.at(dir2) = 5.;
+  CHECK(cpp17::as_const(map).at(dir2) == 5.);
+  CHECK(map.size() == 2);
+  CHECK(&cpp17::as_const(map).find(dir1)->second ==
+        &cpp17::as_const(map).at(dir1));
+  CHECK(&cpp17::as_const(map).find(dir2)->second ==
+        &cpp17::as_const(map).at(dir2));
+  CHECK(cpp17::as_const(map).find(dir3) == map.end());
+
+  const auto check_exception = [&dir3](auto& passed_map) noexcept {
+    try {
+      passed_map.at(dir3);
+      CHECK(false);
+    } catch (const std::out_of_range& e) {
+      CHECK(e.what() == get_output(dir3) + " not in FixedHashMap");
+    } catch (...) {
+      CHECK(false);
+    }
+  };
+  check_exception(map);
+  check_exception(cpp17::as_const(map));
+
+  map[dir3] = 6.;
+  CHECK(map.size() == 3);
+  CHECK(cpp17::as_const(map).at(dir3) == 6.);
+
+  test_iterators(map);
+
+  {
+    // The map doesn't guarantee an iteration order, so this block
+    // would put the map into a difficult-to-describe state.  We use a
+    // copy to not have to deal with that.
+    auto map2 = map;
+    const auto second = std::next(map2.begin());
+    const auto third = std::next(map2.begin(), 2);
+    // Checks iterator mutability correctness for erase
+    const auto next = map2.erase(cpp17::as_const(map2).find(second->first));
+    CHECK(map2.size() == 2);
+    CHECK(next == third);
+    next->second = -1.;
+    CHECK(std::next(map2.begin())->second == -1.);
+  }
+
+  CHECK(map == map);
+  CHECK_FALSE(map != map);
+  {
+    // Test copy and move
+    const auto check_equal = [](const auto& a, const auto& b) noexcept {
+      CHECK(a == b);
+      CHECK(b == a);
+      CHECK_FALSE(a != b);
+      CHECK_FALSE(b != a);
+    };
+    auto map2 = map;
+    check_equal(map, map2);
+    auto map3 = std::move(map2);
+    check_equal(map, map3);
+    decltype(map) map4;
+    map4 = std::move(map3);
+    check_equal(map, map4);
+    decltype(map) map5;
+    map5 = map4;
+    check_equal(map, map5);
+
+    // Test moving non-copyable entries
+    FixedHashMap<MaxSize, Direction<2>, NonCopyable, DirectionHash<2>> nc_map;
+    nc_map.emplace(Direction<2>::upper_xi(), NonCopyable{});
+    FixedHashMap<MaxSize, Direction<2>, NonCopyable, DirectionHash<2>> nc_map2;
+    nc_map2.emplace(Direction<2>::upper_xi(), NonCopyable{});
+
+    check_equal(nc_map, nc_map2);
+    auto nc_map3 = std::move(nc_map2);
+    check_equal(nc_map, nc_map3);
+    FixedHashMap<MaxSize, Direction<2>, NonCopyable, DirectionHash<2>> nc_map4;
+    nc_map4 = std::move(nc_map3);
+    check_equal(nc_map, nc_map4);
+  }
+  {
+    auto map2 = map;
+    map2.erase(dir1);
+    CHECK_FALSE(map == map2);
+    CHECK_FALSE(map2 == map);
+    CHECK(map != map2);
+    CHECK(map2 != map);
+  }
+  {
+    auto map2 = map;
+    map2.at(dir1) = -1.;
+    CHECK_FALSE(map == map2);
+    CHECK_FALSE(map2 == map);
+    CHECK(map != map2);
+    CHECK(map2 != map);
+  }
+  {
+    // Check initializer list constructor
+    CHECK(decltype(map)(
+              std::initializer_list<typename decltype(map)::value_type>{})
+              .empty());
+    CHECK(map == decltype(map){{dir1, map.at(dir1)},
+                               {dir2, map.at(dir2)},
+                               {dir3, map.at(dir3)}});
+    CHECK(map == decltype(map){{dir2, map.at(dir2)},
+                               {dir3, map.at(dir3)},
+                               {dir1, map.at(dir1)}});
+  }
+
+  test_serialization(map);
+
+  CHECK(get_output(map) == get_output(std::unordered_map<Direction<2>, double>(
+                               map.begin(), map.end())));
+
+  CHECK(map.contains(dir1));
+  CHECK(map.erase(dir1) == 1);
+  CHECK_FALSE(map.contains(dir1));
+  CHECK(map.size() == 2);
+  CHECK(map.find(dir1) == map.end());
+  CHECK(map.erase(dir1) == 0);
+  CHECK(map.size() == 2);
+  CHECK(map.find(dir1) == map.end());
+
+  map.clear();
+  CHECK(map.empty());
+  CHECK(map.size() == 0);  // NOLINT(readability-container-size-empty)
+  test_iterators(map);
+
+  test_copy_semantics(map);
+  const auto map2 = map;
+  test_move_semantics(std::move(map), map2);
+}
+
+// A non-copyable size_t wrapper for testing non-copyable keys.
+struct NonCopyableSizeT {
+  constexpr NonCopyableSizeT() = default;
+  constexpr NonCopyableSizeT(const NonCopyableSizeT&) = delete;
+  constexpr NonCopyableSizeT& operator=(const NonCopyableSizeT&) = delete;
+  constexpr NonCopyableSizeT(NonCopyableSizeT&&) = default;
+  NonCopyableSizeT& operator=(NonCopyableSizeT&&) = default;
+  ~NonCopyableSizeT() = default;
+
+  // Intentional implicit conversion
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  NonCopyableSizeT(size_t t) : value(t) {}
+
+  void pup(PUP::er& p) noexcept { p | value; }  // NOLINT
+
+  size_t value = 0;
+};
+inline bool operator==(const NonCopyableSizeT& a,
+                       const NonCopyableSizeT& b) noexcept {
+  return a.value == b.value;
+}
+inline bool operator!=(const NonCopyableSizeT& a,
+                       const NonCopyableSizeT& b) noexcept {
+  return not(a == b);
+}
+inline std::ostream& operator<<(std::ostream& os,
+                                const NonCopyableSizeT& v) noexcept {
+  return os << v.value;
+}
+
+// A hash that hashes two inputs to the same value
+struct RepeatedHash {
+  size_t operator()(const size_t t) const noexcept {
+    if (t == 3) {
+      return 2;
+    }
+    if (t == 4) {
+      return 5;
+    }
+    return t;
+  }
+
+  size_t operator()(const NonCopyableSizeT& t) const noexcept {
+    if (t.value == 3) {
+      return 2;
+    }
+    if (t.value == 4) {
+      return 5;
+    }
+    return t.value;
+  }
+};
+
+template <typename KeyType>
+// NOLINTNEXTLINE(google-readability-function-size)
+void test_repeated_key() {
+  using CopyableKeyMapType = FixedHashMap<6, size_t, size_t, RepeatedHash>;
+  using NonCopyableKeyMapType =
+      FixedHashMap<6, NonCopyableSizeT, size_t, RepeatedHash>;
+  FixedHashMap<6, KeyType, size_t, RepeatedHash> map;
+  CHECK(map.empty());
+  // NOLINTNEXTLINE(readability-container-size-empty)
+  CHECK(map.size() == 0);
+
+  map.emplace(1, 11);
+  CHECK_FALSE(map.empty());
+  CHECK(map.size() == 1);
+  CHECK(map.at(1) == 11);
+  CHECK(map.count(1) == 1);
+  CHECK(map.count(2) == 0);
+  CHECK(map.contains(1));
+  CHECK_FALSE(map.contains(2));
+  CHECK_FALSE(map.contains(3));
+  CHECK(map.find(1) != map.end());
+  CHECK(map.find(2) == map.end());
+  CHECK(cpp17::as_const(map).find(1) != map.end());
+  CHECK(cpp17::as_const(map).find(2) == map.end());
+
+  make_overloader([](gsl::not_null<CopyableKeyMapType*>
+                         local_map) noexcept { (*local_map)[2] = 12; },
+                  [](gsl::not_null<NonCopyableKeyMapType*> local_map) noexcept {
+                    local_map->insert({2, 12});
+                  })(make_not_null(&map));
+  CHECK(map.size() == 2);
+  CHECK_FALSE(map.empty());
+  CHECK(map.at(2) == 12);
+  CHECK(map.count(1) == 1);
+  CHECK(map.count(2) == 1);
+  CHECK(map.count(3) == 0);
+  CHECK(map.contains(1));
+  CHECK(map.contains(2));
+  CHECK_FALSE(map.contains(3));
+  CHECK(map.find(1) != map.end());
+  CHECK(map.find(2) != map.end());
+  CHECK(map.find(3) == map.end());
+  CHECK(cpp17::as_const(map).find(1) != map.end());
+  CHECK(cpp17::as_const(map).find(2) != map.end());
+  CHECK(cpp17::as_const(map).find(3) == map.end());
+
+  map.insert({3, 13});
+  CHECK(map.size() == 3);
+  CHECK_FALSE(map.empty());
+  CHECK(map.at(3) == 13);
+  CHECK(cpp17::as_const(map).at(3) == 13);
+  make_overloader(
+      [](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+        CHECK((*local_map)[3] == 13);
+      },
+      [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+      make_not_null(&map));
+  CHECK(map.count(1) == 1);
+  CHECK(map.count(2) == 1);
+  CHECK(map.count(3) == 1);
+  CHECK(map.contains(1));
+  CHECK(map.contains(2));
+  CHECK(map.contains(3));
+  CHECK(map.find(1) != map.end());
+  CHECK(map.find(2) != map.end());
+  CHECK(map.find(3) != map.end());
+  CHECK(map.find(2) != map.find(3));
+  CHECK(cpp17::as_const(map).find(1) != map.end());
+  CHECK(cpp17::as_const(map).find(2) != map.end());
+  CHECK(cpp17::as_const(map).find(3) != map.end());
+  CHECK(cpp17::as_const(map).find(2) != map.find(3));
+
+  map.erase(2);
+  CHECK(map.size() == 2);
+  CHECK_FALSE(map.empty());
+  CHECK(map.count(1) == 1);
+  CHECK(map.count(2) == 0);
+  CHECK(map.count(3) == 1);
+  CHECK(map.contains(1));
+  CHECK_FALSE(map.contains(2));
+  CHECK(map.contains(3));
+  CHECK(map.find(1) != map.end());
+  CHECK(map.find(2) == map.end());
+  CHECK(map.find(3) != map.end());
+  CHECK(map.find(2) != map.find(3));
+
+  // Now check key that results in wrapping past end of storage_type
+  map.insert({4, 14});
+  CHECK(map.size() == 3);
+  CHECK_FALSE(map.empty());
+  CHECK(map.count(1) == 1);
+  CHECK(map.count(2) == 0);
+  CHECK(map.count(3) == 1);
+  CHECK(map.count(4) == 1);
+  CHECK(map.contains(4));
+  CHECK_FALSE(map.contains(2));
+  CHECK(map.find(1) != map.end());
+  CHECK(map.find(2) == map.end());
+  CHECK(map.find(3) != map.end());
+  CHECK(map.find(4) != map.end());
+  CHECK(map.at(4) == 14);
+  CHECK(cpp17::as_const(map).at(4) == 14);
+  make_overloader(
+      [](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+        CHECK((*local_map)[4] == 14);
+      },
+      [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+      make_not_null(&map));
+
+  make_overloader([](gsl::not_null<CopyableKeyMapType*>
+                         local_map) noexcept { (*local_map)[5] = 15; },
+                  [](gsl::not_null<NonCopyableKeyMapType*> local_map) noexcept {
+                    local_map->insert_or_assign(5, 15);
+                  })(make_not_null(&map));
+  CHECK(map.size() == 4);
+  CHECK_FALSE(map.empty());
+  CHECK(map.count(1) == 1);
+  CHECK(map.count(2) == 0);
+  CHECK(map.count(3) == 1);
+  CHECK(map.count(4) == 1);
+  CHECK(map.count(5) == 1);
+  CHECK(map.contains(5));
+  CHECK(map.find(1) != map.end());
+  CHECK(map.find(2) == map.end());
+  CHECK(map.find(3) != map.end());
+  CHECK(map.find(4) != map.end());
+  CHECK(map.find(5) != map.end());
+  CHECK(map.find(4) != map.find(5));
+  CHECK(map.at(5) == 15);
+  CHECK(cpp17::as_const(map).at(5) == 15);
+  make_overloader(
+      [](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+        CHECK((*local_map)[5] == 15);
+      },
+      [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+      make_not_null(&map));
+
+  map.erase(4);
+  CHECK(map.size() == 3);
+  CHECK_FALSE(map.empty());
+  CHECK(map.count(1) == 1);
+  CHECK(map.count(2) == 0);
+  CHECK(map.count(3) == 1);
+  CHECK(map.count(5) == 1);
+  CHECK(map.contains(5));
+  CHECK(map.find(1) != map.end());
+  CHECK(map.find(2) == map.end());
+  CHECK(map.find(3) != map.end());
+  CHECK(map.find(4) == map.end());
+  CHECK(map.find(5) != map.end());
+  CHECK(map.find(4) != map.find(5));
+  CHECK(map.at(5) == 15);
+  CHECK(cpp17::as_const(map).at(5) == 15);
+  make_overloader(
+      [](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+        CHECK((*local_map)[5] == 15);
+      },
+      [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+      make_not_null(&map));
+
+  const auto check_4 = [](
+      const auto& l_it_bool_to_4, const size_t expected, const bool inserted,
+      // GCC warns about shadowing so we make a very specific name for the map
+      auto check_4_local_map) noexcept {
+    CHECK(l_it_bool_to_4.second == inserted);
+    CHECK(check_4_local_map->size() == 4);
+    CHECK_FALSE(check_4_local_map->empty());
+    CHECK(check_4_local_map->count(1) == 1);
+    CHECK(check_4_local_map->count(2) == 0);
+    CHECK(check_4_local_map->count(3) == 1);
+    CHECK(check_4_local_map->count(4) == 1);
+    CHECK(check_4_local_map->count(5) == 1);
+    CHECK(check_4_local_map->contains(4));
+    CHECK(check_4_local_map->find(1) != check_4_local_map->end());
+    CHECK(check_4_local_map->find(2) == check_4_local_map->end());
+    CHECK(check_4_local_map->find(3) != check_4_local_map->end());
+    CHECK(check_4_local_map->find(4) != check_4_local_map->end());
+    CHECK(check_4_local_map->find(5) != check_4_local_map->end());
+    CHECK(check_4_local_map->find(4) != check_4_local_map->find(5));
+    CHECK(check_4_local_map->find(4) == l_it_bool_to_4.first);
+    CHECK(check_4_local_map->at(4) == expected);
+    CHECK(cpp17::as_const(*check_4_local_map).at(4) == expected);
+    make_overloader(
+        [expected](gsl::not_null<CopyableKeyMapType*> more_local_map) noexcept {
+          CHECK((*more_local_map)[4] == expected);
+        },
+        [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+        check_4_local_map);
+  };
+
+  make_overloader(
+      [&check_4](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+        // Test serialization and that FixedHashMap works correctly after.
+        test_serialization(*local_map);
+
+        auto after_map = serialize_and_deserialize(*local_map);
+        CHECK(after_map.size() == 3);
+        CHECK_FALSE(after_map.empty());
+        CHECK(after_map.count(1) == 1);
+        CHECK(after_map.count(2) == 0);
+        CHECK(after_map.count(3) == 1);
+        CHECK(after_map.count(5) == 1);
+        CHECK(after_map.contains(5));
+        CHECK(after_map.find(1) != after_map.end());
+        CHECK(after_map.find(2) == after_map.end());
+        CHECK(after_map.find(3) != after_map.end());
+        CHECK(after_map.find(4) == after_map.end());
+        CHECK(after_map.find(5) != after_map.end());
+        CHECK(after_map.find(4) != after_map.find(5));
+        CHECK(after_map.at(5) == 15);
+        CHECK(cpp17::as_const(after_map).at(5) == 15);
+        CHECK(after_map[5] == 15);
+
+        check_4(after_map.insert_or_assign(4, 14), 14, true, &after_map);
+        check_4(after_map.insert_or_assign(4, 24), 24, false, &after_map);
+
+        after_map.erase(4);
+        const size_t key_4 = 4;
+        check_4(after_map.insert_or_assign(key_4, 34), 34, true, &after_map);
+        check_4(after_map.insert_or_assign(key_4, 44), 44, false, &after_map);
+      },
+      [&check_4](gsl::not_null<NonCopyableKeyMapType*> local_map) noexcept {
+        check_4(local_map->insert_or_assign(4, 14), 14, true, local_map);
+        check_4(local_map->insert_or_assign(4, 24), 24, false, local_map);
+
+        local_map->erase(4);
+        const size_t key_4 = 4;
+        check_4(local_map->insert_or_assign(key_4, 34), 34, true, local_map);
+        check_4(local_map->insert_or_assign(key_4, 44), 44, false, local_map);
+      })(make_not_null(&map));
+
+  test_iterators(map);
+  make_overloader(
+      [](gsl::not_null<CopyableKeyMapType*> local_map) noexcept {
+        test_copy_semantics(*local_map);
+        const auto map2 = *local_map;
+        test_move_semantics(std::move(*local_map), map2);
+      },
+      [](gsl::not_null<NonCopyableKeyMapType*> /*local_map*/) noexcept {})(
+      make_not_null(&map));
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.FixedHashMap",
+                  "[DataStructures][Unit]") {
+  test_direction_key<4>();
+  test_repeated_key<size_t>();
+  test_repeated_key<NonCopyableSizeT>();
+}
+}  // namespace

--- a/tests/Unit/Domain/Test_Direction.cpp
+++ b/tests/Unit/Domain/Test_Direction.cpp
@@ -120,7 +120,7 @@ void test_helper_functions() {
   CHECK(lower_zeta_3.side() == Side::Lower);
 }
 
-void test_hash() {
+void test_std_hash() {
   size_t upper_xi_1_hash = std::hash<Direction<1>>{}(Direction<1>::upper_xi());
   size_t lower_xi_1_hash = std::hash<Direction<1>>{}(Direction<1>::lower_xi());
 
@@ -158,6 +158,23 @@ void test_hash() {
       CHECK(gsl::at(direction_3, i) != gsl::at(direction_3, j));
     }
   }
+}
+
+void test_direction_hash() {
+  CHECK(DirectionHash<1>{}(Direction<1>::lower_xi()) == 0);
+  CHECK(DirectionHash<1>{}(Direction<1>::upper_xi()) == 1);
+
+  CHECK(DirectionHash<2>{}(Direction<2>::lower_xi()) == 0);
+  CHECK(DirectionHash<2>{}(Direction<2>::upper_xi()) == 1);
+  CHECK(DirectionHash<2>{}(Direction<2>::lower_eta()) == 2);
+  CHECK(DirectionHash<2>{}(Direction<2>::upper_eta()) == 3);
+
+  CHECK(DirectionHash<3>{}(Direction<3>::lower_xi()) == 0);
+  CHECK(DirectionHash<3>{}(Direction<3>::upper_xi()) == 1);
+  CHECK(DirectionHash<3>{}(Direction<3>::lower_eta()) == 2);
+  CHECK(DirectionHash<3>{}(Direction<3>::upper_eta()) == 3);
+  CHECK(DirectionHash<3>{}(Direction<3>::lower_zeta()) == 4);
+  CHECK(DirectionHash<3>{}(Direction<3>::upper_zeta()) == 5);
 }
 
 void test_output() {
@@ -198,7 +215,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction", "[Domain][Unit]") {
   test_construction_2d();
   test_construction_3d();
   test_helper_functions();
-  test_hash();
+  test_std_hash();
+  test_direction_hash();
   test_output();
 }
 

--- a/tests/Unit/Domain/Test_Direction.cpp
+++ b/tests/Unit/Domain/Test_Direction.cpp
@@ -15,7 +15,8 @@
 #include "Utilities/Gsl.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction1D", "[Domain][Unit]") {
+namespace {
+void test_construction_1d() {
   auto upper_xi_1 = Direction<1>::upper_xi();
   CHECK(upper_xi_1.opposite() == Direction<1>::lower_xi());
   CHECK(upper_xi_1.opposite().sign() == -1.0);
@@ -29,7 +30,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction1D", "[Domain][Unit]") {
   test_serialization(lower_xi_1);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction2D", "[Domain][Unit]") {
+void test_construction_2d() {
   auto upper_xi_2 = Direction<2>(0, Side::Upper);
   CHECK(upper_xi_2 == Direction<2>::upper_xi());
   CHECK(upper_xi_2.axis() == Direction<2>::Axis::Xi);
@@ -55,7 +56,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction2D", "[Domain][Unit]") {
   test_serialization(lower_eta_2);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction3D", "[Domain][Unit]") {
+void test_construction_3d() {
   auto upper_xi = Direction<3>(0, Side::Upper);
   CHECK(upper_xi == Direction<3>::upper_xi());
   CHECK(upper_xi.axis() == Direction<3>::Axis::Xi);
@@ -93,7 +94,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Construction3D", "[Domain][Unit]") {
   test_serialization(lower_zeta);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Direction.HelperFunctions", "[Domain][Unit]") {
+void test_helper_functions() {
   auto upper_xi_3 = Direction<3>::upper_xi();
   CHECK(upper_xi_3.axis() == Direction<3>::Axis::Xi);
   CHECK(upper_xi_3.side() == Side::Upper);
@@ -119,7 +120,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.HelperFunctions", "[Domain][Unit]") {
   CHECK(lower_zeta_3.side() == Side::Lower);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Direction.Hash", "[Domain][Unit]") {
+void test_hash() {
   size_t upper_xi_1_hash = std::hash<Direction<1>>{}(Direction<1>::upper_xi());
   size_t lower_xi_1_hash = std::hash<Direction<1>>{}(Direction<1>::lower_xi());
 
@@ -159,7 +160,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Hash", "[Domain][Unit]") {
   }
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Direction.Output", "[Domain][Unit]") {
+void test_output() {
   auto upper_xi = Direction<1>(0, Side::Upper);
   CHECK(get_output(upper_xi) == "+0");
 
@@ -189,6 +190,16 @@ SPECTRE_TEST_CASE("Unit.Domain.Direction.Output", "[Domain][Unit]") {
 
   auto lower_zeta_3 = Direction<3>(2, Side::Lower);
   CHECK(get_output(lower_zeta_3) == "-2");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Direction", "[Domain][Unit]") {
+  test_construction_1d();
+  test_construction_2d();
+  test_construction_3d();
+  test_helper_functions();
+  test_hash();
+  test_output();
 }
 
 // [[OutputRegex, dim = 1, for Direction<1> only dim = 0 is allowed.]]


### PR DESCRIPTION
## Proposed changes

- Adds a generalized implementation of the DirectionMap from #745. A compile-time size hash table that is stack-allocated for better lookup performance and performs optimally for perfect hashes.
- Adds the perfect hash for Direction from #745 
- Combines Direction tests so we get better overall test runtime

Commit order:
1. Combine direction tests to reduce test runtime.
2. Add perfect hash for directions
3. Put pup functions for Boost in PUP namespace
4. Add FixedHashMap, a compile-time max size hash table

*Note:* There's a `TODO` about what should happen when inserting a duplicate key into the map. Currently it does nothing. I don't really want to support duplicate keys if we don't need to, but I'm not sure if it should error, assign, or do nothing.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
