### PR TITLE
Add ComplexDataView

### DIFF
--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Spectral)
 
 set(LIBRARY_SOURCES
     Chebyshev.cpp
+    ComplexDataView.cpp
     Legendre.cpp
     Projection.cpp
     Spectral.cpp

--- a/src/NumericalAlgorithms/Spectral/ComplexDataView.cpp
+++ b/src/NumericalAlgorithms/Spectral/ComplexDataView.cpp
@@ -1,0 +1,297 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"  // IWYU pragma: keep
+
+namespace Spectral {
+namespace SWSH {
+namespace detail {
+
+template <typename T>
+void sizes_assert(const T& vector, const size_t size) {
+  ASSERT(vector.size() == size,
+         "Assignment must be to the same size,"
+         " not "
+             << vector.size() << " assigned to " << size);
+}
+
+// The constructor of `ComplexDataView<ComplexRepresentation::Interleaved>`
+// makes no copies or allocations
+
+// Due to the nature of this class performing manual memory management, indexing
+// into complex data with perscribed strides, it is necessary to violate type
+// system conventions to index into the complex data as though it is double
+// data, thus using a `reinterpret_cast`. The C++ standard guarantees that
+// complex numbers are represented in memory in such a way that this is correct,
+// despite the type subversion. We also cannot take the address of the
+// components of the complex data, as those are returned by value, not lvalue
+// reference.
+template <>
+ComplexDataView<ComplexRepresentation::Interleaved>::ComplexDataView(
+    const gsl::not_null<ComplexDataVector*> vector, const size_t size,
+    const size_t offset) noexcept
+    : size_{size},
+      real_slices_up_to_date_{false},
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      data_real_{reinterpret_cast<double*>(vector->data() + offset)},
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      data_imag_{data_real_ + 1} {
+  complex_view_.set_data_ref(vector->data() + offset, size);
+}
+
+// Due to the nature of this class performing manual memory management, indexing
+// into complex data with perscribed strides, it is necessary to violate type
+// system conventions to index into the complex data as though it is double
+// data, thus using a `reinterpret_cast`. The C++ standard guarantees that
+// complex numbers are represented in memory in such a way that this is correct,
+// despite the type subversion. We also cannot take the address of the
+// components of the complex data, as those are returned by value, not lvalue
+// reference.
+template <>
+ComplexDataView<ComplexRepresentation::Interleaved>::ComplexDataView(
+    std::complex<double>* const start, const size_t size) noexcept
+    : size_{size},
+      real_slices_up_to_date_{false},
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      data_real_{reinterpret_cast<double*>(start)},
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      data_imag_{data_real_ + 1} {
+  complex_view_.set_data_ref(start, size);
+}
+
+// RealsThenImags constructors cause an allocation and a copy for each of the
+// real and imaginary components of the vector. If it becomes a performance
+// concern, the `real_slice_` and `imag_slice_` could be made as non-owning
+// DataVectors which reference a larger block of memory allocated only once.
+template <>
+ComplexDataView<ComplexRepresentation::RealsThenImags>::ComplexDataView(
+    const gsl::not_null<ComplexDataVector*> vector, const size_t size,
+    const size_t offset) noexcept
+    : size_{size}, real_slices_up_to_date_{true}, complex_view_{} {
+  complex_view_.set_data_ref(vector->data() + offset, size_);
+  real_slice_ = real(complex_view_);
+  imag_slice_ = imag(complex_view_);
+  data_real_ = real_slice_.data();
+  data_imag_ = imag_slice_.data();
+}
+
+template <>
+ComplexDataView<ComplexRepresentation::RealsThenImags>::ComplexDataView(
+    std::complex<double>* const start, const size_t size) noexcept
+    : size_{size}, real_slices_up_to_date_{true}, complex_view_{} {
+  complex_view_.set_data_ref(start, size_);
+  real_slice_ = real(complex_view_);
+  imag_slice_ = imag(complex_view_);
+  data_real_ = real_slice_.data();
+  data_imag_ = imag_slice_.data();
+}
+
+// For `ComplexDataView<ComplexRepresentation::Interleaved>`, assigning
+// individual components is comparatively slow, and is currently implemented as
+// loop with the appropriate stride in the contiguous view.
+
+template <>
+ComplexDataView<ComplexRepresentation::Interleaved>&
+ComplexDataView<ComplexRepresentation::Interleaved>::assign_real(
+    const DataVector& vector) noexcept {
+  if (real_slice_.data() != vector.data() or not real_slices_up_to_date_) {
+    sizes_assert(vector, size_);
+    for (size_t i = 0; i < size_; i++) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      data_real_[stride_ * i] = vector[i];
+    }
+    real_slices_up_to_date_ = false;
+  }
+  return *this;
+}
+
+template <>
+ComplexDataView<ComplexRepresentation::Interleaved>&
+ComplexDataView<ComplexRepresentation::Interleaved>::assign_imag(
+    const DataVector& vector) noexcept {
+  if (imag_slice_.data() != vector.data() or not real_slices_up_to_date_) {
+    sizes_assert(vector, size_);
+    for (size_t i = 0; i < size_; i++) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      data_imag_[stride_ * i] = vector[i];
+    }
+    real_slices_up_to_date_ = false;
+  }
+  return *this;
+}
+
+// For `ComplexDataView<ComplexRepresentation::RealsThenImags>` views, the
+// assignment to individual components assigns directly to the internal
+// DataVectors of the separate components, which is comparatively fast.
+template <>
+ComplexDataView<ComplexRepresentation::RealsThenImags>&
+ComplexDataView<ComplexRepresentation::RealsThenImags>::assign_real(
+    const DataVector& vector) noexcept {
+  if (real_slice_.data() != vector.data()) {
+    sizes_assert(vector, size_);
+    real_slice_ = vector;
+  }
+  return *this;
+}
+
+template <>
+ComplexDataView<ComplexRepresentation::RealsThenImags>&
+ComplexDataView<ComplexRepresentation::RealsThenImags>::assign_imag(
+    const DataVector& vector) noexcept {
+  if (imag_slice_.data() != vector.data()) {
+    sizes_assert(vector, size_);
+    imag_slice_ = vector;
+  }
+  return *this;
+}
+
+// `ComplexDataView<ComplexRepresentation::Interleaved>` views are simply
+// references back to the source data, therefore the source is perpetually in
+// sync with the view. This function is a no-op.
+template <>
+void ComplexDataView<
+    ComplexRepresentation::Interleaved>::copy_back_to_source() noexcept {}
+
+// `ComplexDataView<ComplexRepresentation::RealsThenImags>` views perform a true
+// copy back to the source vector when this function is called
+template <>
+void ComplexDataView<
+    ComplexRepresentation::RealsThenImags>::copy_back_to_source() noexcept {
+  for (size_t i = 0; i < size_; i++) {
+    complex_view_[i] = std::complex<double>{real_slice_[i], imag_slice_[i]};
+  }
+}
+
+// `ComplexDataView<ComplexRepresentation::Interleaved>` views perform
+// assignments from complex vectors comparatively quickly, via the assignments
+// using the underlying complex vector types.
+template <>
+ComplexDataView<ComplexRepresentation::Interleaved>&
+ComplexDataView<ComplexRepresentation::Interleaved>::operator=(
+    const ComplexDataVector& vector) noexcept {
+  if (complex_view_.data() != vector.data()) {
+    sizes_assert(vector, size_);
+    complex_view_ = vector;
+    real_slices_up_to_date_ = false;
+  }
+  return *this;
+}
+
+template <>
+ComplexDataView<ComplexRepresentation::Interleaved>&
+ComplexDataView<ComplexRepresentation::Interleaved>::operator=(
+    const ComplexDataView<ComplexRepresentation::Interleaved>& view) noexcept {
+  if (this != &view) {
+    sizes_assert(view, size_);
+    complex_view_ = view.complex_view_;
+    real_slices_up_to_date_ = false;
+  }
+  return *this;
+}
+
+template <>
+void ComplexDataView<ComplexRepresentation::Interleaved>::conjugate() noexcept {
+  complex_view_ = conj(complex_view_);
+  real_slices_up_to_date_ = false;
+}
+
+// `ComplexDataView<ComplexRepresentation::RealsThenImags>` views perform
+// assignments from complex vectors comparatively slowly. The complex data must
+// be separately converted to the real and imaginary components in the form of
+// DataVectors, then stored in the appropriate internal components.
+template <>
+ComplexDataView<ComplexRepresentation::RealsThenImags>&
+ComplexDataView<ComplexRepresentation::RealsThenImags>::operator=(
+    const ComplexDataVector& vector) noexcept {
+  sizes_assert(vector, size_);
+  real_slice_ = real(vector);
+  imag_slice_ = imag(vector);
+  return *this;
+}
+
+template <>
+ComplexDataView<ComplexRepresentation::RealsThenImags>&
+ComplexDataView<ComplexRepresentation::RealsThenImags>::operator=(
+    const ComplexDataView<ComplexRepresentation::RealsThenImags>&
+        view) noexcept {
+  sizes_assert(view, size_);
+  if (real_slice_.data() != view.real_slice_.data()) {
+    real_slice_ = view.real_slice_;
+  }
+  if (imag_slice_.data() != view.imag_slice_.data()) {
+    imag_slice_ = view.imag_slice_;
+  }
+  return *this;
+}
+
+template <>
+void ComplexDataView<
+    ComplexRepresentation::RealsThenImags>::conjugate() noexcept {
+  imag_slice_ = -imag_slice_;
+}
+
+// `ComplexDataView<ComplexRepresentation::Interleaved>` views have the
+// individual pointer positions only one double length apart, with a memory
+// stride of 2, as the real and imaginary parts alternate in memory.
+template <>
+double*
+ComplexDataView<ComplexRepresentation::Interleaved>::real_data() noexcept {
+  return data_real_;
+}
+
+template <>
+const double* ComplexDataView<ComplexRepresentation::Interleaved>::real_data()
+    const noexcept {
+  return data_real_;
+}
+
+template <>
+double*
+ComplexDataView<ComplexRepresentation::Interleaved>::imag_data() noexcept {
+  return data_imag_;
+}
+
+template <>
+const double* ComplexDataView<ComplexRepresentation::Interleaved>::imag_data()
+    const noexcept {
+  return data_imag_;
+}
+
+// `ComplexDataView<ComplexRepresentation::RealsThenImags>` views have
+// potentially very different pointer positions for the start of the individual
+// vectors, but have a memory stride of 1, as each of the two blocks is a
+// contiguous representation.
+template <>
+double*
+ComplexDataView<ComplexRepresentation::RealsThenImags>::real_data() noexcept {
+  return real_slice_.data();
+}
+
+template <>
+const double*
+ComplexDataView<ComplexRepresentation::RealsThenImags>::real_data() const
+    noexcept {
+  return real_slice_.data();
+}
+
+template <>
+double*
+ComplexDataView<ComplexRepresentation::RealsThenImags>::imag_data() noexcept {
+  return imag_slice_.data();
+}
+
+template <>
+const double*
+ComplexDataView<ComplexRepresentation::RealsThenImags>::imag_data() const
+    noexcept {
+  return imag_slice_.data();
+}
+}  // namespace detail
+}  // namespace SWSH
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/ComplexDataView.hpp
+++ b/src/NumericalAlgorithms/Spectral/ComplexDataView.hpp
@@ -1,0 +1,186 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Spectral {
+/// \ingroup SpectralGroup
+/// Namespace for spin-weighted spherical harmonic utilities.
+namespace SWSH {
+
+/// \brief A set of labels for the possible representations of complex numbers
+/// for the `ComplexDataView` and the computations performed in the
+/// spin-weighted spherical harmonic transform library.
+///
+/// \details The representation describes one of two behaviors:
+///  - `Interleaved`: The vectors of complex numbers will be represented by
+///  alternating doubles in memory. This causes both the real and imaginary part
+///  at a given gridpoint to be near one another, but successive real values
+///  farther. This is the native representation of complex data in the C++
+///  standard, and is the representation needed for Blaze math
+///  operations. Therefore, using this representation type in libsharp
+///  computations will cause operations which access only the real or imaginary
+///  parts individually to trace over larger memory regions. However, this
+///  representation will give rise to fewer copying operations to perform the
+///  libsharp operations.
+///
+///  - `RealsThenImags`: The vectors of complex numbers will primarily be
+///  represented by a pair of vectors of doubles, one for the real values and
+///  one for the imaginary values (the full computation cannot be performed
+///  exclusively in this representation, as it must return to a vector of
+///  `std::complex<double>` for Blaze math operations). This causes the
+///  successive real values for different gridpoints to be closer in memory, but
+///  the real and imaginary parts for a given gridpoint to be farther in
+///  memory. This is not the native representation for complex data in C++, so
+///  the data must be transformed between operations which use Blaze and the
+///  transform operations which use `RealsThenImags`. Therefore, using this
+///  representation in libsharp computations will cause operations which act on
+///  real or imaginary parts individually to have better memory locality (so
+///  likely improved cache performance, but such statements are highly
+///  hardware-dependent). However, this representation will give rise to more
+///  copying operations to perform the libsharp operations.
+///
+/// \note The pair of representations is provided as a means to 'turn a dial' in
+/// optimizations. It is unclear which of these representations will be
+/// preferable, and it may well be the case that different representations are
+/// better for different calculation types or different hardware. Therefore,
+/// when optimizing code which uses libsharp, it is encouraged to profile the
+/// cost of each representation for a computation and choose the one which
+/// performs best.
+enum class ComplexRepresentation { Interleaved, RealsThenImags };
+
+namespace detail {
+// A storage container for storing sub-vector references ("views") of a
+// ComplexDataVector.
+//
+// This class takes as a template argument a ComplexRepresentation to use when
+// returning pointers to the components of the complex data. The representation
+// is either:
+// - `ComplexRepresentation::Interleaved`, which indicates that the complex data
+// is represented as a vector of `std::complex<double>`, and then
+// ComplexDataView acts as a view (a pure reference to a subvector).
+// - `ComplexRepresentation::RealsThenImags`, which indicates that the complex
+// data is represented as a pair of vectors of `double`. This is no longer a
+// strict view in the typical sense, as the memory layout is different from
+// the data which it references. In order to minimize copies, the user must
+// specify when edits to the ComplexDataView are complete by calling the
+// `copy_back_to_source()` member function.
+//
+// Warning: For optimization reasons, mutations applied via member functions or
+// manipulations of data pointed to by pointers returned by member functions
+// *may or may not* be immediately applied to the source vector used to
+// construct the ComplexDataView. Correct use of this class will first perform
+// (potentially several) manipulations of the data via the ComplexDataView, then
+// as a final step flush the data to the source vector via the member function
+// `copy_back_to_source()`. At that point, the vector is guaranteed to be
+// placed in the same state as the ComplexDataView. **The process of
+// constructing a ComplexDataView, then mutating data in both the
+// ComplexDataView and the source vector, then calling `copy_back_to_source()`
+// is considered undefined behavior, and depends on the details of the memory
+// layout chosen.**
+template <ComplexRepresentation Representation>
+class ComplexDataView {
+ public:
+  // The Representation determines the internal data representation
+  static const ComplexRepresentation complex_representation = Representation;
+
+  // The internal storage type
+  using value_type = std::complex<double>;
+
+  // Construct a view which starts at index `offset` of the supplied
+  // vector, and extends for `size` elements
+  ComplexDataView(gsl::not_null<ComplexDataVector*> vector, size_t size,
+                  size_t offset = 0) noexcept;
+
+  // Construct a view which starts at pointer `start` and extends for
+  // `size` elements. Need not be a part of a ComplexDataVector.
+  ComplexDataView(std::complex<double>* start, size_t size) noexcept;
+
+  // For the lifetime of the data view, it points to the same portion of a
+  // single vector. We disallow default move assignment, as it would exhibit
+  // behavior that would contradict that. All assignment operations permitted by
+  // the ComplexDataView are copying operations which act only on the data, not
+  // the reference.
+  ComplexDataView() = delete;
+  ComplexDataView(const ComplexDataView&) = default;
+  ComplexDataView(ComplexDataView&&) = default;
+  ComplexDataView operator=(ComplexDataView&&) = delete;
+  ~ComplexDataView() = default;
+
+  // assign into the view the values of a same-sized ComplexDataVector
+  ComplexDataView<Representation>& operator=(
+      const ComplexDataVector& vector) noexcept;
+
+  // Assign into the view the values from a same-sized view
+  ComplexDataView<Representation>& operator=(
+      const ComplexDataView<Representation>& view) noexcept;
+
+  // Conjugate the data.
+  void conjugate() noexcept;
+
+  // Assign into the real components of a view the values from a
+  // provided `DataVector`
+  ComplexDataView<Representation>& assign_real(
+      const DataVector& vector) noexcept;
+
+  // Assign into the imaginary components of a view the values from a
+  // provided `DataVector`
+  ComplexDataView<Representation>& assign_imag(
+      const DataVector& vector) noexcept;
+
+  // Gets the size of the view (the number of complex entries).
+  size_t size() const noexcept { return size_; }
+
+  // Gets the stride between successive real or successive imaginary components
+  // in memory.
+  static constexpr size_t stride() noexcept { return stride_; }
+
+  // Gets the raw pointer to the start of the real data, which are separated
+  // from one another by `stride()`.
+  double* real_data() noexcept;
+  const double* real_data() const noexcept;
+
+  // Gets the raw pointer to the start of the imaginary data, which are
+  // separated from one another by `stride()`.
+  double* imag_data() noexcept;
+  const double* imag_data() const noexcept;
+
+  // A function for manually flushing the data back to the source. This class
+  // minimizes copies wherever possible, so the manual control of bringing the
+  // data back to the source vector only when necessary is important for
+  // optimization.
+  // Warning: Until this function is called, mutations applied via other member
+  // functions or mutations applied via the pointers obtained from other member
+  // functions are not guaranteed to be applied to the source vector.
+  void copy_back_to_source() noexcept;
+
+ private:
+  size_t size_;
+
+  static const size_t stride_ =
+      Representation == ComplexRepresentation::RealsThenImags ? 1 : 2;
+
+  // In either case, we want to avoid unnecessary copies, so we track whether
+  // the data has been copied from one representation to the other.
+  bool real_slices_up_to_date_;
+  // These two DataVectors are unused in the case of `Interleaved`
+  // representation
+  DataVector real_slice_;
+  DataVector imag_slice_;
+
+  double* data_real_;
+  double* data_imag_;
+
+  ComplexDataVector complex_view_;
+};
+
+}  // namespace detail
+}  // namespace SWSH
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Spectral")
 set(LIBRARY_SOURCES
   Test_ChebyshevGauss.cpp
   Test_ChebyshevGaussLobatto.cpp
+  Test_ComplexDataView.cpp
   Test_LegendreGauss.cpp
   Test_LegendreGaussLobatto.cpp
   Test_Projection.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ComplexDataView.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ComplexDataView.cpp
@@ -1,0 +1,250 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <complex>
+#include <cstddef>
+#include <random>
+#include <vector>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "ErrorHandling/Error.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Spectral {
+namespace SWSH {
+namespace detail {
+namespace {
+
+template <ComplexRepresentation Representation>
+void test_basic_view_functionality(
+    const ComplexDataView<Representation>& view,
+    std::complex<double>* const source_vec_data, const size_t view_size,
+    const size_t offset) noexcept {
+  CHECK(view.size() == view_size);
+  // clang-tidy: This class uses manual memory management deliberately,
+  // so silence complaints about pointer math and casts.
+  // The reinterpret casts are intentional. See
+  // NumericalAlgorithms/Spectral/ComplexDataView.cpp for an explanation
+  if (Representation == ComplexRepresentation::Interleaved) {
+    CHECK(view.real_data() ==
+          reinterpret_cast<double*>(source_vec_data + offset));  // NOLINT
+    CHECK(view.real_data() ==
+          reinterpret_cast<double*>(source_vec_data + offset));  // NOLINT
+  }
+  CHECK(view.stride() ==
+        (Representation == ComplexRepresentation::Interleaved ? 2 : 1));
+}
+
+template <ComplexRepresentation Representation>
+void test_view() noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<double> dist{-100.0, 100.0};
+  UniformCustomDistribution<size_t> sdist{5, 50};
+  const size_t overall_size = sdist(gen);
+  const size_t view_size = sdist(gen) % (overall_size) + 1;
+  const size_t offset = sdist(gen) % (overall_size - view_size + 1);
+  const size_t stride = ComplexDataView<Representation>::stride();
+  ComplexDataVector source_vec{overall_size};
+  std::vector<std::complex<double>> ptr_source_vec(overall_size);
+  ComplexDataVector assign_vec_1{view_size};
+  ComplexDataVector assign_vec_2{view_size};
+  ComplexDataVector assign_view_source{view_size};
+
+  fill_with_random_values(make_not_null(&source_vec), make_not_null(&gen),
+                          make_not_null(&dist));
+  fill_with_random_values(make_not_null(&ptr_source_vec), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  ComplexDataView<Representation> vector_view{make_not_null(&source_vec),
+                                              view_size, offset};
+  test_basic_view_functionality(vector_view, source_vec.data(), view_size,
+                                offset);
+
+  const ComplexDataVector source_vec_copy = source_vec;
+  // check conjugation utility
+  vector_view.conjugate();
+  for (size_t i = 0; i < view_size; i++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(vector_view.real_data()[stride * i] ==
+          real(source_vec_copy[i + offset]));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(vector_view.imag_data()[stride * i] ==
+          -imag(source_vec_copy[i + offset]));
+  }
+
+  vector_view.copy_back_to_source();
+  for (size_t i = 0; i < view_size; i++) {
+    CHECK(source_vec[i + offset] == conj(source_vec_copy)[i + offset]);
+  }
+
+  // reverse the conjugation and check again
+  vector_view.conjugate();
+  for (size_t i = 0; i < view_size; i++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(vector_view.real_data()[stride * i] ==
+          real(source_vec_copy[i + offset]));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(vector_view.imag_data()[stride * i] ==
+          imag(source_vec_copy[i + offset]));
+  }
+
+  vector_view.copy_back_to_source();
+  const ComplexDataView<Representation> ptr_view{
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      ptr_source_vec.data() + offset, view_size};
+  test_basic_view_functionality(ptr_view, ptr_source_vec.data(), view_size,
+                                offset);
+
+  const ComplexDataVector pre_change =
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      ComplexDataVector{source_vec.data() + offset, view_size};
+  // check the various assignment operators
+  for (size_t i = 0; i < view_size; i++) {
+    assign_vec_1[i] = source_vec[i + offset] + std::complex<double>{1.0, 1.0};
+    assign_vec_2[i] = source_vec[i + offset] + std::complex<double>{2.0, 2.0};
+  }
+
+  // real assignment
+  vector_view.assign_real(real(assign_vec_1));
+  for (size_t i = 0; i < view_size; i++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(vector_view.real_data()[stride * i] == real(assign_vec_1)[i]);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(vector_view.imag_data()[stride * i] == imag(pre_change)[i]);
+  }
+
+  vector_view.copy_back_to_source();
+  for (size_t i = 0; i < view_size; i++) {
+    CHECK(real(assign_vec_1[i]) == real(source_vec[i + offset]));
+    CHECK(imag(pre_change[i]) == imag(source_vec[i + offset]));
+  }
+
+  // imag assignment
+  vector_view.assign_imag(imag(assign_vec_2));
+  for (size_t i = 0; i < view_size; i++) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(vector_view.real_data()[stride * i] == real(assign_vec_1)[i]);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(vector_view.imag_data()[stride * i] == imag(assign_vec_2)[i]);
+  }
+
+  vector_view.copy_back_to_source();
+  for (size_t i = 0; i < view_size; i++) {
+    CHECK(real(assign_vec_1[i]) == real(source_vec[i + offset]));
+    CHECK(imag(assign_vec_2[i]) == imag(source_vec[i + offset]));
+  }
+
+  // check self-assignment from the referenced vector
+  assign_vec_1 = assign_vec_1;
+  for (size_t i = 0; i < view_size; i++) {
+    CHECK(real(assign_vec_1[i]) == real(source_vec[i + offset]));
+    CHECK(imag(assign_vec_1[i]) == imag(assign_vec_1[i]));
+  }
+
+  // full assignment from vector
+  fill_with_random_values(make_not_null(&assign_vec_1), make_not_null(&gen),
+                          make_not_null(&dist));
+  vector_view = assign_vec_1;
+  vector_view.copy_back_to_source();
+  for (size_t i = 0; i < view_size; i++) {
+    CHECK(source_vec[i + offset] == assign_vec_1[i]);
+  }
+
+  // full assignment from a view
+  fill_with_random_values(make_not_null(&assign_view_source),
+                          make_not_null(&gen), make_not_null(&dist));
+  ComplexDataView<Representation> assign_view{
+      make_not_null(&assign_view_source), assign_view_source.size()};
+  vector_view = assign_view;
+  vector_view.copy_back_to_source();
+  for (size_t i = 0; i < view_size; i++) {
+    CHECK(source_vec[i + offset] == assign_view_source[i]);
+  }
+
+  // check self-assignment from the view
+  // clang-tidy and gcc ignore for allowing the intentional self-assignment
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wextra"
+  vector_view = vector_view; // NOLINT
+#pragma GCC diagnostic pop
+  for (size_t i = 0; i < view_size; i++) {
+    CHECK(source_vec[i + offset] == assign_view_source[i]);
+  }
+  vector_view.copy_back_to_source();
+  for (size_t i = 0; i < view_size; i++) {
+    CHECK(source_vec[i + offset] == assign_view_source[i]);
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.ComplexDataView",
+                  "[Unit][NumericalAlgorithms]") {
+    {
+        INFO("Test Interleaved view");
+        test_view<ComplexRepresentation::Interleaved>();
+    }
+    {
+        INFO("Test RealsThenImags view");
+        test_view<ComplexRepresentation::RealsThenImags>();
+    }
+}
+
+// spot-test two assignment asserts - they all call the same size-checking
+// function, so this should be sufficiently robust.
+
+// [[OutputRegex, Assignment must be to the same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.Spectral.ComplexDataView.ComplexSizeError",
+    "[Unit][NumericalAlgorithms]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> sdist{5, 50};
+  const size_t overall_size = sdist(gen);
+  const size_t view_size = sdist(gen) % (overall_size - 1) + 1;
+  const size_t offset = sdist(gen) % (overall_size - view_size + 1);
+
+  ComplexDataVector source_vec{overall_size};
+  ComplexDataView<ComplexRepresentation::Interleaved> vector_view_1{
+      make_not_null(&source_vec), view_size, offset};
+  ComplexDataView<ComplexRepresentation::Interleaved> vector_view_2{
+      make_not_null(&source_vec), view_size + 1, offset};
+
+  // this line should fail the size assert
+  vector_view_1 = vector_view_2;
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Assignment must be to the same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.Spectral.ComplexDataView.RealSizeError",
+    "[Unit][NumericalAlgorithms]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> sdist{5, 50};
+  const size_t overall_size = sdist(gen);
+  const size_t view_size = sdist(gen) % (overall_size - 1) + 1;
+  const size_t offset = sdist(gen) % (overall_size - view_size + 1);
+
+  ComplexDataVector source_vec{overall_size};
+  ComplexDataView<ComplexRepresentation::RealsThenImags> vector_view_1{
+      make_not_null(&source_vec), view_size, offset};
+
+  // this line should fail the size assert
+  vector_view_1.assign_real(real(source_vec));
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+}  // namespace
+}  // namespace detail
+}  // namespace SWSH
+}  // namespace Spectral
+


### PR DESCRIPTION
## Proposed changes

 `ComplexDataView` is a utility memory management class for maintaining a convenient representation of complex data either as a pair of contiguous double blocks or as a pair of interleaved double blocks (i.e. a contiguous block of `std::complex<double>`). Steps are taken to avoid unnecessary copies in either representation, in an effort to improve performance and versatility of the
spherical harmonic utilities that will make use of the slice storage.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

- [x] Depends on #1268 