### PR TITLE
Add limiter to Burgers executable

### DIFF
--- a/src/Evolution/Executables/Burgers/CMakeLists.txt
+++ b/src/Evolution/Executables/Burgers/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBS_TO_LINK
   DomainCreators
   Informer
   LinearOperators
+  SlopeLimiters
   Time
   Utilities
   )

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -13,6 +13,9 @@
 #include "Evolution/Actions/ComputeVolumeFluxes.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/LimiterActions.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Tags.hpp"
 #include "Evolution/Systems/Burgers/Equations.hpp"  // IWYU pragma: keep // for LocalLaxFriedrichsFlux
 #include "Evolution/Systems/Burgers/System.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesGlobalTimeStepping.hpp"  // IWYU pragma: keep
@@ -24,13 +27,13 @@
 #include "Parallel/GotoAction.hpp"  // IWYU pragma: keep
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Time/Actions/AdvanceTime.hpp"  // IWYU pragma: keep
-#include "Time/Actions/SelfStartActions.hpp"  // IWYU pragma: keep
 #include "Time/Actions/ChangeStepSize.hpp"  // IWYU pragma: keep
 #include "Time/Actions/FinalTime.hpp"  // IWYU pragma: keep
 #include "Time/Actions/RecordTimeStepperData.hpp"  // IWYU pragma: keep
+#include "Time/Actions/SelfStartActions.hpp"  // IWYU pragma: keep
 #include "Time/Actions/UpdateU.hpp"  // IWYU pragma: keep
 #include "Time/StepChoosers/Cfl.hpp"  // IWYU pragma: keep
 #include "Time/StepChoosers/Constant.hpp"  // IWYU pragma: keep
