### PR TITLE
Add cylindrical blast wave analytic data

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY GrMhdAnalyticData)
 
 set(LIBRARY_SOURCES
   BondiHoyleAccretion.cpp
+  CylindricalBlastWave.cpp
   )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.cpp
@@ -1,0 +1,232 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.hpp"
+
+#include <cmath>
+#include <ostream>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/ConstantExpressions.hpp"  // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp" // IWYU pragma: keep
+
+namespace {
+template <typename DataType>
+Scalar<DataType> compute_piecewise(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double& inner_radius,
+    const double& outer_radius, const double& inner_value,
+    const double& outer_value) noexcept {
+  const DataType cylindrical_radius =
+      sqrt(square(get<0>(x)) + square(get<1>(x)));
+  auto piecewise_scalar = make_with_value<Scalar<DataType>>(x, 0.0);
+
+  // piecewise_scalar should equal inner_value for r < inner_radius,
+  // should equal outer_value for r > outer_radius, and should transition
+  // in between. Here, use step_function() to compute the result
+  // in each region separately.
+  get(piecewise_scalar) +=
+      step_function(inner_radius - cylindrical_radius) * inner_value;
+  get(piecewise_scalar) +=
+      step_function(cylindrical_radius - outer_radius) * outer_value;
+  get(piecewise_scalar) +=
+      // Blaze's step_function() at 0.0 is 1.0. So to get a mask that
+      // is the inverse of the masks used above for inner_radius and
+      // outer_radius without double-counting points on the boundary,
+      // use 1.0 - stepfunction(x) instead of stepfunction(-x) here
+      (1.0 - step_function(inner_radius - cylindrical_radius)) *
+      (1.0 - step_function(cylindrical_radius - outer_radius)) *
+      exp(((-1.0 * cylindrical_radius + inner_radius) * log(outer_value) +
+           (cylindrical_radius - outer_radius) * log(inner_value)) /
+          (inner_radius - outer_radius));
+  return piecewise_scalar;
+}
+}  // namespace
+
+/// \cond
+namespace grmhd {
+namespace AnalyticData {
+
+CylindricalBlastWave::CylindricalBlastWave(
+    const InnerRadius::type inner_radius, const OuterRadius::type outer_radius,
+    const InnerDensity::type inner_density,
+    const OuterDensity::type outer_density,
+    const InnerPressure::type inner_pressure,
+    const OuterPressure::type outer_pressure,
+    const MagneticField::type magnetic_field,
+    const AdiabaticIndex::type adiabatic_index, const OptionContext& context)
+    : inner_radius_(inner_radius),
+      outer_radius_(outer_radius),
+      inner_density_(inner_density),
+      outer_density_(outer_density),
+      inner_pressure_(inner_pressure),
+      outer_pressure_(outer_pressure),
+      magnetic_field_(magnetic_field),
+      adiabatic_index_(adiabatic_index),
+      equation_of_state_(adiabatic_index) {
+  if (inner_radius >= outer_radius) {
+    PARSE_ERROR(context,
+                "CylindricalBlastWave expects InnerRadius < OuterRadius, "
+                "but InnerRadius = "
+                    << inner_radius << " and OuterRadius = " << outer_radius);
+  }
+}
+
+void CylindricalBlastWave::pup(PUP::er& p) noexcept {
+  p | inner_radius_;
+  p | outer_radius_;
+  p | inner_density_;
+  p | outer_density_;
+  p | inner_pressure_;
+  p | outer_pressure_;
+  p | magnetic_field_;
+  p | adiabatic_index_;
+  p | equation_of_state_;
+  p | background_spacetime_;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
+CylindricalBlastWave::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
+    noexcept {
+  return compute_piecewise(x, inner_radius_, outer_radius_, inner_density_,
+                           outer_density_);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
+CylindricalBlastWave::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/) const
+    noexcept {
+  return {make_with_value<db::item_type<
+      hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>>(x, 0.0)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
+CylindricalBlastWave::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
+    noexcept {
+  return equation_of_state_.specific_internal_energy_from_density_and_pressure(
+      get<hydro::Tags::RestMassDensity<DataType>>(
+          variables(x, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{})),
+      get<hydro::Tags::Pressure<DataType>>(
+          variables(x, tmpl::list<hydro::Tags::Pressure<DataType>>{})));
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>
+CylindricalBlastWave::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const noexcept {
+  return compute_piecewise(x, inner_radius_, outer_radius_, inner_pressure_,
+                           outer_pressure_);
+  ;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
+CylindricalBlastWave::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+    noexcept {
+  auto magnetic_field =
+      make_with_value<typename hydro::Tags::MagneticField<DataType, 3>::type>(
+          get<0>(x), 0.0);
+  get<0>(magnetic_field) = gsl::at(magnetic_field_, 0);
+  get<1>(magnetic_field) = gsl::at(magnetic_field_, 1);
+  get<2>(magnetic_field) = gsl::at(magnetic_field_, 2);
+  return magnetic_field;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>
+CylindricalBlastWave::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
+    noexcept {
+  return {make_with_value<
+      db::item_type<hydro::Tags::DivergenceCleaningField<DataType>>>(x, 0.0)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>
+CylindricalBlastWave::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept {
+  return {make_with_value<
+      db::item_type<hydro::Tags::LorentzFactor<DataType>>>(x, 1.0)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
+CylindricalBlastWave::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x,
+    tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
+    noexcept {
+  return equation_of_state_.specific_enthalpy_from_density_and_energy(
+      get<hydro::Tags::RestMassDensity<DataType>>(
+          variables(x, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{})),
+      get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables(
+          x, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{})));
+}
+
+bool operator==(const CylindricalBlastWave& lhs,
+                const CylindricalBlastWave& rhs) noexcept {
+  return lhs.inner_radius_ == rhs.inner_radius_ and
+         lhs.outer_radius_ == rhs.outer_radius_ and
+         lhs.inner_density_ == rhs.inner_density_ and
+         lhs.outer_density_ == rhs.outer_density_ and
+         lhs.inner_pressure_ == rhs.inner_pressure_ and
+         lhs.outer_pressure_ == rhs.outer_pressure_ and
+         lhs.magnetic_field_ == rhs.magnetic_field_ and
+         lhs.adiabatic_index_ == rhs.adiabatic_index_;
+}
+
+bool operator!=(const CylindricalBlastWave& lhs,
+                const CylindricalBlastWave& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define TAG(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_SCALARS(_, data)                         \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>     \
+      CylindricalBlastWave::variables(                       \
+          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x, \
+          tmpl::list<TAG(data) < DTYPE(data)>> /*meta*/) const noexcept;
+
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE_SCALARS, (double, DataVector),
+    (hydro::Tags::RestMassDensity, hydro::Tags::SpecificInternalEnergy,
+     hydro::Tags::Pressure, hydro::Tags::DivergenceCleaningField,
+     hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy))
+
+#define INSTANTIATE_VECTORS(_, data)                                         \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>>                  \
+      CylindricalBlastWave::variables(                                       \
+          const tnsr::I<DTYPE(data), 3, Frame::Inertial>& x,                 \
+          tmpl::list<TAG(data) < DTYPE(data), 3, Frame::Inertial>> /*meta*/) \
+          const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
+                        (hydro::Tags::SpatialVelocity,
+                         hydro::Tags::MagneticField))
+
+#undef DTYPE
+#undef TAG
+#undef INSTANTIATE_SCALARS
+#undef INSTANTIATE_VECTORS
+}  // namespace AnalyticData
+}  // namespace grmhd
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.hpp
@@ -1,0 +1,252 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <limits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/MakeArray.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+// IWYU pragma:  no_include <pup.h>
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+namespace grmhd {
+namespace AnalyticData {
+
+/*!
+ * \brief Analytic initial data for a cylindrical blast wave.
+ *
+ * This class implements analytic initial data for a cylindrical blast wave,
+ * as described, e.g., in https://arxiv.org/abs/1609.00098v2 Sec. 6.2.3.
+ * A uniform magnetic field threads an ideal fluid. The solution begins with
+ * material at fixed (typically high) density and pressure at rest inside a
+ * cylinder of radius \f$r < r_{\rm in}\f$ and material at fixed (typically low)
+ * density and pressure at rest in a cylindrical shell with radius
+ * \f$r > r_{\rm out}\f$. In the region \f$ r_{\rm in} < r < r_{\rm out}\f$,
+ * the solution transitions such that the logarithms of the density and
+ * pressure vary linearly. E.g., if \f$\rho(r < r_{\rm in}) = \rho_{\rm in}\f$
+ * and \f$\rho(r > r_{\rm out}) = \rho_{\rm out}\f$, then
+ * \f[
+ * \log \rho = [(r_{\rm in} - r) \log(\rho_{\rm out})
+ *              + (r - r_{\rm out}) \log(\rho_{\rm in})]
+ *              / (r_{\rm in} - r_{\rm out}).
+ * \f]
+ * Note that the cylinder's axis is the \f$z\f$ axis. To evolve this analytic
+ * initial data, use a cubic or cylindrical domain with periodic boundary
+ * conditions applied to the outer boundaries whose normals are parallel or
+ * antiparallel to the z axis. In the transverse (e.g., x and y) dimensions, the
+ * domain should be large enough that the blast wave doesn't reach the boundary
+ * at the final time. E.g., if `InnerRadius = 0.8`, `OuterRadius = 1.0`, and
+ * the final time is 4.0, a good domain extends from `(x,y)=(-6.0, -6.0)` to
+ * `(x,y)=(6.0, 6.0)`.
+ */
+class CylindricalBlastWave {
+ public:
+  using equation_of_state_type = EquationsOfState::IdealFluid<true>;
+  using background_spacetime_type = gr::Solutions::Minkowski<3>;
+
+  /// Inside InnerRadius, density is InnerDensity.
+  struct InnerRadius {
+    using type = double;
+    static constexpr OptionString help = {
+        "Inside InnerRadius, density is InnerDensity."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  /// Outside OuterRadius, density is OuterDensity.
+  struct OuterRadius {
+    using type = double;
+    static constexpr OptionString help = {
+        "Outside OuterRadius, density is OuterDensity."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  /// Density at radii less than InnerRadius.
+  struct InnerDensity {
+    using type = double;
+    static constexpr OptionString help = {
+        "Density at radii less than InnerRadius."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  /// Density at radii greater than OuterRadius.
+  struct OuterDensity {
+    using type = double;
+    static constexpr OptionString help = {
+        "Density at radii greater than OuterRadius."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  /// Pressure at radii less than InnerRadius.
+  struct InnerPressure {
+    using type = double;
+    static constexpr OptionString help = {
+        "Pressure at radii less than InnerRadius."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  /// Pressure at radii greater than OuterRadius.
+  struct OuterPressure {
+    using type = double;
+    static constexpr OptionString help = {
+        "Pressure at radii greater than OuterRadius."};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  /// The x,y,z components of the uniform magnetic field threading the matter.
+  struct MagneticField {
+    using type = std::array<double, 3>;
+    static constexpr OptionString help = {
+        "The x,y,z components of the uniform magnetic field."};
+  };
+  /// The adiabatic index of the ideal fluid.
+  struct AdiabaticIndex {
+    using type = double;
+    static constexpr OptionString help = {
+        "The adiabatic index of the ideal fluid."};
+    static type lower_bound() noexcept { return 1.0; }
+  };
+
+  using options =
+      tmpl::list<InnerRadius, OuterRadius, InnerDensity, OuterDensity,
+                 InnerPressure, OuterPressure, MagneticField, AdiabaticIndex>;
+
+  static constexpr OptionString help = {
+      "Cylindrical blast wave analytic initial data."};
+
+  CylindricalBlastWave() = default;
+  CylindricalBlastWave(const CylindricalBlastWave& /*rhs*/) = delete;
+  CylindricalBlastWave& operator=(const CylindricalBlastWave& /*rhs*/) = delete;
+  CylindricalBlastWave(CylindricalBlastWave&& /*rhs*/) noexcept = default;
+  CylindricalBlastWave& operator=(CylindricalBlastWave&& /*rhs*/) noexcept =
+      default;
+  ~CylindricalBlastWave() = default;
+
+  CylindricalBlastWave(
+      InnerRadius::type inner_radius, OuterRadius::type outer_radius,
+      InnerDensity::type inner_density, OuterDensity::type outer_density,
+      InnerPressure::type inner_pressure, OuterPressure::type outer_pressure,
+      MagneticField::type magnetic_field, AdiabaticIndex::type adiabatic_index,
+      const OptionContext& context = {});
+
+  explicit CylindricalBlastWave(CkMigrateMessage* /*unused*/) noexcept {}
+
+  // @{
+  /// Retrieve the GRMHD variables at a given position.
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::SpatialVelocity<
+                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<
+          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::MagneticField<
+                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<
+          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
+  // @}
+
+  /// Retrieve a collection of hydrodynamic variables at position x
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    static_assert(sizeof...(Tags) > 1,
+                  "The generic template will recurse infinitely if only one "
+                  "tag is being retrieved.");
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  /// Retrieve the metric variables
+  template <typename DataType, typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x,
+                                     tmpl::list<Tag> /*meta*/) const noexcept {
+    constexpr double dummy_time = 0.0;
+    return background_spacetime_.variables(x, dummy_time, tmpl::list<Tag>{});
+  }
+
+  const EquationsOfState::IdealFluid<true>& equation_of_state() const noexcept {
+    return equation_of_state_;
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
+
+ private:
+  InnerRadius::type inner_radius_ =
+      std::numeric_limits<double>::signaling_NaN();
+  OuterRadius::type outer_radius_ =
+      std::numeric_limits<double>::signaling_NaN();
+  InnerDensity::type inner_density_ =
+      std::numeric_limits<double>::signaling_NaN();
+  OuterDensity::type outer_density_ =
+      std::numeric_limits<double>::signaling_NaN();
+  InnerPressure::type inner_pressure_ =
+      std::numeric_limits<double>::signaling_NaN();
+  OuterPressure::type outer_pressure_ =
+      std::numeric_limits<double>::signaling_NaN();
+  MagneticField::type magnetic_field_ =
+      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN()}};
+  AdiabaticIndex::type adiabatic_index_ =
+      std::numeric_limits<double>::signaling_NaN();
+  EquationsOfState::IdealFluid<true> equation_of_state_{};
+  gr::Solutions::Minkowski<3> background_spacetime_{};
+
+  friend bool operator==(const CylindricalBlastWave& lhs,
+                         const CylindricalBlastWave& rhs) noexcept;
+
+  friend bool operator!=(const CylindricalBlastWave& lhs,
+                         const CylindricalBlastWave& rhs) noexcept;
+};
+
+}  // namespace AnalyticData
+}  // namespace grmhd

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_GrMhdAnalyticData")
 
 set(LIBRARY_SOURCES
   Test_BondiHoyleAccretion.cpp
+  Test_CylindricalBlastWave.cpp
   )
 
 add_test_library(

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/TestFunctions.py
@@ -102,3 +102,103 @@ def bondi_hoyle_specific_enthalpy(x, bh_mass, bh_dimless_spin,
 
 
 # End functions for testing BondiHoyleAccretion.cpp
+
+# Functions for testing CylindricalBlastWave.cpp
+def cylindrical_blast_wave_compute_piecewise(x, inner_radius, outer_radius,
+                                             inner_value, outer_value):
+    radius = np.sqrt(np.square(x[0]) + np.square(x[1]))
+    if (radius > outer_radius):
+        return outer_value
+    elif (radius < inner_radius):
+        return inner_value
+    else:
+        piecewise_scalar = (-1.0 * radius + inner_radius) * \
+            np.log(outer_value)
+        piecewise_scalar += (radius - outer_radius) * np.log(inner_value)
+        piecewise_scalar /= inner_radius - outer_radius
+        return np.exp(piecewise_scalar)
+
+
+def cylindrical_blast_wave_rest_mass_density(x, inner_radius, outer_radius,
+                                             inner_density, outer_density,
+                                             inner_pressure, outer_pressure,
+                                             magnetic_field, adiabatic_index):
+    return cylindrical_blast_wave_compute_piecewise(x, inner_radius, outer_radius,
+                                                    inner_density, outer_density)
+
+
+def cylindrical_blast_wave_spatial_velocity(x, inner_radius, outer_radius,
+                                            inner_density, outer_density,
+                                            inner_pressure, outer_pressure,
+                                            magnetic_field, adiabatic_index):
+    return np.zeros(3)
+
+
+def cylindrical_blast_wave_specific_internal_energy(x, inner_radius, outer_radius,
+                                                    inner_density, outer_density,
+                                                    inner_pressure,
+                                                    outer_pressure,
+                                                    magnetic_field,
+                                                    adiabatic_index):
+    return (1.0 / (adiabatic_index - 1.0) *
+            cylindrical_blast_wave_pressure(x, inner_radius, outer_radius,
+                                            inner_density, outer_density,
+                                            inner_pressure, outer_pressure,
+                                            magnetic_field, adiabatic_index) /
+            cylindrical_blast_wave_rest_mass_density(x, inner_radius,
+                                                     outer_radius,
+                                                     inner_density,
+                                                     outer_density,
+                                                     inner_pressure,
+                                                     outer_pressure,
+                                                     magnetic_field,
+                                                     adiabatic_index))
+
+
+def cylindrical_blast_wave_pressure(x, inner_radius, outer_radius, inner_density,
+                                    outer_density, inner_pressure, outer_pressure,
+                                    magnetic_field, adiabatic_index):
+    return cylindrical_blast_wave_compute_piecewise(x, inner_radius, outer_radius,
+                                                    inner_pressure,
+                                                    outer_pressure)
+
+
+def cylindrical_blast_wave_lorentz_factor(x, inner_radius, outer_radius,
+                                          inner_density, outer_density,
+                                          inner_pressure, outer_pressure,
+                                          magnetic_field, adiabatic_index):
+    return 1.0
+
+
+def cylindrical_blast_wave_specific_enthalpy(x, inner_radius, outer_radius,
+                                             inner_density, outer_density,
+                                             inner_pressure, outer_pressure,
+                                             magnetic_field, adiabatic_index):
+    return (1.0 + adiabatic_index *
+            cylindrical_blast_wave_specific_internal_energy(x, inner_radius,
+                                                            outer_radius,
+                                                            inner_density,
+                                                            outer_density,
+                                                            inner_pressure,
+                                                            outer_pressure,
+                                                            magnetic_field,
+                                                            adiabatic_index))
+
+
+def cylindrical_blast_wave_magnetic_field(x, inner_radius, outer_radius,
+                                          inner_density, outer_density,
+                                          inner_pressure, outer_pressure,
+                                          magnetic_field, adiabatic_index):
+    return np.array(magnetic_field)
+
+
+def cylindrical_blast_wave_divergence_cleaning_field(x, inner_radius,
+                                                     outer_radius, inner_density,
+                                                     outer_density,
+                                                     inner_pressure,
+                                                     outer_pressure,
+                                                     magnetic_field,
+                                                     adiabatic_index):
+    return 0.0
+
+# End for testing CylindricalBlastWave.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_CylindricalBlastWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_CylindricalBlastWave.cpp
@@ -1,0 +1,228 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"        // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp" // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/CylindricalBlastWave.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+struct CylindricalBlastWaveProxy : grmhd::AnalyticData::CylindricalBlastWave {
+  using grmhd::AnalyticData::CylindricalBlastWave::CylindricalBlastWave;
+
+  template <typename DataType>
+  using hydro_variables_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>,
+                 hydro::Tags::SpatialVelocity<DataType, 3>,
+                 hydro::Tags::SpecificInternalEnergy<DataType>,
+                 hydro::Tags::Pressure<DataType>,
+                 hydro::Tags::LorentzFactor<DataType>,
+                 hydro::Tags::SpecificEnthalpy<DataType>>;
+
+  template <typename DataType>
+  using grmhd_variables_tags =
+      tmpl::push_back<hydro_variables_tags<DataType>,
+                      hydro::Tags::MagneticField<DataType, 3>,
+                      hydro::Tags::DivergenceCleaningField<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<hydro_variables_tags<DataType>>
+  hydro_variables(const tnsr::I<DataType, 3, Frame::Inertial>& x) const
+      noexcept {
+    return variables(x, hydro_variables_tags<DataType>{});
+  }
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<grmhd_variables_tags<DataType>>
+  grmhd_variables(const tnsr::I<DataType, 3, Frame::Inertial>& x) const
+      noexcept {
+    return variables(x, grmhd_variables_tags<DataType>{});
+  }
+};
+
+void test_create_from_options() noexcept {
+  const auto cylindrical_blast_wave =
+      test_creation<grmhd::AnalyticData::CylindricalBlastWave>(
+          "  InnerRadius: 0.8\n"
+          "  OuterRadius: 1.0\n"
+          "  InnerDensity: 1.0e-2\n"
+          "  OuterDensity: 1.0e-4\n"
+          "  InnerPressure: 1.0\n"
+          "  OuterPressure: 5.0e-4\n"
+          "  MagneticField: [0.1, 0.0, 0.0]\n"
+          "  AdiabaticIndex: 1.3333333333333333333");
+  CHECK(cylindrical_blast_wave == grmhd::AnalyticData::CylindricalBlastWave(
+                                      0.8, 1.0, 1.0e-2, 1.0e-4, 1.0, 5.0e-4,
+                                      std::array<double, 3>{{0.1, 0.0, 0.0}},
+                                      1.3333333333333333333));
+}
+
+void test_move() noexcept {
+  grmhd::AnalyticData::CylindricalBlastWave cylindrical_blast_wave(
+      0.8, 1.0, 1.0e-2, 1.0e-4, 1.0, 5.0e-4,
+      std::array<double, 3>{{0.1, 0.0, 0.0}}, 1.3333333333333333333);
+  grmhd::AnalyticData::CylindricalBlastWave cylindrical_blast_wave_copy(
+      0.8, 1.0, 1.0e-2, 1.0e-4, 1.0, 5.0e-4,
+      std::array<double, 3>{{0.1, 0.0, 0.0}}, 1.3333333333333333333);
+  test_move_semantics(std::move(cylindrical_blast_wave),
+                      cylindrical_blast_wave_copy);  //  NOLINT
+}
+
+void test_serialize() noexcept {
+  grmhd::AnalyticData::CylindricalBlastWave cylindrical_blast_wave(
+      0.8, 1.0, 1.0e-2, 1.0e-4, 1.0, 5.0e-4,
+      std::array<double, 3>{{0.1, 0.0, 0.0}}, 1.3333333333333333333);
+  test_serialization(cylindrical_blast_wave);
+}
+
+template <typename DataType>
+void test_variables(const DataType& used_for_size) noexcept {
+  const double inner_radius = 0.8;
+  const double outer_radius = 1.0;
+  const double inner_density = 1.0e-2;
+  const double outer_density = 1.0e-4;
+  const double inner_pressure = 1.0;
+  const double outer_pressure = 5.0e-4;
+  const std::array<double, 3> magnetic_field{{0.1, 0.0, 0.0}};
+  const double adiabatic_index = 1.3333333333333333333;
+
+  const auto member_variables = std::make_tuple(
+      inner_radius, outer_radius, inner_density, outer_density, inner_pressure,
+      outer_pressure, magnetic_field, adiabatic_index);
+
+  CylindricalBlastWaveProxy cylindrical_blast_wave(
+      inner_radius, outer_radius, inner_density, outer_density, inner_pressure,
+      outer_pressure, magnetic_field, adiabatic_index);
+
+  // Note: I select random numbers in the range {{-1.1, 1.1}} so that
+  // sometimes the random points are in the transition region and sometimes
+  // in the fixed region.
+  pypp::check_with_random_values<
+      1, CylindricalBlastWaveProxy::hydro_variables_tags<DataType>>(
+      &CylindricalBlastWaveProxy::hydro_variables<DataType>,
+      cylindrical_blast_wave, "AnalyticData.GrMhd.TestFunctions",
+      {"cylindrical_blast_wave_rest_mass_density",
+       "cylindrical_blast_wave_spatial_velocity",
+       "cylindrical_blast_wave_specific_internal_energy",
+       "cylindrical_blast_wave_pressure",
+       "cylindrical_blast_wave_lorentz_factor",
+       "cylindrical_blast_wave_specific_enthalpy"},
+      {{{-1.1, 1.1}}}, member_variables, used_for_size);
+
+  pypp::check_with_random_values<
+      1, CylindricalBlastWaveProxy::grmhd_variables_tags<DataType>>(
+      &CylindricalBlastWaveProxy::grmhd_variables<DataType>,
+      cylindrical_blast_wave, "AnalyticData.GrMhd.TestFunctions",
+      {"cylindrical_blast_wave_rest_mass_density",
+       "cylindrical_blast_wave_spatial_velocity",
+       "cylindrical_blast_wave_specific_internal_energy",
+       "cylindrical_blast_wave_pressure",
+       "cylindrical_blast_wave_lorentz_factor",
+       "cylindrical_blast_wave_specific_enthalpy",
+       "cylindrical_blast_wave_magnetic_field",
+       "cylindrical_blast_wave_divergence_cleaning_field"},
+      {{{-1.1, 1.1}}}, member_variables, used_for_size);
+}
+
+// Check points on and near boundaries. Check that density = inner_density
+// at r = inner radius and at r = inner_radius - epsilon, and check that
+// density is approximately inner_density at r = inner_radius + epsilon.
+// Then do the analogous check for points on and near outer_radius.
+void test_density_on_and_near_boundaries() {
+  const double inner_radius = 0.8;
+  const double outer_radius = 1.0;
+  const double inner_density = 1.0e-2;
+  const double outer_density = 1.0e-4;
+  const double inner_pressure = 1.0;
+  const double outer_pressure = 5.0e-4;
+  const std::array<double, 3> magnetic_field{{0.1, 0.0, 0.0}};
+  const double adiabatic_index = 1.3333333333333333333;
+
+  CylindricalBlastWaveProxy cylindrical_blast_wave(
+      inner_radius, outer_radius, inner_density, outer_density, inner_pressure,
+      outer_pressure, magnetic_field, adiabatic_index);
+
+  const double epsilon = 1.e-10;
+  Approx approx = Approx::custom().epsilon(epsilon * 100.0);
+  auto x =
+      make_with_value<tnsr::I<double, 3, Frame::Inertial>>(inner_radius, 0.0);
+
+  get<0>(x) = inner_radius;
+  CHECK(inner_density == get(get<hydro::Tags::RestMassDensity<double>>(
+                             cylindrical_blast_wave.grmhd_variables(x))));
+  get<0>(x) = inner_radius - epsilon;
+  CHECK(inner_density == get(get<hydro::Tags::RestMassDensity<double>>(
+                             cylindrical_blast_wave.grmhd_variables(x))));
+  get<0>(x) = inner_radius + epsilon;
+  CHECK_ITERABLE_CUSTOM_APPROX(inner_density,
+                               get(get<hydro::Tags::RestMassDensity<double>>(
+                                   cylindrical_blast_wave.grmhd_variables(x))),
+                               approx);
+
+  get<0>(x) = outer_radius;
+  CHECK(outer_density == get(get<hydro::Tags::RestMassDensity<double>>(
+                             cylindrical_blast_wave.grmhd_variables(x))));
+  get<0>(x) = outer_radius + epsilon;
+  CHECK(outer_density == get(get<hydro::Tags::RestMassDensity<double>>(
+                             cylindrical_blast_wave.grmhd_variables(x))));
+  get<0>(x) = outer_radius - epsilon;
+  CHECK_ITERABLE_CUSTOM_APPROX(outer_density,
+                               get(get<hydro::Tags::RestMassDensity<double>>(
+                                   cylindrical_blast_wave.grmhd_variables(x))),
+                               approx);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.CylindricalBlastWave",
+    "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions"};
+
+  test_create_from_options();
+  test_serialize();
+  test_move();
+
+  test_variables(std::numeric_limits<double>::signaling_NaN());
+  test_variables(DataVector(5));
+
+  test_density_on_and_near_boundaries();
+}
+
+struct BlastWave {
+  using type = grmhd::AnalyticData::CylindricalBlastWave;
+  static constexpr OptionString help = {
+      "Cylindrical blast wave analytic initial data."};
+};
+
+// [[OutputRegex, CylindricalBlastWave expects InnerRadius < OuterRadius]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.CylBlastWaveInRadLess",
+    "[Unit][PointwiseFunctions]") {
+  ERROR_TEST();
+  grmhd::AnalyticData::CylindricalBlastWave cylindrical_blast_wave(
+      1.2, 1.0, 1.0e-2, 1.0e-4, 1.0, 5.0e-4,
+      std::array<double, 3>{{0.1, 0.0, 0.0}}, 1.3333333333333333333);
+  ERROR("Failed to trigger PARSE_ERROR in a parse error test");
+}


### PR DESCRIPTION
## Proposed changes

Adds analytic initial data for a cylindrical blast wave.

- [x] depends on #1074

### Types of changes:

- [] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
