### PR TITLE
Build python bindings only if requested

### DIFF
--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -31,6 +31,7 @@ cmake -D CMAKE_BUILD_TYPE=${BUILD_TYPE} \
       -D USE_PCH=${USE_PCH} \
       -D DEBUG_SYMBOLS=OFF \
       -D COVERAGE=${COVERAGE} \
+      -D BUILD_PYTHON_BINDINGS=ON \
       ../spectre/
 
 # Build all Charm++ modules

--- a/cmake/SetupBoost.cmake
+++ b/cmake/SetupBoost.cmake
@@ -1,6 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+option(
+  BUILD_PYTHON_BINDINGS
+  "Build the python bindings for SpECTRE"
+  OFF
+  )
+
 if("" STREQUAL "${PYTHONLIBS_VERSION_STRING}")
   message(FATAL_ERROR
     "Must find python libraries before finding the Boost libraries because "
@@ -16,12 +22,14 @@ list(GET SPECTRE_PYTHON_VERS_LIST 2 PYTHON_LIBS_PATCH_VERSION)
 # Do first find to get version.
 find_package(Boost 1.60.0 REQUIRED)
 
-set(SPECTRE_BOOST_PYTHON_COMPONENT "python")
+if(BUILD_PYTHON_BINDINGS)
+  set(SPECTRE_BOOST_PYTHON_COMPONENT "python")
 
-if ("${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}"
-    VERSION_GREATER 1.66.0)
-  set(SPECTRE_BOOST_PYTHON_COMPONENT
-    "python${PYTHON_LIBS_MAJOR_VERSION}${PYTHON_LIBS_MINOR_VERSION}")
+  if ("${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}"
+      VERSION_GREATER 1.66.0)
+    set(SPECTRE_BOOST_PYTHON_COMPONENT
+      "python${PYTHON_LIBS_MAJOR_VERSION}${PYTHON_LIBS_MINOR_VERSION}")
+  endif()
 endif()
 
 find_package(

--- a/cmake/SpectreSetupPython.cmake
+++ b/cmake/SpectreSetupPython.cmake
@@ -207,6 +207,9 @@ endfunction()
 # - TAGS         A semicolon separated list of labels for the test,
 #                e.g. "unit;DataStructures;python"
 function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS)
+  if(NOT BUILD_PYTHON_BINDINGS)
+    return()
+  endif()
   get_filename_component(FILE "${FILE}" ABSOLUTE)
   string(TOLOWER "${TAGS}" TAGS)
 

--- a/docs/DevGuide/PythonBindings.md
+++ b/docs/DevGuide/PythonBindings.md
@@ -15,7 +15,8 @@ to aid with generating the bindings. The C++ code for the bindings should
 generally go in a `Python` subdirectory. For example, the bindings for the
 DataStructures library would go in `src/DataStructures/Python/`. SpECTRE
 provides the `spectre_python_add_module` CMake function to make adding a new
-python module, be it with or without bindings, easy.
+python module, be it with or without bindings, easy.  The python bindings are
+built only if `-D BUILD_PYTHON_BINDINGS=ON` is passed when invoking cmake.
 
 The function `spectre_python_add_module` takes as its first argument the module,
 in our case

--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -22,4 +22,6 @@ target_link_libraries(
   INTERFACE ErrorHandling
   )
 
-add_subdirectory(Python)
+if(BUILD_PYTHON_BINDINGS)
+  add_subdirectory(Python)
+endif()


### PR DESCRIPTION
## Proposed changes

Do not build python bindings, unless requested by specifying `-D BUILD_PYTHON_BINDINGS` when invoking cmake

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
