### PR TITLE
Add Options to Shell for number of Wedge3Ds to have

### DIFF
--- a/src/Domain/DomainCreators/Shell.cpp
+++ b/src/Domain/DomainCreators/Shell.cpp
@@ -12,6 +12,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/DomainHelpers.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 
 /// \cond
@@ -32,17 +33,19 @@ Shell<TargetFrame>::Shell(
     typename InitialGridPoints::type initial_number_of_grid_points,
     typename UseEquiangularMap::type use_equiangular_map,
     typename AspectRatio::type aspect_ratio,
-    typename UseLogarithmicMap::type use_logarithmic_map) noexcept
+    typename UseLogarithmicMap::type use_logarithmic_map,
+    typename WhichWedges::type which_wedges) noexcept
     // clang-tidy: trivially copyable
-    : inner_radius_(std::move(inner_radius)),                  // NOLINT
-      outer_radius_(std::move(outer_radius)),                  // NOLINT
-      initial_refinement_(                                     // NOLINT
-          std::move(initial_refinement)),                      // NOLINT
-      initial_number_of_grid_points_(                          // NOLINT
-          std::move(initial_number_of_grid_points)),           // NOLINT
-      use_equiangular_map_(std::move(use_equiangular_map)),    // NOLINT
-      aspect_ratio_(std::move(aspect_ratio)),                  // NOLINT
-      use_logarithmic_map_(std::move(use_logarithmic_map)) {}  // NOLINT
+    : inner_radius_(std::move(inner_radius)),                // NOLINT
+      outer_radius_(std::move(outer_radius)),                // NOLINT
+      initial_refinement_(                                   // NOLINT
+          std::move(initial_refinement)),                    // NOLINT
+      initial_number_of_grid_points_(                        // NOLINT
+          std::move(initial_number_of_grid_points)),         // NOLINT
+      use_equiangular_map_(std::move(use_equiangular_map)),  // NOLINT
+      aspect_ratio_(std::move(aspect_ratio)),                // NOLINT
+      use_logarithmic_map_(std::move(use_logarithmic_map)),  // NOLINT
+      which_wedges_(std::move(which_wedges)) {}              // NOLINT
 
 template <typename TargetFrame>
 Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
@@ -50,23 +53,37 @@ Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
       std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
       coord_maps = wedge_coordinate_maps<TargetFrame>(
           inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_, 0.0,
-          false, aspect_ratio_, use_logarithmic_map_);
-  return Domain<3, TargetFrame>{std::move(coord_maps),
-                                corners_for_radially_layered_domains(1, false)};
+          false, aspect_ratio_, use_logarithmic_map_, which_wedges_);
+  return Domain<3, TargetFrame>{
+      std::move(coord_maps),
+      corners_for_radially_layered_domains(1, false, {{1, 2, 3, 4, 5, 6, 7, 8}},
+                                           which_wedges_)};
 }
 
 template <typename TargetFrame>
 std::vector<std::array<size_t, 3>> Shell<TargetFrame>::initial_extents() const
     noexcept {
+  std::vector<std::array<size_t, 3>>::size_type num_wedges = 6;
+  if (UNLIKELY(which_wedges_ == ShellWedges::FourOnEquator)) {
+    num_wedges = 4;
+  } else if (UNLIKELY(which_wedges_ == ShellWedges::OneAlongMinusX)) {
+    num_wedges = 1;
+  }
   return {
-      6,
+      num_wedges,
       {{initial_number_of_grid_points_[1], initial_number_of_grid_points_[1],
         initial_number_of_grid_points_[0]}}};
 }
 template <typename TargetFrame>
 std::vector<std::array<size_t, 3>>
 Shell<TargetFrame>::initial_refinement_levels() const noexcept {
-  return {6, make_array<3>(initial_refinement_)};
+  std::vector<std::array<size_t, 3>>::size_type num_wedges = 6;
+  if (UNLIKELY(which_wedges_ == ShellWedges::FourOnEquator)) {
+    num_wedges = 4;
+  } else if (UNLIKELY(which_wedges_ == ShellWedges::OneAlongMinusX)) {
+    num_wedges = 1;
+  }
+  return {num_wedges, make_array<3>(initial_refinement_)};
 }
 }  // namespace DomainCreators
 

--- a/src/Domain/DomainCreators/Shell.hpp
+++ b/src/Domain/DomainCreators/Shell.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "Domain/Domain.hpp"
+#include "Domain/DomainHelpers.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -72,9 +73,16 @@ class Shell : public DomainCreator<3, TargetFrame> {
     static constexpr type default_value() noexcept { return false; }
   };
 
