### PR TITLE
Add libsharp to docker

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -54,12 +54,12 @@ RUN apt-get update -y && apt-get install -y curl lmod && \
 
 # Install Spack to get remaining dependencies
 WORKDIR /work
-RUN git clone https://github.com/moxcodes/spack.git
+RUN git clone https://github.com/spack/spack.git
 WORKDIR /work/spack
 # Since spack/develop is rather unstable, we check out a commit we
 # know is stable. This should be updated periodically to update
 # installed packages.
-RUN git checkout package/libsharp
+RUN git checkout 470a45c51659156e7d154ea890e798ce32b8767d
 WORKDIR /work
 
 # Spack needs to be pointed to the system OpenSSL to work properly, we add this

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -81,6 +81,7 @@ RUN echo "export PATH=\$PATH:/work/spack/bin" >> /root/.bashrc && \
     /root/.spack/linux/compilers.yaml
 RUN /work/spack/bin/spack install --no-checksum catch@2.1.0 && \
     /work/spack/bin/spack install brigand@master && \
+    /work/spack/bin/spack install libsharp -openmp -mpi&& \
     /work/spack/bin/spack install blaze && \
     /work/spack/bin/spack install gsl%gcc@6.4.0
 RUN /work/spack/bin/spack install libxsmm%gcc@6.4.0
@@ -132,6 +133,7 @@ RUN echo 'spack load catch' >> /root/.bashrc && \
     echo 'spack load brigand' >> /root/.bashrc && \
     echo 'spack load blaze' >> /root/.bashrc && \
     echo 'spack load gsl' >> /root/.bashrc && \
+    echo 'spack load libsharp' >> /root/.bashrc && \
     echo 'spack load libxsmm' >> /root/.bashrc && \
     echo 'spack load yaml-cpp' >> /root/.bashrc && \
     echo 'spack load benchmark' >> /root/.bashrc

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -30,7 +30,8 @@ RUN apt-get update -y && \
 # Update is needed to get libc++ correctly
 # Install jemalloc
 RUN apt-get update -y && apt-get install -y libc++-dev libc++1 libc++abi-dev \
-    && apt-get update -y && apt-get install -y libjemalloc1 libjemalloc-dev
+    && apt-get update -y && apt-get install -y libjemalloc1 libjemalloc-dev && \
+    apt-get install -y libssl-dev
 
 # Install ccache to cache compilations for reduced compile time, Doxygen
 # and coverxygen to check documentation coverage
@@ -53,12 +54,12 @@ RUN apt-get update -y && apt-get install -y curl lmod && \
 
 # Install Spack to get remaining dependencies
 WORKDIR /work
-RUN git clone https://github.com/LLNL/spack.git
+RUN git clone https://github.com/moxcodes/spack.git
 WORKDIR /work/spack
 # Since spack/develop is rather unstable, we check out a commit we
 # know is stable. This should be updated periodically to update
 # installed packages.
-RUN git checkout v0.11.1
+RUN git checkout package/libsharp
 WORKDIR /work
 
 # Spack needs to be pointed to the system OpenSSL to work properly, we add this
@@ -79,6 +80,7 @@ RUN echo "export PATH=\$PATH:/work/spack/bin" >> /root/.bashrc && \
     /root/.spack/linux/compilers.yaml && \
     sed -i 's@f77: null@f77: /usr/bin/gfortran@' \
     /root/.spack/linux/compilers.yaml
+RUN /work/spack/bin/spack install cmake
 RUN /work/spack/bin/spack install --no-checksum catch@2.1.0 && \
     /work/spack/bin/spack install brigand@master && \
     /work/spack/bin/spack install libsharp -openmp -mpi&& \
@@ -86,7 +88,6 @@ RUN /work/spack/bin/spack install --no-checksum catch@2.1.0 && \
     /work/spack/bin/spack install gsl%gcc@6.4.0
 RUN /work/spack/bin/spack install libxsmm%gcc@6.4.0
 # On 09/03/2017 CMake 3.9.0 failed to build with spack
-RUN /work/spack/bin/spack install cmake@3.8.0%gcc@6.4.0
 RUN /work/spack/bin/spack install yaml-cpp@develop%gcc@6.4.0 ^cmake@3.8.0%gcc@6.4.0
 RUN /work/spack/bin/spack install benchmark%gcc@6.4.0 ^cmake@3.8.0%gcc@6.4.0
 


### PR DESCRIPTION
## Proposed changes
Modified the Docker.buildenv to include spack calls for bringing in libsharp.
Assumes a version of spack which has brought in the libsharp package pull
request.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Build system

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

