### PR TITLE
Add InterpolationTargetKerrHorizon

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Interpolation)
 
 set(LIBRARY_SOURCES
   BarycentricRational.cpp
+  InterpolationTargetKerrHorizon.cpp
   InterpolationTargetWedgeSectionTorus.cpp
   IrregularInterpolant.cpp
   )

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.cpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp"
+
+#include <algorithm>
+#include <pup.h>
+
+#include "Parallel/PupStlCpp11.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace intrp {
+namespace OptionHolders {
+KerrHorizon::KerrHorizon(size_t l_max_in, std::array<double, 3> center_in,
+                         double mass_in,
+                         std::array<double, 3> dimensionless_spin_in,
+                         const OptionContext& context)
+    : l_max(l_max_in),
+      center(std::move(center_in)),  // NOLINT
+      mass(mass_in),
+      dimensionless_spin(std::move(dimensionless_spin_in)) {  // NOLINT
+  // above NOLINTs for std::move of trivially copyable type.
+  if (mass <= 0.0) {
+    // Check here, rather than put a lower_bound on the Tag, because
+    // we want to exclude mass being exactly zero.
+    PARSE_ERROR(context, "KerrHorizon expects mass>0, not " << mass);
+  }
+  if (magnitude(dimensionless_spin) > 1.0) {
+    PARSE_ERROR(context, "KerrHorizon expects |dimensionless_spin|<=1, not "
+                             << magnitude(dimensionless_spin));
+  }
+}
+
+void KerrHorizon::pup(PUP::er& p) noexcept {
+  p | l_max;
+  p | center;
+  p | mass;
+  p | dimensionless_spin;
+}
+
+bool operator==(const KerrHorizon& lhs, const KerrHorizon& rhs) noexcept {
+  return lhs.l_max == rhs.l_max and lhs.center == rhs.center and
+         lhs.mass == rhs.mass and
+         lhs.dimensionless_spin == rhs.dimensionless_spin;
+}
+
+bool operator!=(const KerrHorizon& lhs, const KerrHorizon& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace OptionHolders
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -1,0 +1,160 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "ApparentHorizons/Tags.hpp"
+#include "ApparentHorizons/YlmSpherepack.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace intrp {
+namespace Tags {
+template <typename Metavariables>
+struct TemporalIds;
+}  // namespace Tags
+}  // namespace intrp
+/// \endcond
+
+namespace intrp {
+
+namespace OptionHolders {
+/// A surface that conforms to the horizon of a Kerr black hole in
+/// Kerr-Schild coordinates.
+struct KerrHorizon {
+  struct Lmax {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "KerrHorizon is expanded in Ylms up to l=Lmax"};
+  };
+  struct Center {
+    using type = std::array<double, 3>;
+    static constexpr OptionString help = {"Center of black hole"};
+  };
+  struct Mass {
+    using type = double;
+    static constexpr OptionString help = {"Mass of black hole"};
+  };
+  struct DimensionlessSpin {
+    using type = std::array<double, 3>;
+    static constexpr OptionString help = {"Dimensionless spin of black hole"};
+  };
+  using options = tmpl::list<Lmax, Center, Mass, DimensionlessSpin>;
+  static constexpr OptionString help = {
+      "A Strahlkorper conforming to the horizon (in Kerr-Schild coordinates)"
+      " of a Kerr black hole with a specified center, mass, and spin."};
+
+  KerrHorizon(size_t l_max_in, std::array<double, 3> center_in, double mass_in,
+              std::array<double, 3> dimensionless_spin_in,
+              const OptionContext& context = {});
+
+  KerrHorizon() = default;
+  KerrHorizon(const KerrHorizon& /*rhs*/) = default;
+  KerrHorizon& operator=(const KerrHorizon& /*rhs*/) = default;
+  KerrHorizon(KerrHorizon&& /*rhs*/) noexcept = default;
+  KerrHorizon& operator=(KerrHorizon&& /*rhs*/) noexcept = default;
+  ~KerrHorizon() = default;
+
+  // clang-tidy non-const reference pointer.
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  size_t l_max{};
+  std::array<double, 3> center{};
+  double mass{};
+  std::array<double, 3> dimensionless_spin{};
+};
+
+bool operator==(const KerrHorizon& lhs, const KerrHorizon& rhs) noexcept;
+bool operator!=(const KerrHorizon& lhs, const KerrHorizon& rhs) noexcept;
+
+}  // namespace OptionHolders
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \brief Sends points on a Kerr horizon to an `Interpolator`.
+///
+/// The points are such that they conform to the horizon of a Kerr
+/// black hole (in Kerr-Schild coordinates) with given center, mass,
+/// and dimensionless spin, as specified in the options.
+///
+/// \note The returned points are not actually on the horizon;
+/// instead, they are collocation points of a Strahlkorper whose
+/// spectral representation matches the horizon shape up to order
+/// Lmax, where Lmax is the spherical-harmonic order specified in the
+/// options.  As Lmax increases, the returned points converge to the
+/// horizon.
+///
+/// Uses:
+/// - DataBox:
+///   - `::Tags::Domain<VolumeDim, Frame>`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `Tags::IndicesOfFilledInterpPoints`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// For requirements on InterpolationTargetTag, see InterpolationTarget
+template <typename InterpolationTargetTag, typename Frame>
+struct KerrHorizon {
+  using options_type = OptionHolders::KerrHorizon;
+  using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<
+                DbTags, typename Tags::TemporalIds<Metavariables>>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const typename Metavariables::temporal_id& temporal_id) noexcept {
+    const auto& options = Parallel::get<InterpolationTargetTag>(cache);
+
+    // Make a Strahlkorper with the correct shape.
+    ::Strahlkorper<Frame> strahlkorper(
+        options.l_max, options.l_max,
+        get(gr::Solutions::kerr_horizon_radius(
+            ::YlmSpherepack(options.l_max, options.l_max).theta_phi_points(),
+            options.mass, options.dimensionless_spin)),
+        options.center);
+
+    // Make a DataBox so we can get coords from strahlkorper.
+    auto strahlkorper_box = db::create<
+        db::AddSimpleTags<StrahlkorperTags::items_tags<Frame>>,
+        db::AddComputeTags<StrahlkorperTags::compute_items_tags<Frame>>>(
+        std::move(strahlkorper));
+
+    send_points_to_interpolator<InterpolationTargetTag>(
+        box, cache,
+        db::get<StrahlkorperTags::CartesianCoords<Frame>>(strahlkorper_box),
+        temporal_id);
+  }
+};
+
+}  // namespace Actions
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_CleanUpInterpolator.cpp
   Test_InitializeInterpolationTarget.cpp
   Test_InitializeInterpolator.cpp
