### PR TITLE
Add InterpolatorReceivePoints.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
@@ -1,0 +1,104 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+// IWYU pragma: no_forward_declare db::DataBox
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+namespace domain {
+class BlockId;
+}  // namespace domain
+template <typename IdType, typename DataType>
+class IdPair;
+namespace intrp {
+namespace Tags {
+struct NumberOfElements;
+template <typename Metavariables, size_t VolumeDim>
+struct InterpolatedVarsHolders;
+}  // namespace Tags
+}  // namespace intrp
+/// \endcond
+
+namespace intrp {
+namespace Actions {
+
+/// \ingroup ActionsGroup
+/// \brief Receives target points from an InterpolationTarget.
+///
+/// After receiving the points, interpolates volume data onto them
+/// if it already has all the volume data.
+///
+/// Uses:
+/// - Databox:
+///   - `Tags::NumberOfElements`
+///   - `Tags::InterpolatedVarsHolders<Metavariables,VolumeDim>`
+///   - `Tags::VolumeVarsInfo<Metavariables,VolumeDim>`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `Tags::InterpolatedVarsHolders<Metavariables,VolumeDim>`
+///
+/// For requirements on InterpolationTargetTag, see InterpolationTarget
+template <typename InterpolationTargetTag, typename Frame>
+struct ReceivePoints {
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, size_t VolumeDim,
+            Requires<tmpl::list_contains_v<
+                DbTags, typename ::intrp::Tags::NumberOfElements>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const typename Metavariables::temporal_id& temporal_id,
+      std::vector<IdPair<domain::BlockId, tnsr::I<double, VolumeDim,
+                                                  typename ::Frame::Logical>>>&&
+          block_logical_coords) noexcept {
+    db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>(
+        make_not_null(&box),
+        [
+          &temporal_id, &block_logical_coords
+        ](const gsl::not_null<db::item_type<
+              intrp::Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>*>
+              vars_holders) noexcept {
+          auto& vars_infos =
+              get<intrp::Vars::HolderTag<InterpolationTargetTag, Metavariables,
+                                         VolumeDim>>(*vars_holders)
+                  .infos;
+
+          // Add the target interpolation points at this temporal_id.
+          vars_infos.emplace(std::make_pair(
+              temporal_id,
+              intrp::Vars::Info<VolumeDim, typename InterpolationTargetTag::
+                                               vars_to_interpolate_to_target>{
+                  std::move(block_logical_coords)}));
+        });
+
+    try_to_interpolate<InterpolationTargetTag, VolumeDim, Frame>(
+        make_not_null(&box), make_not_null(&cache), temporal_id);
+  }
+};
+
+}  // namespace Actions
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_InitializeInterpolator.cpp
   Test_InterpolationTargetLineSegment.cpp
   Test_InterpolationTargetReceiveVars.cpp
+  Test_InterpolatorReceivePoints.cpp
   Test_InterpolatorReceiveVolumeData.cpp
   Test_InterpolatorRegisterElement.cpp
   Test_IrregularInterpolant.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -1,0 +1,230 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/IdPair.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockId.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/Shell.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/Rational.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+/// \cond
