### PR TITLE
Correct names in parallel interpolator

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
@@ -27,7 +27,7 @@ template <typename Metavariables, typename InterpolationTargetTag,
           size_t VolumeDim, typename Frame>
 class InterpolationTarget;
 namespace Actions {
-template <typename InterpolationTargetTag>
+template <typename InterpolationTargetTag, size_t VolumeDim>
 struct CleanUpInterpolator;
 }  // namespace Actions
 namespace Tags {
@@ -79,7 +79,8 @@ void callback_and_cleanup(
   auto& interpolator_proxy =
       Parallel::get_parallel_component<Interpolator<Metavariables, VolumeDim>>(
           *cache);
-  Parallel::simple_action<Actions::CleanUpInterpolator<InterpolationTargetTag>>(
+  Parallel::simple_action<
+      Actions::CleanUpInterpolator<InterpolationTargetTag, VolumeDim>>(
       interpolator_proxy, temporal_id);
 
   // If there are further temporal_ids, begin interpolation for
@@ -104,7 +105,8 @@ namespace Actions {
 /// If interpolated variables for all target points have been received, then
 /// - Calls `InterpolationTargetTag::post_interpolation_callback`
 /// - Tells `Interpolator`s that the interpolation is complete
-///  (by calling `Actions::CleanUpInterpolator<InterpolationTargetTag>`)
+///  (by calling
+///  `Actions::CleanUpInterpolator<InterpolationTargetTag,VolumeDim>`)
 /// - Removes the first `temporal_id` from `Tags::TemporalIds<Metavariables>`
 /// - If there are more `temporal_id`s, begins interpolation at the next
 ///  `temporal_id` (by calling `InterpolationTargetTag::compute_target_points`)

--- a/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
@@ -19,8 +19,8 @@ namespace intrp {
 template <typename Metavariables, size_t VolumeDim>
 struct Interpolator;
 namespace Actions {
-template <typename InterpolationTargetTag>
-struct ReceiveInterpolationPoints;
+template <typename InterpolationTargetTag, typename Frame>
+struct ReceivePoints;
 }  // namespace Actions
 }  // namespace intrp
 /// \endcond
@@ -74,7 +74,7 @@ void send_points_to_interpolator(
       Parallel::get_parallel_component<Interpolator<Metavariables, VolumeDim>>(
           cache);
   Parallel::simple_action<
-      Actions::ReceiveInterpolationPoints<InterpolationTargetTag>>(
+      Actions::ReceivePoints<InterpolationTargetTag, Frame>>(
       receiver_proxy, temporal_id, std::move(coords));
 }
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -37,8 +37,8 @@
 /// \cond
 namespace intrp {
 namespace Actions {
-template <typename InterpolationTargetTag>
-struct ReceiveInterpolationPoints;
+template <typename InterpolationTargetTag, typename Frame>
+struct ReceivePoints;
 }  // namespace Actions
 }  // namespace intrp
 template <typename IdType, typename DataType>
@@ -81,7 +81,7 @@ struct mock_interpolation_target {
 };
 
 template <typename InterpolationTargetTag>
-struct MockReceiveInterpolationPoints {
+struct MockReceivePoints {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent, size_t VolumeDim,
@@ -131,10 +131,9 @@ struct mock_interpolator {
           VolumeDim>::template return_tag_list<Metavariables>>;
 
   using component_being_mocked = intrp::Interpolator<Metavariables, VolumeDim>;
-  using replace_these_simple_actions =
-      tmpl::list<intrp::Actions::ReceiveInterpolationPoints<
-          typename Metavariables::InterpolationTargetA>>;
-  using with_these_simple_actions = tmpl::list<MockReceiveInterpolationPoints<
+  using replace_these_simple_actions = tmpl::list<intrp::Actions::ReceivePoints<
+      typename Metavariables::InterpolationTargetA, Frame::Inertial>>;
+  using with_these_simple_actions = tmpl::list<MockReceivePoints<
       typename Metavariables::InterpolationTargetA>>;
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -40,7 +40,7 @@
 // IWYU pragma: no_forward_declare Variables
 namespace intrp {
 namespace Actions {
-template <typename InterpolationTargetTag>
+template <typename InterpolationTargetTag, size_t VolumeDim>
 struct CleanUpInterpolator;
 }  // namespace Actions
 }  // namespace intrp
@@ -80,7 +80,7 @@ struct mock_interpolation_target {
                                                             ::Frame::Inertial>>;
 };
 
-template <typename InterpolationTargetTag>
+template <typename InterpolationTargetTag, size_t VolumeDim>
 struct MockCleanUpInterpolator {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -181,9 +181,9 @@ struct mock_interpolator {
   using component_being_mocked = intrp::Interpolator<Metavariables, VolumeDim>;
   using replace_these_simple_actions =
       tmpl::list<intrp::Actions::CleanUpInterpolator<
-          typename Metavariables::InterpolationTargetA>>;
+          typename Metavariables::InterpolationTargetA, 3>>;
   using with_these_simple_actions = tmpl::list<
-      MockCleanUpInterpolator<typename Metavariables::InterpolationTargetA>>;
+      MockCleanUpInterpolator<typename Metavariables::InterpolationTargetA, 3>>;
 };
 
 struct MockMetavariables {


### PR DESCRIPTION
## Proposed changes

Corrects a few names and template parameters of Actions that are called inside of other Actions.
This was not noticed in the tests, because the called Actions were mocked (and the mocked Actions had the wrong names and template parameters).

### Types of changes:

- [x] Bugfix

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
