### PR TITLE
Add SSHT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ include(SetupNumPy)
 include(SetupPapi)
 include(SetupPythonLibs)
 include(SetupSciPy)
+include(SetupSSHT)
 include(SetupYamlCpp)
 
 include(SetupLIBCXXCharm)

--- a/cmake/FindSSHT.cmake
+++ b/cmake/FindSSHT.cmake
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Find ssht: https://github.com/astro-informatics/ssht
+# If not in one of the default paths specify -D SSHT_ROOT=/path/to/ssht to
+# search there as well.
+
+include (CheckCXXSourceRuns)
+
+# find the ssht include directory
+find_path(SSHT_INCLUDE_DIRS ssht.h
+    PATH_SUFFIXES include
+    HINTS ${SSHT_ROOT}/include/)
+
+find_library(SSHT_LIBRARIES
+    NAMES ssht libssht.a
+    PATH_SUFFIXES lib64 lib
+    HINTS ${SSHT_ROOT})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SSHT
+    DEFAULT_MSG SSHT_INCLUDE_DIRS SSHT_LIBRARIES)
+mark_as_advanced(SSHT_INCLUDE_DIRS SSHT_LIBRARIES)

--- a/cmake/SetupSSHT.cmake
+++ b/cmake/SetupSSHT.cmake
@@ -1,0 +1,10 @@
+# Distributed under the MIT License
+# See LICENSE.txt for details
+
+find_package(SSHT REQUIRED)
+
+spectre_include_directories("${SSHT_INCLUDE_DIRS}")
+list(APPEND SPECTRE_LIBRARIES ${SSHT_LIBRARIES})
+
+message(STATUS "SSHT library: ${SSHT_LIBRARIES}")
+message(STATUS "SSHT include: ${SSHT_INCLUDE_DIRS}")

--- a/docs/DevGuide/BuildSystem.md
+++ b/docs/DevGuide/BuildSystem.md
@@ -12,13 +12,14 @@ executables.
 
 To add a dependency first add a `SetupDEPENDENCY.cmake` file to the `cmake`
 directory. You should model this after one of the existing ones for Catch or
-Brigand if you're adding a header-only library and yaml-cpp if the library
-is not header-only. If CMake does not already support `find_package` for the
+Brigand if you're adding a header-only library and yaml-cpp if the library is
+not header-only. If CMake does not already support `find_package` for the
 library you're adding you can write your own. These should be modeled after
-`FindBrigand` or `FindCatch` for header-only libraries, and `FindYAMLCPP`
-for compiled libraries. Be sure to test both that setting `LIBRARY_ROOT`
-works correctly for your library, and also that if the library is required
-that CMake fails if the library is not found.
+`FindBrigand` or `FindCatch` for header-only libraries, and `FindYAMLCPP` for
+compiled libraries. The `SetupDEPENDENCY.cmake` file must then be included in
+the root `spectre/CMakeLists.txt`. Be sure to test both that setting
+`LIBRARY_ROOT` works correctly for your library, and also that if the library is
+required that CMake fails if the library is not found.
 
 ## Adding Unit Tests
 
@@ -36,7 +37,7 @@ the `Data` directory. Please see other unit tests and the
 writing tests. There will also be a section in the dev guide on how to write
 effective tests.  Unit tests should take as short a time as possible, with a
 goal of less than two seconds.
- 
+
 You can check the unit test coverage of your code by installing all the optional
 components and then running `make unit-test-coverage` (after re-running CMake).
 This will create the


### PR DESCRIPTION
## Proposed changes
Add SSHT Setup and Find files to cmake system. Small clarification change to
Dependency documentation.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Documentation
- [ ] Build system

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).