### PR TITLE
Frames in parallel interpolator

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
@@ -37,28 +37,30 @@ namespace Actions {
 template <typename InterpolationTargetTag>
 struct InitializeInterpolationTarget {
   /// For requirements on Metavariables, see InterpolationTarget
-  template <typename Metavariables, size_t VolumeDim, typename Frame>
+  template <typename Metavariables, size_t VolumeDim>
   using return_tag_list = tmpl::list<
       Tags::IndicesOfFilledInterpPoints, Tags::TemporalIds<Metavariables>,
-      ::Tags::Domain<VolumeDim, Frame>,
+      ::Tags::Domain<VolumeDim, typename Metavariables::domain_frame>,
       ::Tags::Variables<
           typename InterpolationTargetTag::vars_to_interpolate_to_target>>;
   template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
-            typename ActionList, typename ParallelComponent, size_t VolumeDim,
-            typename Frame>
+            typename ActionList, typename ParallelComponent, size_t VolumeDim>
   static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/,
-                    Domain<VolumeDim, Frame>&& domain) noexcept {
-    return std::make_tuple(db::create<db::get_items<return_tag_list<
-                               Metavariables, VolumeDim, Frame>>>(
-        db::item_type<Tags::IndicesOfFilledInterpPoints>{},
-        db::item_type<Tags::TemporalIds<Metavariables>>{}, std::move(domain),
-        db::item_type<::Tags::Variables<typename InterpolationTargetTag::
-                                            vars_to_interpolate_to_target>>{}));
+                    Domain<VolumeDim, typename Metavariables::domain_frame>&&
+                        domain) noexcept {
+    return std::make_tuple(
+        db::create<db::get_items<return_tag_list<Metavariables, VolumeDim>>>(
+            db::item_type<Tags::IndicesOfFilledInterpPoints>{},
+            db::item_type<Tags::TemporalIds<Metavariables>>{},
+            std::move(domain),
+            db::item_type<
+                ::Tags::Variables<typename InterpolationTargetTag::
+                                      vars_to_interpolate_to_target>>{}));
   }
 };
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -20,8 +20,8 @@ namespace OptionHolders {
 /// A line segment extending from `Begin` to `End`,
 /// containing `NumberOfPoints` uniformly-spaced points including the endpoints.
 ///
-/// \note Input coordinates are interpreted in the frame given by the `Frame`
-/// by the `Frame` template parameter of the `Actions::LineSegment`.
+/// \note Input coordinates are interpreted in the frame given by
+/// `Metavariables::domain_frame`
 template <size_t VolumeDim>
 struct LineSegment {
   struct Begin {
@@ -90,7 +90,7 @@ namespace Actions {
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
-template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+template <typename InterpolationTargetTag, size_t VolumeDim>
 struct LineSegment {
   using options_type = OptionHolders::LineSegment<VolumeDim>;
   using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
@@ -110,8 +110,8 @@ struct LineSegment {
 
     // Fill points on a line segment
     const double fractional_distance = 1.0 / (options.number_of_points - 1);
-    tnsr::I<DataVector, VolumeDim, Frame> target_points(
-        options.number_of_points);
+    tnsr::I<DataVector, VolumeDim, typename Metavariables::domain_frame>
+        target_points(options.number_of_points);
     for (size_t n = 0; n < options.number_of_points; ++n) {
       for (size_t d = 0; d < VolumeDim; ++d) {
         target_points.get(d)[n] =

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp
@@ -24,7 +24,7 @@ namespace intrp {
 template <class Metavariables, size_t VolumeDim>
 struct Interpolator;
 template <typename Metavariables, typename InterpolationTargetTag,
-          size_t VolumeDim, typename Frame>
+          size_t VolumeDim>
 class InterpolationTarget;
 namespace Actions {
 template <typename InterpolationTargetTag, size_t VolumeDim>
@@ -48,7 +48,7 @@ namespace InterpolationTarget_detail {
 /// Calls the callback function, tells interpolators to clean up the current
 /// temporal_id, and then if there are more temporal_ids to be interpolated,
 /// starts the next one.
-template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame,
+template <typename InterpolationTargetTag, size_t VolumeDim,
           typename DbTags, typename Metavariables>
 void callback_and_cleanup(
     const gsl::not_null<db::DataBox<DbTags>*> box,
@@ -88,7 +88,7 @@ void callback_and_cleanup(
   const auto& temporal_ids = db::get<Tags::TemporalIds<Metavariables>>(*box);
   if (not temporal_ids.empty()) {
     auto& my_proxy = Parallel::get_parallel_component<InterpolationTarget<
-        Metavariables, InterpolationTargetTag, VolumeDim, Frame>>(*cache);
+        Metavariables, InterpolationTargetTag, VolumeDim>>(*cache);
     Parallel::simple_action<
         typename InterpolationTargetTag::compute_target_points>(
         my_proxy, temporal_ids.front());
@@ -128,7 +128,7 @@ namespace Actions {
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
-template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+template <typename InterpolationTargetTag, size_t VolumeDim>
 struct InterpolationTargetReceiveVars {
   /// For requirements on Metavariables, see InterpolationTarget
   template <typename DbTags, typename... InboxTags, typename Metavariables,
@@ -193,7 +193,7 @@ struct InterpolationTargetReceiveVars {
             .number_of_grid_points()) {
       // All the points have been interpolated.
       InterpolationTarget_detail::callback_and_cleanup<InterpolationTargetTag,
-                                                       VolumeDim, Frame>(
+                                                       VolumeDim>(
           make_not_null(&box), make_not_null(&cache));
     }
   }

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -57,7 +57,7 @@ namespace OptionHolders {
 /// then \f$\theta\f$, and finally \f$\phi\f$ varying slowest.
 ///
 /// \note Input coordinates (radii, angles) are interpreted in the frame given
-/// by the `Frame` template parameter of the `Actions::WedgeSectionTorus`.
+/// by `Metavariables::domain_frame`
 struct WedgeSectionTorus {
   struct MinRadius {
     using type = double;
@@ -169,7 +169,7 @@ namespace Actions {
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
 ///
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
-template <typename InterpolationTargetTag, typename Frame>
+template <typename InterpolationTargetTag>
 struct WedgeSectionTorus {
   using options_type = OptionHolders::WedgeSectionTorus;
   using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
@@ -261,7 +261,8 @@ struct WedgeSectionTorus {
 
     // Compute x/y/z coordinates
     // Note: theta measured from +z axis, phi measured from +x axis
-    tnsr::I<DataVector, 3, Frame> target_points(num_total);
+    tnsr::I<DataVector, 3, typename Metavariables::domain_frame> target_points(
+        num_total);
     get<0>(target_points) = radii * sin(thetas) * cos(phis);
     get<1>(target_points) = radii * sin(thetas) * sin(phis);
     get<2>(target_points) = radii * cos(thetas);

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
@@ -58,7 +58,7 @@ namespace Actions {
 ///   - `Tags::InterpolatedVarsHolders<Metavariables,VolumeDim>`
 ///
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
-template <typename InterpolationTargetTag, typename Frame>
+template <typename InterpolationTargetTag>
 struct ReceivePoints {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -95,7 +95,7 @@ struct ReceivePoints {
                   std::move(block_logical_coords)}));
         });
 
-    try_to_interpolate<InterpolationTargetTag, VolumeDim, Frame>(
+    try_to_interpolate<InterpolationTargetTag, VolumeDim>(
         make_not_null(&box), make_not_null(&cache), temporal_id);
   }
 };

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp
@@ -37,7 +37,6 @@ namespace Actions {
 /// - Modifies:
 ///   - `Tags::VolumeVarsInfo<Metavariables,VolumeDim>`
 ///   - `Tags::InterpolatedVarsHolders<Metavariables,VolumeDim>`
-template <typename Frame>
 struct InterpolatorReceiveVolumeData {
   template <
       typename DbTags, typename... InboxTags, typename Metavariables,
@@ -79,9 +78,8 @@ struct InterpolatorReceiveVolumeData {
     tmpl::for_each<typename Metavariables::interpolation_target_tags>(
         [&box, &cache, &temporal_id](auto x) noexcept {
           using tag = typename decltype(x)::type;
-          try_to_interpolate<tag, VolumeDim, Frame>(make_not_null(&box),
-                                                    make_not_null(&cache),
-                                                    temporal_id);
+          try_to_interpolate<tag, VolumeDim>(
+              make_not_null(&box), make_not_null(&cache), temporal_id);
         });
   }
 };

--- a/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
@@ -19,7 +19,7 @@ namespace intrp {
 template <typename Metavariables, size_t VolumeDim>
 struct Interpolator;
 namespace Actions {
-template <typename InterpolationTargetTag, typename Frame>
+template <typename InterpolationTargetTag>
 struct ReceivePoints;
 }  // namespace Actions
 }  // namespace intrp
@@ -74,7 +74,7 @@ void send_points_to_interpolator(
       Parallel::get_parallel_component<Interpolator<Metavariables, VolumeDim>>(
           cache);
   Parallel::simple_action<
-      Actions::ReceivePoints<InterpolationTargetTag, Frame>>(
+      Actions::ReceivePoints<InterpolationTargetTag>>(
       receiver_proxy, temporal_id, std::move(coords));
 }
 

--- a/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
@@ -19,10 +19,10 @@
 /// \cond
 namespace intrp {
 template <typename Metavariables, typename InterpolationTargetTag,
-          size_t VolumeDim, typename Frame>
+          size_t VolumeDim>
 struct InterpolationTarget;
 namespace Actions {
-template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+template <typename InterpolationTargetTag, size_t VolumeDim>
 struct InterpolationTargetReceiveVars;
 }  // namespace Actions
 }  // namespace intrp
@@ -121,7 +121,7 @@ void interpolate_data(
 
 /// Check if we have enough information to interpolate.  If so, do the
 /// interpolation and send data to the InterpolationTarget.
-template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame,
+template <typename InterpolationTargetTag, size_t VolumeDim,
           typename Metavariables, typename DbTags>
 void try_to_interpolate(
     const gsl::not_null<db::DataBox<DbTags>*> box,
@@ -154,10 +154,10 @@ void try_to_interpolate(
       const auto& info = vars_infos.at(temporal_id);
       auto& receiver_proxy =
           Parallel::get_parallel_component<InterpolationTarget<
-              Metavariables, InterpolationTargetTag, VolumeDim, Frame>>(*cache);
+              Metavariables, InterpolationTargetTag, VolumeDim>>(*cache);
       Parallel::simple_action<Actions::InterpolationTargetReceiveVars<
-          InterpolationTargetTag, VolumeDim, Frame>>(receiver_proxy, info.vars,
-                                                     info.global_offsets);
+          InterpolationTargetTag, VolumeDim>>(receiver_proxy, info.vars,
+                                              info.global_offsets);
     }
 
     // Clear interpolated data, since we don't need it anymore.

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -35,7 +35,7 @@
 /// \cond
 namespace intrp {
 namespace Actions {
-template <typename InterpolationTargetTag, typename Frame>
+template <typename InterpolationTargetTag>
 struct ReceivePoints;
 }  // namespace Actions
 }  // namespace intrp
@@ -77,8 +77,7 @@ struct mock_interpolation_target {
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
       typename ::intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
-                                                            ::Frame::Inertial>>;
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3>>;
 };
 
 template <typename InterpolationTargetTag>
@@ -133,7 +132,7 @@ struct mock_interpolator {
 
   using component_being_mocked = intrp::Interpolator<Metavariables, VolumeDim>;
   using replace_these_simple_actions = tmpl::list<intrp::Actions::ReceivePoints<
-      typename Metavariables::InterpolationTargetA, Frame::Inertial>>;
+      typename Metavariables::InterpolationTargetA>>;
   using with_these_simple_actions = tmpl::list<
       MockReceivePoints<typename Metavariables::InterpolationTargetA>>;
 };

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Shell.hpp"
 #include "NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp" // IWYU pragma: keep
@@ -28,9 +29,6 @@
 
 /// \cond
 class DataVector;
-namespace Frame {
-struct Inertial;
-}  // namespace Frame
 namespace intrp {
 namespace Tags {
 struct IndicesOfFilledInterpPoints;
@@ -56,8 +54,7 @@ struct mock_interpolation_target {
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
       typename ::intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
-                                                            ::Frame::Inertial>>;
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3>>;
 };
 
 struct MockComputeTargetPoints {
@@ -93,6 +90,7 @@ struct MockMetavariables {
     using compute_target_points = MockComputeTargetPoints;
   };
   using temporal_id = Time;
+  using domain_frame = Frame::Inertial;
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Shell.hpp"
@@ -25,9 +26,6 @@
 
 /// \cond
 class DataVector;
-namespace Frame {
-struct Inertial;
-}  // namespace Frame
 namespace Tags {
 template <size_t Dim, typename Frame>
 struct Domain;
@@ -45,8 +43,7 @@ struct mock_interpolation_target {
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
       typename ::intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
-                                                            ::Frame::Inertial>>;
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3>>;
 };
 
 struct MockMetavariables {
@@ -55,6 +52,7 @@ struct MockMetavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
   using temporal_id = Time;
+  using domain_frame = Frame::Inertial;
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -25,10 +25,11 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_target_points =
-        ::intrp::Actions::LineSegment<InterpolationTargetA, 3, Frame::Inertial>;
+        ::intrp::Actions::LineSegment<InterpolationTargetA, 3>;
     using type = compute_target_points::options_type;
   };
   using temporal_id = Time;
+  using domain_frame = Frame::Inertial;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetReceiveVars.cpp
@@ -70,14 +70,12 @@ struct mock_interpolation_target {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using component_being_mocked =
-      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3,
-                                 Frame::Inertial>;
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3>;
   using const_global_cache_tag_list = tmpl::list<>;
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
-                                                            ::Frame::Inertial>>;
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3>>;
 };
 
 template <typename InterpolationTargetTag, size_t VolumeDim>
@@ -197,6 +195,7 @@ struct MockMetavariables {
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
   using temporal_id = Time;
+  using domain_frame = Frame::Inertial;
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
@@ -227,21 +226,22 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.ReceiveVars",
   // Set databox to contain two temporal_ids and a vars of num_points points.
   tuples::get<MockDistributedObjectsTagTarget>(dist_objects)
       .emplace(
-          0, ActionTesting::MockDistributedObject<mock_interpolation_target<
-                 metavars, metavars::InterpolationTargetA>>{
-                 db::create<db::get_items<
-                     intrp::Actions::InitializeInterpolationTarget<
-                         metavars::InterpolationTargetA>::
-                         return_tag_list<metavars, 3, Frame::Inertial>>>(
-                     db::item_type<intrp::Tags::IndicesOfFilledInterpPoints>{},
-                     db::item_type<intrp::Tags::TemporalIds<metavars>>{
-                         Time(slab, Rational(13, 15)),
-                         Time(slab, Rational(14, 15))},
-                     domain_creator.create_domain(),
-                     db::item_type<
-                         ::Tags::Variables<metavars::InterpolationTargetA::
-                                               vars_to_interpolate_to_target>>{
-                         num_points})});
+          0,
+          ActionTesting::MockDistributedObject<mock_interpolation_target<
+              metavars, metavars::InterpolationTargetA>>{
+              db::create<
+                  db::get_items<intrp::Actions::InitializeInterpolationTarget<
+                      metavars::InterpolationTargetA>::return_tag_list<metavars,
+                                                                       3>>>(
+                  db::item_type<intrp::Tags::IndicesOfFilledInterpPoints>{},
+                  db::item_type<intrp::Tags::TemporalIds<metavars>>{
+                      Time(slab, Rational(13, 15)),
+                      Time(slab, Rational(14, 15))},
+                  domain_creator.create_domain(),
+                  db::item_type<
+                      ::Tags::Variables<metavars::InterpolationTargetA::
+                                            vars_to_interpolate_to_target>>{
+                      num_points})});
 
   tuples::get<MockDistributedObjectsTagInterpolator>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<
@@ -293,8 +293,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.ReceiveVars",
   runner.simple_action<
       mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
       intrp::Actions::InterpolationTargetReceiveVars<
-          metavars::InterpolationTargetA, 3, Frame::Inertial>>(0, vars_src,
-                                                               global_offsets);
+          metavars::InterpolationTargetA, 3>>(0, vars_src, global_offsets);
 
   // It should have interpolated 4 points by now.
   CHECK(db::get<intrp::Tags::IndicesOfFilledInterpPoints>(box_target).size() ==
@@ -316,8 +315,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.ReceiveVars",
   runner.simple_action<
       mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
       intrp::Actions::InterpolationTargetReceiveVars<
-          metavars::InterpolationTargetA, 3, Frame::Inertial>>(0, vars_src,
-                                                               global_offsets);
+          metavars::InterpolationTargetA, 3>>(0, vars_src, global_offsets);
 
   // It should have interpolated 8 points by now. (The ninth point had
   // a repeated global_offsets so it should be ignored)
@@ -339,8 +337,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.ReceiveVars",
   runner.simple_action<
       mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
       intrp::Actions::InterpolationTargetReceiveVars<
-          metavars::InterpolationTargetA, 3, Frame::Inertial>>(0, vars_src,
-                                                               global_offsets);
+          metavars::InterpolationTargetA, 3>>(0, vars_src, global_offsets);
 
   // It should have interpolated all the points by now.
   CHECK(db::get<intrp::Tags::IndicesOfFilledInterpPoints>(box_target).size() ==

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -27,11 +27,11 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
     using compute_target_points =
-        ::intrp::Actions::WedgeSectionTorus<InterpolationTargetA,
-                                            Frame::Inertial>;
+        ::intrp::Actions::WedgeSectionTorus<InterpolationTargetA>;
     using type = compute_target_points::options_type;
   };
   using temporal_id = Time;
+  using domain_frame = Frame::Inertial;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -37,7 +37,7 @@
 /// \cond
 namespace intrp {
 namespace Actions {
-template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+template <typename InterpolationTargetTag, size_t VolumeDim>
 struct InterpolationTargetReceiveVars;
 }  // namespace Actions
 }  // namespace intrp
@@ -66,7 +66,7 @@ struct Variables;
 namespace {
 
 size_t num_calls_of_target_receive_vars = 0;
-template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+template <typename InterpolationTargetTag, size_t VolumeDim>
 struct MockInterpolationTargetReceiveVars {
   template <
       typename DbTags, typename... InboxTags, typename Metavariables,
@@ -104,20 +104,18 @@ struct mock_interpolation_target {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using component_being_mocked =
-      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3,
-                                 Frame::Inertial>;
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3>;
   using const_global_cache_tag_list = tmpl::list<>;
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
-                                                            ::Frame::Inertial>>;
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3>>;
   using replace_these_simple_actions =
       tmpl::list<intrp::Actions::InterpolationTargetReceiveVars<
-          typename Metavariables::InterpolationTargetA, 3, ::Frame::Inertial>>;
+          typename Metavariables::InterpolationTargetA, 3>>;
   using with_these_simple_actions =
       tmpl::list<MockInterpolationTargetReceiveVars<
-          typename Metavariables::InterpolationTargetA, 3, ::Frame::Inertial>>;
+          typename Metavariables::InterpolationTargetA, 3>>;
 };
 
 template <typename Metavariables, size_t VolumeDim>
@@ -142,6 +140,7 @@ struct MockMetavariables {
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
   using temporal_id = Time;
+  using domain_frame = Frame::Inertial;
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
       mock_interpolator<MockMetavariables, 3>>;
@@ -196,9 +195,9 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
   Slab slab(0.0, 1.0);
   Time temporal_id(slab, Rational(11, 15));
 
-  runner.simple_action<mock_interpolator<metavars, 3>,
-                       intrp::Actions::ReceivePoints<
-                           metavars::InterpolationTargetA, Frame::Inertial>>(
+  runner.simple_action<
+      mock_interpolator<metavars, 3>,
+      intrp::Actions::ReceivePoints<metavars::InterpolationTargetA>>(
       0, temporal_id, block_logical_coords);
 
   const auto& holders =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -54,7 +54,7 @@
 // IWYU pragma: no_forward_declare Tensor
 namespace intrp {
 namespace Actions {
-template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+template <typename InterpolationTargetTag, size_t VolumeDim>
 struct InterpolationTargetReceiveVars;
 }  // namespace Actions
 }  // namespace intrp
@@ -97,7 +97,7 @@ struct SquareComputeItem : Square, db::ComputeTag {
 };
 }  // namespace Tags
 
-template <typename InterpolationTargetTag, size_t VolumeDim, typename Frame>
+template <typename InterpolationTargetTag, size_t VolumeDim>
 struct MockInterpolationTargetReceiveVars {
   template <
       typename DbTags, typename... InboxTags, typename Metavariables,
@@ -160,20 +160,18 @@ struct mock_interpolation_target {
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = size_t;
   using component_being_mocked =
-      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3,
-                                 Frame::Inertial>;
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3>;
   using const_global_cache_tag_list = tmpl::list<>;
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
-                                                            ::Frame::Inertial>>;
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3>>;
   using replace_these_simple_actions =
       tmpl::list<intrp::Actions::InterpolationTargetReceiveVars<
-          typename Metavariables::InterpolationTargetA, 3, ::Frame::Inertial>>;
+          typename Metavariables::InterpolationTargetA, 3>>;
   using with_these_simple_actions =
       tmpl::list<MockInterpolationTargetReceiveVars<
-          typename Metavariables::InterpolationTargetA, 3, ::Frame::Inertial>>;
+          typename Metavariables::InterpolationTargetA, 3>>;
 };
 
 template <typename Metavariables, size_t VolumeDim>
@@ -197,6 +195,7 @@ struct MockMetavariables {
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
   using temporal_id = Time;
+  using domain_frame = Frame::Inertial;
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
       mock_interpolator<MockMetavariables, 3>>;
@@ -317,9 +316,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
                    5.0 * get<2>(inertial_coords);
 
     // Call the action on each element_id.
-    runner.simple_action<
-        mock_interpolator<metavars, 3>,
-        ::intrp::Actions::InterpolatorReceiveVolumeData<Frame::Inertial>>(
+    runner.simple_action<mock_interpolator<metavars, 3>,
+                         ::intrp::Actions::InterpolatorReceiveVolumeData>(
         0, temporal_id, element_id, mesh, std::move(output_vars));
   }
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -151,16 +151,13 @@ struct mock_interpolation_target {
   using array_index = size_t;
   using action_list = tmpl::list<>;
   using component_being_mocked =
-      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3,
-                                 Frame::Inertial>;
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag, 3>;
   using initial_databox = db::compute_databox_type<
       typename intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables, 3,
-                                                            ::Frame::Inertial>>;
+          InterpolationTargetTag>::template return_tag_list<Metavariables, 3>>;
 
   using const_global_cache_tag_list = Parallel::get_const_global_cache_tags<
-      tmpl::list<intrp::Actions::LineSegment<InterpolationTargetTag, 3,
-                                             Frame::Inertial>>>;
+      tmpl::list<intrp::Actions::LineSegment<InterpolationTargetTag, 3>>>;
 };
 
 template <typename Metavariables, size_t VolumeDim>
@@ -182,7 +179,7 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<>;
     using compute_target_points =
-        intrp::Actions::LineSegment<InterpolationTargetA, 3, Frame::Inertial>;
+        intrp::Actions::LineSegment<InterpolationTargetA, 3>;
     using post_interpolation_callback =
         TestFunction<InterpolationTargetA, Tags::Square>;
     // This tag is also an OptionsTag. The type and help string below
@@ -195,7 +192,7 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target = tmpl::list<Tags::Square>;
     using compute_items_on_target = tmpl::list<Tags::NegateComputeItem>;
     using compute_target_points =
-        intrp::Actions::LineSegment<InterpolationTargetB, 3, Frame::Inertial>;
+        intrp::Actions::LineSegment<InterpolationTargetB, 3>;
     using post_interpolation_callback =
         TestFunction<InterpolationTargetB, Tags::Negate>;
     // This tag is also an OptionsTag. The type and help string below
@@ -208,6 +205,7 @@ struct MockMetavariables {
   using interpolation_target_tags =
       tmpl::list<InterpolationTargetA, InterpolationTargetB>;
   using temporal_id = Time;
+  using domain_frame = Frame::Inertial;
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>,
       mock_interpolation_target<MockMetavariables, InterpolationTargetB>,
@@ -322,9 +320,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
                          5.0 * get<2>(inertial_coords);
 
     // Call the InterpolatorReceiveVolumeData action on each element_id.
-    runner.simple_action<
-        mock_interpolator<metavars, 3>,
-        intrp::Actions::InterpolatorReceiveVolumeData<Frame::Inertial>>(
+    runner.simple_action<mock_interpolator<metavars, 3>,
+                         intrp::Actions::InterpolatorReceiveVolumeData>(
         0, temporal_id, element_id, mesh, std::move(output_vars));
   }
 


### PR DESCRIPTION
## Proposed changes

The purpose of this PR is to simplify the treatment of Frames in ParallelInterpolator.

Add a Metavariables type alias `domain_frame` which is the Frame
of the Domain.  This eliminates a `Frame` template parameter on
all Actions (most of which don't use `Frame` at all, but needed
to have the template parameter so that they can call an action that
called an action that needs the Frame).
    
The only Frame needed is the Frame of the Domain, which should be the
same for all the InterpolationTargets because we have only one Domain.
If we want a compute_target_points that expects inputs in a different Frame,
then that compute_target_points Action will be responsible for knowing about
the additional Frame and supplying points in `domain_frame`; knowledge
of the additional Frame is never needed elsewhere.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
