### PR TITLE
Template Variables on contained type

### DIFF
--- a/src/DataStructures/VariablesHelpers.hpp
+++ b/src/DataStructures/VariablesHelpers.hpp
@@ -59,11 +59,13 @@ void data_on_slice(const gsl::not_null<Variables<TagsList>*> interface_vars,
   const size_t volume_grid_points = vars.number_of_grid_points();
   constexpr const size_t number_of_independent_components =
       Variables<TagsList>::number_of_independent_components;
+
   if (interface_vars->number_of_grid_points() != interface_grid_points) {
     *interface_vars = Variables<TagsList>(interface_grid_points);
   }
-  const double* vars_data = vars.data();
-  double* interface_vars_data = interface_vars->data();
+  using value_type = typename Variables<TagsList>::value_type;
+  const value_type* vars_data = vars.data();
+  value_type* interface_vars_data = interface_vars->data();
   for (SliceIterator si(element_extents, sliced_dim, fixed_index); si; ++si) {
     for (size_t i = 0; i < number_of_independent_components; ++i) {
       // clang-tidy: do not use pointer arithmetic
@@ -168,8 +170,9 @@ void add_slice_to_data(const gsl::not_null<Variables<TagsList>*> volume_vars,
          "vars_on_slice has wrong number of grid points.  Expected "
          << slice_grid_points << ", got "
          << vars_on_slice.number_of_grid_points());
-  double* const volume_data = volume_vars->data();
-  const double* const slice_data = vars_on_slice.data();
+  using value_type = typename Variables<TagsList>::value_type;
+  value_type* const volume_data = volume_vars->data();
+  const value_type* const slice_data = vars_on_slice.data();
   for (SliceIterator si(extents, sliced_dim, fixed_index); si; ++si) {
     for (size_t i = 0; i < number_of_independent_components; ++i) {
       // clang-tidy: do not use pointer arithmetic
@@ -217,11 +220,12 @@ Variables<TagsList> orient_variables_on_slice(
     using Tag = tmpl::type_from<decltype(tag)>;
     auto& oriented_tensor = get<Tag>(oriented_variables);
     const auto& tensor_on_slice = get<Tag>(variables_on_slice);
+    using vector_type = typename Variables<TagsList>::vector_type;
     for (decltype(auto) oriented_and_slice_tensor_components :
          boost::combine(oriented_tensor, tensor_on_slice)) {
-      DataVector& oriented_tensor_component =
+      vector_type& oriented_tensor_component =
           boost::get<0>(oriented_and_slice_tensor_components);
-      const DataVector& tensor_component_on_slice =
+      const vector_type& tensor_component_on_slice =
           boost::get<1>(oriented_and_slice_tensor_components);
       for (size_t s = 0; s < number_of_grid_points; ++s) {
         oriented_tensor_component[oriented_offset[s]] =

--- a/src/Utilities/MakeSignalingNan.hpp
+++ b/src/Utilities/MakeSignalingNan.hpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+
+// @{
+/// \ingroup UtilitiesGroup
+/// \brief Returns an appropriate signaling NaN for fundamantal or multi-field
+/// types (such as `std::complex`).
+template <typename T>
+T make_signaling_NaN(const T& /*meta*/) noexcept {
+  return std::numeric_limits<T>::signaling_NaN();
+}
+
+template <typename T>
+std::complex<T> make_signaling_NaN(const std::complex<T>& /*meta*/) noexcept {
+  return {std::numeric_limits<T>::signaling_NaN(),
+          std::numeric_limits<T>::signaling_NaN()};
+}
+
+template <typename T>
+T make_signaling_NaN() noexcept {
+  return make_signaling_NaN(static_cast<T>(0));
+}
+// @}

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -348,6 +348,10 @@ constexpr bool is_unsigned_v = std::is_unsigned<T>::value;
 
 /// \ingroup TypeTraitsGroup
 template <class T>
+constexpr bool is_arithmetic_v = std::is_arithmetic<T>::value;
+
+/// \ingroup TypeTraitsGroup
+template <class T>
 constexpr bool is_floating_point_v = std::is_floating_point<T>::value;
 
 /// \ingroup TypeTraitsGroup

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -156,9 +156,6 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
       "T()=(-3)";
   CHECK(get_output(v) == expected_output);
 
-  Variables<tmpl::list<>> empty_vars;
-  CHECK(get_output(empty_vars) == "Variables is empty!");
-
   // Check self-assignment
 #ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -3,14 +3,12 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
-#include <boost/range/combine.hpp>
-#include <boost/tuple/tuple.hpp>
 #include <cstddef>
+#include <random>
 #include <string>
 #include <tuple>
-#include <type_traits>
-#include <utility>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -19,142 +17,222 @@
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesHelpers.hpp"
 #include "ErrorHandling/Error.hpp"
-#include "Parallel/PupStlCpp11.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
-#include "Utilities/StdHelpers.hpp"
+#include "Utilities/MakeString.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 // IWYU pragma: no_forward_declare Variables
+// IWYU pragma: no_include <boost/tuple/tuple.hpp>
+// IWYU pragma: no_include "DataStructures/VariablesForwardDecl.hpp"
 
 namespace VariablesTestTags_detail {
 /// [simple_variables_tag]
-struct vector : db::SimpleTag {
-  static std::string name() noexcept { return "vector"; }
-  using type = tnsr::I<DataVector, 3, Frame::Grid>;
+template <typename VectorType>
+struct tensor : db::SimpleTag {
+  static std::string name() noexcept { return "tensor"; }
+  using type = tnsr::I<VectorType, 3, Frame::Grid>;
 };
 /// [simple_variables_tag]
-
+template <typename VectorType>
 struct scalar : db::SimpleTag {
   static std::string name() noexcept { return "scalar"; }
-  using type = Scalar<DataVector>;
+  using type = Scalar<VectorType>;
 };
-
+template <typename VectorType>
 struct scalar2 : db::SimpleTag {
   static std::string name() noexcept { return "scalar2"; }
-  using type = Scalar<DataVector>;
+  using type = Scalar<VectorType>;
 };
 
 /// [prefix_variables_tag]
 template <class Tag>
-struct PrefixTag0 : db::PrefixTag, db::SimpleTag {
+struct Prefix0 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static std::string name() noexcept { return "PrefixTag0"; }
+  static std::string name() noexcept { return "Prefix0"; }
 };
 /// [prefix_variables_tag]
 
 template <class Tag>
-struct PrefixTag1 : db::PrefixTag, db::SimpleTag {
+struct Prefix1 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static std::string name() noexcept { return "PrefixTag1"; }
+  static std::string name() noexcept { return "Prefix1"; }
 };
 
 template <class Tag>
-struct PrefixTag2 : db::PrefixTag, db::SimpleTag {
+struct Prefix2 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static std::string name() noexcept { return "PrefixTag2"; }
+  static std::string name() noexcept { return "Prefix2"; }
 };
 
 template <class Tag>
-struct PrefixTag3 : db::PrefixTag, db::SimpleTag {
+struct Prefix3 : db::PrefixTag, db::SimpleTag {
   using type = db::item_type<Tag>;
   using tag = Tag;
-  static std::string name() noexcept { return "PrefixTag3"; }
+  static std::string name() noexcept { return "Prefix3"; }
 };
 }  // namespace VariablesTestTags_detail
 
 static_assert(
-    std::is_nothrow_move_constructible<
-        Variables<tmpl::list<VariablesTestTags_detail::scalar,
-                             VariablesTestTags_detail::vector>>>::value,
+    std::is_nothrow_move_constructible<Variables<
+        tmpl::list<VariablesTestTags_detail::scalar<DataVector>,
+                   VariablesTestTags_detail::tensor<DataVector>>>>::value,
     "Missing move semantics in Variables.");
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
-  Variables<tmpl::list<VariablesTestTags_detail::vector,
-                       VariablesTestTags_detail::scalar,
-                       VariablesTestTags_detail::scalar2>>
-      v(1, -3.0);
-  decltype(v) v_initialize;
-  v_initialize.initialize(1, -3.0);
-  CHECK(v == v_initialize);
+namespace {
+std::string repeat_string_with_commas(const std::string& str,
+                                      const size_t repeats) noexcept {
+  MakeString t;
+  for (size_t i = 0; i < repeats - 1; ++i) {
+    t << str << ",";
+  }
+  t << str;
+  return t;
+}
 
-  CHECK(v.size() ==
-        v.number_of_grid_points() * v.number_of_independent_components);
+template <typename VectorType>
+void test_variables_construction_and_access() noexcept {
+  using value_type = typename VectorType::value_type;
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<tt::get_fundamental_type_t<value_type>> dist{-100.0,
+                                                                         100.0};
+  UniformCustomDistribution<size_t> sdist{5, 20};
 
-  CHECK(1 == v.number_of_grid_points());
-  CHECK(5 == v.size());
+  const size_t number_of_grid_points = sdist(gen);
+  // Test constructed and member function initialized Variables are identical
+  const auto initial_fill_value = make_with_random_values<value_type>(
+      make_not_null(&gen), make_not_null(&dist));
 
-  auto& vector_in_v = get<VariablesTestTags_detail::vector>(v);
+  using VariablesType =
+      Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>,
+                           VariablesTestTags_detail::scalar<VectorType>,
+                           VariablesTestTags_detail::scalar2<VectorType>>>;
+
+  VariablesType filled_variables{number_of_grid_points, initial_fill_value};
+
+  VariablesType initialized_variables;
+  initialized_variables.initialize(number_of_grid_points, initial_fill_value);
+  CHECK(filled_variables == initialized_variables);
+
+  CHECK(filled_variables.size() ==
+        filled_variables.number_of_grid_points() *
+            filled_variables.number_of_independent_components);
+  CHECK(number_of_grid_points == filled_variables.number_of_grid_points());
+  CHECK(number_of_grid_points * 5 == filled_variables.size());
+  for (size_t i = 0; i < filled_variables.size(); ++i) {
+    // clang-tidy: do not use pointer arithmetic
+    CHECK(initial_fill_value == filled_variables.data()[i]);  // NOLINT
+  }
+  // Test that assigning to a tensor pointing into a Variables correctly sets
+  // the Variables
+  auto& tensor_in_filled_variables =
+      get<VariablesTestTags_detail::tensor<VectorType>>(filled_variables);
+  CHECK(VectorType{number_of_grid_points, initial_fill_value} ==
+        get<0>(tensor_in_filled_variables));
+  CHECK(VectorType{number_of_grid_points, initial_fill_value} ==
+        get<1>(tensor_in_filled_variables));
+  CHECK(VectorType{number_of_grid_points, initial_fill_value} ==
+        get<2>(tensor_in_filled_variables));
+
+  const auto value_for_reference_assignment =
+      make_with_random_values<value_type>(make_not_null(&gen),
+                                          make_not_null(&dist));
+
+  tnsr::I<VectorType, 3, Frame::Grid> tensor_for_reference_assignment{
+      number_of_grid_points, value_for_reference_assignment};
+  tensor_in_filled_variables = tensor_for_reference_assignment;
+
   // clang-tidy: do not use pointer arithmetic
-  CHECK(-3.0 == v.data()[0]);  // NOLINT
-  CHECK(-3.0 == vector_in_v.get(0)[0]);
+  for (size_t i = 0; i < number_of_grid_points * 3; ++i) {
+    CHECK(value_for_reference_assignment ==
+          filled_variables.data()[i]);  // NOLINT
+  }
+  CHECK(VectorType{number_of_grid_points, value_for_reference_assignment} ==
+        get<0>(tensor_in_filled_variables));
+  CHECK(VectorType{number_of_grid_points, value_for_reference_assignment} ==
+        get<1>(tensor_in_filled_variables));
+  CHECK(VectorType{number_of_grid_points, value_for_reference_assignment} ==
+        get<2>(tensor_in_filled_variables));
 
-  tnsr::I<DataVector, 3, Frame::Grid> another_vector(1_st, -5.0);
+  const auto value_for_tensor_constructor = make_with_random_values<value_type>(
+      make_not_null(&gen), make_not_null(&dist));
 
-  CHECK(-5.0 == another_vector.get(0)[0]);
-
-  vector_in_v = another_vector;
+  tensor_in_filled_variables = tnsr::I<VectorType, 3, Frame::Grid>{
+      number_of_grid_points, value_for_tensor_constructor};
 
   // clang-tidy: do not use pointer arithmetic
-  CHECK(-5.0 == v.data()[0]);  // NOLINT
-  CHECK(-5.0 == vector_in_v.get(0)[0]);
+  for (size_t i = 0; i < number_of_grid_points * 3; ++i) {
+    CHECK(value_for_tensor_constructor ==
+          filled_variables.data()[i]);  // NOLINT
+  }
+  CHECK(VectorType{number_of_grid_points, value_for_tensor_constructor} ==
+        get<0>(tensor_in_filled_variables));
+  CHECK(VectorType{number_of_grid_points, value_for_tensor_constructor} ==
+        get<1>(tensor_in_filled_variables));
+  CHECK(VectorType{number_of_grid_points, value_for_tensor_constructor} ==
+        get<2>(tensor_in_filled_variables));
 
-  vector_in_v = tnsr::I<DataVector, 3, Frame::Grid>{1_st, -4.0};
+  // Test const vector in variables points to right values
+  const auto& const_tensor_in_filled_variables =
+      get<VariablesTestTags_detail::tensor<VectorType>>(filled_variables);
+  CHECK(get<0>(const_tensor_in_filled_variables) ==
+        VectorType{number_of_grid_points, value_for_tensor_constructor});
+  CHECK(get<1>(const_tensor_in_filled_variables) ==
+        VectorType{number_of_grid_points, value_for_tensor_constructor});
+  CHECK(get<2>(const_tensor_in_filled_variables) ==
+        VectorType{number_of_grid_points, value_for_tensor_constructor});
 
-  // clang-tidy: do not use pointer arithmetic
-  CHECK(-4.0 == v.data()[0]);  // NOLINT
-  CHECK(-4.0 == v.data()[1]);  // NOLINT
-  CHECK(-4.0 == v.data()[2]);  // NOLINT
-  CHECK(-4.0 == vector_in_v.get(0)[0]);
-  CHECK(-4.0 == vector_in_v.get(1)[0]);
-  CHECK(-4.0 == vector_in_v.get(2)[0]);
+  // Test equivalence and inequivalence operators
+  VariablesType another_filled_variables{number_of_grid_points,
+                                         initial_fill_value};
+  // handle case of same value rolled twice on the random number generators
+  CHECK((filled_variables == another_filled_variables) ==
+        (initial_fill_value == value_for_tensor_constructor));
+  another_filled_variables = filled_variables;
+  CHECK(another_filled_variables == filled_variables);
 
-  const auto& kvector_in_v = get<VariablesTestTags_detail::vector>(v);
-  CHECK(kvector_in_v.get(0)[0] == -4.0);
+  // Test default constructed variables is allowed
+  VariablesType default_variables;
 
-  Variables<tmpl::list<VariablesTestTags_detail::vector,
-                       VariablesTestTags_detail::scalar,
-                       VariablesTestTags_detail::scalar2>>
-      v2(1, -3.0);
-  CHECK(v != v2);
-  v2 = v;
-  CHECK(v2 == v);
+  CHECK(default_variables.size() == 0);
+  CHECK(default_variables.number_of_grid_points() == 0);
+  default_variables = another_filled_variables;
+  CHECK(another_filled_variables == default_variables);
 
-  Variables<tmpl::list<VariablesTestTags_detail::vector,
-                       VariablesTestTags_detail::scalar,
-                       VariablesTestTags_detail::scalar2>>
-      v3;
-  CHECK(v3.size() == 0);
-  CHECK(v3.number_of_grid_points() == 0);
-  v3 = v2;
-  CHECK(v2 == v3);
+  std::string expected_output_initial = repeat_string_with_commas(
+      get_output(initial_fill_value), number_of_grid_points);
 
+  std::string expected_output_tensor = repeat_string_with_commas(
+      get_output(value_for_tensor_constructor), number_of_grid_points);
+
+  // Test stream operator
   const std::string expected_output =
-      "vector:\n"
-      "T(0)=(-4)\n"
-      "T(1)=(-4)\n"
-      "T(2)=(-4)\n\n"
+      "tensor:\n"
+      "T(0)=(" +
+      expected_output_tensor +
+      ")\n"
+      "T(1)=(" +
+      expected_output_tensor +
+      ")\n"
+      "T(2)=(" +
+      expected_output_tensor +
+      ")\n\n"
       "scalar:\n"
-      "T()=(-3)\n\n"
+      "T()=(" +
+      expected_output_initial +
+      ")\n\n"
       "scalar2:\n"
-      "T()=(-3)";
-  CHECK(get_output(v) == expected_output);
+      "T()=(" +
+      expected_output_initial + ")";
+  CHECK(get_output(filled_variables) == expected_output);
 
   // Check self-assignment
 #ifndef __APPLE__
@@ -163,364 +241,553 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
 #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
 #endif  // defined(__clang__) && __clang_major__ > 6
 #endif  // ! __APPLE__
-  v = v;
+  filled_variables = filled_variables;  // NOLINT
 #ifndef __APPLE__
 #if defined(__clang__) && __clang_major__ > 6
 #pragma GCC diagnostic pop
 #endif  // defined(__clang__) && __clang_major__ > 6
 #endif  // ! __APPLE__
-  CHECK(v == v2);
+  CHECK(filled_variables == another_filled_variables);
 
   CHECK(
-      Tags::Variables<tmpl::list<VariablesTestTags_detail::vector,
-                                 VariablesTestTags_detail::scalar,
-                                 VariablesTestTags_detail::scalar2>>::name() ==
-      "Variables(vector,scalar,scalar2)");
+      Tags::Variables<
+          tmpl::list<VariablesTestTags_detail::tensor<VectorType>,
+                     VariablesTestTags_detail::scalar<VectorType>,
+                     VariablesTestTags_detail::scalar2<VectorType>>>::name() ==
+      "Variables(tensor,scalar,scalar2)");
 }
 
-// [[OutputRegex, Must copy into same size]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.DataStructures.Variables.BadCopy",
-                               "[DataStructures][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  Variables<tmpl::list<VariablesTestTags_detail::vector,
-                       VariablesTestTags_detail::scalar,
-                       VariablesTestTags_detail::scalar2>>
-      v(1, -3.0);
-  auto& vector_in_v = get<VariablesTestTags_detail::vector>(v);
-  vector_in_v = tnsr::I<DataVector, 3, Frame::Grid>{10_st, -4.0};
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
+template <typename VectorType>
+void test_variables_move() noexcept {
+  using value_type = typename VectorType::value_type;
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<tt::get_fundamental_type_t<value_type>> dist{-100.0,
+                                                                         100.0};
+  UniformCustomDistribution<size_t> sdist{5, 20};
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Variables.Move",
-                  "[DataStructures][Unit]") {
-  Variables<tmpl::list<VariablesTestTags_detail::vector>> x(1, -2.0),
-      z(2, -3.0);
-  CHECK(&get<VariablesTestTags_detail::vector>(z)[0][0] == z.data());
-  Variables<tmpl::list<VariablesTestTags_detail::vector>> y = std::move(x);
-  x = std::move(z);
-  CHECK(
-      (x == Variables<tmpl::list<VariablesTestTags_detail::vector>>{2, -3.0}));
-  CHECK(&get<VariablesTestTags_detail::vector>(x)[0][0] == x.data());
 
-// Intentionally testing self-move
+  const size_t number_of_grid_points1 = sdist(gen);
+  const size_t number_of_grid_points2 = sdist(gen);
+  const std::array<value_type, 2> initial_fill_values =
+      make_with_random_values<std::array<value_type, 2>>(make_not_null(&gen),
+                                                         make_not_null(&dist));
+
+  // Test moving with assignment operator
+  Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>> move_to{
+      number_of_grid_points1, initial_fill_values[0]};
+  Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>> move_from{
+      number_of_grid_points2, initial_fill_values[1]};
+
+  Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>>
+      initializer_move_to = std::move(move_to);
+
+  move_to = std::move(move_from);
+  CHECK(move_to ==
+        Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>>{
+            number_of_grid_points2, initial_fill_values[1]});
+  CHECK(&get<VariablesTestTags_detail::tensor<VectorType>>(move_to)[0][0] ==
+        move_to.data());
+
+  // Intentionally testing self-move
 #ifdef __clang__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
 #endif  // defined(__clang__)
-  x = std::move(x);
+  move_to = std::move(move_to);
 #ifdef __clang__
 #pragma GCC diagnostic pop
 #endif  // defined(__clang__)
-  // clang-tidy: false positive 'x' used after it was moved
-  CHECK((x ==  // NOLINT
-         Variables<tmpl::list<VariablesTestTags_detail::vector>>{2, -3.0}));
-  CHECK(&get<VariablesTestTags_detail::vector>(x)[0][0] == x.data());
+  // clang-tidy: false positive 'move_to' used after it was moved
+  CHECK(move_to ==  // NOLINT
+        Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>>{
+            number_of_grid_points2, initial_fill_values[1]});
+  CHECK(&get<VariablesTestTags_detail::tensor<VectorType>>(move_to)[0][0] ==
+        move_to.data());
 }
 
-namespace {
-template <typename T1, typename VT, bool VF>
-void check_vectors(const Variables<T1>& t1, const blaze::Vector<VT, VF>& t2) {
-  CHECK(t1.size() == (~t2).size());
-  for (size_t i = 0; i < t1.size(); ++i) {
-    // We've removed the subscript operator so people don't try to use that
-    // and as a result we need to use the data() member function
-    // clang-tidy: do not use pointer arithmetic
-    CHECK(t1.data()[i] == approx((~t2)[i]));  // NOLINT
-  }
-}
+template <typename VectorType>
+void test_variables_math() noexcept {
+  using value_type = typename VectorType::value_type;
+  using TestVariablesType =
+      Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>,
+                           VariablesTestTags_detail::scalar<VectorType>,
+                           VariablesTestTags_detail::scalar2<VectorType>>>;
 
-template <typename T1, typename T2>
-void check_vectors(const Variables<T1>& t1, const Variables<T2>& t2) {
-  CHECK(t1.size() == t2.size());
-  for (size_t i = 0; i < t1.size(); ++i) {
-    // We've removed the subscript operator so people don't try to use that
-    // and as a result we need to use the data() member function
-    // clang-tidy: do not use pointer arithmetic
-    CHECK(t1.data()[i] == approx(t2.data()[i]));  // NOLINT
-  }
-}
-}  // namespace
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<tt::get_fundamental_type_t<value_type>> dist{1.0,
+                                                                         100.0};
+  UniformCustomDistribution<size_t> sdist{5, 20};
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Variables.Math",
-                  "[DataStructures][Unit]") {
-  using test_variable_type =
-      Variables<tmpl::list<VariablesTestTags_detail::vector,
-                           VariablesTestTags_detail::scalar,
-                           VariablesTestTags_detail::scalar2>>;
-  test_variable_type three(1, 3.0);
-  check_vectors(test_variable_type{1, 6}, 2.0 * three);
-  check_vectors(test_variable_type{1, 6}, three * 2.0);
-  check_vectors(test_variable_type{1, 1.5}, three / 2.0);
-  check_vectors(test_variable_type{1, 12}, three + three + three + three);
-  check_vectors(test_variable_type{1, 9}, three + (three + three));
+  const size_t num_points = sdist(gen);  // number of grid points
+  const auto value_in_variables = make_with_random_values<value_type>(
+      make_not_null(&gen), make_not_null(&dist));
+  const std::array<value_type, 3> rand_vals =
+      make_with_random_values<std::array<value_type,3>>(make_not_null(&gen),
+                                                        make_not_null(&dist));
 
-  // clang-tidy: point sides of overloaded operator are equivalent
-  check_vectors(test_variable_type{1, -6},
-                three - three - three - three);                      // NOLINT
-  check_vectors(test_variable_type{1, 3}, three - (three - three));  // NOLINT
-  check_vectors(test_variable_type{1, 3}, three - three + three);    // NOLINT
-  check_vectors(test_variable_type{1, 3}, three + three - three);
+  // Test math +, -, *, /
+  const TestVariablesType vars{num_points, value_in_variables};
+  TestVariablesType expected{num_points, rand_vals.at(0) * value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, rand_vals[0] * vars);
+  expected = TestVariablesType{num_points, value_in_variables * rand_vals[0]};
+  CHECK_VARIABLES_APPROX(expected, vars * rand_vals[0]);
+  expected = TestVariablesType{num_points, value_in_variables / rand_vals[0]};
+  CHECK_VARIABLES_APPROX(expected, vars / rand_vals[0]);
 
-  test_variable_type test_assignment(three * 1.0);
-  test_assignment += test_variable_type{1, 3};
-  check_vectors(test_variable_type{1, 6}, test_assignment);
-  test_assignment -= test_variable_type{1, 2};
-  check_vectors(test_variable_type{1, 4}, test_assignment);
-  test_assignment *= 0.25;
-  check_vectors(test_variable_type{1, 1.0}, test_assignment);
-  test_assignment /= 0.1;
-  check_vectors(test_variable_type{1, 10.0}, test_assignment);
+  expected = TestVariablesType{num_points, 4. * value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, vars + vars + vars + vars);
+  expected = TestVariablesType{num_points, 3. * value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, vars + (vars + vars));
+  // clang-tidy: both sides of overloaded operator are equivalent
+  expected = TestVariablesType{num_points, -2. * value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, vars - vars - vars - vars);  // NOLINT
+  expected = TestVariablesType{num_points, value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, vars - (vars - vars));  // NOLINT
+  expected = TestVariablesType{num_points, -value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, vars - (vars + vars));
+  expected = TestVariablesType{num_points, value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, vars - vars + vars);  // NOLINT
+  expected = TestVariablesType{num_points, value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, vars + vars - vars);
 
-  test_assignment += test_variable_type{1, 3} * 3.0;
-  check_vectors(test_variable_type{1, 19.0}, test_assignment);
-  test_assignment -= test_variable_type{1, 3} * 2.0;
-  check_vectors(test_variable_type{1, 13.0}, test_assignment);
+  // Test math_assignment operators +=, -=, *=, /= with values
+  TestVariablesType test_assignment(vars * rand_vals[0]);
+  auto expected_val = value_in_variables * rand_vals[0];
+  test_assignment += TestVariablesType{num_points, value_in_variables};
+  expected_val += value_in_variables;
+  expected = TestVariablesType{num_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected, test_assignment);
+  test_assignment -= TestVariablesType{num_points, rand_vals[1]};
+  expected_val -= rand_vals[1];
+  expected = TestVariablesType{num_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected, test_assignment);
+  test_assignment *= rand_vals[2];
+  expected_val *= rand_vals[2];
+  expected = TestVariablesType{num_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected, test_assignment);
+  test_assignment /= rand_vals[0];
+  expected_val /= rand_vals[0];
+  expected = TestVariablesType{num_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected, test_assignment);
 
-  test_variable_type test_assignment2(1, 0.0);
+  test_assignment +=
+      TestVariablesType{num_points, value_in_variables} * rand_vals[1];
+  expected_val += value_in_variables * rand_vals[1];
+  expected = TestVariablesType{num_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected, test_assignment);
+  test_assignment -= TestVariablesType{num_points, rand_vals[2]} * rand_vals[0];
+  expected_val -= rand_vals[2] * rand_vals[0];
+  expected = TestVariablesType{num_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected, test_assignment);
+
+  TestVariablesType test_assignment2{num_points};
   test_assignment2 = test_assignment * 1.0;
   CHECK(test_assignment2 == test_assignment);
 
   const auto check_components = [](const auto& variables,
-                                   const DataVector& datavector) {
+                                   const VectorType& tensor) noexcept {
     tmpl::for_each<typename std::decay_t<decltype(variables)>::tags_list>(
-        [&variables, &datavector](auto tag) {
+        [&variables, &tensor ](auto tag) noexcept {
           using Tag = tmpl::type_from<decltype(tag)>;
           for (const auto& component : get<Tag>(variables)) {
-            CHECK(component == datavector);
-          }
-        });
-  };
-  const DataVector dv{1., 2., 3., 4.};
-  test_variable_type test_datavector_math(4, 2.);
-  test_datavector_math *= dv;
-  check_components(test_datavector_math, {2., 4., 6., 8.});
-  check_components(test_datavector_math * dv, {2., 8., 18., 32.});
-  check_components(dv * test_datavector_math, {2., 8., 18., 32.});
-  test_datavector_math *= dv;
-  check_components(test_datavector_math, {2., 8., 18., 32.});
-  check_components(test_datavector_math / dv, {2., 4., 6., 8.});
-  test_datavector_math /= dv;
-  check_components(test_datavector_math, {2., 4., 6., 8.});
-}
-
-SPECTRE_TEST_CASE("Unit.DataStructures.Variables.PrefixSemantics",
-                  "[DataStructures][Unit]") {
-  using variable_type =
-      Variables<tmpl::list<VariablesTestTags_detail::vector,
-                           VariablesTestTags_detail::scalar,
-                           VariablesTestTags_detail::scalar2>>;
-  using prefix_variable_type = Variables<tmpl::list<
-      VariablesTestTags_detail::PrefixTag0<VariablesTestTags_detail::vector>,
-      VariablesTestTags_detail::PrefixTag0<VariablesTestTags_detail::scalar>,
-      VariablesTestTags_detail::PrefixTag0<VariablesTestTags_detail::scalar2>>>;
-  prefix_variable_type prefix_vars_0(4, 8.);
-  prefix_variable_type prefix_vars_1(4, 6.);
-  variable_type vars_0(prefix_vars_0);
-  variable_type vars_1(std::move(prefix_vars_1));
-
-  const auto check_variables = [](const auto& lvars_0, const auto& lvars_1) {
-    tmpl::for_each<typename std::decay_t<decltype(lvars_0)>::tags_list>(
-        [&lvars_0, &lvars_1](auto tag) {
-          using Tag = tmpl::type_from<decltype(tag)>;
-          for (const auto& component :
-               boost::combine(get<Tag>(lvars_0), get<Tag>(lvars_1))) {
-            CHECK(boost::get<0>(component) == boost::get<1>(component));
+            CHECK(component == tensor);
           }
         });
   };
 
-  check_variables(vars_0, variable_type(4, 8.0));
-  check_variables(vars_1, variable_type(4, 6.0));
+  const VectorType test_vector = make_with_random_values<VectorType>(
+      make_not_null(&gen), make_not_null(&dist), VectorType{4});
 
-  prefix_variable_type prefix_vars_2(4, 4.);
-  prefix_variable_type prefix_vars_3(4, 2.);
-  vars_0 = prefix_vars_2;
-  check_variables(vars_0, variable_type(4, 4.0));
-  vars_0 = std::move(prefix_vars_3);
-  check_variables(vars_0, variable_type(4, 2.0));
+  // Test math assignment operators +=, -=, *=, /= with vectors
+  TestVariablesType test_vector_math(4, rand_vals[0]);
+  test_vector_math *= test_vector;
+  VectorType vec_expect = rand_vals[0] * test_vector;
+  check_components(test_vector_math, vec_expect);
+  vec_expect *= test_vector;
+  check_components(test_vector_math * test_vector, vec_expect);
+  check_components(test_vector * test_vector_math, vec_expect);
+  test_vector_math *= test_vector;
+  check_components(test_vector_math, vec_expect);
+  vec_expect /= test_vector;
+  check_components(test_vector_math / test_vector, vec_expect);
+  test_vector_math /= test_vector;
+  check_components(test_vector_math, vec_expect);
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Variables.PrefixMath",
-                  "[DataStructures][Unit]") {
-  using prefix0_variable_type = Variables<tmpl::list<
-      VariablesTestTags_detail::PrefixTag0<VariablesTestTags_detail::vector>,
-      VariablesTestTags_detail::PrefixTag0<VariablesTestTags_detail::scalar>,
-      VariablesTestTags_detail::PrefixTag0<VariablesTestTags_detail::scalar2>>>;
-  using prefix1_variable_type = Variables<tmpl::list<
-      VariablesTestTags_detail::PrefixTag1<VariablesTestTags_detail::vector>,
-      VariablesTestTags_detail::PrefixTag1<VariablesTestTags_detail::scalar>,
-      VariablesTestTags_detail::PrefixTag1<VariablesTestTags_detail::scalar2>>>;
-  using prefix2_variable_type = Variables<tmpl::list<
-      VariablesTestTags_detail::PrefixTag2<VariablesTestTags_detail::vector>,
-      VariablesTestTags_detail::PrefixTag2<VariablesTestTags_detail::scalar>,
-      VariablesTestTags_detail::PrefixTag2<VariablesTestTags_detail::scalar2>>>;
-  using prefix3_variable_type = Variables<tmpl::list<
-      VariablesTestTags_detail::PrefixTag3<VariablesTestTags_detail::PrefixTag2<
-          VariablesTestTags_detail::vector>>,
-      VariablesTestTags_detail::PrefixTag3<VariablesTestTags_detail::PrefixTag2<
-          VariablesTestTags_detail::scalar>>,
-      VariablesTestTags_detail::PrefixTag3<VariablesTestTags_detail::PrefixTag2<
-          VariablesTestTags_detail::scalar2>>>>;
+template <typename VectorType>
+void test_variables_prefix_semantics() noexcept {
+  using TagList = tmpl::list<VariablesTestTags_detail::tensor<VectorType>,
+                             VariablesTestTags_detail::scalar<VectorType>,
+                             VariablesTestTags_detail::scalar2<VectorType>>;
+  using VariablesType = Variables<TagList>;
+  using PrefixVariablesType =
+      Variables<db::wrap_tags_in<VariablesTestTags_detail::Prefix0, TagList>>;
+  using value_type = typename VectorType::value_type;
 
-  prefix0_variable_type three_0(1, 3.0);
-  prefix1_variable_type three_1(1, 3.0);
-  prefix2_variable_type three_2(1, 3.0);
-  prefix3_variable_type three_3(1, 3.0);
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<tt::get_fundamental_type_t<value_type>> dist{-100.0,
+                                                                         100.0};
+  UniformCustomDistribution<size_t> sdist{5, 20};
 
-  check_vectors(prefix3_variable_type{1, 6.0}, 2.0 * three_0);
-  check_vectors(prefix3_variable_type{1, 6.0}, three_0 * 2.0);
-  check_vectors(prefix3_variable_type{1, 1.5}, three_0 / 2.0);
-  check_vectors(prefix3_variable_type{1, 12.0},
-                three_0 + three_1 + three_2 + three_3);
-  check_vectors(prefix3_variable_type{1, 12.0},
-                (three_0 + three_1) + (three_2 + three_3));
-  check_vectors(prefix3_variable_type{1, 9.0}, three_0 + (three_1 + three_2));
+  const size_t number_of_grid_points = sdist(gen);
+  const std::array<value_type, 4> variables_vals =
+      make_with_random_values<std::array<value_type, 4>>(make_not_null(&gen),
+                                                         make_not_null(&dist));
 
-  // clang-tidy: point sides of overloaded operator are equivalent
-  check_vectors(prefix3_variable_type{1, -6.0},
-                three_0 - three_1 - three_2 - three_3);  // NOLINT
-  check_vectors(prefix3_variable_type{1, 6.0},
-                three_0 - (three_1 - three_2 - three_3));  // NOLINT
-  check_vectors(prefix3_variable_type{1, 0.0},
-                (three_0 - three_1) - (three_2 - three_3));  // NOLINT
-  check_vectors(prefix3_variable_type{1, 3.0},
-                three_0 - (three_1 - three_2));  // NOLINT
-  check_vectors(prefix3_variable_type{1, 3.0},
-                three_0 - three_1 + three_2);  // NOLINT
-  check_vectors(prefix3_variable_type{1, 3.0}, three_0 + three_1 - three_2);
+  // Check move and copy from prefix variables to non-prefix variables via
+  // constructor
+  PrefixVariablesType prefix_vars_copy_construct_from{number_of_grid_points,
+                                                      variables_vals[0]};
+  PrefixVariablesType prefix_vars_move_construct_from{number_of_grid_points,
+                                                      variables_vals[1]};
+  VariablesType vars_to{prefix_vars_copy_construct_from};
+  VariablesType move_constructed_vars{
+    std::move(prefix_vars_move_construct_from)};
 
-  prefix0_variable_type test_assignment(three_0 * 1.0);
-  test_assignment += prefix1_variable_type{1, 3};
-  check_vectors(prefix0_variable_type{1, 6}, test_assignment);
-  test_assignment -= prefix1_variable_type{1, 2};
-  check_vectors(prefix0_variable_type{1, 4}, test_assignment);
-  test_assignment *= 0.25;
-  check_vectors(prefix0_variable_type{1, 1.0}, test_assignment);
-  test_assignment /= 0.1;
-  check_vectors(prefix0_variable_type{1, 10.0}, test_assignment);
+  VariablesType expected{number_of_grid_points, variables_vals[0]};
+  CHECK_VARIABLES_APPROX(vars_to, expected);
+  expected = VariablesType(number_of_grid_points, variables_vals[1]);
+  CHECK_VARIABLES_APPROX(move_constructed_vars, expected);
 
-  test_assignment += prefix1_variable_type{1, 3} * 3.0;
-  check_vectors(prefix0_variable_type{1, 19.0}, test_assignment);
-  test_assignment -= prefix1_variable_type{1, 3} * 2.0;
-  check_vectors(prefix0_variable_type{1, 13.0}, test_assignment);
+  // Check move and copy from prefix variables to non-prefix variables via
+  // assignment operator
+  PrefixVariablesType prefix_vars_copy_assign_from{number_of_grid_points,
+                                                   variables_vals[2]};
+  PrefixVariablesType prefix_vars_move_assign_from{number_of_grid_points,
+                                                   variables_vals[3]};
+  vars_to = prefix_vars_copy_assign_from;
+  CHECK_VARIABLES_APPROX(
+      vars_to, VariablesType(number_of_grid_points, variables_vals[2]));
+  vars_to = std::move(prefix_vars_move_assign_from);
+  CHECK_VARIABLES_APPROX(
+      vars_to, VariablesType(number_of_grid_points, variables_vals[3]));
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Variables.Serialization",
-                  "[DataStructures][Unit]") {
-  Variables<tmpl::list<VariablesTestTags_detail::vector>> v(1, -3.0);
-  test_serialization(v);
-  auto tuple_of_v = std::make_tuple(
-      Variables<tmpl::list<VariablesTestTags_detail::vector>>{1, -4.0});
-  test_serialization(tuple_of_v);
+template <typename VectorType>
+void test_variables_prefix_math() noexcept {
+  using TagList = tmpl::list<VariablesTestTags_detail::tensor<VectorType>,
+                             VariablesTestTags_detail::scalar<VectorType>,
+                             VariablesTestTags_detail::scalar2<VectorType>>;
+  using Prefix0VariablesType =
+      Variables<db::wrap_tags_in<VariablesTestTags_detail::Prefix0, TagList>>;
+  using Prefix1VariablesType =
+      Variables<db::wrap_tags_in<VariablesTestTags_detail::Prefix1, TagList>>;
+  using Prefix2VariablesType =
+      Variables<db::wrap_tags_in<VariablesTestTags_detail::Prefix2, TagList>>;
+  using Prefix3VariablesType =
+      Variables<db::wrap_tags_in<VariablesTestTags_detail::Prefix3, TagList>>;
+  using value_type = typename VectorType::value_type;
+
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<tt::get_fundamental_type_t<value_type>> dist{1.0,
+                                                                         100.0};
+  UniformCustomDistribution<size_t> sdist{5, 20};
+
+  const size_t number_of_grid_points = sdist(gen);
+  const auto value_in_variables = make_with_random_values<value_type>(
+      make_not_null(&gen), make_not_null(&dist));
+  const std::array<value_type, 3> random_vals =
+      make_with_random_values<std::array<value_type, 3>>(make_not_null(&gen),
+                                                         make_not_null(&dist));
+
+  // Test arithmetic operators +, -, *, / for prefix Variables.
+
+  // We wish to verify that operations among multiple Variables with distinct
+  // prefixes give a Variables populated with the desired data. This is
+  // important for multiplying, for instance a variables populated with time
+  // derivatives with a variables populated with time intervals, which would
+  // have the same types, but have distinct prefixes.
+  Prefix0VariablesType prefix_vars0(number_of_grid_points, value_in_variables);
+  Prefix1VariablesType prefix_vars1(number_of_grid_points, value_in_variables);
+  Prefix2VariablesType prefix_vars2(number_of_grid_points, value_in_variables);
+  Prefix3VariablesType prefix_vars3(number_of_grid_points, value_in_variables);
+
+  Prefix3VariablesType expected{number_of_grid_points,
+                                value_in_variables * random_vals[0]};
+  CHECK_VARIABLES_APPROX(expected, random_vals[0] * prefix_vars0);
+  expected = Prefix3VariablesType{number_of_grid_points,
+                                  value_in_variables * random_vals[0]};
+  CHECK_VARIABLES_APPROX(expected, prefix_vars0 * random_vals[0]);
+  expected = Prefix3VariablesType{number_of_grid_points,
+                                  value_in_variables / random_vals[0]};
+  CHECK_VARIABLES_APPROX(expected, prefix_vars0 / random_vals[0]);
+  expected =
+      Prefix3VariablesType{number_of_grid_points, 4.0 * value_in_variables};
+  CHECK_VARIABLES_APPROX(
+      expected, prefix_vars0 + prefix_vars1 + prefix_vars2 + prefix_vars3);
+  expected =
+      Prefix3VariablesType{number_of_grid_points, 4.0 * value_in_variables};
+  CHECK_VARIABLES_APPROX(
+      expected, (prefix_vars0 + prefix_vars1) + (prefix_vars2 + prefix_vars3));
+  expected =
+      Prefix3VariablesType{number_of_grid_points, 3.0 * value_in_variables};
+
+  CHECK_VARIABLES_APPROX(expected,
+                         prefix_vars0 + (prefix_vars1 + prefix_vars2));
+
+  // clang-tidy: both sides of overloaded operator are equivalent
+  expected =
+      Prefix3VariablesType{number_of_grid_points, -2.0 * value_in_variables};
+  CHECK_VARIABLES_APPROX(
+      expected,
+      prefix_vars0 - prefix_vars1 - prefix_vars2 - prefix_vars3);  // NOLINT
+  expected =
+      Prefix3VariablesType{number_of_grid_points, 2.0 * value_in_variables};
+  CHECK_VARIABLES_APPROX(
+      expected,
+      prefix_vars0 - (prefix_vars1 - prefix_vars2 - prefix_vars3));  // NOLINT
+  expected =
+      Prefix3VariablesType{number_of_grid_points, 0.0 * value_in_variables};
+  CHECK_VARIABLES_APPROX(
+      expected,
+      (prefix_vars0 - prefix_vars1) - (prefix_vars2 - prefix_vars3));  // NOLINT
+  expected =
+      Prefix3VariablesType{number_of_grid_points, 1.0 * value_in_variables};
+  CHECK_VARIABLES_APPROX(
+      expected, prefix_vars0 - (prefix_vars1 - prefix_vars2));  // NOLINT
+  expected =
+      Prefix3VariablesType{number_of_grid_points, 1.0 * value_in_variables};
+  CHECK_VARIABLES_APPROX(expected,
+                         prefix_vars0 - prefix_vars1 + prefix_vars2);  // NOLINT
+  expected =
+      Prefix3VariablesType{number_of_grid_points, 1.0 * value_in_variables};
+  CHECK_VARIABLES_APPROX(expected, prefix_vars0 + prefix_vars1 - prefix_vars2);
+
+  // Test assignment arithmetic operators +=, -=, *=, /= with values
+  Prefix0VariablesType test_assignment(prefix_vars0 * 1.0);
+  test_assignment +=
+      Prefix1VariablesType{number_of_grid_points, value_in_variables};
+  auto expected_val = 2.0 * value_in_variables;
+  Prefix0VariablesType expected_prefix0{number_of_grid_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected_prefix0, test_assignment);
+  test_assignment -=
+      Prefix1VariablesType{number_of_grid_points, random_vals[0]};
+  expected_val -= random_vals[0];
+  expected_prefix0 = Prefix0VariablesType{number_of_grid_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected_prefix0, test_assignment);
+  test_assignment *= random_vals[1];
+  expected_val *= random_vals[1];
+  expected_prefix0 = Prefix0VariablesType{number_of_grid_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected_prefix0, test_assignment);
+  test_assignment /= random_vals[2];
+  expected_val /= random_vals[2];
+  expected_prefix0 = Prefix0VariablesType{number_of_grid_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected_prefix0, test_assignment);
+
+  test_assignment +=
+      Prefix1VariablesType{number_of_grid_points, random_vals[0]} *
+      random_vals[1];
+  expected_val += random_vals[0] * random_vals[1];
+  expected_prefix0 = Prefix0VariablesType{number_of_grid_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected_prefix0, test_assignment);
+  test_assignment -=
+      Prefix1VariablesType{number_of_grid_points, random_vals[0]} *
+      random_vals[2];
+  expected_val -= random_vals[0] * random_vals[2];
+  expected_prefix0 = Prefix0VariablesType{number_of_grid_points, expected_val};
+  CHECK_VARIABLES_APPROX(expected_prefix0, test_assignment);
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Variables.assign_subset",
-                  "[DataStructures][Unit]") {
-  constexpr size_t size = 3;
-  const auto first_test = [&size](const auto& vars_subset0,
-                                  const auto& vars_subset1) noexcept {
-    Variables<tmpl::list<VariablesTestTags_detail::vector,
-                         VariablesTestTags_detail::scalar>>
-        vars_set0{size, 3.0};
-    CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
-          db::item_type<VariablesTestTags_detail::vector>(size, 3.0));
-    CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
-          db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
-    vars_set0.assign_subset(vars_subset0);
-    CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
-          db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
-    CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
-          db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
-    vars_set0.assign_subset(vars_subset1);
-    CHECK(get<VariablesTestTags_detail::vector>(vars_set0) ==
-          db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
-    CHECK(get<VariablesTestTags_detail::scalar>(vars_set0) ==
-          db::item_type<VariablesTestTags_detail::scalar>(size, 4.0));
+template <typename VectorType>
+void test_variables_serialization() noexcept {
+  using value_type = typename VectorType::value_type;
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<tt::get_fundamental_type_t<value_type>> dist{-100.0,
+                                                                         100.0};
+  UniformCustomDistribution<size_t> sdist{5, 20};
+
+  const size_t number_of_grid_points = sdist(gen);
+  const std::array<value_type, 2> values_in_variables =
+      make_with_random_values<std::array<value_type, 2>>(make_not_null(&gen),
+                                                         make_not_null(&dist));
+
+  // Test serialization of a Variables and a tuple of Variables
+  Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>>
+      test_variables(number_of_grid_points, values_in_variables[0]);
+  test_serialization(test_variables);
+  auto tuple_of_test_variables = std::make_tuple(
+      Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>>{
+          number_of_grid_points, values_in_variables[1]});
+  test_serialization(tuple_of_test_variables);
+}
+
+template <typename VectorType>
+void test_variables_assign_subset() noexcept {
+  using value_type = typename VectorType::value_type;
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<tt::get_fundamental_type_t<value_type>> dist{-100.0,
+                                                                         100.0};
+  UniformCustomDistribution<size_t> sdist{5, 20};
+
+  const size_t number_of_grid_points = sdist(gen);
+  const std::array<value_type, 4> values_in_variables =
+      make_with_random_values<std::array<value_type, 4>>(make_not_null(&gen),
+                                                         make_not_null(&dist));
+
+  // Test assigning a single tag to a Variables with two tags, either from a
+  // Variables or a TaggedTuple
+  const auto test_assign_to_vars_with_two_tags =
+      [&number_of_grid_points, &values_in_variables ](
+          const auto& vars_subset0, const auto& vars_subset1,
+          const value_type& vars_subset0_val,
+          const value_type& vars_subset1_val) noexcept {
+    Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>,
+                         VariablesTestTags_detail::scalar<VectorType>>>
+        vars_set{number_of_grid_points, values_in_variables[0]};
+    CHECK(get<VariablesTestTags_detail::tensor<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::tensor<VectorType>>(
+              number_of_grid_points, values_in_variables[0]));
+    CHECK(get<VariablesTestTags_detail::scalar<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::scalar<VectorType>>(
+              number_of_grid_points, values_in_variables[0]));
+    vars_set.assign_subset(vars_subset0);
+    CHECK(get<VariablesTestTags_detail::tensor<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::tensor<VectorType>>(
+              number_of_grid_points, vars_subset0_val));
+    CHECK(get<VariablesTestTags_detail::scalar<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::scalar<VectorType>>(
+              number_of_grid_points, values_in_variables[0]));
+    vars_set.assign_subset(vars_subset1);
+    CHECK(get<VariablesTestTags_detail::tensor<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::tensor<VectorType>>(
+              number_of_grid_points, vars_subset0_val));
+    CHECK(get<VariablesTestTags_detail::scalar<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::scalar<VectorType>>(
+              number_of_grid_points, vars_subset1_val));
   };
 
-  first_test(
-      Variables<tmpl::list<VariablesTestTags_detail::vector>>(size, 8.0),
-      Variables<tmpl::list<VariablesTestTags_detail::scalar>>(size, 4.0));
-  first_test(tuples::TaggedTuple<VariablesTestTags_detail::vector>(
-                 VariablesTestTags_detail::vector::type{size, 8.0}),
-             tuples::TaggedTuple<VariablesTestTags_detail::scalar>(
-                 VariablesTestTags_detail::scalar::type{size, 4.0}));
+  test_assign_to_vars_with_two_tags(
+      Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>>(
+          number_of_grid_points, values_in_variables[1]),
+      Variables<tmpl::list<VariablesTestTags_detail::scalar<VectorType>>>(
+          number_of_grid_points, values_in_variables[2]),
+      values_in_variables[1], values_in_variables[2]);
+  test_assign_to_vars_with_two_tags(
+      tuples::TaggedTuple<VariablesTestTags_detail::tensor<VectorType>>(
+          typename VariablesTestTags_detail::tensor<VectorType>::type{
+              number_of_grid_points, values_in_variables[1]}),
+      tuples::TaggedTuple<VariablesTestTags_detail::scalar<VectorType>>(
+          typename VariablesTestTags_detail::scalar<VectorType>::type{
+              number_of_grid_points, values_in_variables[2]}),
+      values_in_variables[1], values_in_variables[2]);
 
-  const auto second_test = [&size](const auto& vars_subset0,
-                                   const auto& vars_subset1) noexcept {
-    Variables<tmpl::list<VariablesTestTags_detail::vector,
-                         VariablesTestTags_detail::scalar,
-                         VariablesTestTags_detail::scalar2>>
-        vars_set1(size, 3.0);
-    CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
-          db::item_type<VariablesTestTags_detail::vector>(size, 3.0));
-    CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
-          db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
-    CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
-          db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
-    vars_set1.assign_subset(vars_subset0);
-    CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
-          db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
-    CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
-          db::item_type<VariablesTestTags_detail::scalar>(size, 3.0));
-    CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
-          db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
-    vars_set1.assign_subset(vars_subset1);
-    CHECK(get<VariablesTestTags_detail::vector>(vars_set1) ==
-          db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
-    CHECK(get<VariablesTestTags_detail::scalar>(vars_set1) ==
-          db::item_type<VariablesTestTags_detail::scalar>(size, 4.0));
-    CHECK(get<VariablesTestTags_detail::scalar2>(vars_set1) ==
-          db::item_type<VariablesTestTags_detail::scalar2>(size, 3.0));
+  // Test assigning a single tag to a Variables with three tags, either from a
+  // Variables or a TaggedTuple
+  const auto test_assign_to_vars_with_three_tags =
+      [&number_of_grid_points, &values_in_variables ](
+          const auto& vars_subset0, const auto& vars_subset1,
+          const value_type& vars_subset0_val,
+          const value_type& vars_subset1_val) noexcept {
+    Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>,
+                         VariablesTestTags_detail::scalar<VectorType>,
+                         VariablesTestTags_detail::scalar2<VectorType>>>
+        vars_set(number_of_grid_points, values_in_variables[0]);
+    CHECK(get<VariablesTestTags_detail::tensor<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::tensor<VectorType>>(
+              number_of_grid_points, values_in_variables[0]));
+    CHECK(get<VariablesTestTags_detail::scalar<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::scalar<VectorType>>(
+              number_of_grid_points, values_in_variables[0]));
+    CHECK(get<VariablesTestTags_detail::scalar2<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::scalar2<VectorType>>(
+              number_of_grid_points, values_in_variables[0]));
+    vars_set.assign_subset(vars_subset0);
+    CHECK(get<VariablesTestTags_detail::tensor<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::tensor<VectorType>>(
+              number_of_grid_points, vars_subset0_val));
+    CHECK(get<VariablesTestTags_detail::scalar<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::scalar<VectorType>>(
+              number_of_grid_points, values_in_variables[0]));
+    CHECK(get<VariablesTestTags_detail::scalar2<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::scalar2<VectorType>>(
+              number_of_grid_points, values_in_variables[0]));
+    vars_set.assign_subset(vars_subset1);
+    CHECK(get<VariablesTestTags_detail::tensor<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::tensor<VectorType>>(
+              number_of_grid_points, vars_subset0_val));
+    CHECK(get<VariablesTestTags_detail::scalar<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::scalar<VectorType>>(
+              number_of_grid_points, vars_subset1_val));
+    CHECK(get<VariablesTestTags_detail::scalar2<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::scalar2<VectorType>>(
+              number_of_grid_points, values_in_variables[0]));
   };
 
-  second_test(
-      Variables<tmpl::list<VariablesTestTags_detail::vector>>(size, 8.0),
-      Variables<tmpl::list<VariablesTestTags_detail::scalar>>(size, 4.0));
-  second_test(tuples::TaggedTuple<VariablesTestTags_detail::vector>(
-                  VariablesTestTags_detail::vector::type{size, 8.0}),
-              tuples::TaggedTuple<VariablesTestTags_detail::scalar>(
-                  VariablesTestTags_detail::scalar::type{size, 4.0}));
+  test_assign_to_vars_with_three_tags(
+      Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>>(
+          number_of_grid_points, values_in_variables[1]),
+      Variables<tmpl::list<VariablesTestTags_detail::scalar<VectorType>>>(
+          number_of_grid_points, values_in_variables[2]),
+      values_in_variables[1], values_in_variables[2]);
+  test_assign_to_vars_with_three_tags(
+      tuples::TaggedTuple<VariablesTestTags_detail::tensor<VectorType>>(
+          typename VariablesTestTags_detail::tensor<VectorType>::type{
+              number_of_grid_points, values_in_variables[1]}),
+      tuples::TaggedTuple<VariablesTestTags_detail::scalar<VectorType>>(
+          typename VariablesTestTags_detail::scalar<VectorType>::type{
+              number_of_grid_points, values_in_variables[2]}),
+      values_in_variables[1], values_in_variables[2]);
 
-  const auto third_test = [&size](const auto& vars_subset0) noexcept {
-    Variables<tmpl::list<VariablesTestTags_detail::vector>> vars_set2(size,
-                                                                      -7.0);
-    CHECK(get<VariablesTestTags_detail::vector>(vars_set2) ==
-          db::item_type<VariablesTestTags_detail::vector>(size, -7.0));
-    vars_set2.assign_subset(vars_subset0);
-    CHECK(get<VariablesTestTags_detail::vector>(vars_set2) ==
-          db::item_type<VariablesTestTags_detail::vector>(size, 8.0));
+  // Test assignment to a Variables with a single tag either from a Variables or
+  // a TaggedTuple
+  const auto test_assign_to_vars_with_one_tag = [
+    &number_of_grid_points, &values_in_variables
+  ](const auto& vars_subset0, const value_type& vars_subset0_val) noexcept {
+    Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>>
+        vars_set(number_of_grid_points, values_in_variables[0]);
+    CHECK(get<VariablesTestTags_detail::tensor<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::tensor<VectorType>>(
+              number_of_grid_points, values_in_variables[0]));
+    vars_set.assign_subset(vars_subset0);
+    CHECK(get<VariablesTestTags_detail::tensor<VectorType>>(vars_set) ==
+          db::item_type<VariablesTestTags_detail::tensor<VectorType>>(
+              number_of_grid_points, vars_subset0_val));
   };
 
-  third_test(
-      Variables<tmpl::list<VariablesTestTags_detail::vector>>(size, 8.0));
-  third_test(tuples::TaggedTuple<VariablesTestTags_detail::vector>(
-      VariablesTestTags_detail::vector::type{size, 8.0}));
+  test_assign_to_vars_with_one_tag(
+      Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>>(
+          number_of_grid_points, values_in_variables[1]),
+      values_in_variables[1]);
+  test_assign_to_vars_with_one_tag(
+      tuples::TaggedTuple<VariablesTestTags_detail::tensor<VectorType>>(
+          typename VariablesTestTags_detail::tensor<VectorType>::type{
+              number_of_grid_points, values_in_variables[1]}),
+      values_in_variables[1]);
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Variables.SliceVariables",
-                  "[DataStructures][Unit]") {
-  Variables<tmpl::list<VariablesTestTags_detail::vector>> vars(24, 0.);
-  const size_t x_extents = 2, y_extents = 3, z_extents = 4,
-               vec_size = VariablesTestTags_detail::vector::type::size();
+template <typename VectorType>
+void test_variables_slice() noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> sdist{5, 10};
+
+  const size_t x_extents = sdist(gen);
+  const size_t y_extents = sdist(gen);
+  const size_t z_extents = sdist(gen);
+  Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>> vars{
+      x_extents * y_extents * z_extents};
+  const size_t tensor_size =
+      VariablesTestTags_detail::tensor<VectorType>::type::size();
   Index<3> extents(x_extents, y_extents, z_extents);
+
+  // Test data_on_slice function by using a predictable data set where each
+  // entry is assigned a value equal to its index
   for (size_t s = 0; s < vars.size(); ++s) {
     // clang-tidy: do not use pointer arithmetic
     vars.data()[s] = s;  // NOLINT
   }
-  Variables<tmpl::list<VariablesTestTags_detail::vector>>
+  Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>>
       expected_vars_sliced_in_x(y_extents * z_extents, 0.),
       expected_vars_sliced_in_y(x_extents * z_extents, 0.),
       expected_vars_sliced_in_z(x_extents * y_extents, 0.);
-  const size_t x_offset = 1, y_offset = 2, z_offset = 1;
+  const size_t x_offset = sdist(gen) % x_extents;
+  const size_t y_offset = sdist(gen) % y_extents;
+  const size_t z_offset = sdist(gen) % z_extents;
 
   for (size_t s = 0; s < expected_vars_sliced_in_x.size(); ++s) {
     // clang-tidy: do not use pointer arithmetic
     expected_vars_sliced_in_x.data()[s] = x_offset + s * x_extents;  // NOLINT
   }
-  for (size_t i = 0; i < vec_size; ++i) {
+  for (size_t i = 0; i < tensor_size; ++i) {
     for (size_t x = 0; x < x_extents; ++x) {
       for (size_t z = 0; z < z_extents; ++z) {
         // clang-tidy: do not use pointer arithmetic
@@ -530,7 +797,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.SliceVariables",
       }
     }
   }
-  for (size_t i = 0; i < vec_size; ++i) {
+  for (size_t i = 0; i < tensor_size; ++i) {
     for (size_t x = 0; x < x_extents; ++x) {
       for (size_t y = 0; y < y_extents; ++y) {
         // clang-tidy: do not use pointer arithmetic
@@ -544,58 +811,147 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.SliceVariables",
   CHECK(data_on_slice(vars, extents, 1, y_offset) == expected_vars_sliced_in_y);
   CHECK(data_on_slice(vars, extents, 2, z_offset) == expected_vars_sliced_in_z);
 
-  CHECK(
-      data_on_slice<VariablesTestTags_detail::vector>(
-          extents, 0, x_offset, get<VariablesTestTags_detail::vector>(vars)) ==
-      expected_vars_sliced_in_x);
-  CHECK(
-      data_on_slice<VariablesTestTags_detail::vector>(
-          extents, 1, y_offset, get<VariablesTestTags_detail::vector>(vars)) ==
-      expected_vars_sliced_in_y);
-  CHECK(
-      data_on_slice<VariablesTestTags_detail::vector>(
-          extents, 2, z_offset, get<VariablesTestTags_detail::vector>(vars)) ==
-      expected_vars_sliced_in_z);
+  CHECK(data_on_slice<VariablesTestTags_detail::tensor<VectorType>>(
+            extents, 0, x_offset,
+            get<VariablesTestTags_detail::tensor<VectorType>>(vars)) ==
+        expected_vars_sliced_in_x);
+  CHECK(data_on_slice<VariablesTestTags_detail::tensor<VectorType>>(
+            extents, 1, y_offset,
+            get<VariablesTestTags_detail::tensor<VectorType>>(vars)) ==
+        expected_vars_sliced_in_y);
+  CHECK(data_on_slice<VariablesTestTags_detail::tensor<VectorType>>(
+            extents, 2, z_offset,
+            get<VariablesTestTags_detail::tensor<VectorType>>(vars)) ==
+        expected_vars_sliced_in_z);
 }
 
-SPECTRE_TEST_CASE("Unit.DataStructures.Variables.add_slice_to_data",
-                  "[DataStructures][Unit]") {
-  using Vector = VariablesTestTags_detail::vector::type;
-  const Index<2> extents{{{4, 2}}};
-  Variables<tmpl::list<VariablesTestTags_detail::vector>> vars(
-      extents.product());
-  get<VariablesTestTags_detail::vector>(vars) =
-      Vector{{{{1110000., 1120000., 1130000., 1140000., 1210000., 1220000.,
-                1230000., 1240000.},
-               {2110000., 2120000., 2130000., 2140000., 2210000., 2220000.,
-                2230000., 2240000.},
-               {3110000., 3120000., 3130000., 3140000., 3210000., 3220000.,
-                3230000., 3240000.}}}};
+template <typename VectorType>
+void test_variables_add_slice_to_data() noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<
+      tt::get_fundamental_type_t<typename VectorType::value_type>>
+      dist{-100.0, 100.0};
 
+  // Test adding two slices on different 'axes' to a Variables
+  std::array<VectorType, 3> orig_vals;
+  std::fill(orig_vals.begin(), orig_vals.end(), VectorType{8});
+  fill_with_random_values(make_not_null(&orig_vals), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  std::array<VectorType, 3> slice0_vals;
+  std::fill(slice0_vals.begin(), slice0_vals.end(), VectorType{4});
+  fill_with_random_values(make_not_null(&slice0_vals), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  std::array<VectorType, 3> slice1_vals;
+  std::fill(slice1_vals.begin(), slice1_vals.end(), VectorType{2});
+  fill_with_random_values(make_not_null(&slice1_vals), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  using Tensor = typename VariablesTestTags_detail::tensor<VectorType>::type;
+  const Index<2> extents{{{4, 2}}};
+  Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>> vars(
+      extents.product());
+  get<VariablesTestTags_detail::tensor<VectorType>>(vars) =
+      Tensor{{{orig_vals[0], orig_vals[1], orig_vals[2]}}};
   {
     const auto slice_extents = extents.slice_away(0);
-    Variables<tmpl::list<VariablesTestTags_detail::vector>> slice(
+    Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>> slice(
         slice_extents.product(), 0.);
-    get<VariablesTestTags_detail::vector>(slice) =
-        Vector{{{{1100., 1200.}, {2100., 2200.}, {3100., 3200.}}}};
+    get<VariablesTestTags_detail::tensor<VectorType>>(slice) =
+        Tensor{{{slice1_vals[0], slice1_vals[1], slice1_vals[2]}}};
     add_slice_to_data(make_not_null(&vars), slice, extents, 0, 2);
   }
+
   {
     const auto slice_extents = extents.slice_away(1);
-    Variables<tmpl::list<VariablesTestTags_detail::vector>> slice(
+    Variables<tmpl::list<VariablesTestTags_detail::tensor<VectorType>>> slice(
         slice_extents.product(), 0.);
-    get<VariablesTestTags_detail::vector>(slice) = Vector{
-        {{{11., 12., 13., 14.}, {21., 22., 23., 24.}, {31., 32., 33., 34.}}}};
+    get<VariablesTestTags_detail::tensor<VectorType>>(slice) =
+        Tensor{{{slice0_vals[0], slice0_vals[1], slice0_vals[2]}}};
     add_slice_to_data(make_not_null(&vars), slice, extents, 1, 1);
   }
 
-  CHECK((Vector{{{{1110000., 1120000., 1131100., 1140000., 1210011., 1220012.,
-                   1231213., 1240014.},
-                  {2110000., 2120000., 2132100., 2140000., 2210021., 2220022.,
-                   2232223., 2240024.},
-                  {3110000., 3120000., 3133100., 3140000., 3210031., 3220032.,
-                   3233233., 3240034.}}}}) ==
-        get<VariablesTestTags_detail::vector>(vars));
+  // The slice0_vals should have been added to the second half of each of the
+  // three vectors in the tensor. The slice1_vals should have been added to
+  // entries 2 and 6 in each vector.
+  // clang-format off
+  const Tensor expected{
+      {{{orig_vals[0].at(0),
+         orig_vals[0].at(1),
+         orig_vals[0].at(2) + slice1_vals[0].at(0),
+         orig_vals[0].at(3),
+         orig_vals[0].at(4) + slice0_vals[0].at(0),
+         orig_vals[0].at(5) + slice0_vals[0].at(1),
+         orig_vals[0].at(6) + slice0_vals[0].at(2) + slice1_vals[0].at(1),
+         orig_vals[0].at(7) + slice0_vals[0].at(3)},
+        {orig_vals[1].at(0),
+         orig_vals[1].at(1),
+         orig_vals[1].at(2) + slice1_vals[1].at(0),
+         orig_vals[1].at(3),
+         orig_vals[1].at(4) + slice0_vals[1].at(0),
+         orig_vals[1].at(5) + slice0_vals[1].at(1),
+         orig_vals[1].at(6) + slice0_vals[1].at(2) + slice1_vals[1].at(1),
+         orig_vals[1].at(7) + slice0_vals[1].at(3)},
+        {orig_vals[2].at(0),
+         orig_vals[2].at(1),
+         orig_vals[2].at(2) + slice1_vals[2].at(0),
+         orig_vals[2].at(3),
+         orig_vals[2].at(4) + slice0_vals[2].at(0),
+         orig_vals[2].at(5) + slice0_vals[2].at(1),
+         orig_vals[2].at(6) + slice0_vals[2].at(2) + slice1_vals[2].at(1),
+         orig_vals[2].at(7) + slice0_vals[2].at(3)}}}};
+  // clang-format on
+
+  CHECK_ITERABLE_APPROX(
+      expected, get<VariablesTestTags_detail::tensor<VectorType>>(vars));
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
+  SECTION("Test Variables construction, access, and assignment") {
+    test_variables_construction_and_access<DataVector>();
+  }
+  SECTION("Test Variables move operations") {
+    test_variables_move<DataVector>();
+  }
+  SECTION("Test Variables arithmetic operations") {
+    test_variables_math<DataVector>();
+  }
+  SECTION("Test Prefix Variables move and copy semantics") {
+    test_variables_prefix_semantics<DataVector>();
+  }
+  SECTION("Test Prefix Variables arithmetic operations") {
+    test_variables_prefix_math<DataVector>();
+  }
+  SECTION("Test Variables serialization") {
+    test_variables_serialization<DataVector>();
+  }
+  SECTION("Test Variables assign subset") {
+    test_variables_assign_subset<DataVector>();
+  }
+  SECTION("Test Variables slice utilities") {
+    test_variables_slice<DataVector>();
+  }
+  SECTION("Test adding slice values to Variables") {
+    test_variables_add_slice_to_data<DataVector>();
+  }
+}
+}  // namespace
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.DataStructures.Variables.BadCopy",
+                               "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  Variables<tmpl::list<VariablesTestTags_detail::tensor<DataVector>,
+                       VariablesTestTags_detail::scalar<DataVector>,
+                       VariablesTestTags_detail::scalar2<DataVector>>>
+      vars(1, -3.0);
+  auto& tensor_in_vars =
+      get<VariablesTestTags_detail::tensor<DataVector>>(vars);
+  tensor_in_vars = tnsr::I<DataVector, 3, Frame::Grid>{10_st, -4.0};
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
 }
 
 // [[OutputRegex, Must copy into same size]]
@@ -603,9 +959,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.add_slice_to_data",
     "Unit.DataStructures.Variables.assign_to_default",
     "[DataStructures][Unit]") {
   ASSERTION_TEST();
-  #ifdef SPECTRE_DEBUG
-  Variables<tmpl::list<VariablesTestTags_detail::scalar>> vars;
-  get<VariablesTestTags_detail::scalar>(vars) = Scalar<DataVector>{{{{0.}}}};
+#ifdef SPECTRE_DEBUG
+  Variables<tmpl::list<VariablesTestTags_detail::scalar<DataVector>>> vars;
+  get<VariablesTestTags_detail::scalar<DataVector>>(vars) =
+      Scalar<DataVector>{{{{0.}}}};
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
@@ -617,8 +974,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.add_slice_to_data",
     "[DataStructures][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  Variables<tmpl::list<VariablesTestTags_detail::vector>> vars(10, 0.);
-  const Variables<tmpl::list<VariablesTestTags_detail::vector>> slice(2, 0.);
+  Variables<tmpl::list<VariablesTestTags_detail::tensor<DataVector>>> vars(10,
+                                                                           0.);
+  const Variables<tmpl::list<VariablesTestTags_detail::tensor<DataVector>>>
+      slice(2, 0.);
   add_slice_to_data(make_not_null(&vars), slice, Index<2>{{{4, 2}}}, 0, 0);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
@@ -631,8 +990,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Variables.add_slice_to_data",
     "[DataStructures][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  Variables<tmpl::list<VariablesTestTags_detail::vector>> vars(8, 0.);
-  const Variables<tmpl::list<VariablesTestTags_detail::vector>> slice(5, 0.);
+  Variables<tmpl::list<VariablesTestTags_detail::tensor<DataVector>>> vars(8,
+                                                                           0.);
+  const Variables<tmpl::list<VariablesTestTags_detail::tensor<DataVector>>>
+      slice(5, 0.);
   add_slice_to_data(make_not_null(&vars), slice, Index<2>{{{4, 2}}}, 0, 0);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif

--- a/tests/Unit/Utilities/CMakeLists.txt
+++ b/tests/Unit/Utilities/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_SOURCES
   Test_GetOutput.cpp
   Test_Gsl.cpp
   Test_MakeArray.cpp
+  Test_MakeSignalingNan.cpp
   Test_MakeString.cpp
   Test_MakeVector.cpp
   Test_MakeWithValue.cpp

--- a/tests/Unit/Utilities/Test_MakeSignalingNan.cpp
+++ b/tests/Unit/Utilities/Test_MakeSignalingNan.cpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <complex>
+
+#include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/MakeSignalingNan.hpp"
+
+SPECTRE_TEST_CASE("Unit.Utilities.MakeSignalingNaN", "[Unit][Utilities]") {
+  disable_floating_point_exceptions();
+  auto double_snan = make_signaling_NaN<double>();
+  CHECK(std::isnan(double_snan));
+  auto float_snan = make_signaling_NaN<float>();
+  CHECK(std::isnan(float_snan));
+  std::complex<double> complex_snan =
+      make_signaling_NaN<std::complex<double>>();
+  CHECK(std::isnan(complex_snan.real()));
+  CHECK(std::isnan(complex_snan.imag()));
+  enable_floating_point_exceptions();
+}

--- a/tests/Utilities/MakeWithRandomValues.hpp
+++ b/tests/Utilities/MakeWithRandomValues.hpp
@@ -163,7 +163,6 @@ ReturnType make_with_random_values(
   return result;
 }
 
-// {@
 /// \ingroup TestingFrameworkGroup
 /// \brief Make a fixed-size data structure and fill with random values
 ///
@@ -174,26 +173,11 @@ ReturnType make_with_random_values(
 /// Used as
 /// `make_with_random_values<Type>(make_not_null(&gen),make_not_null(&dist))`
 template <typename T, typename UniformRandomBitGenerator,
-          typename RandomNumberDistribution,
-          Requires<cpp17::is_floating_point_v<tt::get_fundamental_type_t<T>>> =
-              nullptr>
+          typename RandomNumberDistribution>
 T make_with_random_values(
     const gsl::not_null<UniformRandomBitGenerator*> generator,
     const gsl::not_null<RandomNumberDistribution*> distribution) noexcept {
-  T result{std::numeric_limits<tt::get_fundamental_type_t<T>>::signaling_NaN()};
+  T result{};
   fill_with_random_values(make_not_null(&result), generator, distribution);
   return result;
 }
-
-template <
-    typename T, typename UniformRandomBitGenerator,
-    typename RandomNumberDistribution,
-    Requires<cpp17::is_integral_v<tt::get_fundamental_type_t<T>>> = nullptr>
-T make_with_random_values(
-    const gsl::not_null<UniformRandomBitGenerator*> generator,
-    const gsl::not_null<RandomNumberDistribution*> distribution) noexcept {
-  T result{std::numeric_limits<tt::get_fundamental_type_t<T>>::max()};
-  fill_with_random_values(make_not_null(&result), generator, distribution);
-  return result;
-}
-// @}


### PR DESCRIPTION
## Proposed changes

- Tensor is templated on type, so Variables can easily be templated on the type
  to be stored in the Tensor.
- Necessary for usage of extensions such as ComplexDataVector
- Update tests to be a single test case and to use random variables where
  possible

New data structures which take advantage of this templating should add tests to the Variables test case, as well as extending the Tensor static_asserts. I will do this for ComplexDataVector, and include additional documentation in the datavectorimpl PR explaining these extra implications.  

Note: the type inference from the tags now requires there to be at least 1 tag for the variables class. I understand it was deliberately permitted to have a tagless variables type, but the only thing that broke when I added that `static_assert` was the empty variables test case. So, unless there is a compelling reason to add extra syntax (probably SFINAE) around an empty variables, I think it seems cleaner to just demand non-empty variables.

### Logical order of the commits
- Add utilitiy for making signaling NaNs
- Template Variables on contained type
- Convert test of variables construct and assign
- convert variables move test to template
- convert variables math test for template
- convert variables prefix move semantics test
- convert template variables prefix arithmetic test
- convert variables serialization test to template
- convert variables test assign subset to template
- convert variables slice utilities test to template
- convert test for adding slice to variables
- convert assertion variable tests to template

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
