### PR TITLE
Fix root-finding bounds in BondiMichel

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp
@@ -134,6 +134,8 @@ class BondiMichel {
                                    polytropic_constant_,
                                    polytropic_exponent_,
                                    bernoulli_constant_squared_minus_one_,
+                                   sonic_radius_,
+                                   sonic_density_,
                                    x};
     return {get<Tags>(variables(x, tmpl::list<Tags>{}, intermediate_vars))...};
   }
@@ -146,7 +148,8 @@ class BondiMichel {
         IntermediateVars<DataType>{rest_mass_density_at_infinity_,
                                    mass_accretion_rate_over_four_pi_, mass_,
                                    polytropic_constant_, polytropic_exponent_,
-                                   bernoulli_constant_squared_minus_one_, x});
+                                   bernoulli_constant_squared_minus_one_,
+                                   sonic_radius_, sonic_density_, x});
   }
 
   // @{
@@ -226,6 +229,7 @@ class BondiMichel {
                      double in_polytropic_constant,
                      double in_polytropic_exponent,
                      double in_bernoulli_constant_squared_minus_one,
+                     double in_sonic_radius, double in_sonic_density,
                      const tnsr::I<DataType, 3>& x) noexcept;
     DataType radius{};
     DataType rest_mass_density{};
@@ -234,6 +238,8 @@ class BondiMichel {
     double polytropic_constant{};
     double polytropic_exponent{};
     double bernoulli_constant_squared_minus_one{};
+    double sonic_radius{};
+    double sonic_density{};
     double bernoulli_root_function(double rest_mass_density_guess,
                                    double current_radius) const noexcept;
   };

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/TestFunctions.py
@@ -225,11 +225,14 @@ def bondi_michel_rest_mass_density(x, mass, sonic_radius,
                             sonic_density, adiabatic_exponent, magnetic_field):
     variables = bondi_michel_intermediate_variables(mass, sonic_radius, sonic_density, adiabatic_exponent)
     radius = np.sqrt(x[0]**2 + x[1]**2 + x[2]**2)
-    upper_bound = 2.0 * variables["rest_mass_density_at_horizon"]
-    lower_bound = 1.e-3 * variables["rest_mass_density_at_infinity"]
-    if radius > 0.9 * sonic_radius:
+    if radius < sonic_radius:
       upper_bound = variables["mass_accretion_rate_over_four_pi"] * \
-      np.sqrt(2.0 / (mass * radius**3))
+        np.sqrt(2.0 / (mass * radius**3))
+      lower_bound = variables["rest_mass_density_at_infinity"]
+    if radius >= sonic_radius:
+      upper_bound = sonic_density
+      lower_bound = variables["mass_accretion_rate_over_four_pi"] * \
+        np.sqrt(2.0 / (mass * radius**3))
     return opt.brentq( \
       bondi_michel_bernoulli_root_function, \
       lower_bound, upper_bound, xtol = 1.e-15, rtol = 1.e-15, args = ( \

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_BondiMichel.cpp
@@ -77,7 +77,7 @@ void test_serialize() noexcept {
 template <typename DataType>
 void test_variables(const DataType& used_for_size) {
   const double mass = 1.6;
-  const double sonic_radius = 400.0;
+  const double sonic_radius = 4.0;
   const double sonic_density = 0.4;
   const double polytropic_exponent = 4. / 3.;
   const double mag_field_strength = 2.3;
@@ -91,7 +91,7 @@ void test_variables(const DataType& used_for_size) {
       {"bondi_michel_rest_mass_density", "bondi_michel_spatial_velocity",
        "bondi_michel_specific_internal_energy", "bondi_michel_pressure",
        "bondi_michel_lorentz_factor", "bondi_michel_specific_enthalpy"},
-      {{{1.0, 4.0}}},
+      {{{1.0, 20.0}}},
       std::make_tuple(mass, sonic_radius, sonic_density, polytropic_exponent,
                       mag_field_strength),
       used_for_size);
@@ -106,7 +106,7 @@ void test_variables(const DataType& used_for_size) {
        "bondi_michel_specific_internal_energy", "bondi_michel_pressure",
        "bondi_michel_lorentz_factor", "bondi_michel_specific_enthalpy",
        "bondi_michel_magnetic_field", "bondi_michel_divergence_cleaning_field"},
-      {{{1.0, 4.0}}},
+      {{{1.0, 20.0}}},
       std::make_tuple(mass, sonic_radius, sonic_density, polytropic_exponent,
                       mag_field_strength),
       used_for_size);


### PR DESCRIPTION
## Proposed changes

The bound used currently in Bondi succeeds in bracketing a unique root, but fails to bracket the correct one beyond the sonic radius - this is most easily seen by the fact that in the current code, the upper bound on the density falls to 0 as r goes to infinity, but there is a non-zero asymptotic value for the density in the correct solution.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
