### PR TITLE
Add `ModalVector`

### DIFF
--- a/src/DataStructures/DiagonalModalOperator.hpp
+++ b/src/DataStructures/DiagonalModalOperator.hpp
@@ -1,0 +1,112 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/VectorImpl.hpp"
+#include "Utilities/PointerVector.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class ModalVector;
+/// \endcond
+
+// IWYU pragma: no_include <blaze/math/expressions/DVecMapExpr.h>
+// IWYU pragma: no_include <blaze/math/typetraits/IsVector.h>
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief A class for an element-wise multiplier of modal coefficients.
+ *
+ * \details A `DiagonalModalOperator` holds an array of factors to multiply by
+ * spectral coefficients, and can be either owning (the array is deleted when
+ * the `DiagonalModalOperator` goes out of scope) or non-owning, meaning it just
+ * has a pointer to an array.
+ *
+ * `DiagonalModalOperator`s are intended to represent a diagonal matrix that can
+ * operate (via the `*` operator) on spectral coefficients represented by
+ * `ModalVector`s easily. Only basic mathematical operations are supported with
+ * `DiagonalModalOperator`s. `DiagonalModalOperator`s may be added, subtracted,
+ * multiplied, or divided, and may be multiplied with a `ModalVector`, which
+ * results in a new `ModalVector`. This multiplication is commutative,
+ * supporting the interpretation of the `ModalVector` as either a 'row' or a
+ * 'column' vector.
+ *
+ * Also, addition, subtraction, multiplication and division of
+ * `DiagonalModalOperator`s with doubles is supported.
+ */
+class DiagonalModalOperator : public VectorImpl<double, DiagonalModalOperator> {
+ public:
+  using VectorImpl<double, DiagonalModalOperator>::operator=;
+  using VectorImpl<double, DiagonalModalOperator>::VectorImpl;
+
+  MAKE_MATH_ASSIGN_EXPRESSION_ARITHMETIC(DiagonalModalOperator)
+};
+
+namespace blaze {
+VECTOR_BLAZE_TRAIT_SPECIALIZE_ARITHMETIC_TRAITS(DiagonalModalOperator);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ModalVector,
+                                               DiagonalModalOperator,
+                                               MultTrait);
+
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+template <typename Operator>
+struct UnaryMapTrait<DiagonalModalOperator, Operator> {
+  // Selectively allow unary operations for spectral coefficient operators
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<
+              // these traits are required for operators acting with doubles
+              blaze::AddScalar<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
+              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>>,
+          Operator>,
+      "This unary operation is not permitted on a DiagonalModalOperator");
+  using Type = DiagonalModalOperator;
+};
+
+template <typename Operator>
+struct BinaryMapTrait<DiagonalModalOperator, DiagonalModalOperator, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // DiagonalModalOperator that are unlikely to be used on spectral
+  // coefficients. Currently no non-arithmetic binary operations are supported.
+  static_assert(
+      tmpl::list_contains_v<tmpl::list<>, Operator>,
+      "This binary operation is not permitted on a DiagonalModalOperator.");
+  using Type = DiagonalModalOperator;
+};
+#else
+template <typename Operator>
+struct MapTrait<DiagonalModalOperator, Operator> {
+  // Selectively allow unary operations for spectral coefficient operators
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<
+              // these traits are required for operators acting with doubles
+              blaze::AddScalar<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<DiagonalModalOperator::ElementType>>,
+              blaze::DivideScalarByVector<DiagonalModalOperator::ElementType>>,
+          Operator>,
+      "This unary operation is not permitted on a DiagonalModalOperator");
+  using Type = DiagonalModalOperator;
+};
+
+template <typename Operator>
+struct MapTrait<DiagonalModalOperator, DiagonalModalOperator, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // DiagonalModalOperator that are unlikely to be used on spectral
+  // coefficients. Currently no non-arithmetic binary operations are supported.
+  static_assert(
+      tmpl::list_contains_v<tmpl::list<>, Operator>,
+      "This binary operation is not permitted on a DiagonalModalOperator.");
+  using Type = DiagonalModalOperator;
+};
+#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+}  // namespace blaze
+
+MAKE_STD_ARRAY_VECTOR_BINOPS(DiagonalModalOperator)
+
+MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(DiagonalModalOperator)

