### PR TITLE
Control observation frequency

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
@@ -34,6 +34,17 @@ namespace Actions {
  *   Look for `time_by_timestep_value` to update.
  */
 struct Observe {
+  struct ObserveNSlabs {
+    using type = size_t;
+    static constexpr OptionString help = {"Observe every Nth slab"};
+  };
+  struct ObserveAtT0 {
+    using type = bool;
+    static constexpr OptionString help = {"If true observe at t=0"};
+  };
+
+  using const_global_cache_tags = tmpl::list<ObserveNSlabs, ObserveAtT0>;
+
   template <typename... DbTags, typename... InboxTags, typename Metavariables,
             size_t Dim, typename ActionList, typename ParallelComponent>
   static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
@@ -42,16 +53,21 @@ struct Observe {
                     const ElementIndex<Dim>& array_index,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    const auto& time = db::get<::Tags::Time>(box);
-    // Note: this currently assumes a constant time step that is a power of ten.
-    const size_t time_by_timestep_value = static_cast<size_t>(
-        std::round(time.value() / db::get<::Tags::TimeStep>(box).value()));
+    const auto& time_id = db::get<::Tags::TimeId>(box);
+    if (time_id.substep() != 0 or (time_id.slab_number() == 0 and
+                                   not Parallel::get<ObserveAtT0>(cache))) {
+      return std::forward_as_tuple(std::move(box));
+    }
 
+    const auto& time = time_id.time();
     const std::string element_name = MakeString{} << ElementId<Dim>(array_index)
                                                   << '/';
     // We hard-code the writing frequency to large time values to avoid breaking
     // the tests.
-    if (time_by_timestep_value % 1000 == 0 and time_by_timestep_value > 0) {
+    if (time_id.slab_number() >= 0 and time_id.time().is_at_slab_start() and
+        static_cast<size_t>(time_id.slab_number()) %
+                Parallel::get<ObserveNSlabs>(cache) ==
+            0) {
       const auto& extents = db::get<::Tags::Mesh<Dim>>(box).extents();
       // Retrieve the tensors and compute the solution error.
       const auto& tilde_d = db::get<Tags::TildeD>(box);

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -48,3 +48,7 @@ DampingParameter: 0.0
 
 SlopeLimiterParams:
   Type: LambdaPi1
+
+
+ObserveNSlabs: 1000
+ObserveAtT0: false

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -42,3 +42,6 @@ StepChoosers:
 NumericalFluxParams:
 
 VolumeFileName: "./ScalarWave1DPeriodic"
+
+ObserveNSlabs: 10000000
+ObserveAtT0: false

--- a/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
@@ -42,3 +42,6 @@ StepChoosers:
 NumericalFluxParams:
 
 VolumeFileName: "./ScalarWave2DPeriodic"
+
+ObserveNSlabs: 10000000
+ObserveAtT0: false

--- a/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
@@ -42,3 +42,6 @@ StepChoosers:
 NumericalFluxParams:
 
 VolumeFileName: "./ScalarWave3DPeriodic"
+
+ObserveNSlabs: 10
+ObserveAtT0: false


### PR DESCRIPTION
## Proposed changes

Previously we hard-coded the observation frequency, which meant recompiling when changing it. This is not ideal for quick debugging. This adds the core components necessary to control observation from an input file and can be extended for more control if necessary.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
