### PR TITLE
Enable FixToAtmosphere for ideal fluids.

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Initialize.hpp
@@ -75,7 +75,9 @@ struct Initialize {
       auto equation_of_state =
           Parallel::get<solution_tag>(cache).equation_of_state();
 
-      VariableFixing::FixToAtmosphere<1> fixer{1.e-12};
+      VariableFixing::FixToAtmosphere<decltype(
+          equation_of_state)::thermodynamic_dim>
+          fixer{1.e-12};
       fixer(
           &get<hydro::Tags::RestMassDensity<DataVector>>(primitive_vars),
           &get<hydro::Tags::SpecificInternalEnergy<DataVector>>(primitive_vars),

--- a/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_FixToAtmosphere.cpp
@@ -54,16 +54,65 @@ void test_variable_fixer(
   CHECK_ITERABLE_APPROX(lorentz_factor, expected_lorentz_factor);
   CHECK_ITERABLE_APPROX(spatial_velocity, expected_spatial_velocity);
 }
+
+void test_variable_fixer(
+    const VariableFixing::FixToAtmosphere<2>& variable_fixer) {
+  EquationsOfState::IdealFluid<true> ideal_fluid{5.0 / 3.0};
+
+  Scalar<DataVector> density{DataVector{1.e-13, 1.e-11}};
+  Scalar<DataVector> specific_internal_energy{DataVector{2.0, 3.0}};
+  auto pressure = ideal_fluid.pressure_from_density_and_energy(
+      density, specific_internal_energy);
+  auto specific_enthalpy =
+      ideal_fluid.specific_enthalpy_from_density_and_energy(
+          density, specific_internal_energy);
+
+  Scalar<DataVector> lorentz_factor{DataVector{5.0 / 3.0, 1.25}};
+  auto spatial_velocity =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(density, 0.0);
+  spatial_velocity.get(0) = DataVector{0.8, 0.6};
+  variable_fixer(&density, &specific_internal_energy, &spatial_velocity,
+                 &lorentz_factor, &pressure, &specific_enthalpy, ideal_fluid);
+
+  Scalar<DataVector> expected_density{DataVector{1.e-12, 1.e-11}};
+  Scalar<DataVector> expected_specific_internal_energy{DataVector{0.0, 3.0}};
+  auto expected_pressure = ideal_fluid.pressure_from_density_and_energy(
+      expected_density, expected_specific_internal_energy);
+  auto expected_specific_enthalpy =
+      ideal_fluid.specific_enthalpy_from_density_and_energy(
+          expected_density, expected_specific_internal_energy);
+  Scalar<DataVector> expected_lorentz_factor{DataVector{1.0, 1.25}};
+  auto expected_spatial_velocity =
+      make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(density, 0.0);
+  expected_spatial_velocity.get(0)[1] = 0.6;
+
+  CHECK_ITERABLE_APPROX(density, expected_density);
+  CHECK_ITERABLE_APPROX(pressure, expected_pressure);
+  CHECK_ITERABLE_APPROX(specific_enthalpy, expected_specific_enthalpy);
+  CHECK_ITERABLE_APPROX(specific_internal_energy,
+                        expected_specific_internal_energy);
+  CHECK_ITERABLE_APPROX(lorentz_factor, expected_lorentz_factor);
+  CHECK_ITERABLE_APPROX(spatial_velocity, expected_spatial_velocity);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.FixToAtmosphere",
                   "[VariableFixing][Unit]") {
-  VariableFixing::FixToAtmosphere<1> variable_fixer{1.e-12};
-  test_variable_fixer(variable_fixer);
-  test_serialization(variable_fixer);
+  VariableFixing::FixToAtmosphere<1> variable_fixer_1d{1.e-12};
+  test_variable_fixer(variable_fixer_1d);
+  test_serialization(variable_fixer_1d);
 
-  const auto fixer_from_options =
+  const auto fixer_from_options_1d =
       test_creation<VariableFixing::FixToAtmosphere<1>>(
           "  DensityOfAtmosphere: 1.0e-12\n");
-  test_variable_fixer(fixer_from_options);
+  test_variable_fixer(fixer_from_options_1d);
+
+  VariableFixing::FixToAtmosphere<2> variable_fixer_2d{1.e-12};
+  test_variable_fixer(variable_fixer_2d);
+  test_serialization(variable_fixer_2d);
+
+  const auto fixer_from_options_2d =
+      test_creation<VariableFixing::FixToAtmosphere<2>>(
+          "  DensityOfAtmosphere: 1.0e-12\n");
+  test_variable_fixer(fixer_from_options_2d);
 }


### PR DESCRIPTION
## Proposed changes

Extends FixToAtmosphere to two-dimensional equations of state such as IdealFluid.
At points where the rest mass density is less than the specified minimum, the rest
mass density is set to the minimum, the specific internal energy is set to zero, other
thermodynamic quantities are set to satisfy the equation of state, and the spatial
velocity is set to zero

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [x] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
