### PR TITLE
Add wedge-section torus InterpolationTarget

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/BarycentricRational.hpp
+++ b/src/NumericalAlgorithms/Interpolation/BarycentricRational.hpp
@@ -11,10 +11,6 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
-/*!
- * \ingroup NumericalAlgorithmsGroup
- * \brief Contains classes and functions for interpolation
- */
 namespace intrp {
 /*!
  * \ingroup NumericalAlgorithmsGroup

--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Interpolation)
 
 set(LIBRARY_SOURCES
   BarycentricRational.cpp
+  InterpolationTargetWedgeSectionTorus.cpp
   IrregularInterpolant.cpp
   )
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -19,6 +19,9 @@ namespace intrp {
 namespace OptionHolders {
 /// A line segment extending from `Begin` to `End`,
 /// containing `NumberOfPoints` uniformly-spaced points including the endpoints.
+///
+/// \note Input coordinates are interpreted in the frame given by the `Frame`
+/// by the `Frame` template parameter of the `Actions::LineSegment`.
 template <size_t VolumeDim>
 struct LineSegment {
   struct Begin {

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp"
+
+#include <pup.h>
+
+namespace intrp {
+namespace OptionHolders {
+
+WedgeSectionTorus::WedgeSectionTorus(
+    const double min_radius_in, const double max_radius_in,
+    const double min_theta_in, const double max_theta_in,
+    const size_t number_of_radial_points_in,
+    const size_t number_of_theta_points_in,
+    const size_t number_of_phi_points_in, const bool use_uniform_radial_grid_in,
+    const bool use_uniform_theta_grid_in, const OptionContext& context)
+    : min_radius(min_radius_in),
+      max_radius(max_radius_in),
+      min_theta(min_theta_in),
+      max_theta(max_theta_in),
+      number_of_radial_points(number_of_radial_points_in),
+      number_of_theta_points(number_of_theta_points_in),
+      number_of_phi_points(number_of_phi_points_in),
+      use_uniform_radial_grid(use_uniform_radial_grid_in),
+      use_uniform_theta_grid(use_uniform_theta_grid_in) {
+  if (min_radius >= max_radius) {
+    PARSE_ERROR(context, "WedgeSectionTorus expects min_radius < max_radius");
+  }
+  if (min_theta >= max_theta) {
+    PARSE_ERROR(context, "WedgeSectionTorus expects min_theta < max_theta");
+  }
+}
+
+void WedgeSectionTorus::pup(PUP::er& p) noexcept {
+  p | min_radius;
+  p | max_radius;
+  p | min_theta;
+  p | max_theta;
+  p | number_of_radial_points;
+  p | number_of_theta_points;
+  p | number_of_phi_points;
+  p | use_uniform_radial_grid;
+  p | use_uniform_theta_grid;
+}
+
+}  // namespace OptionHolders
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -1,0 +1,275 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace intrp {
+namespace Tags {
+template <typename Metavariables>
+struct TemporalIds;
+}  // namespace Tags
+}  // namespace intrp
+
+namespace intrp {
+
+namespace OptionHolders {
+/// \brief A solid torus of points, useful, e.g., when measuring data from an
+/// accretion disc.
+///
+/// The torus's cross section (e.g., a cut at \f$\phi=0\f$) is a wedge-like
+/// shape bounded by \f$r_{\text{min}} \le r \le r_{\text{max}}\f$ and
+/// \f$\theta_{\text{min}} \le \theta \le \theta_{\text{max}}\f$.
+///
+/// The grid points are located on surfaces of constant \f$r\f$, \f$\theta\f$,
+/// and \f$\phi\f$. There are `NumberRadialPoints` points in the radial
+/// direction between `MinRadius` and `MaxRadius` (including these endpoints);
+/// `NumberThetaPoints` points in the \f$\theta\f$ direction between `MinTheta`
+/// and `MaxTheta` (including these endpoints); `NumberPhiPoints` points in the
+/// \f$\phi\f$ direction (with one point always at \f$\phi=0\f$).
+///
+/// By default, the points follow a Legendre Gauss-Lobatto distribution in the
+/// \f$r\f$ and \f$\theta\f$ directions, and a uniform distribution in the
+/// \f$\phi\f$ direction. The distribution in the \f$r\f$ (and/or \f$\theta\f$)
+/// direction can be made uniform using the `UniformRadialGrid` (and/or
+/// `UniformThetaGrid`) option.
+///
+/// The `target_points` form a 3D mesh ordered with \f$r\f$ varying fastest,
+/// then \f$\theta\f$, and finally \f$\phi\f$ varying slowest.
+///
+/// \note Input coordinates (radii, angles) are interpreted in the frame given
+/// by the `Frame` template parameter of the `Actions::WedgeSectionTorus`.
+struct WedgeSectionTorus {
+  struct MinRadius {
+    using type = double;
+    static constexpr OptionString help = {"Inner radius of torus"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct MaxRadius {
+    using type = double;
+    static constexpr OptionString help = {"Outer radius of torus"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct MinTheta {
+    using type = double;
+    static constexpr OptionString help = {"Angle of top of wedge (radians)"};
+    static type lower_bound() noexcept { return 0.0; }
+    static type upper_bound() noexcept { return M_PI; }
+  };
+  struct MaxTheta {
+    using type = double;
+    static constexpr OptionString help = {"Angle of bottom of wedge (radians)"};
+    static type lower_bound() noexcept { return 0.0; }
+    static type upper_bound() noexcept { return M_PI; }
+  };
+  struct NumberRadialPoints {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Number of radial points, including endpoints"};
+    static type lower_bound() noexcept { return 2; }
+  };
+  struct NumberThetaPoints {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Number of theta points, including endpoints"};
+    static type lower_bound() noexcept { return 2; }
+  };
+  struct NumberPhiPoints {
+    using type = size_t;
+    static constexpr OptionString help = {"Number of phi points"};
+    static type lower_bound() noexcept { return 1; }
+  };
+  struct UniformRadialGrid {
+    using type = bool;
+    static constexpr OptionString help = {
+        "Use uniform radial grid [default: LGL grid]"};
+    static type default_value() noexcept { return false; }
+  };
+  struct UniformThetaGrid {
+    using type = bool;
+    static constexpr OptionString help = {
+        "Use uniform theta grid [default: LGL grid]"};
+    static type default_value() noexcept { return false; }
+  };
+
+  using options =
+      tmpl::list<MinRadius, MaxRadius, MinTheta, MaxTheta, NumberRadialPoints,
+                 NumberThetaPoints, NumberPhiPoints, UniformRadialGrid,
+                 UniformThetaGrid>;
+  static constexpr OptionString help = {
+      "A torus extending from MinRadius to MaxRadius in r, MinTheta to MaxTheta"
+      " in theta, and 2pi in phi."};
+
+  WedgeSectionTorus(double min_radius_in, double max_radius_in,
+                    double min_theta_in, double max_theta_in,
+                    size_t number_of_radial_points_in,
+                    size_t number_of_theta_points_in,
+                    size_t number_of_phi_points_in,
+                    bool use_uniform_radial_grid_in,
+                    bool use_uniform_theta_grid_in,
+                    const OptionContext& context = {});
+
+  WedgeSectionTorus() = default;
+  WedgeSectionTorus(const WedgeSectionTorus& /*rhs*/) = default;
+  WedgeSectionTorus& operator=(const WedgeSectionTorus& /*rhs*/) = default;
+  WedgeSectionTorus(WedgeSectionTorus&& /*rhs*/) noexcept = default;
+  WedgeSectionTorus& operator=(WedgeSectionTorus&& /*rhs*/) noexcept = default;
+  ~WedgeSectionTorus() = default;
+
+  // clang-tidy non-const reference pointer
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  double min_radius;
+  double max_radius;
+  double min_theta;
+  double max_theta;
+  size_t number_of_radial_points;
+  size_t number_of_theta_points;
+  size_t number_of_phi_points;
+  bool use_uniform_radial_grid;
+  bool use_uniform_theta_grid;
+};
+}  // namespace OptionHolders
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \brief Sends points in a wedge-sectioned torus to an `Interpolator`.
+///
+/// Uses:
+/// - DataBox:
+///   - `::Tags::Domain<3, Frame>`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `Tags::IndicesOfFilledInterpPoints`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// For requirements on InterpolationTargetTag, see InterpolationTarget
+template <typename InterpolationTargetTag, typename Frame>
+struct WedgeSectionTorus {
+  using options_type = OptionHolders::WedgeSectionTorus;
+  using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<
+                DbTags, typename Tags::TemporalIds<Metavariables>>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const typename Metavariables::temporal_id& temporal_id) noexcept {
+    const auto& options = Parallel::get<InterpolationTargetTag>(cache);
+
+    // Compute locations of constant r/theta/phi surfaces
+    const size_t num_radial = options.number_of_radial_points;
+    const DataVector radii_1d = [&num_radial, &options ]() noexcept {
+      DataVector result(num_radial);
+      if (options.use_uniform_radial_grid) {
+        // uniform point distribution
+        for (size_t r = 0; r < num_radial; ++r) {
+          result[r] =
+              options.min_radius + (options.max_radius - options.min_radius) *
+                                       r / (num_radial - 1.0);
+        }
+      } else {
+        // Legendre Gauss-Lobatto point distribution
+        const double mean = 0.5 * (options.max_radius + options.min_radius);
+        const double diff = 0.5 * (options.max_radius - options.min_radius);
+        result =
+            mean + diff * Spectral::collocation_points<
+                              Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto>(num_radial);
+      }
+      return result;
+    }
+    ();
+    const size_t num_theta = options.number_of_theta_points;
+    const DataVector thetas_1d = [&num_theta, &options ]() noexcept {
+      DataVector result(num_theta);
+      if (options.use_uniform_theta_grid) {
+        // uniform point distribution
+        for (size_t theta = 0; theta < num_theta; ++theta) {
+          result[theta] =
+              options.min_theta + (options.max_theta - options.min_theta) *
+                                      theta / (num_theta - 1.0);
+        }
+      } else {
+        // Legendre Gauss-Lobatto point distribution
+        const double mean = 0.5 * (options.max_theta + options.min_theta);
+        const double diff = 0.5 * (options.max_theta - options.min_theta);
+        result =
+            mean + diff * Spectral::collocation_points<
+                              Spectral::Basis::Legendre,
+                              Spectral::Quadrature::GaussLobatto>(num_theta);
+      }
+      return result;
+    }
+    ();
+    const size_t num_phi = options.number_of_phi_points;
+    const DataVector phis_1d = [&num_phi]() noexcept {
+      DataVector result(num_phi);
+      for (size_t phi = 0; phi < num_phi; ++phi) {
+        // We do NOT want a grid point at phi = 2pi, as this would duplicate the
+        // phi = 0 data. So, divide by num_phi rather than (n-1) as elsewhere.
+        result[phi] = 2.0 * M_PI * phi / num_phi;
+      }
+      return result;
+    }
+    ();
+
+    // Take tensor product to get full 3D r/theta/phi points
+    const size_t num_total = num_radial * num_theta * num_phi;
+    DataVector radii(num_total), thetas(num_total), phis(num_total);
+    for (size_t phi = 0; phi < num_phi; ++phi) {
+      for (size_t theta = 0; theta < num_theta; ++theta) {
+        for (size_t r = 0; r < num_radial; ++r) {
+          const size_t i =
+              r + theta * num_radial + phi * num_theta * num_radial;
+          radii[i] = radii_1d[r];
+          thetas[i] = thetas_1d[theta];
+          phis[i] = phis_1d[phi];
+        }
+      }
+    }
+
+    // Compute x/y/z coordinates
+    // Note: theta measured from +z axis, phi measured from +x axis
+    tnsr::I<DataVector, 3, Frame> target_points(num_total);
+    get<0>(target_points) = radii * sin(thetas) * cos(phis);
+    get<1>(target_points) = radii * sin(thetas) * sin(phis);
+    get<2>(target_points) = radii * cos(thetas);
+
+    send_points_to_interpolator<InterpolationTargetTag>(
+        box, cache, target_points, temporal_id);
+  }
+};
+
+}  // namespace Actions
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/Intrp.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Intrp.hpp
@@ -1,0 +1,10 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Contains classes and functions for interpolation
+ */
+namespace intrp;

