### PR TITLE
Enable source terms in GrMhd executable

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -10,11 +10,13 @@
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Evolution/Actions/ComputeVolumeDuDt.hpp"
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"
+#include "Evolution/Actions/ComputeVolumeSources.hpp"
 #include "Evolution/Conservative/UpdatePrimitives.hpp"
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "IO/Observer/Actions.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesGlobalTimeStepping.hpp"
@@ -84,7 +86,7 @@ struct EvolutionMetavars {
   using compute_rhs = tmpl::flatten<tmpl::list<
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
-      Actions::ComputeVolumeDuDt,
+      Actions::ComputeVolumeSources, Actions::ComputeVolumeDuDt,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyBoundaryFluxesGlobalTimeStepping>,
@@ -115,7 +117,8 @@ struct EvolutionMetavars {
   using const_global_cache_tag_list =
       tmpl::list<analytic_solution_tag,
                  OptionTags::TypedTimeStepper<tmpl::conditional_t<
-                     local_time_stepping, LtsTimeStepper, TimeStepper>>>;
+                     local_time_stepping, LtsTimeStepper, TimeStepper>>,
+                 OptionTags::DampingParameter>;
 
   using domain_creator_tag = OptionTags::DomainCreator<3, Frame::Inertial>;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
@@ -20,11 +21,6 @@ class not_null;
 }  // namespace gsl
 
 class DataVector;
-
-namespace Tags {
-template <typename>
-struct Fluxes;
-}  // namespace Tags
 /// \endcond
 
 // IWYU pragma: no_forward_declare Tensor
@@ -60,11 +56,16 @@ namespace ValenciaDivClean {
  */
 struct ComputeFluxes {
   using return_tags =
-      tmpl::list<::Tags::Fluxes<grmhd::ValenciaDivClean::Tags::TildeD>,
-                 ::Tags::Fluxes<grmhd::ValenciaDivClean::Tags::TildeTau>,
-                 ::Tags::Fluxes<grmhd::ValenciaDivClean::Tags::TildeS<>>,
-                 ::Tags::Fluxes<grmhd::ValenciaDivClean::Tags::TildeB<>>,
-                 ::Tags::Fluxes<grmhd::ValenciaDivClean::Tags::TildePhi>>;
+      tmpl::list<::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeD,
+                              tmpl::size_t<3>, Frame::Inertial>,
+                 ::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeTau,
+                              tmpl::size_t<3>, Frame::Inertial>,
+                 ::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeS<>,
+                              tmpl::size_t<3>, Frame::Inertial>,
+                 ::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildeB<>,
+                              tmpl::size_t<3>, Frame::Inertial>,
+                 ::Tags::Flux<grmhd::ValenciaDivClean::Tags::TildePhi,
+                              tmpl::size_t<3>, Frame::Inertial>>;
 
   using argument_tags =
       tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp
@@ -20,6 +20,7 @@
 #include "Evolution/Initialization/Domain.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/Interface.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
@@ -44,9 +45,9 @@ struct Initialize {
   struct PrimitiveTags {
     using system = typename Metavariables::system;
     using primitives_tag = typename system::primitive_variables_tag;
-    using simple_tags =
-        db::AddSimpleTags<primitives_tag,
-                          typename Metavariables::equation_of_state_tag>;
+    using simple_tags = db::AddSimpleTags<
+        primitives_tag, typename Metavariables::equation_of_state_tag,
+        grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter>;
     using compute_tags = db::AddComputeTags<>;
 
     template <typename TagsList>
@@ -57,10 +58,10 @@ struct Initialize {
       using PrimitiveVars = typename primitives_tag::type;
 
       const size_t num_grid_points =
-          db::get<Tags::Mesh<Dim>>(box).number_of_grid_points();
+          db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points();
 
       const auto& inertial_coords =
-          db::get<Tags::Coordinates<Dim, Frame::Inertial>>(box);
+          db::get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
 
       // Set initial data from analytic solution
       using solution_tag = OptionTags::AnalyticSolutionBase;
@@ -95,7 +96,8 @@ struct Initialize {
 
       return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
           std::move(box), std::move(primitive_vars),
-          std::move(equation_of_state));
+          std::move(equation_of_state),
+          Parallel::get<OptionTags::DampingParameter>(cache));
     }
   };
 
@@ -113,9 +115,9 @@ struct Initialize {
       using GrVars = typename gr_tag::type;
 
       const size_t num_grid_points =
-          db::get<Tags::Mesh<Dim>>(box).number_of_grid_points();
+          db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points();
       const auto& inertial_coords =
-          db::get<Tags::Coordinates<Dim, Frame::Inertial>>(box);
+          db::get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
 
       // Set initial data from analytic solution
       using solution_tag = OptionTags::AnalyticSolutionBase;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Sources.cpp
@@ -9,8 +9,11 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"              // IWYU pragma: keep
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -71,8 +74,7 @@ tnsr::II<DataVector, 3, Frame::Inertial> densitized_stress(
 namespace grmhd {
 namespace ValenciaDivClean {
 
-void compute_source_terms_of_u(
-    gsl::not_null<Scalar<DataVector>*> source_tilde_d,
+void ComputeSources::apply(
     gsl::not_null<Scalar<DataVector>*> source_tilde_tau,
     gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> source_tilde_s,
     gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> source_tilde_b,
@@ -95,8 +97,6 @@ void compute_source_terms_of_u(
     const Scalar<DataVector>& sqrt_det_spatial_metric,
     const tnsr::ii<DataVector, 3, Frame::Inertial>& extrinsic_curvature,
     const double constraint_damping_parameter) noexcept {
-  get(*source_tilde_d) = 0.0;
-
   const auto tilde_s_M = raise_or_lower_index(tilde_s, inv_spatial_metric);
   const auto tilde_s_MN =
       densitized_stress(rest_mass_density, specific_enthalpy, lorentz_factor,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -13,6 +13,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Sources.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -53,12 +54,19 @@ struct System {
       ::Tags::Variables<tmpl::list<Tags::TildeD, Tags::TildeTau, Tags::TildeS<>,
                                    Tags::TildeB<>, Tags::TildePhi>>;
 
-  using spacetime_variables_tag = ::Tags::Variables<
-      tmpl::list<gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<3, Frame::Inertial, DataVector>,
-                 gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
-                 gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
-                 gr::Tags::SqrtDetSpatialMetric<DataVector>>>;
+  using spacetime_variables_tag = ::Tags::Variables<tmpl::list<
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                    Frame::Inertial>,
+      ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial>,
+      ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial>,
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>>;
 
   template <typename Tag>
   using magnitude_tag = ::Tags::NonEuclideanMagnitude<
@@ -74,10 +82,13 @@ struct System {
 
   using volume_fluxes = ComputeFluxes;
 
+  using volume_sources = ComputeSources;
+
   using du_dt = ConservativeDuDt<System>;
 
-  // hack for Minkowski plus not constraint damping
-  using sourced_variables = tmpl::list<>;
+  // skip TildeD as its source is zero.
+  using sourced_variables = tmpl::list<Tags::TildeTau, Tags::TildeS<>,
+                                       Tags::TildeB<>, Tags::TildePhi>;
 };
 }  // namespace ValenciaDivClean
 }  // namespace grmhd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp
@@ -9,8 +9,18 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"
+#include "Options/Options.hpp"
 
 class DataVector;
+
+namespace OptionTags {
+/// \brief The constraint damping parameter
+struct DampingParameter {
+  using type = double;
+  static constexpr OptionString help{
+      "constraint damping parameter for divergence cleaning"};
+};
+}  // namespace OptionTags
 
 namespace grmhd {
 namespace ValenciaDivClean {
@@ -22,6 +32,12 @@ namespace Tags {
 struct CharacteristicSpeeds : db::SimpleTag {
   using type = std::array<DataVector, 9>;
   static std::string name() noexcept { return "CharacteristicSpeeds"; }
+};
+
+/// The constraint damping parameter for divergence cleaning
+struct ConstraintDampingParameter : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "ConstraintDampingParameter"; }
 };
 
 /// The densitized rest-mass density \f${\tilde D}\f$

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp
@@ -14,6 +14,7 @@ namespace grmhd {
 namespace ValenciaDivClean {
 namespace Tags {
 struct CharacteristicSpeeds;
+struct ConstraintDampingParameter;
 struct TildeD;
 struct TildeTau;
 template <typename Fr = Frame::Inertial>

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -40,3 +40,5 @@ StepChoosers:
 VolumeFileName: "./GrMhd"
 
 NumericalFluxParams:
+
+DampingParameter: 0.0

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -160,14 +160,18 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
   CHECK(get_output(empty_vars) == "Variables is empty!");
 
   // Check self-assignment
+#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif  // defined(__clang__) && __clang_major__ > 6
+#endif  // ! __APPLE__
   v = v;
+#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic pop
 #endif  // defined(__clang__) && __clang_major__ > 6
+#endif  // ! __APPLE__
   CHECK(v == v2);
 
   CHECK(

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/TestFunctions.py
@@ -173,15 +173,6 @@ def tilde_phi_flux(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi, lapse,
 
 
 # Functions for testing Sources.cpp
-def source_tilde_d(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
-                   spatial_velocity, magnetic_field, rest_mass_density,
-                   specific_enthalpy, lorentz_factor, pressure,
-                   lapse, d_lapse, d_shift, spatial_metric, d_spatial_metric,
-                   inv_spatial_metric, sqrt_det_spatial_metric,
-                   extrinsic_curvature, constraint_damping_parameter):
-    return 0.0
-
-
 def source_tilde_tau(tilde_d, tilde_tau, tilde_s, tilde_b, tilde_phi,
                      spatial_velocity, magnetic_field, rest_mass_density,
                      specific_enthalpy, lorentz_factor, pressure,

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Sources.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Sources.cpp
@@ -17,8 +17,8 @@ SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Sources", "[Unit][GrMhd]") {
       "Evolution/Systems/GrMhd/ValenciaDivClean"};
 
   pypp::check_with_random_values<1>(
-      &grmhd::ValenciaDivClean::compute_source_terms_of_u, "TestFunctions",
-      {"source_tilde_d", "source_tilde_tau", "source_tilde_s", "source_tilde_b",
+      &grmhd::ValenciaDivClean::ComputeSources::apply, "TestFunctions",
+      {"source_tilde_tau", "source_tilde_s", "source_tilde_b",
        "source_tilde_phi"},
       {{{0.0, 1.0}}}, DataVector{5});
 }

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -84,15 +84,19 @@ void test_copy_semantics(const T& a) {
   // constructor
   const T c(a);  // NOLINT
   CHECK(c == a);
+#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif  // defined(__clang__) && __clang_major__ > 6
+#endif  // ! __APPLE__
   // clang-tidy: self-assignment
   b = b;  // NOLINT
+#ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic pop
 #endif  // defined(__clang__) && __clang_major__ > 6
+#endif  // ! __APPLE__
   CHECK(b == a);
 }
 


### PR DESCRIPTION
## Proposed changes

Adds the source terms to the volume computation of the time derivatives of the conservative variables.

Fixes #1038 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
