### PR TITLE
 Add SphericalHarmonicCollocation

### DIFF
--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
     Legendre.cpp
     Projection.cpp
     Spectral.cpp
+    SwshCollocation.cpp
     )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/NumericalAlgorithms/Spectral/ComplexDataView.cpp
+++ b/src/NumericalAlgorithms/Spectral/ComplexDataView.cpp
@@ -10,7 +10,7 @@
 #include "Utilities/Math.hpp"  // IWYU pragma: keep
 
 namespace Spectral {
-namespace SWSH {
+namespace Swsh {
 namespace detail {
 
 template <typename T>
@@ -293,5 +293,5 @@ ComplexDataView<ComplexRepresentation::RealsThenImags>::imag_data() const
   return imag_slice_.data();
 }
 }  // namespace detail
-}  // namespace SWSH
+}  // namespace Swsh
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/ComplexDataView.hpp
+++ b/src/NumericalAlgorithms/Spectral/ComplexDataView.hpp
@@ -13,7 +13,7 @@
 namespace Spectral {
 /// \ingroup SpectralGroup
 /// Namespace for spin-weighted spherical harmonic utilities.
-namespace SWSH {
+namespace Swsh {
 
 /// \brief A set of labels for the possible representations of complex numbers
 /// for the `ComplexDataView` and the computations performed in the
@@ -182,5 +182,5 @@ class ComplexDataView {
 };
 
 }  // namespace detail
-}  // namespace SWSH
+}  // namespace Swsh
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshCollocation.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCollocation.cpp
@@ -1,0 +1,121 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <cmath>
+#include <ostream>
+#include <sharp_cxx.h>
+#include <type_traits>
+#include <utility>
+
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Spectral {
+namespace Swsh {
+
+template <ComplexRepresentation Representation>
+Collocation<Representation>::Collocation(const size_t l_max) noexcept
+    : l_max_{l_max} {
+  sharp_geom_info* geometry_to_initialize;
+  sharp_make_gauss_geom_info(
+      l_max_ + 1, 2 * l_max_ + 1, 0.0,
+      detail::ComplexDataView<Representation>::stride(),
+      detail::ComplexDataView<Representation>::stride() * (1 * l_max_ + 1),
+      &geometry_to_initialize);
+  geom_info_.reset(geometry_to_initialize);
+}
+
+template <ComplexRepresentation Representation>
+double Collocation<Representation>::theta(const size_t offset) const noexcept {
+  ASSERT(offset < (2 * l_max_ + 1) * (l_max_ + 1),
+         "invalid offset " << offset
+                           << " passed to phi lookup. Must be less than (2 * "
+                              "l_max + 1) * (l_max + 1) = "
+                           << (2 * l_max_ + 1) * (l_max_ + 1));
+  // clang-tidy pointer arithmetic
+  if (offset < (2 * l_max_ + 1) * (l_max_ / 2 + 1)) {
+    return (geom_info_.get())  // NOLINT
+        ->pair[offset / (2 * l_max_ + 1)]
+        .r1.theta;  // NOLINT
+  } else {
+    return (geom_info_.get())                       // NOLINT
+        ->pair[l_max_ - offset / (2 * l_max_ + 1)]  // NOLINT
+        .r2.theta;
+  }
+}
+
+template <ComplexRepresentation Representation>
+double Collocation<Representation>::phi(const size_t offset) const noexcept {
+  ASSERT(offset < (2 * l_max_ + 1) * (l_max_ + 1),
+         "invalid offset " << offset
+                           << " passed to phi lookup. Must be less than (2 * "
+                              "l_max + 1) * (l_max + 1) = "
+                           << (2 * l_max_ + 1) * (l_max_ + 1));
+  return 2.0 * M_PI * ((offset % (2 * l_max_ + 1)) / (2.0 * l_max_ + 1.0));
+}
+
+namespace detail {
+// We use a `std::index_sequence` to loop over the function lambdas
+// for the cases we want to evaluate in order to only compute and store
+// a specific `l_max` that is requested, not all values up to
+// `collocation_maximum_l_max`. This cannot be done in the more traditional
+// way of either having a `std::vector` or `std::undordered_map` that is
+// `static` because only the construction phase is guaranteed to be thread-safe,
+// not the access. This would mean were we to use a `std::vector` or
+// `std::unordered_map` we would need to compute all values up to
+// `collocation_maximum_l_max` immediately. By doing the loop over `Is` we
+// are able to generate `sizeof...(Is)` different static objects and thus each
+// one can be constructed only when it is needed and in a thread-safe manner.
+
+template <ComplexRepresentation Representation, size_t... Is>
+SPECTRE_ALWAYS_INLINE const Collocation<Representation>&
+dispatch_to_precomputed_static_collocation_impl(
+    const size_t index, std::index_sequence<Is...> /*meta*/) noexcept {
+  if (UNLIKELY(index > collocation_maximum_l_max)) {
+    ERROR("The provided l_max "
+          << index
+          << "is not below the maximum l_max to cache, which is currently "
+          << collocation_maximum_l_max
+          << ". Either "
+             "construct the Collocation manually, or consider (with caution) "
+             "increasing `collocation_maximum_l_max`.");
+  }
+  const Collocation<Representation>* collocation = nullptr;
+  auto get_collocation_if_match = [&collocation, &index ](auto i) noexcept {
+    if (UNLIKELY(decltype(i)::value == index)) {
+      static const Collocation<Representation> precomputed_collocation =
+          Collocation<Representation>{decltype(i)::value};
+      collocation = &precomputed_collocation;
+    }
+    return 0;
+  };
+  expand_pack(
+      get_collocation_if_match(std::integral_constant<size_t, Is>{})...);
+  // clang-tidy warns about null reference return, but will only return null in
+  // the erroring execution path.
+  return *collocation;  // NOLINT
+}
+}  // namespace detail
+
+template <ComplexRepresentation Representation>
+const Collocation<Representation>& precomputed_spherical_harmonic_collocation(
+    const size_t l_max) noexcept {
+  return detail::dispatch_to_precomputed_static_collocation_impl<
+      Representation>(
+      l_max, std::make_index_sequence<collocation_maximum_l_max + 1>{});
+}
+
+template class Collocation<ComplexRepresentation::Interleaved>;
+template class Collocation<ComplexRepresentation::RealsThenImags>;
+
+template const Collocation<ComplexRepresentation::Interleaved>&
+precomputed_spherical_harmonic_collocation(const size_t l_max) noexcept;
+template const Collocation<ComplexRepresentation::RealsThenImags>&
+precomputed_spherical_harmonic_collocation(const size_t l_max) noexcept;
+
+}  // namespace Swsh
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
@@ -1,0 +1,196 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstdlib>
+#include <memory>
+#include <sharp_cxx.h>
+
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Spectral {
+namespace Swsh {
+
+// In the static caching mechanism, we permit an l_max up to this macro
+// value. Higher l_max values may still be created manually using the
+// `Collocation` constructor. If l_max's are used several times at higher value,
+// consider increasing this value, but only after memory costs have been
+// evaluated.
+constexpr size_t collocation_maximum_l_max = 200;
+
+namespace detail {
+// Helping functor to appropriately delete a stored `sharp_geom_info**`
+struct DestroySharpGeometry {
+  void operator()(sharp_geom_info* to_delete) noexcept {
+    sharp_destroy_geom_info(to_delete);
+  }
+};
+}  // namespace detail
+
+/// A container for reporting a single collocation point for libsharp compatible
+/// data structures
+struct LibsharpCollocationPoint {
+  size_t offset;
+  double theta;
+  double phi;
+};
+
+/// \brief A wrapper class for the spherical harmonic library collocation data
+///
+/// \details The currently chosen library for spin-weighted spherical harmonic
+/// transforms is libsharp. The `Collocation` class stores the
+/// libsharp `sharp_geom_info` object, which contains data about
+/// 1. The angular collocation points used in spin-weighted spherical harmonic
+/// transforms
+/// 2. The memory representation of double-type values at those collocation
+/// points
+///
+/// \tparam Representation the ComplexRepresentation, either
+/// `ComplexRepresentation::Interleaved` or
+/// `ComplexRepresentation::RealsThenImags` compatible with the generated
+/// `Collocation` - this is necessary because the stored libsharp type contains
+/// memory stride information.
+template <ComplexRepresentation Representation>
+class Collocation {
+ public:
+  class CollocationConstIterator {
+   public:
+    /// create a new iterator. defaults to the start of the supplied object
+    explicit CollocationConstIterator(
+        const gsl::not_null<const Collocation<Representation>*> collocation,
+        const size_t start_index = 0) noexcept
+        : index_{start_index}, collocation_{collocation} {}
+
+    /// recovers the data at the collocation point using a
+    /// `LibsharpCollocationPoint`, which stores the vector `offset` of the
+    /// location of the `theta`, `phi` point in libsharp compatible data
+    LibsharpCollocationPoint operator*() const noexcept {
+      return LibsharpCollocationPoint{index_, collocation_->theta(index_),
+                                      collocation_->phi(index_)};
+    }
+    /// advance the iterator by one position (prefix)
+    CollocationConstIterator& operator++() noexcept {
+      ++index_;
+      return *this;
+    };
+    /// advance the iterator by one position (postfix)
+    // clang-tidy wants this to return a const iterator
+    CollocationConstIterator operator++(int)noexcept {  // NOLINT
+      return CollocationConstIterator(collocation_, index_++);
+    }
+
+    /// retreat the iterator by one position (prefix)
+    CollocationConstIterator& operator--() noexcept {
+      --index_;
+      return *this;
+    };
+    /// retreat the iterator by one position (prefix)
+    // clang-tidy wants this to return a const iterator
+    CollocationConstIterator operator--(int)noexcept {  // NOLINT
+      return CollocationConstIterator(collocation_, index_--);
+    }
+
+    // @{
+    /// (In)Equivalence checks both the object and index for the iterator
+    bool operator==(const CollocationConstIterator& rhs) const noexcept {
+      return index_ == rhs.index_ and collocation_ == rhs.collocation_;
+    }
+    bool operator!=(const CollocationConstIterator& rhs) const noexcept {
+      return not(*this == rhs);
+    }
+    // @}
+
+   private:
+    size_t index_;
+    const Collocation<Representation>* const collocation_;
+  };
+
+  /// The representation of the block of complex values, which sets the stride
+  /// inside the libsharp type
+  static constexpr ComplexRepresentation complex_representation =
+      Representation;
+
+  /// \brief Generates the libsharp collocation information and stores it in
+  /// `geom_info_`.
+  ///
+  /// \note If you will potentially use the same `l_max` collocation set more
+  /// than once, it is probably better to use the
+  /// `precomputed_spherical_harmonic_collocation` function
+  explicit Collocation(size_t l_max) noexcept;
+
+  /// default constructor required for iterator use
+  ~Collocation() = default;
+  Collocation() = default;
+  Collocation(const Collocation&) = default;
+  Collocation(Collocation&&) = default;
+  Collocation& operator=(Collocation&) = default;
+  Collocation& operator=(Collocation&&) = default;
+
+  /// retrieve the `sharp_geom_info*` stored. This should largely be used only
+  /// for passing to other libsharp functions. Otherwise, access elements
+  /// through iterator or access functions.
+  sharp_geom_info* get_sharp_geom_info() const noexcept {
+    return geom_info_.get();
+  }
+
+  /// Retrieve the \f$\theta\f$ value for a given index in a libsharp-compatible
+  /// array
+  double theta(size_t offset) const noexcept;
+  /// Retrieve the \f$\phi\f$ value for a given index in a libsharp-compatible
+  /// array
+  double phi(size_t offset) const noexcept;
+
+  constexpr size_t l_max() const noexcept { return l_max_; }
+
+  /// Compute the number of entries the libsharp-compatible data structure
+  /// should have
+  constexpr size_t size() const noexcept {
+    return (l_max_ + 1) * (2 * l_max_ + 1);
+  }
+
+  // @{
+  /// Get a bidirectional iterator to the start of the grid. `operator*` for
+  /// that iterator gives a `LibsharpCollocationPoint` with members `offset`,
+  /// `theta`, and `phi` with operator *
+  Collocation<Representation>::CollocationConstIterator begin() const noexcept {
+    return CollocationConstIterator{make_not_null(this), 0};
+  }
+  Collocation<Representation>::CollocationConstIterator cbegin() const
+      noexcept {
+    return begin();
+  }
+  // @}
+  // @{
+  /// Get a bidirectional iterator to the end of the grid. `operator*` for
+  /// that iterator gives a `LibsharpCollocationPoint` with members `offset`,
+  /// `theta`, and `phi` with operator *
+  Collocation<Representation>::CollocationConstIterator end() const noexcept {
+    return CollocationConstIterator{make_not_null(this), size()};
+  }
+  Collocation<Representation>::CollocationConstIterator cend() const noexcept {
+    return end();
+  }
+  // @}
+
+ private:
+  // an extra pointer layer is required for the peculiar way that libsharp
+  // constructs these values.
+  size_t l_max_ = 0;
+  std::unique_ptr<sharp_geom_info, detail::DestroySharpGeometry> geom_info_;
+};
+
+/// \brief precomputation function for those collocation grids that are
+/// requested
+///
+/// \details keeps a compile-time structure which acts as a thread-safe lookup
+/// table for all l_max values that have been requested so far during execution,
+/// so that the libsharp generation need not be re-run. If it has been
+/// generated, it's returned by reference. Otherwise, the new grid is generated
+/// and put in the lookup table before it is returned by reference.
+template <ComplexRepresentation Representation>
+const Collocation<Representation>& precomputed_spherical_harmonic_collocation(
+    size_t l_max) noexcept;
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_LegendreGaussLobatto.cpp
   Test_Projection.cpp
   Test_Spectral.cpp
+  Test_SwshCollocation.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ComplexDataView.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ComplexDataView.cpp
@@ -18,7 +18,7 @@
 #include "tests/Utilities/MakeWithRandomValues.hpp"
 
 namespace Spectral {
-namespace SWSH {
+namespace Swsh {
 namespace detail {
 namespace {
 
@@ -267,5 +267,5 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.ComplexDataView",
 }
 }  // namespace
 }  // namespace detail
-}  // namespace SWSH
+}  // namespace Swsh
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <random>
+#include <sharp_cxx.h>
+
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Spectral {
+namespace Swsh {
+namespace {
+
+// IWYU pragma: no_include <sharp_geomhelpers.h>
+// IWYU pragma: no_include <sharp_lowlevel.h>
+
+template <ComplexRepresentation Representation>
+void test_spherical_harmonic_collocation() noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> sdist{8, 64};
+  const size_t l_max = sdist(gen);
+
+  CAPTURE(l_max);
+  const Collocation<Representation>& precomputed_collocation =
+      precomputed_spherical_harmonic_collocation<Representation>(l_max);
+
+  const Collocation<Representation>& another_precomputed_collocation =
+      precomputed_spherical_harmonic_collocation<Representation>(l_max);
+
+  // checks that the same pointer is in both
+  CHECK(precomputed_collocation.get_sharp_geom_info() ==
+        another_precomputed_collocation.get_sharp_geom_info());
+
+  const Collocation<Representation> computed_collocation{l_max};
+
+  CHECK(precomputed_collocation.l_max() == l_max);
+  CHECK(computed_collocation.l_max() == l_max);
+
+  const int expected_stride = detail::ComplexDataView<Representation>::stride();
+
+  sharp_geom_info* manual_sgi;
+  sharp_make_gauss_geom_info(
+      l_max + 1, 2 * l_max + 1, 0.0, expected_stride,
+      static_cast<unsigned long>(expected_stride) * (2 * l_max + 1),
+      &manual_sgi);
+
+  // clang-tidy doesn't like the pointer manipulation needed to work with the
+  // libsharp types.
+  CHECK(precomputed_collocation  // NOLINT
+            .get_sharp_geom_info()
+            ->pair[0]
+            .r1.stride == expected_stride);  // NOLINT
+  CHECK(precomputed_collocation              // NOLINT
+            .get_sharp_geom_info()
+            ->pair[0]
+            .r2.stride == expected_stride);  // NOLINT
+  CHECK(computed_collocation                 // NOLINT
+            .get_sharp_geom_info()
+            ->pair[0]
+            .r1.stride == expected_stride);  // NOLINT
+  CHECK(computed_collocation                 // NOLINT
+            .get_sharp_geom_info()
+            ->pair[0]
+            .r2.stride == expected_stride);  // NOLINT
+
+  size_t offset_counter = 0;
+
+  sharp_geom_info* computed_sgi = computed_collocation.get_sharp_geom_info();
+
+  // check iterator equivalence. The for loop below is also a check of the
+  // iterator functionality.
+  CHECK(precomputed_collocation.begin() == precomputed_collocation.cbegin());
+  CHECK(precomputed_collocation.end() == precomputed_collocation.cend());
+  CHECK(precomputed_collocation.begin() != precomputed_collocation.end());
+  for (const auto& collocation_point : precomputed_collocation) {
+    CHECK(collocation_point.offset == offset_counter);
+    CHECK(collocation_point.theta ==
+          computed_collocation.theta(offset_counter));
+    CHECK(collocation_point.phi == computed_collocation.phi(offset_counter));
+    CAPTURE(offset_counter);
+    // check theta values:
+    if (offset_counter < (2 * l_max + 1) * (l_max / 2 + 1)) {
+      CAPTURE(offset_counter / (2 * l_max + 1));
+      CHECK(approx(computed_collocation.theta(offset_counter)) ==
+            computed_sgi  // NOLINT
+                ->pair[offset_counter / (2 * l_max + 1)]
+                .r1.theta);  // NOLINT
+      CHECK(approx(computed_collocation.theta(offset_counter)) ==
+            manual_sgi  // NOLINT
+                ->pair[offset_counter / (2 * l_max + 1)]
+                .r1.theta);  // NOLINT
+    } else {
+      CAPTURE(l_max - (offset_counter / (2 * l_max + 1)));
+      CHECK(approx(computed_collocation.theta(offset_counter)) ==
+            computed_sgi  // NOLINT
+                ->pair[l_max - offset_counter / (2 * l_max + 1)]
+                .r2.theta);  // NOLINT
+      CHECK(approx(computed_collocation.theta(offset_counter)) ==
+            manual_sgi  // NOLINT
+                ->pair[l_max - offset_counter / (2 * l_max + 1)]
+                .r2.theta);  // NOLINT
+    }
+
+    // check phi values:
+    CHECK(approx(computed_collocation.phi(offset_counter)) ==
+          2.0 * M_PI *
+              ((offset_counter % (2 * l_max + 1)) / (2.0 * l_max + 1.0)));
+    CHECK(approx(computed_collocation.phi(offset_counter)) ==
+          2.0 * M_PI *
+              ((offset_counter % (2 * l_max + 1)) / (2.0 * l_max + 1.0)));
+    offset_counter++;
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCollocation",
+                  "[Unit][NumericalAlgorithms]") {
+  {
+    INFO("Collocation based on contiguous complex data (Interleaved)");
+    test_spherical_harmonic_collocation<ComplexRepresentation::Interleaved>();
+  }
+  {
+    INFO(
+        "Collocation based on a pair of contiguous blocks representing complex "
+        "data (RealsThenImags)");
+    test_spherical_harmonic_collocation<
+        ComplexRepresentation::RealsThenImags>();
+  }
+}
+
+// [[OutputRegex, is not below the maximum l_max]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.Spectral.SwshCollocation.PrecomputationOverrun",
+    "[Unit][NumericalAlgorithms]") {
+  ERROR_TEST();
+  const Collocation<ComplexRepresentation::RealsThenImags>&
+      precomputed_collocation = precomputed_spherical_harmonic_collocation<
+          ComplexRepresentation::RealsThenImags>(collocation_maximum_l_max + 1);
+  ERROR("Failed to trigger ERROR in an error test");
+}
+}  // namespace
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tools/Iwyu/iwyu.imp
+++ b/tools/Iwyu/iwyu.imp
@@ -45,6 +45,11 @@
   { include: ["<pythonrun.h>", private,
               "<Python.h>", public]},
 
+  { include: ["<sharp_lowlevel.h>", public,
+              "<sharp_cxx.h>", public]},
+  { include: ["<sharp_geomhelpers.h>", public,
+              "<sharp_cxx.h>", public]},
+
   { include: ["<boost/optional/optional.hpp>", public,
               "<boost/optional.hpp>", public]},
   { include: ["<boost/optional/detail/optional_relops.hpp>", public,


### PR DESCRIPTION
## Proposed changes

Add a container class to wrap the collocation information storage from libsharp. The wrapper class allows easy access to the angular collocation information, including access functions for the theta and phi, the necessary size for the associated memory storage, and an iterator for marching over the memory locations and retrieving the associated theta, phi pairs. 

Also included is a caching functions with a static lookup procedure for keeping any of these collocation objects that are requested, so duplicates are not generated. These are not large objects, their size scales with max_l, so I don't anticipate too much memory consumption, especially if only a few lmax are requested over the runtime (as will likely be the design of CCE at least).

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments
Dependencies
- [x] [PR1268](https://github.com/sxs-collaboration/spectre/pull/1067)
- [x] [PR1135](https://github.com/sxs-collaboration/spectre/pull/1135)