### PR TITLE
Fix problem with step_function types

### DIFF
--- a/src/Utilities/PointerVector.hpp
+++ b/src/Utilities/PointerVector.hpp
@@ -27,19 +27,26 @@ template <typename T>
 BLAZE_ALWAYS_INLINE SIMDdouble step_function(const SIMDf64<T>& v) noexcept
 #if BLAZE_AVX512F_MODE || BLAZE_MIC_MODE
 {
-  return _mm512_set_pd((~v)[7] < 0.0 ? 0.0 : 1.0, (~v)[6] < 0.0 ? 0.0 : 1.0,
-                       (~v)[5] < 0.0 ? 0.0 : 1.0, (~v)[4] < 0.0 ? 0.0 : 1.0,
-                       (~v)[3] < 0.0 ? 0.0 : 1.0, (~v)[2] < 0.0 ? 0.0 : 1.0,
-                       (~v)[1] < 0.0 ? 0.0 : 1.0, (~v)[0] < 0.0 ? 0.0 : 1.0);
+  return _mm512_set_pd((~v).eval().value[7] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[6] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[5] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[4] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[3] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[2] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[1] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[0] < 0.0 ? 0.0 : 1.0);
 }
 #elif BLAZE_AVX_MODE
 {
-  return _mm256_set_pd((~v)[3] < 0.0 ? 0.0 : 1.0, (~v)[2] < 0.0 ? 0.0 : 1.0,
-                       (~v)[1] < 0.0 ? 0.0 : 1.0, (~v)[0] < 0.0 ? 0.0 : 1.0);
+  return _mm256_set_pd((~v).eval().value[3] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[2] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[1] < 0.0 ? 0.0 : 1.0,
+                       (~v).eval().value[0] < 0.0 ? 0.0 : 1.0);
 }
 #elif BLAZE_SSE2_MODE
 {
-  return _mm_set_pd((~v)[1] < 0.0 ? 0.0 : 1.0, (~v)[0] < 0.0 ? 0.0 : 1.0);
+  return _mm_set_pd((~v).eval().value[1] < 0.0 ? 0.0 : 1.0,
+                    (~v).eval().value[0] < 0.0 ? 0.0 : 1.0);
 }
 #else
 {

--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -296,6 +296,11 @@ void test_datavector_math() noexcept {
   const DataVector step_function_data{-12.3, 2.0, -4.0, 0.0, 7.0, -8.0};
   check_vectors(step_function(wrap<WrapLeftOp>(step_function_data)),
                 DataVector{0.0, 1.0, 0.0, 1.0, 1.0, 0.0});
+  // check that the step_function works with multiple blaze operations
+  // prior to step evaluation
+  check_vectors(step_function(wrap<WrapLeftOp>(0.5 * step_function_data
+                                               + DataVector(6, 1.0))),
+                DataVector{0.0, 1.0, 0.0, 1.0, 1.0, 0.0});
 
   check_vectors(sqrt(wrap<WrapLeftOp>(nine)), DataVector(num_pts, 3.0));
   check_vectors(invsqrt(wrap<WrapLeftOp>(nine)),


### PR DESCRIPTION
Fixes [Issue 1122](https://github.com/sxs-collaboration/spectre/issues/1122).

Re-write of the internals of the step_function to more directly use the intel vectorization utilities.

I do note that this could be implemented by simply converting all `(~v)` in current `step_function` ternaries to `(~v).eval().value`, but it seemed more desirable to me to keep all operations in the intel `_mm...` vectorization tools, if only because it should scale better with larger vector instructions.

If detailed benchmarks are preferred before merging this, I can accommodate that as well.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code

Edit:
I've taken another browse through the machine instructions and found a way to use a compare operation I previously misunderstood to save a few vector ops and make a cleaner vector representation. 