### PR TITLE
Interpolator receive volume data

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -54,9 +54,10 @@ struct Info {
   /// The size of `global_offsets` changes as more `Element`s
   /// send data to this `Interpolator`.
   std::vector<std::vector<size_t>> global_offsets{};
-  /// Holds the `ElementId`s of `Element`s that have already sent their data
-  /// to this `Interpolator`.
-  std::unordered_set<ElementId<VolumeDim>> element_has_communicated{};
+  /// Holds the `ElementId`s of `Element`s for which interpolation has
+  /// already been done for this `Info`.
+  std::unordered_set<ElementId<VolumeDim>>
+      interpolation_is_done_for_these_elements{};
 };
 
 /// Holds `Info`s at all `temporal_id`s for a given

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace intrp {
+namespace Actions {
+
+/// \ingroup ActionsGroup
+/// \brief Adds volume data from an `Element`.
+///
+/// Attempts to interpolate if it already has received target points from
+/// any InterpolationTargets.
+///
+/// Uses:
+/// - DataBox:
+///   - `Tags::NumberOfElements`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `Tags::VolumeVarsInfo<Metavariables,VolumeDim>`
+///   - `Tags::InterpolatedVarsHolders<Metavariables,VolumeDim>`
+template <typename Frame>
+struct InterpolatorReceiveVolumeData {
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      size_t VolumeDim,
+      Requires<tmpl::list_contains_v<DbTags, typename Tags::NumberOfElements>> =
+          nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const typename Metavariables::temporal_id& temporal_id,
+      const ElementId<VolumeDim>& element_id, const ::Mesh<VolumeDim>& mesh,
+      Variables<typename Metavariables::interpolator_source_vars>&&
+          vars) noexcept {
+    db::mutate<Tags::VolumeVarsInfo<Metavariables, VolumeDim>>(
+        make_not_null(&box),
+        [&temporal_id, &element_id, &mesh,
+         &vars ](const gsl::not_null<
+                 db::item_type<Tags::VolumeVarsInfo<Metavariables, VolumeDim>>*>
+                     container) noexcept {
+          if (container->find(temporal_id) == container->end()) {
+            container->emplace(
+                temporal_id,
+                std::unordered_map<ElementId<VolumeDim>,
+                                   typename Tags::VolumeVarsInfo<
+                                       Metavariables, VolumeDim>::Info>{});
+          }
+          container->at(temporal_id)
+              .emplace(std::make_pair(
+                  element_id,
+                  typename Tags::VolumeVarsInfo<Metavariables, VolumeDim>::Info{
+                      mesh, std::move(vars)}));
+        });
+
+    // Try to interpolate data for all InterpolationTargets.
+    tmpl::for_each<typename Metavariables::interpolation_target_tags>(
+        [&box, &cache, &temporal_id](auto x) noexcept {
+          using tag = typename decltype(x)::type;
+          try_to_interpolate<tag, VolumeDim, Frame>(make_not_null(&box),
+                                                    make_not_null(&cache),
+                                                    temporal_id);
+        });
+  }
+};
+
+}  // namespace Actions
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
@@ -1,0 +1,176 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/ElementLogicalCoordinates.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/Interpolation/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace intrp {
+template <typename Metavariables, typename InterpolationTargetTag,
+          size_t VolumeDim, typename Frame>
+struct InterpolationTarget;
+namespace Actions {
+template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+struct InterpolationTargetReceiveVars;
+}  // namespace Actions
+}  // namespace intrp
+/// \endcond
+
+namespace intrp {
+
+namespace interpolator_detail {
+
+// Interpolates data onto a set of points desired by an InterpolationTarget.
+template <typename InterpolationTargetTag, typename Metavariables,
+          size_t VolumeDim, typename DbTags>
+void interpolate_data(
+    const gsl::not_null<db::DataBox<DbTags>*> box,
+    const typename Metavariables::temporal_id& temporal_id) noexcept {
+  db::mutate_apply<
+      tmpl::list<Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>,
+      tmpl::list<Tags::VolumeVarsInfo<Metavariables, VolumeDim>>>(
+      [&temporal_id](
+          const gsl::not_null<db::item_type<
+              Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>*>
+              holders,
+          const db::item_type<Tags::VolumeVarsInfo<Metavariables, VolumeDim>>&
+              volume_vars_info) noexcept {
+        auto& interp_info =
+            get<Vars::HolderTag<InterpolationTargetTag, Metavariables,
+                                VolumeDim>>(*holders)
+                .infos.at(temporal_id);
+
+        for (const auto& volume_info_outer : volume_vars_info) {
+          // Are we at the right time?
+          if (volume_info_outer.first != temporal_id) {
+            continue;
+          }
+
+          // Get list of ElementIds that have the correct temporal_id and that
+          // have not yet been interpolated.
+          std::vector<ElementId<VolumeDim>> element_ids;
+
+          for (const auto& volume_info_inner : volume_info_outer.second) {
+            // Have we interpolated this element before?
+            if (interp_info.interpolation_is_done_for_these_elements.find(
+                    volume_info_inner.first) ==
+                interp_info.interpolation_is_done_for_these_elements.end()) {
+              interp_info.interpolation_is_done_for_these_elements.emplace(
+                  volume_info_inner.first);
+              element_ids.push_back(volume_info_inner.first);
+            }
+          }
+
+          // Get element logical coordinates.
+          const auto element_coord_holders = element_logical_coordinates(
+              element_ids, interp_info.block_coord_holders);
+
+          // Construct local vars and interpolate.
+          for (const auto& element_coord_pair : element_coord_holders) {
+            const auto& element_id = element_coord_pair.first;
+            const auto& element_coord_holder = element_coord_pair.second;
+            const auto& volume_info = volume_info_outer.second.at(element_id);
+
+            // Construct local_vars which is some set of variables
+            // derived from volume_info.vars plus an arbitrary set
+            // of compute items in
+            // InterpolationTargetTag::compute_items_on_source.
+
+            auto new_box = db::create<
+                db::AddSimpleTags<::Tags::Variables<
+                    typename Metavariables::interpolator_source_vars>>,
+                db::AddComputeTags<
+                    typename InterpolationTargetTag::compute_items_on_source>>(
+                volume_info.vars);
+
+            Variables<
+                typename InterpolationTargetTag::vars_to_interpolate_to_target>
+                local_vars(volume_info.mesh.number_of_grid_points());
+
+            tmpl::for_each<
+                typename InterpolationTargetTag::vars_to_interpolate_to_target>(
+                [&new_box, &local_vars](auto x) noexcept {
+                  using tag = typename decltype(x)::type;
+                  get<tag>(local_vars) = db::get<tag>(new_box);
+                });
+
+            // Now interpolate.
+            intrp::Irregular<VolumeDim> interpolator(
+                volume_info.mesh, element_coord_holder.element_logical_coords);
+            interp_info.vars.emplace_back(interpolator.interpolate(local_vars));
+            interp_info.global_offsets.emplace_back(
+                element_coord_holder.offsets);
+          }
+        }
+      },
+      box);
+}
+}  // namespace interpolator_detail
+
+/// Check if we have enough information to interpolate.  If so, do the
+/// interpolation and send data to the InterpolationTarget.
+template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame,
+          typename Metavariables, typename DbTags>
+void try_to_interpolate(
+    const gsl::not_null<db::DataBox<DbTags>*> box,
+    const gsl::not_null<Parallel::ConstGlobalCache<Metavariables>*> cache,
+    const typename Metavariables::temporal_id& temporal_id) noexcept {
+  const auto& holders =
+      db::get<Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>(*box);
+  const auto& vars_infos =
+      get<Vars::HolderTag<InterpolationTargetTag, Metavariables, VolumeDim>>(
+          holders)
+          .infos;
+
+  // If we don't yet have any points for this InterpolationTarget at
+  // this temporal_id, we should exit (we can't interpolate anyway).
+  if (vars_infos.count(temporal_id) == 0) {
+    return;
+  }
+
+  interpolator_detail::interpolate_data<InterpolationTargetTag, Metavariables,
+                                        VolumeDim>(box, temporal_id);
+
+  // Send interpolated data only if interpolation has been done on all
+  // of the local elements.
+  const auto& num_elements = db::get<Tags::NumberOfElements>(*box);
+  if (vars_infos.at(temporal_id)
+          .interpolation_is_done_for_these_elements.size() == num_elements) {
+    // Send data to InterpolationTarget, but only if the list of points is
+    // non-empty.
+    if (not vars_infos.at(temporal_id).global_offsets.empty()) {
+      const auto& info = vars_infos.at(temporal_id);
+      auto& receiver_proxy =
+          Parallel::get_parallel_component<InterpolationTarget<
+              Metavariables, InterpolationTargetTag, VolumeDim, Frame>>(*cache);
+      Parallel::simple_action<Actions::InterpolationTargetReceiveVars<
+          InterpolationTargetTag, VolumeDim, Frame>>(receiver_proxy, info.vars,
+                                                     info.global_offsets);
+    }
+
+    // Clear interpolated data, since we don't need it anymore.
+    db::mutate<Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>(
+        box, [&temporal_id](
+                 const gsl::not_null<db::item_type<
+                     Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>*>
+                     holders_l) noexcept {
+          get<Vars::HolderTag<InterpolationTargetTag, Metavariables,
+                              VolumeDim>>(*holders_l)
+              .infos.erase(temporal_id);
+        });
+  }
+}
+
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_InitializeInterpolationTarget.cpp
   Test_InitializeInterpolator.cpp
   Test_InterpolationTargetLineSegment.cpp
+  Test_InterpolatorReceiveVolumeData.cpp
   Test_InterpolatorRegisterElement.cpp
   Test_IrregularInterpolant.cpp
   Test_LagrangePolynomial.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -1,0 +1,345 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/IdPair.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/Shell.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/InitialElementIds.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Rational.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+/// \cond
+// IWYU pragma: no_forward_declare Tensor
+namespace intrp {
+namespace Actions {
+template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+struct InterpolationTargetReceiveVars;
+}  // namespace Actions
+}  // namespace intrp
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace intrp {
+namespace Tags {
+template <typename Metavariables, size_t VolumeDim>
+struct InterpolatedVarsHolders;
+template <typename Metavariables>
+struct TemporalIds;
+template <typename Metavariables, size_t VolumeDim>
+struct VolumeVarsInfo;
+}  // namespace Tags
+}  // namespace intrp
+/// \endcond
+
+namespace {
+
+// Simple DataBoxItems for test.
+namespace Tags {
+struct Square : db::SimpleTag {
+  static std::string name() noexcept { return "Square"; }
+  using type = Scalar<DataVector>;
+};
+struct SquareComputeItem : Square, db::ComputeTag {
+  static std::string name() noexcept { return "Square"; }
+  static Scalar<DataVector> function(const Scalar<DataVector>& x) noexcept {
+    auto result = make_with_value<Scalar<DataVector>>(x, 0.0);
+    get<>(result) = square(get<>(x));
+    return result;
+  }
+  using argument_tags = tmpl::list<gr::Tags::Lapse<DataVector>>;
+};
+}  // namespace Tags
+
+template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+struct MockInterpolationTargetReceiveVars {
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<tmpl::list_contains_v<
+          DbTags, typename intrp::Tags::TemporalIds<Metavariables>>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const std::vector<db::item_type<::Tags::Variables<
+          typename InterpolationTargetTag::vars_to_interpolate_to_target>>>&
+          vars_src,
+      const std::vector<std::vector<size_t>>& global_offsets) noexcept {
+    size_t number_of_interpolated_points = 0;
+    for (size_t i = 0; i < global_offsets.size(); ++i) {
+      Scalar<DataVector> expected_vars{global_offsets[i].size()};
+      number_of_interpolated_points += global_offsets[i].size();
+      for (size_t s = 0; s < global_offsets[i].size(); ++s) {
+        // Coords at this point. They are the same as the input coordinates,
+        // but in strange order because of global_offsets.
+        std::array<double, VolumeDim> coords{
+            {1.0 + 0.1 * global_offsets[i][s],
+             1.0 + 0.12 * global_offsets[i][s],
+             1.0 + 0.14 * global_offsets[i][s]}};
+        const double lapse =
+            2.0 * get<0>(coords) + 3.0 * get<1>(coords) +
+            5.0 * get<2>(coords);  // Same formula as input lapse.
+        get<>(expected_vars)[s] = square(lapse);
+      }
+      // We don't have that many points, so interpolation is good for
+      // only a few digits.
+      Approx custom_approx = Approx::custom().epsilon(1.e-5).scale(1.0);
+      CHECK_ITERABLE_CUSTOM_APPROX(
+          expected_vars, get<Tags::Square>(vars_src[i]), custom_approx);
+    }
+    // Make sure we have interpolated at the correct number of points.
+    CHECK(number_of_interpolated_points == 15);
+    // Change something in the DataBox so we can test that this function was
+    // indeed called.  Put some unusual temporal_id into Tags::TemporalIds.
+    // This is not the usual usage of Tags::TemporalIds; this is done just
+    // for the test.
+    Slab slab(0.0, 1.0);
+    Time temporal_id(slab, Rational(111, 135));
+    db::mutate<intrp::Tags::TemporalIds<Metavariables>>(
+        make_not_null(&box), [&temporal_id](
+                                 const gsl::not_null<db::item_type<
+                                     intrp::Tags::TemporalIds<Metavariables>>*>
+                                     temporal_ids) noexcept {
+          temporal_ids->push_back(temporal_id);
+        });
+  }
+};
+
+template <typename Metavariables, typename InterpolationTargetTag>
+struct mock_interpolation_target {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked =
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3,
+                                 Frame::Inertial>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename intrp::Actions::InitializeInterpolationTarget<
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
+                                                            ::Frame::Inertial>>;
+  using replace_these_simple_actions =
+      tmpl::list<intrp::Actions::InterpolationTargetReceiveVars<
+          typename Metavariables::InterpolationTargetA, 3, ::Frame::Inertial>>;
+  using with_these_simple_actions =
+      tmpl::list<MockInterpolationTargetReceiveVars<
+          typename Metavariables::InterpolationTargetA, 3, ::Frame::Inertial>>;
+};
+
+template <typename Metavariables, size_t VolumeDim>
+struct mock_interpolator {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox =
+      db::compute_databox_type<typename intrp::Actions::InitializeInterpolator<
+          VolumeDim>::template return_tag_list<Metavariables>>;
+  using component_being_mocked = void;  // not needed.
+};
+
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
+    using compute_items_on_source = tmpl::list<Tags::SquareComputeItem>;
+  };
+  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+  using temporal_id = Time;
+  using component_list = tmpl::list<
+      mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
+      mock_interpolator<MockMetavariables, 3>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialize, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
+                  "[Unit]") {
+  using metavars = MockMetavariables;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  using TupleOfMockDistributedObjects =
+      MockRuntimeSystem::TupleOfMockDistributedObjects;
+  TupleOfMockDistributedObjects dist_objects{};
+  using MockDistributedObjectsTagTarget =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolation_target<metavars, metavars::InterpolationTargetA>>;
+  using MockDistributedObjectsTagInterpolator =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolator<metavars, 3>>;
+
+  tuples::get<MockDistributedObjectsTagTarget>(dist_objects)
+      .emplace(0,
+               ActionTesting::MockDistributedObject<mock_interpolation_target<
+                   metavars, metavars::InterpolationTargetA>>{});
+
+  // Make an InterpolatedVarsHolders containing the target points.
+  const auto domain_creator =
+      DomainCreators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{7, 7}}, false);
+  const auto domain = domain_creator.create_domain();
+  Slab slab(0.0, 1.0);
+  Time temporal_id(slab, Rational(11, 15));
+  auto vars_holders = [&domain, &temporal_id]() {
+    const size_t n_pts = 15;
+    tnsr::I<DataVector, 3, Frame::Inertial> points(n_pts);
+    for (size_t d = 0; d < 3; ++d) {
+      for (size_t i = 0; i < n_pts; ++i) {
+        points.get(d)[i] = 1.0 + (0.1 + 0.02 * d) * i;  // Chosen by hand.
+      }
+    }
+    auto coords = block_logical_coordinates(domain, points);
+    db::item_type<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>
+        vars_holders_l{};
+    auto& vars_infos =
+        get<intrp::Vars::HolderTag<metavars::InterpolationTargetA, metavars,
+                                   3>>(vars_holders_l)
+            .infos;
+    vars_infos.emplace(std::make_pair(
+        temporal_id,
+        intrp::Vars::Info<3, typename metavars::InterpolationTargetA::
+                                 vars_to_interpolate_to_target>{
+            std::move(coords)}));
+    return vars_holders_l;
+  }();
+
+  // Set initial DataBox of Interpolator to contain an InterpolatedVarsHolders
+  // containing the target points.
+  tuples::get<MockDistributedObjectsTagInterpolator>(dist_objects)
+      .emplace(
+          0,
+          ActionTesting::MockDistributedObject<mock_interpolator<metavars, 3>>{
+              db::create<db::get_items<intrp::Actions::InitializeInterpolator<
+                  3>::return_tag_list<metavars>>>(
+                  0_st,
+                  db::item_type<intrp::Tags::VolumeVarsInfo<metavars, 3>>{},
+                  db::item_type<
+                      intrp::Tags::InterpolatedVarsHolders<metavars, 3>>{
+                      vars_holders})});
+
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
+
+  runner.simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
+      ::intrp::Actions::InitializeInterpolationTarget<
+          metavars::InterpolationTargetA>>(0, domain_creator.create_domain());
+
+  const auto& box_target =
+      runner
+          .template algorithms<mock_interpolation_target<
+              metavars, metavars::InterpolationTargetA>>()
+          .at(0)
+          .template get_databox<typename mock_interpolation_target<
+              metavars, metavars::InterpolationTargetA>::initial_databox>();
+
+  // Create Element_ids.
+  std::vector<ElementId<3>> element_ids{};
+  for (const auto& block : domain.blocks()) {
+    const auto initial_ref_levs =
+        domain_creator.initial_refinement_levels()[block.id()];
+    auto elem_ids = initial_element_ids(block.id(), initial_ref_levs);
+    element_ids.insert(element_ids.end(), elem_ids.begin(), elem_ids.end());
+  }
+
+  // Tell the interpolator how many elements there are by registering
+  // each one.
+  for (const auto& element_id : element_ids) {
+    runner.simple_action<mock_interpolator<metavars, 3>,
+                         intrp::Actions::RegisterElement>(0);
+  }
+
+  // Create volume data and send it to the interpolator.
+  for (const auto& element_id : element_ids) {
+    const auto& block = domain.blocks()[element_id.block_id()];
+    ::Mesh<3> mesh{domain_creator.initial_extents()[element_id.block_id()],
+                   Spectral::Basis::Legendre,
+                   Spectral::Quadrature::GaussLobatto};
+    ElementMap<3, Frame::Inertial> map{element_id,
+                                       block.coordinate_map().get_clone()};
+    const auto inertial_coords = map(logical_coordinates(mesh));
+    db::item_type<
+        ::Tags::Variables<typename metavars::interpolator_source_vars>>
+        output_vars(mesh.number_of_grid_points());
+    auto& lapse = get<gr::Tags::Lapse<DataVector>>(output_vars);
+
+    // Fill lapse with some analytic solution.
+    get<>(lapse) = 2.0 * get<0>(inertial_coords) +
+                   3.0 * get<1>(inertial_coords) +
+                   5.0 * get<2>(inertial_coords);
+
+    // Call the action on each element_id.
+    runner.simple_action<
+        mock_interpolator<metavars, 3>,
+        ::intrp::Actions::InterpolatorReceiveVolumeData<Frame::Inertial>>(
+        0, temporal_id, element_id, mesh, std::move(output_vars));
+  }
+
+  // Should be no temporal_ids in the target box, since we never
+  // put any there.
+  CHECK(db::get<intrp::Tags::TemporalIds<metavars>>(box_target).empty());
+
+  // Should be one queued simple action, MockInterpolationTargetReceiveVars.
+  runner.invoke_queued_simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>>(0);
+
+  // Make sure that MockInterpolationTargetReceiveVars was called,
+  // by looking for a funny temporal_id that it inserts for the specific
+  // purpose of this test.
+  CHECK(db::get<intrp::Tags::TemporalIds<metavars>>(box_target).front() ==
+        Time(Slab(0.0, 1.0), Rational(111, 135)));
+
+  // No more queued simple actions.
+  CHECK(runner.is_simple_action_queue_empty<
+        mock_interpolation_target<metavars, metavars::InterpolationTargetA>>(
+      0));
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes
 
Add InterpolatorReceiveVolumeData.
This also adds the function that actually does the interpolation.
And it does some minor fixes to previous PRs (renaming a variable to a clearer name).

This is another PR towards parallel interpolation.
This is independent of #1075

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