--- a/src/DataStructures/ModalVector.hpp
+++ b/src/DataStructures/ModalVector.hpp
@@ -1,0 +1,124 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/VectorImpl.hpp"
+#include "Utilities/PointerVector.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_include <blaze/math/expressions/DVecMapExpr.h>
+// IWYU pragma: no_include <blaze/math/typetraits/IsVector.h>
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief A class for storing spectral coefficients on a spectral grid.
+ *
+ * \details A ModalVector holds an array of spectral coefficients, and can be
+ * either owning (the array is deleted when the ModalVector goes out of scope)
+ * or non-owning, meaning it just has a pointer to an array.
+ *
+ * Only basic mathematical operations are supported with
+ * ModalVectors. ModalVectors may be added or subtracted, and the following
+ * unary operations are supported:
+ * - abs
+ *
+ * Also multiplication is supported with doubles and `ModalVector`s, and
+ * `ModalVector`s can be divided by doubles. Multiplication is supported with
+ * `DiagonalModalOperator`s and `ModalVector`s.
+ */
+class ModalVector : public VectorImpl<double, ModalVector> {
+ public:
+  using VectorImpl<double, ModalVector>::operator=;
+  using VectorImpl<double, ModalVector>::VectorImpl;
+
+  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(+=, ModalVector)
+  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(-=, ModalVector)
+};
+
+namespace blaze {
+template <>
+struct IsVector<ModalVector> : std::true_type {};
+template <>
+struct TransposeFlag<ModalVector> : BoolConstant<ModalVector::transpose_flag> {
+};
+template <>
+struct AddTrait<ModalVector, ModalVector> {
+  using Type = ModalVector;
+};
+template <>
+struct SubTrait<ModalVector, ModalVector> {
+  using Type = ModalVector;
+};
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ModalVector, double, MultTrait);
+template <>
+struct DivTrait<ModalVector, double> {
+  using Type = ModalVector;
+};
+
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+template <typename Operator>
+struct UnaryMapTrait<ModalVector, Operator> {
+  // Selectively allow unary operations for spectral coefficients
+  static_assert(tmpl::list_contains_v<
+                    tmpl::list<blaze::Abs,
+                               // Following 3 reqd. by operator(+,+=), (-,-=),
+                               // (-) w/doubles
+                               blaze::AddScalar<ModalVector::ElementType>,
+                               blaze::SubScalarRhs<ModalVector::ElementType>,
+                               blaze::SubScalarLhs<ModalVector::ElementType>>,
+                    Operator>,
+                "Only unary operation permitted on a ModalVector are:"
+                " abs");
+  using Type = ModalVector;
+};
+
+template <typename Operator>
+struct BinaryMapTrait<ModalVector, ModalVector, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // ModalVector that are unlikely to be used on spectral coefficients.
+  // Currently no non-arithmetic binary operations are supported.
+  static_assert(tmpl::list_contains_v<tmpl::list<>, Operator>,
+                "This binary operation is not permitted on a ModalVector.");
+  using Type = ModalVector;
+};
+#else
+template <typename Operator>
+struct MapTrait<ModalVector, Operator> {
+  // Selectively allow unary operations for spectral coefficients
+  static_assert(tmpl::list_contains_v<
+                    tmpl::list<blaze::Abs,
+                               // Following 3 reqd. by operator(+,+=), (-,-=),
+                               // (-) w/doubles
+                               blaze::AddScalar<ModalVector::ElementType>,
+                               blaze::SubScalarRhs<ModalVector::ElementType>,
+                               blaze::SubScalarLhs<ModalVector::ElementType>>,
+                    Operator>,
+                "Only unary operation permitted on a ModalVector are:"
+                " abs.");
+  using Type = ModalVector;
+};
+
+template <typename Operator>
+struct MapTrait<ModalVector, ModalVector, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // ModalVector that are unlikely to be used on spectral coefficients.
+  // Currently no non-arithmetic binary operations are supported.
+  static_assert(tmpl::list_contains_v<tmpl::list<>, Operator>,
+                "This binary operation is not permitted on a ModalVector.");
+  using Type = ModalVector;
+};
+#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+}  // namespace blaze
+
+/// \cond
+DEFINE_STD_ARRAY_BINOP(ModalVector, ModalVector, ModalVector, operator+,
+                       std::plus<>())
+DEFINE_STD_ARRAY_BINOP(ModalVector, ModalVector, ModalVector, operator-,
+                       std::minus<>())
+DEFINE_STD_ARRAY_INPLACE_BINOP(ModalVector, ModalVector, operator+=,
+                               std::plus<>())
+DEFINE_STD_ARRAY_INPLACE_BINOP(ModalVector, ModalVector, operator-=,
+                               std::minus<>())
+/// \endcond
+MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(ModalVector)

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
 #include "DataStructures/Tensor/Expressions/Contract.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
