### PR TITLE
Allow disabling debug flags

### DIFF
--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -19,6 +19,8 @@ export PATH=$PATH:/work/texlive/bin/x86_64-linux
 
 ccache -z
 
+# We don't need debug symbols during CI and we are able to reduce memory
+# usage by 1.5x during compilation.
 cmake -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -D CMAKE_C_COMPILER=${CC} \
       -D CMAKE_CXX_COMPILER=${CXX} \
@@ -27,6 +29,7 @@ cmake -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -D CHARM_ROOT=/work/charm/multicore-linux64-${CHARM_CC} \
       -D USE_CCACHE=ON \
       -D USE_PCH=${USE_PCH} \
+      -D DEBUG_SYMBOLS=OFF \
       -D COVERAGE=${COVERAGE} \
       ../spectre/
 

--- a/.travis/MacOsBuild.sh
+++ b/.travis/MacOsBuild.sh
@@ -37,6 +37,9 @@ if [ ! -d $SPECTRE_BUILD_DIR ]; then
 fi
 cd $SPECTRE_BUILD_DIR
 ccache -z
+
+# We don't need debug symbols during CI and we are able to reduce memory
+# usage by 1.5x during compilation.
 cmake -D CHARM_ROOT=$DEP_CACHE/charm-${CHARM_VERSION} \
       -D BLAZE_ROOT=$DEP_CACHE/blaze-${BLAZE_VERSION}/ \
       -D BRIGAND_ROOT=$DEP_CACHE/brigand\
@@ -48,6 +51,7 @@ cmake -D CHARM_ROOT=$DEP_CACHE/charm-${CHARM_VERSION} \
       -D LAPACK_openblas_LIBRARY=/usr/local/opt/openblas/lib/libopenblas.dylib\
       -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -D USE_PCH=${USE_PCH} \
+      -D DEBUG_SYMBOLS=OFF \
       ${SPECTRE_SOURCE_DIR}
 
 # Build all Charm++ modules

--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -1,14 +1,19 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-set(
-    CMAKE_CXX_FLAGS_DEBUG
-    "${CMAKE_CXX_FLAGS_DEBUG} -DSPECTRE_DEBUG"
-)
+option(DEBUG_SYMBOLS "Add -g to CMAKE_CXX_FLAGS if ON, -g0 if OFF." ON)
+
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DSPECTRE_DEBUG")
+
+if(NOT ${DEBUG_SYMBOLS})
+  string(REPLACE "-g " "-g0 " CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+endif()
 
 # Always build with -g so we can view backtraces, etc. when production code
-# fails. This can be overridden by passing `-D CMAKE_CXX_FLAGS="-g0"` to CMake
-set(CMAKE_CXX_FLAGS "-g ${CMAKE_CXX_FLAGS}")
+# fails. This can be overridden by passing `-D DEBUG_SYMBOLS=OFF` to CMake
+if(${DEBUG_SYMBOLS})
+  set(CMAKE_CXX_FLAGS "-g ${CMAKE_CXX_FLAGS}")
+endif(${DEBUG_SYMBOLS})
 
 # Always compile only for the current architecture. This can be overridden
 # by passing `-D CMAKE_CXX_FLAGS="-march=THE_ARCHITECTURE"` to CMake


### PR DESCRIPTION
## Proposed changes

- Disabling debug symbols reduces memory usage by ~1.5x with GCC (clang it also is reduced but I can't remember how much)
- Disable debug symbols on TravisCI to avoid OOM errors and timeouts.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