--- a/src/NumericalAlgorithms/Interpolation/IntrpOptionHolders.hpp
+++ b/src/NumericalAlgorithms/Interpolation/IntrpOptionHolders.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace intrp {
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Contains structs defining the options of various InterpolationTargets
+ */
+namespace OptionHolders;
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_InitializeInterpolator.cpp
   Test_InterpolationTargetLineSegment.cpp
   Test_InterpolationTargetReceiveVars.cpp
+  Test_InterpolationTargetWedgeSectionTorus.cpp
   Test_InterpolatorReceivePoints.cpp
   Test_InterpolatorReceiveVolumeData.cpp
   Test_InterpolatorRegisterElement.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -1,0 +1,265 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/Shell.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+/// \cond
+namespace intrp {
+namespace Actions {
+template <typename InterpolationTargetTag, typename Frame>
+struct ReceivePoints;
+}  // namespace Actions
+}  // namespace intrp
+template <typename IdType, typename DataType>
+class IdPair;
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace intrp {
+namespace Tags {
+struct IndicesOfFilledInterpPoints;
+template <typename Metavariables, size_t VolumeDim>
+struct InterpolatedVarsHolders;
+struct NumberOfElements;
+}  // namespace Tags
+}  // namespace intrp
+namespace domain {
+class BlockId;
+}  // namespace domain
+/// \endcond
+
+namespace InterpTargetTestHelpers {
+
+template <typename Metavariables, typename InterpolationTargetTag>
+struct mock_interpolation_target {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked = void;  // not needed.
+  using const_global_cache_tag_list =
+      Parallel::get_const_global_cache_tags<tmpl::list<
+          typename Metavariables::InterpolationTargetA::compute_target_points>>;
+
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename ::intrp::Actions::InitializeInterpolationTarget<
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
+                                                            ::Frame::Inertial>>;
+};
+
+template <typename InterpolationTargetTag>
+struct MockReceivePoints {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, size_t VolumeDim,
+            Requires<tmpl::list_contains_v<
+                DbTags, typename ::intrp::Tags::NumberOfElements>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const typename Metavariables::temporal_id& temporal_id,
+      std::vector<IdPair<domain::BlockId,
+                         tnsr::I<double, VolumeDim, typename Frame::Logical>>>&&
+          block_coord_holders) noexcept {
+    db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>(
+        make_not_null(&box),
+        [
+          &temporal_id, &block_coord_holders
+        ](const gsl::not_null<db::item_type<
+              intrp::Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>*>
+              vars_holders) noexcept {
+          auto& vars_infos =
+              get<intrp::Vars::HolderTag<InterpolationTargetTag, Metavariables,
+                                         VolumeDim>>(*vars_holders)
+                  .infos;
+
+          // Add the target interpolation points at this timestep.
+          vars_infos.emplace(std::make_pair(
+              temporal_id,
+              intrp::Vars::Info<VolumeDim, typename InterpolationTargetTag::
+                                               vars_to_interpolate_to_target>{
+                  std::move(block_coord_holders)}));
+        });
+  }
+};
+
+template <typename Metavariables, size_t VolumeDim>
+struct mock_interpolator {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename ::intrp::Actions::InitializeInterpolator<
+          VolumeDim>::template return_tag_list<Metavariables>>;
+
+  using component_being_mocked = intrp::Interpolator<Metavariables, VolumeDim>;
+  using replace_these_simple_actions = tmpl::list<intrp::Actions::ReceivePoints<
+      typename Metavariables::InterpolationTargetA, Frame::Inertial>>;
+  using with_these_simple_actions = tmpl::list<
+      MockReceivePoints<typename Metavariables::InterpolationTargetA>>;
+};
+
+template <typename MetaVariables, typename DomainCreator,
+          typename InterpolationTargetOption, typename BlockCoordHolder>
+void test_interpolation_target(
+    const DomainCreator& domain_creator,
+    const InterpolationTargetOption& options,
+    const BlockCoordHolder& expected_block_coord_holders) noexcept {
+  using metavars = MetaVariables;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  using TupleOfMockDistributedObjects =
+      typename MockRuntimeSystem::TupleOfMockDistributedObjects;
+  TupleOfMockDistributedObjects dist_objects{};
+  using MockDistributedObjectsTagTarget =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolation_target<metavars,
+                                    typename metavars::InterpolationTargetA>>;
+  using MockDistributedObjectsTagInterpolator =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolator<metavars, 3>>;
+  tuples::get<MockDistributedObjectsTagTarget>(dist_objects)
+      .emplace(0,
+               ActionTesting::MockDistributedObject<mock_interpolation_target<
+                   metavars, typename metavars::InterpolationTargetA>>{});
+  tuples::get<MockDistributedObjectsTagInterpolator>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<
+                      mock_interpolator<metavars, 3>>{});
+
+  tuples::TaggedTuple<typename metavars::InterpolationTargetA> tuple_of_opts(
+      options);
+
+  MockRuntimeSystem runner{tuple_of_opts, std::move(dist_objects)};
+
+  runner.template simple_action<
+      mock_interpolation_target<metavars,
+                                typename metavars::InterpolationTargetA>,
+      ::intrp::Actions::InitializeInterpolationTarget<
+          typename metavars::InterpolationTargetA>>(
+      0, domain_creator.create_domain());
+
+  runner.template simple_action<mock_interpolator<metavars, 3>,
+                                ::intrp::Actions::InitializeInterpolator<3>>(0);
+
+  const auto& box_target =
+      runner
+          .template algorithms<mock_interpolation_target<
+              metavars, typename metavars::InterpolationTargetA>>()
+          .at(0)
+          .template get_databox<typename mock_interpolation_target<
+              metavars,
+              typename metavars::InterpolationTargetA>::initial_databox>();
+
+  const auto& box_interpolator =
+      runner.template algorithms<mock_interpolator<metavars, 3>>()
+          .at(0)
+          .template get_databox<
+              typename mock_interpolator<metavars, 3>::initial_databox>();
+
+  Slab slab(0.0, 1.0);
+  Time temporal_id(slab, 0);
+
+  runner.template simple_action<
+      mock_interpolation_target<metavars,
+                                typename metavars::InterpolationTargetA>,
+      typename metavars::InterpolationTargetA::compute_target_points>(
+      0, temporal_id);
+
+  // This should not have changed.
+  CHECK(
+      db::get<::intrp::Tags::IndicesOfFilledInterpPoints>(box_target).empty());
+
+  // Should be no queued actions in mock_interpolation_target
+  CHECK(runner.template is_simple_action_queue_empty<mock_interpolation_target<
+            metavars, typename metavars::InterpolationTargetA>>(0));
+
+  // But there should be one in mock_interpolator
+  runner.template invoke_queued_simple_action<mock_interpolator<metavars, 3>>(
+      0);
+
+  // Should be no more queued actions in mock_interpolator
+  CHECK(runner.template is_simple_action_queue_empty<
+        mock_interpolator<metavars, 3>>(0));
+
+  const auto& vars_holders =
+      db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(
+          box_interpolator);
+  const auto& vars_infos =
+      get<intrp::Vars::HolderTag<typename metavars::InterpolationTargetA,
+                                 metavars, 3>>(vars_holders)
+          .infos;
+  // Should be one entry in the vars_infos
+  CHECK(vars_infos.size() == 1);
+  const auto& info = vars_infos.at(temporal_id);
+  const auto& block_coord_holders = info.block_coord_holders;
+
+  // Check number of points
+  const size_t number_of_points = expected_block_coord_holders.size();
+  CHECK(block_coord_holders.size() == number_of_points);
+
+  for (size_t i = 0; i < number_of_points; ++i) {
+    CHECK(block_coord_holders[i].id == expected_block_coord_holders[i].id);
+    CHECK_ITERABLE_APPROX(block_coord_holders[i].data,
+                          expected_block_coord_holders[i].data);
+  }
+
+  // Call again at a different temporal_id
+  Time new_temporal_id(slab, 1);
+  runner.template simple_action<
+      mock_interpolation_target<metavars,
+                                typename metavars::InterpolationTargetA>,
+      typename metavars::InterpolationTargetA::compute_target_points>(
+      0, new_temporal_id);
+  runner.template invoke_queued_simple_action<mock_interpolator<metavars, 3>>(
+      0);
+
+  // Should be two entries in the vars_infos
+  CHECK(vars_infos.size() == 2);
+  const auto& new_block_coord_holders =
+      vars_infos.at(new_temporal_id).block_coord_holders;
+  for (size_t i = 0; i < number_of_points; ++i) {
+    CHECK(new_block_coord_holders[i].id == expected_block_coord_holders[i].id);
+    CHECK_ITERABLE_APPROX(new_block_coord_holders[i].data,
+                          expected_block_coord_holders[i].data);
+  }
+}
+
+}  // namespace InterpTargetTestHelpers

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -5,137 +5,20 @@
 
 #include <array>
 #include <cstddef>
