### PR TITLE
Spinweight

### DIFF
--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -25,8 +25,9 @@ struct SpinWeighted {
   constexpr static int spin = Spin;
 };
 
+// {@
 /// \brief Add two spin-weighted quantities if the types are compatible and
-/// spins are the same.
+/// spins are the same. Un-weighted quantities are assumed to be spin 0.
 template <typename T1, typename T2, int Spin>
 SPECTRE_ALWAYS_INLINE
     SpinWeighted<decltype(std::declval<T1>() + std::declval<T2>()), Spin>
@@ -34,9 +35,21 @@ SPECTRE_ALWAYS_INLINE
               const SpinWeighted<T2, Spin>& rhs) noexcept {
   return {lhs.data + rhs.data};
 }
+template <typename T>
+SPECTRE_ALWAYS_INLINE SpinWeighted<T, 0> operator+(
+    const SpinWeighted<T, 0>& lhs, const T& rhs) noexcept {
+  return {lhs.data + rhs};
+}
+template <typename T>
+SPECTRE_ALWAYS_INLINE SpinWeighted<T, 0> operator+(
+    const T& lhs, const SpinWeighted<T, 0>& rhs) noexcept {
+  return {lhs + rhs.data};
+}
+// @}
 
+// @{
 /// \brief Subtract two spin-weighted quantities if the types are compatible and
-/// spins are the same.
+/// spins are the same. Un-weighted quantities are assumed to be spin 0.
 template <typename T1, typename T2, int Spin>
 SPECTRE_ALWAYS_INLINE
     SpinWeighted<decltype(std::declval<T1>() - std::declval<T2>()), Spin>
@@ -44,9 +57,21 @@ SPECTRE_ALWAYS_INLINE
               const SpinWeighted<T2, Spin>& rhs) noexcept {
   return {lhs.data - rhs.data};
 }
+template <typename T>
+SPECTRE_ALWAYS_INLINE SpinWeighted<T, 0> operator-(
+    const SpinWeighted<T, 0>& lhs, const T& rhs) noexcept {
+  return {lhs.data - rhs};
+}
+template <typename T>
+SPECTRE_ALWAYS_INLINE SpinWeighted<T, 0> operator-(
+    const T& lhs, const SpinWeighted<T, 0>& rhs) noexcept {
+  return {lhs - rhs.data};
+}
+// @}
 
+// @{
 /// \brief Multiply two spin-weighted quantities if the types are compatible and
-/// add the spins.
+/// add the spins. Un-weighted quantities are assumed to be spin 0.
 template <typename T1, typename T2, int Spin1, int Spin2>
 SPECTRE_ALWAYS_INLINE SpinWeighted<
     decltype(std::declval<T1>() * std::declval<T2>()), Spin1 + Spin2>
@@ -54,9 +79,21 @@ operator*(const SpinWeighted<T1, Spin1>& lhs,
           const SpinWeighted<T2, Spin2>& rhs) noexcept {
   return {lhs.data * rhs.data};
 }
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE SpinWeighted<T, Spin> operator*(
+    const SpinWeighted<T, Spin>& lhs, const T& rhs) noexcept {
+  return {lhs.data * rhs};
+}
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE SpinWeighted<T, Spin> operator*(
+    const T& lhs, const SpinWeighted<T, Spin>& rhs) noexcept {
+  return {lhs * rhs.data};
+}
+// @}
 
+// @{
 /// \brief Divide two spin-weighted quantities if the types are compatible and
-/// subtract the spins.
+/// subtract the spins. Un-weighted quantities are assumed to be spin 0.
 template <typename T1, typename T2, int Spin1, int Spin2>
 SPECTRE_ALWAYS_INLINE SpinWeighted<
     decltype(std::declval<T1>() / std::declval<T2>()), Spin1 - Spin2>
@@ -64,21 +101,58 @@ operator/(const SpinWeighted<T1, Spin1>& lhs,
           const SpinWeighted<T2, Spin2>& rhs) noexcept {
   return {lhs.data / rhs.data};
 }
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE SpinWeighted<T, Spin> operator/(
+    const SpinWeighted<T, Spin>& lhs, const T& rhs) noexcept {
+  return {lhs.data / rhs};
+}
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE SpinWeighted<T, -Spin> operator/(
+    const T& lhs, const SpinWeighted<T, Spin>& rhs) noexcept {
+  return {lhs / rhs.data};
+}
+// @}
 
+// @{
 /// \brief Test equivalence of spin-weighted quantities if the types are
