### PR TITLE
Add Generalized Harmonic Characteristic Fields &  Speeds

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1,6 +1,6 @@
 @article{Lindblom2005qh,
-      author         = "Lindblom, Lee and Scheel, Mark A. and Kidder,
-                        Lawrence E. and Owen, Robert and Rinne, Oliver",
+      author         = "Lindblom, Lee and Scheel, Mark A. and Kidder, Lawrence E.
+                        and Owen, Robert and Rinne, Oliver",
       title          = "{A New generalized harmonic evolution system}",
       journal        = "Class. Quant. Grav.",
       volume         = "23",

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -100,4 +100,17 @@ struct Next : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
   static std::string name() noexcept { return "Next(" + Tag::name() + ")"; }
 };
+
+/// \ingroup DataBoxTagsGroup
+/// \brief Prefix corresponding to the characteristic speed of the
+/// characteristic field given by `Tag`. Its `type` is always a
+/// `Scalar<DataVector>`.
+template<typename Tag>
+struct CharSpeed : db::PrefixTag, db::SimpleTag {
+  using type = Scalar<DataVector>;
+  using tag = Tag;
+  static std::string name() noexcept {
+    return "CharSpeed(" + Tag::name() + ")";
+  }
+};
 }  // namespace Tags

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -940,6 +940,9 @@ using TempII = TempTensor<N, tnsr::II<DataVector, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
   typename DataType = DataVector>
 using Tempijj = TempTensor<N, tnsr::ijj<DataType, SpatialDim, Fr>>;
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+  typename DataType = DataVector>
+using Tempiaa = TempTensor<N, tnsr::iaa<DataType, SpatialDim, Fr>>;
 
 // @}
 }  // namespace Tags