@@ -81,9 +82,10 @@ class Tensor<X, Symm, IndexList<Indices...>> {
                 "SpECTRE.");
   static_assert(
       cpp17::is_same_v<X, double> or cpp17::is_same_v<X, DataVector> or
+          cpp17::is_same_v<X, ModalVector> or
           cpp17::is_same_v<X, std::complex<double>> or
           cpp17::is_same_v<X, ComplexDataVector>,
-      "Only a Tensor<double>, Tensor<DataVector>, "
+      "Only a Tensor<double>, Tensor<DataVector>, Tensor<ModalVector>, "
       "Tensor<std::complex<double>>, or Tensor<ComplexDataVector> is currently "
       "allowed. While other types are technically possible it is not "
       "clear that Tensor is the correct container for them. Please "

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBRARY_SOURCES
   Test_Index.cpp
   Test_IndexIterator.cpp
   Test_LeviCivitaIterator.cpp
+  Test_ModalVector.cpp
   Test_OrientVariables.cpp
   Test_SliceIterator.cpp
   Test_SpinWeighted.cpp

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_DataVector.cpp
   Test_DenseMatrix.cpp
   Test_DenseVector.cpp
+  Test_DiagonalModalOperator.cpp
   Test_FixedHashMap.cpp
   Test_GeneralIndexIterator.cpp
   Test_IdPair.cpp

--- a/tests/Unit/DataStructures/Test_DiagonalModalOperator.cpp
+++ b/tests/Unit/DataStructures/Test_DiagonalModalOperator.cpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <tuple>
+
+#include "DataStructures/DiagonalModalOperator.hpp"
+#include "DataStructures/ModalVector.hpp"  // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"         // IWYU pragma: keep
+#include "Utilities/Functional.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// IWYU pragma: no_include <algorithm>
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.DiagonalModalOperator.ExpressionAssignError",
+    "[Unit][DataStructures]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<DiagonalModalOperator>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::ExpressionAssign);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.DiagonalModalOperator.RefDiffSize",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<DiagonalModalOperator>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::Copy);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.DiagonalModalOperator.MoveRefDiffSize",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<DiagonalModalOperator>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::Move);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+void test_diagonal_modal_operator_math() noexcept {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+
+  const auto binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, DiagonalModalOperator>(
+      binary_ops);
+
+  const auto inplace_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::DivAssign<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::MinusAssign<>{},
+                      std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::MultAssign<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::PlusAssign<>{},
+                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Inplace, DiagonalModalOperator>(
+      inplace_binary_ops);
+
+  const auto acting_on_modal_vector = std::make_tuple(std::make_tuple(
+      funcl::Multiplies<>{}, std::make_tuple(generic, generic)));
+
+  // the operation isn't really "inplace", but we carefully forbid the operation
+  // between two ModalVectors, which will be avoided in the inplace test case,
+  // which checks only combinations with the DiagonalModalOperator as the first
+  // argument.
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Inplace, DiagonalModalOperator,
+      ModalVector>(acting_on_modal_vector);
+  // testing the other ordering
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
+      DiagonalModalOperator>(acting_on_modal_vector);
+
+  const auto cascaded_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)),
+      std::make_tuple(funcl::Minus<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, DiagonalModalOperator>(
+      cascaded_ops);
+
+  const auto array_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict,
+      std::array<DiagonalModalOperator, 2>>(array_binary_ops);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DiagonalModalOperator",
+                  "[DataStructures][Unit]") {
+  {
+    INFO("test construct and assign");
+    TestHelpers::VectorImpl::vector_test_construct_and_assign<
+        DiagonalModalOperator, double>();
+  }
+  {
+    INFO("test serialize and deserialize");
+    TestHelpers::VectorImpl::vector_test_serialize<DiagonalModalOperator,
+                                                   double>();
+  }
+  {
+    INFO("test set_data_ref functionality");
+    TestHelpers::VectorImpl::vector_test_ref<DiagonalModalOperator, double>();
+  }
+  {
+    INFO("test math after move");
+    TestHelpers::VectorImpl::vector_test_math_after_move<DiagonalModalOperator,
+                                                         double>();
+  }
+  {
+    INFO("test DiagonalModalOperator math operations");
+    test_diagonal_modal_operator_math();
+  }
+}

