### PR TITLE
Use FixedHashMap instead of unordered_map in Domain, Block

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -19,8 +19,7 @@ Block<VolumeDim, TargetFrame>::Block(
     std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>&&
         map,
     const size_t id,
-    std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>
-        neighbors) noexcept
+    DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors) noexcept
     : map_(std::move(map)), id_(id), neighbors_(std::move(neighbors)) {
   // Loop over Directions to search which Directions were not set to neighbors_,
   // set these Directions to external_boundaries_.

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -9,12 +9,12 @@
 #include <cstddef>
 #include <memory>
 #include <ostream>
-#include <unordered_map>
 #include <unordered_set>
 
-#include "Domain/BlockNeighbor.hpp"  // IWYU pragma: keep
+#include "Domain/BlockNeighbor.hpp"                 // IWYU pragma: keep
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"  // IWYU pragma: keep
-#include "Domain/Direction.hpp"  // IWYU pragma: keep
+#include "Domain/Direction.hpp"                     // IWYU pragma: keep
+#include "Domain/DirectionMap.hpp"
 
 /// \cond
 namespace Frame {
@@ -48,8 +48,7 @@ class Block {
   Block(std::unique_ptr<
             CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>&& map,
         size_t id,
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>
-            neighbors) noexcept;
+        DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors) noexcept;
 
   Block() = default;
   ~Block() = default;
@@ -69,8 +68,8 @@ class Block {
   size_t id() const noexcept { return id_; }
 
   /// Information about the neighboring Blocks.
-  const std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>&
-  neighbors() const noexcept {
+  const DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>& neighbors() const
+      noexcept {
     return neighbors_;
   }
 
@@ -87,7 +86,7 @@ class Block {
   std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>
       map_;
   size_t id_{0};
-  std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>> neighbors_;
+  DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors_;
   std::unordered_set<Direction<VolumeDim>> external_boundaries_;
 };
 

--- a/src/Domain/DirectionMap.hpp
+++ b/src/Domain/DirectionMap.hpp
@@ -1,0 +1,34 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pup.h>
+
+#include "DataStructures/FixedHashMap.hpp"
+#include "Domain/Direction.hpp"
+
+/// \ingroup DataStructuresGroup
+/// \ingroup ComputationalDomainGroup
+/// An optimized map with Direction keys
+template <size_t Dim, typename T>
+class DirectionMap
+    : public FixedHashMap<2 * Dim, Direction<Dim>, T, DirectionHash<Dim>> {
+ public:
+  using base = FixedHashMap<2 * Dim, Direction<Dim>, T, DirectionHash<Dim>>;
+  using base::base;
+};
+
+namespace PUP {
+template <size_t Dim, typename T>
+// NOLINTNEXTLINE(google-runtime-references)
+void pup(PUP::er& p, DirectionMap<Dim, T>& t) noexcept {
+  pup(p, static_cast<typename DirectionMap<Dim, T>::base&>(t));
+}
+
+template <size_t Dim, typename T>
+// NOLINTNEXTLINE(google-runtime-references)
+void operator|(PUP::er& p, DirectionMap<Dim, T>& t) noexcept {
+  p | static_cast<typename DirectionMap<Dim, T>::base&>(t);
+}
+}  // namespace PUP

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -5,11 +5,11 @@
 
 #include <ostream>
 #include <pup.h>  // IWYU pragma: keep
-#include <unordered_map>
 
 #include "Domain/BlockNeighbor.hpp"                 // IWYU pragma: keep
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"                     // IWYU pragma: keep
+#include "Domain/DirectionMap.hpp"                  // IWYU pragma: keep
 #include "Domain/DomainHelpers.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -35,8 +35,7 @@ Domain<VolumeDim, TargetFrame>::Domain(
     const std::vector<PairOfFaces>& identifications) noexcept {
   ASSERT(maps.size() == corners_of_all_blocks.size(),
          "Must pass same number of maps as block corner sets.");
-  std::vector<
-      std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>
+  std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>
       neighbors_of_all_blocks;
   set_internal_boundaries<VolumeDim>(corners_of_all_blocks,
                                      &neighbors_of_all_blocks);

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -24,6 +24,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Domain/Side.hpp"
@@ -272,8 +273,8 @@ void set_cartesian_periodic_boundaries(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
     const std::vector<OrientationMap<VolumeDim>>& orientations_of_all_blocks,
-    gsl::not_null<std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
+    gsl::not_null<
+        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks) noexcept {
   ASSERT(orientations_of_all_blocks.size() == corners_of_all_blocks.size(),
          "Each block must have an OrientationMap relative to an edifice.");
@@ -368,12 +369,12 @@ template <size_t VolumeDim>
 void set_internal_boundaries(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    gsl::not_null<std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
+    gsl::not_null<
+        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks) noexcept {
   for (size_t block1_index = 0; block1_index < corners_of_all_blocks.size();
        block1_index++) {
-    std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>> neighbor;
+    DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbor;
     for (size_t block2_index = 0; block2_index < corners_of_all_blocks.size();
          block2_index++) {
       if (block1_index != block2_index and
@@ -400,8 +401,8 @@ void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    gsl::not_null<std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
+    gsl::not_null<
+        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks) noexcept {
   for (const auto& pair : identifications) {
     const auto& face1 = pair.first;
@@ -953,8 +954,7 @@ Domain<VolumeDim, TargetFrame> rectilinear_domain(
     corners_of_all_blocks[i] =
         discrete_rotation(rotations_of_all_blocks[i], corners_of_all_blocks[i]);
   }
-  std::vector<
-      std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>
+  std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>
       neighbors_of_all_blocks;
   set_internal_boundaries<VolumeDim>(corners_of_all_blocks,
                                      &neighbors_of_all_blocks);
@@ -1001,37 +1001,31 @@ ShellWedges create_from_yaml<ShellWedges>::create(const Option& options) {
 
 template void set_internal_boundaries(
     const std::vector<std::array<size_t, 2>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>*>
+    gsl::not_null<std::vector<DirectionMap<1, BlockNeighbor<1>>>*>
         neighbors_of_all_blocks) noexcept;
 template void set_internal_boundaries(
     const std::vector<std::array<size_t, 4>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>*>
+    gsl::not_null<std::vector<DirectionMap<2, BlockNeighbor<2>>>*>
         neighbors_of_all_blocks) noexcept;
 template void set_internal_boundaries(
     const std::vector<std::array<size_t, 8>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>*>
+    gsl::not_null<std::vector<DirectionMap<3, BlockNeighbor<3>>>*>
         neighbors_of_all_blocks) noexcept;
 
 template void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 2>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>*>
+    gsl::not_null<std::vector<DirectionMap<1, BlockNeighbor<1>>>*>
         neighbors_of_all_blocks) noexcept;
 template void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 4>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>*>
+    gsl::not_null<std::vector<DirectionMap<2, BlockNeighbor<2>>>*>
         neighbors_of_all_blocks) noexcept;
 template void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, 8>>& corners_of_all_blocks,
-    gsl::not_null<
-        std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>*>
+    gsl::not_null<std::vector<DirectionMap<3, BlockNeighbor<3>>>*>
         neighbors_of_all_blocks) noexcept;
 template std::vector<std::array<size_t, 2>> corners_for_rectilinear_domains(
     const Index<1>& domain_extents,

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -11,7 +11,6 @@
 #include <iosfwd>
 #include <limits>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 #include "DataStructures/Index.hpp"
@@ -27,6 +26,8 @@ template <size_t VolumeDim>
 class BlockNeighbor;
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
+template <size_t VolumeDim, typename T>
+class DirectionMap;
 template <size_t VolumeDim, typename TargetFrame>
 class Domain;
 template <size_t VolumeDim>
@@ -54,8 +55,8 @@ template <size_t VolumeDim>
 void set_internal_boundaries(
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    gsl::not_null<std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
+    gsl::not_null<
+        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks) noexcept;
 
 /// \ingroup ComputationalDomainGroup
@@ -67,8 +68,8 @@ void set_identified_boundaries(
     const std::vector<PairOfFaces>& identifications,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,
-    gsl::not_null<std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>*>
+    gsl::not_null<
+        std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>*>
         neighbors_of_all_blocks) noexcept;
 
 /// \ingroup ComputationalDomainGroup

--- a/src/Domain/Element.hpp
+++ b/src/Domain/Element.hpp
@@ -8,10 +8,10 @@
 
 #include <cstddef>
 #include <iosfwd>
-#include <unordered_map>
 #include <unordered_set>
 
 #include "Domain/Direction.hpp"  // IWYU pragma: keep
+#include "Domain/DirectionMap.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/Neighbors.hpp"  // IWYU pragma: keep
 
@@ -28,8 +28,7 @@ class er;
 template <size_t VolumeDim>
 class Element {
  public:
-  using Neighbors_t =
-      std::unordered_map<Direction<VolumeDim>, Neighbors<VolumeDim>>;
+  using Neighbors_t = DirectionMap<VolumeDim, Neighbors<VolumeDim>>;
 
   /// Constructor
   ///

--- a/tests/Unit/Domain/Amr/Test_UpdateAmrDecision.cpp
+++ b/tests/Unit/Domain/Amr/Test_UpdateAmrDecision.cpp
@@ -8,7 +8,6 @@
 #include <functional>
 #include <map>
 #include <sstream>
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -16,6 +15,7 @@
 #include "Domain/Amr/Flag.hpp"
 #include "Domain/Amr/UpdateAmrDecision.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/Neighbors.hpp"
@@ -83,7 +83,7 @@ Element<1> make_element(
     const ElementId<1>& element_id,
     const std::unordered_set<ElementId<1>>& lower_xi_neighbor_ids,
     const std::unordered_set<ElementId<1>>& upper_xi_neighbor_ids) noexcept {
-  std::unordered_map<Direction<1>, Neighbors<1>> neighbors;
+  DirectionMap<1, Neighbors<1>> neighbors;
   if (not lower_xi_neighbor_ids.empty()) {
     neighbors.emplace(Direction<1>::lower_xi(),
                       Neighbors<1>{{lower_xi_neighbor_ids}, {}});
@@ -101,7 +101,7 @@ Element<2> make_element(
     const std::unordered_set<ElementId<2>>& upper_xi_neighbor_ids,
     const std::unordered_set<ElementId<2>>& lower_eta_neighbor_ids,
     const std::unordered_set<ElementId<2>>& upper_eta_neighbor_ids) noexcept {
-  std::unordered_map<Direction<2>, Neighbors<2>> neighbors;
+  DirectionMap<2, Neighbors<2>> neighbors;
   if (not lower_xi_neighbor_ids.empty()) {
     neighbors.emplace(Direction<2>::lower_xi(),
                       Neighbors<2>{{lower_xi_neighbor_ids}, {}});

--- a/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Brick.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -18,6 +17,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Brick.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
@@ -39,7 +39,7 @@ void test_brick_construction(
     const std::array<double, 3>& upper_bound,
     const std::vector<std::array<size_t, 3>>& expected_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>&
+    const std::vector<DirectionMap<3, BlockNeighbor<3>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<3>>>&
         expected_external_boundaries) {
@@ -70,23 +70,23 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   const DomainCreators::Brick<Frame::Inertial> brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, false, false}},
       refinement_level[0], grid_points[0]};
-  test_brick_construction(
-      brick, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{{}},
-      std::vector<std::unordered_set<Direction<3>>>{
-          {{Direction<3>::lower_xi()},
-           {Direction<3>::upper_xi()},
-           {Direction<3>::lower_eta()},
-           {Direction<3>::upper_eta()},
-           {Direction<3>::lower_zeta()},
-           {Direction<3>::upper_zeta()}}});
+  test_brick_construction(brick, lower_bound, upper_bound, grid_points,
+                          refinement_level,
+                          std::vector<DirectionMap<3, BlockNeighbor<3>>>{{}},
+                          std::vector<std::unordered_set<Direction<3>>>{
+                              {{Direction<3>::lower_xi()},
+                               {Direction<3>::upper_xi()},
+                               {Direction<3>::lower_eta()},
+                               {Direction<3>::upper_eta()},
+                               {Direction<3>::lower_zeta()},
+                               {Direction<3>::upper_zeta()}}});
 
   const DomainCreators::Brick<Frame::Inertial> periodic_x_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, false, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
       periodic_x_brick, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
            {Direction<3>::upper_xi(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<3>>>{
@@ -100,7 +100,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
       refinement_level[0], grid_points[0]};
   test_brick_construction(
       periodic_y_brick, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_eta(), {0, aligned_orientation}},
            {Direction<3>::upper_eta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<3>>>{
@@ -114,7 +114,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
       refinement_level[0], grid_points[0]};
   test_brick_construction(
       periodic_z_brick, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_zeta(), {0, aligned_orientation}},
            {Direction<3>::upper_zeta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<3>>>{
@@ -129,7 +129,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   test_brick_construction(
       periodic_xy_brick, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
            {Direction<3>::upper_xi(), {0, aligned_orientation}},
            {Direction<3>::lower_eta(), {0, aligned_orientation}},
@@ -143,7 +143,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   test_brick_construction(
       periodic_yz_brick, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_eta(), {0, aligned_orientation}},
            {Direction<3>::upper_eta(), {0, aligned_orientation}},
            {Direction<3>::lower_zeta(), {0, aligned_orientation}},
@@ -159,7 +159,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   test_brick_construction(
       periodic_xz_brick, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
            {Direction<3>::upper_xi(), {0, aligned_orientation}},
            {Direction<3>::lower_zeta(), {0, aligned_orientation}},
@@ -173,7 +173,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick", "[Domain][Unit]") {
   test_brick_construction(
       periodic_xyz_brick, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, aligned_orientation}},
            {Direction<3>::upper_xi(), {0, aligned_orientation}},
            {Direction<3>::lower_eta(), {0, aligned_orientation}},
@@ -213,7 +213,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Brick.Factory",
   test_brick_construction(
       *brick_creator, {{0., 0., 0.}}, {{1., 2., 3.}}, {{{3, 4, 3}}},
       {{{2, 3, 2}}},
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::lower_xi(), {0, {}}},
            {Direction<3>::upper_xi(), {0, {}}},
            {Direction<3>::lower_zeta(), {0, {}}},

--- a/tests/Unit/Domain/DomainCreators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Cylinder.cpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -21,6 +20,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Cylinder.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
@@ -49,28 +49,26 @@ void test_cylinder_construction(
   const OrientationMap<3> quarter_turn_cw(std::array<Direction<3>, 3>{
       {Direction<3>::upper_eta(), Direction<3>::lower_xi(),
        Direction<3>::upper_zeta()}});
-  std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{};
+  std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{};
   std::vector<std::unordered_set<Direction<3>>> expected_external_boundaries{};
   if (not is_periodic_in_z) {
-    expected_block_neighbors =
-        std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
-            {{Direction<3>::lower_eta(), {3, aligned_orientation}},
-             {Direction<3>::upper_eta(), {1, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, aligned_orientation}}},
-            {{Direction<3>::lower_eta(), {0, aligned_orientation}},
-             {Direction<3>::upper_eta(), {2, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, quarter_turn_cw}}},
-            {{Direction<3>::lower_eta(), {1, aligned_orientation}},
-             {Direction<3>::upper_eta(), {3, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, half_turn}}},
-            {{Direction<3>::lower_eta(), {2, aligned_orientation}},
-             {Direction<3>::upper_eta(), {0, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, quarter_turn_ccw}}},
-            {{Direction<3>::upper_xi(), {0, aligned_orientation}},
-             {Direction<3>::upper_eta(), {1, quarter_turn_ccw}},
-             {Direction<3>::lower_xi(), {2, half_turn}},
-             {Direction<3>::lower_eta(), {3, quarter_turn_cw}}}};
+    expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        {{Direction<3>::lower_eta(), {3, aligned_orientation}},
+         {Direction<3>::upper_eta(), {1, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, aligned_orientation}}},
+        {{Direction<3>::lower_eta(), {0, aligned_orientation}},
+         {Direction<3>::upper_eta(), {2, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, quarter_turn_cw}}},
+        {{Direction<3>::lower_eta(), {1, aligned_orientation}},
+         {Direction<3>::upper_eta(), {3, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, half_turn}}},
+        {{Direction<3>::lower_eta(), {2, aligned_orientation}},
+         {Direction<3>::upper_eta(), {0, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, quarter_turn_ccw}}},
+        {{Direction<3>::upper_xi(), {0, aligned_orientation}},
+         {Direction<3>::upper_eta(), {1, quarter_turn_ccw}},
+         {Direction<3>::lower_xi(), {2, half_turn}},
+         {Direction<3>::lower_eta(), {3, quarter_turn_cw}}}};
     expected_external_boundaries =
         std::vector<std::unordered_set<Direction<3>>>{
             {{Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
@@ -83,34 +81,33 @@ void test_cylinder_construction(
               Direction<3>::lower_zeta()}},
             {Direction<3>::upper_zeta(), Direction<3>::lower_zeta()}};
   } else {
-    expected_block_neighbors =
-        std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
-            {{Direction<3>::lower_eta(), {3, aligned_orientation}},
-             {Direction<3>::upper_eta(), {1, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, aligned_orientation}},
-             {Direction<3>::upper_zeta(), {0, aligned_orientation}},
-             {Direction<3>::lower_zeta(), {0, aligned_orientation}}},
-            {{Direction<3>::lower_eta(), {0, aligned_orientation}},
-             {Direction<3>::upper_eta(), {2, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, quarter_turn_cw}},
-             {Direction<3>::upper_zeta(), {1, aligned_orientation}},
-             {Direction<3>::lower_zeta(), {1, aligned_orientation}}},
-            {{Direction<3>::lower_eta(), {1, aligned_orientation}},
-             {Direction<3>::upper_eta(), {3, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, half_turn}},
-             {Direction<3>::upper_zeta(), {2, aligned_orientation}},
-             {Direction<3>::lower_zeta(), {2, aligned_orientation}}},
-            {{Direction<3>::lower_eta(), {2, aligned_orientation}},
-             {Direction<3>::upper_eta(), {0, aligned_orientation}},
-             {Direction<3>::lower_xi(), {4, quarter_turn_ccw}},
-             {Direction<3>::upper_zeta(), {3, aligned_orientation}},
-             {Direction<3>::lower_zeta(), {3, aligned_orientation}}},
-            {{Direction<3>::upper_xi(), {0, aligned_orientation}},
-             {Direction<3>::upper_eta(), {1, quarter_turn_ccw}},
-             {Direction<3>::lower_xi(), {2, half_turn}},
-             {Direction<3>::lower_eta(), {3, quarter_turn_cw}},
-             {Direction<3>::upper_zeta(), {4, aligned_orientation}},
-             {Direction<3>::lower_zeta(), {4, aligned_orientation}}}};
+    expected_block_neighbors = std::vector<DirectionMap<3, BlockNeighbor<3>>>{
+        {{Direction<3>::lower_eta(), {3, aligned_orientation}},
+         {Direction<3>::upper_eta(), {1, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, aligned_orientation}},
+         {Direction<3>::upper_zeta(), {0, aligned_orientation}},
+         {Direction<3>::lower_zeta(), {0, aligned_orientation}}},
+        {{Direction<3>::lower_eta(), {0, aligned_orientation}},
+         {Direction<3>::upper_eta(), {2, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, quarter_turn_cw}},
+         {Direction<3>::upper_zeta(), {1, aligned_orientation}},
+         {Direction<3>::lower_zeta(), {1, aligned_orientation}}},
+        {{Direction<3>::lower_eta(), {1, aligned_orientation}},
+         {Direction<3>::upper_eta(), {3, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, half_turn}},
+         {Direction<3>::upper_zeta(), {2, aligned_orientation}},
+         {Direction<3>::lower_zeta(), {2, aligned_orientation}}},
+        {{Direction<3>::lower_eta(), {2, aligned_orientation}},
+         {Direction<3>::upper_eta(), {0, aligned_orientation}},
+         {Direction<3>::lower_xi(), {4, quarter_turn_ccw}},
+         {Direction<3>::upper_zeta(), {3, aligned_orientation}},
+         {Direction<3>::lower_zeta(), {3, aligned_orientation}}},
+        {{Direction<3>::upper_xi(), {0, aligned_orientation}},
+         {Direction<3>::upper_eta(), {1, quarter_turn_ccw}},
+         {Direction<3>::lower_xi(), {2, half_turn}},
+         {Direction<3>::lower_eta(), {3, quarter_turn_cw}},
+         {Direction<3>::upper_zeta(), {4, aligned_orientation}},
+         {Direction<3>::lower_zeta(), {4, aligned_orientation}}}};
 
     expected_external_boundaries =
         std::vector<std::unordered_set<Direction<3>>>{

--- a/tests/Unit/Domain/DomainCreators/Test_Disk.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Disk.cpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -21,6 +20,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge2D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/Disk.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
@@ -44,24 +44,23 @@ void test_disk_construction(
       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}});
   const OrientationMap<2> quarter_turn_cw(std::array<Direction<2>, 2>{
       {Direction<2>::upper_eta(), Direction<2>::lower_xi()}});
-  const std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>
-      expected_block_neighbors{
-          {{Direction<2>::lower_eta(), {3, aligned_orientation}},
-           {Direction<2>::upper_eta(), {1, aligned_orientation}},
-           {Direction<2>::lower_xi(), {4, aligned_orientation}}},
-          {{Direction<2>::lower_eta(), {0, aligned_orientation}},
-           {Direction<2>::upper_eta(), {2, aligned_orientation}},
-           {Direction<2>::lower_xi(), {4, quarter_turn_cw}}},
-          {{Direction<2>::lower_eta(), {1, aligned_orientation}},
-           {Direction<2>::upper_eta(), {3, aligned_orientation}},
-           {Direction<2>::lower_xi(), {4, half_turn}}},
-          {{Direction<2>::lower_eta(), {2, aligned_orientation}},
-           {Direction<2>::upper_eta(), {0, aligned_orientation}},
-           {Direction<2>::lower_xi(), {4, quarter_turn_ccw}}},
-          {{Direction<2>::upper_xi(), {0, aligned_orientation}},
-           {Direction<2>::upper_eta(), {1, quarter_turn_ccw}},
-           {Direction<2>::lower_xi(), {2, half_turn}},
-           {Direction<2>::lower_eta(), {3, quarter_turn_cw}}}};
+  const std::vector<DirectionMap<2, BlockNeighbor<2>>> expected_block_neighbors{
+      {{Direction<2>::lower_eta(), {3, aligned_orientation}},
+       {Direction<2>::upper_eta(), {1, aligned_orientation}},
+       {Direction<2>::lower_xi(), {4, aligned_orientation}}},
+      {{Direction<2>::lower_eta(), {0, aligned_orientation}},
+       {Direction<2>::upper_eta(), {2, aligned_orientation}},
+       {Direction<2>::lower_xi(), {4, quarter_turn_cw}}},
+      {{Direction<2>::lower_eta(), {1, aligned_orientation}},
+       {Direction<2>::upper_eta(), {3, aligned_orientation}},
+       {Direction<2>::lower_xi(), {4, half_turn}}},
+      {{Direction<2>::lower_eta(), {2, aligned_orientation}},
+       {Direction<2>::upper_eta(), {0, aligned_orientation}},
+       {Direction<2>::lower_xi(), {4, quarter_turn_ccw}}},
+      {{Direction<2>::upper_xi(), {0, aligned_orientation}},
+       {Direction<2>::upper_eta(), {1, quarter_turn_ccw}},
+       {Direction<2>::lower_xi(), {2, half_turn}},
+       {Direction<2>::lower_eta(), {3, quarter_turn_cw}}}};
   const std::vector<std::unordered_set<Direction<2>>>
       expected_external_boundaries{{{Direction<2>::upper_xi()}},
                                    {{Direction<2>::upper_xi()}},

--- a/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Interval.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -17,6 +16,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/Interval.hpp"
@@ -35,7 +35,7 @@ void test_interval_construction(
     const std::array<double, 1>& upper_bound,
     const std::vector<std::array<size_t, 1>>& expected_extents,
     const std::vector<std::array<size_t, 1>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>&
+    const std::vector<DirectionMap<1, BlockNeighbor<1>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<1>>>&
         expected_external_boundaries) noexcept {
@@ -64,7 +64,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval", "[Domain][Unit]") {
       refinement_level[0], grid_points[0]};
   test_interval_construction(
       interval, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{{}},
+      std::vector<DirectionMap<1, BlockNeighbor<1>>>{{}},
       std::vector<std::unordered_set<Direction<1>>>{
           {{Direction<1>::lower_xi()}, {Direction<1>::upper_xi()}}});
 
@@ -74,7 +74,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval", "[Domain][Unit]") {
   test_interval_construction(
       periodic_interval, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+      std::vector<DirectionMap<1, BlockNeighbor<1>>>{
           {{Direction<1>::lower_xi(), {0, aligned_orientation}},
            {Direction<1>::upper_xi(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<1>>>{{}});
@@ -107,10 +107,10 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Interval.Factory",
   const auto* interval_creator =
       dynamic_cast<const DomainCreators::Interval<Frame::Inertial>*>(
           domain_creator.get());
-  test_interval_construction(
-      *interval_creator, {{0.}}, {{1.}}, {{{3}}}, {{{2}}},
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
-          {{Direction<1>::lower_xi(), {0, {}}},
-           {Direction<1>::upper_xi(), {0, {}}}}},
-      std::vector<std::unordered_set<Direction<1>>>{{}});
+  test_interval_construction(*interval_creator, {{0.}}, {{1.}}, {{{3}}},
+                             {{{2}}},
+                             std::vector<DirectionMap<1, BlockNeighbor<1>>>{
+                                 {{Direction<1>::lower_xi(), {0, {}}},
+                                  {Direction<1>::upper_xi(), {0, {}}}}},
+                             std::vector<std::unordered_set<Direction<1>>>{{}});
 }

--- a/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Rectangle.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -18,6 +17,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/Rectangle.hpp"
@@ -38,7 +38,7 @@ void test_rectangle_construction(
     const std::array<double, 2>& upper_bound,
     const std::vector<std::array<size_t, 2>>& expected_extents,
     const std::vector<std::array<size_t, 2>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>&
+    const std::vector<DirectionMap<2, BlockNeighbor<2>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<2>>>&
         expected_external_boundaries) {
@@ -68,7 +68,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
       rectangle, lower_bound, upper_bound, grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{{}},
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{{}},
       std::vector<std::unordered_set<Direction<2>>>{
           {{Direction<2>::lower_xi()},
            {Direction<2>::upper_xi()},
@@ -81,7 +81,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
   test_rectangle_construction(
       periodic_x_rectangle, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::lower_xi(), {0, aligned_orientation}},
            {Direction<2>::upper_xi(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<2>>>{
@@ -93,7 +93,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
   test_rectangle_construction(
       periodic_y_rectangle, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::lower_eta(), {0, aligned_orientation}},
            {Direction<2>::upper_eta(), {0, aligned_orientation}}}},
       std::vector<std::unordered_set<Direction<2>>>{
@@ -105,7 +105,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle", "[Domain][Unit]") {
   test_rectangle_construction(
       periodic_xy_rectangle, lower_bound, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::lower_xi(), {0, aligned_orientation}},
            {Direction<2>::upper_xi(), {0, aligned_orientation}},
            {Direction<2>::lower_eta(), {0, aligned_orientation}},
@@ -144,7 +144,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Rectangle.Factory",
           domain_creator.get());
   test_rectangle_construction(
       *rectangle_creator, {{0., 0.}}, {{1., 2.}}, {{{3, 4}}}, {{{2, 3}}},
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::lower_xi(), {0, {}}},
            {Direction<2>::upper_xi(), {0, {}}}}},
       std::vector<std::unordered_set<Direction<2>>>{

--- a/tests/Unit/Domain/DomainCreators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_RotatedBricks.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -18,6 +17,7 @@
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/RotatedBricks.hpp"
@@ -33,7 +33,7 @@ void test_rotated_bricks_construction(
     const std::array<double, 3>& upper_bound,
     const std::vector<std::array<size_t, 3>>& expected_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>&
+    const std::vector<DirectionMap<3, BlockNeighbor<3>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<3>>>&
         expected_external_boundaries) noexcept {
@@ -146,7 +146,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedBricks",
   test_rotated_bricks_construction(
       rotated_bricks, lower_bound, midpoint, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::upper_xi(), {1, rotation_F}},
            {Direction<3>::upper_eta(), {2, rotation_R}},
            {Direction<3>::upper_zeta(), {4, rotation_U}}},
@@ -203,7 +203,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedBricks",
   test_rotated_bricks_construction(
       rotated_periodic_bricks, lower_bound, midpoint, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::upper_xi(), {1, rotation_F}},
            {Direction<3>::upper_eta(), {2, rotation_R}},
            {Direction<3>::upper_zeta(), {4, rotation_U}},
@@ -305,7 +305,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedBricks.Factory",
        {{0, 2, 1}},
        {{1, 0, 2}},
        {{2, 1, 0}}},
-      std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>{
+      std::vector<DirectionMap<3, BlockNeighbor<3>>>{
           {{Direction<3>::upper_xi(), {1, rotation_F}},
            {Direction<3>::upper_eta(), {2, rotation_R}},
            {Direction<3>::upper_zeta(), {4, rotation_U}}},

--- a/tests/Unit/Domain/DomainCreators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_RotatedIntervals.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -18,6 +17,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/RotatedIntervals.hpp"
@@ -34,7 +34,7 @@ void test_rotated_intervals_construction(
     const std::array<double, 1>& upper_bound,
     const std::vector<std::array<size_t, 1>>& expected_extents,
     const std::vector<std::array<size_t, 1>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>&
+    const std::vector<DirectionMap<1, BlockNeighbor<1>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<1>>>&
         expected_external_boundaries) noexcept {
@@ -75,7 +75,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedIntervals",
   test_rotated_intervals_construction(
       rotated_intervals, lower_bound, midpoint, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+      std::vector<DirectionMap<1, BlockNeighbor<1>>>{
           {{Direction<1>::upper_xi(), {1, flipped}}},
           {{Direction<1>::upper_xi(), {0, flipped}}}},
       std::vector<std::unordered_set<Direction<1>>>{
@@ -90,7 +90,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedIntervals",
   test_rotated_intervals_construction(
       periodic_rotated_intervals, lower_bound, midpoint, upper_bound,
       grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+      std::vector<DirectionMap<1, BlockNeighbor<1>>>{
           {{Direction<1>::lower_xi(), {1, flipped}},
            {Direction<1>::upper_xi(), {1, flipped}}},
           {{Direction<1>::lower_xi(), {0, flipped}},
@@ -117,7 +117,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedIntervals.Factory",
   test_rotated_intervals_construction(
       *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
       {{{2}}, {{2}}},
-      std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+      std::vector<DirectionMap<1, BlockNeighbor<1>>>{
           {{Direction<1>::lower_xi(), {1, flipped}},
            {Direction<1>::upper_xi(), {1, flipped}}},
           {{Direction<1>::lower_xi(), {0, flipped}},

--- a/tests/Unit/Domain/DomainCreators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_RotatedRectangles.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -18,6 +17,7 @@
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/RotatedRectangles.hpp"
@@ -34,7 +34,7 @@ void test_rotated_rectangles_construction(
     const std::array<double, 2>& upper_bound,
     const std::vector<std::array<size_t, 2>>& expected_extents,
     const std::vector<std::array<size_t, 2>>& expected_refinement_level,
-    const std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>&
+    const std::vector<DirectionMap<2, BlockNeighbor<2>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<2>>>&
         expected_external_boundaries) noexcept {
@@ -106,7 +106,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles",
   test_rotated_rectangles_construction(
       rotated_rectangles, lower_bound, midpoint, upper_bound, grid_points,
       refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::upper_xi(), {1, half_turn}},
            {Direction<2>::upper_eta(), {2, quarter_turn_ccw}}},
           {{Direction<2>::upper_xi(), {0, half_turn}},
@@ -134,7 +134,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles",
   test_rotated_rectangles_construction(
       rotated_periodic_rectangles, lower_bound, midpoint, upper_bound,
       grid_points, refinement_level,
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::upper_xi(), {1, half_turn}},
            {Direction<2>::upper_eta(), {2, quarter_turn_ccw}},
            {Direction<2>::lower_xi(), {1, half_turn}},
@@ -179,7 +179,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.RotatedRectangles.Factory",
       *rotated_rectangles_creator, {{0.1, -0.4}}, {{2.6, 3.2}}, {{5.1, 6.2}},
       {{{3, 1}}, {{2, 1}}, {{4, 3}}, {{4, 2}}},
       {{{2, 1}}, {{2, 1}}, {{1, 2}}, {{1, 2}}},
-      std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>{
+      std::vector<DirectionMap<2, BlockNeighbor<2>>>{
           {{Direction<2>::upper_xi(), {1, half_turn}},
            {Direction<2>::upper_eta(), {2, quarter_turn_ccw}}},
           {{Direction<2>::upper_xi(), {0, half_turn}},

--- a/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Shell.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -17,6 +16,7 @@
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/Shell.hpp"
@@ -52,32 +52,31 @@ void test_shell_construction(
       std::array<Direction<3>, 3>{{Direction<3>::upper_eta(),
                                    Direction<3>::lower_xi(),
                                    Direction<3>::upper_zeta()}});
-  std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{
-          {{Direction<3>::upper_xi(), {4, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::upper_eta(), {2, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, quarter_turn_cw_about_zeta}},
-           {Direction<3>::lower_eta(), {3, aligned_orientation}}},
-          {{Direction<3>::upper_xi(), {4, quarter_turn_cw_about_zeta}},
-           {Direction<3>::upper_eta(), {3, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::lower_eta(), {2, aligned_orientation}}},
-          {{Direction<3>::upper_xi(), {4, half_turn_about_zeta}},
-           {Direction<3>::upper_eta(), {1, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, half_turn_about_zeta}},
-           {Direction<3>::lower_eta(), {0, aligned_orientation}}},
-          {{Direction<3>::upper_xi(), {4, aligned_orientation}},
-           {Direction<3>::upper_eta(), {0, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, aligned_orientation}},
-           {Direction<3>::lower_eta(), {1, aligned_orientation}}},
-          {{Direction<3>::upper_xi(), {2, half_turn_about_zeta}},
-           {Direction<3>::upper_eta(), {0, quarter_turn_cw_about_zeta}},
-           {Direction<3>::lower_xi(), {3, aligned_orientation}},
-           {Direction<3>::lower_eta(), {1, quarter_turn_ccw_about_zeta}}},
-          {{Direction<3>::upper_xi(), {3, aligned_orientation}},
-           {Direction<3>::upper_eta(), {0, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::lower_xi(), {2, half_turn_about_zeta}},
-           {Direction<3>::lower_eta(), {1, quarter_turn_cw_about_zeta}}}};
+  std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
+      {{Direction<3>::upper_xi(), {4, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::upper_eta(), {2, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, quarter_turn_cw_about_zeta}},
+       {Direction<3>::lower_eta(), {3, aligned_orientation}}},
+      {{Direction<3>::upper_xi(), {4, quarter_turn_cw_about_zeta}},
+       {Direction<3>::upper_eta(), {3, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::lower_eta(), {2, aligned_orientation}}},
+      {{Direction<3>::upper_xi(), {4, half_turn_about_zeta}},
+       {Direction<3>::upper_eta(), {1, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, half_turn_about_zeta}},
+       {Direction<3>::lower_eta(), {0, aligned_orientation}}},
+      {{Direction<3>::upper_xi(), {4, aligned_orientation}},
+       {Direction<3>::upper_eta(), {0, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, aligned_orientation}},
+       {Direction<3>::lower_eta(), {1, aligned_orientation}}},
+      {{Direction<3>::upper_xi(), {2, half_turn_about_zeta}},
+       {Direction<3>::upper_eta(), {0, quarter_turn_cw_about_zeta}},
+       {Direction<3>::lower_xi(), {3, aligned_orientation}},
+       {Direction<3>::lower_eta(), {1, quarter_turn_ccw_about_zeta}}},
+      {{Direction<3>::upper_xi(), {3, aligned_orientation}},
+       {Direction<3>::upper_eta(), {0, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::lower_xi(), {2, half_turn_about_zeta}},
+       {Direction<3>::lower_eta(), {1, quarter_turn_cw_about_zeta}}}};
   std::vector<std::unordered_set<Direction<3>>> expected_external_boundaries{
       {{Direction<3>::upper_zeta()}, {Direction<3>::lower_zeta()}},
       {{Direction<3>::upper_zeta()}, {Direction<3>::lower_zeta()}},

--- a/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/DomainCreators/Test_Sphere.cpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -21,6 +20,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainCreators/DomainCreator.hpp"
 #include "Domain/DomainCreators/Sphere.hpp"
@@ -68,49 +68,47 @@ void test_sphere_construction(
                                    Direction<3>::upper_zeta(),
                                    Direction<3>::lower_xi()}});
 
-  const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{
-          {{Direction<3>::upper_xi(), {4, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::upper_eta(), {2, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, quarter_turn_cw_about_zeta}},
-           {Direction<3>::lower_eta(), {3, aligned_orientation}},
-           {Direction<3>::lower_zeta(), {6, aligned_orientation}}},
-          {{Direction<3>::upper_xi(), {4, quarter_turn_cw_about_zeta}},
-           {Direction<3>::upper_eta(), {3, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::lower_eta(), {2, aligned_orientation}},
-           {Direction<3>::lower_zeta(), {6, center_relative_to_minus_z}}},
-          {{Direction<3>::upper_xi(), {4, half_turn_about_zeta}},
-           {Direction<3>::upper_eta(), {1, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, half_turn_about_zeta}},
-           {Direction<3>::lower_eta(), {0, aligned_orientation}},
-           {Direction<3>::lower_zeta(), {6, center_relative_to_plus_y}}},
-          {{Direction<3>::upper_xi(), {4, aligned_orientation}},
-           {Direction<3>::upper_eta(), {0, aligned_orientation}},
-           {Direction<3>::lower_xi(), {5, aligned_orientation}},
-           {Direction<3>::lower_eta(), {1, aligned_orientation}},
-           {Direction<3>::lower_zeta(), {6, center_relative_to_minus_y}}},
-          {{Direction<3>::upper_xi(), {2, half_turn_about_zeta}},
-           {Direction<3>::upper_eta(), {0, quarter_turn_cw_about_zeta}},
-           {Direction<3>::lower_xi(), {3, aligned_orientation}},
-           {Direction<3>::lower_eta(), {1, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::lower_zeta(), {6, center_relative_to_plus_x}}},
-          {{Direction<3>::upper_xi(), {3, aligned_orientation}},
-           {Direction<3>::upper_eta(), {0, quarter_turn_ccw_about_zeta}},
-           {Direction<3>::lower_xi(), {2, half_turn_about_zeta}},
-           {Direction<3>::lower_eta(), {1, quarter_turn_cw_about_zeta}},
-           {Direction<3>::lower_zeta(), {6, center_relative_to_minus_x}}},
-          {{Direction<3>::upper_zeta(), {0, aligned_orientation}},
-           {Direction<3>::lower_zeta(),
-            {1, center_relative_to_minus_z.inverse_map()}},
-           {Direction<3>::upper_eta(),
-            {2, center_relative_to_plus_y.inverse_map()}},
-           {Direction<3>::lower_eta(),
-            {3, center_relative_to_minus_y.inverse_map()}},
-           {Direction<3>::upper_xi(),
-            {4, center_relative_to_plus_x.inverse_map()}},
-           {Direction<3>::lower_xi(),
-            {5, center_relative_to_minus_x.inverse_map()}}}};
+  const std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
+      {{Direction<3>::upper_xi(), {4, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::upper_eta(), {2, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, quarter_turn_cw_about_zeta}},
+       {Direction<3>::lower_eta(), {3, aligned_orientation}},
+       {Direction<3>::lower_zeta(), {6, aligned_orientation}}},
+      {{Direction<3>::upper_xi(), {4, quarter_turn_cw_about_zeta}},
+       {Direction<3>::upper_eta(), {3, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::lower_eta(), {2, aligned_orientation}},
+       {Direction<3>::lower_zeta(), {6, center_relative_to_minus_z}}},
+      {{Direction<3>::upper_xi(), {4, half_turn_about_zeta}},
+       {Direction<3>::upper_eta(), {1, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, half_turn_about_zeta}},
+       {Direction<3>::lower_eta(), {0, aligned_orientation}},
+       {Direction<3>::lower_zeta(), {6, center_relative_to_plus_y}}},
+      {{Direction<3>::upper_xi(), {4, aligned_orientation}},
+       {Direction<3>::upper_eta(), {0, aligned_orientation}},
+       {Direction<3>::lower_xi(), {5, aligned_orientation}},
+       {Direction<3>::lower_eta(), {1, aligned_orientation}},
+       {Direction<3>::lower_zeta(), {6, center_relative_to_minus_y}}},
+      {{Direction<3>::upper_xi(), {2, half_turn_about_zeta}},
+       {Direction<3>::upper_eta(), {0, quarter_turn_cw_about_zeta}},
+       {Direction<3>::lower_xi(), {3, aligned_orientation}},
+       {Direction<3>::lower_eta(), {1, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::lower_zeta(), {6, center_relative_to_plus_x}}},
+      {{Direction<3>::upper_xi(), {3, aligned_orientation}},
+       {Direction<3>::upper_eta(), {0, quarter_turn_ccw_about_zeta}},
+       {Direction<3>::lower_xi(), {2, half_turn_about_zeta}},
+       {Direction<3>::lower_eta(), {1, quarter_turn_cw_about_zeta}},
+       {Direction<3>::lower_zeta(), {6, center_relative_to_minus_x}}},
+      {{Direction<3>::upper_zeta(), {0, aligned_orientation}},
+       {Direction<3>::lower_zeta(),
+        {1, center_relative_to_minus_z.inverse_map()}},
+       {Direction<3>::upper_eta(),
+        {2, center_relative_to_plus_y.inverse_map()}},
+       {Direction<3>::lower_eta(),
+        {3, center_relative_to_minus_y.inverse_map()}},
+       {Direction<3>::upper_xi(), {4, center_relative_to_plus_x.inverse_map()}},
+       {Direction<3>::lower_xi(),
+        {5, center_relative_to_minus_x.inverse_map()}}}};
 
   const std::vector<std::unordered_set<Direction<3>>>
       expected_external_boundaries{{{Direction<3>::upper_zeta()}},

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <typeinfo>
+#include <unordered_map>
 
 #include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
@@ -14,7 +15,8 @@
 #include "Domain/BlockNeighbor.hpp"          // IWYU pragma: keep
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/Direction.hpp"
-#include "Domain/Domain.hpp"  // IWYU pragma: keep
+#include "Domain/DirectionMap.hpp"  // IWYU pragma: keep
+#include "Domain/Domain.hpp"        // IWYU pragma: keep
 #include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/InitialElementIds.hpp"
@@ -283,8 +285,7 @@ double physical_separation(
 template <size_t VolumeDim, typename Fr>
 void test_domain_construction(
     const Domain<VolumeDim, Fr>& domain,
-    const std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>&
+    const std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
@@ -374,8 +375,7 @@ tnsr::i<DataVector, SpatialDim, Fr> euclidean_basis_vector(
 #define INSTANTIATE2(_, data)                                                  \
   template void test_domain_construction<DIM(data)>(                           \
       const Domain<DIM(data), FRAME(data)>& domain,                            \
-      const std::vector<                                                       \
-          std::unordered_map<Direction<DIM(data)>, BlockNeighbor<DIM(data)>>>& \
+      const std::vector<DirectionMap<DIM(data), BlockNeighbor<DIM(data)>>>&    \
           expected_block_neighbors,                                            \
       const std::vector<std::unordered_set<Direction<DIM(data)>>>&             \
           expected_external_boundaries,                                        \

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -7,7 +7,6 @@
 #include <boost/rational.hpp>
 #include <cstddef>
 #include <memory>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -23,6 +22,8 @@ class CoordinateMapBase;
 class DataVector;
 template <size_t VolumeDim>
 class Direction;
+template <size_t VolumeDim, typename T>
+class DirectionMap;
 template <size_t VolumeDim, typename TargetFrame>
 class Domain;
 template <size_t VolumeDim>
@@ -33,8 +34,7 @@ class ElementId;
 template <size_t VolumeDim, typename Fr = Frame::Inertial>
 void test_domain_construction(
     const Domain<VolumeDim, Fr>& domain,
-    const std::vector<
-        std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>>&
+    const std::vector<DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>>&
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -6,11 +6,9 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
-#include <functional>
 #include <memory>
 #include <pup.h>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
 
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -19,6 +17,7 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
@@ -63,7 +62,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Block.Identity", "[Domain][Unit]") {
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Block.Neighbors", "[Domain][Unit]") {
-  // Create std::unordered_map<Direction<VolumeDim>, BlockNeighbor<VolumeDim>>
+  // Create DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>
 
   // Each BlockNeighbor is an id and an OrientationMap:
   const BlockNeighbor<2> block_neighbor1(
@@ -72,7 +71,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Block.Neighbors", "[Domain][Unit]") {
   const BlockNeighbor<2> block_neighbor2(
       2, OrientationMap<2>(std::array<Direction<2>, 2>{
              {Direction<2>::lower_xi(), Direction<2>::upper_eta()}}));
-  std::unordered_map<Direction<2>, BlockNeighbor<2>> neighbors = {
+  DirectionMap<2, BlockNeighbor<2>> neighbors = {
       {Direction<2>::upper_xi(), block_neighbor1},
       {Direction<2>::lower_eta(), block_neighbor2}};
   using coordinate_map =

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -6,7 +6,6 @@
 #include <functional>
 #include <memory>
 #include <pup.h>
-#include <unordered_map>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Block.hpp"
@@ -15,6 +14,7 @@
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CreateInitialElement.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/Neighbors.hpp"
@@ -25,8 +25,7 @@
 namespace {
 void test_create_initial_element(
     const ElementId<2>& element_id, const Block<2, Frame::Inertial>& block,
-    const std::unordered_map<Direction<2>, Neighbors<2>>&
-        expected_neighbors) noexcept {
+    const DirectionMap<2, Neighbors<2>>& expected_neighbors) noexcept {
   const auto created_element = create_initial_element(element_id, block);
   const Element<2> expected_element{element_id, expected_neighbors};
   CHECK(created_element == expected_element);

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -5,11 +5,9 @@
 
 #include <array>
 #include <cstddef>
-#include <functional>
 #include <memory>
 #include <pup.h>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -21,6 +19,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
@@ -57,11 +56,11 @@ void test_1d_domains() {
     const OrientationMap<1> unaligned_orientation{{{Direction<1>::lower_xi()}},
                                                   {{Direction<1>::upper_xi()}}};
 
-    const std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>
-        expected_neighbors{{{Direction<1>::upper_xi(),
-                             BlockNeighbor<1>{1, unaligned_orientation}}},
-                           {{Direction<1>::upper_xi(),
-                             BlockNeighbor<1>{0, unaligned_orientation}}}};
+    const std::vector<DirectionMap<1, BlockNeighbor<1>>> expected_neighbors{
+        {{Direction<1>::upper_xi(),
+          BlockNeighbor<1>{1, unaligned_orientation}}},
+        {{Direction<1>::upper_xi(),
+          BlockNeighbor<1>{0, unaligned_orientation}}}};
 
     const std::vector<std::unordered_set<Direction<1>>> expected_boundaries{
         {Direction<1>::lower_xi()}, {Direction<1>::lower_xi()}};
@@ -124,7 +123,7 @@ void test_1d_domains() {
     const auto expected_neighbors = []() {
       OrientationMap<1> orientation{{{Direction<1>::lower_xi()}},
                                     {{Direction<1>::lower_xi()}}};
-      return std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>{
+      return std::vector<DirectionMap<1, BlockNeighbor<1>>>{
           {{Direction<1>::lower_xi(), BlockNeighbor<1>{0, orientation}},
            {Direction<1>::upper_xi(), BlockNeighbor<1>{0, orientation}}}};
     }();
@@ -143,11 +142,11 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear1D1", "[Domain][Unit]") {
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
         {}, {}, {{false}}, {}, true);
     const OrientationMap<1> aligned{};
-    std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>
-        expected_block_neighbors{{{Direction<1>::upper_xi(), {1, aligned}}},
-                                 {{Direction<1>::lower_xi(), {0, aligned}},
-                                  {Direction<1>::upper_xi(), {2, aligned}}},
-                                 {{Direction<1>::lower_xi(), {1, aligned}}}};
+    std::vector<DirectionMap<1, BlockNeighbor<1>>> expected_block_neighbors{
+        {{Direction<1>::upper_xi(), {1, aligned}}},
+        {{Direction<1>::lower_xi(), {0, aligned}},
+         {Direction<1>::upper_xi(), {2, aligned}}},
+        {{Direction<1>::lower_xi(), {1, aligned}}}};
     const std::vector<std::unordered_set<Direction<1>>>
         expected_external_boundaries{
             {{Direction<1>::lower_xi()}}, {}, {{Direction<1>::upper_xi()}}};
@@ -169,12 +168,11 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear1D1", "[Domain][Unit]") {
         Index<1>{3}, std::array<std::vector<double>, 1>{{{0.0, 1.0, 2.0, 3.0}}},
         {}, std::vector<OrientationMap<1>>{aligned, antialigned, aligned},
         {{false}}, {}, true);
-    std::vector<std::unordered_map<Direction<1>, BlockNeighbor<1>>>
-        expected_block_neighbors{
-            {{Direction<1>::upper_xi(), {1, antialigned}}},
-            {{Direction<1>::lower_xi(), {2, antialigned}},
-             {Direction<1>::upper_xi(), {0, antialigned}}},
-            {{Direction<1>::lower_xi(), {1, antialigned}}}};
+    std::vector<DirectionMap<1, BlockNeighbor<1>>> expected_block_neighbors{
+        {{Direction<1>::upper_xi(), {1, antialigned}}},
+        {{Direction<1>::lower_xi(), {2, antialigned}},
+         {Direction<1>::upper_xi(), {0, antialigned}}},
+        {{Direction<1>::lower_xi(), {1, antialigned}}}};
     const std::vector<std::unordered_set<Direction<1>>>
         expected_external_boundaries{
             {{Direction<1>::lower_xi()}}, {}, {{Direction<1>::upper_xi()}}};
@@ -208,16 +206,15 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear2D", "[Domain][Unit]") {
       Index<2>{2, 2},
       std::array<std::vector<double>, 2>{{{0.0, 1.0, 2.0}, {0.0, 1.0, 2.0}}},
       {}, orientations_of_all_blocks);
-  std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>
-      expected_block_neighbors{
-          {{Direction<2>::upper_xi(), {1, half_turn}},
-           {Direction<2>::upper_eta(), {2, quarter_turn_cw}}},
-          {{Direction<2>::upper_xi(), {0, half_turn}},
-           {Direction<2>::lower_eta(), {3, quarter_turn_cw}}},
-          {{Direction<2>::upper_xi(), {0, quarter_turn_ccw}},
-           {Direction<2>::upper_eta(), {3, half_turn}}},
-          {{Direction<2>::lower_xi(), {1, quarter_turn_ccw}},
-           {Direction<2>::upper_eta(), {2, half_turn}}}};
+  std::vector<DirectionMap<2, BlockNeighbor<2>>> expected_block_neighbors{
+      {{Direction<2>::upper_xi(), {1, half_turn}},
+       {Direction<2>::upper_eta(), {2, quarter_turn_cw}}},
+      {{Direction<2>::upper_xi(), {0, half_turn}},
+       {Direction<2>::lower_eta(), {3, quarter_turn_cw}}},
+      {{Direction<2>::upper_xi(), {0, quarter_turn_ccw}},
+       {Direction<2>::upper_eta(), {3, half_turn}}},
+      {{Direction<2>::lower_xi(), {1, quarter_turn_ccw}},
+       {Direction<2>::upper_eta(), {2, half_turn}}}};
   const std::vector<std::unordered_set<Direction<2>>>
       expected_external_boundaries{
           {{Direction<2>::lower_xi(), Direction<2>::lower_eta()}},
@@ -249,10 +246,9 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear3D", "[Domain][Unit]") {
       std::array<std::vector<double>, 3>{
           {{0.0, 1.0, 2.0}, {0.0, 1.0}, {0.0, 1.0}}},
       {}, orientations_of_all_blocks);
-  std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{
-          {{Direction<3>::upper_xi(), {1, quarter_turn_cw_xi}}},
-          {{Direction<3>::lower_xi(), {0, quarter_turn_cw_xi.inverse_map()}}}};
+  std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
+      {{Direction<3>::upper_xi(), {1, quarter_turn_cw_xi}}},
+      {{Direction<3>::lower_xi(), {0, quarter_turn_cw_xi.inverse_map()}}}};
   const std::vector<std::unordered_set<Direction<3>>>
       expected_external_boundaries{
           {{Direction<3>::lower_xi(), Direction<3>::lower_eta(),

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -8,7 +8,6 @@
 #include <memory>
 #include <pup.h>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -24,6 +23,7 @@
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/Wedge3D.hpp"
 #include "Domain/Direction.hpp"
+#include "Domain/DirectionMap.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
@@ -38,8 +38,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.SameBlock",
                   "[Domain][Unit]") {
   const std::vector<std::array<size_t, 8>> corners_of_all_blocks{
       {{0, 1, 2, 3, 4, 5, 6, 7}}, {{8, 9, 10, 11, 0, 1, 2, 3}}};
-  std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      neighbors_of_all_blocks;
+  std::vector<DirectionMap<3, BlockNeighbor<3>>> neighbors_of_all_blocks;
   set_internal_boundaries<3>(corners_of_all_blocks, &neighbors_of_all_blocks);
 
   const OrientationMap<3> aligned{};
@@ -54,11 +53,11 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.SameBlock",
   CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
         aligned);
 
-  const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{{{Direction<3>::upper_xi(), {0, aligned}},
-                                {Direction<3>::lower_xi(), {0, aligned}},
-                                {Direction<3>::lower_zeta(), {1, aligned}}},
-                               {{Direction<3>::upper_zeta(), {0, aligned}}}};
+  const std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
+      {{Direction<3>::upper_xi(), {0, aligned}},
+       {Direction<3>::lower_xi(), {0, aligned}},
+       {Direction<3>::lower_zeta(), {1, aligned}}},
+      {{Direction<3>::upper_zeta(), {0, aligned}}}};
 
   CHECK(neighbors_of_all_blocks == expected_block_neighbors);
 }
@@ -67,8 +66,7 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.DifferentBlocks",
                   "[Domain][Unit]") {
   const std::vector<std::array<size_t, 8>> corners_of_all_blocks{
       {{0, 1, 2, 3, 4, 5, 6, 7}}, {{8, 9, 10, 11, 0, 1, 2, 3}}};
-  std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      neighbors_of_all_blocks;
+  std::vector<DirectionMap<3, BlockNeighbor<3>>> neighbors_of_all_blocks;
   set_internal_boundaries<3>(corners_of_all_blocks, &neighbors_of_all_blocks);
 
   const OrientationMap<3> aligned{};
@@ -82,11 +80,11 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.DifferentBlocks",
                                &neighbors_of_all_blocks);
   CHECK(neighbors_of_all_blocks[0][Direction<3>::upper_xi()].orientation() ==
         aligned);
-  const std::vector<std::unordered_map<Direction<3>, BlockNeighbor<3>>>
-      expected_block_neighbors{{{Direction<3>::upper_xi(), {1, aligned}},
-                                {Direction<3>::lower_zeta(), {1, aligned}}},
-                               {{Direction<3>::lower_xi(), {0, aligned}},
-                                {Direction<3>::upper_zeta(), {0, aligned}}}};
+  const std::vector<DirectionMap<3, BlockNeighbor<3>>> expected_block_neighbors{
+      {{Direction<3>::upper_xi(), {1, aligned}},
+       {Direction<3>::lower_zeta(), {1, aligned}}},
+      {{Direction<3>::lower_xi(), {0, aligned}},
+       {Direction<3>::upper_zeta(), {0, aligned}}}};
 
   CHECK(neighbors_of_all_blocks == expected_block_neighbors);
 }
@@ -1357,24 +1355,23 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.SetCartesianPeriodicBoundaries3",
       {}, orientations_of_all_blocks, std::array<bool, 2>{{true, true}}, {},
       false);
 
-  std::vector<std::unordered_map<Direction<2>, BlockNeighbor<2>>>
-      expected_block_neighbors{
-          {{Direction<2>::upper_xi(), {1, flipped}},
-           {Direction<2>::upper_eta(), {2, quarter_turn_cw}},
-           {Direction<2>::lower_xi(), {1, flipped}},
-           {Direction<2>::lower_eta(), {2, quarter_turn_cw}}},
-          {{Direction<2>::upper_xi(), {0, flipped}},
-           {Direction<2>::lower_eta(), {3, quarter_turn_cw}},
-           {Direction<2>::lower_xi(), {0, flipped}},
-           {Direction<2>::upper_eta(), {3, quarter_turn_cw}}},
-          {{Direction<2>::upper_xi(), {0, quarter_turn_ccw}},
-           {Direction<2>::upper_eta(), {3, flipped}},
-           {Direction<2>::lower_xi(), {0, quarter_turn_ccw}},
-           {Direction<2>::lower_eta(), {3, flipped}}},
-          {{Direction<2>::lower_xi(), {1, quarter_turn_ccw}},
-           {Direction<2>::upper_eta(), {2, flipped}},
-           {Direction<2>::upper_xi(), {1, quarter_turn_ccw}},
-           {Direction<2>::lower_eta(), {2, flipped}}}};
+  std::vector<DirectionMap<2, BlockNeighbor<2>>> expected_block_neighbors{
+      {{Direction<2>::upper_xi(), {1, flipped}},
+       {Direction<2>::upper_eta(), {2, quarter_turn_cw}},
+       {Direction<2>::lower_xi(), {1, flipped}},
+       {Direction<2>::lower_eta(), {2, quarter_turn_cw}}},
+      {{Direction<2>::upper_xi(), {0, flipped}},
+       {Direction<2>::lower_eta(), {3, quarter_turn_cw}},
+       {Direction<2>::lower_xi(), {0, flipped}},
+       {Direction<2>::upper_eta(), {3, quarter_turn_cw}}},
+      {{Direction<2>::upper_xi(), {0, quarter_turn_ccw}},
+       {Direction<2>::upper_eta(), {3, flipped}},
+       {Direction<2>::lower_xi(), {0, quarter_turn_ccw}},
+       {Direction<2>::lower_eta(), {3, flipped}}},
+      {{Direction<2>::lower_xi(), {1, quarter_turn_ccw}},
+       {Direction<2>::upper_eta(), {2, flipped}},
+       {Direction<2>::upper_xi(), {1, quarter_turn_ccw}},
+       {Direction<2>::lower_eta(), {2, flipped}}}};
   std::vector<std::unordered_set<Direction<2>>> expected_external_boundaries{
       {}, {}, {}, {}};
   for (size_t i = 0; i < domain.blocks().size(); i++) {

--- a/tools/Iwyu/iwyu.imp
+++ b/tools/Iwyu/iwyu.imp
@@ -68,6 +68,9 @@
   { include: ["\"DataStructures/Tensor/Structure.hpp\"", private,
               "\"DataStructures/Tensor/Tensor.hpp\"", public]},
 
+  { include: ["\"DataStructures/FixedHashMap.hpp\"", public,
+              "\"Domain/DirectionMap.hpp\"", public]},
+
   { include: ["\"NumericalAlgorithms/LinearOperators/Divergence.hpp\"",
               public,
               "\"NumericalAlgorithms/LinearOperators/Divergence.tpp\"",


### PR DESCRIPTION
## Proposed changes

Implements the last bit of #745 using `FixedHashMap`

closes #745

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