--- a/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY GeneralizedHarmonic)
 
 set(LIBRARY_SOURCES
+    Characteristics.cpp
     Constraints.cpp
     Equations.cpp
     )

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.cpp
@@ -1,0 +1,226 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Tags::CharSpeed
+// IWYU pragma: no_forward_declare Tags::Pi
+// IWYU pragma: no_forward_declare Tags::Phi
+// IWYU pragma: no_forward_declare Tags::UPsi
+// IWYU pragma: no_forward_declare Tags::UZero
+// IWYU pragma: no_forward_declare Tags::UMinus
+// IWYU pragma: no_forward_declare Tags::UPlus
+// IWYU pragma: no_include <array>
+
+namespace GeneralizedHarmonic {
+
+template <size_t Dim, typename Frame>
+void compute_characteristic_speeds(
+    const gsl::not_null<typename Tags::CharacteristicSpeeds<Dim, Frame>::type*>
+        char_speeds,
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const tnsr::i<DataVector, Dim, Frame>& normal) noexcept {
+  const auto shift_dot_normal = get(dot_product(shift, normal));
+  get(get<::Tags::CharSpeed<Tags::UPsi<Dim, Frame>>>(*char_speeds)) =
+      -(1. + get(gamma_1)) * shift_dot_normal;
+  get(get<::Tags::CharSpeed<Tags::UZero<Dim, Frame>>>(*char_speeds)) =
+      -shift_dot_normal;
+  get(get<::Tags::CharSpeed<Tags::UPlus<Dim, Frame>>>(*char_speeds)) =
+      -shift_dot_normal + get(lapse);
+  get(get<::Tags::CharSpeed<Tags::UMinus<Dim, Frame>>>(*char_speeds)) =
+      -shift_dot_normal - get(lapse);
+}
+
+template <size_t Dim, typename Frame>
+typename Tags::CharacteristicSpeeds<Dim, Frame>::type
+CharacteristicSpeedsCompute<Dim, Frame>::function(
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const tnsr::i<DataVector, Dim, Frame>& normal) noexcept {
+  auto char_speeds =
+      make_with_value<typename Tags::CharacteristicSpeeds<Dim, Frame>::type>(
+          get(lapse), 0.);
+  compute_characteristic_speeds(make_not_null(&char_speeds), gamma_1, lapse,
+                                shift, normal);
+  return char_speeds;
+}
+
+template <size_t Dim, typename Frame>
+void compute_characteristic_fields(
+    const gsl::not_null<typename Tags::CharacteristicFields<Dim, Frame>::type*>
+        char_fields,
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame>& phi,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::I<DataVector, Dim, Frame>& unit_normal_vector) noexcept {
+  auto phi_dot_normal =
+      make_with_value<tnsr::aa<DataVector, Dim, Frame>>(pi, 0.);
+
+  // Compute phi_dot_normal_{ab} = n^i \Phi_{iab}
+  for (size_t a = 0; a < Dim + 1; ++a) {
+    for (size_t b = 0; b < a + 1; ++b) {
+      for (size_t i = 0; i < Dim; ++i) {
+        phi_dot_normal.get(a, b) +=
+            unit_normal_vector.get(i) * phi.get(i, a, b);
+      }
+    }
+  }
+
+  // Eq.(34) of Lindblom+ (2005)
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t a = 0; a < Dim + 1; ++a) {
+      for (size_t b = 0; b < a + 1; ++b) {
+        get<Tags::UZero<Dim, Frame>>(*char_fields).get(i, a, b) =
+            phi.get(i, a, b) -
+            unit_normal_one_form.get(i) * phi_dot_normal.get(a, b);
+      }
+    }
+  }
+
+  // Eq.(32) of Lindblom+ (2005)
+  get<Tags::UPsi<Dim, Frame>>(*char_fields) = spacetime_metric;
+
+  for (size_t a = 0; a < Dim + 1; ++a) {
+    for (size_t b = 0; b < a + 1; ++b) {
+      // Eq.(33) of Lindblom+ (2005)
+      get<Tags::UPlus<Dim, Frame>>(*char_fields).get(a, b) =
+          pi.get(a, b) + phi_dot_normal.get(a, b) -
+          get(gamma_2) * spacetime_metric.get(a, b);
+      get<Tags::UMinus<Dim, Frame>>(*char_fields).get(a, b) =
+          pi.get(a, b) - phi_dot_normal.get(a, b) -
+          get(gamma_2) * spacetime_metric.get(a, b);
+    }
+  }
+}
+
+template <size_t Dim, typename Frame>
+typename Tags::CharacteristicFields<Dim, Frame>::type
+CharacteristicFieldsCompute<Dim, Frame>::function(
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame>& phi,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::I<DataVector, Dim, Frame>& unit_normal_vector) noexcept {
+  auto char_fields =
+      make_with_value<typename Tags::CharacteristicFields<Dim, Frame>::type>(
+          get(gamma_2), 0.);
+  compute_characteristic_fields(make_not_null(&char_fields), gamma_2,
+                                spacetime_metric, pi, phi, unit_normal_one_form,
+                                unit_normal_vector);
+  return char_fields;
+}
+
+template <size_t Dim, typename Frame>
+void compute_evolved_fields_from_characteristic_fields(
+    const gsl::not_null<
+        typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type*>
+        evolved_fields,
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::aa<DataVector, Dim, Frame>& u_psi,
+    const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
+    const tnsr::aa<DataVector, Dim, Frame>& u_plus,
+    const tnsr::aa<DataVector, Dim, Frame>& u_minus,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
+  // Invert Eq.(32) of Lindblom+ (2005) for Psi
+  get<::gr::Tags::SpacetimeMetric<Dim, Frame, DataVector>>(*evolved_fields) =
+      u_psi;
+
+  for (size_t a = 0; a < Dim + 1; ++a) {
+    for (size_t b = 0; b < a + 1; ++b) {
+      // Invert Eq.(32) - (34) of Lindblom+ (2005) for Pi and Phi
+      get<Tags::Pi<Dim, Frame>>(*evolved_fields).get(a, b) =
+          0.5 * (u_plus.get(a, b) + u_minus.get(a, b)) +
+          get(gamma_2) * u_psi.get(a, b);
+      for (size_t i = 0; i < Dim; ++i) {
+        get<Tags::Phi<Dim, Frame>>(*evolved_fields).get(i, a, b) =
+            0.5 * (u_plus.get(a, b) - u_minus.get(a, b)) *
+                unit_normal_one_form.get(i) +
+            u_zero.get(i, a, b);
+      }
+    }
+  }
+}
+
+template <size_t Dim, typename Frame>
+typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type
+EvolvedFieldsFromCharacteristicFieldsCompute<Dim, Frame>::function(
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::aa<DataVector, Dim, Frame>& u_psi,
+    const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
+    const tnsr::aa<DataVector, Dim, Frame>& u_plus,
+    const tnsr::aa<DataVector, Dim, Frame>& u_minus,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept {
+  auto evolved_fields = make_with_value<
+      typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type>(
+      get(gamma_2), 0.);
+  compute_evolved_fields_from_characteristic_fields(
+      make_not_null(&evolved_fields), gamma_2, u_psi, u_zero, u_plus, u_minus,
+      unit_normal_one_form);
+  return evolved_fields;
+}
+}  // namespace GeneralizedHarmonic
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATION(_, data)                                                 \
+  template void GeneralizedHarmonic::compute_characteristic_speeds(            \
+      const gsl::not_null<                                                     \
+          typename GeneralizedHarmonic::Tags::CharacteristicSpeeds<            \
+              DIM(data), FRAME(data)>::type*>                                  \
+          char_speeds,                                                         \
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,      \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>& shift,                \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>& normal) noexcept;     \
+  template struct GeneralizedHarmonic::CharacteristicSpeedsCompute<            \
+      DIM(data), FRAME(data)>;                                                 \
+  template void GeneralizedHarmonic::compute_characteristic_fields(            \
+      const gsl::not_null<                                                     \
+          typename GeneralizedHarmonic::Tags::CharacteristicFields<            \
+              DIM(data), FRAME(data)>::type*>                                  \
+          char_fields,                                                         \
+      const Scalar<DataVector>& gamma_2,                                       \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& spacetime_metric,    \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& pi,                  \
+      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& phi,                \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>& unit_normal_one_form, \
+      const tnsr::I<DataVector, DIM(data), FRAME(data)>&                       \
+          unit_normal_vector) noexcept;                                        \
+  template struct GeneralizedHarmonic::CharacteristicFieldsCompute<            \
+      DIM(data), FRAME(data)>;                                                 \
+  template void                                                                \
+  GeneralizedHarmonic::compute_evolved_fields_from_characteristic_fields(      \
+      const gsl::not_null<typename GeneralizedHarmonic::Tags::                 \
+                              EvolvedFieldsFromCharacteristicFields<           \
+                                  DIM(data), FRAME(data)>::type*>              \
+          evolved_fields,                                                      \
+      const Scalar<DataVector>& gamma_2,                                       \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_psi,               \
+      const tnsr::iaa<DataVector, DIM(data), FRAME(data)>& u_zero,             \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_plus,              \
+      const tnsr::aa<DataVector, DIM(data), FRAME(data)>& u_minus,             \
+      const tnsr::i<DataVector, DIM(data), FRAME(data)>&                       \
+          unit_normal_one_form) noexcept;                                      \
+  template struct GeneralizedHarmonic::                                        \
+      EvolvedFieldsFromCharacteristicFieldsCompute<DIM(data), FRAME(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),
+                        (Frame::Inertial, Frame::Grid))
+
+#undef INSTANTIATION
+#undef DIM
+#undef FRAME

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -1,0 +1,194 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+namespace Tags {
+template <typename Tag>
+struct Normalized;
+}  // namespace Tags
+/// \endcond
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace GeneralizedHarmonic {
+// @{
+/*!
+ * \ingroup GeneralizedHarmonic
+ * \brief Compute the characteristic speeds for the generalized harmonic system.
+ *
+ * Computes the speeds as described in "A New Generalized Harmonic
+ * Evolution System" by Lindblom et. al \cite Lindblom2005qh
+ * [see text following Eq.(34)]. The characteristic fields' names used here
+ * differ from this paper:
+ *
+ * \f{align*}
+ * \mathrm{SpECTRE} && \mathrm{Lindblom} \\
+ * u^{\psi}_{ab} && u^\hat{0}_{ab} \\
+ * u^0_{iab} && u^\hat{2}_{iab} \\
+ * u^{\pm}_{ab} && u^{\hat{1}\pm}_{ab}
+ * \f}
+ *
+ * The corresponding characteristic speeds \f$v\f$ are given in the text between
+ * Eq.(34) and Eq.(35) of \cite Lindblom2005qh :
+ *
+ * \f{align*}
+ * v_{\psi} =& -(1 + \gamma_1) n_k N^k \\
+ * v_{0} =& -n_k N^k \\
+ * v_{\pm} =& -n_k N^k \pm N
+ * \f}
+ *
+ * where \f$N, N^k\f$ are the lapse and shift respectively, \f$\gamma_1\f$ is a
+ * constraint damping parameter, and \f$n_k\f$ is the unit normal to the
+ * surface.
+ */
+template <size_t Dim, typename Frame>
+struct CharacteristicSpeedsCompute : db::ComputeTag {
+  using argument_tags = tmpl::list<
+      Tags::ConstraintGamma1, gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame, DataVector>,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
+
+  static typename Tags::CharacteristicSpeeds<Dim, Frame>::type function(
+      const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, Dim, Frame>& shift,
+      const tnsr::i<DataVector, Dim, Frame>& normal) noexcept;
+};
+
+template <size_t Dim, typename Frame>
+void compute_characteristic_speeds(
+    gsl::not_null<typename Tags::CharacteristicSpeeds<Dim, Frame>::type*>
+        char_speeds,
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const tnsr::i<DataVector, Dim, Frame>& normal) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralizedHarmonic
+ * \brief Computes characteristic fields from evolved fields
+ *
+ * \ref CharacteristicFieldsCompute and
+ * \ref EvolvedFieldsFromCharacteristicFieldsCompute convert between
+ * characteristic and evolved fields for the generalized harmonic system.
+ *
+ * \ref CharacteristicFieldsCompute computes
+ * characteristic fields as described in "A New Generalized Harmonic
+ * Evolution System" by Lindblom et. al \cite Lindblom2005qh .
+ * Their names used here differ from this paper:
+ *
+ * \f{align*}
+ * \mathrm{SpECTRE} && \mathrm{Lindblom} \\
+ * u^{\psi}_{ab} && u^\hat{0}_{ab} \\
+ * u^0_{iab} && u^\hat{2}_{iab} \\
+ * u^{\pm}_{ab} && u^{\hat{1}\pm}_{ab}
+ * \f}
+ *
+ * The characteristic fields \f$u\f$ are given in terms of the evolved fields by
+ * Eq.(32) - (34) of \cite Lindblom2005qh, respectively:
+ * \f{align*}
+ * u^{\psi}_{ab} =& \psi_{ab} \\
+ * u^0_{iab} =& (\delta^k_i - n_i n^k) \Phi_{kab} := P^k_i \Phi_{kab} \\
+ * u^{\pm}_{ab} =& \Pi_{ab} \pm n^i \Phi_{iab} - \gamma_2\psi_{ab}
+ * \f}
+ *
+ * where \f$\psi_{ab}\f$ is the spacetime metric, \f$\Pi_{ab}\f$ and
+ * \f$\Phi_{iab}\f$ are evolved generalized harmonic fields introduced by first
+ * derivatives of \f$\psi_{ab}\f$, \f$\gamma_2\f$ is a constraint damping
+ * parameter, and \f$n_k\f$ is the unit normal to the surface.
+ *
+ * \ref EvolvedFieldsFromCharacteristicFieldsCompute computes evolved fields
+ * \f$w\f$ in terms of the characteristic fields. This uses the inverse of
+ * above relations:
+ *
+ * \f{align*}
+ * \psi_{ab} =& u^{\psi}_{ab}, \\
+ * \Pi_{ab} =& \frac{1}{2}(u^{+}_{ab} + u^{-}_{ab}) + \gamma_2 u^{\psi}_{ab}, \\
+ * \Phi_{iab} =& \frac{1}{2}(u^{+}_{ab} - u^{-}_{ab}) n_i + u^0_{iab}.
+ * \f}
+ *
+ * The corresponding characteristic speeds \f$v\f$ are computed by
+ * \ref CharacteristicSpeedsCompute .
+ */
+template <size_t Dim, typename Frame>
+struct CharacteristicFieldsCompute : db::ComputeTag {
+  using argument_tags = tmpl::list<
+      Tags::ConstraintGamma2, gr::Tags::SpacetimeMetric<Dim, Frame, DataVector>,
+      gr::Tags::InverseSpatialMetric<Dim, Frame, DataVector>,
+      Tags::Pi<Dim, Frame>, Tags::Phi<Dim, Frame>,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
+
+  static typename Tags::CharacteristicFields<Dim, Frame>::type function(
+      const Scalar<DataVector>& gamma_2,
+      const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
+      const tnsr::aa<DataVector, Dim, Frame>& pi,
+      const tnsr::iaa<DataVector, Dim, Frame>& phi,
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+      const tnsr::I<DataVector, Dim, Frame>& unit_normal_vector) noexcept;
+};
+
+template <size_t Dim, typename Frame>
+void compute_characteristic_fields(
+    gsl::not_null<typename Tags::CharacteristicFields<Dim, Frame>::type*>
+        char_fields,
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame>& phi,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
+    const tnsr::I<DataVector, Dim, Frame>& unit_normal_vector) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralizedHarmonic
+ * \brief For expressions used here to compute evolved fields from
+ * characteristic ones, see \ref CharacteristicFieldsCompute.
+ */
+template <size_t Dim, typename Frame>
+struct EvolvedFieldsFromCharacteristicFieldsCompute : db::ComputeTag {
+  using argument_tags = tmpl::list<
+      Tags::ConstraintGamma2, Tags::UPsi<Dim, Frame>, Tags::UZero<Dim, Frame>,
+      Tags::UPlus<Dim, Frame>, Tags::UMinus<Dim, Frame>,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>>;
+
+  static typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type
+  function(
+      const Scalar<DataVector>& gamma_2,
+      const tnsr::aa<DataVector, Dim, Frame>& u_psi,
+      const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
+      const tnsr::aa<DataVector, Dim, Frame>& u_plus,
+      const tnsr::aa<DataVector, Dim, Frame>& u_minus,
+      const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+};
+
+template <size_t Dim, typename Frame>
+void compute_evolved_fields_from_characteristic_fields(
+    gsl::not_null<
+        typename Tags::EvolvedFieldsFromCharacteristicFields<Dim, Frame>::type*>
+        evolved_fields,
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::aa<DataVector, Dim, Frame>& u_psi,
+    const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
+    const tnsr::aa<DataVector, Dim, Frame>& u_plus,
+    const tnsr::aa<DataVector, Dim, Frame>& u_minus,
+    const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form) noexcept;
+
+// @}
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -41,21 +41,21 @@ namespace GeneralizedHarmonic {
 template <size_t Dim>
 struct ComputeDuDt {
  public:
-  using argument_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>,
-                 Tags::deriv<gr::Tags::SpacetimeMetric<Dim>, tmpl::size_t<Dim>,
-                             Frame::Inertial>,
-                 Tags::deriv<Pi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
-                 Tags::deriv<Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
-                 ConstraintGamma0, ConstraintGamma1, ConstraintGamma2,
-                 GaugeH<Dim>, SpacetimeDerivGaugeH<Dim>, gr::Tags::Lapse<>,
-                 gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
-                 gr::Tags::InverseSpacetimeMetric<Dim>,
-                 gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim>,
-                 gr::Tags::SpacetimeChristoffelFirstKind<Dim>,
-                 gr::Tags::SpacetimeChristoffelSecondKind<Dim>,
-                 gr::Tags::SpacetimeNormalVector<Dim>,
-                 gr::Tags::SpacetimeNormalOneForm<Dim>>;
+  using argument_tags = tmpl::list<
+      gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
+      ::Tags::deriv<gr::Tags::SpacetimeMetric<Dim>, tmpl::size_t<Dim>,
+                    Frame::Inertial>,
+      ::Tags::deriv<Tags::Pi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+      ::Tags::deriv<Tags::Phi<Dim>, tmpl::size_t<Dim>, Frame::Inertial>,
+      Tags::ConstraintGamma0, Tags::ConstraintGamma1, Tags::ConstraintGamma2,
+      Tags::GaugeH<Dim>, Tags::SpacetimeDerivGaugeH<Dim>, gr::Tags::Lapse<>,
+      gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>,
+      gr::Tags::InverseSpacetimeMetric<Dim>,
+      gr::Tags::TraceSpacetimeChristoffelFirstKind<Dim>,
+      gr::Tags::SpacetimeChristoffelFirstKind<Dim>,
+      gr::Tags::SpacetimeChristoffelSecondKind<Dim>,
+      gr::Tags::SpacetimeNormalVector<Dim>,
+      gr::Tags::SpacetimeNormalOneForm<Dim>>;
 
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*> dt_spacetime_metric,
@@ -111,9 +111,10 @@ template <size_t Dim>
 struct ComputeNormalDotFluxes {
  public:
   using argument_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<Dim>, Pi<Dim>, Phi<Dim>,
-                 ConstraintGamma1, ConstraintGamma2, gr::Tags::Lapse<>,
-                 gr::Tags::Shift<Dim>, gr::Tags::InverseSpatialMetric<Dim>>;
+      tmpl::list<gr::Tags::SpacetimeMetric<Dim>, Tags::Pi<Dim>, Tags::Phi<Dim>,
+                 Tags::ConstraintGamma1, Tags::ConstraintGamma2,
+                 gr::Tags::Lapse<>, gr::Tags::Shift<Dim>,
+                 gr::Tags::InverseSpatialMetric<Dim>>;
 
   static void apply(
       gsl::not_null<tnsr::aa<DataVector, Dim>*>

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -6,12 +6,15 @@
 #include <string>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 
 class DataVector;
 
 namespace GeneralizedHarmonic {
+namespace Tags {
 /*!
  * \brief Conjugate momentum to the spacetime metric.
  *
@@ -60,4 +63,59 @@ struct SpacetimeDerivGaugeH : db::SimpleTag {
   using type = tnsr::ab<DataVector, Dim, Frame>;
   static std::string name() noexcept { return "SpacetimeDerivGaugeH"; }
 };
+
+// @{
+/// \ingroup GeneralizedHarmonicGroup
+/// \brief Tags corresponding to the characteristic fields of the generalized
+/// harmonic system.
+///
+/// \details For details on how these are defined and computed, see
+/// CharacteristicSpeedsCompute
+template <size_t Dim, typename Frame>
+struct UPsi {
+  using type = tnsr::aa<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "UPsi"; }
+};
+template <size_t Dim, typename Frame>
+struct UZero {
+  using type = tnsr::iaa<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "UZero"; }
+};
+template <size_t Dim, typename Frame>
+struct UPlus {
+  using type = tnsr::aa<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "UPlus"; }
+};
+template <size_t Dim, typename Frame>
+struct UMinus {
+  using type = tnsr::aa<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "UMinus"; }
+};
+// @}
+
+template <size_t Dim, typename Frame>
+struct CharacteristicSpeeds : db::SimpleTag {
+  using type = Variables<db::wrap_tags_in<
+      ::Tags::CharSpeed, tmpl::list<UPsi<Dim, Frame>, UZero<Dim, Frame>,
+                                    UPlus<Dim, Frame>, UMinus<Dim, Frame>>>>;
+  static std::string name() noexcept { return "CharacteristicSpeeds"; }
+};
+
+template <size_t Dim, typename Frame>
+struct CharacteristicFields : db::SimpleTag {
+  using type = Variables<tmpl::list<UPsi<Dim, Frame>, UZero<Dim, Frame>,
+                                    UPlus<Dim, Frame>, UMinus<Dim, Frame>>>;
+  static std::string name() noexcept { return "CharacteristicFields"; }
+};
+
+template <size_t Dim, typename Frame>
+struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
+  using type =
+      Variables<tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame, DataVector>,
+                           Pi<Dim, Frame>, Phi<Dim, Frame>>>;
+  static std::string name() noexcept {
+    return "EvolvedFieldsFromCharacteristicFields";
+  }
+};
+}  // namespace Tags
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -8,6 +8,7 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 
 namespace GeneralizedHarmonic {
+namespace Tags {
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct Pi;
 template <size_t Dim, typename Frame = Frame::Inertial>
@@ -20,4 +21,21 @@ template <size_t Dim, typename Frame = Frame::Inertial>
 struct GaugeH;
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeDerivGaugeH;
+
+template<size_t Dim, typename Frame>
+struct UPsi;
+template<size_t Dim, typename Frame>
+struct UZero;
+template<size_t Dim, typename Frame>
+struct UPlus;
+template<size_t Dim, typename Frame>
+struct UMinus;
+
+template<size_t Dim, typename Frame>
+struct CharacteristicSpeeds;
+template<size_t Dim, typename Frame>
+struct CharacteristicFields;
+template<size_t Dim, typename Frame>
+struct EvolvedFieldsFromCharacteristicFields;
+}  // namespace Tags
 }  // namespace GeneralizedHarmonic

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -23,4 +23,5 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
   /// [next_name]
   CHECK(Tags::Next<Tag>::name() == "Next(" + Tag::name() + ")");
   /// [next_name]
+  CHECK(Tags::CharSpeed<Tag>::name() == "CharSpeed(Tag)");
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_GeneralizedHarmonic")
 
 set(LIBRARY_SOURCES
+  Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_DuDt.cpp
   Test_Fluxes.cpp

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -207,3 +207,63 @@ def four_index_constraint(d_phi):
     return constraint
 
 # End test functions for four-index constraint
+
+# Test functions for characteristic speeds
+def char_speed_upsi(gamma1, lapse, shift, unit_normal):
+    return - (1. + gamma1) * np.dot(shift, unit_normal)
+
+
+def char_speed_uzero(gamma1, lapse, shift, unit_normal):
+    return - np.dot(shift, unit_normal)
+
+
+def char_speed_uplus(gamma1, lapse, shift, unit_normal):
+    return - np.dot(shift, unit_normal) + lapse
+
+
+def char_speed_uminus(gamma1, lapse, shift, unit_normal):
+    return - np.dot(shift, unit_normal) - lapse
+
+# End test functions for characteristic speeds
+
+
+# Test functions for characteristic fields
+def char_field_upsi(gamma2, spacetime_metric,
+                    pi, phi, normal_one_form, normal_vector):
+    return spacetime_metric
+
+
+def char_field_uzero(gamma2, spacetime_metric,
+                     pi, phi, normal_one_form, normal_vector):
+    projection_tensor = np.identity(len(normal_vector)) -\
+        np.einsum('i,j', normal_one_form, normal_vector)
+    return np.einsum('ij,jab->iab', projection_tensor, phi)
+
+
+def char_field_uplus(gamma2, spacetime_metric,
+                     pi, phi, normal_one_form, normal_vector):
+    phi_dot_normal = np.einsum('i,iab->ab', normal_vector, phi)
+    return pi + 1*phi_dot_normal - (gamma2 * spacetime_metric)
+
+
+def char_field_uminus(gamma2, spacetime_metric,
+                      pi, phi, normal_one_form, normal_vector):
+    phi_dot_normal = np.einsum('i,iab->ab', normal_vector, phi)
+    return pi - phi_dot_normal - (gamma2 * spacetime_metric)
+
+# Test functions for evolved fields
+
+
+def evol_field_psi(gamma2, upsi, uzero, uplus, uminus, normal_one_form):
+    return upsi
+
+
+def evol_field_pi(gamma2, upsi, uzero, uplus, uminus, normal_one_form):
+    return 0.5 * (uplus + uminus) + gamma2 * upsi
+
+
+def evol_field_phi(gamma2, upsi, uzero, uplus, uminus, normal_one_form):
+    udiff = 0.5 * (uplus - uminus)
+    return np.einsum('i,ab->iab', normal_one_form, udiff) + uzero
+
+# End test functions for characteristic fields

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -1,0 +1,545 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"        // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"  //IWYU pragma: keep
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::Pi
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::Phi
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPsi
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UZero
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UMinus
+// IWYU pragma: no_forward_declare GeneralizedHarmonic::Tags::UPlus
+// IWYU pragma: no_forward_declare Tags::CharSpeed
+// IWYU pragma: no_forward_declare Tags::dt
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Variables
+
+namespace {
+template <typename Tag, size_t Dim, typename Frame>
+Scalar<DataVector> compute_speed_with_tag(
+    const Scalar<DataVector>& gamma_1, const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, Dim, Frame>& shift,
+    const tnsr::i<DataVector, Dim, Frame>& normal) {
+  return get<Tag>(
+      GeneralizedHarmonic::CharacteristicSpeedsCompute<Dim, Frame>::function(
+          gamma_1, lapse, shift, normal));
+}
+
+template <size_t Dim, typename Frame>
+void test_characteristic_speeds() noexcept {
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<1>(
+      compute_speed_with_tag<
+          Tags::CharSpeed<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>>, Dim,
+          Frame>,
+      "TestFunctions", "char_speed_upsi", {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      compute_speed_with_tag<
+          Tags::CharSpeed<GeneralizedHarmonic::Tags::UZero<Dim, Frame>>, Dim,
+          Frame>,
+      "TestFunctions", "char_speed_uzero", {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      compute_speed_with_tag<
+          Tags::CharSpeed<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>>, Dim,
+          Frame>,
+      "TestFunctions", "char_speed_uminus", {{{-10.0, 10.0}}}, used_for_size);
+  pypp::check_with_random_values<1>(
+      compute_speed_with_tag<
+          Tags::CharSpeed<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>>, Dim,
+          Frame>,
+      "TestFunctions", "char_speed_uplus", {{{-10.0, 10.0}}}, used_for_size);
+}
+
+// Test return-by-reference GH char speeds by comparing to Kerr-Schild
+template <typename Solution>
+void test_characteristic_speeds_analytic(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Set up grid
+  const size_t spatial_dim = 3;
+  const size_t data_size = pow<spatial_dim>(grid_size_each_dimension);
+  Mesh<spatial_dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& shift = get<gr::Tags::Shift<spatial_dim>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<spatial_dim>>(vars);
+
+  // Get ingredients
+  const auto gamma_1 = make_with_value<Scalar<DataVector>>(x, 0.1);
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  // Outward 3-normal to the surface on which characteristic fields are needed
+  auto unit_normal_one_form =
+      make_with_value<tnsr::i<DataVector, spatial_dim, Frame::Inertial>>(x, 1.);
+  const auto norm_of_one_form =
+      magnitude(unit_normal_one_form, inverse_spatial_metric);
+  for (size_t i = 0; i < spatial_dim; ++i) {
+    unit_normal_one_form.get(i) /= get(norm_of_one_form);
+  }
+
+  // Get generalized harmonic characteristic speeds locally
+  const auto shift_dot_normal = dot_product(shift, unit_normal_one_form);
+  const auto& upsi_speed = -(1. + get(gamma_1)) * get(shift_dot_normal);
+  const auto& uzero_speed = -get(shift_dot_normal);
+  const auto& uplus_speed = -get(shift_dot_normal) + get(lapse);
+  const auto& uminus_speed = -get(shift_dot_normal) - get(lapse);
+
+  // Check that locally computed fields match returned ones
+  const auto char_speeds_from_func =
+      GeneralizedHarmonic::CharacteristicSpeedsCompute<
+          spatial_dim, Frame::Inertial>::function(gamma_1, lapse, shift,
+                                                  unit_normal_one_form);
+  const auto& upsi_speed_from_func =
+      get(get<Tags::CharSpeed<
+              GeneralizedHarmonic::Tags::UPsi<spatial_dim, Frame::Inertial>>>(
+          char_speeds_from_func));
+  const auto& uzero_speed_from_func =
+      get(get<Tags::CharSpeed<
+              GeneralizedHarmonic::Tags::UZero<spatial_dim, Frame::Inertial>>>(
+          char_speeds_from_func));
+  const auto& uplus_speed_from_func =
+      get(get<Tags::CharSpeed<
+              GeneralizedHarmonic::Tags::UPlus<spatial_dim, Frame::Inertial>>>(
+          char_speeds_from_func));
+  const auto& uminus_speed_from_func =
+      get(get<Tags::CharSpeed<
+              GeneralizedHarmonic::Tags::UMinus<spatial_dim, Frame::Inertial>>>(
+          char_speeds_from_func));
+
+  CHECK_ITERABLE_APPROX(upsi_speed, upsi_speed_from_func);
+  CHECK_ITERABLE_APPROX(uzero_speed, uzero_speed_from_func);
+  CHECK_ITERABLE_APPROX(uplus_speed, uplus_speed_from_func);
+  CHECK_ITERABLE_APPROX(uminus_speed, uminus_speed_from_func);
+}
+}  // namespace
+
+namespace {
+template <typename Tag, size_t Dim, typename Frame>
+typename Tag::type compute_field_with_tag(
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::aa<DataVector, Dim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, Dim, Frame>& pi,
+    const tnsr::iaa<DataVector, Dim, Frame>& phi,
+    const tnsr::i<DataVector, Dim, Frame>& normal_one_form,
+    const tnsr::I<DataVector, Dim, Frame>& normal_vector) {
+  return get<Tag>(
+      GeneralizedHarmonic::CharacteristicFieldsCompute<Dim, Frame>::function(
+          gamma_2, spacetime_metric, pi, phi, normal_one_form, normal_vector));
+}
+
+template <size_t Dim, typename Frame>
+void test_characteristic_fields() noexcept {
+  const DataVector used_for_size(20);
+  // UPsi
+  pypp::check_with_random_values<1>(
+      compute_field_with_tag<GeneralizedHarmonic::Tags::UPsi<Dim, Frame>, Dim,
+                             Frame>,
+      "TestFunctions", "char_field_upsi", {{{-100., 100.}}}, used_for_size);
+  // UZero
+  pypp::check_with_random_values<1>(
+      compute_field_with_tag<GeneralizedHarmonic::Tags::UZero<Dim, Frame>, Dim,
+                             Frame>,
+      "TestFunctions", "char_field_uzero", {{{-100., 100.}}}, used_for_size);
+  // UPlus
+  pypp::check_with_random_values<1>(
+      compute_field_with_tag<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>, Dim,
+                             Frame>,
+      "TestFunctions", "char_field_uplus", {{{-100., 100.}}}, used_for_size);
+  // UMinus
+  pypp::check_with_random_values<1>(
+      compute_field_with_tag<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>, Dim,
+                             Frame>,
+      "TestFunctions", "char_field_uminus", {{{-100., 100.}}}, used_for_size);
+}
+
+// Test return-by-reference GH char fields by comparing to Kerr-Schild
+template <typename Solution>
+void test_characteristic_fields_analytic(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Set up grid
+  const size_t spatial_dim = 3;
+  const size_t data_size = pow<spatial_dim>(grid_size_each_dimension);
+  Mesh<spatial_dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<>>>(vars);
+  const auto& d_lapse =
+      get<typename Solution::template DerivLapse<DataVector>>(vars);
+  const auto& shift = get<gr::Tags::Shift<spatial_dim>>(vars);
+  const auto& d_shift =
+      get<typename Solution::template DerivShift<DataVector>>(vars);
+  const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<spatial_dim>>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<spatial_dim>>(vars);
+  const auto& dt_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<spatial_dim>>>(vars);
+  const auto& d_spatial_metric =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
+
+  // Get ingredients
+  const size_t n_pts = x.begin()->size();
+  const auto gamma_2 = make_with_value<Scalar<DataVector>>(x, 0.1);
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+  const auto normal_one_form =
+      gr::spacetime_normal_one_form<spatial_dim, Frame::Inertial>(lapse);
+  const auto normal_vector = gr::spacetime_normal_vector(lapse, shift);
+  // Outward 3-normal to the surface on which characteristic fields are needed
+  auto unit_normal_one_form =
+      make_with_value<tnsr::i<DataVector, spatial_dim, Frame::Inertial>>(x, 1.);
+  const auto norm_of_one_form =
+      magnitude(unit_normal_one_form, inverse_spatial_metric);
+  for (size_t i = 0; i < spatial_dim; ++i) {
+    unit_normal_one_form.get(i) /= get(norm_of_one_form);
+  }
+  const auto normal =
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
+
+  // Compute characteristic fields locally
+  tnsr::aa<DataVector, spatial_dim, Frame::Inertial> phi_dot_normal{
+      DataVector(n_pts, 0.)};
+  // Compute phi_dot_normal_{ab} = n^i \Phi_{iab}
+  for (size_t mu = 0; mu < spatial_dim + 1; ++mu) {
+    for (size_t nu = 0; nu < mu + 1; ++nu) {
+      for (size_t i = 0; i < spatial_dim; ++i) {
+        phi_dot_normal.get(mu, nu) += normal.get(i) * phi.get(i, mu, nu);
+      }
+    }
+  }
+  tnsr::iaa<DataVector, spatial_dim, Frame::Inertial> phi_dot_projection_tensor{
+      DataVector(n_pts, 0.)};
+  // Compute phi_dot_projection_tensor_{kab} = projection_tensor^i_k \Phi_{kab}
+  for (size_t i = 0; i < spatial_dim; ++i) {
+    for (size_t mu = 0; mu < spatial_dim + 1; ++mu) {
+      for (size_t nu = 0; nu < mu + 1; ++nu) {
+        phi_dot_projection_tensor.get(i, mu, nu) =
+            phi.get(i, mu, nu) -
+            unit_normal_one_form.get(i) * phi_dot_normal.get(mu, nu);
+      }
+    }
+  }
+  // Eq.(32)-(34) of Lindblom+ (2005)
+  const auto& upsi = spacetime_metric;
+  const auto& uzero = phi_dot_projection_tensor;
+  tnsr::aa<DataVector, spatial_dim, Frame::Inertial> uplus{
+      DataVector(n_pts, 0.)};
+  tnsr::aa<DataVector, spatial_dim, Frame::Inertial> uminus{
+      DataVector(n_pts, 0.)};
+  for (size_t mu = 0; mu < spatial_dim + 1; ++mu) {
+    for (size_t nu = 0; nu < mu + 1; ++nu) {
+      uplus.get(mu, nu) = pi.get(mu, nu) + phi_dot_normal.get(mu, nu) -
+                          get(gamma_2) * spacetime_metric.get(mu, nu);
+      uminus.get(mu, nu) = pi.get(mu, nu) - phi_dot_normal.get(mu, nu) -
+                           get(gamma_2) * spacetime_metric.get(mu, nu);
+    }
+  }
+
+  // Check that locally computed fields match returned ones
+  const auto uvars = GeneralizedHarmonic::CharacteristicFieldsCompute<
+      spatial_dim, Frame::Inertial>::function(gamma_2, spacetime_metric, pi,
+                                              phi, unit_normal_one_form,
+                                              normal);
+
+  const auto& upsi_from_func =
+      get<GeneralizedHarmonic::Tags::UPsi<spatial_dim, Frame::Inertial>>(uvars);
+  const auto& uzero_from_func =
+      get<GeneralizedHarmonic::Tags::UZero<spatial_dim, Frame::Inertial>>(
+          uvars);
+  const auto& uplus_from_func =
+      get<GeneralizedHarmonic::Tags::UPlus<spatial_dim, Frame::Inertial>>(
+          uvars);
+  const auto& uminus_from_func =
+      get<GeneralizedHarmonic::Tags::UMinus<spatial_dim, Frame::Inertial>>(
+          uvars);
+
+  CHECK_ITERABLE_APPROX(upsi, upsi_from_func);
+  CHECK_ITERABLE_APPROX(uzero, uzero_from_func);
+  CHECK_ITERABLE_APPROX(uplus, uplus_from_func);
+  CHECK_ITERABLE_APPROX(uminus, uminus_from_func);
+}
+}  // namespace
+
+namespace {
+template <typename Tag, size_t Dim, typename Frame>
+typename Tag::type compute_evol_field_with_tag(
+    const Scalar<DataVector>& gamma_2,
+    const tnsr::aa<DataVector, Dim, Frame>& u_psi,
+    const tnsr::iaa<DataVector, Dim, Frame>& u_zero,
+    const tnsr::aa<DataVector, Dim, Frame>& u_plus,
+    const tnsr::aa<DataVector, Dim, Frame>& u_minus,
+    const tnsr::i<DataVector, Dim, Frame>& normal_one_form) {
+  return get<Tag>(
+      GeneralizedHarmonic::EvolvedFieldsFromCharacteristicFieldsCompute<
+          Dim, Frame>::function(gamma_2, u_psi, u_zero, u_plus, u_minus,
+                                normal_one_form));
+}
+
+template <size_t Dim, typename Frame>
+void test_evolved_from_characteristic_fields() noexcept {
+  const DataVector used_for_size(20);
+  // Psi
+  pypp::check_with_random_values<1>(
+      compute_evol_field_with_tag<gr::Tags::SpacetimeMetric<Dim, Frame>, Dim,
+                                  Frame>,
+      "TestFunctions", "evol_field_psi", {{{-100., 100.}}}, used_for_size);
+  // Pi
+  pypp::check_with_random_values<1>(
+      compute_evol_field_with_tag<GeneralizedHarmonic::Tags::Pi<Dim, Frame>,
+                                  Dim, Frame>,
+      "TestFunctions", "evol_field_pi", {{{-100., 100.}}}, used_for_size);
+  // Phi
+  pypp::check_with_random_values<1>(
+      compute_evol_field_with_tag<GeneralizedHarmonic::Tags::Phi<Dim, Frame>,
+                                  Dim, Frame>,
+      "TestFunctions", "evol_field_phi", {{{-100., 100.}}}, used_for_size);
+}
+
+// Test return-by-reference GH fundamental fields by comparing to Kerr-Schild
+template <typename Solution>
+void test_evolved_from_characteristic_fields_analytic(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound) noexcept {
+  // Set up grid
+  const size_t spatial_dim = 3;
+  const size_t data_size = pow<spatial_dim>(grid_size_each_dimension);
+  Mesh<spatial_dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<>>>(vars);
+  const auto& d_lapse =
+      get<typename Solution::template DerivLapse<DataVector>>(vars);
+  const auto& shift = get<gr::Tags::Shift<spatial_dim>>(vars);
+  const auto& d_shift =
+      get<typename Solution::template DerivShift<DataVector>>(vars);
+  const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<spatial_dim>>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<spatial_dim>>(vars);
+  const auto& dt_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<spatial_dim>>>(vars);
+  const auto& d_spatial_metric =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
+
+  // Get ingredients
+  const size_t n_pts = x.begin()->size();
+  const auto gamma_2 = make_with_value<Scalar<DataVector>>(x, 0.1);
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+  const auto normal_one_form =
+      gr::spacetime_normal_one_form<spatial_dim, Frame::Inertial>(lapse);
+  const auto normal_vector = gr::spacetime_normal_vector(lapse, shift);
+  // Outward 3-normal to the surface on which characteristic fields are needed
+  auto unit_normal_one_form =
+      make_with_value<tnsr::i<DataVector, spatial_dim, Frame::Inertial>>(x, 1.);
+  const auto norm_of_one_form =
+      magnitude(unit_normal_one_form, inverse_spatial_metric);
+  for (size_t i = 0; i < spatial_dim; ++i) {
+    unit_normal_one_form.get(i) /= get(norm_of_one_form);
+  }
+  const auto normal =
+      raise_or_lower_index(unit_normal_one_form, inverse_spatial_metric);
+
+  // Fundamental fields (psi, pi, phi) have already been computed locally.
+  // Now, check that these locally computed fields match returned ones
+  tnsr::aa<DataVector, spatial_dim, Frame::Inertial> phi_dot_normal{
+      DataVector(n_pts, 0.)};
+  // Compute phi_dot_normal_{ab} = n^i \Phi_{iab}
+  for (size_t mu = 0; mu < spatial_dim + 1; ++mu) {
+    for (size_t nu = 0; nu < mu + 1; ++nu) {
+      for (size_t i = 0; i < spatial_dim; ++i) {
+        phi_dot_normal.get(mu, nu) += normal.get(i) * phi.get(i, mu, nu);
+      }
+    }
+  }
+  tnsr::iaa<DataVector, spatial_dim, Frame::Inertial> phi_dot_projection_tensor{
+      DataVector(n_pts, 0.)};
+  // Compute phi_dot_projection_tensor_{kab} = projection_tensor^i_k \Phi_{kab}
+  for (size_t i = 0; i < spatial_dim; ++i) {
+    for (size_t mu = 0; mu < spatial_dim + 1; ++mu) {
+      for (size_t nu = 0; nu < mu + 1; ++nu) {
+        phi_dot_projection_tensor.get(i, mu, nu) =
+            phi.get(i, mu, nu) -
+            unit_normal_one_form.get(i) * phi_dot_normal.get(mu, nu);
+      }
+    }
+  }
+  // Eq.(32)-(34) of Lindblom+ (2005)
+  const auto& upsi = spacetime_metric;
+  const auto& uzero = phi_dot_projection_tensor;
+  tnsr::aa<DataVector, spatial_dim, Frame::Inertial> uplus{
+      DataVector(n_pts, 0.)};
+  tnsr::aa<DataVector, spatial_dim, Frame::Inertial> uminus{
+      DataVector(n_pts, 0.)};
+  for (size_t mu = 0; mu < spatial_dim + 1; ++mu) {
+    for (size_t nu = 0; nu < mu + 1; ++nu) {
+      uplus.get(mu, nu) = pi.get(mu, nu) + phi_dot_normal.get(mu, nu) -
+                          get(gamma_2) * spacetime_metric.get(mu, nu);
+      uminus.get(mu, nu) = pi.get(mu, nu) - phi_dot_normal.get(mu, nu) -
+                           get(gamma_2) * spacetime_metric.get(mu, nu);
+    }
+  }
+  const auto ffields =
+      GeneralizedHarmonic::EvolvedFieldsFromCharacteristicFieldsCompute<
+          spatial_dim, Frame::Inertial>::function(gamma_2, upsi, uzero, uplus,
+                                                  uminus, unit_normal_one_form);
+  const auto& psi_from_func =
+      get<gr::Tags::SpacetimeMetric<spatial_dim, Frame::Inertial>>(ffields);
+  const auto& pi_from_func =
+      get<GeneralizedHarmonic::Tags::Pi<spatial_dim, Frame::Inertial>>(ffields);
+  const auto& phi_from_func =
+      get<GeneralizedHarmonic::Tags::Phi<spatial_dim, Frame::Inertial>>(
+          ffields);
+
+  CHECK_ITERABLE_APPROX(spacetime_metric, psi_from_func);
+  CHECK_ITERABLE_APPROX(pi, pi_from_func);
+  CHECK_ITERABLE_APPROX(phi, phi_from_func);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.Characteristics",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GeneralizedHarmonic/"};
+
+  test_characteristic_speeds<1, Frame::Grid>();
+  test_characteristic_speeds<2, Frame::Grid>();
+  test_characteristic_speeds<3, Frame::Grid>();
+  test_characteristic_speeds<1, Frame::Inertial>();
+  test_characteristic_speeds<2, Frame::Inertial>();
+  test_characteristic_speeds<3, Frame::Inertial>();
+
+  // Test GH characteristic speeds against Kerr Schild
+  const double mass = 2.;
+  const std::array<double, 3> spin{{0.3, 0.5, 0.2}};
+  const std::array<double, 3> center{{0.2, 0.3, 0.4}};
+  const gr::Solutions::KerrSchild solution(mass, spin, center);
+
+  const size_t grid_size = 8;
+  const std::array<double, 3> lower_bound{{0.82, 1.22, 1.32}};
+  const std::array<double, 3> upper_bound{{0.78, 1.18, 1.28}};
+
+  test_characteristic_speeds_analytic(solution, grid_size, lower_bound,
+                                      upper_bound);
+
+  test_characteristic_fields<1, Frame::Grid>();
+  test_characteristic_fields<2, Frame::Grid>();
+  test_characteristic_fields<3, Frame::Grid>();
+  test_characteristic_fields<1, Frame::Inertial>();
+  test_characteristic_fields<2, Frame::Inertial>();
+  test_characteristic_fields<3, Frame::Inertial>();
+
+  test_evolved_from_characteristic_fields<1, Frame::Grid>();
+  test_evolved_from_characteristic_fields<2, Frame::Grid>();
+  test_evolved_from_characteristic_fields<3, Frame::Grid>();
+  test_evolved_from_characteristic_fields<1, Frame::Inertial>();
+  test_evolved_from_characteristic_fields<2, Frame::Inertial>();
+  test_evolved_from_characteristic_fields<3, Frame::Inertial>();
+
+  // Test GH characteristic fields against Kerr Schild
+  test_characteristic_fields_analytic(solution, grid_size, lower_bound,
+                                      upper_bound);
+  test_evolved_from_characteristic_fields_analytic(solution, grid_size,
+                                                   lower_bound, upper_bound);
+}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -179,9 +179,9 @@ void test_two_index_constraint_analytic(
     const double error_tolerance) noexcept {
   // Shorter names for tags.
   using SpacetimeMetric = gr::Tags::SpacetimeMetric<3, Frame::Inertial>;
-  using Pi = ::GeneralizedHarmonic::Pi<3, Frame::Inertial>;
-  using Phi = ::GeneralizedHarmonic::Phi<3, Frame::Inertial>;
-  using GaugeH = ::GeneralizedHarmonic::GaugeH<3, Frame::Inertial>;
+  using Pi = ::GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>;
+  using Phi = ::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>;
+  using GaugeH = ::GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>;
   using VariablesTags = tmpl::list<SpacetimeMetric, Pi, Phi, GaugeH>;
 
   // Check vs. time-independent analytic solution
@@ -309,7 +309,7 @@ void test_four_index_constraint_analytic(
     const std::array<double, 3>& upper_bound,
     const double error_tolerance) noexcept {
   // Shorter names for tags.
-  using Phi = ::GeneralizedHarmonic::Phi<3, Frame::Inertial>;
+  using Phi = ::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>;
   using VariablesTags = tmpl::list<Phi>;
 
   // Check vs. time-independent analytic solution

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -55,9 +55,9 @@ void verify_time_independent_einstein_solution(
     const double error_tolerance) noexcept {
   // Shorter names for tags.
   using SpacetimeMetric = gr::Tags::SpacetimeMetric<3, Frame::Inertial>;
-  using Pi = ::GeneralizedHarmonic::Pi<3, Frame::Inertial>;
-  using Phi = ::GeneralizedHarmonic::Phi<3, Frame::Inertial>;
-  using GaugeH = ::GeneralizedHarmonic::GaugeH<3, Frame::Inertial>;
+  using Pi = ::GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>;
+  using Phi = ::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>;
+  using GaugeH = ::GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>;
   using VariablesTags = tmpl::list<SpacetimeMetric, Pi, Phi, GaugeH>;
 
   // Set up grid


### PR DESCRIPTION
## Proposed changes
- Adds functionality to compute characteristic speeds for the GH system.
- Adds functionality to compute characteristic fields for the GH system.
- Adds functionality to compute evolved GH fields from its characteristic fields.
- All fields are stored in a Variables container, which is returned to the user.
- This PR uses code from #1071 that adds characteristic speeds for the GH system, _and replaces it_


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