+  Test_InterpolationTargetKerrHorizon.cpp
   Test_InterpolationTargetLineSegment.cpp
   Test_InterpolationTargetReceiveVars.cpp
   Test_InterpolationTargetWedgeSectionTorus.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -1,0 +1,134 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/DomainCreators/Shell.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Spherepack.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+
+namespace {
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_target_points =
+        ::intrp::Actions::KerrHorizon<InterpolationTargetA, ::Frame::Inertial>;
+    using type = compute_target_points::options_type;
+  };
+  using temporal_id = Time;
+  using domain_frame = Frame::Inertial;
+  static constexpr size_t domain_dim = 3;
+  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+
+  using component_list = tmpl::list<
+      InterpTargetTestHelpers::mock_interpolation_target<MockMetavariables,
+                                                         InterpolationTargetA>,
+      InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  enum class Phase { Initialize, Exit };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.KerrHorizon",
+                  "[Unit]") {
+  // Constants used in this test.
+  // We use l_max=18 to get enough points that the surface is
+  // represented to roundoff error; for smaller l_max we would need to
+  // modify InterpTargetTestHelpers::test_interpolation_target to
+  // handle a custom `approx`.
+  const size_t l_max = 18;
+  const double mass = 1.8;
+  const std::array<double, 3> center = {{0.05, 0.06, 0.07}};
+  const std::array<double, 3> dimless_spin = {{0.2, 0.3, 0.4}};
+
+  // Options for KerrHorizon
+  intrp::OptionHolders::KerrHorizon kerr_horizon_opts(l_max, center, mass,
+                                                      dimless_spin);
+
+  // Test creation of options
+  const auto created_opts = test_creation<intrp::OptionHolders::KerrHorizon>(
+      "  Center: [0.05, 0.06, 0.07]\n"
+      "  DimensionlessSpin: [0.2, 0.3, 0.4]\n"
+      "  Lmax: 18\n"
+      "  Mass: 1.8");
+  CHECK(created_opts == kerr_horizon_opts);
+
+  const auto domain_creator =
+      DomainCreators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);
+
+  const auto expected_block_coord_holders =
+      [&domain_creator, &mass, &center, &dimless_spin ]() noexcept {
+    // How many points are supposed to be in a Strahlkorper,
+    // reproduced here by hand for the test.
+    const size_t n_theta = l_max + 1;
+    const size_t n_phi = 2 * l_max + 1;
+
+    // The theta points of a Strahlkorper are Gauss-Legendre points.
+    const std::vector<double> theta_points = []() noexcept {
+      std::vector<double> thetas(n_theta);
+      std::vector<double> work(n_theta + 1);
+      std::vector<double> unused_weights(n_theta);
+      int err = 0;
+      gaqd_(static_cast<int>(n_theta), thetas.data(), unused_weights.data(),
+            work.data(), static_cast<int>(n_theta + 1), &err);
+      return thetas;
+    }
+    ();
+
+    // Radius as function of theta, phi
+    const auto radius =
+        [&mass, &dimless_spin ](const double theta, const double phi) noexcept {
+      // Recoding kerr_horizon_radius in a different way for the test.
+      const std::array<double, 3> spin_a = {{mass * dimless_spin[0],
+                                             mass * dimless_spin[1],
+                                             mass * dimless_spin[2]}};
+      const double spin_a_squared =
+          square(spin_a[0]) + square(spin_a[1]) + square(spin_a[2]);
+      const double a_dot_xhat_squared =
+          square(spin_a[0] * sin(theta) * cos(phi) +
+                 spin_a[1] * sin(theta) * sin(phi) + spin_a[2] * cos(theta));
+      const double r_boyer_lindquist_squared =
+          square(mass + sqrt(square(mass) - spin_a_squared));
+      return sqrt((r_boyer_lindquist_squared + spin_a_squared) /
+                  (1.0 + a_dot_xhat_squared / r_boyer_lindquist_squared));
+    };
+
+    const double two_pi_over_n_phi = 2.0 * M_PI / n_phi;
+    tnsr::I<DataVector, 3, Frame::Inertial> points(n_theta * n_phi);
+    size_t s = 0;
+    for (size_t i_phi = 0; i_phi < n_phi; ++i_phi) {
+      const double phi = two_pi_over_n_phi * i_phi;
+      for (size_t i_theta = 0; i_theta < n_theta; ++i_theta) {
+        const double theta = theta_points[i_theta];
+        const double r = radius(theta, phi);
+        points.get(0)[s] = r * sin(theta) * cos(phi) + center[0];
+        points.get(1)[s] = r * sin(theta) * sin(phi) + center[1],
+        points.get(2)[s] = r * cos(theta) + center[2];
+        ++s;
+      }
+    }
+    return block_logical_coordinates(domain_creator.create_domain(), points);
+  }
+  ();
+
+  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
+      domain_creator, kerr_horizon_opts, expected_block_coord_holders);
+}


### PR DESCRIPTION
## Proposed changes

Adds an InterpolationTarget::compute_target_points that specifies points on a Strahlkorper
that conforms to a Kerr horizon.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