@@ -56,10 +59,12 @@ struct EvolutionMetavars {
   using temporal_id = Tags::TimeId;
   static constexpr bool local_time_stepping = false;
   using analytic_solution_tag =
-      OptionTags::AnalyticSolution<Burgers::Solutions::Linear>;
+      OptionTags::AnalyticSolution<Burgers::Solutions::Step>;
   using boundary_condition_tag = analytic_solution_tag;
   using normal_dot_numerical_flux =
       OptionTags::NumericalFluxParams<Burgers::LocalLaxFriedrichsFlux>;
+  using limiter = OptionTags::SlopeLimiterParams<
+      SlopeLimiters::Minmod<1, system::variables_tag::tags_list>>;
   using const_global_cache_tag_list =
       tmpl::list<analytic_solution_tag,
                  OptionTags::TypedTimeStepper<tmpl::conditional_t<
@@ -75,8 +80,7 @@ struct EvolutionMetavars {
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeVolumeDuDt,
-      dg::Actions::ImposeDirichletBoundaryConditions<
-          EvolutionMetavars>,
+      dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyBoundaryFluxesGlobalTimeStepping>,
@@ -85,7 +89,9 @@ struct EvolutionMetavars {
       tmpl::conditional_t<local_time_stepping,
                           dg::Actions::ApplyBoundaryFluxesLocalTimeStepping,
                           tmpl::list<>>,
-      Actions::UpdateU>>;
+      Actions::UpdateU,
+      SlopeLimiters::Actions::SendData<EvolutionMetavars>,
+      SlopeLimiters::Actions::Limit<EvolutionMetavars>>>;
 
   struct EvolvePhaseStart;
   using component_list = tmpl::list<DgElementArray<

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -54,7 +54,7 @@ class CProxy_ConstGlobalCache;
 struct EvolutionMetavars {
   using system = Burgers::System;
   using temporal_id = Tags::TimeId;
-  static constexpr bool local_time_stepping = true;
+  static constexpr bool local_time_stepping = false;
   using analytic_solution_tag =
       OptionTags::AnalyticSolution<Burgers::Solutions::Linear>;
   using boundary_condition_tag = analytic_solution_tag;
@@ -120,9 +120,6 @@ struct EvolutionMetavars {
 
 static const std::vector<void (*)()> charm_init_node_funcs{
     &setup_error_handling, &DomainCreators::register_derived_with_charm,
-    &Parallel::register_derived_classes_with_charm<
-        StepChooser<EvolutionMetavars::step_choosers>>,
-    &Parallel::register_derived_classes_with_charm<StepController>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -43,6 +43,7 @@
 #include "Time/StepChoosers/Constant.hpp"          // IWYU pragma: keep
 #include "Time/StepChoosers/Increase.hpp"          // IWYU pragma: keep
 #include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/StepControllers/StepController.hpp"
 #include "Time/Tags.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Utilities/Functional.hpp"
@@ -64,7 +65,7 @@ struct EvolutionMetavars {
   // Customization/"input options" to simulation
   using system = ScalarWave::System<Dim>;
   using temporal_id = Tags::TimeId;
-  static constexpr bool local_time_stepping = false;
+  static constexpr bool local_time_stepping = true;
   using analytic_solution_tag =
       OptionTags::AnalyticSolution<ScalarWave::Solutions::PlaneWave<Dim>>;
   using boundary_condition_tag = analytic_solution_tag;
@@ -161,6 +162,7 @@ static const std::vector<void (*)()> charm_init_node_funcs{
     &Parallel::register_derived_classes_with_charm<MathFunction<1>>,
     &Parallel::register_derived_classes_with_charm<
         StepChooser<metavariables::step_choosers>>,
+    &Parallel::register_derived_classes_with_charm<StepController>,
     &Parallel::register_derived_classes_with_charm<TimeStepper>};
 static const std::vector<void (*)()> charm_init_proc_funcs{
     &enable_floating_point_exceptions};

--- a/src/Evolution/Systems/Burgers/System.hpp
+++ b/src/Evolution/Systems/Burgers/System.hpp
@@ -16,6 +16,9 @@
 /// \ingroup EvolutionSystemsGroup
 /// \brief Items related to evolving the %Burgers equation
 /// \f$0 = \partial_t U + \partial_x\left(U^2/2\right)\f$.
+///
+/// \note For this definition (i.e., with the factor of one half in the flux)
+/// of the Burgers system, the local characteristic speed is \f$U\f$.
 namespace Burgers {
 struct System {
   static constexpr bool is_conservative = true;

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY BurgersSolutions)
 set(LIBRARY_SOURCES
   Bump.cpp
   Linear.cpp
+  Step.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.cpp
@@ -1,0 +1,77 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp"
+
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp"  // IWYU pragma: keep
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace Burgers {
+namespace Solutions {
+
+Step::Step(const double left_value, const double right_value,
+           const double initial_shock_position, const OptionContext& context)
+    : left_value_(left_value),
+      right_value_(right_value),
+      initial_shock_position_(initial_shock_position) {
+  if (left_value <= right_value) {
+    PARSE_ERROR(context, "Shock solution expects left_value > right_value");
+  }
+}
+
+template <typename T>
+Scalar<T> Step::u(const tnsr::I<T, 1>& x, const double t) const noexcept {
+  const double current_shock_position =
+      initial_shock_position_ + 0.5 * (left_value_ + right_value_) * t;
+  return Scalar<T>(left_value_ -
+                   (left_value_ - right_value_) *
+                       step_function(get<0>(x) - current_shock_position));
+}
+
+template <typename T>
+Scalar<T> Step::du_dt(const tnsr::I<T, 1>& x, const double /*t*/) const
+    noexcept {
+  return make_with_value<Scalar<T>>(x, 0.0);
+}
+
+tuples::TaggedTuple<Tags::U> Step::variables(const tnsr::I<DataVector, 1>& x,
+                                             const double t,
+                                             tmpl::list<Tags::U> /*meta*/) const
+    noexcept {
+  return {u(x, t)};
+}
+
+tuples::TaggedTuple<::Tags::dt<Tags::U>> Step::variables(
+    const tnsr::I<DataVector, 1>& x, const double t,
+    tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const noexcept {
+  return {du_dt(x, t)};
+}
+
+void Step::pup(PUP::er& p) noexcept {
+  p | left_value_;
+  p | right_value_;
+  p | initial_shock_position_;
+}
+
+}  // namespace Solutions
+}  // namespace Burgers
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                      \
+  template Scalar<DTYPE(data)> Burgers::Solutions::Step::u(       \
+      const tnsr::I<DTYPE(data), 1>& x, double t) const noexcept; \
+  template Scalar<DTYPE(data)> Burgers::Solutions::Step::du_dt(   \
+      const tnsr::I<DTYPE(data), 1>& x, double t) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+// IWYU pragma: no_forward_declare Tensor
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Burgers {
+namespace Solutions {
+/// \brief A propagating shock between two constant states
+///
+/// The shock propagates left-to-right, with profile
+/// \f$U(x, t) = U_R + (U_L - U_R) H(-(x - x_0 - v t))\f$.
+/// Here \f$U_L\f$ and \f$U_R\f$ are the left and right constant states,
+/// satisfying \f$U_L > U_R\f$; \f$H\f$ is the Heaviside function; \f$x_0\f$ is
+/// the initial (i.e., \f$t=0\f$) position of the shock; and
+/// \f$v = 0.5 (U_L + U_R)\f$ is the speed of the shock.
+///
+/// \note At the shock, where \f$x = x_0 + vt\f$, we have \f$U(x, t) = U_L\f$.
+/// (This is inherited from the Heaviside implementation `step_function`.)
+/// Additionally, the time derivative \f$\partial_t u0\f$ is zero, rather than
+/// the correct delta function.
+class Step {
+ public:
+  struct LeftValue {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static type default_value() { return 2.0; }
+    static constexpr OptionString help{"The value of U, left of the shock"};
+  };
+  struct RightValue {
+    using type = double;
+    static type lower_bound() { return 0.0; }
+    static type default_value() { return 1.0; }
+    static constexpr OptionString help{"The value of U, right of the shock"};
+  };
+  struct InitialPosition {
+    using type = double;
+    static constexpr OptionString help{"The shock's position at t==0"};
+  };
+
+  using options = tmpl::list<LeftValue, RightValue, InitialPosition>;
+  static constexpr OptionString help{"A propagating shock solution"};
+
+  Step(double left_value, double right_value, double initial_shock_position,
+       const OptionContext& context = {});
+
+  Step() = default;
+  Step(const Step&) noexcept = default;
+  Step& operator=(const Step&) noexcept = default;
+  Step(Step&&) noexcept = default;
+  Step& operator=(Step&&) noexcept = default;
+  ~Step() noexcept = default;
+
+  template <typename T>
+  Scalar<T> u(const tnsr::I<T, 1>& x, double t) const noexcept;
+
+  template <typename T>
+  Scalar<T> du_dt(const tnsr::I<T, 1>& x, double t) const noexcept;
+
+  tuples::TaggedTuple<Tags::U> variables(const tnsr::I<DataVector, 1>& x,
+                                         double t,
+                                         tmpl::list<Tags::U> /*meta*/) const
+      noexcept;
+
+  tuples::TaggedTuple<::Tags::dt<Tags::U>> variables(
+      const tnsr::I<DataVector, 1>& x, double t,
+      tmpl::list<::Tags::dt<Tags::U>> /*meta*/) const noexcept;
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+ private:
+  double left_value_ = std::numeric_limits<double>::signaling_NaN();
+  double right_value_ = std::numeric_limits<double>::signaling_NaN();
+  double initial_shock_position_ = std::numeric_limits<double>::signaling_NaN();
+};
+}  // namespace Solutions
+}  // namespace Burgers

--- a/tests/InputFiles/Burgers/Linear.yaml
+++ b/tests/InputFiles/Burgers/Linear.yaml
@@ -10,7 +10,6 @@ AnalyticSolution:
 InitialTime: 0.0
 FinalTime: 0.1
 InitialTimeStep: 0.001
-InitialSlabSize: 0.01
 
 DomainCreator:
   Interval:
@@ -23,14 +22,5 @@ DomainCreator:
 TimeStepper:
   AdamsBashforthN:
     Order: 3
-
-StepController: BinaryFraction
-
-StepChoosers:
-  - Constant: 0.05
-  - Increase:
-      Factor: 2
-  - Cfl:
-      SafetyFactor: 0.2
 
 NumericalFluxParams:

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -5,7 +5,9 @@
 # Check: execute
 
 AnalyticSolution:
-  ShockTime: -1.
+  LeftValue: 2.
+  RightValue: 1.
+  InitialPosition: -0.5
 
 InitialTime: 0.0
 FinalTime: 0.1
@@ -24,3 +26,6 @@ TimeStepper:
     Order: 3
 
 NumericalFluxParams:
+
+SlopeLimiterParams:
+  Type: LambdaPi1

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -15,7 +15,8 @@ AnalyticSolution:
 
 InitialTime: 0.0
 FinalTime: 0.1
-InitialTimeStep: 0.01
+InitialTimeStep: 0.001
+InitialSlabSize: 0.01
 
 DomainCreator:
   Interval:
@@ -28,6 +29,15 @@ DomainCreator:
 TimeStepper:
   AdamsBashforthN:
     Order: 3
+
+StepController: BinaryFraction
+
+StepChoosers:
+  - Constant: 0.05
+  - Increase:
+      Factor: 2
+  - Cfl:
+      SafetyFactor: 0.2
 
 NumericalFluxParams:
 

--- a/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
@@ -14,8 +14,9 @@ AnalyticSolution:
       Phase: 0.0
 
 InitialTime: 0.0
-FinalTime: 0.1
-InitialTimeStep: 0.01
+FinalTime: 0.05
+InitialTimeStep: 0.001
+InitialSlabSize: 0.01
 
 DomainCreator:
   Rectangle:
@@ -28,6 +29,15 @@ DomainCreator:
 TimeStepper:
   AdamsBashforthN:
     Order: 3
+
+StepController: BinaryFraction
+
+StepChoosers:
+  - Constant: 0.05
+  - Increase:
+      Factor: 2
+  - Cfl:
+      SafetyFactor: 0.2
 
 NumericalFluxParams:
 

--- a/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
@@ -15,7 +15,8 @@ AnalyticSolution:
 
 InitialTime: 0.0
 FinalTime: 0.05
-InitialTimeStep: 0.01
+InitialTimeStep: 0.001
+InitialSlabSize: 0.01
 
 DomainCreator:
   Brick:
@@ -28,6 +29,15 @@ DomainCreator:
 TimeStepper:
   AdamsBashforthN:
     Order: 3
+
+StepController: BinaryFraction
+
+StepChoosers:
+  - Constant: 0.05
+  - Increase:
+      Factor: 2
+  - Cfl:
+      SafetyFactor: 0.2
 
 NumericalFluxParams:
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_BurgersSolutions")
 set(LIBRARY_SOURCES
   Test_Bump.cpp
   Test_Linear.cpp
+  Test_Step.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Bump.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Bump.cpp
@@ -7,8 +7,11 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Burgers/Bump.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/CheckBurgersSolution.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -33,8 +36,12 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Bump",
           tnsr::I<DataVector, 1>{{{positions}}}, 0.)),
       height * (1. - square((positions - center) / half_width)));
 
-  test_creation<Burgers::Solutions::Bump>(
+  const auto created_solution = test_creation<Burgers::Solutions::Bump>(
       "  HalfWidth: 5.\n"
       "  Height: 3.\n"
       "  Center: -8.\n");
+  const auto x = tnsr::I<DataVector, 1>{{{positions}}};
+  const double t = 0.0;
+  CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==
+        solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Linear.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Linear.cpp
@@ -7,7 +7,10 @@
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/CheckBurgersSolution.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -29,5 +32,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Linear",
                             tnsr::I<DataVector, 1>{{{positions}}}, 0.)),
                         positions / -shock_time);
 
-  test_creation<Burgers::Solutions::Linear>("  ShockTime: 1.5");
+  const auto created_solution =
+      test_creation<Burgers::Solutions::Linear>("  ShockTime: 1.5");
+  const auto x = tnsr::I<DataVector, 1>{{{positions}}};
+  const double t = 0.0;
+  CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==
+        solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}));
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Step.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/Test_Step.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <vector>  // IWYU pragma: keep
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Burgers/Step.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/PointwiseFunctions/AnalyticSolutions/Burgers/CheckBurgersSolution.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Burgers.Step",
+                  "[PointwiseFunctions][Unit]") {
+  const double left_value = 2.3;
+  const double right_value = 1.2;
+  const double initial_position = -0.5;
+  const Burgers::Solutions::Step solution(left_value, right_value,
+                                          initial_position);
+  const DataVector positions{-1., 0., 1., 2.5};
+
+  // Check that the initial profile is correct.
+  const DataVector expected_initial_profile =
+      right_value +
+      (left_value - right_value) *
+          step_function(DataVector(-positions + initial_position));
+  CHECK_ITERABLE_APPROX(
+      get(solution.u(tnsr::I<DataVector, 1>{{{positions}}}, 0.)),
+      expected_initial_profile);
+
+  // Check serialization
+  CHECK_ITERABLE_APPROX(get(serialize_and_deserialize(solution).u(
+                            tnsr::I<DataVector, 1>{{{positions}}}, 0.)),
+                        expected_initial_profile);
+
+  // Check consistency
+  // Note that we avoid checking at any times where x_i == x0 + speed * t,
+  // because at these times the shock is near a grid point and the jump in the
+  // solution breaks the tests of check_burgers_solution
+  check_burgers_solution(solution, positions, {0., 0.7, 1.2, 10.0});
+
+  const auto created_solution = test_creation<Burgers::Solutions::Step>(
+      "  LeftValue: 2.3\n"
+      "  RightValue: 1.2\n"
+      "  InitialPosition: -0.5");
+  const auto x = tnsr::I<DataVector, 1>{{{positions}}};
+  const double t = 0.0;
+  CHECK(created_solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}) ==
+        solution.variables(x, t, tmpl::list<Burgers::Tags::U>{}));
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
@@ -24,12 +24,16 @@
 namespace {
 
 void test_create_from_options() noexcept {
-  test_creation<NewtonianEuler::Solutions::IsentropicVortex>(
-      "  AdiabaticIndex: 1.43\n"
-      "  Center: [2.3, -1.3, -0.6]\n"
-      "  MeanVelocity: [-0.3, 0.1, 0.7]\n"
-      "  PerturbAmplitude: 0.5\n"
-      "  Strength: 3.76");
+  const auto created_solution =
+      test_creation<NewtonianEuler::Solutions::IsentropicVortex>(
+          "  AdiabaticIndex: 1.43\n"
+          "  Center: [2.3, -1.3, -0.6]\n"
+          "  MeanVelocity: [-0.3, 0.1, 0.7]\n"
+          "  PerturbAmplitude: 0.5\n"
+          "  Strength: 3.76");
+  CHECK(created_solution ==
+        NewtonianEuler::Solutions::IsentropicVortex(
+            1.43, {{2.3, -1.3, -0.6}}, {{-0.3, 0.1, 0.7}}, 0.5, 3.76));
 }
 
 void test_move() noexcept {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_PlaneWave.cpp
@@ -157,12 +157,20 @@ void test_1d() {
       std::array<DataVector, 2>{{-6.0 * omega * kx * u, 6.0 * square(kx) * u}},
       deserialized_pw, x, t);
 
-  test_creation<ScalarWave::Solutions::PlaneWave<1>>(
-      "  WaveVector: [3.5]\n"
-      "  Center: [3.5]\n"
-      "  Profile:\n"
-      "    PowX:\n"
-      "      Power: 4");
+  const auto created_solution =
+      test_creation<ScalarWave::Solutions::PlaneWave<1>>(
+          "  WaveVector: [-1.5]\n"
+          "  Center: [2.4]\n"
+          "  Profile:\n"
+          "    PowX:\n"
+          "      Power: 3");
+  CHECK(
+      created_solution.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<1>, ScalarWave::Psi>{}) ==
+      pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<1>, ScalarWave::Psi>{}));
 }
 
 void test_2d() {
@@ -209,12 +217,20 @@ void test_2d() {
           {-6.0 * omega * ky * u, 6.0 * kx * ky * u, 6.0 * square(ky) * u}},
       deserialized_pw, x, t);
 
