### PR TITLE
Add InterpolationTargetReceiveVars.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
@@ -1,0 +1,200 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+// IWYU pragma: no_forward_declare db::DataBox
+namespace intrp {
+template <class Metavariables, size_t VolumeDim>
+struct Interpolator;
+template <typename Metavariables, typename InterpolationTargetTag,
+          size_t VolumeDim, typename Frame>
+class InterpolationTarget;
+namespace Actions {
+template <typename InterpolationTargetTag>
+struct CleanUpInterpolator;
+}  // namespace Actions
+namespace Tags {
+struct IndicesOfFilledInterpPoints;
+template <typename Metavariables>
+struct TemporalIds;
+}  // namespace Tags
+}  // namespace intrp
+namespace Tags {
+template <typename TagsList>
+struct Variables;
+}  // namespace Tags
+/// \endcond
+
+namespace intrp {
+
+namespace InterpolationTarget_detail {
+/// Calls the callback function, tells interpolators to clean up the current
+/// temporal_id, and then if there are more temporal_ids to be interpolated,
+/// starts the next one.
+template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame,
+          typename DbTags, typename Metavariables>
+void callback_and_cleanup(
+    const gsl::not_null<db::DataBox<DbTags>*> box,
+    const gsl::not_null<Parallel::ConstGlobalCache<Metavariables>*>
+        cache) noexcept {
+  const auto temporal_id =
+      db::get<Tags::TemporalIds<Metavariables>>(*box).front();
+
+  // Do the callback
+  const auto& new_box = db::create_from<
+      db::RemoveTags<>, db::AddSimpleTags<>,
+      db::AddComputeTags<
+          typename InterpolationTargetTag::compute_items_on_target>>(*box);
+  InterpolationTargetTag::post_interpolation_callback::apply(new_box, *cache,
+                                                             temporal_id);
+
+  // In the future, when generalizing this function to accommodate
+  // horizon finding, we will need to think more carefully about
+  // control flow and the point at which the temporal_id should be
+  // popped from the list.
+  db::mutate<Tags::TemporalIds<Metavariables>>(
+      box, [](const gsl::not_null<
+               db::item_type<Tags::TemporalIds<Metavariables>>*>
+                  ids) noexcept { ids->pop_front(); });
+
+  // Tell interpolators to clean up at this temporal_id for this
+  // InterpolationTargetTag.
+  auto& interpolator_proxy =
+      Parallel::get_parallel_component<Interpolator<Metavariables, VolumeDim>>(
+          *cache);
+  Parallel::simple_action<Actions::CleanUpInterpolator<InterpolationTargetTag>>(
+      interpolator_proxy, temporal_id);
+
+  // If there are further temporal_ids, begin interpolation for
+  // the next one.
+  const auto& temporal_ids = db::get<Tags::TemporalIds<Metavariables>>(*box);
+  if (not temporal_ids.empty()) {
+    auto& my_proxy = Parallel::get_parallel_component<InterpolationTarget<
+        Metavariables, InterpolationTargetTag, VolumeDim, Frame>>(*cache);
+    Parallel::simple_action<
+        typename InterpolationTargetTag::compute_target_points>(
+        my_proxy, temporal_ids.front());
+  }
+}
+
+}  // namespace InterpolationTarget_detail
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \brief Receives interpolated variables from an `Interpolator` on a subset
+///  of the target points.
+///
+/// If interpolated variables for all target points have been received, then
+/// - Calls `InterpolationTargetTag::post_interpolation_callback`
+/// - Tells `Interpolator`s that the interpolation is complete
+///  (by calling `Actions::CleanUpInterpolator<InterpolationTargetTag>`)
+/// - Removes the first `temporal_id` from `Tags::TemporalIds<Metavariables>`
+/// - If there are more `temporal_id`s, begins interpolation at the next
+///  `temporal_id` (by calling `InterpolationTargetTag::compute_target_points`)
+///
+/// Uses:
+/// - DataBox:
+///   - `Tags::TemporalIds<Metavariables>`
+///   - `Tags::IndicesOfFilledInterpPoints`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `Tags::TemporalIds<Metavariables>`
+///   - `Tags::IndicesOfFilledInterpPoints`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// For requirements on InterpolationTargetTag, see InterpolationTarget
+template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+struct InterpolationTargetReceiveVars {
+  /// For requirements on Metavariables, see InterpolationTarget
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<
+                DbTags, typename Tags::TemporalIds<Metavariables>>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const std::vector<db::item_type<::Tags::Variables<
+          typename InterpolationTargetTag::vars_to_interpolate_to_target>>>&
+          vars_src,
+      const std::vector<std::vector<size_t>>& global_offsets) noexcept {
+    db::mutate<
+        Tags::IndicesOfFilledInterpPoints,
+        ::Tags::Variables<
+            typename InterpolationTargetTag::vars_to_interpolate_to_target>>(
+        make_not_null(&box),
+        [
+          &vars_src, &global_offsets
+        ](const gsl::not_null<db::item_type<Tags::IndicesOfFilledInterpPoints>*>
+              indices_of_filled,
+          const gsl::not_null<db::item_type<::Tags::Variables<
+              typename InterpolationTargetTag::vars_to_interpolate_to_target>>*>
+              vars_dest) noexcept {
+          const size_t npts_dest = vars_dest->number_of_grid_points();
+          const size_t nvars = vars_dest->number_of_independent_components;
+          for (size_t j = 0; j < global_offsets.size(); ++j) {
+            const size_t npts_src = global_offsets[j].size();
+            for (size_t i = 0; i < npts_src; ++i) {
+              // If a point is on the boundary of two (or more)
+              // elements, it is possible that we have received data
+              // for this point from more than one Interpolator.
+              // This will rarely occur, but it does occur, e.g. when
+              // a point is exactly on some symmetry
+              // boundary (such as the x-y plane) and this symmetry
+              // boundary is exactly the boundary between two
+              // elements.  If this happens, we accept the first
+              // duplicated point, and we ignore subsequent
+              // duplicated points.  The points are easy to keep track
+              // of because global_offsets uniquely identifies them.
+              if (indices_of_filled->insert(global_offsets[j][i]).second) {
+                for (size_t v = 0; v < nvars; ++v) {
+                  // clang-tidy: no pointer arithmetic
+                  vars_dest->data()[global_offsets[j][i] +   // NOLINT
+                                    v * npts_dest] =         // NOLINT
+                      vars_src[j].data()[i + v * npts_src];  // NOLINT
+                }
+              }
+            }
+          }
+        });
+
+    if (db::get<Tags::IndicesOfFilledInterpPoints>(box).size() ==
+        db::get<::Tags::Variables<
+            typename InterpolationTargetTag::vars_to_interpolate_to_target>>(
+            box)
+            .number_of_grid_points()) {
+      // All the points have been interpolated.
+      InterpolationTarget_detail::callback_and_cleanup<InterpolationTargetTag,
+                                                       VolumeDim, Frame>(
+          make_not_null(&box), make_not_null(&cache));
+    }
+  }
+};
+}  // namespace Actions
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_InitializeInterpolationTarget.cpp
   Test_InitializeInterpolator.cpp
   Test_InterpolationTargetLineSegment.cpp