-#include <utility>
 #include <vector>
 
-#include "DataStructures/DataBox/DataBox.hpp"
-#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Shell.hpp"
-#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
-#include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
-#include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp"
-#include "NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp"
-#include "Parallel/ParallelComponentHelpers.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Slab.hpp"
 #include "Time/Time.hpp"
-#include "Utilities/Gsl.hpp"
-#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TaggedTuple.hpp"
-#include "tests/Unit/ActionTesting.hpp"
-
-/// \cond
-namespace intrp {
-namespace Actions {
-template <typename InterpolationTargetTag, typename Frame>
-struct ReceivePoints;
-}  // namespace Actions
-}  // namespace intrp
-template <typename IdType, typename DataType>
-class IdPair;
-namespace Parallel {
-template <typename Metavariables>
-class ConstGlobalCache;
-}  // namespace Parallel
-namespace db {
-template <typename TagsList>
-class DataBox;
-}  // namespace db
-namespace intrp {
-namespace Tags {
-struct IndicesOfFilledInterpPoints;
-template <typename Metavariables, size_t VolumeDim>
-struct InterpolatedVarsHolders;
-struct NumberOfElements;
-}  // namespace Tags
-}  // namespace intrp
-namespace domain {
-class BlockId;
-}  // namespace domain
-/// \endcond
+#include "tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 
 namespace {
-
-template <typename Metavariables, typename InterpolationTargetTag>
-struct mock_interpolation_target {
-  using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
-  using array_index = size_t;
-  using component_being_mocked = void;  // not needed.
-  using const_global_cache_tag_list =
-      Parallel::get_const_global_cache_tags<tmpl::list<
-          typename Metavariables::InterpolationTargetA::compute_target_points>>;
-
-  using action_list = tmpl::list<>;
-  using initial_databox = db::compute_databox_type<
-      typename ::intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
-                                                            ::Frame::Inertial>>;
-};
-
-template <typename InterpolationTargetTag>
-struct MockReceivePoints {
-  template <typename DbTags, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent, size_t VolumeDim,
-            Requires<tmpl::list_contains_v<
-                DbTags, typename ::intrp::Tags::NumberOfElements>> = nullptr>
-  static void apply(
-      db::DataBox<DbTags>& box,
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/,
-      const typename Metavariables::temporal_id& temporal_id,
-      std::vector<IdPair<domain::BlockId,
-                         tnsr::I<double, VolumeDim, typename Frame::Logical>>>&&
-          block_coord_holders) noexcept {
-    db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>(
-        make_not_null(&box),
-        [&temporal_id, &block_coord_holders](
-            const gsl::not_null<
-                db::item_type<intrp::Tags::InterpolatedVarsHolders<
-                    Metavariables, VolumeDim>>*>
-                vars_holders) {
-          auto& vars_infos =
-              get<intrp::Vars::HolderTag<InterpolationTargetTag, Metavariables,
-                                         VolumeDim>>(*vars_holders)
-                  .infos;
-
-          // Add the target interpolation points at this timestep.
-          vars_infos.emplace(std::make_pair(
-              temporal_id,
-              intrp::Vars::Info<VolumeDim, typename InterpolationTargetTag::
-                                               vars_to_interpolate_to_target>{
-                  std::move(block_coord_holders)}));
-        });
-  }
-};
-
-template <typename Metavariables, size_t VolumeDim>
-struct mock_interpolator {
-  using metavariables = Metavariables;
-  using chare_type = ActionTesting::MockArrayChare;
-  using array_index = size_t;
-  using const_global_cache_tag_list = tmpl::list<>;
-  using action_list = tmpl::list<>;
-  using initial_databox = db::compute_databox_type<
-      typename ::intrp::Actions::InitializeInterpolator<
-          VolumeDim>::template return_tag_list<Metavariables>>;
-
-  using component_being_mocked = intrp::Interpolator<Metavariables, VolumeDim>;
-  using replace_these_simple_actions = tmpl::list<intrp::Actions::ReceivePoints<
-      typename Metavariables::InterpolationTargetA, Frame::Inertial>>;
-  using with_these_simple_actions = tmpl::list<MockReceivePoints<
-      typename Metavariables::InterpolationTargetA>>;
-};
-
 struct MockMetavariables {
   struct InterpolationTargetA {
     using vars_to_interpolate_to_target =
@@ -149,136 +32,12 @@ struct MockMetavariables {
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
 
   using component_list = tmpl::list<
-      mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
-      mock_interpolator<MockMetavariables, 3>>;
+      InterpTargetTestHelpers::mock_interpolation_target<MockMetavariables,
+                                                         InterpolationTargetA>,
+      InterpTargetTestHelpers::mock_interpolator<MockMetavariables, 3>>;
   using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialize, Exit };
 };
-
-template <typename MetaVariables, typename DomainCreator,
-          typename InterpolationTargetOption, typename BlockCoordHolder>
-void test_interpolation_target(
-    const DomainCreator& domain_creator,
-    const InterpolationTargetOption& options,
-    const BlockCoordHolder& expected_block_coord_holders) noexcept {
-  using metavars = MetaVariables;
-  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
-  using TupleOfMockDistributedObjects =
-      typename MockRuntimeSystem::TupleOfMockDistributedObjects;
-  TupleOfMockDistributedObjects dist_objects{};
-  using MockDistributedObjectsTagTarget =
-      typename MockRuntimeSystem::template MockDistributedObjectsTag<
-          mock_interpolation_target<metavars,
-                                    typename metavars::InterpolationTargetA>>;
-  using MockDistributedObjectsTagInterpolator =
-      typename MockRuntimeSystem::template MockDistributedObjectsTag<
-          mock_interpolator<metavars, 3>>;
-  tuples::get<MockDistributedObjectsTagTarget>(dist_objects)
-      .emplace(0,
-               ActionTesting::MockDistributedObject<mock_interpolation_target<
-                   metavars, typename metavars::InterpolationTargetA>>{});
-  tuples::get<MockDistributedObjectsTagInterpolator>(dist_objects)
-      .emplace(0, ActionTesting::MockDistributedObject<
-                      mock_interpolator<metavars, 3>>{});
-
-  tuples::TaggedTuple<typename metavars::InterpolationTargetA> tuple_of_opts(
-      options);
-
-  MockRuntimeSystem runner{tuple_of_opts, std::move(dist_objects)};
-
-  runner.template simple_action<
-      mock_interpolation_target<metavars,
-                                typename metavars::InterpolationTargetA>,
-      ::intrp::Actions::InitializeInterpolationTarget<
-          typename metavars::InterpolationTargetA>>(
-      0, domain_creator.create_domain());
-
-  runner.template simple_action<mock_interpolator<metavars, 3>,
-                                ::intrp::Actions::InitializeInterpolator<3>>(0);
-
-  const auto& box_target =
-      runner
-          .template algorithms<mock_interpolation_target<
-              metavars, typename metavars::InterpolationTargetA>>()
-          .at(0)
-          .template get_databox<typename mock_interpolation_target<
-              metavars,
-              typename metavars::InterpolationTargetA>::initial_databox>();
-
-  const auto& box_interpolator =
-      runner.template algorithms<mock_interpolator<metavars, 3>>()
-          .at(0)
-          .template get_databox<
-              typename mock_interpolator<metavars, 3>::initial_databox>();
-
-  Slab slab(0.0, 1.0);
-  Time temporal_id(slab, 0);
-
-  runner.template simple_action<
-      mock_interpolation_target<metavars,
-                                typename metavars::InterpolationTargetA>,
-      typename metavars::InterpolationTargetA::compute_target_points>(
-      0, temporal_id);
-
-  // This should not have changed.
-  CHECK(
-      db::get<::intrp::Tags::IndicesOfFilledInterpPoints>(box_target).empty());
-
-  // Should be no queued actions in mock_interpolation_target
-  CHECK(runner.template is_simple_action_queue_empty<mock_interpolation_target<
-            metavars, typename metavars::InterpolationTargetA>>(0));
-
-  // But there should be one in mock_interpolator
-  runner.template invoke_queued_simple_action<mock_interpolator<metavars, 3>>(
-      0);
-
-  // Should be no more queued actions in mock_interpolator
-  CHECK(runner.template is_simple_action_queue_empty<
-        mock_interpolator<metavars, 3>>(0));
-
-  const auto& vars_holders =
-      db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(
-          box_interpolator);
-  const auto& vars_infos =
-      get<intrp::Vars::HolderTag<typename metavars::InterpolationTargetA,
-                                 metavars, 3>>(vars_holders)
-          .infos;
-  // Should be one entry in the vars_infos
-  CHECK(vars_infos.size() == 1);
-  const auto& info = vars_infos.at(temporal_id);
-  const auto& block_coord_holders = info.block_coord_holders;
-
-  // Check number of points
-  const size_t number_of_points = expected_block_coord_holders.size();
-  CHECK(block_coord_holders.size() == number_of_points);
-
-  for (size_t i = 0; i < number_of_points; ++i) {
-    CHECK(block_coord_holders[i].id == expected_block_coord_holders[i].id);
-    CHECK_ITERABLE_APPROX(block_coord_holders[i].data,
-                          expected_block_coord_holders[i].data);
-  }
-
-  // Call again at a different temporal_id
-  Time new_temporal_id(slab, 1);
-  runner.template simple_action<
-      mock_interpolation_target<metavars,
-                                typename metavars::InterpolationTargetA>,
-      typename metavars::InterpolationTargetA::compute_target_points>(
-      0, new_temporal_id);
-  runner.template invoke_queued_simple_action<mock_interpolator<metavars, 3>>(
-      0);
-
-  // Should be two entries in the vars_infos
-  CHECK(vars_infos.size() == 2);
-  const auto& new_block_coord_holders =
-      vars_infos.at(new_temporal_id).block_coord_holders;
-  for (size_t i = 0; i < number_of_points; ++i) {
-    CHECK(new_block_coord_holders[i].id == expected_block_coord_holders[i].id);
-    CHECK_ITERABLE_APPROX(new_block_coord_holders[i].data,
-                          expected_block_coord_holders[i].data);
-  }
-}
-
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
@@ -302,6 +61,6 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
   }
   ();
 
-  test_interpolation_target<MockMetavariables>(
+  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
       domain_creator, line_segment_opts, expected_block_coord_holders);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -17,6 +17,7 @@
 #include "Time/Time.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
+#include "tests/Unit/TestCreation.hpp"
 
 namespace {
 struct MockMetavariables {
@@ -40,11 +41,28 @@ struct MockMetavariables {
 };
 }  // namespace
 
+// operator== for testing creation:
+namespace intrp {
+namespace OptionHolders {
+bool operator==(const LineSegment<3>& lhs, const LineSegment<3>& rhs) noexcept {
+  return lhs.begin == rhs.begin and lhs.end == rhs.end and
+         lhs.number_of_points == rhs.number_of_points;
+}
+}  // namespace OptionHolders
+}  // namespace intrp
+
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
                   "[Unit]") {
   // Options for LineSegment
   intrp::OptionHolders::LineSegment<3> line_segment_opts({{1.0, 1.0, 1.0}},
                                                          {{2.4, 2.4, 2.4}}, 15);
+
+  // Test creation of options
+  const auto created_opts = test_creation<intrp::OptionHolders::LineSegment<3>>(
+      "  Begin: [1.0, 1.0, 1.0]\n"
+      "  End: [2.4, 2.4, 2.4]\n"
+      "  NumberOfPoints: 15");
+  CHECK(created_opts == line_segment_opts);
 
   const auto domain_creator =
       DomainCreators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -1,0 +1,167 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/Shell.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+
+namespace {
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_target_points =
+        ::intrp::Actions::WedgeSectionTorus<InterpolationTargetA,
+                                            Frame::Inertial>;
+    using type = compute_target_points::options_type;
+  };
+  using temporal_id = Time;
+  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+
+  using component_list = tmpl::list<
+      InterpTargetTestHelpers::mock_interpolation_target<MockMetavariables,
+                                                         InterpolationTargetA>,
+      InterpTargetTestHelpers::mock_interpolator<MockMetavariables, 3>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialize, Exit };
+};
+
+void test_r_theta_lgl() noexcept {
+  const size_t num_radial = 3;
+  const size_t num_theta = 4;
+  const size_t num_phi = 5;
+  // Test with a torus that is not symmetric above/below the equator.
+  intrp::OptionHolders::WedgeSectionTorus wedge_section_torus_opts(
+      1.2, 4.0, 0.35 * M_PI, 0.55 * M_PI, num_radial, num_theta, num_phi, false,
+      false);
+
+  const auto domain_creator =
+      DomainCreators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+
+  const size_t num_total = num_radial * num_theta * num_phi;
+  const auto expected_block_coord_holders =
+      [&domain_creator, &num_total ]() noexcept {
+    tnsr::I<DataVector, 3, Frame::Inertial> points(num_total);
+    for (size_t r = 0; r < num_radial; ++r) {
+      const double radius =
+          2.6 +
+          1.4 *
+              Spectral::collocation_points<Spectral::Basis::Legendre,
+                                           Spectral::Quadrature::GaussLobatto>(
+                  num_radial)[r];
+      for (size_t t = 0; t < num_theta; ++t) {
+        const double theta =
+            M_PI * (0.45 + 0.1 * Spectral::collocation_points<
+                                     Spectral::Basis::Legendre,
+                                     Spectral::Quadrature::GaussLobatto>(
+                                     num_theta)[t]);
+        for (size_t p = 0; p < num_phi; ++p) {
+          const double phi = 2.0 * M_PI * p / num_phi;
+          const double i = r + t * num_radial + p * num_theta * num_radial;
+          get<0>(points)[i] = radius * sin(theta) * cos(phi);
+          get<1>(points)[i] = radius * sin(theta) * sin(phi);
+          get<2>(points)[i] = radius * cos(theta);
+        }
+      }
+    }
+    return block_logical_coordinates(domain_creator.create_domain(), points);
+  }
+  ();
+
+  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
+      domain_creator, wedge_section_torus_opts, expected_block_coord_holders);
+}
+
+void test_r_theta_uniform() noexcept {
+  const size_t num_radial = 4;
+  const size_t num_theta = 5;
+  const size_t num_phi = 6;
+  // Test with a torus that is symmetric above/below the equator.
+  intrp::OptionHolders::WedgeSectionTorus wedge_section_torus_opts(
+      1.8, 3.6, 0.25 * M_PI, 0.75 * M_PI, num_radial, num_theta, num_phi, true,
+      true);
+
+  const auto domain_creator =
+      DomainCreators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+
+  const size_t num_total = num_radial * num_theta * num_phi;
+  const auto expected_block_coord_holders =
+      [&domain_creator, &num_total ]() noexcept {
+    tnsr::I<DataVector, 3, Frame::Inertial> points(num_total);
+    for (size_t r = 0; r < num_radial; ++r) {
+      const double radius = 1.8 + 1.8 * r / (num_radial - 1.0);
+      for (size_t t = 0; t < num_theta; ++t) {
+        const double theta = M_PI * (0.25 + 0.5 * t / (num_theta - 1.0));
+        for (size_t p = 0; p < num_phi; ++p) {
+          const double phi = 2.0 * M_PI * p / num_phi;
+          const double i = r + t * num_radial + p * num_theta * num_radial;
+          get<0>(points)[i] = radius * sin(theta) * cos(phi);
+          get<1>(points)[i] = radius * sin(theta) * sin(phi);
+          get<2>(points)[i] = radius * cos(theta);
+        }
+      }
+    }
+    return block_logical_coordinates(domain_creator.create_domain(), points);
+  }
+  ();
+
+  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
+      domain_creator, wedge_section_torus_opts, expected_block_coord_holders);
+}
+}  // namespace
+
+// operator== for testing creation:
+namespace intrp {
+namespace OptionHolders {
+bool operator==(const WedgeSectionTorus& lhs,
+                const WedgeSectionTorus& rhs) noexcept {
+  return lhs.min_radius == rhs.min_radius and
+         lhs.max_radius == rhs.max_radius and lhs.min_theta == rhs.min_theta and
+         lhs.max_theta == rhs.max_theta and
+         lhs.number_of_radial_points == rhs.number_of_radial_points and
+         lhs.number_of_theta_points == rhs.number_of_theta_points and
+         lhs.number_of_phi_points == rhs.number_of_phi_points and
+         lhs.use_uniform_radial_grid == rhs.use_uniform_radial_grid and
+         lhs.use_uniform_theta_grid == rhs.use_uniform_theta_grid;
+}
+}  // namespace OptionHolders
+}  // namespace intrp
+
+SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.InterpolationTarget.WedgeSectionTorus",
+    "[Unit]") {
+  // Check creating the options
+  const auto created_torus =
+      test_creation<intrp::OptionHolders::WedgeSectionTorus>(
+          "  MinRadius: 1.8\n"
+          "  MaxRadius: 20.\n"
+          "  MinTheta: 0.785\n"
+          "  MaxTheta: 2.356\n"
+          "  NumberRadialPoints: 20\n"
+          "  NumberThetaPoints: 10\n"
+          "  NumberPhiPoints: 20\n"
+          "  UniformThetaGrid: true\n");
+  CHECK(created_torus == intrp::OptionHolders::WedgeSectionTorus(
+                             1.8, 20., 0.785, 2.356, 20, 10, 20, false, true));
+
+  // Check computing the points
+  test_r_theta_lgl();
+  test_r_theta_uniform();
+}


### PR DESCRIPTION
## Proposed changes

Adds an InterpolationTarget `WedgeSectionTorus` that computes the (r, theta, phi) grid for the accretion disk diagnostics.

Commit order:
1. Reorganize InterpTargetLineSegment test to facilitate factoring
2. Factor InterpolationTarget test work
3. Add InterpolationTargetWedgeSectionTorus

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

