### PR TITLE
Promote GH gauge constraint from test to function

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -37,4 +37,44 @@ void three_index_constraint(
     const tnsr::iaa<DataType, SpatialDim, Frame>& d_spacetime_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
 // @}
+
+// @{
+/*!
+ * \brief Computes the generalized-harmonic gauge constraint.
+ *
+ * \details Computes the generalized-harmonic gauge constraint
+ * [Eq. (40) of http://arXiv.org/abs/gr-qc/0512093v3],
+ * \f[
+ * C_a = H_a + g^{ij} \Phi_{ija} + t^b \Pi_{ba}
+ * - \frac{1}{2} g^i_a \psi^{bc} \Phi_{ibc}
+ * - \frac{1}{2} t_a \psi^{bc} \Pi_{bc},
+ * \f]
+ * where \f$H_a\f$ is the gauge function,
+ * \f$\psi_{ab}\f$ is the spacetime metric,
+ * \f$\Pi_{ab}=-t^c\partial_c \psi_{ab}\f$, and
+ * \f$\Phi_{iab} = \partial_i\psi_{ab}\f$; \f$t^a\f$ is the timelike unit
+ * normal vector to the spatial slice, \f$g^{ij}\f$ is the inverse spatial
+ * metric, and \f$g^b_c = \delta^b_c + t^b t_c\f$.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> gauge_constraint(
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void gauge_constraint(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+// @}
 }  // namespace GeneralizedHarmonic

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -25,3 +25,21 @@ def phi_dot_flux(spacetime_metric, pi, phi, gamma1, gamma2, lapse, shift,
         + lapse * np.einsum("i,ab->iab", unit_normal, pi) \
            - gamma2 * lapse * np.einsum("i,ab->iab", unit_normal,
                                         spacetime_metric)
+
+def gauge_constraint(gauge_function, spacetime_normal_one_form,
+                     spacetime_normal_vector, inverse_spatial_metric,
+                     inverse_spacetime_metric, pi, phi):
+    # Sums only go over spatial indices of second index of phi
+    phi_ija = phi[:,1:,:]
+    spacetime_normal_vector_I = spacetime_normal_vector[1:]
+    constraint = gauge_function \
+      + np.einsum("ij,ija->a", inverse_spatial_metric, phi_ija) \
+      + np.einsum("b,ba->a", spacetime_normal_vector, pi) \
+      - 0.5 * np.insert(np.einsum("bc,ibc->i", inverse_spacetime_metric, phi), \
+                                  0, np.zeros(phi[0][0][0].shape)) \
+      - 0.5 * np.einsum("a,i,bc,ibc->a", spacetime_normal_one_form, \
+                        spacetime_normal_vector_I, \
+                        inverse_spacetime_metric, phi) \
+      - 0.5 * np.einsum("a,bc,bc->a", spacetime_normal_one_form, \
+                        inverse_spacetime_metric, pi)
+    return constraint

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -3,12 +3,33 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <array>
 #include <cstddef>
 #include <limits>
+#include <memory>
+#include <pup.h>
 
+#include "DataStructures/DataBox/Prefixes.hpp" // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Constraints.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 
@@ -25,6 +46,100 @@ void test_three_index_constraint(const DataType& used_for_size) noexcept {
           &GeneralizedHarmonic::three_index_constraint<SpatialDim, Frame,
                                                        DataType>),
       "numpy", "subtract", {{{-10.0, 10.0}}}, used_for_size);
+}
+
+// Test the return-by-value gauge constraint function using random values
+template <size_t SpatialDim, typename Frame, typename DataType>
+void test_gauge_constraint_random(const DataType& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
+          const tnsr::a<DataType, SpatialDim, Frame>&,
+          const tnsr::a<DataType, SpatialDim, Frame>&,
+          const tnsr::A<DataType, SpatialDim, Frame>&,
+          const tnsr::II<DataType, SpatialDim, Frame>&,
+          const tnsr::AA<DataType, SpatialDim, Frame>&,
+          const tnsr::aa<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&)>(
+          &GeneralizedHarmonic::gauge_constraint<SpatialDim, Frame, DataType>),
+      "TestFunctions", "gauge_constraint", {{{-10.0, 10.0}}}, used_for_size);
+}
+
+// Test test return-by-reference gauge constraint by comparing to Kerr-Schild
+template <typename Solution>
+void test_gauge_constraint_analytic(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Check vs. time-independent analytic solution
+  // Set up grid
+  const size_t data_size = pow<3>(grid_size_each_dimension);
+  Mesh<3> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto};
+
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<>>>(vars);
+  const auto& d_lapse =
+      get<typename Solution::template DerivLapse<DataVector>>(vars);
+  const auto& shift = get<gr::Tags::Shift<3>>(vars);
+  const auto& d_shift =
+      get<typename Solution::template DerivShift<DataVector>>(vars);
+  const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<3>>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<3>>(vars);
+  const auto& dt_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<3>>>(vars);
+  const auto& d_spatial_metric =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
+
+  // Get ingredients for computing the gauge constraint
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto& inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+  const auto& gauge_function = GeneralizedHarmonic::gauge_source(
+      lapse, dt_lapse, d_lapse, shift, dt_shift, d_shift, spatial_metric,
+      trace(gr::extrinsic_curvature(lapse, shift, d_shift, spatial_metric,
+                                    dt_spatial_metric, d_spatial_metric),
+            inverse_spatial_metric),
+      trace_last_indices(gr::christoffel_first_kind(d_spatial_metric),
+                         inverse_spatial_metric));
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                             spatial_metric, d_spatial_metric);
+  const auto& pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+  const auto& normal_one_form =
+      gr::spacetime_normal_one_form<3, Frame::Inertial>(lapse);
+  const auto& normal_vector = gr::spacetime_normal_vector(lapse, shift);
+
+  // Get the constraint, and check that it vanishes
+  auto constraint =
+      make_with_value<tnsr::a<DataVector, 3, Frame::Inertial>>(x, 0.0);
+  const gsl::not_null<tnsr::a<DataVector, 3, Frame::Inertial>*>
+      constraint_pointer = &(constraint);
+  GeneralizedHarmonic::gauge_constraint(
+      constraint_pointer, gauge_function, normal_one_form, normal_vector,
+      inverse_spatial_metric, inverse_spacetime_metric, pi, phi);
+  CHECK_ITERABLE_APPROX(constraint,
+                        make_with_value<decltype(constraint)>(x, 0.0));
 }
 }  // namespace
 
@@ -59,5 +174,51 @@ SPECTRE_TEST_CASE(
   test_three_index_constraint<3, Frame::Grid, double>(
       std::numeric_limits<double>::signaling_NaN());
   test_three_index_constraint<3, Frame::Inertial, double>(
+      std::numeric_limits<double>::signaling_NaN());
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.GaugeConstraint",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GeneralizedHarmonic/"};
+
+  // Test the gauge constraint against Kerr Schild
+  const double mass = 1.4;
+  const std::array<double, 3> spin{{0.4, 0.3, 0.2}};
+  const std::array<double, 3> center{{0.2, 0.3, 0.4}};
+  const gr::Solutions::KerrSchild solution(mass, spin, center);
+
+  const size_t grid_size = 8;
+  const std::array<double, 3> lower_bound{{0.82, 1.24, 1.32}};
+  const std::array<double, 3> upper_bound{{0.8, 1.22, 1.30}};
+
+  test_gauge_constraint_analytic(solution, grid_size, lower_bound, upper_bound);
+
+  // Test the gauge constraint with random numbers
+  test_gauge_constraint_random<1, Frame::Grid, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_gauge_constraint_random<1, Frame::Inertial, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_gauge_constraint_random<1, Frame::Grid, double>(
+      std::numeric_limits<double>::signaling_NaN());
+  test_gauge_constraint_random<1, Frame::Inertial, double>(
+      std::numeric_limits<double>::signaling_NaN());
+
+  test_gauge_constraint_random<2, Frame::Grid, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_gauge_constraint_random<2, Frame::Inertial, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_gauge_constraint_random<2, Frame::Grid, double>(
+      std::numeric_limits<double>::signaling_NaN());
+  test_gauge_constraint_random<2, Frame::Inertial, double>(
+      std::numeric_limits<double>::signaling_NaN());
+
+  test_gauge_constraint_random<3, Frame::Grid, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_gauge_constraint_random<3, Frame::Inertial, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_gauge_constraint_random<3, Frame::Grid, double>(
+      std::numeric_limits<double>::signaling_NaN());
+  test_gauge_constraint_random<3, Frame::Inertial, double>(
       std::numeric_limits<double>::signaling_NaN());
 }


### PR DESCRIPTION
## Proposed changes

Move GH gauge constraint from a test file (VerifyGrSolution.hpp) to GeneralizedHarmonic/Constraints.?pp, and test by checking for Kerr-Schild and with fuzzy testing.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
