### PR TITLE
Enable fallback primitive variable inversion schemes.

### DIFF
--- a/src/Evolution/Conservative/UpdatePrimitives.hpp
+++ b/src/Evolution/Conservative/UpdatePrimitives.hpp
@@ -22,6 +22,9 @@ namespace Actions {
 /// \ingroup ActionsGroup
 /// \brief Compute the primitive variables from the conservative variables
 ///
+/// \note `Metavariables` must specify an
+/// `ordered_list_of_primitive_recovery_schemes`.
+///
 /// Uses:
 /// - DataBox: Items in system::volume_sources::argument_tags
 ///
@@ -40,11 +43,12 @@ struct UpdatePrimitives {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    using system = typename Metavariables::system;
-    db::mutate_apply<
-        typename system::primitive_from_conservative::return_tags,
-        typename system::primitive_from_conservative::argument_tags>(
-        typename system::primitive_from_conservative{}, make_not_null(&box));
+    using PrimFromCon =
+        typename Metavariables::system::template primitive_from_conservative<
+            typename Metavariables::ordered_list_of_primitive_recovery_schemes>;
+    db::mutate_apply<typename PrimFromCon::return_tags,
+                     typename PrimFromCon::argument_tags>(PrimFromCon{},
+                                                          make_not_null(&box));
     return std::forward_as_tuple(std::move(box));
   }
 };

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -92,6 +92,8 @@ struct EvolutionMetavars {
       tmpl::list<StepChoosers::Register::Cfl<3, Frame::Inertial>,
                  StepChoosers::Register::Constant,
                  StepChoosers::Register::Increase>;
+  using ordered_list_of_primitive_recovery_schemes = tmpl::list<
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin>;
 
   // hack this has to be synchronized with the Observe action :(
   using Redum = Parallel::ReductionDatum<double, funcl::Plus<>,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservative.hpp
@@ -41,7 +41,8 @@ namespace ValenciaDivClean {
  * (http://iopscience.iop.org/article/10.3847/1538-4357/aabcc5/meta)
  * compares several inversion methods.
  */
-template <typename PrimitiveRecoveryScheme, size_t ThermodynamicDim>
+template <typename OrderedListOfPrimitiveRecoverySchemes,
+          size_t ThermodynamicDim>
 struct PrimitiveFromConservative {
   using return_tags =
       tmpl::list<hydro::Tags::RestMassDensity<DataVector>,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveRecoveryData.hpp
@@ -17,10 +17,10 @@ namespace PrimitiveRecoverySchemes {
  * density, \f$h\f$ is the specific enthalpy, and \f$W\f$ is the Lorentz factor.
  */
 struct PrimitiveRecoveryData {
-  const double rest_mass_density;
-  const double lorentz_factor;
-  const double pressure;
-  const double rho_h_w_squared;
+  double rest_mass_density;
+  double lorentz_factor;
+  double pressure;
+  double rho_h_w_squared;
 };
 }  // namespace PrimitiveRecoverySchemes
 }  // namespace ValenciaDivClean

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp
@@ -80,8 +80,10 @@ struct System {
       ComputeLargestCharacteristicSpeed;
 
   using conservative_from_primitive = ConservativeFromPrimitive;
+
+  template <typename OrderedListOfPrimitiveRecoverySchemes>
   using primitive_from_conservative =
-      PrimitiveFromConservative<PrimitiveRecoverySchemes::NewmanHamlin,
+      PrimitiveFromConservative<OrderedListOfPrimitiveRecoverySchemes,
                                 EquationOfStateType::thermodynamic_dim>;
 
   using volume_fluxes = ComputeFluxes;


### PR DESCRIPTION
Must specify an ordered list of inversion schemes in the metavariables.
Newman Hamlin now returns boost::none instead of aborting on failures.
More information is output on failure of inversion.

Note: PalenzuelaEtAl still needs to be updated to fail gracefully.

Breaking change:  The Metavariables must specify a `ordered_list_of_primitive_recovery_schemes`

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
