### PR TITLE
Enable minmod limiter for GrMhd

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBS_TO_LINK
   Informer
   LinearOperators
   MathFunctions
+  SlopeLimiters
   Time
   Utilities
   ValenciaDivClean

--- a/src/Evolution/Initialization/Limiter.hpp
+++ b/src/Evolution/Initialization/Limiter.hpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/SizeOfElement.hpp"
+
+namespace Initialization {
+
+/// \brief Allocate items for minmod limiter
+///
+/// DataBox changes:
+/// - Adds:
+///   * `Tags::SizeOfElement<Dim>`
+///
+/// - Removes: nothing
+/// - Modifies: nothing
+template <size_t Dim>
+struct MinMod {
+  using simple_tags = db::AddSimpleTags<>;
+  using compute_tags = tmpl::list<Tags::SizeOfElement<Dim>>;
+  template <typename TagsList>
+  static auto initialize(db::DataBox<TagsList>&& box) noexcept {
+    return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+        std::move(box));
+  }
+};
+
+}  // namespace Initialization

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp
@@ -20,6 +20,7 @@
 #include "Evolution/Initialization/Domain.hpp"
 #include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/Interface.hpp"
+#include "Evolution/Initialization/Limiter.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
 #include "Parallel/ConstGlobalCache.hpp"
@@ -144,6 +145,7 @@ struct Initialize {
           typename Metavariables::system>::simple_tags,
       typename Initialization::DiscontinuousGalerkin<
           Metavariables>::simple_tags,
+      typename Initialization::MinMod<Dim>::simple_tags,
       typename Initialization::Domain<Dim>::compute_tags,
       typename GrTags<typename Metavariables::system>::compute_tags,
       typename PrimitiveTags<Metavariables>::compute_tags,
@@ -154,7 +156,8 @@ struct Initialize {
       typename Initialization::Evolution<
           typename Metavariables::system>::compute_tags,
       typename Initialization::DiscontinuousGalerkin<
-          Metavariables>::compute_tags>;
+          Metavariables>::compute_tags,
+      typename Initialization::MinMod<Dim>::compute_tags>;
 
   template <typename... InboxTags, typename Metavariables, typename ActionList,
             typename ParallelComponent>
@@ -188,8 +191,9 @@ struct Initialize {
     auto dg_box =
         Initialization::DiscontinuousGalerkin<Metavariables>::initialize(
             std::move(evolution_box), initial_extents);
-    // Note, no support for non-self-starting yet as the history is empty
-    return std::make_tuple(std::move(dg_box));
+    auto limiter_box =
+        Initialization::MinMod<Dim>::initialize(std::move(dg_box));
+    return std::make_tuple(std::move(limiter_box));
   }
 };
 }  // namespace Actions

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -5,9 +5,11 @@
 # Check: execute
 
 InitialTime: 0.0
-InitialTimeStep: 0.001
+InitialTimeStep: 0.01
 FinalTime: 0.1
-InitialSlabSize: 0.01
+
+# InitialSlabSize is only needed for local time stepping
+# InitialSlabSize: 0.01
 
 DomainCreator:
   Brick:
@@ -28,17 +30,21 @@ TimeStepper:
   AdamsBashforthN:
     Order: 3
 
-StepController: BinaryFraction
+# StepController and StepChoosers are needed only for local time stepping
+# StepController: BinaryFraction
 
-StepChoosers:
-  - Constant: 0.05
-  - Increase:
-      Factor: 2
-  - Cfl:
-      SafetyFactor: 0.2
+# StepChoosers:
+#   - Constant: 0.05
+#   - Increase:
+#       Factor: 2
+#   - Cfl:
+#       SafetyFactor: 0.2
 
 VolumeFileName: "./GrMhd"
 
 NumericalFluxParams:
 
 DampingParameter: 0.0
+
+SlopeLimiterParams:
+  Type: LambdaPi1


### PR DESCRIPTION
Turn off local time stepping as limiter does not support it

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
