### PR TITLE
Extend wedge_coordinate_maps to multiple layers

### DIFF
--- a/src/Domain/DomainCreators/Shell.cpp
+++ b/src/Domain/DomainCreators/Shell.cpp
@@ -34,7 +34,8 @@ Shell<TargetFrame>::Shell(
     typename UseEquiangularMap::type use_equiangular_map,
     typename AspectRatio::type aspect_ratio,
     typename UseLogarithmicMap::type use_logarithmic_map,
-    typename WhichWedges::type which_wedges) noexcept
+    typename WhichWedges::type which_wedges,
+    typename RadialBlockLayers::type number_of_layers) noexcept
     // clang-tidy: trivially copyable
     : inner_radius_(std::move(inner_radius)),                // NOLINT
       outer_radius_(std::move(outer_radius)),                // NOLINT
@@ -45,7 +46,8 @@ Shell<TargetFrame>::Shell(
       use_equiangular_map_(std::move(use_equiangular_map)),  // NOLINT
       aspect_ratio_(std::move(aspect_ratio)),                // NOLINT
       use_logarithmic_map_(std::move(use_logarithmic_map)),  // NOLINT
-      which_wedges_(std::move(which_wedges)) {}              // NOLINT
+      which_wedges_(std::move(which_wedges)),                // NOLINT
+      number_of_layers_(std::move(number_of_layers)) {}      // NOLINT
 
 template <typename TargetFrame>
 Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
@@ -53,21 +55,23 @@ Domain<3, TargetFrame> Shell<TargetFrame>::create_domain() const noexcept {
       std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
       coord_maps = wedge_coordinate_maps<TargetFrame>(
           inner_radius_, outer_radius_, 1.0, 1.0, use_equiangular_map_, 0.0,
-          false, aspect_ratio_, use_logarithmic_map_, which_wedges_);
+          false, aspect_ratio_, use_logarithmic_map_, which_wedges_,
+          number_of_layers_);
   return Domain<3, TargetFrame>{
       std::move(coord_maps),
-      corners_for_radially_layered_domains(1, false, {{1, 2, 3, 4, 5, 6, 7, 8}},
-                                           which_wedges_)};
+      corners_for_radially_layered_domains(
+          number_of_layers_, false, {{1, 2, 3, 4, 5, 6, 7, 8}}, which_wedges_)};
 }
 
 template <typename TargetFrame>
 std::vector<std::array<size_t, 3>> Shell<TargetFrame>::initial_extents() const
     noexcept {
-  std::vector<std::array<size_t, 3>>::size_type num_wedges = 6;
+  std::vector<std::array<size_t, 3>>::size_type num_wedges =
+      6 * number_of_layers_;
   if (UNLIKELY(which_wedges_ == ShellWedges::FourOnEquator)) {
-    num_wedges = 4;
+    num_wedges = 4 * number_of_layers_;
   } else if (UNLIKELY(which_wedges_ == ShellWedges::OneAlongMinusX)) {
-    num_wedges = 1;
+    num_wedges = number_of_layers_;
   }
   return {
       num_wedges,
@@ -77,11 +81,12 @@ std::vector<std::array<size_t, 3>> Shell<TargetFrame>::initial_extents() const
 template <typename TargetFrame>
 std::vector<std::array<size_t, 3>>
 Shell<TargetFrame>::initial_refinement_levels() const noexcept {
-  std::vector<std::array<size_t, 3>>::size_type num_wedges = 6;
+  std::vector<std::array<size_t, 3>>::size_type num_wedges =
+      6 * number_of_layers_;
   if (UNLIKELY(which_wedges_ == ShellWedges::FourOnEquator)) {
-    num_wedges = 4;
+    num_wedges = 4 * number_of_layers_;
   } else if (UNLIKELY(which_wedges_ == ShellWedges::OneAlongMinusX)) {
-    num_wedges = 1;
+    num_wedges = number_of_layers_;
   }
   return {num_wedges, make_array<3>(initial_refinement_)};
 }

--- a/src/Domain/DomainCreators/Shell.hpp
+++ b/src/Domain/DomainCreators/Shell.hpp
@@ -80,9 +80,17 @@ class Shell : public DomainCreator<3, TargetFrame> {
     static constexpr type default_value() noexcept { return ShellWedges::All; }
   };
 
+  struct RadialBlockLayers {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "The number of concentric layers of Blocks to have."};
+    static constexpr type default_value() noexcept { return 1; }
+    static type lower_bound() { return 1; }
+  };
+
   using options = tmpl::list<InnerRadius, OuterRadius, InitialRefinement,
                              InitialGridPoints, UseEquiangularMap, AspectRatio,
-                             UseLogarithmicMap, WhichWedges>;
+                             UseLogarithmicMap, WhichWedges, RadialBlockLayers>;
 
   static constexpr OptionString help{
       "Creates a 3D spherical shell with 6 Blocks. `UseEquiangularMap` has\n"
@@ -95,7 +103,8 @@ class Shell : public DomainCreator<3, TargetFrame> {
       "the radial gridpoints will be spaced uniformly in \f$log(r)\f$. The\n"
       "user may also choose to use only a single wedge (along the -x\n"
       "direction), or four wedges along the x-y plane using the `WhichWedges`\n"
-      "option."};
+      "option. Using the RadialBlockLayers option, a user may increase the\n"
+      "number of Blocks in the radial direction."};
 
   Shell(typename InnerRadius::type inner_radius,
         typename OuterRadius::type outer_radius,
@@ -104,7 +113,8 @@ class Shell : public DomainCreator<3, TargetFrame> {
         typename UseEquiangularMap::type use_equiangular_map,
         typename AspectRatio::type aspect_ratio = 1.0,
         typename UseLogarithmicMap::type use_logarithmic_map = false,
-        typename WhichWedges::type which_wedges = ShellWedges::All) noexcept;
+        typename WhichWedges::type which_wedges = ShellWedges::All,
+        typename RadialBlockLayers::type number_of_layers = 1) noexcept;
 
   Shell() = default;
   Shell(const Shell&) = delete;
@@ -129,5 +139,6 @@ class Shell : public DomainCreator<3, TargetFrame> {
   typename AspectRatio::type aspect_ratio_ = 1.0;
   typename UseLogarithmicMap::type use_logarithmic_map_ = false;
   typename WhichWedges::type which_wedges_ = ShellWedges::All;
+  typename RadialBlockLayers::type number_of_layers_ = 1;
 };
 }  // namespace DomainCreators

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -112,6 +112,8 @@ enum class ShellWedges {
 /// This is done if `aspect_ratio` is set to something other than the default
 /// value of one. When the argument `use_logarithmic_map` is set to `true`,
 /// the radial gridpoints of the wedge map are set to be spaced logarithmically.
+/// The `number_of_layers` is used when the user wants to have multiple layers
+/// of Blocks in the radial direction.
 template <typename TargetFrame>
 auto wedge_coordinate_maps(double inner_radius, double outer_radius,
                            double inner_sphericity, double outer_sphericity,
@@ -120,7 +122,8 @@ auto wedge_coordinate_maps(double inner_radius, double outer_radius,
                            bool use_half_wedges = false,
                            double aspect_ratio = 1.0,
                            bool use_logarithmic_map = false,
-                           ShellWedges which_wedges = ShellWedges::All) noexcept
+                           ShellWedges which_wedges = ShellWedges::All,
+                           size_t number_of_layers = 1) noexcept
     -> std::vector<
         std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
 

--- a/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
@@ -4,32 +4,44 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <pup.h>
 #include <unordered_set>
 #include <vector>
 
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/IdPair.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/BlockId.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/BlockNeighbor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
+#include "Domain/CreateInitialElement.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/Shell.hpp"
 #include "Domain/DomainHelpers.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/InitialElementIds.hpp"
 #include "Domain/OrientationMap.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/MakeVector.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
-
 // IWYU pragma: no_forward_declare BlockNeighbor
-
 namespace {
 void test_shell_construction(
     const DomainCreators::Shell<Frame::Inertial>& shell,
@@ -416,4 +428,108 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.Factory.ShellWedges",
         {1, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map,
         which_wedges);
   }
+}
+
+namespace {
+// Tests that the underlying element structure is the same regardless of
+// whether they are created through InitialRefinement or RadialBlockLayers.
+// This is done by constructing a set of expected boundary points dependent on
+// only the total number of Elements in the Domain. The Domain is then created
+// using either InitialRefinement or RadialBlockLayers. Comparing the resulting
+// Element boundary points against the expected points ensures that both methods
+// of creating Elements lead to the same boundary locations.
+// To verify that the Block structures created are indeed distinct, this test
+// also checks the Block structure.
+void test_radial_block_layers(const double inner_radius,
+                              const double outer_radius,
+                              const size_t refinement_level,
+                              const bool use_logarithmic_map,
+                              const size_t radial_block_layers,
+                              const std::vector<size_t>& expected_block_ids) {
+  const size_t number_of_divisions =
+      radial_block_layers * two_to_the(refinement_level);
+  const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
+  const bool use_equiangular_map = true;
+  const double aspect_ratio = 1.0;
+  const ShellWedges which_wedges = ShellWedges::OneAlongMinusX;
+  // Points on the interior of Blocks used to check Block structure:
+  DataVector x_in_block_interior(number_of_divisions);
+  // Points on the boundary of Elements used to check Element structure:
+  DataVector x_on_element_boundary(number_of_divisions + 1);
+  for (size_t i = 0; i < number_of_divisions; i++) {
+    const double delta_boundary =
+        static_cast<double>(i) / static_cast<double>(number_of_divisions);
+    const double delta_interior = (static_cast<double>(i) + 0.5) /
+                                  static_cast<double>(number_of_divisions);
+    if (use_logarithmic_map) {
+      x_in_block_interior[i] =
+          inner_radius * pow(outer_radius / inner_radius, delta_interior);
+      x_on_element_boundary[i] =
+          inner_radius * pow(outer_radius / inner_radius, delta_boundary);
+    } else {
+      x_in_block_interior[i] =
+          inner_radius + delta_interior * (outer_radius - inner_radius);
+      x_on_element_boundary[i] =
+          inner_radius + delta_boundary * (outer_radius - inner_radius);
+    }
+  }
+  x_on_element_boundary[number_of_divisions] = outer_radius;
+
+  const auto zero = make_with_value<DataVector>(x_in_block_interior, 0.0);
+  tnsr::I<DataVector, 3, Frame::Inertial> interior_inertial_coords{
+      {{-x_in_block_interior, zero, zero}}};
+  const DomainCreators::Shell<Frame::Inertial> shell{
+      inner_radius,          outer_radius,        refinement_level,
+      grid_points_r_angular, use_equiangular_map, aspect_ratio,
+      use_logarithmic_map,   which_wedges,        radial_block_layers};
+  auto domain = shell.create_domain();
+  const auto blogical_coords =
+      block_logical_coordinates(domain, interior_inertial_coords);
+  for (size_t s = 0; s < expected_block_ids.size(); ++s) {
+    CHECK(blogical_coords[s].id.get_index() == expected_block_ids[s]);
+  }
+  size_t element_count = 0;
+  for (const auto& block : domain.blocks()) {
+    const auto initial_ref_levs = shell.initial_refinement_levels()[block.id()];
+    const std::vector<ElementId<3>> element_ids =
+        initial_element_ids(block.id(), initial_ref_levs);
+    for (const auto& element_id : element_ids) {
+      const auto element = create_initial_element(element_id, block);
+      // Creating elements through InitialRefinement creates Elements in all
+      // three logical dimensions. It is sufficient to only check the elements
+      // in the radial direction lying along a ray at a fixed angle.
+      // This is done by getting the desired Elements through their SegmentIds.
+      if (element_id.segment_ids()[0] == SegmentId{refinement_level, 0} and
+          element_id.segment_ids()[1] == SegmentId{refinement_level, 0}) {
+        element_count++;
+        const auto map = ElementMap<3, Frame::Inertial>{
+            element_id, block.coordinate_map().get_clone()};
+        const tnsr::I<double, 3, Frame::Logical> logical_point(
+            std::array<double, 3>{{0.0, 0.0, 1.0}});
+        CHECK(magnitude(map(logical_point)).get() ==
+              approx(x_on_element_boundary[element_count]));
+      }
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.RadialBlockLayers",
+                  "[Domain][Unit]") {
+  const auto log_shell =
+      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+          "  Shell:\n"
+          "    InnerRadius: 1\n"
+          "    OuterRadius: 3\n"
+          "    InitialRefinement: 2\n"
+          "    InitialGridPoints: [2,3]\n"
+          "    UseEquiangularMap: false\n"
+          "    AspectRatio: 2.0        \n"
+          "    UseLogarithmicMap: true\n"
+          "    RadialBlockLayers: 6\n");
+
+   test_radial_block_layers(1.0, 10.0, 0, true, 8, {0, 1, 2, 3, 4, 5, 6, 7});
+   test_radial_block_layers(2.0, 9.0, 0, false, 8, {0, 1, 2, 3, 4, 5, 6, 7});
+   test_radial_block_layers(4.0, 9.0, 3, true, 1, {0, 0, 0, 0, 0, 0, 0, 0});
+   test_radial_block_layers(3.0, 6.0, 3, false, 1, {0, 0, 0, 0, 0, 0, 0, 0});
 }

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -305,6 +305,107 @@ void test_wedge_map_generation_against_domain_helpers(
 }
 
 }  // namespace
+
+// [[OutputRegex, If we are using half wedges we must also be using
+// ShellWedges::All.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert1", "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const double inner_radius = 0.5;
+  const double outer_radius = 2.0;
+  const double inner_sphericity = 1.0;
+  const double outer_sphericity = 1.0;
+  const bool use_equiangular_map = true;
+  const double x_coord_of_shell_center = 0.1;
+  const bool use_half_wedges = true;
+  const double aspect_ratio = 1.0;
+  const bool use_logarithmic_map = true;
+  const ShellWedges which_wedges = ShellWedges::FourOnEquator;
+  const size_t number_of_layers = 3;
+  static_cast<void>(wedge_coordinate_maps<Frame::Inertial>(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
+      aspect_ratio, use_logarithmic_map, which_wedges, number_of_layers));
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, If we are using more than one layer the inner and outer
+// sphericities must match.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert2", "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const double inner_radius = 0.5;
+  const double outer_radius = 2.0;
+  const double inner_sphericity = 0.9;
+  const double outer_sphericity = 1.0;
+  const bool use_equiangular_map = true;
+  const double x_coord_of_shell_center = 0.1;
+  const bool use_half_wedges = true;
+  const double aspect_ratio = 1.0;
+  const bool use_logarithmic_map = true;
+  const ShellWedges which_wedges = ShellWedges::All;
+  const size_t number_of_layers = 3;
+  static_cast<void>(wedge_coordinate_maps<Frame::Inertial>(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
+      aspect_ratio, use_logarithmic_map, which_wedges, number_of_layers));
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Only one of: using a non-zero translation, using half wedges,
+// or using a non-unity aspect_ratio, can be done at a time.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert3", "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const double inner_radius = 0.5;
+  const double outer_radius = 2.0;
+  const double inner_sphericity = 0.2;
+  const double outer_sphericity = 0.2;
+  const bool use_equiangular_map = true;
+  const double x_coord_of_shell_center = 0.1;
+  const bool use_half_wedges = true;
+  const double aspect_ratio = 1.0;
+  const bool use_logarithmic_map = false;
+  const ShellWedges which_wedges = ShellWedges::All;
+  const size_t number_of_layers = 3;
+  static_cast<void>(wedge_coordinate_maps<Frame::Inertial>(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
+      aspect_ratio, use_logarithmic_map, which_wedges, number_of_layers));
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Only one of: using a non-zero translation, using half wedges,
+// or using a non-unity aspect_ratio, can be done at a time.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert4", "[Domain][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const double inner_radius = 0.5;
+  const double outer_radius = 2.0;
+  const double inner_sphericity = 0.2;
+  const double outer_sphericity = 0.2;
+  const bool use_equiangular_map = true;
+  const double x_coord_of_shell_center = 0.0;
+  const bool use_half_wedges = true;
+  const double aspect_ratio = 0.3;
+  const bool use_logarithmic_map = false;
+  const ShellWedges which_wedges = ShellWedges::All;
+  const size_t number_of_layers = 3;
+  static_cast<void>(wedge_coordinate_maps<Frame::Inertial>(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
+      aspect_ratio, use_logarithmic_map, which_wedges, number_of_layers));
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
 SPECTRE_TEST_CASE(
     "Unit.Domain.DomainHelpers.DefaultSixWedgeDirections.Equiangular",
     "[Domain][Unit]") {


### PR DESCRIPTION
## Proposed changes

Shell is currently created with 6 blocks - this enables the creation of Shell with 6n blocks, with n blocks in the radial direction - this is to help examine the effect of having Blocks vs Elements in regards to communication.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
