### PR TITLE
Add SSHT to docker

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -81,6 +81,7 @@ RUN echo "export PATH=\$PATH:/work/spack/bin" >> /root/.bashrc && \
     /root/.spack/linux/compilers.yaml
 RUN /work/spack/bin/spack install --no-checksum catch@2.1.0 && \
     /work/spack/bin/spack install brigand@master && \
+    /work/spack/bin/spack install fftw && \
     /work/spack/bin/spack install blaze && \
     /work/spack/bin/spack install gsl%gcc@6.4.0
 RUN /work/spack/bin/spack install libxsmm%gcc@6.4.0
@@ -132,9 +133,23 @@ RUN echo 'spack load catch' >> /root/.bashrc && \
     echo 'spack load brigand' >> /root/.bashrc && \
     echo 'spack load blaze' >> /root/.bashrc && \
     echo 'spack load gsl' >> /root/.bashrc && \
+    echo 'spack load fftw' >> /root/.bashrc && \
     echo 'spack load libxsmm' >> /root/.bashrc && \
     echo 'spack load yaml-cpp' >> /root/.bashrc && \
     echo 'spack load benchmark' >> /root/.bashrc
+
+# Download and build SSHT, install to /usr
+# commands in `spack load` to work in the container build
+RUN /bin/bash -c 'git clone https://github.com/astro-informatics/ssht.git && \
+                  cd /work/ssht && \
+                  /etc/profile.d/lmod.sh && \
+                  source /etc/profile && \
+                  source /work/spack/share/spack/setup-env.sh && \
+                  cd /work/ssht/ && \
+                  spack load fftw && \
+                  make default && \
+                  cp /work/ssht/lib/c/libssht.a /usr/lib/ && \
+                  cp /work/ssht/include/c/ssht.h /usr/include'
 
 # - Set the environment variable SPECTRE_CONTAINER so we can check if we are
 #   inside a container (0 is true in bash)


### PR DESCRIPTION
## Proposed changes

Modify the Docker.buildenv to include a script for bringing in fftw3 via
spack and using it to build SSHT, then installing it to /usr/include and
/usr/lib.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Build system

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

I will require assistance in posting the resulting image to docker hub.