-  using options =
-      tmpl::list<InnerRadius, OuterRadius, InitialRefinement, InitialGridPoints,
-                 UseEquiangularMap, AspectRatio, UseLogarithmicMap>;
+  struct WhichWedges {
+    using type = ShellWedges;
+    static constexpr OptionString help = {
+        "Which wedges to include in the shell."};
+    static constexpr type default_value() noexcept { return ShellWedges::All; }
+  };
+
+  using options = tmpl::list<InnerRadius, OuterRadius, InitialRefinement,
+                             InitialGridPoints, UseEquiangularMap, AspectRatio,
+                             UseLogarithmicMap, WhichWedges>;
 
   static constexpr OptionString help{
       "Creates a 3D spherical shell with 6 Blocks. `UseEquiangularMap` has\n"
@@ -91,7 +99,8 @@ class Shell : public DomainCreator<3, TargetFrame> {
         typename InitialGridPoints::type initial_number_of_grid_points,
         typename UseEquiangularMap::type use_equiangular_map,
         typename AspectRatio::type aspect_ratio = 1.0,
-        typename UseLogarithmicMap::type use_logarithmic_map = false) noexcept;
+        typename UseLogarithmicMap::type use_logarithmic_map = false,
+        typename WhichWedges::type which_wedges = ShellWedges::All) noexcept;
 
   Shell() = default;
   Shell(const Shell&) = delete;
@@ -115,5 +124,6 @@ class Shell : public DomainCreator<3, TargetFrame> {
   typename UseEquiangularMap::type use_equiangular_map_ = true;
   typename AspectRatio::type aspect_ratio_ = 1.0;
   typename UseLogarithmicMap::type use_logarithmic_map_ = false;
+  typename WhichWedges::type which_wedges_ = ShellWedges::All;
 };
 }  // namespace DomainCreators

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -8,6 +8,7 @@
 
 #include <array>
 #include <cstddef>
+#include <iosfwd>
 #include <limits>
 #include <memory>
 #include <unordered_map>
@@ -30,6 +31,9 @@ template <size_t VolumeDim, typename TargetFrame>
 class Domain;
 template <size_t VolumeDim>
 class OrientationMap;
+class Option;
+template <typename T>
+struct create_from_yaml;
 /// \endcond
 
 /// \ingroup ComputationalDomainGroup
@@ -82,6 +86,17 @@ corners_for_rectilinear_domains(const Index<VolumeDim>& domain_extents,
                                     block_indices_to_exclude = {}) noexcept;
 
 /// \ingroup ComputationalDomainGroup
+/// The number of wedges to include in the Shell domain.
+enum class ShellWedges {
+  /// Use the entire shell
+  All,
+  /// Use only the four equatorial wedges
+  FourOnEquator,
+  /// Use only the single wedge along -x
+  OneAlongMinusX
+};
+
+/// \ingroup ComputationalDomainGroup
 /// These are the CoordinateMaps of the Wedge3Ds used in the Sphere, Shell, and
 /// binary compact object DomainCreators. This function can also be used to
 /// wrap the Sphere or Shell in a cube made of six Wedge3Ds.
@@ -103,7 +118,8 @@ wedge_coordinate_maps(double inner_radius, double outer_radius,
                       bool use_equiangular_map,
                       double x_coord_of_shell_center = 0.0,
                       bool use_half_wedges = false, double aspect_ratio = 1.0,
-                      bool use_logarithmic_map = false) noexcept;
+                      bool use_logarithmic_map = false,
+                      ShellWedges which_wedges = ShellWedges::All) noexcept;
 
 /// \ingroup ComputationalDomainGroup
 /// These are the ten Frustums used in the DomainCreators for binary compact
@@ -129,8 +145,9 @@ frustum_coordinate_maps(double length_inner_cube, double length_outer_cube,
 /// for the surrounding Blocks.
 std::vector<std::array<size_t, 8>> corners_for_radially_layered_domains(
     size_t number_of_layers, bool include_central_block,
-    const std::array<size_t, 8>& central_block_corners = {
-        {1, 2, 3, 4, 5, 6, 7, 8}}) noexcept;
+    const std::array<size_t, 8>& central_block_corners = {{1, 2, 3, 4, 5, 6, 7,
+                                                           8}},
+    ShellWedges which_wedges = ShellWedges::All) noexcept;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief The corners for a domain with biradial layers.
@@ -349,3 +366,11 @@ FaceCornerIterator<VolumeDim>::FaceCornerIterator(
     corner_[i] = 2 * static_cast<int>(get_nth_bit(index_, i)) - 1;
   }
 }
+
+std::ostream& operator<<(std::ostream& os,
+                         const ShellWedges& which_wedges) noexcept;
+
+template <>
+struct create_from_yaml<ShellWedges> {
+  static ShellWedges create(const Option& options);
+};

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -28,6 +29,7 @@
 #include "Domain/OrientationMap.hpp"
 #include "Domain/Side.hpp"
 #include "ErrorHandling/Error.hpp"
+#include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/StdHelpers.hpp"
@@ -1384,4 +1386,10 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.SetCartesianPeriodicBoundaries3",
     INFO(i);
     CHECK(domain.blocks()[i].neighbors() == expected_block_neighbors[i]);
   }
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.WhichWedges", "[Domain][Unit]") {
+  CHECK(get_output(ShellWedges::All) == "All");
+  CHECK(get_output(ShellWedges::FourOnEquator) == "FourOnEquator");
+  CHECK(get_output(ShellWedges::OneAlongMinusX) == "OneAlongMinusX");
 }


### PR DESCRIPTION
## Proposed changes

There is now an option to toggle the number of Wedge3Ds to include:
All 6, 4 on the equator, or 1 on the equator.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
