### PR TITLE
Add CHECK_ALSO variable to iwyu make calls to individual files

### DIFF
--- a/cmake/SetupIwyu.cmake
+++ b/cmake/SetupIwyu.cmake
@@ -19,6 +19,7 @@ function(add_iwyu_tool_targets IWYU_TOOL)
     -p ${CMAKE_BINARY_DIR}
     \${FILE}
     --
+    --check_also=\${CHECK_ALSO}
     --mapping_file=${CMAKE_SOURCE_DIR}/tools/Iwyu/iwyu.imp
     )
   add_dependencies(


### PR DESCRIPTION
## Proposed changes

A proposed assistance for [Issue 1089](https://github.com/sxs-collaboration/spectre/issues/1089). The IWYU check_also flag permits specifying additional headers in the include tree of the checked file.
With this, we can check files as:
```
make iwyu FILE=path/to/including/test.cpp CHECK_ALSO="/full/path/to/spectre/src/Utilities/*.hpp"
```
This will then check the test.cpp and all hpp files in Utilities that are included by it (and I think all Utilities hpp's included by those as well, but I'm less certain of the results on that...)

I was unable to find a way to make the check_also flag work with relative paths.

No fix yet for travis to check the headers, but I could look into that too. I just wanted to post this as the first best thing I thought of in case anyone else had input.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Build system

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