+  Test_InterpolationTargetReceiveVars.cpp
   Test_InterpolatorReceiveVolumeData.cpp
   Test_InterpolatorRegisterElement.cpp
   Test_IrregularInterpolant.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -1,0 +1,378 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <deque>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/Shell.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Rational.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+/// \cond
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+namespace intrp {
+namespace Actions {
+template <typename InterpolationTargetTag>
+struct CleanUpInterpolator;
+}  // namespace Actions
+}  // namespace intrp
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace intrp {
+namespace Tags {
+struct IndicesOfFilledInterpPoints;
+struct NumberOfElements;
+template <typename Metavariables>
+struct TemporalIds;
+}  // namespace Tags
+}  // namespace intrp
+/// \endcond
+
+namespace {
+
+template <typename Metavariables, typename InterpolationTargetTag>
+struct mock_interpolation_target {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked =
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3,
+                                 Frame::Inertial>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename intrp::Actions::InitializeInterpolationTarget<
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
+                                                            ::Frame::Inertial>>;
+};
+
+template <typename InterpolationTargetTag>
+struct MockCleanUpInterpolator {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<
+                DbTags, typename intrp::Tags::NumberOfElements>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const typename Metavariables::temporal_id& temporal_id) noexcept {
+    Slab slab(0.0, 1.0);
+    CHECK(temporal_id == Time(slab, Rational(13, 15)));
+    // Put something in NumberOfElements so we can check later whether
+    // this function was called.  This isn't the usual usage of
+    // NumberOfElements.
+    db::mutate<intrp::Tags::NumberOfElements>(
+        make_not_null(&box), [](const gsl::not_null<
+                                 db::item_type<intrp::Tags::NumberOfElements>*>
+                                    number_of_elements) noexcept {
+          ++(*number_of_elements);
+        });
+  }
+};
+
+struct MockComputeTargetPoints {
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<tmpl::list_contains_v<
+          DbTags, typename intrp::Tags::TemporalIds<Metavariables>>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const typename Metavariables::temporal_id& temporal_id) noexcept {
+    Slab slab(0.0, 1.0);
+    CHECK(temporal_id == Time(slab, Rational(14, 15)));
+    // Increment IndicesOfFilledInterpPoints so we can check later
+    // whether this function was called.  This isn't the usual usage
+    // of IndicesOfFilledInterpPoints; this is done only for the test.
+    db::mutate<intrp::Tags::IndicesOfFilledInterpPoints>(
+        make_not_null(&box), [](const gsl::not_null<db::item_type<
+                                    intrp::Tags::IndicesOfFilledInterpPoints>*>
+                                    indices) noexcept {
+          indices->insert(indices->size() + 1);
+        });
+  }
+};
+
+// Simple DataBoxItems to test.
+namespace Tags {
+struct Square : db::SimpleTag {
+  static std::string name() noexcept { return "Square"; }
+  using type = Scalar<DataVector>;
+};
+struct SquareComputeItem : Square, db::ComputeTag {
+  static std::string name() noexcept { return "Square"; }
+  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
+    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
+    get<>(result) = square(get<>(x));
+    return result;
+  }
+  using argument_tags = tmpl::list<gr::Tags::Lapse<DataVector>>;
+};
+}  // namespace Tags
+
+struct MockPostInterpolationCallback {
+  template <typename DbTags, typename Metavariables>
+  static void apply(
+      const db::DataBox<DbTags>& box,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const typename Metavariables::temporal_id& temporal_id) noexcept {
+    Slab slab(0.0, 1.0);
+    CHECK(temporal_id == Time(slab, Rational(13, 15)));
+    // The result should be the square of the first 10 integers, in
+    // a Scalar<DataVector>.
+    const Scalar<DataVector> expected{
+        DataVector{{0.0, 1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 49.0, 64.0, 81.0}}};
+    CHECK_ITERABLE_APPROX(expected, db::get<Tags::Square>(box));
+  }
+};
+
+template <typename Metavariables, size_t VolumeDim>
+struct mock_interpolator {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox =
+      db::compute_databox_type<typename intrp::Actions::InitializeInterpolator<
+          VolumeDim>::template return_tag_list<Metavariables>>;
+  using component_being_mocked = intrp::Interpolator<Metavariables, VolumeDim>;
+  using replace_these_simple_actions =
+      tmpl::list<intrp::Actions::CleanUpInterpolator<
+          typename Metavariables::InterpolationTargetA>>;
+  using with_these_simple_actions = tmpl::list<
+      MockCleanUpInterpolator<typename Metavariables::InterpolationTargetA>>;
+};
+
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_target_points = MockComputeTargetPoints;
+    using post_interpolation_callback = MockPostInterpolationCallback;
+    using compute_items_on_target = tmpl::list<Tags::SquareComputeItem>;
+  };
+  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+  using temporal_id = Time;
+
+  using component_list = tmpl::list<
+      mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
+      mock_interpolator<MockMetavariables, 3>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialize, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.ReceiveVars",
+                  "[Unit]") {
+  using metavars = MockMetavariables;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  using TupleOfMockDistributedObjects =
+      MockRuntimeSystem::TupleOfMockDistributedObjects;
+  TupleOfMockDistributedObjects dist_objects{};
+  using MockDistributedObjectsTagTarget =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolation_target<metavars, metavars::InterpolationTargetA>>;
+  using MockDistributedObjectsTagInterpolator =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolator<metavars, 3>>;
+
+  const auto domain_creator =
+      DomainCreators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+  Slab slab(0.0, 1.0);
+  const size_t num_points = 10;
+
+  // Set databox to contain two temporal_ids and a vars of num_points points.
+  tuples::get<MockDistributedObjectsTagTarget>(dist_objects)
+      .emplace(
+          0, ActionTesting::MockDistributedObject<mock_interpolation_target<
+                 metavars, metavars::InterpolationTargetA>>{
+                 db::create<db::get_items<
+                     intrp::Actions::InitializeInterpolationTarget<
+                         metavars::InterpolationTargetA>::
+                         return_tag_list<metavars, 3, Frame::Inertial>>>(
+                     db::item_type<intrp::Tags::IndicesOfFilledInterpPoints>{},
+                     db::item_type<intrp::Tags::TemporalIds<metavars>>{
+                         Time(slab, Rational(13, 15)),
+                         Time(slab, Rational(14, 15))},
+                     domain_creator.create_domain(),
+                     db::item_type<
+                         ::Tags::Variables<metavars::InterpolationTargetA::
+                                               vars_to_interpolate_to_target>>{
+                         num_points})});
+
+  tuples::get<MockDistributedObjectsTagInterpolator>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<
+                      mock_interpolator<metavars, 3>>{});
+
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
+
+  runner.simple_action<mock_interpolator<metavars, 3>,
+                       intrp::Actions::InitializeInterpolator<3>>(0);
+
+  const auto& box_target =
+      runner
+          .template algorithms<mock_interpolation_target<
+              metavars, metavars::InterpolationTargetA>>()
+          .at(0)
+          .template get_databox<typename mock_interpolation_target<
+              metavars, metavars::InterpolationTargetA>::initial_databox>();
+
+  const auto& box_interpolator =
+      runner.template algorithms<mock_interpolator<metavars, 3>>()
+          .at(0)
+          .template get_databox<
+              typename mock_interpolator<metavars, 3>::initial_databox>();
+
+  // Now set up the vars.
+  std::vector<db::item_type<::Tags::Variables<
+      metavars::InterpolationTargetA::vars_to_interpolate_to_target>>>
+      vars_src;
+  std::vector<std::vector<size_t>> global_offsets;
+
+  // Adds more data to vars_src and global_offsets.
+  auto add_to_vars_src = [&vars_src, &global_offsets](
+                             const std::vector<double>& lapse_vals,
+                             const std::vector<size_t>& offset_vals) {
+    vars_src.emplace_back(
+        db::item_type<::Tags::Variables<
+            metavars::InterpolationTargetA::vars_to_interpolate_to_target>>{
+            lapse_vals.size()});
+    global_offsets.emplace_back(offset_vals);
+    auto& lapse = get<gr::Tags::Lapse<DataVector>>(vars_src.back());
+    for (size_t i = 0; i < lapse_vals.size(); ++i) {
+      get<>(lapse)[i] = lapse_vals[i];
+    }
+  };
+
+  add_to_vars_src({{3.0, 6.0}}, {{3, 6}});
+  add_to_vars_src({{2.0, 7.0}}, {{2, 7}});
+
+  runner.simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
+      intrp::Actions::InterpolationTargetReceiveVars<
+          metavars::InterpolationTargetA, 3, Frame::Inertial>>(0, vars_src,
+                                                               global_offsets);
+
+  // It should have interpolated 4 points by now.
+  CHECK(db::get<intrp::Tags::IndicesOfFilledInterpPoints>(box_target).size() ==
+        4);
+
+  // Should be no queued simple action until we get num_points points.
+  CHECK(runner.is_simple_action_queue_empty<
+        mock_interpolation_target<metavars, metavars::InterpolationTargetA>>(
+      0));
+  CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars, 3>>(0));
+  CHECK(db::get<intrp::Tags::TemporalIds<metavars>>(box_target).size() == 2);
+
+  vars_src.clear();
+  global_offsets.clear();
+  add_to_vars_src({{1.0, 888888.0}},
+                  {{1, 6}});  // 6 is repeated, point will be ignored.
+  add_to_vars_src({{8.0, 0.0, 4.0}}, {{8, 0, 4}});
+
+  runner.simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
+      intrp::Actions::InterpolationTargetReceiveVars<
+          metavars::InterpolationTargetA, 3, Frame::Inertial>>(0, vars_src,
+                                                               global_offsets);
+
+  // It should have interpolated 8 points by now. (The ninth point had
+  // a repeated global_offsets so it should be ignored)
+  CHECK(db::get<intrp::Tags::IndicesOfFilledInterpPoints>(box_target).size() ==
+        8);
+
+  // Should be no queued simple action until we have added 10 points.
+  CHECK(runner.is_simple_action_queue_empty<
+        mock_interpolation_target<metavars, metavars::InterpolationTargetA>>(
+      0));
+  CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars, 3>>(0));
+
+  vars_src.clear();
+  global_offsets.clear();
+  add_to_vars_src({{9.0, 5.0}}, {{9, 5}});
+
+  // This will call InterpolationTargetA::post_interpolation_callback
+  // where we check that the points are correct.
+  runner.simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
+      intrp::Actions::InterpolationTargetReceiveVars<
+          metavars::InterpolationTargetA, 3, Frame::Inertial>>(0, vars_src,
+                                                               global_offsets);
+
+  // It should have interpolated all the points by now.
+  CHECK(db::get<intrp::Tags::IndicesOfFilledInterpPoints>(box_target).size() ==
+        num_points);
+
+  // Now there should be a queued simple action, which is
+  // CleanUpInterpolator, which here we mock.
+  runner.invoke_queued_simple_action<mock_interpolator<metavars, 3>>(0);
+
+  // Check that MockCleanUpInterpolator was called.  It resets the
+  // (fake) number of elements, specifically so we can test it here.
+  CHECK(db::get<intrp::Tags::NumberOfElements>(box_interpolator) == 1);
+
+  // Also, there should be only 1 TemporalId left.
+  CHECK(db::get<intrp::Tags::TemporalIds<metavars>>(box_target).size() == 1);
+
+  // And there is yet one more simple action, compute_target_points,
+  // which here we mock just to check that it is called.
+  runner.invoke_queued_simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>>(0);
+
+  // Check that MockComputeTargetPoints was called.
+  // It sets a (fake) value of IndicesOfFilledInterpPoints for the express
+  // purpose of this check.
+  CHECK(db::get<intrp::Tags::IndicesOfFilledInterpPoints>(box_target).size() ==
+        num_points + 1);
+
+  // There should be no more queued actions; verify this.
+  CHECK(runner.is_simple_action_queue_empty<
+        mock_interpolation_target<metavars, metavars::InterpolationTargetA>>(
+      0));
+  CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars, 3>>(0));
+}
+
+}  // namespace


### PR DESCRIPTION
Another PR towards ParallelInterpolator.

This is an Action that receives interpolated variables from
an Interpolator at a subset of points, and then calls other
actions if it has received variables at all the points.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
