### PR TITLE
Add InterpolatorRegisterElement.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp
@@ -1,0 +1,50 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace intrp {
+namespace Actions {
+
+/// \ingroup ActionsGroup
+/// \brief Called by each local Element to register itself with an Interpolator.
+///
+/// Uses: nothing
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `Tags::NumberOfElements`
+///
+/// For requirements on Metavariables, see InterpolationTarget.
+struct RegisterElement {
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<tmpl::list_contains_v<DbTags, typename Tags::NumberOfElements>> =
+          nullptr>
+  static void apply(db::DataBox<DbTags>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    db::mutate<Tags::NumberOfElements>(
+        make_not_null(&box), [](const gsl::not_null<
+                                 db::item_type<Tags::NumberOfElements>*>
+                                    num_elements) noexcept {
+          ++(*num_elements);
+        });
+  }
+};
+
+}  // namespace Actions
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_BarycentricRational.cpp
   Test_InitializeInterpolationTarget.cpp
   Test_InitializeInterpolator.cpp
+  Test_InterpolatorRegisterElement.cpp
   Test_IrregularInterpolant.cpp
   Test_LagrangePolynomial.cpp
   )

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp" // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp" // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+/// \cond
+class DataVector;
+namespace intrp {
+namespace Tags {
+struct NumberOfElements;
+} // namespace Tags
+} // namespace intrp
+/// \endcond
+
+namespace {
+
+template <typename Metavariables, size_t VolumeDim>
+struct mock_interpolator {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename ::intrp::Actions::InitializeInterpolator<
+          VolumeDim>::template return_tag_list<Metavariables>>;
+};
+
+struct MockMetavariables {
+  struct InterpolatorTargetA {
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::Lapse<DataVector>>;
+  };
+  using temporal_id = Time;
+  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;
+
+  using component_list = tmpl::list<mock_interpolator<MockMetavariables, 3>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialize, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.RegisterElement",
+                  "[Unit]") {
+  using metavars = MockMetavariables;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  using TupleOfMockDistributedObjects =
+      MockRuntimeSystem::TupleOfMockDistributedObjects;
+  TupleOfMockDistributedObjects dist_objects{};
+  using MockDistributedObjectsTag =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolator<metavars, 3>>;
+  tuples::get<MockDistributedObjectsTag>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<
+                      mock_interpolator<metavars, 3>>{});
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
+
+  runner.simple_action<mock_interpolator<metavars, 3>,
+                       ::intrp::Actions::InitializeInterpolator<3>>(0);
+
+  const auto& box =
+      runner.template algorithms<mock_interpolator<metavars, 3>>()
+          .at(0)
+          .template get_databox<
+              typename mock_interpolator<metavars, 3>::initial_databox>();
+
+  CHECK(db::get<::intrp::Tags::NumberOfElements>(box) == 0);
+
+  runner.simple_action<mock_interpolator<metavars, 3>,
+                       ::intrp::Actions::RegisterElement>(0);
+
+  CHECK(db::get<::intrp::Tags::NumberOfElements>(box) == 1);
+
+  runner.simple_action<mock_interpolator<metavars, 3>,
+                       ::intrp::Actions::RegisterElement>(0);
+
+  CHECK(db::get<::intrp::Tags::NumberOfElements>(box) == 2);
+}
+
+}  // namespace


### PR DESCRIPTION
This is another PR adding to the ParallelInterpolation framework.

This is independent of #1052

### Types of changes:

- [x] New feature

### Component:

- [x] Code
### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