-/// compatible and spins are the same.
+/// compatible and spins are the same. Un-weighted quantities are assumed to be
+/// spin 0.
 template <typename T1, typename T2, int Spin>
 SPECTRE_ALWAYS_INLINE bool operator==(
     const SpinWeighted<T1, Spin>& lhs,
     const SpinWeighted<T2, Spin>& rhs) noexcept {
   return lhs.data == rhs.data;
 }
+template <typename T>
+SPECTRE_ALWAYS_INLINE bool operator==(const SpinWeighted<T, 0>& lhs,
+                                      const T& rhs) noexcept {
+  return lhs.data == rhs;
+}
+template <typename T>
+SPECTRE_ALWAYS_INLINE bool operator==(const T& lhs,
+                                      const SpinWeighted<T, 0>& rhs) noexcept {
+  return lhs == rhs.data;
+}
+// @}
 
+// @{
 /// \brief Test inequivalence of spin-weighted quantities if the types are
-/// compatible and spins are the same.
+/// compatible and spins are the same. Un-weighted quantities are assumed to be
+/// spin 0.
 template <typename T1, typename T2, int Spin>
 SPECTRE_ALWAYS_INLINE bool operator!=(
     const SpinWeighted<T1, Spin>& lhs,
     const SpinWeighted<T2, Spin>& rhs) noexcept {
   return not(lhs == rhs);
 }
