### PR TITLE
Add support for h-refined grids in Minmod limiter

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -32,6 +32,8 @@ template <size_t VolumeDim>
 class ElementId;
 template <size_t>
 class Mesh;
+template <size_t>
+class OrientationMap;
 
 namespace PUP {
 class er;
@@ -164,8 +166,10 @@ namespace SlopeLimiters {
 ///    some (untested) tweaks that try to reduce spurious limiter activations
 ///    near these fake kinks.
 ///
-/// The limiter as implemented expects an element to have one neighbor in each
-/// direction, and therefore does not support h-refinement.
+/// When an element has multiple neighbors in any direction, an effective mean
+/// and neighbor size in this direction are computed by averaging over the
+/// multiple neighbors. This simple generalization of the minmod limiter enables
+/// it to operate on h-refined grids.
 ///
 /// \tparam VolumeDim The number of spatial dimensions.
 /// \tparam Tags A typelist of tags specifying the tensors to limit.


### PR DESCRIPTION
Add support for h-refined grids in the Minmod limiter, by handling the case where an element has multiple neighbors in one direction. The new algorithm computes an "effective" neighbor state by averaging over the different neighbors.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
