### PR TITLE
Split TimeStepper base class

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -60,7 +60,10 @@ struct EvolutionMetavars {
   using boundary_condition_tag = analytic_solution_tag;
   using normal_dot_numerical_flux =
       OptionTags::NumericalFluxParams<Burgers::LocalLaxFriedrichsFlux>;
-  using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
+  using const_global_cache_tag_list =
+      tmpl::list<analytic_solution_tag,
+                 OptionTags::TypedTimeStepper<tmpl::conditional_t<
+                     local_time_stepping, LtsTimeStepper, TimeStepper>>>;
   using domain_creator_tag = OptionTags::DomainCreator<1, Frame::Inertial>;
 
   using step_choosers =

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -112,7 +112,10 @@ struct EvolutionMetavars {
               compute_rhs, update_variables,
               Actions::Goto<EvolvePhaseStart>>>>>;
 
-  using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
+  using const_global_cache_tag_list =
+      tmpl::list<analytic_solution_tag,
+                 OptionTags::TypedTimeStepper<tmpl::conditional_t<
+                     local_time_stepping, LtsTimeStepper, TimeStepper>>>;
 
   using domain_creator_tag = OptionTags::DomainCreator<3, Frame::Inertial>;
 

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -72,7 +72,10 @@ struct EvolutionMetavars {
       OptionTags::NumericalFluxParams<ScalarWave::UpwindFlux<Dim>>;
   // A tmpl::list of tags to be added to the ConstGlobalCache by the
   // metavariables
-  using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
+  using const_global_cache_tag_list =
+      tmpl::list<analytic_solution_tag,
+                 OptionTags::TypedTimeStepper<tmpl::conditional_t<
+                     local_time_stepping, LtsTimeStepper, TimeStepper>>>;
   using domain_creator_tag = OptionTags::DomainCreator<Dim, Frame::Inertial>;
 
   using Redum = Parallel::ReductionDatum<double, funcl::Plus<>,

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp
@@ -15,6 +15,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"  // IWYU pragma: keep // for db::item_type<Tags::Mortars<...>>
 #include "Time/Tags.hpp"  // IWYU pragma: keep // for db::item_type<Tags::TimeStep>
+#include "Time/TimeSteppers/TimeStepper.hpp"  // IWYU pragma: keep
 // IWYU pragma: no_include "Time/Time.hpp" // for TimeDelta
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -92,7 +93,8 @@ struct ApplyBoundaryFluxesLocalTimeStepping {
           ]() noexcept {
             const auto& normal_dot_numerical_flux_computer =
                 get<typename Metavariables::normal_dot_numerical_flux>(cache);
-            const auto& time_stepper = get<OptionTags::TimeStepper>(cache);
+            const LtsTimeStepper& time_stepper =
+                get<OptionTags::TimeStepper>(cache);
 
             for (auto& mortar_id_and_data : *mortar_data) {
               const auto& mortar_id = mortar_id_and_data.first;

--- a/src/Time/Actions/AdvanceTime.hpp
+++ b/src/Time/Actions/AdvanceTime.hpp
@@ -43,8 +43,6 @@ namespace Actions {
 /// - Removes: nothing
 /// - Modifies: Tags::TimeId, Tags::TimeStep
 struct AdvanceTime {
-  using const_global_cache_tags = tmpl::list<OptionTags::TimeStepper>;
-
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/src/Time/Actions/ChangeStepSize.hpp
+++ b/src/Time/Actions/ChangeStepSize.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Time/Tags.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -44,8 +45,7 @@ template <typename StepChooserRegistrars>
 struct ChangeStepSize {
   using step_choosers_tag = OptionTags::StepChoosers<StepChooserRegistrars>;
   using const_global_cache_tags =
-      tmpl::list<OptionTags::TimeStepper, step_choosers_tag,
-                 OptionTags::StepController>;
+      tmpl::list<step_choosers_tag, OptionTags::StepController>;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -62,7 +62,8 @@ struct ChangeStepSize {
     using variables_tag = typename Metavariables::system::variables_tag;
     using dt_variables_tag = db::add_tag_prefix<Tags::dt, variables_tag>;
 
-    const auto& time_stepper = Parallel::get<OptionTags::TimeStepper>(cache);
+    const LtsTimeStepper& time_stepper =
+        Parallel::get<OptionTags::TimeStepper>(cache);
     const auto& step_choosers = Parallel::get<step_choosers_tag>(cache);
     const auto& step_controller =
         Parallel::get<OptionTags::StepController>(cache);

--- a/src/Time/Actions/UpdateU.hpp
+++ b/src/Time/Actions/UpdateU.hpp
@@ -45,8 +45,6 @@ namespace Actions {
 ///   - variables_tag
 ///   - Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>
 struct UpdateU {
-  using const_global_cache_tags = tmpl::list<OptionTags::TimeStepper>;
-
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent>

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -97,9 +97,17 @@ struct FinalTime {
 /// \ingroup OptionTagsGroup
 /// \ingroup TimeGroup
 /// \brief The ::TimeStepper
-struct TimeStepper {
-  using type = std::unique_ptr<::TimeStepper>;
+struct TimeStepper {};
+
+/// \ingroup OptionTagsGroup
+/// \ingroup TimeGroup
+/// \brief The ::TimeStepper, specifying a (base) type.  Can be
+/// retrieved through OptionTags::TimeStepper.
+template <typename StepperType>
+struct TypedTimeStepper : TimeStepper {
+  static std::string name() noexcept { return "TimeStepper"; }
   static constexpr OptionString help{"The time stepper"};
+  using type = std::unique_ptr<StepperType>;
 };
 
 /// \ingroup OptionTagsGroup

--- a/src/Time/TimeSteppers/AdamsBashforthN.cpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.cpp
@@ -16,10 +16,6 @@ AdamsBashforthN::AdamsBashforthN(const size_t order) noexcept : order_(order) {
   }
 }
 
-uint64_t AdamsBashforthN::number_of_substeps() const noexcept {
-  return 1;
-}
-
 size_t AdamsBashforthN::number_of_past_steps() const noexcept {
   return order_ - 1;
 }
@@ -160,7 +156,7 @@ std::vector<double> AdamsBashforthN::constant_coefficients(
 }
 
 void AdamsBashforthN::pup(PUP::er& p) noexcept {
-  TimeStepper::Inherit::pup(p);
+  LtsTimeStepper::Inherit::pup(p);
   p | order_;
 }
 

--- a/src/Time/TimeSteppers/AdamsBashforthN.hpp
+++ b/src/Time/TimeSteppers/AdamsBashforthN.hpp
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <boost/iterator/transform_iterator.hpp>
 #include <cstddef>
-#include <cstdint>
 #include <iterator>
 #include <map>
 #include <pup.h>
@@ -44,7 +43,7 @@ namespace TimeSteppers {
 /// \ingroup TimeSteppersGroup
 ///
 /// An Nth Adams-Bashforth time stepper.
-class AdamsBashforthN : public TimeStepper::Inherit {
+class AdamsBashforthN : public LtsTimeStepper::Inherit {
  public:
   static constexpr const size_t maximum_order = 8;
 
@@ -195,8 +194,6 @@ class AdamsBashforthN : public TimeStepper::Inherit {
       gsl::not_null<BoundaryHistoryType<LocalVars, RemoteVars, Coupling>*>
           history,
       const TimeDelta& time_step) const noexcept;
-
-  uint64_t number_of_substeps() const noexcept override;
 
   size_t number_of_past_steps() const noexcept override;
 

--- a/src/Time/TimeSteppers/RungeKutta3.cpp
+++ b/src/Time/TimeSteppers/RungeKutta3.cpp
@@ -5,6 +5,7 @@
 
 #include <cmath>
 
+#include "ErrorHandling/Assert.hpp"
 #include "Time/TimeId.hpp"
 
 namespace TimeSteppers {

--- a/src/Time/TimeSteppers/TimeStepper.hpp
+++ b/src/Time/TimeSteppers/TimeStepper.hpp
@@ -1,9 +1,6 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-/// \file
-/// Defines class TimeStepper.
-
 #pragma once
 
 #include <cstddef>
@@ -20,6 +17,7 @@
 /// \cond
 class TimeDelta;
 namespace TimeSteppers {
+class AdamsBashforthN;  // IWYU pragma: keep
 template <typename LocalVars, typename RemoteVars, typename CouplingResult>
 class BoundaryHistory;
 template <typename Vars, typename DerivVars>
@@ -36,8 +34,6 @@ class RungeKutta3;  // IWYU pragma: keep
 }  // namespace TimeSteppers
 
 namespace TimeStepper_detail {
-DEFINE_FAKE_VIRTUAL(can_change_step_size)
-DEFINE_FAKE_VIRTUAL(compute_boundary_delta)
 DEFINE_FAKE_VIRTUAL(update_u)
 }  // namespace TimeStepper_detail
 
@@ -46,22 +42,11 @@ DEFINE_FAKE_VIRTUAL(update_u)
 /// Abstract base class for TimeSteppers.
 class TimeStepper : public PUP::able {
  public:
-  using Inherit = TimeStepper_detail::FakeVirtualInherit_can_change_step_size<
-      TimeStepper_detail::FakeVirtualInherit_compute_boundary_delta<
-          TimeStepper_detail::FakeVirtualInherit_update_u<TimeStepper>>>;
+  using Inherit = TimeStepper_detail::FakeVirtualInherit_update_u<TimeStepper>;
   using creatable_classes =
       tmpl::list<TimeSteppers::AdamsBashforthN, TimeSteppers::RungeKutta3>;
 
   WRAPPED_PUPable_abstract(TimeStepper);  // NOLINT
-
-  /// \cond HIDDEN_SYMBOLS
-  TimeStepper() = default;
-  TimeStepper(const TimeStepper&) noexcept = default;
-  TimeStepper& operator=(const TimeStepper&) noexcept = default;
-  TimeStepper(TimeStepper&&) noexcept = default;
-  TimeStepper& operator=(TimeStepper&&) noexcept = default;
-  ~TimeStepper() noexcept override = default;
-  /// \endcond
 
   /// Add the change for the current substep to u.
   template <typename Vars, typename DerivVars>
@@ -72,6 +57,45 @@ class TimeStepper : public PUP::able {
     return TimeStepper_detail::fake_virtual_update_u<creatable_classes>(
         this, u, history, time_step);
   }
+
+  /// Number of substeps in this TimeStepper
+  virtual uint64_t number_of_substeps() const noexcept = 0;
+
+  /// Number of past time steps needed for multi-step method
+  virtual size_t number_of_past_steps() const noexcept = 0;
+
+  /// Rough estimate of the maximum step size this method can take
+  /// stably as a multiple of the step for Euler's method.
+  virtual double stable_step() const noexcept = 0;
+
+  /// The TimeId after the current substep
+  virtual TimeId next_time_id(const TimeId& current_id,
+                              const TimeDelta& time_step) const noexcept = 0;
+};
+
+// LtsTimeStepper cannot be split out into its own file because the
+// LtsTimeStepper -> TimeStepper -> AdamsBashforthN -> LtsTimeStepper
+// include loop causes AdamsBashforthN to be defined before its base
+// class if LtsTimeStepper is included first.
+namespace LtsTimeStepper_detail {
+DEFINE_FAKE_VIRTUAL(can_change_step_size)
+DEFINE_FAKE_VIRTUAL(compute_boundary_delta)
+}  // namespace LtsTimeStepper_detail
+
+/// \ingroup TimeSteppersGroup
+///
+/// Base class for TimeSteppers with local time-stepping support,
+/// derived from TimeStepper.
+class LtsTimeStepper : public TimeStepper::Inherit {
+ public:
+  using Inherit =
+      LtsTimeStepper_detail::FakeVirtualInherit_can_change_step_size<
+          LtsTimeStepper_detail::FakeVirtualInherit_compute_boundary_delta<
+              LtsTimeStepper>>;
+  // When you add a class here, remember to add it to TimeStepper as well.
+  using creatable_classes = tmpl::list<TimeSteppers::AdamsBashforthN>;
+
+  WRAPPED_PUPable_abstract(LtsTimeStepper);  // NOLINT
 
   /// \brief Compute the change in a boundary quantity due to the
   /// coupling on the interface.
@@ -90,23 +114,12 @@ class TimeStepper : public PUP::able {
           std::result_of_t<const Coupling&(LocalVars, RemoteVars)>>*>
           history,
       const TimeDelta& time_step) const noexcept {
-    return TimeStepper_detail::fake_virtual_compute_boundary_delta<
+    return LtsTimeStepper_detail::fake_virtual_compute_boundary_delta<
         creatable_classes>(this, coupling, history, time_step);
   }
 
-  /// Number of substeps in this TimeStepper
-  virtual uint64_t number_of_substeps() const noexcept = 0;
-
-  /// Number of past time steps needed for multi-step method
-  virtual size_t number_of_past_steps() const noexcept = 0;
-
-  /// Rough estimate of the maximum step size this method can take
-  /// stably as a multiple of the step for Euler's method.
-  virtual double stable_step() const noexcept = 0;
-
-  /// The TimeId after the current substep
-  virtual TimeId next_time_id(const TimeId& current_id,
-                              const TimeDelta& time_step) const noexcept = 0;
+  /// Substep LTS integrators are not supported, so this is always 1.
+  uint64_t number_of_substeps() const noexcept final { return 1; }
 
   /// Whether a local change in the step size is allowed before taking
   /// a step.  This should be called after the history has been
@@ -117,10 +130,25 @@ class TimeStepper : public PUP::able {
   bool can_change_step_size(
       const TimeId& time_id,
       const TimeSteppers::History<Vars, DerivVars>& history) const noexcept {
-    return TimeStepper_detail::fake_virtual_can_change_step_size<
+    return LtsTimeStepper_detail::fake_virtual_can_change_step_size<
         creatable_classes>(this, time_id, history);
   }
+
+  /// \cond
+  // FakeVirtual forces derived classes to override the fake virtual
+  // methods.  Here the base class method is actually what we want
+  // because we are not a most-derived class, so we forward to the
+  // TimeStepper version.
+  template <typename Vars, typename DerivVars>
+  void update_u(
+      const gsl::not_null<Vars*> u,
+      const gsl::not_null<TimeSteppers::History<Vars, DerivVars>*> history,
+      const TimeDelta& time_step) const noexcept {
+    return TimeStepper::update_u(u, history, time_step);
+  }
+  /// \endcond
 };
+
 
 #include "Time/TimeSteppers/AdamsBashforthN.hpp"  // IWYU pragma: keep
 #include "Time/TimeSteppers/RungeKutta3.hpp"  // IWYU pragma: keep

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -55,6 +55,7 @@
 #include "tests/Unit/ActionTesting.hpp"
 
 // IWYU pragma: no_forward_declare ElementIndex
+class TimeStepper;
 // IWYU pragma: no_forward_declare Variables
 namespace PUP {
 class er;  // IWYU pragma: keep
@@ -123,7 +124,7 @@ struct component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<Dim>;
   using const_global_cache_tag_list =
-      tmpl::list<OptionTags::TimeStepper,
+      tmpl::list<OptionTags::TypedTimeStepper<TimeStepper>,
                  OptionTags::AnalyticSolution<SystemAnalyticSolution>>;
   using action_list = tmpl::list<>;
   using initial_databox =

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryFluxesLocalTimeStepping.cpp
@@ -40,6 +40,7 @@
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 
+class LtsTimeStepper;
 // IWYU pragma: no_forward_declare db::DataBox
 // IWYU pragma: no_forward_declare Tensor
 namespace PUP {
@@ -82,7 +83,8 @@ struct component {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = ElementIndex<2>;
   using const_global_cache_tag_list =
-      tmpl::list<OptionTags::TimeStepper, NumericalFluxTag>;
+      tmpl::list<OptionTags::TypedTimeStepper<LtsTimeStepper>,
+                 NumericalFluxTag>;
   using action_list =
       tmpl::list<dg::Actions::ApplyBoundaryFluxesLocalTimeStepping>;
   using simple_tags =

--- a/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
+++ b/tests/Unit/Time/Actions/Test_AdvanceTime.cpp
@@ -24,6 +24,7 @@
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 
+class TimeStepper;
 // IWYU pragma: no_forward_declare db::DataBox
 
 namespace {
@@ -32,7 +33,8 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<OptionTags::TimeStepper>;
+  using const_global_cache_tag_list =
+      tmpl::list<OptionTags::TypedTimeStepper<TimeStepper>>;
   using action_list = tmpl::list<Actions::AdvanceTime>;
   using simple_tags =
       db::AddSimpleTags<Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep>;

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -34,6 +34,8 @@
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 
+class TimeStepper;
+
 namespace {
 struct Var : db::SimpleTag {
   static std::string name() noexcept { return "Var"; }
@@ -64,7 +66,8 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<OptionTags::TimeStepper>;
+  using const_global_cache_tag_list =
+      tmpl::list<OptionTags::TypedTimeStepper<TimeStepper>>;
   using action_list = tmpl::append<
       SelfStart::self_start_procedure<
           tmpl::list<Actions::ComputeVolumeDuDt,

--- a/tests/Unit/Time/Actions/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Actions/Test_UpdateU.cpp
@@ -24,6 +24,8 @@
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 
+class TimeStepper;
+
 namespace {
 struct Var : db::SimpleTag {
   static std::string name() noexcept { return "Var"; }
@@ -44,7 +46,8 @@ struct component {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<OptionTags::TimeStepper>;
+  using const_global_cache_tag_list =
+      tmpl::list<OptionTags::TypedTimeStepper<TimeStepper>>;
   using action_list = tmpl::list<Actions::UpdateU>;
   using simple_tags =
       db::AddSimpleTags<Tags::TimeStep, variables_tag, history_tag>;

--- a/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Cfl.cpp
@@ -27,6 +27,8 @@
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+class TimeStepper;
+
 namespace {
 constexpr size_t dim = 1;
 using frame = Frame::Grid;
@@ -40,7 +42,8 @@ struct CharacteristicSpeed : db::SimpleTag {
 
 struct Metavariables {
   using component_list = tmpl::list<>;
-  using const_global_cache_tag_list = tmpl::list<OptionTags::TimeStepper>;
+  using const_global_cache_tag_list =
+      tmpl::list<OptionTags::TypedTimeStepper<TimeStepper>>;
   struct system {
     struct compute_largest_characteristic_speed {
       using argument_tags = tmpl::list<CharacteristicSpeed>;

--- a/tests/Unit/Time/TimeSteppers/CMakeLists.txt
+++ b/tests/Unit/Time/TimeSteppers/CMakeLists.txt
@@ -5,4 +5,5 @@ set(LIBRARY_SOURCES
   ${LIBRARY_SOURCES}
   TimeSteppers/Test_AdamsBashforthN.cpp
   TimeSteppers/Test_RungeKutta3.cpp
+  TimeSteppers/TimeStepperTestUtils.cpp
   PARENT_SCOPE)

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -138,6 +138,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Factory",
                   "[Unit][Time]") {
   test_factory_creation<TimeStepper>("  AdamsBashforthN:\n"
                                      "    Order: 3");
+  test_factory_creation<LtsTimeStepper>("  AdamsBashforthN:\n"
+                                        "    Order: 3");
   // Catch requires us to have at least one CHECK in each test
   // The Unit.Time.TimeSteppers.AdamsBashforthN.Factory does not need to
   // check anything
@@ -425,6 +427,8 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Serialization",
   TimeSteppers::AdamsBashforthN ab(4);
   test_serialization(ab);
   test_serialization_via_base<TimeStepper, TimeSteppers::AdamsBashforthN>(4_st);
+  test_serialization_via_base<LtsTimeStepper, TimeSteppers::AdamsBashforthN>(
+      4_st);
   // test operator !=
   TimeSteppers::AdamsBashforthN ab2(2);
   CHECK(ab != ab2);

--- a/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_AdamsBashforthN.cpp
@@ -32,14 +32,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN", "[Unit][Time]") {
     INFO(order);
     const TimeSteppers::AdamsBashforthN stepper(order);
     TimeStepperTestUtils::check_multistep_properties(stepper);
-    const double epsilon = std::max(std::pow(1e-3, order), 1e-14);
-    TimeStepperTestUtils::integrate_test(stepper, order - 1, 1., epsilon);
-  }
-
-  for (size_t order = 1; order < 9; ++order) {
-    INFO(order);
-    const TimeSteppers::AdamsBashforthN stepper(order);
-    TimeStepperTestUtils::check_multistep_properties(stepper);
     for (size_t start_points = 0; start_points < order; ++start_points) {
       INFO(start_points);
       const double epsilon = std::max(std::pow(1e-3, start_points + 1), 1e-14);
@@ -71,13 +63,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Variable",
                   "[Unit][Time]") {
   for (size_t order = 1; order < 9; ++order) {
     INFO(order);
-    const double epsilon = std::max(std::pow(1e-3, order), 1e-14);
-    TimeStepperTestUtils::integrate_variable_test(
-        TimeSteppers::AdamsBashforthN(order), order - 1, epsilon);
-  }
-
-  for (size_t order = 1; order < 9; ++order) {
-    INFO(order);
     for (size_t start_points = 0; start_points < order; ++start_points) {
       INFO(start_points);
       const double epsilon = std::max(std::pow(1e-3, start_points + 1), 1e-14);
@@ -89,13 +74,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Variable",
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.AdamsBashforthN.Backwards",
                   "[Unit][Time]") {
-  for (size_t order = 1; order < 9; ++order) {
-    INFO(order);
-    const double epsilon = std::max(std::pow(1e-3, order), 1e-14);
-    TimeStepperTestUtils::integrate_test(
-        TimeSteppers::AdamsBashforthN(order), order - 1, -1., epsilon);
-  }
-
   for (size_t order = 1; order < 9; ++order) {
     INFO(order);
     for (size_t start_points = 0; start_points < order; ++start_points) {

--- a/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
+++ b/tests/Unit/Time/TimeSteppers/Test_RungeKutta3.cpp
@@ -4,10 +4,6 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include "Parallel/PupStlCpp11.hpp"
-#include "Time/History.hpp"
-#include "Time/Slab.hpp"
-#include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
 #include "Time/TimeSteppers/RungeKutta3.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "tests/Unit/TestCreation.hpp"
@@ -18,13 +14,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3", "[Unit][Time]") {
   const TimeSteppers::RungeKutta3 stepper{};
   TimeStepperTestUtils::check_substep_properties(stepper);
   TimeStepperTestUtils::integrate_test(stepper, 0, 1., 1e-9);
-
-  const Slab slab(0., 1.);
-  const TimeId time_id(true, 0, slab.start());
-  TimeSteppers::History<double, double> history;
-  CHECK_FALSE(stepper.can_change_step_size(time_id, history));
-  history.insert(slab.start(), 0., 0.);
-  CHECK_FALSE(stepper.can_change_step_size(time_id, history));
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Variable",
@@ -37,13 +26,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Backwards",
                   "[Unit][Time]") {
   const TimeSteppers::RungeKutta3 stepper{};
   TimeStepperTestUtils::integrate_test(stepper, 0, -1., 1e-9);
-
-  const Slab slab(0., 1.);
-  const TimeId time_id(false, 0, slab.end());
-  TimeSteppers::History<double, double> history;
-  CHECK_FALSE(stepper.can_change_step_size(time_id, history));
-  history.insert(slab.start(), 0., 0.);
-  CHECK_FALSE(stepper.can_change_step_size(time_id, history));
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Stability",
@@ -58,18 +40,6 @@ SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Factory",
   // The Unit.Time.TimeSteppers.RungeKutta3.Factory does not need to
   // check anything
   CHECK(true);
-}
-
-SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Boundary.Equal",
-                  "[Unit][Time]") {
-  TimeStepperTestUtils::equal_rate_boundary(
-      TimeSteppers::RungeKutta3{}, 0, 1e-9, true);
-}
-
-SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Boundary.Equal.Backwards",
-                  "[Unit][Time]") {
-  TimeStepperTestUtils::equal_rate_boundary(
-      TimeSteppers::RungeKutta3{}, 0, 1e-9, false);
 }
 
 SPECTRE_TEST_CASE("Unit.Time.TimeSteppers.RungeKutta3.Serialization",

--- a/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.cpp
+++ b/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.cpp
@@ -1,0 +1,256 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "ErrorHandling/Assert.hpp"
+#include "Time/BoundaryHistory.hpp"
+#include "Time/History.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace TimeStepperTestUtils {
+
+namespace {
+template <typename F>
+void take_step(
+    const gsl::not_null<Time*> time,
+    const gsl::not_null<double*> y,
+    const gsl::not_null<TimeSteppers::History<double, double>*> history,
+    const TimeStepper& stepper,
+    F&& rhs,
+    const TimeDelta& step_size) noexcept {
+  TimeId time_id(step_size.is_positive(), 0, *time);
+  for (uint64_t substep = 0;
+       substep < stepper.number_of_substeps();
+       ++substep) {
+    CHECK(time_id.substep() == substep);
+    history->insert(time_id.time(), *y, rhs(*y));
+    stepper.update_u(y, history, step_size);
+    time_id = stepper.next_time_id(time_id, step_size);
+  }
+  CHECK(time_id.time() - *time == step_size);
+  *time = time_id.time();
+}
+
+template <typename F1, typename F2>
+void initialize_history(
+    Time time,
+    const gsl::not_null<TimeSteppers::History<double, double>*> history,
+    F1&& analytic,
+    F2&& rhs,
+    TimeDelta step_size,
+    const size_t number_of_past_steps) noexcept {
+  for (size_t j = 0; j < number_of_past_steps; ++j) {
+    ASSERT(time.slab() == step_size.slab(), "Slab mismatch");
+    if ((step_size.is_positive() and time.is_at_slab_start()) or
+        (not step_size.is_positive() and time.is_at_slab_end())) {
+      const Slab new_slab = time.slab().advance_towards(-step_size);
+      time = time.with_slab(new_slab);
+      step_size = step_size.with_slab(new_slab);
+    }
+    time -= step_size;
+    history->insert_initial(time, analytic(time.value()),
+                            rhs(analytic(time.value())));
+  }
+}
+}  // namespace
+
+void integrate_test(const TimeStepper& stepper,
+                    const size_t number_of_past_steps,
+                    const double integration_time,
+                    const double epsilon) noexcept {
+  auto analytic = [](double t) { return sin(t); };
+  auto rhs = [](double v) { return sqrt(1. - square(v)); };
+
+  const uint64_t num_steps = 800;
+  const Slab slab = integration_time > 0
+      ? Slab::with_duration_from_start(0., integration_time)
+      : Slab::with_duration_to_end(0., -integration_time);
+  const TimeDelta step_size = integration_time > 0
+      ? slab.duration() / num_steps
+      : -slab.duration() / num_steps;
+
+  Time time = integration_time > 0 ? slab.start() : slab.end();
+  double y = analytic(time.value());
+  TimeSteppers::History<double, double> history;
+
+  initialize_history(time, &history, analytic, rhs, step_size,
+                     number_of_past_steps);
+
+  for (uint64_t i = 0; i < num_steps; ++i) {
+    take_step(&time, &y, &history, stepper, rhs, step_size);
+    // This check needs a looser tolerance for lower-order time steppers.
+    CHECK(y == approx(analytic(time.value())).epsilon(epsilon));
+  }
+  // Make sure history is being cleaned up.  The limit of 20 is
+  // arbitrary, but much larger than the order of any integrators we
+  // care about and much smaller than the number of time steps in the
+  // test.
+  CHECK(history.size() < 20);
+}
+
+void integrate_variable_test(const TimeStepper& stepper,
+                             const size_t number_of_past_steps,
+                             const double epsilon) noexcept {
+  auto analytic = [](double t) { return sin(t); };
+  auto rhs = [](double v) { return sqrt(1. - square(v)); };
+
+  const uint64_t num_steps = 800;
+  const double average_step = 1. / num_steps;
+
+  Slab slab = Slab::with_duration_to_end(0., average_step);
+  Time time = slab.end();
+  double y = analytic(time.value());
+
+  TimeSteppers::History<double, double> history;
+  initialize_history(time, &history, analytic, rhs, slab.duration(),
+                     number_of_past_steps);
+
+  for (uint64_t i = 0; i < num_steps; ++i) {
+    slab = slab.advance().with_duration_from_start(
+        (1. + 0.5 * sin(i)) * average_step);
+    time = time.with_slab(slab);
+
+    take_step(&time, &y, &history, stepper, rhs, slab.duration());
+    // This check needs a looser tolerance for lower-order time steppers.
+    CHECK(y == approx(analytic(time.value())).epsilon(epsilon));
+  }
+}
+
+void stability_test(const TimeStepper& stepper) noexcept {
+  const uint64_t num_steps = 5000;
+  const double bracket_size = 1.1;
+
+  // This is integrating dy/dt = -2y, which is chosen so that the stable
+  // step size for Euler's method is 1.
+
+  // Stable region
+  {
+    const Slab slab = Slab::with_duration_from_start(
+        0., num_steps * stepper.stable_step() / bracket_size);
+    const TimeDelta step_size = slab.duration() / num_steps;
+
+    Time time = slab.start();
+    double y = 1.;
+    TimeSteppers::History<double, double> history;
+    initialize_history(time, &history,
+                       [](double t) { return exp(-2. * t); },
+                       [](double v) { return -2. * v; },
+                       step_size, stepper.number_of_past_steps());
+
+    for (uint64_t i = 0; i < num_steps; ++i) {
+      take_step(&time, &y, &history, stepper, [](double v) { return -2. * v; },
+                step_size);
+      CHECK(std::abs(y) < 10.);
+    }
+  }
+
+  // Unstable region
+  {
+    const Slab slab = Slab::with_duration_from_start(
+        0., num_steps * stepper.stable_step() * bracket_size);
+    const TimeDelta step_size = slab.duration() / num_steps;
+
+    Time time = slab.start();
+    double y = 1.;
+    TimeSteppers::History<double, double> history;
+    initialize_history(time, &history,
+                       [](double t) { return exp(-2. * t); },
+                       [](double v) { return -2. * v; },
+                       step_size, stepper.number_of_past_steps());
+
+    for (uint64_t i = 0; i < num_steps; ++i) {
+      take_step(&time, &y, &history, stepper, [](double v) { return -2. * v; },
+                step_size);
+      if (std::abs(y) > 10.) {
+        return;
+      }
+    }
+    CHECK(false);
+  }
+}
+
+void equal_rate_boundary(const LtsTimeStepper& stepper,
+                         const size_t number_of_past_steps,
+                         const double epsilon, const bool forward) noexcept {
+  // This does an integral putting the entire derivative into the
+  // boundary term.
+  const double unused_local_deriv = 4444.;
+
+  auto analytic = [](double t) { return sin(t); };
+  auto driver = [](double t) { return cos(t); };
+  auto coupling = [=](const double& local, const double& remote) {
+    CHECK(local == unused_local_deriv);
+    return remote;
+  };
+
+  Approx approx = Approx::custom().epsilon(epsilon);
+
+  const uint64_t num_steps = 100;
+  const Slab slab(0.875, 1.);
+  const TimeDelta step_size = (forward ? 1 : -1) * slab.duration() / num_steps;
+
+  TimeId time_id(forward, 0, forward ? slab.start() : slab.end());
+  double y = analytic(time_id.time().value());
+  TimeSteppers::History<double, double> volume_history;
+  TimeSteppers::BoundaryHistory<double, double, double> boundary_history;
+
+  {
+    Time history_time = time_id.time();
+    TimeDelta history_step_size = step_size;
+    for (size_t j = 0; j < number_of_past_steps; ++j) {
+      ASSERT(history_time.slab() == history_step_size.slab(), "Slab mismatch");
+      if ((history_step_size.is_positive() and
+           history_time.is_at_slab_start()) or
+          (not history_step_size.is_positive() and
+           history_time.is_at_slab_end())) {
+        const Slab new_slab =
+            history_time.slab().advance_towards(-history_step_size);
+        history_time = history_time.with_slab(new_slab);
+        history_step_size = history_step_size.with_slab(new_slab);
+      }
+      history_time -= history_step_size;
+      volume_history.insert_initial(history_time,
+                                    analytic(history_time.value()), 0.);
+      boundary_history.local_insert_initial(TimeId(forward, 0, history_time),
+                                            unused_local_deriv);
+      boundary_history.remote_insert_initial(TimeId(forward, 0, history_time),
+                                             driver(history_time.value()));
+    }
+  }
+
+  for (uint64_t i = 0; i < num_steps; ++i) {
+    for (uint64_t substep = 0;
+         substep < stepper.number_of_substeps();
+         ++substep) {
+      volume_history.insert(time_id.time(), y, 0.);
+      boundary_history.local_insert(time_id, unused_local_deriv);
+      boundary_history.remote_insert(time_id, driver(time_id.time().value()));
+
+      stepper.update_u(make_not_null(&y), make_not_null(&volume_history),
+                       step_size);
+      y += stepper.compute_boundary_delta(
+          coupling, make_not_null(&boundary_history), step_size);
+      time_id = stepper.next_time_id(time_id, step_size);
+    }
+    CHECK(y == approx(analytic(time_id.time().value())));
+  }
+  // Make sure history is being cleaned up.  The limit of 20 is
+  // arbitrary, but much larger than the order of any integrators we
+  // care about and much smaller than the number of time steps in the
+  // test.
+  CHECK(boundary_history.local_size() < 20);
+  CHECK(boundary_history.remote_size() < 20);
+}
+
+}  // namespace TimeStepperTestUtils

--- a/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp
+++ b/tests/Unit/Time/TimeSteppers/TimeStepperTestUtils.hpp
@@ -5,263 +5,31 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <cmath>
 #include <cstddef>
-#include <cstdint>
 
-#include "ErrorHandling/Assert.hpp"
-#include "Time/BoundaryHistory.hpp"
-#include "Time/History.hpp"
-#include "Time/Slab.hpp"
-#include "Time/Time.hpp"
-#include "Time/TimeId.hpp"
-#include "Utilities/ConstantExpressions.hpp"
-#include "Utilities/Gsl.hpp"
+#include "Time/TimeSteppers/TimeStepper.hpp"
 
 namespace TimeStepperTestUtils {
 
-template <typename Stepper, typename F>
-void take_step(
-    const gsl::not_null<Time*> time,
-    const gsl::not_null<double*> y,
-    const gsl::not_null<TimeSteppers::History<double, double>*> history,
-    const Stepper& stepper,
-    F&& rhs,
-    const TimeDelta& step_size) noexcept {
-  TimeId time_id(step_size.is_positive(), 0, *time);
-  for (uint64_t substep = 0;
-       substep < stepper.number_of_substeps();
-       ++substep) {
-    CHECK(time_id.substep() == substep);
-    history->insert(time_id.time(), *y, rhs(*y));
-    stepper.update_u(y, history, step_size);
-    time_id = stepper.next_time_id(time_id, step_size);
-  }
-  CHECK(time_id.time() - *time == step_size);
-  *time = time_id.time();
-}
-
-template <typename F1, typename F2>
-void initialize_history(
-    Time time,
-    const gsl::not_null<TimeSteppers::History<double, double>*> history,
-    F1&& analytic,
-    F2&& rhs,
-    TimeDelta step_size,
-    const size_t number_of_past_steps) noexcept {
-  for (size_t j = 0; j < number_of_past_steps; ++j) {
-    ASSERT(time.slab() == step_size.slab(), "Slab mismatch");
-    if ((step_size.is_positive() and time.is_at_slab_start()) or
-        (not step_size.is_positive() and time.is_at_slab_end())) {
-      const Slab new_slab = time.slab().advance_towards(-step_size);
-      time = time.with_slab(new_slab);
-      step_size = step_size.with_slab(new_slab);
-    }
-    time -= step_size;
-    history->insert_initial(time, analytic(time.value()),
-                            rhs(analytic(time.value())));
-  }
-}
-
-template <typename Stepper>
-void check_multistep_properties(const Stepper& stepper) noexcept {
+inline void check_multistep_properties(const TimeStepper& stepper) noexcept {
   CHECK(stepper.number_of_substeps() == 1);
 }
 
-template <typename Stepper>
-void check_substep_properties(const Stepper& stepper) noexcept {
+inline void check_substep_properties(const TimeStepper& stepper) noexcept {
   CHECK(stepper.number_of_past_steps() == 0);
 }
 
-template <typename Stepper>
-void integrate_test(const Stepper& stepper, const size_t number_of_past_steps,
-                    const double integration_time,
-                    const double epsilon) noexcept {
-  auto analytic = [](double t) { return sin(t); };
-  auto rhs = [](double v) { return sqrt(1. - square(v)); };
+void integrate_test(const TimeStepper& stepper, size_t number_of_past_steps,
+                    double integration_time, double epsilon) noexcept;
 
-  const uint64_t num_steps = 800;
-  const Slab slab = integration_time > 0
-      ? Slab::with_duration_from_start(0., integration_time)
-      : Slab::with_duration_to_end(0., -integration_time);
-  const TimeDelta step_size = integration_time > 0
-      ? slab.duration() / num_steps
-      : -slab.duration() / num_steps;
+void integrate_variable_test(const TimeStepper& stepper,
+                             size_t number_of_past_steps,
+                             double epsilon) noexcept;
 
-  Time time = integration_time > 0 ? slab.start() : slab.end();
-  double y = analytic(time.value());
-  TimeSteppers::History<double, double> history;
+void stability_test(const TimeStepper& stepper) noexcept;
 
-  initialize_history(time, &history, analytic, rhs, step_size,
-                     number_of_past_steps);
-
-  for (uint64_t i = 0; i < num_steps; ++i) {
-    take_step(&time, &y, &history, stepper, rhs, step_size);
-    // This check needs a looser tolerance for lower-order time steppers.
-    CHECK(y == approx(analytic(time.value())).epsilon(epsilon));
-  }
-  // Make sure history is being cleaned up.  The limit of 20 is
-  // arbitrary, but much larger than the order of any integrators we
-  // care about and much smaller than the number of time steps in the
-  // test.
-  CHECK(history.size() < 20);
-}
-
-template <typename Stepper>
-void integrate_variable_test(const Stepper& stepper,
-                             const size_t number_of_past_steps,
-                             const double epsilon) noexcept {
-  auto analytic = [](double t) { return sin(t); };
-  auto rhs = [](double v) { return sqrt(1. - square(v)); };
-
-  const uint64_t num_steps = 800;
-  const double average_step = 1. / num_steps;
-
-  Slab slab = Slab::with_duration_to_end(0., average_step);
-  Time time = slab.end();
-  double y = analytic(time.value());
-
-  TimeSteppers::History<double, double> history;
-  initialize_history(time, &history, analytic, rhs, slab.duration(),
-                     number_of_past_steps);
-
-  for (uint64_t i = 0; i < num_steps; ++i) {
-    slab = slab.advance().with_duration_from_start(
-        (1. + 0.5 * sin(i)) * average_step);
-    time = time.with_slab(slab);
-
-    take_step(&time, &y, &history, stepper, rhs, slab.duration());
-    // This check needs a looser tolerance for lower-order time steppers.
-    CHECK(y == approx(analytic(time.value())).epsilon(epsilon));
-  }
-}
-
-template <typename Stepper>
-void stability_test(const Stepper& stepper) noexcept {
-  const uint64_t num_steps = 5000;
-  const double bracket_size = 1.1;
-
-  // This is integrating dy/dt = -2y, which is chosen so that the stable
-  // step size for Euler's method is 1.
-
-  // Stable region
-  {
-    const Slab slab = Slab::with_duration_from_start(
-        0., num_steps * stepper.stable_step() / bracket_size);
-    const TimeDelta step_size = slab.duration() / num_steps;
-
-    Time time = slab.start();
-    double y = 1.;
-    TimeSteppers::History<double, double> history;
-    initialize_history(time, &history,
-                       [](double t) { return exp(-2. * t); },
-                       [](double v) { return -2. * v; },
-                       step_size, stepper.number_of_past_steps());
-
-    for (uint64_t i = 0; i < num_steps; ++i) {
-      take_step(&time, &y, &history, stepper, [](double v) { return -2. * v; },
-                step_size);
-      CHECK(std::abs(y) < 10.);
-    }
-  }
-
-  // Unstable region
-  {
-    const Slab slab = Slab::with_duration_from_start(
-        0., num_steps * stepper.stable_step() * bracket_size);
-    const TimeDelta step_size = slab.duration() / num_steps;
-
-    Time time = slab.start();
-    double y = 1.;
-    TimeSteppers::History<double, double> history;
-    initialize_history(time, &history,
-                       [](double t) { return exp(-2. * t); },
-                       [](double v) { return -2. * v; },
-                       step_size, stepper.number_of_past_steps());
-
-    for (uint64_t i = 0; i < num_steps; ++i) {
-      take_step(&time, &y, &history, stepper, [](double v) { return -2. * v; },
-                step_size);
-      if (std::abs(y) > 10.) {
-        return;
-      }
-    }
-    CHECK(false);
-  }
-}
-
-template <typename Stepper>
-void equal_rate_boundary(const Stepper& stepper,
-                         const size_t number_of_past_steps,
-                         const double epsilon, const bool forward) {
-  // This does an integral putting the entire derivative into the
-  // boundary term.
-  const double unused_local_deriv = 4444.;
-
-  auto analytic = [](double t) { return sin(t); };
-  auto driver = [](double t) { return cos(t); };
-  auto coupling = [=](const double& local, const double& remote) {
-    CHECK(local == unused_local_deriv);
-    return remote;
-  };
-
-  Approx approx = Approx::custom().epsilon(epsilon);
-
-  const uint64_t num_steps = 100;
-  const Slab slab(0.875, 1.);
-  const TimeDelta step_size = (forward ? 1 : -1) * slab.duration() / num_steps;
-
-  TimeId time_id(forward, 0, forward ? slab.start() : slab.end());
-  double y = analytic(time_id.time().value());
-  TimeSteppers::History<double, double> volume_history;
-  TimeSteppers::BoundaryHistory<double, double, double> boundary_history;
-
-  {
-    Time history_time = time_id.time();
-    TimeDelta history_step_size = step_size;
-    for (size_t j = 0; j < number_of_past_steps; ++j) {
-      ASSERT(history_time.slab() == history_step_size.slab(), "Slab mismatch");
-      if ((history_step_size.is_positive() and
-           history_time.is_at_slab_start()) or
-          (not history_step_size.is_positive() and
-           history_time.is_at_slab_end())) {
-        const Slab new_slab =
-            history_time.slab().advance_towards(-history_step_size);
-        history_time = history_time.with_slab(new_slab);
-        history_step_size = history_step_size.with_slab(new_slab);
-      }
-      history_time -= history_step_size;
-      volume_history.insert_initial(history_time,
-                                    analytic(history_time.value()), 0.);
-      boundary_history.local_insert_initial(TimeId(forward, 0, history_time),
-                                            unused_local_deriv);
-      boundary_history.remote_insert_initial(TimeId(forward, 0, history_time),
-                                             driver(history_time.value()));
-    }
-  }
-
-  for (uint64_t i = 0; i < num_steps; ++i) {
-    for (uint64_t substep = 0;
-         substep < stepper.number_of_substeps();
-         ++substep) {
-      volume_history.insert(time_id.time(), y, 0.);
-      boundary_history.local_insert(time_id, unused_local_deriv);
-      boundary_history.remote_insert(time_id, driver(time_id.time().value()));
-
-      stepper.update_u(make_not_null(&y), make_not_null(&volume_history),
-                       step_size);
-      y += stepper.compute_boundary_delta(
-          coupling, make_not_null(&boundary_history), step_size);
-      time_id = stepper.next_time_id(time_id, step_size);
-    }
-    CHECK(y == approx(analytic(time_id.time().value())));
-  }
-  // Make sure history is being cleaned up.  The limit of 20 is
-  // arbitrary, but much larger than the order of any integrators we
-  // care about and much smaller than the number of time steps in the
-  // test.
-  CHECK(boundary_history.local_size() < 20);
-  CHECK(boundary_history.remote_size() < 20);
-}
+void equal_rate_boundary(const LtsTimeStepper& stepper,
+                         size_t number_of_past_steps,
+                         double epsilon, bool forward) noexcept;
 
 }  // namespace TimeStepperTestUtils


### PR DESCRIPTION
The LTS interface is now in LtsTimeStepper (inherits from TimeStepper) and local time-stepping executables can enforce an LTS-capable time stepper at compile time.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