-  test_creation<ScalarWave::Solutions::PlaneWave<2>>(
-      "  WaveVector: [-2, 3.5]\n"
-      "  Center: [-2, 3.5]\n"
-      "  Profile:\n"
-      "    PowX:\n"
-      "      Power: 4");
+  const auto created_solution =
+      test_creation<ScalarWave::Solutions::PlaneWave<2>>(
+          "  WaveVector: [1.5, -7.2]\n"
+          "  Center: [2.4, -4.8]\n"
+          "  Profile:\n"
+          "    PowX:\n"
+          "      Power: 3");
+  CHECK(
+      created_solution.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<2>, ScalarWave::Psi>{}) ==
+      pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<2>, ScalarWave::Psi>{}));
 }
 
 void test_3d() {
@@ -279,12 +295,20 @@ void test_3d() {
                                  6.0 * ky * kz * u, 6.0 * square(kz) * u}},
       deserialized_pw, x, t);
 
-  test_creation<ScalarWave::Solutions::PlaneWave<3>>(
-      "  WaveVector: [-1, -2, 3.5]\n"
-      "  Center: [-1, -2, 3.5]\n"
-      "  Profile:\n"
-      "    PowX:\n"
-      "      Power: 4");
+  const auto created_solution =
+      test_creation<ScalarWave::Solutions::PlaneWave<3>>(
+          "  WaveVector: [1.5, -7.2, 2.7]\n"
+          "  Center: [2.4, -4.8, 8.4]\n"
+          "  Profile:\n"
+          "    PowX:\n"
+          "      Power: 3");
+  CHECK(
+      created_solution.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{}) ==
+      pw.variables(
+          x, t,
+          tmpl::list<ScalarWave::Pi, ScalarWave::Phi<3>, ScalarWave::Psi>{}));
 }
 }  // namespace
 


### PR DESCRIPTION
Before this is fully ready to go, I think the following is needed:
- (by the group:) Discussion of how the limiter actions should be bundled into the actions list
- (by me:) Cleaning up of tags for initializing limiter

But I'm putting this PR in now so the code can be used as reference ASAP.

Commit order:
1. Add a step function shock solution for Burgers
2. Clarify shock speed in Burgers documentation
3. Enable LTS in ScalarWave executable
4. Disable LTS in Burgers executable
5. Add limiter to Burgers executable

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).