### PR TITLE
Minor fixes to Wedge3D documentation

### DIFF
--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -148,7 +148,7 @@ namespace CoordinateMaps {
  *  F_1 &= \partial_{\zeta} F = \frac{1}{2} \big\{ (1-s_{outer})R_{outer} -
  * (1-s_{inner})R_{inner}\big\}\\
  *  S_0 &= \frac{1}{2} \big\{ s_{outer}R_{outer} + s_{inner}R_{inner}\big\}\\
- *  S_1 &= \partial_{\zeta} F = \frac{1}{2} \big\{ s_{outer}R_{outer} -
+ *  S_1 &= \partial_{\zeta} S = \frac{1}{2} \big\{ s_{outer}R_{outer} -
  * s_{inner}R_{inner}\big\}\f}
  *
  *  The map can then be rewritten as:
@@ -187,15 +187,21 @@ namespace CoordinateMaps {
  *
  *  ### Changing the radial distribution of the gridpoints
  *  By default, Wedge3D linearly distributes its gridpoints in the radial
- *  direction. An exponential map can be applied to the sphere factor
- *  \f$S(\zeta)\f$ in order to obtain a relatively higher resolution at smaller
- *  radii. Since this is a radial rescaling of Wedge3D, this option is only
- *  supported for fully spherical wedges with
- *  `sphericity_inner` = `sphericity_outer` = 1.
+ *  direction. An exponential distribution of gridpoints can be obtained by
+ *  linearly interpolating in the logarithm of the radius, in order to obtain
+ *  a relatively higher resolution at smaller radii. Since this is a radial
+ *  rescaling of Wedge3D, this option is only supported for fully spherical
+ *  wedges with `sphericity_inner` = `sphericity_outer` = 1.
+ *
+ *  The linear interpolation done is:
+ *  \f[
+ *  \log r = \frac{1-\zeta}{2}\log R_{inner} +
+ *  \frac{1+\zeta}{2}\log R_{outer}
+ *  \f]
  *
  *  The map then is:
  *  \f[\vec{x}(\xi,\eta,\zeta) =
- *  \frac{e^{S(\zeta)}}{\rho}\begin{bmatrix}
+ *  \frac{\sqrt{R_{inner}^{1-\zeta}R_{outer}^{1+\zeta}}}{\rho}\begin{bmatrix}
  *  \Xi\\
  *  \mathrm{H}\\
  *  1\\


### PR DESCRIPTION
## Proposed changes

Clarification of the log radial scaling used in Wedge3D, as well as a typo fix.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
