### PR TITLE
Add Generalized Harmonic Characteristic Speeds

### DIFF
--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -100,4 +100,16 @@ struct Next : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
   static std::string name() noexcept { return "Next(" + Tag::name() + ")"; }
 };
+
+/// \ingroup DataBoxTagsGroup
+/// \brief Prefix corresponding to the characteristic speed of the field given
+/// by `Tag`. `type` is always a `Scalar<DataVector>`.
+template<typename Tag>
+struct CharSpeed : db::PrefixTag, db::SimpleTag {
+  using type = Scalar<DataVector>;
+  using tag = Tag;
+  static std::string name() noexcept {
+    return "CharSpeed(" + Tag::name() + ")";
+  }
+};
 }  // namespace Tags

--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY GeneralizedHarmonic)
 
 set(LIBRARY_SOURCES
+    Characteristics.cpp
     Constraints.cpp
     Equations.cpp
     )

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -1,0 +1,57 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+// IWYU pragma: no_include <array>
+
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Characteristics.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp" // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp" // IWYU pragma: keep
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Tags::CharSpeed
+
+namespace GeneralizedHarmonic {
+
+template <size_t Dim, typename Frame>
+typename Tags::CharacteristicSpeeds<Dim, Frame>::type
+CharacteristicSpeedsCompute<Dim, Frame>::function(
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const tnsr::i<DataVector, Dim, Frame>& normal) noexcept {
+  auto char_speeds =
+      make_with_value<typename Tags::CharacteristicSpeeds<Dim, Frame>::type>(
+          get(lapse), 0.);
+  const auto shift_dot_normal = get(dot_product(shift, normal));
+  get(get<::Tags::CharSpeed<Tags::UPsi<Dim, Frame>>>(char_speeds)) =
+      -(1. + get(gamma_1)) * shift_dot_normal;
+  get(get<::Tags::CharSpeed<Tags::UZero<Dim, Frame>>>(char_speeds)) =
+      -shift_dot_normal;
+  get(get<::Tags::CharSpeed<Tags::UPlus<Dim, Frame>>>(char_speeds)) =
+      -shift_dot_normal + get(lapse);
+  get(get<::Tags::CharSpeed<Tags::UMinus<Dim, Frame>>>(char_speeds)) =
+      -shift_dot_normal - get(lapse);
+
+  return char_speeds;
+}
+
+}  // namespace GeneralizedHarmonic
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(_, data)                                      \
+  template struct GeneralizedHarmonic::CharacteristicSpeedsCompute< \
+      DIM(data), FRAME(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
+                        (Frame::Inertial, Frame::Grid))
+
+#undef INSTANTIATION
+#undef DIM

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace Tags {
+template <typename Tag>
+struct Normalized;
+}  // namespace Tags
+/// \endcond
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace GeneralizedHarmonic {
+/*!
+ * \ingroup GeneralizedHarmonic
+ * \brief Compute the characteristic speeds for the generalized harmonic system.
+ *
+ * Computes the speeds as described in "A New Generalized Harmonic
+ * Evolution System" by Lindblom et. al, https://arxiv.org/abs/gr-qc/0512093.
+ * The characteristic fields' names used here differ from this paper:
+ *
+ * \f{align*}
+ * \mathrm{SpECTRE} && \mathrm{Lindblom} \\
+ * u^{\psi}_{ab} && u^0_{ab} \\
+ * u^{\pm}_{ab} && u^{1\pm}_{ab} \\
+ * u^0_{iab} && u^2_{iab}
+ * \f}
+ *
+ * The speeds \f$v\f$, are given by:
+ * \f{align*}
+ * v_{\psi} =& -(1 + \gamma_1) n_k N^k \\
+ * v_{0} =& -n_k N^k \\
+ * v_{\pm} =& -n_k N^k \pm N
+ * \f}
+ *
+ * where \f$N, N^k\f$ are the lapse and shift respectively, \f$\gamma_1\f$ is a
+ * constraint damping parameter, and \f$n_k\f$ is the unit normal to the
+ * surface.
+ */
+template <size_t Dim, typename Frame>
+struct CharacteristicSpeedsCompute : db::ComputeTag {
+  using argument_tags = tmpl::list<
+      Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame, DataVector>,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
+
+  using volume_tags = tmpl::list<>;
+
+  static typename Tags::CharacteristicSpeeds<Dim, Frame>::type function(
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, Dim, Frame>& shift,
+      const tnsr::i<DataVector, Dim, Frame>& normal) noexcept;
+};
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -41,21 +41,21 @@ namespace GeneralizedHarmonic {
 template <size_t Dim>
 struct ComputeDuDt {
  public:
-  using argument_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>,
-                 Tags::deriv<gr::Tags::SpacetimeMetric<Dim>, tmpl::size_t<Dim>,
-                             Frame::Inertial>,
-                 Tags::deriv<Pi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
-                 Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
-                 ConstraintGamma0, ConstraintGamma1, ConstraintGamma2,
-                 GaugeH<Dim>, SpacetimeDerivGaugeH<Dim>, gr::Tags::Lapse<>,
-                 gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
-                 gr::Tags::InverseSpacetimeMetric<Dim>,
-                 gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim>,
-                 gr::Tags::SpacetimeChristoffelFirstKind<Dim>,
-                 gr::Tags::SpacetimeChristoffelSecondKind<Dim>,
-                 gr::Tags::SpacetimeNormalVector<Dim>,
-                 gr::Tags::SpacetimeNormalOneForm<Dim>>;
+  using argument_tags = tmpl::list<
+      gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
+      ::Tags::deriv<gr::Tags::SpacetimeMetric<Dim>, tmpl::size_t<Dim>,
+                    Frame::Inertial>,
+      ::Tags::deriv<Tags::Pi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<Tags::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+      Tags::ConstraintGamma0, Tags::ConstraintGamma1, Tags::ConstraintGamma2,
+      Tags::GaugeH<Dim>, Tags::SpacetimeDerivGaugeH<Dim>, gr::Tags::Lapse<>,
+      gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
+      gr::Tags::InverseSpacetimeMetric<Dim>,
+      gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim>,
+      gr::Tags::SpacetimeChristoffelFirstKind<Dim>,
+      gr::Tags::SpacetimeChristoffelSecondKind<Dim>,
+      gr::Tags::SpacetimeNormalVector<Dim>,
+      gr::Tags::SpacetimeNormalOneForm<Dim>>;
 
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,
@@ -111,9 +111,10 @@ template <size_t Dim>
 struct ComputeNormalDotFluxes {
  public:
   using argument_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>,
-                 ConstraintGamma1, ConstraintGamma2, gr::Tags::Lapse<>,
-                 gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>>;
+      tmpl::list<gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
+                 Tags::ConstraintGamma1, Tags::ConstraintGamma2,
+                 gr::Tags::Lapse<>, gr::Tags::Shift<Dim>,
+                 gr::Tags::InverseSpatialMetric<Dim>>;
 
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*>

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -12,6 +12,7 @@
 class DataVector;
 
 namespace GeneralizedHarmonic {
+namespace Tags {
 /*!
  * \brief Conjugate momentum to the spacetime metric.
  *
@@ -60,4 +61,5 @@ struct SpacetimeDerivGaugeH : db::SimpleTag {
   using type = tnsr::ab<DataVector, Dim, Frame>;
   static std::string name() noexcept { return "SpacetimeDerivGaugeH"; }
 };
+}  // namespace Tags
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
 
@@ -60,6 +61,43 @@ template <size_t Dim, typename Frame>
 struct SpacetimeDerivGaugeH : db::SimpleTag {
   using type = tnsr::ab<DataVector, Dim, Frame>;
   static std::string name() noexcept { return "SpacetimeDerivGaugeH"; }
+};
+
+// {@
+/// \ingroup GeneralizedHarmonicGroup
+/// \brief Tags corresponding to the characteristic fields of the generalized
+/// system.
+///
+/// \details For details on how these are defined and computed, see
+/// ComputeCharacteristicSpeeds
+template<size_t Dim, typename Frame>
+struct UPsi {
+  using type = tnsr::aa<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "UPsi"; }
+};
+template<size_t Dim, typename Frame>
+struct UZero {
+  using type = tnsr::iaa<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "UZero"; }
+};
+template<size_t Dim, typename Frame>
+struct UPlus {
+  using type = tnsr::aa<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "UPlus"; }
+};
+template<size_t Dim, typename Frame>
+struct UMinus {
+  using type = tnsr::aa<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "UMinus"; }
+};
+// @}
+
+template<size_t Dim, typename Frame>
+struct CharacteristicSpeeds : db::SimpleTag {
+  using type = Variables<db::wrap_tags_in<
+      ::Tags::CharSpeed, tmpl::list<UPsi<Dim, Frame>, UZero<Dim, Frame>,
+                                    UPlus<Dim, Frame>, UMinus<Dim, Frame>>>>;
+  static std::string name() noexcept { return "CharacteristicSpeeds"; }
 };
 }  // namespace Tags
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 
 namespace GeneralizedHarmonic {
+namespace Tags {
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct Pi;
 template <size_t Dim, typename Frame = Frame::Inertial>
@@ -20,4 +21,5 @@ template <size_t Dim, typename Frame = Frame::Inertial>
 struct GaugeH;
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeDerivGaugeH;
+}  // namespace Tags
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -21,5 +21,17 @@ template <size_t Dim, typename Frame = Frame::Inertial>
 struct GaugeH;
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeDerivGaugeH;
+
+template<size_t Dim, typename>
+struct UPsi;
+template<size_t Dim, typename>
+struct UZero;
+template<size_t Dim, typename>
+struct UPlus;
+template<size_t Dim, typename>
+struct UMinus;
+
+template<size_t Dim, typename>
+struct CharacteristicSpeeds;
 }  // namespace Tags
 }  // namespace GeneralizedHarmonic

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -23,4 +23,5 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
   /// [next_name]
   CHECK(Tags::Next<Tag>::name() == "Next(" + Tag::name() + ")");
   /// [next_name]
+  CHECK(Tags::CharSpeed<Tag>::name() == "CharSpeed(Tag)");
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_GeneralizedHarmonic")
 
 set(LIBRARY_SOURCES
+  Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_DuDt.cpp
   Test_Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -26,6 +26,7 @@ def phi_dot_flux(spacetime_metric, pi, phi, gamma1, gamma2, lapse, shift,
            - gamma2 * lapse * np.einsum("i,ab->iab", unit_normal,
                                         spacetime_metric)
 
+
 def gauge_constraint(gauge_function, spacetime_normal_one_form,
                      spacetime_normal_vector, inverse_spatial_metric,
                      inverse_spacetime_metric, pi, phi):
@@ -43,3 +44,20 @@ def gauge_constraint(gauge_function, spacetime_normal_one_form,
       - 0.5 * np.einsum("a,bc,bc->a", spacetime_normal_one_form, \
                         inverse_spacetime_metric, pi)
     return constraint
+
+
+# Test functions for characteristics
+def char_speed_upsi(gamma1, lapse, shift, unit_normal):
+    return - (1. + gamma1) * np.dot(shift, unit_normal)
+
+
+def char_speed_uzero(gamma1, lapse, shift, unit_normal):
+    return - np.dot(shift, unit_normal)
+
+
+def char_speed_uplus(gamma1, lapse, shift, unit_normal):
+    return - np.dot(shift, unit_normal) + lapse
+
+
+def char_speed_uminus(gamma1, lapse, shift, unit_normal):
+    return - np.dot(shift, unit_normal) - lapse

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -1,0 +1,73 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp" // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp" //IWYU pragma: keep
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+// IWYU pragma: no_forward_declare Tags::CharSpeed
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPsi
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UZero
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UMinus
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPlus
+
+namespace {
+template <typename Tag, size_t Dim, typename Frame>
+Scalar<DataVector> compute_speed_with_tag(
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const tnsr::i<DataVector, Dim, Frame>& normal) {
+  return get<Tag>(
+      GeneralizedHarmonic::CharacteristicSpeedsCompute<Dim, Frame>::function(
+          gamma_1, lapse, shift, normal));
+}
+
+template <size_t Dim, typename Frame>
+void test_characteristic_speeds() noexcept {
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<1>(
+      compute_speed_with_tag<
+          Tags::CharSpeed<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>>, Dim,
+          Frame>,
+      "TestFunctions", "char_speed_upsi", {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      compute_speed_with_tag<
+          Tags::CharSpeed<GeneralizedHarmonic::Tags::UZero<Dim, Frame>>, Dim,
+          Frame>,
+      "TestFunctions", "char_speed_uzero", {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      compute_speed_with_tag<
+          Tags::CharSpeed<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>>, Dim,
+          Frame>,
+      "TestFunctions", "char_speed_uminus", {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      compute_speed_with_tag<
+          Tags::CharSpeed<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>>, Dim,
+          Frame>,
+      "TestFunctions", "char_speed_uplus", {{{-10.0, 10.0}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.CharSpeeds",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GeneralizedHarmonic/"};
+
+  test_characteristic_speeds<1, Frame::Grid>();
+  test_characteristic_speeds<2, Frame::Grid>();
+  test_characteristic_speeds<3, Frame::Grid>();
+  test_characteristic_speeds<1, Frame::Inertial>();
+  test_characteristic_speeds<2, Frame::Inertial>();
+  test_characteristic_speeds<3, Frame::Inertial>();
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -55,9 +55,9 @@ void verify_time_independent_einstein_solution(
     const double error_tolerance) noexcept {
   // Shorter names for tags.
   using SpacetimeMetric = gr::Tags::SpacetimeMetric<3, Frame::Inertial>;
-  using Pi = ::GeneralizedHarmonic::Pi<3, Frame::Inertial>;
-  using Phi = ::GeneralizedHarmonic::Phi<3, Frame::Inertial>;
-  using GaugeH = ::GeneralizedHarmonic::GaugeH<3, Frame::Inertial>;
+  using Pi = ::GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>;
+  using Phi = ::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>;
+  using GaugeH = ::GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>;
   using VariablesTags = tmpl::list<SpacetimeMetric, Pi, Phi, GaugeH>;
 
   // Set up grid

--- a/tests/Unit/Pypp/PyppFundamentals.hpp
+++ b/tests/Unit/Pypp/PyppFundamentals.hpp
@@ -221,7 +221,8 @@ struct FromPyObject<long, std::nullptr_t> {
 #if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
     } else if (not PyInt_Check(t) and not PyLong_Check(t)) {
 #elif PY_MAJOR_VERSION == 3
-    } else if (not PyLong_Check(t)) {
+      // clang-tidy: hicpp-signed-bitwise
+    } else if (not PyLong_Check(t)) { // NOLINT
 #else
     } else {
       static_assert(false, "Only works on Python 2.7 and 3.x")
@@ -240,7 +241,8 @@ struct FromPyObject<unsigned long, std::nullptr_t> {
 #if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
     } else if (not PyInt_Check(t) and not PyLong_Check(t)) {
 #elif PY_MAJOR_VERSION == 3
-    } else if (not PyLong_Check(t)) {
+      // clang-tidy: hicpp-signed-bitwise
+    } else if (not PyLong_Check(t)) { // NOLINT
 #else
     } else {
       static_assert(false, "Only works on Python 2.7 and 3.x");


### PR DESCRIPTION
## Proposed changes

- Adds a prefix tag CharSpeed. This is useful because for every field, the characteristic speed is just a scalar, so CharSpeed<T> is always a scalar, and it means we can make a variables of characteristic speeds. 
- Adds the characteristic speeds. The function to compute them currently returns a Variables of the speeds. 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
