### PR TITLE
Grmhd boundary conditions

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1568,7 +1568,8 @@ template <typename... ReturnTags, typename... ArgumentTags, typename F,
           typename BoxTags, typename... Args,
           Requires<is_apply_callable_v<
               F, const gsl::not_null<db::item_type<ReturnTags>*>...,
-              const std::add_lvalue_reference_t<db::item_type<ArgumentTags>>...,
+              const std::add_lvalue_reference_t<
+                  db::item_type<ArgumentTags, BoxTags>>...,
               Args...>> = nullptr>
 inline constexpr auto mutate_apply(
     F /*f*/, const gsl::not_null<db::DataBox<BoxTags>*> box,
@@ -1583,12 +1584,12 @@ inline constexpr auto mutate_apply(
   ::db::mutate<ReturnTags...>(
       box,
       [](const gsl::not_null<db::item_type<ReturnTags>*>... mutated_items,
-         const db::item_type<ArgumentTags>&... args_items,
+         const db::item_type<ArgumentTags, BoxTags>&... args_items,
          decltype(std::forward<Args>(args))... l_args)
       // clang-format off
       noexcept(noexcept(F::apply(
           std::declval<gsl::not_null<db::item_type<ReturnTags>*>>()...,
-          std::declval<const db::item_type<ArgumentTags>&>()...,
+          std::declval<const db::item_type<ArgumentTags, BoxTags>&>()...,
           std::forward<Args>(args)...))) {
         // clang-format on
         return F::apply(mutated_items..., args_items...,
@@ -1601,7 +1602,8 @@ template <typename... ReturnTags, typename... ArgumentTags, typename F,
           typename BoxTags, typename... Args,
           Requires<::tt::is_callable_v<
               F, const gsl::not_null<db::item_type<ReturnTags>*>...,
-              const std::add_lvalue_reference_t<db::item_type<ArgumentTags>>...,
+              const std::add_lvalue_reference_t<
+                  db::item_type<ArgumentTags, BoxTags>>...,
               Args...>> = nullptr>
 inline constexpr auto mutate_apply(
     F f, const gsl::not_null<db::DataBox<BoxTags>*> box,
@@ -1610,7 +1612,7 @@ inline constexpr auto mutate_apply(
     // clang-format off
     noexcept(noexcept(f(
         std::declval<gsl::not_null<db::item_type<ReturnTags>*>>()...,
-        std::declval<const db::item_type<ArgumentTags>&>()...,
+        std::declval<const db::item_type<ArgumentTags, BoxTags>&>()...,
         std::forward<Args>(args)...))) {
   // clang-format on
   static_assert(
@@ -1622,7 +1624,7 @@ inline constexpr auto mutate_apply(
   ::db::mutate<ReturnTags...>(
       box,
       [&f](const gsl::not_null<db::item_type<ReturnTags>*>... mutated_items,
-           const db::item_type<ArgumentTags>&... args_items,
+           const db::item_type<ArgumentTags, BoxTags>&... args_items,
            decltype(std::forward<Args>(args))... l_args)
       // clang-format off
       noexcept(noexcept(f(mutated_items...,
@@ -1648,22 +1650,23 @@ constexpr void error_mutate_apply_not_callable() noexcept {
 template <
     typename... ReturnTags, typename... ArgumentTags, typename F,
     typename BoxTags, typename... Args,
-    Requires<not(
-        is_apply_callable_v<
-            F, const gsl::not_null<db::item_type<ReturnTags>*>...,
-            const std::add_lvalue_reference_t<db::item_type<ArgumentTags>>...,
-            Args...> or
-        ::tt::is_callable_v<
-            F, const gsl::not_null<db::item_type<ReturnTags>*>...,
-            const std::add_lvalue_reference_t<db::item_type<ArgumentTags>>...,
-            Args...>)> = nullptr>
+    Requires<not(is_apply_callable_v<
+                     F, const gsl::not_null<db::item_type<ReturnTags>*>...,
+                     const std::add_lvalue_reference_t<
+                         db::item_type<ArgumentTags, BoxTags>>...,
+                     Args...> or
+                 ::tt::is_callable_v<
+                     F, const gsl::not_null<db::item_type<ReturnTags>*>...,
+                     const std::add_lvalue_reference_t<
+                         db::item_type<ArgumentTags, BoxTags>>...,
+                     Args...>)> = nullptr>
 inline constexpr auto mutate_apply(
     F /*f*/, const gsl::not_null<db::DataBox<BoxTags>*> /*box*/,
     tmpl::list<ReturnTags...> /*meta*/, tmpl::list<ArgumentTags...> /*meta*/,
     Args&&... /*args*/) noexcept {
   error_mutate_apply_not_callable<
       F, gsl::not_null<db::item_type<ReturnTags>*>...,
-      const db::item_type<ArgumentTags>&..., Args&&...>();
+      const db::item_type<ArgumentTags, BoxTags>&..., Args&&...>();
 }
 
 template <typename Tag, typename BoxTags>

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1625,13 +1625,7 @@ inline constexpr auto mutate_apply(
       box,
       [&f](const gsl::not_null<db::item_type<ReturnTags>*>... mutated_items,
            const db::item_type<ArgumentTags, BoxTags>&... args_items,
-           decltype(std::forward<Args>(args))... l_args)
-      // clang-format off
-      noexcept(noexcept(f(mutated_items...,
-                          args_items..., std::forward<Args>(
-                              l_args)...)))
-      // clang-format on
-      {
+           decltype(std::forward<Args>(args))... l_args) noexcept {
         return f(mutated_items..., args_items...,
                  std::forward<Args>(l_args)...);
       },

--- a/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InitializeElement.hpp
@@ -139,7 +139,8 @@ struct InitializeElement {
   };
 
   // Tags related only to the system
-  template <typename System, bool IsConservative = System::is_conservative>
+  template <typename System, bool IsInFluxConservativeForm =
+                                 System::is_in_flux_conservative_form>
   struct SystemTags {
     using simple_tags = db::AddSimpleTags<typename System::variables_tag>;
 
@@ -282,7 +283,8 @@ struct InitializeElement {
         Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>>;
 
     template <typename LocalSystem,
-              bool IsConservative = LocalSystem::is_conservative>
+              bool IsInFluxConservativeForm =
+                  LocalSystem::is_in_flux_conservative_form>
     struct ComputeTags {
       using type = db::AddComputeTags<
           Tags::Time, Tags::DerivCompute<
@@ -470,7 +472,8 @@ struct InitializeElement {
     }
 
     template <typename LocalSystem,
-              bool IsConservative = LocalSystem::is_conservative>
+              bool IsInFluxConservativeForm =
+                  LocalSystem::is_in_flux_conservative_form>
     struct Impl {
       using simple_tags = db::AddSimpleTags<
           mortar_data_tag,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBS_TO_LINK
   Informer
   LinearOperators
   MathFunctions
+  RelativisticEulerSolutions
   SlopeLimiters
   Time
   Utilities

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -62,11 +62,16 @@ class CProxy_ConstGlobalCache;
 /// \endcond
 
 struct EvolutionMetavars {
-  using system = grmhd::ValenciaDivClean::System;
+  // To switch which analytic solution is evolved you only need to change the
+  // line `using analytic_solution = ...;` and include the header file for the
+  // solution.
+  using analytic_solution = grmhd::Solutions::SmoothFlow;
+
+  using system = grmhd::ValenciaDivClean::System<
+      typename analytic_solution::equation_of_state_type>;
   using temporal_id = Tags::TimeId;
   static constexpr bool local_time_stepping = false;
-  using analytic_solution_tag =
-      OptionTags::AnalyticSolution<grmhd::Solutions::SmoothFlow>;
+  using analytic_solution_tag = OptionTags::AnalyticSolution<analytic_solution>;
   using boundary_condition_tag = analytic_solution_tag;
   using analytic_variables_tags =
       typename system::primitive_variables_tag::tags_list;

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -25,6 +25,7 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesGlobalTimeStepping.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/FluxCommunication.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NumericalFluxes/LocalLaxFriedrichs.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "Options/Options.hpp"
@@ -66,6 +67,7 @@ struct EvolutionMetavars {
   static constexpr bool local_time_stepping = false;
   using analytic_solution_tag =
       OptionTags::AnalyticSolution<grmhd::Solutions::SmoothFlow>;
+  using boundary_condition_tag = analytic_solution_tag;
   using analytic_variables_tags =
       typename system::primitive_variables_tag::tags_list;
   using equation_of_state_tag = hydro::Tags::EquationOfState<
@@ -92,6 +94,7 @@ struct EvolutionMetavars {
       Actions::ComputeVolumeFluxes,
       dg::Actions::SendDataForFluxes<EvolutionMetavars>,
       Actions::ComputeVolumeSources, Actions::ComputeVolumeDuDt,
+      dg::Actions::ImposeDirichletBoundaryConditions<EvolutionMetavars>,
       dg::Actions::ReceiveDataForFluxes<EvolutionMetavars>,
       tmpl::conditional_t<local_time_stepping, tmpl::list<>,
                           dg::Actions::ApplyBoundaryFluxesGlobalTimeStepping>,

--- a/src/Evolution/Initialization/ConservativeSystem.hpp
+++ b/src/Evolution/Initialization/ConservativeSystem.hpp
@@ -42,7 +42,8 @@ namespace Initialization {
 /// variables are initialized.
 template <typename System>
 struct ConservativeSystem {
-  static_assert(System::is_conservative, "System is not conservative");
+  static_assert(System::is_in_flux_conservative_form,
+                "System is not in flux conservative form");
   static constexpr size_t dim = System::volume_dim;
   using variables_tag = typename System::variables_tag;
   using fluxes_tag = db::add_tag_prefix<Tags::Flux, variables_tag,

--- a/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
@@ -109,8 +109,8 @@ struct DiscontinuousGalerkin {
         std::move(mortar_sizes));
   }
 
-  template <typename LocalSystem,
-            bool IsConservative = LocalSystem::is_conservative>
+  template <typename LocalSystem, bool IsInFluxConservativeForm =
+                                      LocalSystem::is_in_flux_conservative_form>
   struct Impl {
     using simple_tags = db::AddSimpleTags<
         mortar_data_tag, Tags::Mortars<Tags::Next<temporal_id_tag>, dim>,

--- a/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
@@ -66,6 +66,14 @@ struct DiscontinuousGalerkin {
   template <typename Tag>
   using interface_tag = Tags::Interface<Tags::InternalDirections<dim>, Tag>;
 
+  template <typename Tag>
+  using interior_boundary_tag =
+      Tags::Interface<Tags::BoundaryDirectionsInterior<dim>, Tag>;
+
+  template <typename Tag>
+  using external_boundary_tag =
+      Tags::Interface<Tags::BoundaryDirectionsExterior<dim>, Tag>;
+
   template <typename TagsList>
   static auto add_mortar_data(
       db::DataBox<TagsList>&& box,
@@ -98,6 +106,19 @@ struct DiscontinuousGalerkin {
       }
     }
 
+    for (const auto& direction : element.external_boundaries()) {
+      const auto mortar_id =
+          std::make_pair(direction, ElementId<dim>::external_boundary_id());
+      mortar_data[mortar_id];
+      // Since no communication needs to happen for boundary conditions,
+      // the temporal id is not advanced on the boundary, so we set it equal
+      // to the current temporal id in the element
+      mortar_next_temporal_ids.insert({mortar_id, temporal_id});
+      mortar_meshes.emplace(mortar_id, mesh.slice_away(direction.dimension()));
+      mortar_sizes.emplace(mortar_id,
+                           make_array<dim - 1>(Spectral::MortarSize::Full));
+    }
+
     return db::create_from<
         db::RemoveTags<>,
         db::AddSimpleTags<mortar_data_tag,
@@ -116,7 +137,9 @@ struct DiscontinuousGalerkin {
         mortar_data_tag, Tags::Mortars<Tags::Next<temporal_id_tag>, dim>,
         Tags::Mortars<Tags::Mesh<dim - 1>, dim>,
         Tags::Mortars<Tags::MortarSize<dim - 1>, dim>,
-        interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>>;
+        interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>,
+        interior_boundary_tag<typename flux_comm_types::normal_dot_fluxes_tag>,
+        external_boundary_tag<typename flux_comm_types::normal_dot_fluxes_tag>>;
 
     using compute_tags = db::AddComputeTags<>;
 
@@ -129,21 +152,46 @@ struct DiscontinuousGalerkin {
       const auto& internal_directions =
           db::get<Tags::InternalDirections<dim>>(box2);
 
+      const auto& boundary_directions =
+          db::get<Tags::BoundaryDirectionsInterior<dim>>(box2);
+
       typename interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>::
-          type normal_dot_fluxes{};
+          type normal_dot_fluxes_interface{};
       for (const auto& direction : internal_directions) {
         const auto& interface_num_points =
             db::get<interface_tag<Tags::Mesh<dim - 1>>>(box2)
                 .at(direction)
                 .number_of_grid_points();
-        normal_dot_fluxes[direction].initialize(interface_num_points, 0.);
+        normal_dot_fluxes_interface[direction].initialize(interface_num_points,
+                                                          0.);
+      }
+
+      typename interior_boundary_tag<
+          typename flux_comm_types::normal_dot_fluxes_tag>::type
+          normal_dot_fluxes_boundary_exterior{},
+          normal_dot_fluxes_boundary_interior{};
+      for (const auto& direction : boundary_directions) {
+        const auto& boundary_num_points =
+            db::get<interior_boundary_tag<Tags::Mesh<dim - 1>>>(box2)
+                .at(direction)
+                .number_of_grid_points();
+        normal_dot_fluxes_boundary_exterior[direction].initialize(
+            boundary_num_points, 0.);
+        normal_dot_fluxes_boundary_interior[direction].initialize(
+            boundary_num_points, 0.);
       }
 
       return db::create_from<
           db::RemoveTags<>,
           db::AddSimpleTags<
-              interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>>>(
-          std::move(box2), std::move(normal_dot_fluxes));
+              interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>,
+              interior_boundary_tag<
+                  typename flux_comm_types::normal_dot_fluxes_tag>,
+              external_boundary_tag<
+                  typename flux_comm_types::normal_dot_fluxes_tag>>>(
+          std::move(box2), std::move(normal_dot_fluxes_interface),
+          std::move(normal_dot_fluxes_boundary_interior),
+          std::move(normal_dot_fluxes_boundary_exterior));
     }
   };
 
@@ -183,12 +231,14 @@ struct DiscontinuousGalerkin {
                                tmpl::size_t<dim>, Frame::Inertial>>,
         boundary_interior_compute_tag<Tags::ComputeNormalDotFlux<
             typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
-        Tags::Slice<Tags::BoundaryDirectionsExterior<dim>,
-                    db::add_tag_prefix<Tags::Flux,
-                                       typename LocalSystem::variables_tag,
-                                       tmpl::size_t<dim>, Frame::Inertial>>,
+        boundary_interior_compute_tag<char_speed_tag>,
+        Tags::Slice<
+            Tags::BoundaryDirectionsExterior<dim>,
+            db::add_tag_prefix<Tags::Flux, typename LocalSystem::variables_tag,
+                               tmpl::size_t<dim>, Frame::Inertial>>,
         boundary_exterior_compute_tag<Tags::ComputeNormalDotFlux<
-            typename LocalSystem::variables_tag, dim, Frame::Inertial>>>;
+            typename LocalSystem::variables_tag, dim, Frame::Inertial>>,
+        boundary_exterior_compute_tag<char_speed_tag>>;
 
     template <typename TagsList>
     static auto initialize(

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -57,8 +57,8 @@ struct Evolution {
       Tags::TimeId, Tags::Next<Tags::TimeId>, Tags::TimeStep, dt_variables_tag,
       Tags::HistoryEvolvedVariables<variables_tag, dt_variables_tag>>;
 
-  template <typename LocalSystem,
-            bool IsConservative = LocalSystem::is_conservative>
+  template <typename LocalSystem, bool IsInFluxConservativeForm =
+                                      LocalSystem::is_in_flux_conservative_form>
   struct ComputeTags {
     using type = db::AddComputeTags<
         Tags::Time,

--- a/src/Evolution/Systems/Burgers/System.hpp
+++ b/src/Evolution/Systems/Burgers/System.hpp
@@ -21,7 +21,8 @@
 /// of the Burgers system, the local characteristic speed is \f$U\f$.
 namespace Burgers {
 struct System {
-  static constexpr bool is_conservative = true;
+  static constexpr bool is_in_flux_conservative_form = true;
+  static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = 1;
 
   using variables_tag = ::Tags::Variables<tmpl::list<Tags::U>>;

--- a/src/Evolution/Systems/CurvedScalarWave/System.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/System.hpp
@@ -22,6 +22,8 @@ namespace CurvedScalarWave {
 
 template <size_t Dim>
 struct System {
+  static constexpr bool is_in_flux_conservative_form = false;
+  static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = Dim;
 
   using variables_tag = Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;

--- a/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/System.hpp
@@ -23,6 +23,8 @@ class Variables;
 namespace GeneralizedHarmonic {
 template <size_t Dim>
 struct System {
+  static constexpr bool is_in_flux_conservative_form = false;
+  static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = Dim;
   static constexpr bool is_euclidean = false;
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.cpp
@@ -14,6 +14,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/Tags.hpp"              // IWYU pragma: keep
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/Overloader.hpp"
@@ -116,9 +117,27 @@ std::array<DataVector, 9> characteristic_speeds(
       lapse, shift, spatial_velocity, spatial_velocity_squared,
       sound_speed_squared, alfven_speed_squared, unit_normal);
 }
+
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)                                              \
+  template std::array<DataVector, 9> characteristic_speeds<GET_DIM(data)>(  \
+      const Scalar<DataVector>& rest_mass_density,                          \
+      const Scalar<DataVector>& specific_internal_energy,                   \
+      const Scalar<DataVector>& specific_enthalpy,                          \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,      \
+      const Scalar<DataVector>& lorentz_factor,                             \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,        \
+      const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift, \
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,       \
+      const tnsr::i<DataVector, 3>& unit_normal,                            \
+      const EquationsOfState::EquationOfState<true, GET_DIM(data)>&         \
+          equation_of_state) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2))
+
+#undef GET_DIM
+#undef INSTANTIATION
 }  // namespace ValenciaDivClean
 }  // namespace grmhd
-
-template struct grmhd::ValenciaDivClean::Tags::CharacteristicSpeedsCompute<1>;
-template struct grmhd::ValenciaDivClean::Tags::CharacteristicSpeedsCompute<2>;
 /// \endcond

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
@@ -117,22 +117,22 @@ namespace Tags {
 /// GRMHD with divergence cleaning.
 ///
 /// \details see grmhd::ValenciaDivClean::characteristic_speeds
-template <size_t ThermodynamicDim>
+template <typename EquationOfStateType>
 struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds,
                                      db::ComputeTag {
-  using argument_tags = tmpl::list<
-      hydro::Tags::RestMassDensity<DataVector>,
-      hydro::Tags::SpecificInternalEnergy<DataVector>,
-      hydro::Tags::SpecificEnthalpy<DataVector>,
-      hydro::Tags::SpatialVelocity<DataVector, 3>,
-      hydro::Tags::LorentzFactor<DataVector>,
-      hydro::Tags::MagneticField<DataVector, 3>, gr::Tags::Lapse<>,
-      gr::Tags::Shift<3>, gr::Tags::SpatialMetric<3>,
-      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<3>>,
-      hydro::Tags::EquationOfState<EquationsOfState::IdealFluid<true>>>;
+  using argument_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataVector>,
+                 hydro::Tags::SpecificInternalEnergy<DataVector>,
+                 hydro::Tags::SpecificEnthalpy<DataVector>,
+                 hydro::Tags::SpatialVelocity<DataVector, 3>,
+                 hydro::Tags::LorentzFactor<DataVector>,
+                 hydro::Tags::MagneticField<DataVector, 3>, gr::Tags::Lapse<>,
+                 gr::Tags::Shift<3>, gr::Tags::SpatialMetric<3>,
+                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<3>>,
+                 hydro::Tags::EquationOfState<EquationOfStateType>>;
 
-  using volume_tags = tmpl::list<
-      hydro::Tags::EquationOfState<EquationsOfState::IdealFluid<true>>>;
+  using volume_tags =
+      tmpl::list<hydro::Tags::EquationOfState<EquationOfStateType>>;
 
   static constexpr auto function(
       const Scalar<DataVector>& rest_mass_density,
@@ -144,9 +144,10 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds,
       const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,
       const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
       const tnsr::i<DataVector, 3>& unit_normal,
-      const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+      const EquationsOfState::EquationOfState<
+          true, EquationOfStateType::thermodynamic_dim>&
           equation_of_state) noexcept {
-    return characteristic_speeds<ThermodynamicDim>(
+    return characteristic_speeds<EquationOfStateType::thermodynamic_dim>(
         rest_mass_density, specific_internal_energy, specific_enthalpy,
         spatial_velocity, lorentz_factor, magnetic_field, lapse, shift,
         spatial_metric, unit_normal, equation_of_state);

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp
@@ -102,9 +102,8 @@ struct Initialize {
       // Set initial data from analytic solution
       using solution_tag = OptionTags::AnalyticSolutionBase;
       GrVars gr_vars{num_grid_points};
-      gr_vars.assign_subset(
-          Parallel::get<solution_tag>(cache).background_spacetime().variables(
-              inertial_coords, initial_time, typename GrVars::tags_list{}));
+      gr_vars.assign_subset(Parallel::get<solution_tag>(cache).variables(
+          inertial_coords, initial_time, typename GrVars::tags_list{}));
 
       return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
           std::move(box), std::move(gr_vars));

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
@@ -53,14 +53,15 @@ struct PrimitiveFromConservative {
                  hydro::Tags::Pressure<DataVector>,
                  hydro::Tags::SpecificEnthalpy<DataVector>>;
 
-  using argument_tags = tmpl::list<
-      grmhd::ValenciaDivClean::Tags::TildeD,
-      grmhd::ValenciaDivClean::Tags::TildeTau,
-      grmhd::ValenciaDivClean::Tags::TildeS<>,
-      grmhd::ValenciaDivClean::Tags::TildeB<>,
-      grmhd::ValenciaDivClean::Tags::TildePhi, gr::Tags::SpatialMetric<3>,
-      gr::Tags::InverseSpatialMetric<3>, gr::Tags::SqrtDetSpatialMetric<>,
-      hydro::Tags::EquationOfState<EquationsOfState::IdealFluid<true>>>;
+  using argument_tags =
+      tmpl::list<grmhd::ValenciaDivClean::Tags::TildeD,
+                 grmhd::ValenciaDivClean::Tags::TildeTau,
+                 grmhd::ValenciaDivClean::Tags::TildeS<>,
+                 grmhd::ValenciaDivClean::Tags::TildeB<>,
+                 grmhd::ValenciaDivClean::Tags::TildePhi,
+                 gr::Tags::SpatialMetric<3>, gr::Tags::InverseSpatialMetric<3>,
+                 gr::Tags::SqrtDetSpatialMetric<>,
+                 hydro::Tags::EquationOfStateBase>;
 
   static void apply(
       gsl::not_null<Scalar<DataVector>*> rest_mass_density,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -38,7 +38,8 @@ namespace grmhd {
 namespace ValenciaDivClean {
 
 struct System {
-  static constexpr bool is_conservative = true;
+  static constexpr bool is_in_flux_conservative_form = true;
+  static constexpr bool has_primitive_and_conservative_vars = true;
   static constexpr size_t volume_dim = 3;
 
   using primitive_variables_tag = ::Tags::Variables<tmpl::list<

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -37,6 +37,7 @@ namespace grmhd {
 /// (http://iopscience.iop.org/article/10.1088/0264-9381/31/1/015005)
 namespace ValenciaDivClean {
 
+template <typename EquationOfStateType>
 struct System {
   static constexpr bool is_in_flux_conservative_form = true;
   static constexpr bool has_primitive_and_conservative_vars = true;
@@ -73,13 +74,15 @@ struct System {
   using magnitude_tag = ::Tags::NonEuclideanMagnitude<
       Tag, gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>>;
 
-  using char_speeds_tag = Tags::CharacteristicSpeedsCompute<2>;
+  using char_speeds_tag =
+      Tags::CharacteristicSpeedsCompute<EquationOfStateType>;
   using compute_largest_characteristic_speed =
       ComputeLargestCharacteristicSpeed;
 
   using conservative_from_primitive = ConservativeFromPrimitive;
   using primitive_from_conservative =
-      PrimitiveFromConservative<PrimitiveRecoverySchemes::NewmanHamlin, 2>;
+      PrimitiveFromConservative<PrimitiveRecoverySchemes::NewmanHamlin,
+                                EquationOfStateType::thermodynamic_dim>;
 
   using volume_fluxes = ComputeFluxes;
 

--- a/src/Evolution/Systems/NewtonianEuler/System.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/System.hpp
@@ -11,6 +11,8 @@ namespace NewtonianEuler {
 
 template <size_t Dim>
 struct System {
+  static constexpr bool is_in_flux_conservative_form = true;
+  static constexpr bool has_primitive_and_conservative_vars = true;
   static constexpr size_t volume_dim = Dim;
 };
 

--- a/src/Evolution/Systems/RelativisticEuler/Valencia/System.hpp
+++ b/src/Evolution/Systems/RelativisticEuler/Valencia/System.hpp
@@ -23,6 +23,8 @@ namespace Valencia {
 
 template <size_t Dim>
 struct System {
+  static constexpr bool is_in_flux_conservative_form = true;
+  static constexpr bool has_primitive_and_conservative_vars = true;
   static constexpr size_t volume_dim = Dim;
 
   using variables_tag =

--- a/src/Evolution/Systems/ScalarWave/System.hpp
+++ b/src/Evolution/Systems/ScalarWave/System.hpp
@@ -26,7 +26,8 @@ namespace ScalarWave {
 
 template <size_t Dim>
 struct System {
-  static constexpr bool is_conservative = false;
+  static constexpr bool is_in_flux_conservative_form = false;
+  static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = Dim;
 
   using variables_tag = Tags::Variables<tmpl::list<Pi, Phi<Dim>, Psi>>;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -25,6 +25,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 /// \cond
 namespace Tags {
@@ -90,9 +91,11 @@ struct ImposeDirichletBoundaryConditions {
     using system = typename Metavariables::system;
 
     static_assert(
-        system::is_conservative or
-            cpp17::is_same_v<typename Metavariables::analytic_solution_tag,
-                             typename Metavariables::boundary_condition_tag>,
+        (system::is_in_flux_conservative_form or
+         cpp17::is_same_v<
+             typename Metavariables::analytic_solution_tag,
+             typename Metavariables::boundary_condition_tag>)and not system::
+            has_primitive_and_conservative_vars,
         "Only analytic boundary conditions, or dirichlet boundary conditions "
         "for conservative systems are implemented");
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -114,10 +114,48 @@ struct ImposeDirichletBoundaryConditions {
   }
 
  private:
+  template <typename DbTags>
+  static void contribute_data_to_mortar(
+      const gsl::not_null<db::DataBox<DbTags>*> box,
+      const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+    using system = typename Metavariables::system;
+    constexpr size_t volume_dim = system::volume_dim;
+
+    const auto& element = db::get<Tags::Element<volume_dim>>(*box);
+    const auto& temporal_id =
+        db::get<typename Metavariables::temporal_id>(*box);
+    const auto& normal_dot_numerical_flux_computer =
+        get<typename Metavariables::normal_dot_numerical_flux>(cache);
+
+    for (const auto& direction : element.external_boundaries()) {
+      const auto mortar_id = std::make_pair(
+          direction, ElementId<volume_dim>::external_boundary_id());
+
+      auto interior_data = DgActions_detail::compute_local_mortar_data(
+          *box, direction, normal_dot_numerical_flux_computer,
+          Tags::BoundaryDirectionsInterior<volume_dim>{}, Metavariables{});
+
+      auto exterior_data = DgActions_detail::compute_packaged_data(
+          *box, direction, normal_dot_numerical_flux_computer,
+          Tags::BoundaryDirectionsExterior<volume_dim>{}, Metavariables{});
+
+      db::mutate<Tags::VariablesBoundaryData>(
+          box, [&mortar_id, &temporal_id, &interior_data, &exterior_data ](
+                   const gsl::not_null<
+                       db::item_type<Tags::VariablesBoundaryData, DbTags>*>
+                       mortar_data) noexcept {
+            mortar_data->at(mortar_id).local_insert(temporal_id,
+                                                    std::move(interior_data));
+            mortar_data->at(mortar_id).remote_insert(temporal_id,
+                                                     std::move(exterior_data));
+          });
+    }
+  }
+
   template <size_t VolumeDim, typename DbTags>
   static std::tuple<db::DataBox<DbTags>&&> apply_impl(
       db::DataBox<DbTags>& box,
-      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
       std::integral_constant<
           BoundaryConditionMethod,
           BoundaryConditionMethod::AnalyticBcNoPrimitives> /*meta*/) noexcept {
@@ -155,35 +193,7 @@ struct ImposeDirichletBoundaryConditions {
                                 Tags::Coordinates<VolumeDim, Frame::Inertial>>>(
             box));
 
-    const auto& element = db::get<Tags::Element<VolumeDim>>(box);
-    const auto& temporal_id = db::get<typename Metavariables::temporal_id>(box);
-    const auto& normal_dot_numerical_flux_computer =
-        get<typename Metavariables::normal_dot_numerical_flux>(cache);
-
-    for (const auto& direction : element.external_boundaries()) {
-      const auto mortar_id = std::make_pair(
-          direction, ElementId<VolumeDim>::external_boundary_id());
-
-      auto interior_data = DgActions_detail::compute_local_mortar_data(
-          box, direction, normal_dot_numerical_flux_computer,
-          Tags::BoundaryDirectionsInterior<VolumeDim>{}, Metavariables{});
-
-      auto exterior_data = DgActions_detail::compute_packaged_data(
-          box, direction, normal_dot_numerical_flux_computer,
-          Tags::BoundaryDirectionsExterior<VolumeDim>{}, Metavariables{});
-
-      db::mutate<Tags::VariablesBoundaryData>(
-          make_not_null(&box),
-          [&mortar_id, &temporal_id, &interior_data, &
-           exterior_data ](const gsl::not_null<
-                           db::item_type<Tags::VariablesBoundaryData, DbTags>*>
-                               mortar_data) noexcept {
-            mortar_data->at(mortar_id).local_insert(temporal_id,
-                                                    std::move(interior_data));
-            mortar_data->at(mortar_id).remote_insert(temporal_id,
-                                                     std::move(exterior_data));
-          });
-    }
+    contribute_data_to_mortar(make_not_null(&box), cache);
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -15,5 +15,6 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE DataStructures
   INTERFACE ErrorHandling
+  INTERFACE GeneralRelativity
   INTERFACE Interpolation
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp
@@ -260,7 +260,9 @@ class KerrSchild {
       DerivShift<DataType>,
       gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>,
       ::Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>,
-      DerivSpatialMetric<DataType>>;
+      DerivSpatialMetric<DataType>, gr::Tags::SqrtDetSpatialMetric<DataType>,
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataType>,
+      gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataType>>;
 
   template <typename DataType>
   tuples::tagged_tuple_from_typelist<tags<DataType>> variables(

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
@@ -152,15 +152,15 @@ AlfvenWave::variables(
 bool operator==(const AlfvenWave& lhs, const AlfvenWave& rhs) noexcept {
   // there is no comparison operator for the EoS, but should be okay as
   // the adiabatic_indexs are compared
-  return lhs.wavenumber() == rhs.wavenumber() and
-         lhs.pressure() == rhs.pressure() and
-         lhs.rest_mass_density() == rhs.rest_mass_density() and
-         lhs.adiabatic_index() == rhs.adiabatic_index() and
-         lhs.background_mag_field() == rhs.background_mag_field() and
-         lhs.perturbation_size() == rhs.perturbation_size() and
-         lhs.alfven_speed() == rhs.alfven_speed() and
-         lhs.fluid_speed() == rhs.fluid_speed() and
-         lhs.background_spacetime() == rhs.background_spacetime();
+  return lhs.wavenumber_ == rhs.wavenumber_ and
+         lhs.pressure_ == rhs.pressure_ and
+         lhs.rest_mass_density_ == rhs.rest_mass_density_ and
+         lhs.adiabatic_index_ == rhs.adiabatic_index_ and
+         lhs.background_mag_field_ == rhs.background_mag_field_ and
+         lhs.perturbation_size_ == rhs.perturbation_size_ and
+         lhs.alfven_speed_ == rhs.alfven_speed_ and
+         lhs.fluid_speed_ == rhs.fluid_speed_ and
+         lhs.background_spacetime_ == rhs.background_spacetime_;
 }
 
 bool operator!=(const AlfvenWave& lhs, const AlfvenWave& rhs) noexcept {

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
@@ -195,6 +195,13 @@ class AlfvenWave {
     return {get<Tags>(variables(x, t, tmpl::list<Tags>{}))...};
   }
 
+  /// Retrieve the metric variables
+  template <typename DataType, typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x, double t,
+                                     tmpl::list<Tag> /*meta*/) const noexcept {
+    return background_spacetime_.variables(x, t, tmpl::list<Tag>{});
+  }
+
   // clang-tidy: no runtime references
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
   WaveNumber::type wavenumber() const noexcept { return wavenumber_; }

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
@@ -204,32 +204,14 @@ class AlfvenWave {
 
   // clang-tidy: no runtime references
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
-  WaveNumber::type wavenumber() const noexcept { return wavenumber_; }
-  Pressure::type pressure() const noexcept { return pressure_; }
-  RestMassDensity::type rest_mass_density() const noexcept {
-    return rest_mass_density_;
-  }
-  AdiabaticIndex::type adiabatic_index() const noexcept {
-    return adiabatic_index_;
-  }
-  BackgroundMagField::type background_mag_field() const noexcept {
-    return background_mag_field_;
-  }
-  PerturbationSize::type perturbation_size() const noexcept {
-    return perturbation_size_;
-  }
-  double alfven_speed() const noexcept { return alfven_speed_; }
-  double fluid_speed() const noexcept { return fluid_speed_; }
 
   const EquationsOfState::IdealFluid<true>& equation_of_state() const noexcept {
     return equation_of_state_;
   }
 
-  const gr::Solutions::Minkowski<3>& background_spacetime() const noexcept {
-    return background_spacetime_;
-  }
-
  private:
+  friend bool operator==(const AlfvenWave& lhs, const AlfvenWave& rhs) noexcept;
+
   // Computes the phase.
   template <typename DataType>
   DataType k_dot_x_minus_vt(const tnsr::I<DataType, 3>& x, double t) const
@@ -249,8 +231,6 @@ class AlfvenWave {
   EquationsOfState::IdealFluid<true> equation_of_state_{};
   gr::Solutions::Minkowski<3> background_spacetime_{};
 };
-
-bool operator==(const AlfvenWave& lhs, const AlfvenWave& rhs) noexcept;
 
 bool operator!=(const AlfvenWave& lhs, const AlfvenWave& rhs) noexcept;
 

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/CMakeLists.txt
@@ -14,5 +14,6 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE DataStructures
   INTERFACE ErrorHandling
+  INTERFACE GeneralRelativitySolutions
   INTERFACE Hydro
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.cpp
@@ -154,13 +154,13 @@ SmoothFlow::variables(
 bool operator==(const SmoothFlow& lhs, const SmoothFlow& rhs) noexcept {
   // there is no comparison operator for the EoS, but should be okay as
   // the adiabatic_indexs are compared
-  return lhs.mean_velocity() == rhs.mean_velocity() and
-         lhs.wavevector() == rhs.wavevector() and
-         lhs.pressure() == rhs.pressure() and
-         lhs.adiabatic_index() == rhs.adiabatic_index() and
-         lhs.perturbation_size() == rhs.perturbation_size() and
-         lhs.k_dot_v() == rhs.k_dot_v() and
-         lhs.background_spacetime() == rhs.background_spacetime();
+  return lhs.mean_velocity_ == rhs.mean_velocity_ and
+         lhs.wavevector_ == rhs.wavevector_ and
+         lhs.pressure_ == rhs.pressure_ and
+         lhs.adiabatic_index_ == rhs.adiabatic_index_ and
+         lhs.perturbation_size_ == rhs.perturbation_size_ and
+         lhs.k_dot_v_ == rhs.k_dot_v_ and
+         lhs.background_spacetime_ == rhs.background_spacetime_;
 }
 
 bool operator!=(const SmoothFlow& lhs, const SmoothFlow& rhs) noexcept {

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
@@ -163,6 +163,13 @@ class SmoothFlow {
     return {get<Tags>(variables(x, t, tmpl::list<Tags>{}))...};
   }
 
+  /// Retrieve the metric variables
+  template <typename DataType, typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x, double t,
+                                     tmpl::list<Tag> /*meta*/) const noexcept {
+    return background_spacetime_.variables(x, t, tmpl::list<Tag>{});
+  }
+
   // clang-tidy: no runtime references
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
   MeanVelocity::type mean_velocity() const noexcept { return mean_velocity_; }

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp
@@ -172,26 +172,14 @@ class SmoothFlow {
 
   // clang-tidy: no runtime references
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
-  MeanVelocity::type mean_velocity() const noexcept { return mean_velocity_; }
-  WaveVector::type wavevector() const noexcept { return wavevector_; }
-  Pressure::type pressure() const noexcept { return pressure_; }
-  AdiabaticIndex::type adiabatic_index() const noexcept {
-    return adiabatic_index_;
-  }
-  PerturbationSize::type perturbation_size() const noexcept {
-    return perturbation_size_;
-  }
-  double k_dot_v() const noexcept { return k_dot_v_; }
 
   const EquationsOfState::IdealFluid<true>& equation_of_state() const noexcept {
     return equation_of_state_;
   }
 
-  const gr::Solutions::Minkowski<3>& background_spacetime() const noexcept {
-    return background_spacetime_;
-  }
-
  private:
+  friend bool operator==(const SmoothFlow& lhs, const SmoothFlow& rhs) noexcept;
+
   // Computes the phase.
   template <typename DataType>
   DataType k_dot_x_minus_vt(const tnsr::I<DataType, 3>& x, double t) const
@@ -211,7 +199,6 @@ class SmoothFlow {
   gr::Solutions::Minkowski<3> background_spacetime_{};
 };
 
-bool operator==(const SmoothFlow& lhs, const SmoothFlow& rhs) noexcept;
 bool operator!=(const SmoothFlow& lhs, const SmoothFlow& rhs) noexcept;
 }  // namespace Solutions
 }  // namespace grmhd

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
@@ -13,5 +13,6 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE DataStructures
   INTERFACE ErrorHandling
+  INTERFACE GeneralRelativitySolutions
   INTERFACE Hydro
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -336,12 +336,12 @@ void FishboneMoncriefDisk::variables_impl(
 
 bool operator==(const FishboneMoncriefDisk& lhs,
                 const FishboneMoncriefDisk& rhs) noexcept {
-  return lhs.black_hole_mass() == rhs.black_hole_mass() and
-         lhs.black_hole_spin() == rhs.black_hole_spin() and
-         lhs.inner_edge_radius() == rhs.inner_edge_radius() and
-         lhs.max_pressure_radius() == rhs.max_pressure_radius() and
-         lhs.polytropic_constant() == rhs.polytropic_constant() and
-         lhs.polytropic_exponent() == rhs.polytropic_exponent();
+  return lhs.black_hole_mass_ == rhs.black_hole_mass_ and
+         lhs.black_hole_spin_ == rhs.black_hole_spin_ and
+         lhs.inner_edge_radius_ == rhs.inner_edge_radius_ and
+         lhs.max_pressure_radius_ == rhs.max_pressure_radius_ and
+         lhs.polytropic_constant_ == rhs.polytropic_constant_ and
+         lhs.polytropic_exponent_ == rhs.polytropic_exponent_;
 }
 
 bool operator!=(const FishboneMoncriefDisk& lhs,

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -5,7 +5,6 @@
 
 #include <limits>
 
-#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
@@ -14,6 +13,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/MakeArray.hpp"  // IWYU pragma: keep
+#include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
@@ -282,20 +282,9 @@ class FishboneMoncriefDisk {
   // clang-tidy: no runtime references
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
 
-  double black_hole_mass() const noexcept { return black_hole_mass_; }
-  double black_hole_spin() const noexcept { return black_hole_spin_; }
-  double inner_edge_radius() const noexcept { return inner_edge_radius_; }
-  double max_pressure_radius() const noexcept { return max_pressure_radius_; }
-  double polytropic_constant() const noexcept { return polytropic_constant_; }
-  double polytropic_exponent() const noexcept { return polytropic_exponent_; }
-
   const EquationsOfState::PolytropicFluid<true>& equation_of_state() const
       noexcept {
     return equation_of_state_;
-  }
-
-  const gr::Solutions::KerrSchild& background_spacetime() const noexcept {
-    return background_spacetime_;
   }
 
  private:
@@ -400,6 +389,9 @@ class FishboneMoncriefDisk {
     tnsr::ii<DataType, 3, Frame::Inertial> spatial_metric{};
   };
 
+  friend bool operator==(const FishboneMoncriefDisk& lhs,
+                         const FishboneMoncriefDisk& rhs) noexcept;
+
   double black_hole_mass_ = std::numeric_limits<double>::signaling_NaN();
   double black_hole_spin_ = std::numeric_limits<double>::signaling_NaN();
   double inner_edge_radius_ = std::numeric_limits<double>::signaling_NaN();
@@ -410,8 +402,6 @@ class FishboneMoncriefDisk {
   gr::Solutions::KerrSchild background_spacetime_{};
 };
 
-bool operator==(const FishboneMoncriefDisk& lhs,
-                const FishboneMoncriefDisk& rhs) noexcept;
 bool operator!=(const FishboneMoncriefDisk& lhs,
                 const FishboneMoncriefDisk& rhs) noexcept;
 }  // namespace Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -163,6 +163,8 @@ class FishboneMoncriefDisk {
   struct IntermediateVariables;
 
  public:
+  using equation_of_state_type = EquationsOfState::PolytropicFluid<true>;
+
   /// The mass of the black hole.
   struct BlackHoleMass {
     using type = double;

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -21,7 +21,10 @@
 #include "Time/TimeId.hpp"
 #include "Utilities/TMPL.hpp"
 
+/// \cond
+// NOLINTNEXTLINE(misc-forward-declaration-namespace)
 class TimeStepper;
+/// \endcond
 
 namespace Tags {
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -104,9 +104,10 @@ struct SystemAnalyticSolution {
   void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
 };
 
-template <size_t Dim, bool IsConservative>
+template <size_t Dim, bool IsInFluxConservativeForm>
 struct System {
-  static constexpr bool is_conservative = IsConservative;
+  static constexpr bool is_in_flux_conservative_form = IsInFluxConservativeForm;
+  static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = Dim;
   using variables_tag = Tags::Variables<tmpl::list<Var>>;
   using gradients_tags = tmpl::list<Var>;
@@ -351,7 +352,7 @@ void test_initialize_element(
   test_interface_tags<Tags::BoundaryDirectionsExterior<dim>, system,
                       databox_t>();
 
-  TestConservativeOrNonconservativeParts<system::is_conservative>::
+  TestConservativeOrNonconservativeParts<system::is_in_flux_conservative_form>::
       template apply<Metavariables>(make_not_null(&box));
 }
 

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -122,7 +122,8 @@ struct BoundaryConditionTag {
 
 struct System {
   static constexpr const size_t volume_dim = Dim;
-  static constexpr bool is_conservative = true;
+  static constexpr bool is_in_flux_conservative_form = true;
+  static constexpr bool has_primitive_and_conservative_vars = false;
 
   using variables_tag = Tags::Variables<tmpl::list<Var>>;
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
@@ -4,6 +4,7 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <limits>
 #include <tuple>
 
@@ -11,7 +12,9 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
@@ -119,6 +122,33 @@ void test_variables(const DataType& used_for_size) {
       std::make_tuple(wavenumber, pressure, rest_mass_density, adiabatic_index,
                       background_mag_field, perturbation_size),
       used_for_size);
+
+  // Test a few of the GR components to make sure that the implementation
+  // correctly forwards to the background solution. Not meant to be extensive.
+  grmhd::Solutions::AlfvenWave soln(wavenumber, pressure, rest_mass_density,
+                                    adiabatic_index, background_mag_field,
+                                    perturbation_size);
+  const auto coords = make_with_value<tnsr::I<DataType, 3>>(used_for_size, 1.0);
+  CHECK_ITERABLE_APPROX(
+      make_with_value<Scalar<DataType>>(used_for_size, 1.0),
+      get<gr::Tags::Lapse<DataType>>(soln.variables(
+          coords, 0.0, tmpl::list<gr::Tags::Lapse<DataType>>{})));
+  CHECK_ITERABLE_APPROX(
+      make_with_value<Scalar<DataType>>(used_for_size, 1.0),
+      get<gr::Tags::SqrtDetSpatialMetric<DataType>>(soln.variables(
+          coords, 0.0,
+          tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>>{})));
+  auto expected_spatial_metric =
+      make_with_value<tnsr::ii<DataType, 3, Frame::Inertial>>(used_for_size,
+                                                              0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    expected_spatial_metric.get(i, i) = 1.0;
+  }
+  const auto spatial_metric =
+      get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>(soln.variables(
+          coords, 0.0,
+          tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>{}));
+  CHECK_ITERABLE_APPROX(expected_spatial_metric, spatial_metric);
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_AlfvenWave.cpp
@@ -66,12 +66,7 @@ void test_create_from_options() noexcept {
       "  AdiabaticIndex: 1.4\n"
       "  BackgroundMagField: 2.0\n"
       "  PerturbationSize: 0.75");
-  CHECK(wave.wavenumber() == 2.2);
-  CHECK(wave.pressure() == 1.23);
-  CHECK(wave.rest_mass_density() == 0.2);
-  CHECK(wave.adiabatic_index() == 1.4);
-  CHECK(wave.background_mag_field() == 2.0);
-  CHECK(wave.perturbation_size() == 0.75);
+  CHECK(wave == grmhd::Solutions::AlfvenWave(2.2, 1.23, 0.2, 1.4, 2.0, 0.75));
 }
 
 void test_move() noexcept {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
@@ -66,11 +66,9 @@ void test_create_from_options() noexcept {
       "  Pressure: 1.23\n"
       "  AdiabaticIndex: 1.4\n"
       "  PerturbationSize: 0.75");
-  CHECK(flow.mean_velocity() == std::array<double, 3>{{0.1, -0.2, 0.3}});
-  CHECK(flow.wavevector() == std::array<double, 3>{{-0.13, -0.54, 0.04}});
-  CHECK(flow.pressure() == 1.23);
-  CHECK(flow.adiabatic_index() == 1.4);
-  CHECK(flow.perturbation_size() == 0.75);
+  CHECK(flow == grmhd::Solutions::SmoothFlow({{0.1, -0.2, 0.3}},
+                                             {{-0.13, -0.54, 0.04}}, 1.23, 1.4,
+                                             0.75));
 }
 
 void test_move() noexcept {

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_SmoothFlow.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <limits>
 #include <tuple>
 
@@ -12,7 +13,9 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/SmoothFlow.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
@@ -120,6 +123,32 @@ void test_variables(const DataType& used_for_size) {
       std::make_tuple(mean_velocity, wave_vector, pressure, adiabatic_index,
                       perturbation_size),
       used_for_size);
+
+  // Test a few of the GR components to make sure that the implementation
+  // correctly forwards to the background solution. Not meant to be extensive.
+  grmhd::Solutions::SmoothFlow soln(mean_velocity, wave_vector, pressure,
+                                    adiabatic_index, perturbation_size);
+  const auto coords = make_with_value<tnsr::I<DataType, 3>>(used_for_size, 1.0);
+  CHECK_ITERABLE_APPROX(
+      make_with_value<Scalar<DataType>>(used_for_size, 1.0),
+      get<gr::Tags::Lapse<DataType>>(soln.variables(
+          coords, 0.0, tmpl::list<gr::Tags::Lapse<DataType>>{})));
+  CHECK_ITERABLE_APPROX(
+      make_with_value<Scalar<DataType>>(used_for_size, 1.0),
+      get<gr::Tags::SqrtDetSpatialMetric<DataType>>(soln.variables(
+          coords, 0.0,
+          tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>>{})));
+  auto expected_spatial_metric =
+      make_with_value<tnsr::ii<DataType, 3, Frame::Inertial>>(used_for_size,
+                                                              0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    expected_spatial_metric.get(i, i) = 1.0;
+  }
+  const auto spatial_metric =
+      get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>(soln.variables(
+          coords, 0.0,
+          tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>{}));
+  CHECK_ITERABLE_APPROX(expected_spatial_metric, spatial_metric);
 }
 }  // namespace
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <tuple>
 
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"


### PR DESCRIPTION
## Proposed changes

Changes required for being able to:
- Evolve GRMHD without periodic boundary conditions
- Easily switch between different analytic solutions in GRMHD executable

Commit order:
1. Fix clang-tidy and cond in Time/Tags.hpp
2. Enable pure base tags for argument tags in db::mutate_apply
3. Remove noexcept that caused segfault on GCC
4. Add separate flags for flux conservative and prim systems
5. Add Dirichlet BC infra to select method depending on system
6. Clean up scoping in ImposeDirichletBoundaryConditions
7. Factor common code in ImposeDirichletBoundaryConditions
8. Add inv g, sqrt(det(g)), and ext curvature to Kerr-Schild
9. Allow retrieving GR variables from relativistic hydro solns
10. Add Dirichlet BCs for prim+cons systems
11. Add boundary initialization to Intialization/DG.hpp
12. Add dirichlet analytic boundary condition to GRMHD
13. Remove member accessors from hydro solutions
14. Expose EoS type in FishboneMoncrief
15. Retrieve EoS using base class in GRMHD::PrimFromCons
16. Link GR solutions from GRMHD and rel euler solutions
17. Link Rel Euler solutions in GRMHD Valencia exec
18. Allow easy switching of analytic soln in GRMHD exec

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
