### PR TITLE
Prevent git constraint circumvention

### DIFF
--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -9,6 +9,14 @@
 top_level=$(git rev-parse --show-cdup) || exit 1
 . "${top_level}tools/FileTestDefs.sh"
 
+# redefine grep functions to run on the working directory
+staged_grep() {
+    grep "$@";
+}
+pretty_grep() {
+    GREP_COLOR='1;37;41' grep --with-filename -n $color_option "$@"
+}
+
 # Check for iostream header
 iostream() {
     is_c++ "$1" && grep -q '#include <iostream>' "$1"

--- a/tools/Hooks/ClangFormat.py
+++ b/tools/Hooks/ClangFormat.py
@@ -11,6 +11,7 @@ import re
 # List of all the clang-format versions we are willing to use
 # The general case is needed on a Mac
 clang_format_list = ["git-clang-format",
+                     "git-clang-format-6.0",
                      "git-clang-format-4.0",
                      "git-clang-format-3.9",
                      "git-clang-format-3.8"]
@@ -78,5 +79,6 @@ if output not in ['\n', '', 'no modified files to format\n',
           "then staging the modified files and amending your original "
           "commit.\n" %
           (output_file_name, output_file_name))
+    sys.exit(1)
 
 sys.exit(0)


### PR DESCRIPTION
by actually checking the files as they are in the staging area

## Proposed changes

- the pre-commit tests now parse the files in the staging area instead of working directory
- addresses #1085 

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

- Constraints by clang-format are only suggestions and are not enforced