+template <typename T>
+SPECTRE_ALWAYS_INLINE bool operator!=(const SpinWeighted<T, 0>& lhs,
+                                      const T& rhs) noexcept {
+  return not(lhs == rhs);
+}
+template <typename T>
+SPECTRE_ALWAYS_INLINE bool operator!=(const T& lhs,
+                                      const SpinWeighted<T, 0>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+// @}

--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details
+
+#pragma once
+
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief Make a spin-weighted type `T` with spin-weight `Spin`. Mathematical
+ * operators are restricted to addition, subtraction, multiplication and
+ * division, with spin-weights checked for validity.
+ *
+ * \details For a spin-weighted object, we limit operations to those valid for a
+ * pair of spin-weighted quantities - i.e. addition only makes sense when the
+ * two summands possess the same spin weight, and multiplication (or division)
+ * result in a summed (or subtracted) spin weight.
+ */
+template <typename T, int Spin>
+struct SpinWeighted {
+  T data;
+  using value_type = T;
+  constexpr static int spin = Spin;
+};
+
+/// \brief Add two spin-weighted quantities if the types are compatible and
+/// spins are the same.
+template <typename T1, typename T2, int Spin>
+SPECTRE_ALWAYS_INLINE
+    SpinWeighted<decltype(std::declval<T1>() + std::declval<T2>()), Spin>
+    operator+(const SpinWeighted<T1, Spin>& lhs,
+              const SpinWeighted<T2, Spin>& rhs) noexcept {
+  return {lhs.data + rhs.data};
+}
+
+/// \brief Subtract two spin-weighted quantities if the types are compatible and
+/// spins are the same.
+template <typename T1, typename T2, int Spin>
+SPECTRE_ALWAYS_INLINE
+    SpinWeighted<decltype(std::declval<T1>() - std::declval<T2>()), Spin>
+    operator-(const SpinWeighted<T1, Spin>& lhs,
+              const SpinWeighted<T2, Spin>& rhs) noexcept {
+  return {lhs.data - rhs.data};
+}
+
+/// \brief Multiply two spin-weighted quantities if the types are compatible and
+/// add the spins.
+template <typename T1, typename T2, int Spin1, int Spin2>
+SPECTRE_ALWAYS_INLINE SpinWeighted<
+    decltype(std::declval<T1>() * std::declval<T2>()), Spin1 + Spin2>
+operator*(const SpinWeighted<T1, Spin1>& lhs,
+          const SpinWeighted<T2, Spin2>& rhs) noexcept {
+  return {lhs.data * rhs.data};
+}
+
+/// \brief Divide two spin-weighted quantities if the types are compatible and
+/// subtract the spins.
+template <typename T1, typename T2, int Spin1, int Spin2>
+SPECTRE_ALWAYS_INLINE SpinWeighted<
+    decltype(std::declval<T1>() / std::declval<T2>()), Spin1 - Spin2>
+operator/(const SpinWeighted<T1, Spin1>& lhs,
+          const SpinWeighted<T2, Spin2>& rhs) noexcept {
+  return {lhs.data / rhs.data};
+}
+
+/// \brief Test equivalence of spin-weighted quantities if the types are
+/// compatible and spins are the same.
+template <typename T1, typename T2, int Spin>
+SPECTRE_ALWAYS_INLINE bool operator==(
+    const SpinWeighted<T1, Spin>& lhs,
+    const SpinWeighted<T2, Spin>& rhs) noexcept {
+  return lhs.data == rhs.data;
+}
+
+/// \brief Test inequivalence of spin-weighted quantities if the types are
+/// compatible and spins are the same.
+template <typename T1, typename T2, int Spin>
+SPECTRE_ALWAYS_INLINE bool operator!=(
+    const SpinWeighted<T1, Spin>& lhs,
+    const SpinWeighted<T2, Spin>& rhs) noexcept {
+  return not(lhs == rhs);
+}

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_SOURCES
   Test_LeviCivitaIterator.cpp
   Test_OrientVariablesOnSlice.cpp
   Test_SliceIterator.cpp
+  Test_SpinWeighted.cpp
   Test_StripeIterator.cpp
   Test_Variables.cpp
   )

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -1,0 +1,58 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <complex>
+#include <random>
+
+#include "DataStructures/SpinWeighted.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace {
+template <typename T>
+void test_spinweights() {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<T> dist{static_cast<T>(-100.0),
+                                    static_cast<T>(100.0)};
+
+  const auto v1 = make_with_random_values<SpinWeighted<T, 0>>(
+      make_not_null(&gen), make_not_null(&dist));
+  const auto v2 = make_with_random_values<SpinWeighted<T, 1>>(
+      make_not_null(&gen), make_not_null(&dist));
+  const auto v3 = make_with_random_values<SpinWeighted<T, -2>>(
+      make_not_null(&gen), make_not_null(&dist));
+
+  const auto v4 = make_with_random_values<SpinWeighted<std::complex<T>, 0>>(
+      make_not_null(&gen), make_not_null(&dist));
+  const auto v5 = make_with_random_values<SpinWeighted<std::complex<T>, 1>>(
+      make_not_null(&gen), make_not_null(&dist));
+
+  // check compile-time spin values
+  static_assert(decltype(v1)::spin == 0,
+                "assert failed for the spin of a spin-weight 0");
+  static_assert(decltype(v2)::spin == 1,
+                "assert failed for the spin of a spin-weight 1");
+  static_assert(decltype(v4 / v3)::spin == 2,
+                "assert failed for the spin of a spin-weight ratio.");
+  static_assert(decltype(v5 * v2)::spin == 2,
+                "assert failed for the spin of a spin-weight product.");
+
+  // check that valid spin combinations work
+  CHECK(v1 + v1 == SpinWeighted<T, 0>{v1.data + v1.data});
+  CHECK(v2 - v5 == SpinWeighted<std::complex<T>, 1>{v2.data - v5.data});
+  CHECK(v2 * v3 == SpinWeighted<T, -1>{v2.data * v3.data});
+  CHECK(v5 / v3 == SpinWeighted<std::complex<T>, 3>{v5.data / v3.data});
+}
+
+using SpinWeightedTypes = tmpl::list<double, int, long>;
+
+SPECTRE_TEST_CASE("Unit.DataStructures.SpinWeight", "[DataStructures][Unit]") {
+  tmpl::for_each<SpinWeightedTypes>([](auto x) noexcept {
+    test_spinweights<typename decltype(x)::type>();
+  });
+}
+}  // namespace

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -4,10 +4,10 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <complex>
-#include <random>
 
 #include "DataStructures/SpinWeighted.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 #include "tests/Utilities/MakeWithRandomValues.hpp"
@@ -31,6 +31,10 @@ void test_spinweights() {
   const auto v5 = make_with_random_values<SpinWeighted<std::complex<T>, 1>>(
       make_not_null(&gen), make_not_null(&dist));
 
+  const auto v7 = make_with_random_values<T>(make_not_null(&gen),
+                                            make_not_null(&dist));
+  const auto v8 = make_with_random_values<std::complex<T>>(make_not_null(&gen),
+                                                          make_not_null(&dist));
   // check compile-time spin values
   static_assert(decltype(v1)::spin == 0,
                 "assert failed for the spin of a spin-weight 0");
@@ -46,6 +50,12 @@ void test_spinweights() {
   CHECK(v2 - v5 == SpinWeighted<std::complex<T>, 1>{v2.data - v5.data});
   CHECK(v2 * v3 == SpinWeighted<T, -1>{v2.data * v3.data});
   CHECK(v5 / v3 == SpinWeighted<std::complex<T>, 3>{v5.data / v3.data});
+
+  // check that plain data types act as spin 0
+  CHECK(v1 + v7 == SpinWeighted<T, 0>{v1.data + v7});
+  CHECK(v8 - v4 == SpinWeighted<std::complex<T>, 0>{v8 - v4.data});
+  CHECK(v2 * v7 == SpinWeighted<T, 1>{v2.data * v7});
+  CHECK(v7 / v3 == SpinWeighted<std::complex<T>, 2>{v7 / v3.data});
 }
 
 using SpinWeightedTypes = tmpl::list<double, int, long>;
@@ -55,4 +65,31 @@ SPECTRE_TEST_CASE("Unit.DataStructures.SpinWeight", "[DataStructures][Unit]") {
     test_spinweights<typename decltype(x)::type>();
   });
 }
