### PR TITLE
Add gr::inverse_spatial_metric(inverse_spacetime_metric)

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -79,6 +79,22 @@ tnsr::AA<DataType, Dim, Frame> inverse_spacetime_metric(
 }
 
 template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::II<DataType, SpatialDim, Frame> inverse_spatial_metric(
+    const tnsr::AA<DataType, SpatialDim, Frame>&
+        inverse_spacetime_metric) noexcept {
+  auto inverse_spatial_metric =
+      make_with_value<tnsr::II<DataType, SpatialDim, Frame>>(
+          inverse_spacetime_metric, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      inverse_spatial_metric.get(i, j) =
+          inverse_spacetime_metric.get(i + 1, j + 1);
+    }
+  }
+  return inverse_spatial_metric;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::I<DataType, SpatialDim, Frame> shift(
     const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric,
     const tnsr::II<DataType, SpatialDim, Frame>&
@@ -245,6 +261,10 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,               \
       const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                     \
           inverse_spatial_metric) noexcept;                                    \
+  template tnsr::II<DTYPE(data), DIM(data), FRAME(data)>                       \
+  gr::inverse_spatial_metric(                                                  \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          inverse_spacetime_metric) noexcept;                                  \
   template tnsr::I<DTYPE(data), DIM(data), FRAME(data)> gr::shift(             \
       const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& spacetime_metric,   \
       const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                     \

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -65,6 +65,16 @@ tnsr::AA<DataType, SpatialDim, Frame> inverse_spacetime_metric(
 
 /*!
  * \ingroup GeneralRelativityGroup
+ * \brief Compute inverse spatial metric from inverse spacetime metric.
+ * \details Simply pull out the spatial components.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::II<DataType, SpatialDim, Frame> inverse_spatial_metric(
+    const tnsr::AA<DataType, SpatialDim, Frame>&
+        inverse_spacetime_metric) noexcept;
+
+/*!
+ * \ingroup GeneralRelativityGroup
  * \brief Compute shift from spacetime metric and inverse spatial metric.
  *
  * \details Computes

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/TestFunctions.py
@@ -63,6 +63,12 @@ def inverse_spacetime_metric(lapse, shift, inverse_spatial_metric):
             1:] = inverse_spatial_metric - np.outer(shift, shift) / lapse**2
     return inv_psi
 
+def inverse_spatial_metric(inverse_spacetime_metric):
+    spatial_dim = inverse_spacetime_metric.shape[0] - 1
+    inverse_spatial_metric = np.zeros([spatial_dim, spatial_dim])
+    inverse_spatial_metric[0:,0:] = inverse_spacetime_metric[1:,1:]
+    return inverse_spatial_metric
+
 
 def derivatives_of_spacetime_metric(lapse, dt_lapse, deriv_lapse, shift,
                                     dt_shift, deriv_shift, spatial_metric,

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -31,6 +31,13 @@ void test_compute_inverse_spacetime_metric(const DataType& used_for_size) {
       used_for_size);
 }
 template <size_t Dim, typename DataType>
+void test_compute_inverse_spatial_metric(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      &gr::inverse_spatial_metric<Dim, Frame::Inertial, DataType>,
+      "TestFunctions", "inverse_spatial_metric", {{{-10., 10.}}},
+      used_for_size);
+}
+template <size_t Dim, typename DataType>
 void test_compute_derivatives_of_spacetime_metric(
     const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
@@ -124,6 +131,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_spacetime_metric, (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_inverse_spacetime_metric,
+                                    (1, 2, 3));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_compute_inverse_spatial_metric,
                                     (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(
       test_compute_derivatives_of_spacetime_metric, (1, 2, 3));


### PR DESCRIPTION
## Proposed changes

There's a function gr::spatial_metric(spacetime_metric). This adds the analogous function to read out the components of the inverse spatial metric from the inverse spacetime metric.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->