+namespace intrp {
+namespace Actions {
+template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+struct InterpolationTargetReceiveVars;
+}  // namespace Actions
+}  // namespace intrp
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace intrp {
+namespace Tags {
+template <typename Metavariables, size_t VolumeDim>
+struct InterpolatedVarsHolders;
+template <typename Metavariables>
+struct TemporalIds;
+}  // namespace Tags
+}  // namespace intrp
+namespace Tags {
+template <typename TagsList>
+struct Variables;
+}  // namespace Tags
+/// \endcond
+
+namespace {
+
+size_t num_calls_of_target_receive_vars = 0;
+template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+struct MockInterpolationTargetReceiveVars {
+  template <
+      typename DbTags, typename... InboxTags, typename Metavariables,
+      typename ArrayIndex, typename ActionList, typename ParallelComponent,
+      Requires<tmpl::list_contains_v<
+          DbTags, typename intrp::Tags::TemporalIds<Metavariables>>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const std::vector<db::item_type<::Tags::Variables<
+          typename InterpolationTargetTag::vars_to_interpolate_to_target>>>&
+      /*vars_src*/,
+      const std::vector<std::vector<size_t>>& /*global_offsets*/) noexcept {
+    // InterpolationTargetReceiveVars will not be called in this test,
+    // because we are not supplying volume data (so try_to_interpolate
+    // inside TryToInterpolate.hpp will not actually interpolate). However, the
+    // compiler thinks that InterpolationTargetReceiveVars might be called, so
+    // we mock it so that everything compiles.
+    //
+    // Note that try_to_interpolate and InterpolationTargetReceiveVars have
+    // already been tested by other tests.
+
+    // Here we increment a variable so that later we can
+    // verify that this wasn't called.
+    ++num_calls_of_target_receive_vars;
+  }
+};
+
+template <typename Metavariables, typename InterpolationTargetTag>
+struct mock_interpolation_target {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using component_being_mocked =
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3,
+                                 Frame::Inertial>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<
+      typename intrp::Actions::InitializeInterpolationTarget<
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
+                                                            ::Frame::Inertial>>;
+  using replace_these_simple_actions =
+      tmpl::list<intrp::Actions::InterpolationTargetReceiveVars<
+          typename Metavariables::InterpolationTargetA, 3, ::Frame::Inertial>>;
+  using with_these_simple_actions =
+      tmpl::list<MockInterpolationTargetReceiveVars<
+          typename Metavariables::InterpolationTargetA, 3, ::Frame::Inertial>>;
+};
+
+template <typename Metavariables, size_t VolumeDim>
+struct mock_interpolator {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using initial_databox =
+      db::compute_databox_type<typename intrp::Actions::InitializeInterpolator<
+          VolumeDim>::template return_tag_list<Metavariables>>;
+  using component_being_mocked = void;  // not needed.
+};
+
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_items_on_source = tmpl::list<>;
+  };
+  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+  using temporal_id = Time;
+  using component_list = tmpl::list<
+      mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
+      mock_interpolator<MockMetavariables, 3>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialize, Exit };
+};
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
+                  "[Unit]") {
+  using metavars = MockMetavariables;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  using TupleOfMockDistributedObjects =
+      MockRuntimeSystem::TupleOfMockDistributedObjects;
+  TupleOfMockDistributedObjects dist_objects{};
+  using MockDistributedObjectsTagInterpolator =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolator<metavars, 3>>;
+  tuples::get<MockDistributedObjectsTagInterpolator>(dist_objects)
+      .emplace(0, ActionTesting::MockDistributedObject<
+                      mock_interpolator<metavars, 3>>{});
+  MockRuntimeSystem runner{{}, std::move(dist_objects)};
+
+  runner.simple_action<mock_interpolator<metavars, 3>,
+                       ::intrp::Actions::InitializeInterpolator<3>>(0);
+
+  // Make sure that we have one Element registered,
+  // or else ReceivePoints will (correctly) do nothing because it
+  // thinks it will never have any Elements to interpolate onto.
+  runner.simple_action<mock_interpolator<metavars, 3>,
+                       ::intrp::Actions::RegisterElement>(0);
+
+  const auto& box =
+      runner.template algorithms<mock_interpolator<metavars, 3>>()
+          .at(0)
+          .template get_databox<
+              typename mock_interpolator<metavars, 3>::initial_databox>();
+
+  const auto domain_creator =
+      DomainCreators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{7, 7}}, false);
+  const auto domain = domain_creator.create_domain();
+  const auto block_logical_coords = [&domain]() noexcept {
+    const size_t n_pts = 15;
+    tnsr::I<DataVector, 3, Frame::Inertial> points(n_pts);
+    for (size_t d = 0; d < 3; ++d) {
+      for (size_t i = 0; i < n_pts; ++i) {
+        points.get(d)[i] = 1.0 + (0.1 + 0.02 * d) * i;  // Chosen by hand.
+      }
+    }
+    return block_logical_coordinates(domain, points);
+  }
+  ();
+  Slab slab(0.0, 1.0);
+  Time temporal_id(slab, Rational(11, 15));
+
+  runner.simple_action<mock_interpolator<metavars, 3>,
+                       intrp::Actions::ReceivePoints<
+                           metavars::InterpolationTargetA, Frame::Inertial>>(
+      0, temporal_id, block_logical_coords);
+
+  const auto& holders =
+      db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box);
+  const auto& holder =
+      get<intrp::Vars::HolderTag<metavars::InterpolationTargetA, metavars, 3>>(
+          holders);
+
+  // Should now be a single info in holder, indexed by temporal_id.
+  CHECK(holder.infos.size() == 1);
+  const auto& vars_info = holder.infos.at(temporal_id);
+
+  // We haven't done any interpolation because we never received
+  // volume data from any Elements, so these fields should be empty.
+  CHECK(holder.temporal_ids_when_data_has_been_interpolated.empty());
+  CHECK(vars_info.interpolation_is_done_for_these_elements.empty());
+  CHECK(vars_info.global_offsets.empty());
+  CHECK(vars_info.vars.empty());
+
+  // But block_coord_holders should be filled.
+  CHECK(vars_info.block_coord_holders == block_logical_coords);
+
+  // There should be no more queued actions; verify this.
+  CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars, 3>>(0));
+
+  // Make sure that the action was not called.
+  CHECK(num_calls_of_target_receive_vars == 0);
+}
+}  // namespace


### PR DESCRIPTION
This is another PR towards parallel interpolation.

Adds an Action via which an Interpolator receives its target points from an InterpolationTarget.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