+
+/// \cond HIDDEN_SYMBOLS
+// A macro which will static_assert fail when LHSTYPE OP RHSTYPE succeeds during
+// SFINAE. Used to make sure we can't violate spin addition rules.
+// clang-tidy: wants parens around macro argument, but that breaks macro
+#define CHECK_TYPE_OPERATION_FAIL(TAG, OP, LHSTYPE, RHSTYPE)             \
+  template <typename T1, typename T2, typename = cpp17::void_t<>>        \
+  struct TAG : std::true_type {};                                        \
+  template <typename T1, typename T2>                                    \
+  struct TAG<                                                            \
+      T1, T2,                                                            \
+      cpp17::void_t<decltype(std::declval<T1>() OP std::declval<T2>())>> \
+      : std::false_type {};                                              \
+  static_assert(TAG<LHSTYPE, RHSTYPE>::value, /*NOLINT*/                 \
+                "static_assert failed, " #LHSTYPE #OP #RHSTYPE " had a type")
+
+using SpinZero = SpinWeighted<double, 0>;
+using SpinOne = SpinWeighted<double, 1>;
+using SpinTwo = SpinWeighted<double, 2>;
+
+CHECK_TYPE_OPERATION_FAIL(spin_check_1, +, SpinZero, SpinOne);
+CHECK_TYPE_OPERATION_FAIL(spin_check_2, +, SpinOne, SpinTwo);
+CHECK_TYPE_OPERATION_FAIL(spin_check_3, +,
+                          decltype(std::declval<SpinZero>() *
+                                   std::declval<SpinTwo>()),
+                          SpinOne);
+/// \endcond
 }  // namespace

--- a/tests/Unit/TestHelpers.hpp
+++ b/tests/Unit/TestHelpers.hpp
@@ -15,6 +15,7 @@
 #include <iterator>
 #include <memory>
 #include <ostream>
+#include <random>
 #include <string>
 
 #include "ErrorHandling/Assert.hpp"
@@ -336,3 +337,16 @@ void test_throw_exception(const ThrowingFunctor& func,
     CHECK(false);
   }
 }
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Make a generator of type `std::mt19937`, stores it in a declared
+/// variable of name `NAME`
+///
+/// \details As the generator is made, `INFO` is called to make sure failed
+/// tests provide seed information.
+#define MAKE_GENERATOR(NAME)                    \
+    std::random_device r;                       \
+    const auto seed = r();                      \
+    INFO("Seed is: " << seed);                  \
+    auto (NAME) = std::mt19937{seed};           \
+

--- a/tests/Utilities/MakeWithRandomValues.hpp
+++ b/tests/Utilities/MakeWithRandomValues.hpp
@@ -11,6 +11,7 @@
 #include <limits>
 #include <random>
 
+#include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -50,6 +51,18 @@ struct FillWithRandomValuesImpl<std::complex<T>> {
         "Mismatch between data type and random number type.");
     data->real((*distribution)(*generator));
     data->imag((*distribution)(*generator));
+  }
+};
+
+template <typename T, int Spin>
+struct FillWithRandomValuesImpl<SpinWeighted<T, Spin>> {
+  template <typename UniformRandomBitGenerator,
+            typename RandomNumberDistribution>
+  static void apply(
+      const gsl::not_null<SpinWeighted<T, Spin>*> data,
+      const gsl::not_null<UniformRandomBitGenerator*> generator,
+      const gsl::not_null<RandomNumberDistribution*> distribution) noexcept {
+    FillWithRandomValuesImpl<T>::apply(&(data->data), generator, distribution);
   }
 };
 


### PR DESCRIPTION
## Proposed changes

Add spin-weight wrapper and convenience functions for random values used in the spin-weighted tests. The spin-weight wrapper ensures that math operations are permitted only for valid combinations of spin-weight. Unwrapped objects are treated as spin-weight 0 (this might be a concerning choice; it is definitely looser than insisting that spin-weights are always consistent).

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
