### PR TITLE
Add InterpolationTargetLineSegment

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -70,7 +70,7 @@ template <typename Metavariables, size_t VolumeDim,
 struct Holder {
   std::unordered_map<typename Metavariables::temporal_id,
                      Info<VolumeDim, TagList>>
-      info;
+      infos;
   std::unordered_set<typename Metavariables::temporal_id>
       temporal_ids_when_data_has_been_interpolated;
 };

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -1,0 +1,127 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace intrp {
+
+namespace OptionHolders {
+/// A line segment extending from `Begin` to `End`,
+/// containing `NumberOfPoints` uniformly-spaced points including the endpoints.
+template <size_t VolumeDim>
+struct LineSegment {
+  struct Begin {
+    using type = std::array<double, VolumeDim>;
+    static constexpr OptionString help = {"Beginning endpoint"};
+  };
+  struct End {
+    using type = std::array<double, VolumeDim>;
+    static constexpr OptionString help = {"Ending endpoint"};
+  };
+  struct NumberOfPoints {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Number of points including endpoints"};
+    static type lower_bound() { return 2; }
+  };
+  using options = tmpl::list<Begin, End, NumberOfPoints>;
+  static constexpr OptionString help = {
+      "A line segment extending from Begin to End, containing NumberOfPoints"
+      " uniformly-spaced points including the endpoints."};
+
+  LineSegment(std::array<double, VolumeDim> begin_in,
+              std::array<double, VolumeDim> end_in,
+              size_t number_of_points_in)
+      : begin(std::move(begin_in)),  // NOLINT
+        end(std::move(end_in)),      // NOLINT
+        number_of_points(number_of_points_in) {}
+  // above NOLINT for std::move of trivially copyable type.
+
+  LineSegment() = default;
+  LineSegment(const LineSegment& /*rhs*/) = default;
+  LineSegment& operator=(const LineSegment& /*rhs*/) = default;
+  LineSegment(LineSegment&& /*rhs*/) noexcept = default;
+  LineSegment& operator=(LineSegment&& /*rhs*/) noexcept = default;
+  ~LineSegment() = default;
+
+  // clang-tidy non-const reference pointer.
+  void pup(PUP::er& p) noexcept {  // NOLINT
+    p | begin;
+    p | end;
+    p | number_of_points;
+  }
+
+  std::array<double, VolumeDim> begin{};
+  std::array<double, VolumeDim> end{};
+  size_t number_of_points{};
+};
+}  // namespace OptionHolders
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \brief Sends points on a line segment to an `Interpolator`.
+///
+/// Uses:
+/// - DataBox:
+///   - `::Tags::Domain<VolumeDim, Frame>`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `Tags::IndicesOfFilledInterpPoints`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// For requirements on InterpolationTargetTag, see InterpolationTarget
+template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+struct LineSegment {
+  using options_type = OptionHolders::LineSegment<VolumeDim>;
+  using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<
+                DbTags, typename Tags::TemporalIds<Metavariables>>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const typename Metavariables::temporal_id& temporal_id) noexcept {
+    const auto& options = Parallel::get<InterpolationTargetTag>(cache);
+
+    // Fill points on a line segment
+    const double fractional_distance = 1.0 / (options.number_of_points - 1);
+    tnsr::I<DataVector, VolumeDim, Frame> target_points(
+        options.number_of_points);
+    for (size_t n = 0; n < options.number_of_points; ++n) {
+      for (size_t d = 0; d < VolumeDim; ++d) {
+        target_points.get(d)[n] =
+            gsl::at(options.begin, d) +
+            n * fractional_distance *
+                (gsl::at(options.end, d) - gsl::at(options.begin, d));
+      }
+    }
+
+    send_points_to_interpolator<InterpolationTargetTag>(
+        box, cache, target_points, temporal_id);
+  }
+};
+
+}  // namespace Actions
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
@@ -4,17 +4,10 @@
 #pragma once
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Utilities/TMPL.hpp"
-
-/// \cond
-namespace intrp {
-namespace Actions {
-struct InitializeInterpolator;
-}  // namespace Actions
-}  // namespace intrp
-/// \endcond
 
 namespace intrp {
 
@@ -29,8 +22,8 @@ struct Interpolator {
   using metavariables = Metavariables;
   using action_list = tmpl::list<>;
   using initial_databox =
-      db::compute_databox_type<typename Actions::InitializeInterpolator::
-                                   return_tag_list<Metavariables, VolumeDim>>;
+      db::compute_databox_type<typename Actions::InitializeInterpolator<
+          VolumeDim>:: template return_tag_list<Metavariables>>;
   using options = tmpl::list<>;
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache);

--- a/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
@@ -1,0 +1,81 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <algorithm>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+
+/// \cond
+namespace intrp {
+template <typename Metavariables, size_t VolumeDim>
+struct Interpolator;
+namespace Actions {
+template <typename InterpolationTargetTag>
+struct ReceiveInterpolationPoints;
+}  // namespace Actions
+}  // namespace intrp
+/// \endcond
+
+namespace intrp {
+
+/// Sends to all the Interpolators a list of all the points that need
+/// to be interpolated onto.  Also clears information about data that
+/// has already been interpolated, since calling this function triggers
+/// a new interpolation.
+///
+/// Called by InterpolationTargetTag::compute_target_points.  This is not an
+/// Action, but rather a helper function that is called by every
+/// Action (LineSegment, Strahlkorper, etc.) that specifies a
+/// particular set of points.
+template <typename InterpolationTargetTag, typename DbTags,
+          typename Metavariables, size_t VolumeDim, typename Frame>
+void send_points_to_interpolator(
+    db::DataBox<DbTags>& box, Parallel::ConstGlobalCache<Metavariables>& cache,
+    const tnsr::I<DataVector, VolumeDim, Frame>& target_points,
+    const typename Metavariables::temporal_id& temporal_id) noexcept {
+  const auto& domain = db::get<::Tags::Domain<VolumeDim, Frame>>(box);
+  auto coords = block_logical_coordinates(domain, target_points);
+
+  db::mutate<
+      Tags::IndicesOfFilledInterpPoints,
+      ::Tags::Variables<
+          typename InterpolationTargetTag::vars_to_interpolate_to_target>>(
+      make_not_null(&box),
+      [&coords](
+          const gsl::not_null<db::item_type<Tags::IndicesOfFilledInterpPoints>*>
+              indices_of_filled,
+          const gsl::not_null<db::item_type<::Tags::Variables<
+              typename InterpolationTargetTag::vars_to_interpolate_to_target>>*>
+              vars_dest) noexcept {
+        // Because we are sending new points to the interpolator,
+        // we know that none of these points have been interpolated to,
+        // so clear the list.
+        indices_of_filled->clear();
+
+        // We will be filling vars_dest with interpolated data.
+        // Here we make sure it is allocated to the correct size.
+        if (vars_dest->number_of_grid_points() != coords.size()) {
+          *vars_dest = db::item_type<::Tags::Variables<
+              typename InterpolationTargetTag::vars_to_interpolate_to_target>>(
+              coords.size());
+        }
+      });
+
+  auto& receiver_proxy =
+      Parallel::get_parallel_component<Interpolator<Metavariables, VolumeDim>>(
+          cache);
+  Parallel::simple_action<
+      Actions::ReceiveInterpolationPoints<InterpolationTargetTag>>(
+      receiver_proxy, temporal_id, std::move(coords));
+}
+
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_BarycentricRational.cpp
   Test_InitializeInterpolationTarget.cpp
   Test_InitializeInterpolator.cpp
+  Test_InterpolationTargetLineSegment.cpp
   Test_InterpolatorRegisterElement.cpp
   Test_IrregularInterpolant.cpp
   Test_LagrangePolynomial.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
@@ -84,7 +84,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Initialize",
   const auto& holder =
       get<intrp::Vars::HolderTag<metavars::InterpolatorTargetA, metavars, 3>>(
           holders);
-  CHECK(holder.info.empty());
+  CHECK(holder.infos.empty());
   // Check that 'holders' has only one tag.
   CHECK(holders.size() == 1);
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -1,0 +1,291 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockId.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/Shell.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp"
+#include "NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+/// \cond
+namespace intrp {
+namespace Actions {
+template <typename InterpolationTargetTag>
+struct ReceiveInterpolationPoints;
+}  // namespace Actions
+}  // namespace intrp
+template <typename IdType, typename DataType>
+class IdPair;
+namespace Parallel {
+template <typename Metavariables> class ConstGlobalCache;
+} // namespace Parallel
+namespace db {
+template <typename TagsList>
+class DataBox;
+} // namespace db
+namespace intrp {
+namespace Tags {
+struct IndicesOfFilledInterpPoints;
+template <typename Metavariables, size_t VolumeDim>
+struct InterpolatedVarsHolders;
+struct NumberOfElements;
+} // namespace Tags
+} // namespace intrp
+/// \endcond
+
+namespace {
+
+template <typename Metavariables, typename InterpolationTargetTag>
+struct mock_interpolation_target {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked = void; // not needed.
+  using const_global_cache_tag_list =
+      Parallel::get_const_global_cache_tags<
+          tmpl::list<intrp::Actions::LineSegment<InterpolationTargetTag, 3,
+                                                 Frame::Inertial>>>;
+
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename ::intrp::Actions::InitializeInterpolationTarget<
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
+                                                            ::Frame::Inertial>>;
+};
+
+template <typename InterpolationTargetTag>
+struct MockReceiveInterpolationPoints {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, size_t VolumeDim,
+            Requires<tmpl::list_contains_v<
+                DbTags, typename ::intrp::Tags::NumberOfElements>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const typename Metavariables::temporal_id& temporal_id,
+      std::vector<IdPair<domain::BlockId,
+                         tnsr::I<double, VolumeDim, typename Frame::Logical>>>&&
+          block_coord_holders) noexcept {
+    db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>(
+        make_not_null(&box),
+        [&temporal_id, &block_coord_holders](
+            const gsl::not_null<
+                db::item_type<intrp::Tags::InterpolatedVarsHolders<
+                    Metavariables, VolumeDim>>*>
+                vars_holders) {
+          auto& vars_infos =
+              get<intrp::Vars::HolderTag<InterpolationTargetTag, Metavariables,
+                                         VolumeDim>>(*vars_holders)
+                  .infos;
+
+          // Add the target interpolation points at this timestep.
+          vars_infos.emplace(std::make_pair(
+              temporal_id,
+              intrp::Vars::Info<VolumeDim, typename InterpolationTargetTag::
+                                               vars_to_interpolate_to_target>{
+                  std::move(block_coord_holders)}));
+        });
+  }
+};
+
+template <typename Metavariables, size_t VolumeDim>
+struct mock_interpolator {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename ::intrp::Actions::InitializeInterpolator<
+          VolumeDim>::template return_tag_list<Metavariables>>;
+
+  using component_being_mocked = intrp::Interpolator<Metavariables, VolumeDim>;
+  using replace_these_simple_actions =
+      tmpl::list<intrp::Actions::ReceiveInterpolationPoints<
+          typename Metavariables::InterpolationTargetA>>;
+  using with_these_simple_actions = tmpl::list<MockReceiveInterpolationPoints<
+      typename Metavariables::InterpolationTargetA>>;
+};
+
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_target_points =
+        intrp::Actions::LineSegment<InterpolationTargetA, 3, Frame::Inertial>;
+    // This tag is also an OptionsTag. The type and help string below
+    // refer to the options that are read from the input file.
+    using type = typename compute_target_points::options_type;
+    static constexpr OptionString help = {"Options for InterpolateeA"};
+  };
+  using temporal_id = Time;
+  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+
+  using component_list = tmpl::list<
+      mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
+      mock_interpolator<MockMetavariables, 3>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialize, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
+                  "[Unit]") {
+  using metavars = MockMetavariables;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  using TupleOfMockDistributedObjects =
+      MockRuntimeSystem::TupleOfMockDistributedObjects;
+  TupleOfMockDistributedObjects dist_objects{};
+  using MockDistributedObjectsTagTarget =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolation_target<metavars, metavars::InterpolationTargetA>>;
+  using MockDistributedObjectsTagInterpolator =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolator<metavars, 3>>;
+  tuples::get<MockDistributedObjectsTagTarget>(dist_objects)
+      .emplace(0,
+               ActionTesting::MockDistributedObject<mock_interpolation_target<
+                   metavars, metavars::InterpolationTargetA>>{});
+  tuples::get<MockDistributedObjectsTagInterpolator>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<
+                      mock_interpolator<metavars, 3>>{});
+
+  // Options for LineSegment
+  intrp::OptionHolders::LineSegment<3> line_segment_opts({{1.0, 1.0, 1.0}},
+                                                         {{2.4, 2.4, 2.4}}, 15);
+  tuples::TaggedTuple<metavars::InterpolationTargetA> tuple_of_opts(
+      line_segment_opts);
+
+  MockRuntimeSystem runner{tuple_of_opts, std::move(dist_objects)};
+
+  const auto domain_creator =
+      DomainCreators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+
+  runner.simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
+      ::intrp::Actions::InitializeInterpolationTarget<
+          metavars::InterpolationTargetA>>(0, domain_creator.create_domain());
+
+  runner.simple_action<mock_interpolator<metavars, 3>,
+                       ::intrp::Actions::InitializeInterpolator<3>>(0);
+
+  const auto& box_target =
+      runner
+          .template algorithms<mock_interpolation_target<
+              metavars, metavars::InterpolationTargetA>>()
+          .at(0)
+          .template get_databox<typename mock_interpolation_target<
+              metavars, metavars::InterpolationTargetA>::initial_databox>();
+
+  const auto& box_interpolator =
+      runner.template algorithms<mock_interpolator<metavars, 3>>()
+          .at(0)
+          .template get_databox<
+              typename mock_interpolator<metavars, 3>::initial_databox>();
+
+  Slab slab(0.0, 1.0);
+  Time temporal_id(slab, 0);
+
+  runner.simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
+      ::intrp::Actions::LineSegment<metavars::InterpolationTargetA, 3,
+                                    Frame::Inertial>>(0, temporal_id);
+
+  // This should not have changed.
+  CHECK(
+      db::get<::intrp::Tags::IndicesOfFilledInterpPoints>(box_target).empty());
+
+  // Should be no queued actions in mock_interpolation_target
+  CHECK(runner.is_simple_action_queue_empty<
+        mock_interpolation_target<metavars, metavars::InterpolationTargetA>>(
+      0));
+
+  // But there should be one in mock_interpolator
+  runner.invoke_queued_simple_action<mock_interpolator<metavars, 3>>(0);
+
+  // Should be no more queued actions in mock_interpolator
+  CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars, 3>>(0));
+
+  const auto& vars_holders =
+      db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(
+          box_interpolator);
+  const auto& vars_infos =
+      get<intrp::Vars::HolderTag<metavars::InterpolationTargetA, metavars, 3>>(
+          vars_holders)
+          .infos;
+  // Should be one entry in the vars_infos
+  CHECK(vars_infos.size() == 1);
+  const auto& info = vars_infos.at(temporal_id);
+  const auto& block_coord_holders = info.block_coord_holders;
+
+  // Should be 15 points.
+  CHECK(block_coord_holders.size() == 15);
+
+  const auto expected_block_coord_holders = [&domain_creator]() {
+    const size_t n_pts = 15;
+    tnsr::I<DataVector, 3, Frame::Inertial> points(n_pts);
+    for (size_t d = 0; d < 3; ++d) {
+      for (size_t i = 0; i < n_pts; ++i) {
+        points.get(d)[i] = 1.0 + 0.1 * i;  // Worked out by hand.
+      }
+    }
+    return block_logical_coordinates(domain_creator.create_domain(), points);
+  }();
+  for (size_t i = 0; i < 15; ++i) {
+    CHECK(block_coord_holders[i].id == expected_block_coord_holders[i].id);
+    CHECK_ITERABLE_APPROX(block_coord_holders[i].data,
+                          expected_block_coord_holders[i].data);
+  }
+
+  // Call again at a different temporal_id
+  Time new_temporal_id(slab, 1);
+  runner.simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
+      ::intrp::Actions::LineSegment<metavars::InterpolationTargetA, 3,
+                                    Frame::Inertial>>(0, new_temporal_id);
+  runner.invoke_queued_simple_action<mock_interpolator<metavars, 3>>(0);
+
+  // Should be two entries in the vars_infos
+  CHECK(vars_infos.size() == 2);
+  const auto& new_block_coord_holders =
+      vars_infos.at(new_temporal_id).block_coord_holders;
+  for (size_t i = 0; i < 15; ++i) {
+    CHECK(new_block_coord_holders[i].id == expected_block_coord_holders[i].id);
+    CHECK_ITERABLE_APPROX(new_block_coord_holders[i].data,
+                          expected_block_coord_holders[i].data);
+  }
+}
+
+}  // namespace


### PR DESCRIPTION
This is another PR towards parallel interpolation.

This adds an Action (LineSegment) that specifies interpolation onto a  line segment.
Other similar Actions can be added later for spheres, planes, or any other set of points that we wish to interpolate onto.

This PR also includes a few small fixes (in separate commits) to previous PRs.

### Types of changes:

- [x] New feature

### Component:

- [x] Code
### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