--- a/tests/Unit/DataStructures/Test_ModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ModalVector.cpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <tuple>
+
+#include "DataStructures/ModalVector.hpp"
+#include "ErrorHandling/Error.hpp"           // IWYU pragma: keep
+#include "Utilities/DereferenceWrapper.hpp"  // IWYU pragma: keep
+#include "Utilities/Functional.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// IWYU pragma: no_include <algorithm>
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.ModalVector.ExpressionAssignError",
+    "[Unit][DataStructures]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<ModalVector>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::ExpressionAssign);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+        "Unit.DataStructures.ModalVector.RefDiffSize",
+        "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<ModalVector>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::Copy);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.ModalVector.MoveRefDiffSize",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<ModalVector>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::Move);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+void test_modal_vector_math() noexcept {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+
+  const auto unary_ops = std::make_tuple(
+      std::make_tuple(funcl::Abs<>{}, std::make_tuple(generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, ModalVector>(unary_ops);
+
+  const auto binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, ModalVector>(binary_ops);
+
+  const auto cascaded_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, ModalVector>(cascaded_ops);
+
+  const auto array_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, std::array<ModalVector, 2>>(
+      array_binary_ops);
+
+  const auto just_double_with_modal_vector_ops =
+      std::make_tuple(std::make_tuple(funcl::Multiplies<>{},
+                                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, double,
+      ModalVector>(just_double_with_modal_vector_ops);
+
+  const auto just_modal_vector_with_double_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
+      double>(just_modal_vector_with_double_ops);
+
+  const auto just_modal_vector_with_modal_vector_ops =
+      std::make_tuple(std::make_tuple(funcl::MinusAssign<>{},
+                                      std::make_tuple(generic, generic)),
+                      std::make_tuple(funcl::PlusAssign<>{},
+                                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
+      ModalVector>(just_modal_vector_with_modal_vector_ops);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.ModalVector", "[DataStructures][Unit]") {
+  {
+    INFO("test construct and assign");
+    TestHelpers::VectorImpl::vector_test_construct_and_assign<ModalVector,
+                                                              double>();
+  }
+  {
+    INFO("test serialize and deserialize");
+    TestHelpers::VectorImpl::vector_test_serialize<ModalVector, double>();
+  }
+  {
+    INFO("test set_data_ref functionality");
+    TestHelpers::VectorImpl::vector_test_ref<ModalVector, double>();
+  }
+  {
+    INFO("test math after move");
+    TestHelpers::VectorImpl::vector_test_math_after_move<ModalVector, double>();
+  }
+  {
+    INFO("test ModalVector math operations");
+    test_modal_vector_math();
+  }
+}

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
+#include "DataStructures/ModalVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesHelpers.hpp"
@@ -912,38 +913,48 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
   SECTION("Test Variables construction, access, and assignment") {
     test_variables_construction_and_access<DataVector>();
     test_variables_construction_and_access<ComplexDataVector>();
+    test_variables_construction_and_access<ModalVector>();
   }
   SECTION("Test Variables move operations") {
     test_variables_move<DataVector>();
     test_variables_move<ComplexDataVector>();
+    test_variables_move<ModalVector>();
   }
   SECTION("Test Variables arithmetic operations") {
     test_variables_math<DataVector>();
     test_variables_math<ComplexDataVector>();
+    // test for ModalVector omitted due to limited arithmetic operation support
+    // for ModalVectors
   }
   SECTION("Test Prefix Variables move and copy semantics") {
     test_variables_prefix_semantics<DataVector>();
     test_variables_prefix_semantics<ComplexDataVector>();
+    test_variables_prefix_semantics<ModalVector>();
   }
   SECTION("Test Prefix Variables arithmetic operations") {
     test_variables_prefix_math<DataVector>();
     test_variables_prefix_math<ComplexDataVector>();
+    test_variables_prefix_math<ModalVector>();
   }
   SECTION("Test Variables serialization") {
     test_variables_serialization<DataVector>();
     test_variables_serialization<ComplexDataVector>();
+    test_variables_serialization<ModalVector>();
   }
   SECTION("Test Variables assign subset") {
     test_variables_assign_subset<DataVector>();
     test_variables_assign_subset<ComplexDataVector>();
+    test_variables_assign_subset<ModalVector>();
   }
   SECTION("Test Variables slice utilities") {
     test_variables_slice<DataVector>();
     test_variables_slice<ComplexDataVector>();
+    test_variables_slice<ModalVector>();
   }
   SECTION("Test adding slice values to Variables") {
     test_variables_add_slice_to_data<DataVector>();
     test_variables_add_slice_to_data<ComplexDataVector>();
+    test_variables_add_slice_to_data<ModalVector>();
   }
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

This is based on the `ModalVector` changes implemented by @prayush, but updated
to fit into the framework with a templated `VectorImpl`. Multiplication,
division, and absolute values are omitted for `ModalVector`s, as these
operations do not have a clear and present use-case for spectral coefficients.

closes #378 

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

## Dependencies
- [x] #970