### PR TITLE
Corrections and extensions to AlfvenWave

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
@@ -32,11 +32,18 @@ AlfvenWave::AlfvenWave(const WaveNumber::type wavenumber,
       background_mag_field_(background_mag_field),
       perturbation_size_(perturbation_size),
       equation_of_state_{adiabatic_index_} {
-  alfven_speed_ = background_mag_field /
-                  sqrt((rest_mass_density_ + pressure_ * adiabatic_index_ /
-                                                 (adiabatic_index_ - 1.0)) +
-                       square(background_mag_field));
-  fluid_speed_ = -perturbation_size * alfven_speed_ / background_mag_field;
+  const double auxiliary_speed_b0 =
+      background_mag_field /
+      sqrt((rest_mass_density_ +
+            pressure_ * adiabatic_index_ / (adiabatic_index_ - 1.0)) +
+           square(background_mag_field) + square(perturbation_size));
+  const double auxiliary_speed_b1 =
+      perturbation_size * auxiliary_speed_b0 / background_mag_field;
+  const double one_over_speed_denominator =
+      1.0 / sqrt(0.5 * (1.0 + sqrt(1.0 - 4.0 * square(auxiliary_speed_b0 *
+                                                      auxiliary_speed_b1))));
+  alfven_speed_ = auxiliary_speed_b0 * one_over_speed_denominator;
+  fluid_speed_ = -auxiliary_speed_b1 * one_over_speed_denominator;
 }
 
 void AlfvenWave::pup(PUP::er& p) noexcept {

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.cpp
@@ -4,13 +4,20 @@
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp"
 
 #include <cmath>
-#include <pup.h>
+#include <cstddef>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"                   // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/CrossProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"                // IWYU pragma: keep
+#include "ErrorHandling/Assert.hpp"
+#include "Parallel/PupStlCpp11.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
 // IWYU pragma:  no_include "DataStructures/Tensor/TypeAliases.hpp"
@@ -19,26 +26,49 @@
 namespace grmhd {
 namespace Solutions {
 
-AlfvenWave::AlfvenWave(const WaveNumber::type wavenumber,
-                       const Pressure::type pressure,
-                       const RestMassDensity::type rest_mass_density,
-                       const AdiabaticIndex::type adiabatic_index,
-                       const BackgroundMagField::type background_mag_field,
-                       const PerturbationSize::type perturbation_size) noexcept
+AlfvenWave::AlfvenWave(
+    const WaveNumber::type wavenumber, const Pressure::type pressure,
+    const RestMassDensity::type rest_mass_density,
+    const AdiabaticIndex::type adiabatic_index,
+    const BackgroundMagneticField::type background_magnetic_field,
+    const WaveMagneticField::type wave_magnetic_field) noexcept
     : wavenumber_(wavenumber),
       pressure_(pressure),
       rest_mass_density_(rest_mass_density),
       adiabatic_index_(adiabatic_index),
-      background_mag_field_(background_mag_field),
-      perturbation_size_(perturbation_size),
-      equation_of_state_{adiabatic_index_} {
+      background_magnetic_field_(background_magnetic_field),
+      wave_magnetic_field_(wave_magnetic_field),
+      equation_of_state_{adiabatic_index_},
+      initial_unit_vector_along_background_magnetic_field_{
+          background_magnetic_field},
+      initial_unit_vector_along_wave_magnetic_field_{wave_magnetic_field},
+      initial_unit_vector_along_wave_electric_field_{
+          cross_product(initial_unit_vector_along_wave_magnetic_field_,
+                        initial_unit_vector_along_background_magnetic_field_)} {
+  magnitude_B0_ =
+      magnitude(initial_unit_vector_along_background_magnetic_field_).get();
+  magnitude_B1_ =
+      magnitude(initial_unit_vector_along_wave_magnetic_field_).get();
+  magnitude_E_ =
+      magnitude(initial_unit_vector_along_wave_electric_field_).get();
+  for (size_t d = 0; d < 3; d++) {
+    initial_unit_vector_along_background_magnetic_field_.get(d) /=
+        magnitude_B0_;
+    initial_unit_vector_along_wave_magnetic_field_.get(d) /= magnitude_B1_;
+    initial_unit_vector_along_wave_electric_field_.get(d) /= magnitude_E_;
+  }
+  ASSERT(equal_within_roundoff(
+             dot_product(initial_unit_vector_along_background_magnetic_field_,
+                         initial_unit_vector_along_wave_magnetic_field_)
+                 .get(),
+             0.0),
+         "The background and wave magnetic fields must be perpendicular.");
   const double auxiliary_speed_b0 =
-      background_mag_field /
-      sqrt((rest_mass_density_ +
-            pressure_ * adiabatic_index_ / (adiabatic_index_ - 1.0)) +
-           square(background_mag_field) + square(perturbation_size));
+      magnitude_B0_ / sqrt((rest_mass_density_ + pressure_ * adiabatic_index_ /
+                                                     (adiabatic_index_ - 1.0)) +
+                           square(magnitude_B0_) + square(magnitude_B1_));
   const double auxiliary_speed_b1 =
-      perturbation_size * auxiliary_speed_b0 / background_mag_field;
+      magnitude_B1_ * auxiliary_speed_b0 / magnitude_B0_;
   const double one_over_speed_denominator =
       1.0 / sqrt(0.5 * (1.0 + sqrt(1.0 - 4.0 * square(auxiliary_speed_b0 *
                                                       auxiliary_speed_b1))));
@@ -51,10 +81,16 @@ void AlfvenWave::pup(PUP::er& p) noexcept {
   p | pressure_;
   p | rest_mass_density_;
   p | adiabatic_index_;
-  p | background_mag_field_;
-  p | perturbation_size_;
+  p | background_magnetic_field_;
+  p | wave_magnetic_field_;
   p | alfven_speed_;
   p | fluid_speed_;
+  p | initial_unit_vector_along_background_magnetic_field_;
+  p | initial_unit_vector_along_wave_magnetic_field_;
+  p | initial_unit_vector_along_wave_electric_field_;
+  p | magnitude_B0_;
+  p | magnitude_B1_;
+  p | magnitude_E_;
   p | equation_of_state_;
   p | background_spacetime_;
 }
@@ -63,7 +99,10 @@ template <typename DataType>
 DataType AlfvenWave::k_dot_x_minus_vt(const tnsr::I<DataType, 3>& x,
                                       const double t) const noexcept {
   auto result = make_with_value<DataType>(x, -wavenumber_ * alfven_speed_ * t);
-  result += wavenumber_ * x.get(2);
+  for (size_t d = 0; d < 3; d++) {
+    result += wavenumber_ * x.get(d) *
+              initial_unit_vector_along_background_magnetic_field_.get(d);
+  }
   return result;
 }
 
@@ -104,8 +143,12 @@ AlfvenWave::variables(const tnsr::I<DataType, 3>& x, double t,
   const DataType phase = k_dot_x_minus_vt(x, t);
   auto result = make_with_value<db::item_type<
       hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>>(x, 0.0);
-  get<0>(result) = fluid_speed_ * cos(phase);
-  get<1>(result) = fluid_speed_ * sin(phase);
+  for (size_t d = 0; d < 3; d++) {
+    result.get(d) =
+        fluid_speed_ *
+        (cos(phase) * initial_unit_vector_along_wave_magnetic_field_[d] -
+         sin(phase) * initial_unit_vector_along_wave_electric_field_[d]);
+  }
   return {std::move(result)};
 }
 
@@ -118,9 +161,14 @@ AlfvenWave::variables(const tnsr::I<DataType, 3>& x, double t,
   const DataType phase = k_dot_x_minus_vt(x, t);
   auto result = make_with_value<
       db::item_type<hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>>(
-      x, background_mag_field_);
-  get<0>(result) = perturbation_size_ * cos(phase);
-  get<1>(result) = perturbation_size_ * sin(phase);
+      x, 0.0);
+  for (size_t d = 0; d < 3; d++) {
+    result.get(d) =
+        gsl::at(background_magnetic_field_, d) +
+        magnitude_B1_ *
+            (cos(phase) * initial_unit_vector_along_wave_magnetic_field_[d] -
+             sin(phase) * initial_unit_vector_along_wave_electric_field_[d]);
+  }
   return {std::move(result)};
 }
 
@@ -163,8 +211,17 @@ bool operator==(const AlfvenWave& lhs, const AlfvenWave& rhs) noexcept {
          lhs.pressure_ == rhs.pressure_ and
          lhs.rest_mass_density_ == rhs.rest_mass_density_ and
          lhs.adiabatic_index_ == rhs.adiabatic_index_ and
-         lhs.background_mag_field_ == rhs.background_mag_field_ and
-         lhs.perturbation_size_ == rhs.perturbation_size_ and
+         lhs.background_magnetic_field_ == rhs.background_magnetic_field_ and
+         lhs.wave_magnetic_field_ == rhs.wave_magnetic_field_ and
+         lhs.initial_unit_vector_along_background_magnetic_field_ ==
+             rhs.initial_unit_vector_along_background_magnetic_field_ and
+         lhs.initial_unit_vector_along_wave_magnetic_field_ ==
+             rhs.initial_unit_vector_along_wave_magnetic_field_ and
+         lhs.initial_unit_vector_along_wave_electric_field_ ==
+             rhs.initial_unit_vector_along_wave_electric_field_ and
+         lhs.magnitude_B0_ == rhs.magnitude_B0_ and
+         lhs.magnitude_B1_ == rhs.magnitude_B1_ and
+         lhs.magnitude_E_ == rhs.magnitude_E_ and
          lhs.alfven_speed_ == rhs.alfven_speed_ and
          lhs.fluid_speed_ == rhs.fluid_speed_ and
          lhs.background_spacetime_ == rhs.background_spacetime_;

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
@@ -35,13 +35,19 @@ namespace Solutions {
  * fluid \f$\rho_0\f$, the adiabatic index for the ideal fluid equation of
  * state \f$\gamma\f$, the background magnetic field strength \f$B_0\f$,
  * and the strength of the perturbation of the magnetic field \f$B_1\f$.
- * The Alfv&eacute;n wave phase speed is then given by:
  *
- * \f[v_A = \frac{B_0}{\sqrt{\rho_0 h + B_0^2}}\f]
+ * We define the auxiliary velocities:
+ * \f[v_{B0} = \frac{B_0}{\sqrt{\rho_0 h + B_0^2 + B_1^2}}\f]
+ * \f[v_{B1} = \frac{B_1}{\sqrt{\rho_0 h + B_0^2 + B_1^2}}\f]
+ *
+ * The Alfv&eacute;n wave phase speed that solves the grmhd equations, even for
+ * finite amplitudes \ref alfven_ref "[1]", is given by:
+ *
+ * \f[v_A = \frac{v_{B0}}{\frac{1}{2}(1 + \sqrt{1 - (2 v_{B0}v_{B1})^2})}\f]
  *
  * The amplitude of the fluid velocity is given by:
  *
- * \f[v_f = \frac{-B_1}{\sqrt{\rho_0 h + B_0^2}}\f]
+ * \f[v_f = \frac{v_{B1}}{\frac{1}{2}(1 + \sqrt{1 - (2 v_{B0}v_{B1})^2})}\f]
  *
  * In Cartesian coordinates \f$(x, y, z)\f$, and using
  * dimensionless units, the primitive quantities at a given time \f$t\f$ are
@@ -49,8 +55,8 @@ namespace Solutions {
  *
  * \f{align*}
  * \rho(\vec{x},t) &= \rho_0 \\
- * v_x(\vec{x},t) &= v_f \cos(k_z(z - v_A t))\\
- * v_y(\vec{x},t) &= v_f \sin(k_z(z - v_A t))\\
+ * v_x(\vec{x},t) &= -v_f \cos(k_z(z - v_A t))\\
+ * v_y(\vec{x},t) &= -v_f \sin(k_z(z - v_A t))\\
  * v_z(\vec{x},t) &= 0\\
  * P(\vec{x},t) &= P, \\
  * \epsilon(\vec{x}, t) &= \frac{P}{(\gamma - 1)\rho_0}\\
@@ -58,6 +64,23 @@ namespace Solutions {
  * B_y(\vec{x},t) &= B_1 \sin(k_z(z - v_A t))\\
  * B_z(\vec{x},t) &= B_0
  * \f}
+ *
+ * Note that the phase speed is not the characteristic Alfv&eacute;n speed
+ * \f$c_A\f$, which is the speed in the case where the magnetic field is
+ * parallel to the direction of propagation \ref alfven_ref "[1]":
+ *
+ * \f[c_A = \frac{b}{\sqrt{\rho_0 h + b^2}}\f]
+ *
+ * Where \f$b^2\f$ is the invariant quantity \f$B^2 - E^2\f$, given by:
+ *
+ * \f[b^2 = B_0^2 + B_1^2 - B_0^2 v_f^2\f]
+ *
+ * \anchor alfven_ref [1]
+ * L. Del Zanna, O. Zanotti, N. Bucciantini, P. Londrillo, ECHO: an Eulerian
+ * Conservative High Order scheme for general relativistic magnetohydrodynamics
+ * and magnetodynamics. Astronomy & Astrophysics,
+ * [473(1):11–30, 2007](https://arxiv.org/pdf/0704.3206.pdf)
+ *
  */
 class AlfvenWave {
  public:
@@ -106,8 +129,6 @@ class AlfvenWave {
     using type = double;
     static constexpr OptionString help = {
         "The perturbation amplitude of the magnetic field."};
-    static type lower_bound() noexcept { return -1.0; }
-    static type upper_bound() noexcept { return 1.0; }
   };
 
   using options =

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <array>
 #include <limits>
+#include <string>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Options/Options.hpp"
@@ -27,49 +29,58 @@ namespace Solutions {
 
 /*!
  * \brief Circularly polarized Alfv&eacute;n wave solution in Minkowski
- * spacetime travelling in the z-direction.
+ * spacetime travelling along a background magnetic field.
  *
- * An analytic solution to the 3-D GrMhd system. The user specifies the
- * wavenumber \f$k_z\f$ of the Alfv&eacute;n wave, the constant pressure
+ * An analytic solution to the 3-D GRMHD system. The user specifies the
+ * wavenumber \f$k\f$ of the Alfv&eacute;n wave, the constant pressure
  * throughout the fluid \f$P\f$, the constant rest mass density throughout the
  * fluid \f$\rho_0\f$, the adiabatic index for the ideal fluid equation of
- * state \f$\gamma\f$, the background magnetic field strength \f$B_0\f$,
- * and the strength of the perturbation of the magnetic field \f$B_1\f$.
+ * state \f$\gamma\f$, the magnetic field parallel to the wavevector
+ * \f$\vec{B}_0\f$, and the transverse magnetic field vector \f$\vec{B}_1\f$ at
+ * \f$x=y=z=t=0\f$.
  *
  * We define the auxiliary velocities:
- * \f[v_{B0} = \frac{B_0}{\sqrt{\rho_0 h + B_0^2 + B_1^2}}\f]
- * \f[v_{B1} = \frac{B_1}{\sqrt{\rho_0 h + B_0^2 + B_1^2}}\f]
+ * \f[v^2_{B0} = \frac{B_0^2}{\rho_0 h + B_0^2 + B_1^2}\f]
+ * \f[v^2_{B1} = \frac{B_1^2}{\rho_0 h + B_0^2 + B_1^2}\f]
  *
- * The Alfv&eacute;n wave phase speed that solves the grmhd equations, even for
+ * The Alfv&eacute;n wave phase speed that solves the GRMHD equations, even for
  * finite amplitudes \ref alfven_ref "[1]", is given by:
  *
- * \f[v_A = \frac{v_{B0}}{\frac{1}{2}(1 + \sqrt{1 - (2 v_{B0}v_{B1})^2})}\f]
+ * \f[v_A^2 = \frac{2v^2_{B0}}{1 + \sqrt{1 - 4 v^2_{B0}v^2_{B1}}}\f]
  *
  * The amplitude of the fluid velocity is given by:
  *
- * \f[v_f = \frac{v_{B1}}{\frac{1}{2}(1 + \sqrt{1 - (2 v_{B0}v_{B1})^2})}\f]
+ * \f[v_f^2 = \frac{2v^2_{B1}}{1 + \sqrt{1 - 4 v^2_{B0}v^2_{B1}}}\f]
  *
+ * The electromagnetic field vectors define a set of basis vectors:
+ *
+ * \f{align*}{
+ * \hat{b}_0 &= \vec{B_0}/B_0 \\
+ * \hat{b}_1 &= \vec{B_1}/B_1 \\
+ * \hat{e} &= \hat{b}_1 \times \hat{b}_0
+ * \f}
+ *
+ * We also define the auxiliary variable for the phase \f$\phi\f$:
+ * \f[\phi = k(\vec{x}\cdot\hat{b}_0 - v_A t)\f]
  * In Cartesian coordinates \f$(x, y, z)\f$, and using
  * dimensionless units, the primitive quantities at a given time \f$t\f$ are
  * then
  *
  * \f{align*}
  * \rho(\vec{x},t) &= \rho_0 \\
- * v_x(\vec{x},t) &= -v_f \cos(k_z(z - v_A t))\\
- * v_y(\vec{x},t) &= -v_f \sin(k_z(z - v_A t))\\
- * v_z(\vec{x},t) &= 0\\
+ * \vec{v}(\vec{x},t) &= v_f(-\hat{b}_1\cos\phi
+ *  +\hat{e}\sin\phi)\\
  * P(\vec{x},t) &= P, \\
  * \epsilon(\vec{x}, t) &= \frac{P}{(\gamma - 1)\rho_0}\\
- * B_x(\vec{x},t) &= B_1 \cos(k_z(z - v_A t))\\
- * B_y(\vec{x},t) &= B_1 \sin(k_z(z - v_A t))\\
- * B_z(\vec{x},t) &= B_0
+ * \vec{B}(\vec{x},t) &= B_1(\hat{b}_1\cos\phi
+ *  -\hat{e}\sin\phi) + \vec{B_0}
  * \f}
  *
  * Note that the phase speed is not the characteristic Alfv&eacute;n speed
- * \f$c_A\f$, which is the speed in the case where the magnetic field is
- * parallel to the direction of propagation \ref alfven_ref "[1]":
+ * \f$c_A\f$, which is the speed in the limiting case where the total magnetic
+ * field is parallel to the direction of propagation \ref alfven_ref "[1]":
  *
- * \f[c_A = \frac{b}{\sqrt{\rho_0 h + b^2}}\f]
+ * \f[c_A^2 = \frac{b^2}{\rho_0 h + b^2}\f]
  *
  * Where \f$b^2\f$ is the invariant quantity \f$B^2 - E^2\f$, given by:
  *
@@ -117,23 +128,26 @@ class AlfvenWave {
     static type lower_bound() noexcept { return 1.0; }
   };
 
-  /// The strength of the background magnetic field.
-  struct BackgroundMagField {
-    using type = double;
+  /// The background static magnetic field vector.
+  struct BackgroundMagneticField {
+    using type = std::array<double, 3>;
+    static std::string name() noexcept { return "BkgdMagneticField"; }
     static constexpr OptionString help = {
-        "The background magnetic field strength."};
+        "The background magnetic field [B0^x, B0^y, B0^z]."};
   };
 
-  /// The amplitude of the perturbation of the magnetic field.
-  struct PerturbationSize {
-    using type = double;
+  /// The sinusoidal magnetic field vector associated with
+  /// the Alfv&eacute;n wave, perpendicular to the background
+  /// magnetic field vector.
+  struct WaveMagneticField {
+    using type = std::array<double, 3>;
     static constexpr OptionString help = {
-        "The perturbation amplitude of the magnetic field."};
+        "The wave magnetic field [B1^x, B1^y, B1^z]."};
   };
 
   using options =
       tmpl::list<WaveNumber, Pressure, RestMassDensity, AdiabaticIndex,
-                 BackgroundMagField, PerturbationSize>;
+                 BackgroundMagneticField, WaveMagneticField>;
   static constexpr OptionString help = {
       "Circularly polarized Alfven wave in Minkowski spacetime."};
 
@@ -147,8 +161,8 @@ class AlfvenWave {
   AlfvenWave(WaveNumber::type wavenumber, Pressure::type pressure,
              RestMassDensity::type rest_mass_density,
              AdiabaticIndex::type adiabatic_index,
-             BackgroundMagField::type background_mag_field,
-             PerturbationSize::type perturbation_size) noexcept;
+             BackgroundMagneticField::type background_magnetic_field,
+             WaveMagneticField::type wave_magnetic_field) noexcept;
 
   // @{
   /// Retrieve hydro variable at `(x, t)`
@@ -243,13 +257,22 @@ class AlfvenWave {
       std::numeric_limits<double>::signaling_NaN();
   AdiabaticIndex::type adiabatic_index_ =
       std::numeric_limits<double>::signaling_NaN();
-  BackgroundMagField::type background_mag_field_ =
-      std::numeric_limits<double>::signaling_NaN();
-  PerturbationSize::type perturbation_size_ =
-      std::numeric_limits<double>::signaling_NaN();
+  BackgroundMagneticField::type background_magnetic_field_{
+      {std::numeric_limits<double>::signaling_NaN()}};
+  WaveMagneticField::type wave_magnetic_field_{
+      {std::numeric_limits<double>::signaling_NaN()}};
+  EquationsOfState::IdealFluid<true> equation_of_state_{};
+  tnsr::I<double, 3, Frame::Inertial>
+      initial_unit_vector_along_background_magnetic_field_{};
+  tnsr::I<double, 3, Frame::Inertial>
+      initial_unit_vector_along_wave_magnetic_field_{};
+  tnsr::I<double, 3, Frame::Inertial>
+      initial_unit_vector_along_wave_electric_field_{};
+  double magnitude_B0_ = std::numeric_limits<double>::signaling_NaN();
+  double magnitude_B1_ = std::numeric_limits<double>::signaling_NaN();
+  double magnitude_E_ = std::numeric_limits<double>::signaling_NaN();
   double alfven_speed_ = std::numeric_limits<double>::signaling_NaN();
   double fluid_speed_ = std::numeric_limits<double>::signaling_NaN();
-  EquationsOfState::IdealFluid<true> equation_of_state_{};
   gr::Solutions::Minkowski<3> background_spacetime_{};
 };
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/TestFunctions.py
@@ -71,10 +71,15 @@ def alfven_spatial_velocity(x, t, wavenumber, pressure, rest_mass_density,
     rho_zero_times_h = \
      (rest_mass_density + pressure *
       (adiabatic_index)/(adiabatic_index - 1.0))
-    alfven_speed = background_mag_field / \
-     np.sqrt(rho_zero_times_h + background_mag_field ** 2)
+    aux_speed_b0 = background_mag_field / \
+     np.sqrt(rho_zero_times_h + background_mag_field ** 2 + \
+     perturbation_size**2)
+    aux_speed_b1 = perturbation_size * aux_speed_b0 / background_mag_field
+    one_over_speed_denominator = 1.0 / np.sqrt( \
+     0.5 * (1.0 + np.sqrt(1.0 - 4.0 * aux_speed_b0**2 * aux_speed_b1**2)))
+    alfven_speed = aux_speed_b0 * one_over_speed_denominator
     phase = wavenumber * (x[2] - alfven_speed * t)
-    fluid_velocity = -perturbation_size * alfven_speed / background_mag_field
+    fluid_velocity = -aux_speed_b1 * one_over_speed_denominator
     return np.array([fluid_velocity * np.cos(phase), \
      fluid_velocity * np.sin(phase), 0.0])
 
@@ -113,10 +118,14 @@ def alfven_magnetic_field(x, t, wavenumber, pressure, rest_mass_density,
     rho_zero_times_h = \
      (rest_mass_density + pressure *
       (adiabatic_index)/(adiabatic_index - 1.0))
-    alfven_speed = background_mag_field / \
-     np.sqrt(rho_zero_times_h + background_mag_field ** 2)
+    aux_speed_b0 = background_mag_field / \
+     np.sqrt(rho_zero_times_h + background_mag_field ** 2 + \
+     perturbation_size**2)
+    aux_speed_b1 = perturbation_size * aux_speed_b0 / background_mag_field
+    one_over_speed_denominator = 1.0 / np.sqrt( \
+     0.5 * (1.0 + np.sqrt(1.0 - 4.0 * aux_speed_b0**2 * aux_speed_b1 **2)))
+    alfven_speed = aux_speed_b0 * one_over_speed_denominator
     phase = wavenumber * (x[2] - alfven_speed * t)
-    fluid_velocity = -perturbation_size * alfven_speed / background_mag_field
     return np.array([perturbation_size * np.cos(phase), \
      perturbation_size * np.sin(phase), background_mag_field])
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/TestFunctions.py
@@ -60,79 +60,88 @@ def smooth_flow_divergence_cleaning_field(x, t, mean_velocity, wave_vector,
 
 # Functions for testing AlfvenWave.cpp
 def alfven_rest_mass_density(x, t, wavenumber, pressure, rest_mass_density,
-                             adiabatic_index, background_mag_field,
-                             perturbation_size):
+                             adiabatic_index, bkgd_magnetic_field,
+                             wave_magnetic_field):
     return rest_mass_density
 
 
 def alfven_spatial_velocity(x, t, wavenumber, pressure, rest_mass_density,
-                            adiabatic_index, background_mag_field,
-                            perturbation_size):
+                            adiabatic_index, bkgd_magnetic_field,
+                            wave_magnetic_field):
+    magnitude_B0 = np.linalg.norm(bkgd_magnetic_field)
+    magnitude_B1 = np.linalg.norm(wave_magnetic_field)
+    unit_B0 = np.array(bkgd_magnetic_field) / magnitude_B0
+    unit_B1 = np.array(wave_magnetic_field) / magnitude_B1
+    unit_E = np.cross(unit_B1, unit_B0)
     rho_zero_times_h = \
      (rest_mass_density + pressure *
       (adiabatic_index)/(adiabatic_index - 1.0))
-    aux_speed_b0 = background_mag_field / \
-     np.sqrt(rho_zero_times_h + background_mag_field ** 2 + \
-     perturbation_size**2)
-    aux_speed_b1 = perturbation_size * aux_speed_b0 / background_mag_field
+    aux_speed_b0 = magnitude_B0 / \
+     np.sqrt(rho_zero_times_h + magnitude_B0 ** 2 + \
+     magnitude_B1 **2)
+    aux_speed_b1 = magnitude_B1 * aux_speed_b0 / magnitude_B0
     one_over_speed_denominator = 1.0 / np.sqrt( \
      0.5 * (1.0 + np.sqrt(1.0 - 4.0 * aux_speed_b0**2 * aux_speed_b1**2)))
     alfven_speed = aux_speed_b0 * one_over_speed_denominator
-    phase = wavenumber * (x[2] - alfven_speed * t)
+    phase = wavenumber * (np.dot(unit_B0, x) - alfven_speed * t)
     fluid_velocity = -aux_speed_b1 * one_over_speed_denominator
-    return np.array([fluid_velocity * np.cos(phase), \
-     fluid_velocity * np.sin(phase), 0.0])
+    return fluid_velocity * (np.cos(phase) * unit_B1 - np.sin(phase) * unit_E)
 
 
 def alfven_specific_internal_energy(x, t, wavenumber, pressure,
                                     rest_mass_density, adiabatic_index,
-                                    background_mag_field, perturbation_size):
+                                    bkgd_magnetic_field, wave_magnetic_field):
     return pressure / (rest_mass_density * (adiabatic_index - 1.0))
 
 
 def alfven_pressure(x, t, wavenumber, pressure, rest_mass_density,
-                    adiabatic_index, background_mag_field, perturbation_size):
+                    adiabatic_index, bkgd_magnetic_field, wave_magnetic_field):
     return pressure
 
 
 def alfven_specific_enthalpy(x, t, wavenumber, pressure, rest_mass_density,
-                             adiabatic_index, background_mag_field,
-                             perturbation_size):
+                             adiabatic_index, bkgd_magnetic_field,
+                             wave_magnetic_field):
     return 1.0 + adiabatic_index * alfven_specific_internal_energy(
         x, t, wavenumber, pressure, rest_mass_density, adiabatic_index,
-        background_mag_field, perturbation_size)
+        bkgd_magnetic_field, wave_magnetic_field)
 
 
 def alfven_lorentz_factor(x, t, wavenumber, pressure, rest_mass_density,
-                          adiabatic_index, background_mag_field,
-                          perturbation_size):
+                          adiabatic_index, bkgd_magnetic_field,
+                          wave_magnetic_field):
     return 1.0 / np.sqrt(1.0 - np.linalg.norm(
         alfven_spatial_velocity(x, t, wavenumber, pressure, rest_mass_density,
-                                adiabatic_index, background_mag_field,
-                                perturbation_size))**2)
+                                adiabatic_index, bkgd_magnetic_field,
+                                wave_magnetic_field))**2)
 
 
 def alfven_magnetic_field(x, t, wavenumber, pressure, rest_mass_density,
-                          adiabatic_index, background_mag_field,
-                          perturbation_size):
+                          adiabatic_index, bkgd_magnetic_field,
+                          wave_magnetic_field):
+    magnitude_B0 = np.linalg.norm(bkgd_magnetic_field)
+    magnitude_B1 = np.linalg.norm(wave_magnetic_field)
+    unit_B0 = np.array(bkgd_magnetic_field) / magnitude_B0
+    unit_B1 = np.array(wave_magnetic_field) / magnitude_B1
+    unit_E = np.cross(unit_B1, unit_B0)
     rho_zero_times_h = \
      (rest_mass_density + pressure *
       (adiabatic_index)/(adiabatic_index - 1.0))
-    aux_speed_b0 = background_mag_field / \
-     np.sqrt(rho_zero_times_h + background_mag_field ** 2 + \
-     perturbation_size**2)
-    aux_speed_b1 = perturbation_size * aux_speed_b0 / background_mag_field
+    aux_speed_b0 = magnitude_B0 / \
+     np.sqrt(rho_zero_times_h + magnitude_B0 ** 2 + \
+     magnitude_B1 ** 2)
+    aux_speed_b1 = magnitude_B1 * aux_speed_b0 / magnitude_B0
     one_over_speed_denominator = 1.0 / np.sqrt( \
      0.5 * (1.0 + np.sqrt(1.0 - 4.0 * aux_speed_b0**2 * aux_speed_b1 **2)))
     alfven_speed = aux_speed_b0 * one_over_speed_denominator
-    phase = wavenumber * (x[2] - alfven_speed * t)
-    return np.array([perturbation_size * np.cos(phase), \
-     perturbation_size * np.sin(phase), background_mag_field])
+    phase = wavenumber * (np.dot(unit_B0, x) - alfven_speed * t)
+    return np.array(bkgd_magnetic_field) + \
+      magnitude_B1 * (np.cos(phase) * unit_B1 - np.sin(phase) * unit_E)
 
 
 def alfven_divergence_cleaning_field(x, t, wavenumber, pressure,
                                      rest_mass_density, adiabatic_index,
-                                     background_mag_field, perturbation_size):
+                                     bkgd_magnetic_field, wave_magnetic_field):
     return 0.0
 
 


### PR DESCRIPTION
## Proposed changes
Follows [the ECHO paper](https://arxiv.org/pdf/0704.3206.pdf) in setting up the correct Alfven speeds for finite amplitude waves. Also extends the solution to allow for arbitrary wavevectors.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
