### PR TITLE
Add clarifying documentation to YlmSpherepack and Strahlkorper.

### DIFF
--- a/src/ApparentHorizons/Strahlkorper.hpp
+++ b/src/ApparentHorizons/Strahlkorper.hpp
@@ -55,6 +55,20 @@ class Strahlkorper {
 
   /// Construct a Strahlkorper from a DataVector containing the radius
   /// at the collocation points.
+  ///
+  /// \note The collocation points of the constructed Strahlkorper
+  /// will not be exactly `radius_at_collocation_points`.  Instead,
+  /// the constructed Strahlkorper will match the shape given by
+  /// `radius_at_collocation_points` only to order (`l_max`,`m_max`).
+  /// This is because the YlmSpherepack representation of the
+  /// Strahlkorper has more collocation points than spectral
+  /// coefficients.  Specifically, `radius_at_collocation_points` has
+  /// \f$(l_{\rm max} + 1) (2 m_{\rm max} + 1)\f$ degrees of freedom,
+  /// but because there are only
+  /// \f$m_{\rm max}^2+(l_{\rm max}-m_{\rm max})(2m_{\rm max}+1)\f$
+  /// spectral coefficients, it is not possible to choose spectral
+  /// coefficients to exactly match all points in
+  /// `radius_at_collocation_points`.
   Strahlkorper(size_t l_max, size_t m_max,
                const DataVector& radius_at_collocation_points,
                std::array<double, 3> center) noexcept;

--- a/src/ApparentHorizons/YlmSpherepack.hpp
+++ b/src/ApparentHorizons/YlmSpherepack.hpp
@@ -53,6 +53,12 @@ class YlmSpherepack {
       const size_t l_max, const size_t m_max) noexcept {
     return (l_max + 1) * (2 * m_max + 1);
   }
+  /// \note `spectral_size` is the size of the buffer that holds the
+  /// coefficients; it is not the number of coefficients (which is
+  /// \f$m_{\rm max}^2+(l_{\rm max}-m_{\rm max})(2m_{\rm max}+1)\f$).
+  /// To simplify its internal indexing, SPHEREPACK uses a buffer with
+  /// more space than necessary. See SpherepackIterator for
+  /// how to index the coefficients in the buffer.
   SPECTRE_ALWAYS_INLINE static constexpr size_t spectral_size(
       const size_t l_max, const size_t m_max) noexcept {
     return 2 * (l_max + 1) * (m_max + 1);


### PR DESCRIPTION
## Proposed changes

Documents two member functions of YlmSpherepack and Strahlkorper that
may be otherwise confusing.

### Component:

- [x] Documentation

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments
