### PR TITLE
Move kerr_horizon_radius out of a test helper into its own function.

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY GeneralRelativitySolutions)
 
 set(LIBRARY_SOURCES
+    KerrHorizon.cpp
     KerrSchild.cpp
     Minkowski.cpp
     Tov.cpp

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.cpp
@@ -1,0 +1,69 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+
+#include <cmath>
+
+#include "DataStructures/DataVector.hpp"                 // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp" // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace gr {
+namespace Solutions {
+
+template <typename DataType>
+Scalar<DataType> kerr_horizon_radius(
+    const std::array<DataType, 2>& theta_phi, const double& mass,
+    const std::array<double, 3>& dimensionless_spin) noexcept {
+  const double spin_magnitude_squared = square(magnitude(dimensionless_spin));
+  const double mass_squared = square(mass);
+
+  const double equatorial_radius_squared =
+      2.0 * mass_squared * (1.0 + sqrt(1.0 - spin_magnitude_squared));
+  const double polar_radius_squared =
+      mass_squared * square(1.0 + sqrt(1.0 - spin_magnitude_squared));
+
+  const auto& theta = theta_phi[0];
+  const auto& phi = theta_phi[1];
+  const DataType sin_theta = sin(theta);
+  const DataType cos_theta = cos(theta);
+  const DataType sin_phi = sin(phi);
+  const DataType cos_phi = cos(phi);
+
+  auto denominator =
+      make_with_value<DataType>(theta_phi[0], polar_radius_squared);
+  denominator += mass_squared * dimensionless_spin[0] * dimensionless_spin[0] *
+                 square(sin_theta * cos_phi);
+  denominator += mass_squared * dimensionless_spin[1] * dimensionless_spin[1] *
+                 square(sin_theta * sin_phi);
+  denominator += mass_squared * dimensionless_spin[2] * dimensionless_spin[2] *
+                 square(cos_theta);
+  denominator += 2.0 * mass_squared * dimensionless_spin[0] *
+                 dimensionless_spin[1] * square(sin_theta) * sin_phi * cos_phi;
+  denominator += 2.0 * mass_squared * dimensionless_spin[0] *
+                 dimensionless_spin[2] * sin_theta * cos_theta * cos_phi;
+  denominator += 2.0 * mass_squared * dimensionless_spin[1] *
+                 dimensionless_spin[2] * sin_theta * cos_theta * sin_phi;
+
+  auto radius_squared =
+      make_with_value<DataType>(theta_phi[0], polar_radius_squared);
+  radius_squared *= equatorial_radius_squared;
+  radius_squared /= denominator;
+
+  return Scalar<DataType>{sqrt(radius_squared)};
+}
+
+template Scalar<DataVector> kerr_horizon_radius(
+    const std::array<DataVector, 2>& theta_phi, const double& mass,
+    const std::array<double, 3>& dimensionless_spin) noexcept;
+
+template Scalar<double> kerr_horizon_radius(
+    const std::array<double, 2>& theta_phi, const double& mass,
+    const std::array<double, 3>& dimensionless_spin) noexcept;
+
+}  // namespace Solutions
+}  // namespace gr
+

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+
+namespace gr {
+namespace Solutions {
+
+/*!
+ * \brief Radius of Kerr horizon in Kerr-Schild coordinates.
+ *
+ * \details Computes the radius of a Kerr black hole as a function of
+ * angles.  The input argument `theta_phi` is typically the output of
+ * the `theta_phi_points()` method of a `YlmSpherepack` object; i.e.,
+ * a std::array of two DataVectors containing the values of theta and
+ * phi at each point on a Strahlkorper.
+ *
+ * \note If the spin is nearly extremal, this function has accuracy
+ *       limited to roughly \f$10^{-8}\f$, because of roundoff amplification
+ *       from computing \f$M + \sqrt{M^2-a^2}\f$.
+ *
+ * Derivation:
+ *
+ * Define spherical coordinates \f$(r,\theta,\phi)\f$ in the usual way
+ * from the Cartesian Kerr-Schild coordinates \f$(x,y,z)\f$
+ * (i.e. \f$x = r \sin\theta \cos\phi\f$ and so on).
+ * Then the relationship between \f$r\f$ and the radial
+ * Boyer-Lindquist coordinate \f$r_{BL}\f$ is
+ * \f[
+ * r_{BL}^2 = \frac{1}{2}(r^2 - a^2)
+ *     + \left(\frac{1}{4}(r^2-a^2)^2 +
+ *             r^2(\vec{a}\cdot \hat{x})^2\right)^{1/2},
+ * \f]
+ * where \f$\vec{a}\f$ is the Kerr spin vector (with units of mass),
+ * \f$\hat{x}\f$ means \f$(x/r,y/r,z/r)\f$, and the dot product is
+ * taken as in flat space.
+ *
+ * The horizon is a surface of constant \f$r_{BL}\f$. Therefore
+ * we can solve the above equation for \f$r^2\f$ as a function of angles,
+ * yielding
+ * \f[
+ *     r^2 = \frac{r_{BL}^2 (r_{BL}^2 + a^2)}
+                  {r_{BL}^2+(\vec{a}\cdot \hat{x})^2},
+ * \f]
+ * where the angles are encoded in \f$\hat x\f$ and everything else on the
+ * right-hand side is constant.
+ *
+ * `kerr_horizon_radius` evaluates \f$r\f$ using the above equation, and
+ * using the standard expression for the Boyer-Lindquist radius of the
+ * Kerr horizon:
+ * \f[
+ *   r_{BL} = r_+ = M + \sqrt{M^2-a^2}.
+ * \f]
+ *
+ */
+template <typename DataType>
+Scalar<DataType> kerr_horizon_radius(
+    const std::array<DataType, 2>& theta_phi, const double& mass,
+    const std::array<double, 3>& dimensionless_spin) noexcept;
+
+}  // namespace Solutions
+}  // namespace gr

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.cpp
@@ -71,45 +71,6 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature_sphere(
 
 namespace Kerr {
 template <typename DataType>
-Scalar<DataType> horizon_radius(const std::array<DataType, 2>& theta_phi,
-                                const double& mass,
-                                const std::array<double, 3>& spin) noexcept {
-  const double spin_magnitude_squared = square(magnitude(spin));
-  const double mass_squared = square(mass);
-
-  const double equatorial_radius_squared =
-      2.0 * mass_squared * (1.0 + sqrt(1.0 - spin_magnitude_squared));
-  const double polar_radius_squared =
-      mass_squared * square(1.0 + sqrt(1.0 - spin_magnitude_squared));
-
-  const auto& theta = theta_phi[0];
-  const auto& phi = theta_phi[1];
-  const DataType sin_theta = sin(theta);
-  const DataType cos_theta = cos(theta);
-  const DataType sin_phi = sin(phi);
-  const DataType cos_phi = cos(phi);
-
-  auto denominator =
-      make_with_value<DataType>(theta_phi[0], polar_radius_squared);
-  denominator += mass_squared * spin[0] * spin[0] * square(sin_theta * cos_phi);
-  denominator += mass_squared * spin[1] * spin[1] * square(sin_theta * sin_phi);
-  denominator += mass_squared * spin[2] * spin[2] * square(cos_theta);
-  denominator += 2.0 * mass_squared * spin[0] * spin[1] * square(sin_theta) *
-                 sin_phi * cos_phi;
-  denominator +=
-      2.0 * mass_squared * spin[0] * spin[2] * sin_theta * cos_theta * cos_phi;
-  denominator +=
-      2.0 * mass_squared * spin[1] * spin[2] * sin_theta * cos_theta * sin_phi;
-
-  auto radius_squared =
-      make_with_value<DataType>(theta_phi[0], polar_radius_squared);
-  radius_squared *= equatorial_radius_squared;
-  radius_squared /= denominator;
-
-  return Scalar<DataType>{sqrt(radius_squared)};
-}
-
-template <typename DataType>
 Scalar<DataType> horizon_ricci_scalar(
     const Scalar<DataType>& horizon_radius, const double& mass,
     const double& dimensionless_spin_z) noexcept {
@@ -257,9 +218,6 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (3), (double, DataVector),
 #undef INDEXTYPE
 #undef INSTANTIATE
 
-template Scalar<DataVector> TestHelpers::Kerr::horizon_radius(
-    const std::array<DataVector, 2>& theta_phi, const double& mass,
-    const std::array<double, 3>& spin) noexcept;
 template Scalar<DataVector> TestHelpers::Kerr::horizon_ricci_scalar(
     const Scalar<DataVector>& horizon_radius, const double& mass,
     const double& dimensionless_spin_z) noexcept;

--- a/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
+++ b/tests/Unit/ApparentHorizons/StrahlkorperGrTestHelpers.hpp
@@ -48,23 +48,6 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature_sphere(
 namespace Kerr {
 /*!
  * \ingroup TestingFrameworkGroup
- * \brief Radius of Kerr horizon in Kerr-Schild coordinates
- *
- * \details
- * Computes the radius of a Kerr black hole with mass `mass`
- * and dimensionless spin `spin`. The input
- * argument `theta_phi` is the output of the
- * `theta_phi_points()` method of a `YlmSpherepack` object;
- * i.e., it is typically a std::array of two DataVectors containing
- * the values of theta and phi at each point on a Strahlkorper.
- */
-template <typename DataType>
-Scalar<DataType> horizon_radius(const std::array<DataType, 2>& theta_phi,
-                                const double& mass,
-                                const std::array<double, 3>& spin) noexcept;
-
-/*!
- * \ingroup TestingFrameworkGroup
  * \brief Kerr (Kerr-Schild) horizon ricci scalar (spin on z axis)
  *
  * \details

--- a/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
+++ b/tests/Unit/ApparentHorizons/Test_StrahlkorperGr.cpp
@@ -19,6 +19,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"   // IWYU prgma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
@@ -528,7 +529,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.Expansion",
   const std::array<double, 3> spin{{0.3, 0.4, 0.5}};
   const std::array<double, 3> center{{0.0, 0.0, 0.0}};
 
-  const auto horizon_radius = TestHelpers::Kerr::horizon_radius(
+  const auto horizon_radius = gr::Solutions::kerr_horizon_radius(
       Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
@@ -595,7 +596,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.AreaElement",
   // Eq. (26.84a) of Thorne and Blandford
   const double expected_area = 8.0 * M_PI * mass * kerr_horizon_radius;
 
-  const auto horizon_radius = TestHelpers::Kerr::horizon_radius(
+  const auto horizon_radius = gr::Solutions::kerr_horizon_radius(
       Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
@@ -616,7 +617,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.SpinFunction",
   const std::array<double, 3> spin{{0.4, 0.33, 0.22}};
   const std::array<double, 3> center{{0.0, 0.0, 0.0}};
 
-  const auto horizon_radius = TestHelpers::Kerr::horizon_radius(
+  const auto horizon_radius = gr::Solutions::kerr_horizon_radius(
       Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
@@ -660,7 +661,7 @@ SPECTRE_TEST_CASE(
   const double aligned_l_max = 12;
   const std::array<double, 3> aligned_dimensionless_spin = {
       {0.0, 0.0, expected_dimensionless_spin_magnitude}};
-  const auto aligned_horizon_radius = TestHelpers::Kerr::horizon_radius(
+  const auto aligned_horizon_radius = gr::Solutions::kerr_horizon_radius(
       Strahlkorper<Frame::Inertial>(aligned_l_max, aligned_l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
@@ -679,7 +680,7 @@ SPECTRE_TEST_CASE(
       magnitude(generic_dimensionless_spin);
   const double expected_generic_spin_magnitude =
       expected_generic_dimensionless_spin_magnitude * square(mass);
-  const auto generic_horizon_radius = TestHelpers::Kerr::horizon_radius(
+  const auto generic_horizon_radius = gr::Solutions::kerr_horizon_radius(
       Strahlkorper<Frame::Inertial>(generic_l_max, generic_l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
@@ -689,7 +690,7 @@ SPECTRE_TEST_CASE(
 
   // Create rotated horizon radius, Strahlkorper, with same spin magnitude
   // but with spin on the z axis
-  const auto rotated_horizon_radius = TestHelpers::Kerr::horizon_radius(
+  const auto rotated_horizon_radius = gr::Solutions::kerr_horizon_radius(
       Strahlkorper<Frame::Inertial>(generic_l_max, generic_l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
@@ -712,7 +713,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.SpinVector",
   const auto spin_magnitude = magnitude(spin);
   const std::array<double, 3> center{{0.0, 0.0, 0.0}};
 
-  const auto horizon_radius = TestHelpers::Kerr::horizon_radius(
+  const auto horizon_radius = gr::Solutions::kerr_horizon_radius(
       Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
           .ylm_spherepack()
           .theta_phi_points(),
@@ -721,7 +722,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperGr.SpinVector",
       Strahlkorper<Frame::Inertial>(l_max, l_max, get(horizon_radius), center);
 
   const auto horizon_radius_with_spin_on_z_axis =
-      TestHelpers::Kerr::horizon_radius(
+      gr::Solutions::kerr_horizon_radius(
           Strahlkorper<Frame::Inertial>(l_max, l_max, 2.0, center)
               .ylm_spherepack()
               .theta_phi_points(),

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_GeneralRelativitySolutions")
 
 set(LIBRARY_SOURCES
+  Test_KerrHorizon.cpp
   Test_KerrSchild.cpp
   Test_Minkowski.cpp
   Test_Tov.cpp
@@ -13,5 +14,5 @@ add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/"
   "${LIBRARY_SOURCES}"
-  "GeneralRelativitySolutions;GeneralizedHarmonic;GeneralRelativity;Utilities"
+  "Test_Pypp;GeneralRelativitySolutions;GeneralizedHarmonic;GeneralRelativity;Utilities"
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TestFunctions.py
@@ -1,0 +1,22 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Functions for testing KerrHorizon.cpp
+
+def kerr_horizon_radius(theta, phi, mass, dimless_spin_magnitude,
+                        spin_theta, spin_phi):
+    spin_a = mass*dimless_spin_magnitude* \
+             np.array((np.sin(spin_theta)*np.cos(spin_phi),
+                       np.sin(spin_theta)*np.sin(spin_phi),
+                       np.cos(spin_theta)))
+    a_squared = np.dot(spin_a,spin_a)
+    r_plus    = mass+np.sqrt(mass**2-a_squared)
+    n_hat     = np.array((np.sin(theta)*np.cos(phi),
+                          np.sin(theta)*np.sin(phi),
+                          np.cos(theta)))
+    return np.sqrt(r_plus**2*(r_plus**2+a_squared)/ \
+                   (r_plus**2+np.dot(spin_a,n_hat)**2))
+
+# End functions for testing KerrHorizon.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrHorizon.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_KerrHorizon.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <limits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+namespace gr {
+namespace Solutions {
+namespace {
+
+// This wraps the kerr_horizon_radius function with
+// types that CheckWithRandomValues can understand.
+// We use magnitude and angle of dimensionless spin so that
+// we know their bounds.
+template <typename DataType>
+Scalar<DataType> wrap_kerr_horizon_radius(
+    const Scalar<DataType>& theta, const Scalar<DataType>& phi,
+    const double mass, const double dimless_spin_magnitude,
+    const double dimless_spin_theta, const double dimless_spin_phi) noexcept {
+  return kerr_horizon_radius<DataType>(
+      {{get(theta), get(phi)}}, mass,
+      {{dimless_spin_magnitude * sin(dimless_spin_theta) *
+            cos(dimless_spin_phi),
+        dimless_spin_magnitude * sin(dimless_spin_theta) *
+            sin(dimless_spin_phi),
+        dimless_spin_magnitude * cos(dimless_spin_theta)}});
+}
+
+template <typename DataType>
+void test_kerr_horizon(const DataType& used_for_size) {
+  pypp::check_with_random_values<6>(&wrap_kerr_horizon_radius<DataType>,
+                                    "TestFunctions", "kerr_horizon_radius",
+                                    {{{0.0, M_PI},
+                                      {0.0, 2.0 * M_PI},
+                                      {1.0, 2.0},
+                                      {0.0, 1.0},
+                                      {0.0, M_PI},
+                                      {0.0, 2.0 * M_PI}}},
+                                    used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.KerrHorizon",
+                  "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/");
+  const DataVector dv(5);
+  test_kerr_horizon(dv);
+  test_kerr_horizon(0.0);
+
+  // Test for Schwarzschild (mass=2) at randomly-chosen point
+  CHECK(4.0 == get(kerr_horizon_radius<double>({{1.12345, 2.2222}}, 2.0,
+                                               {{0.0, 0.0, 0.0}})));
+
+  // Test for Kerr (mass=2) along pole, for spin not in z direction.
+  CHECK(approx(2.0 * (1.0 + sqrt(0.86))) ==
+        get(kerr_horizon_radius<double>(
+            {{acos(0.3 / sqrt(0.14)), atan2(0.2, 0.1)}}, 2.0,
+            {{0.1, 0.2, 0.3}})));
+
+  // Test for Kerr (mass=2) along equator, for spin not in z direction.
+  // Angles and radius worked out by hand.
+  CHECK(approx(sqrt(square(2.0 * (1.0 + sqrt(0.86))) + 4.0 * 0.14)) ==
+        get(kerr_horizon_radius<double>(
+            {{acos(0.3 / sqrt(0.14)) + M_PI_2, atan2(0.2, 0.1)}}, 2.0,
+            {{0.1, 0.2, 0.3}})));
+
+  // Test for Kerr (mass=2) along pole, for extremal spin not in z direction.
+  // one_minus_eps to make sure we don't get FPE in sqrt(M^2-a^2).
+  const double one_minus_eps = 1.0 - std::numeric_limits<double>::min();
+  Approx numerical_approx = Approx::custom().epsilon(1.e-8).scale(1.0);
+  CHECK(
+      numerical_approx(2.0) ==
+      get(kerr_horizon_radius<double>(
+          {{acos(0.3 / sqrt(0.14)), atan2(0.2, 0.1)}}, 2.0,
+          {{one_minus_eps * 0.1 / sqrt(0.14), one_minus_eps * 0.2 / sqrt(0.14),
+            one_minus_eps * 0.3 / sqrt(0.14)}})));
+
+  // Test for Kerr (mass=2) along equator,
+  // for extremal spin not in z direction.
+  CHECK(
+      numerical_approx(sqrt(8.0)) ==
+      get(kerr_horizon_radius<double>(
+          {{acos(0.3 / sqrt(0.14)) + M_PI_2, atan2(0.2, 0.1)}}, 2.0,
+          {{one_minus_eps * 0.1 / sqrt(0.14), one_minus_eps * 0.2 / sqrt(0.14),
+            one_minus_eps * 0.3 / sqrt(0.14)}})));
+}
+}  // namespace Solutions
+}  // namespace gr


### PR DESCRIPTION
Moves kerr_horizon_radius out of a test helper, and makes it accessible outside tests.

I want to use it for making a Strahlkorper corresponding to a Kerr
horizon.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
