### PR TITLE
ParallelInterpolator: Simplify occurrences of VolumeDim param.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
@@ -37,30 +37,29 @@ namespace Actions {
 template <typename InterpolationTargetTag>
 struct InitializeInterpolationTarget {
   /// For requirements on Metavariables, see InterpolationTarget
-  template <typename Metavariables, size_t VolumeDim>
+  template <typename Metavariables>
   using return_tag_list = tmpl::list<
       Tags::IndicesOfFilledInterpPoints, Tags::TemporalIds<Metavariables>,
-      ::Tags::Domain<VolumeDim, typename Metavariables::domain_frame>,
+      ::Tags::Domain<Metavariables::domain_dim,
+                     typename Metavariables::domain_frame>,
       ::Tags::Variables<
           typename InterpolationTargetTag::vars_to_interpolate_to_target>>;
   template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
-            typename ActionList, typename ParallelComponent, size_t VolumeDim>
-  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
-                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/,
-                    Domain<VolumeDim, typename Metavariables::domain_frame>&&
-                        domain) noexcept {
-    return std::make_tuple(
-        db::create<db::get_items<return_tag_list<Metavariables, VolumeDim>>>(
-            db::item_type<Tags::IndicesOfFilledInterpPoints>{},
-            db::item_type<Tags::TemporalIds<Metavariables>>{},
-            std::move(domain),
-            db::item_type<
-                ::Tags::Variables<typename InterpolationTargetTag::
-                                      vars_to_interpolate_to_target>>{}));
+            typename ActionList, typename ParallelComponent>
+  static auto apply(
+      const db::DataBox<tmpl::list<>>& /*box*/,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      Domain<Metavariables::domain_dim,
+             typename Metavariables::domain_frame>&& domain) noexcept {
+    return std::make_tuple(db::create<
+                           db::get_items<return_tag_list<Metavariables>>>(
+        db::item_type<Tags::IndicesOfFilledInterpPoints>{},
+        db::item_type<Tags::TemporalIds<Metavariables>>{}, std::move(domain),
+        db::item_type<::Tags::Variables<typename InterpolationTargetTag::
+                                            vars_to_interpolate_to_target>>{}));
   }
 };
 

--- a/src/NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp
@@ -22,9 +22,9 @@ class ConstGlobalCache;
 namespace intrp {
 namespace Tags {
 struct NumberOfElements;
-template <typename Metavariables, size_t VolumeDim>
+template <typename Metavariables>
 struct InterpolatedVarsHolders;
-template <typename Metavariables, size_t VolumeDim>
+template <typename Metavariables>
 struct VolumeVarsInfo;
 }  // namespace Tags
 }  // namespace intrp
@@ -41,17 +41,16 @@ namespace Actions {
 /// DataBox changes:
 /// - Adds:
 ///   - `Tags::NumberOfElements`
-///   - `Tags::VolumeVarsInfo<Metavariables,VolumeDim>`
-///   - `Tags::InterpolatedVarsHolders<Metavariables,VolumeDim>`
+///   - `Tags::VolumeVarsInfo<Metavariables>`
+///   - `Tags::InterpolatedVarsHolders<Metavariables>`
 /// - Removes: nothing
 /// - Modifies: nothing
-template <size_t VolumeDim>
 struct InitializeInterpolator {
   template <typename Metavariables>
   using return_tag_list =
       tmpl::list<Tags::NumberOfElements,
-                 Tags::VolumeVarsInfo<Metavariables, VolumeDim>,
-                 Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>;
+                 Tags::VolumeVarsInfo<Metavariables>,
+                 Tags::InterpolatedVarsHolders<Metavariables>>;
   template <typename... InboxTags, typename Metavariables, typename ArrayIndex,
             typename ActionList, typename ParallelComponent>
   static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
@@ -63,9 +62,9 @@ struct InitializeInterpolator {
     return std::make_tuple(
         db::create<db::get_items<return_tag_list<Metavariables>>>(
             0_st,
-            db::item_type<Tags::VolumeVarsInfo<Metavariables, VolumeDim>>{},
+            db::item_type<Tags::VolumeVarsInfo<Metavariables>>{},
             db::item_type<
-                Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>{}));
+                Tags::InterpolatedVarsHolders<Metavariables>>{}));
   }
 };
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -69,11 +69,12 @@ struct Info {
 /// `Holder`s for all `InterpolationTargetTags` are held in a single
 /// `TaggedTuple` that is in the `Interpolator`'s `DataBox` with the
 /// tag `Tags::InterpolatedVarsHolders`.
-template <typename Metavariables, size_t VolumeDim,
+template <typename Metavariables,
           typename InterpolationTargetTag, typename TagList>
 struct Holder {
-  std::unordered_map<typename Metavariables::temporal_id,
-                     Info<VolumeDim, TagList>>
+  std::unordered_map<
+      typename Metavariables::temporal_id,
+      Info<Metavariables::domain_dim, TagList>>
       infos;
   std::unordered_set<typename Metavariables::temporal_id>
       temporal_ids_when_data_has_been_interpolated;
@@ -82,11 +83,10 @@ struct Holder {
 /// Indexes a particular `Holder` in the `TaggedTuple` that is
 /// accessed from the `Interpolator`'s `DataBox` with tag
 /// `Tags::InterpolatedVarsHolders`.
-template <typename InterpolationTargetTag, typename Metavariables,
-          size_t VolumeDim>
+template <typename InterpolationTargetTag, typename Metavariables>
 struct HolderTag {
   using type =
-      Holder<Metavariables, VolumeDim, InterpolationTargetTag,
+      Holder<Metavariables, InterpolationTargetTag,
              typename InterpolationTargetTag::vars_to_interpolate_to_target>;
 };
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -62,23 +62,26 @@ namespace intrp {
 ///                               `InterpolationTargetTag`s.
 /// - temporal_id:                the type held by ::intrp::Tags::TemporalIds.
 /// - domain_frame:               The `::Frame` of the Domain.
-template <class Metavariables, typename InterpolationTargetTag,
-          size_t VolumeDim>
+/// `Metavariables` must contain the following static constexpr members:
+/// - size_t domain_dim:    The dimension of the Domain.
+template <class Metavariables, typename InterpolationTargetTag>
 struct InterpolationTarget {
   using chare_type = ::Parallel::Algorithms::Singleton;
   using metavariables = Metavariables;
   using action_list = tmpl::list<>;
-  using initial_databox = db::compute_databox_type<
-      typename Actions::InitializeInterpolationTarget<InterpolationTargetTag>::
-          template return_tag_list<Metavariables, VolumeDim>>;
+  using initial_databox =
+      db::compute_databox_type<typename Actions::InitializeInterpolationTarget<
+          InterpolationTargetTag>::template return_tag_list<Metavariables>>;
   using options = tmpl::list<::OptionTags::DomainCreator<
-      VolumeDim, typename Metavariables::domain_frame>>;
+      Metavariables::domain_dim,
+      typename Metavariables::domain_frame>>;
   using const_global_cache_tag_list = tmpl::list<>;
 
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<metavariables>& global_cache,
       std::unique_ptr<
-          DomainCreator<VolumeDim, typename Metavariables::domain_frame>>
+          DomainCreator<Metavariables::domain_dim,
+                        typename Metavariables::domain_frame>>
           domain_creator) noexcept;
   static void execute_next_phase(
       typename metavariables::Phase /*next_phase*/,
@@ -87,11 +90,11 @@ struct InterpolationTarget {
 };
 
 template <class Metavariables, typename InterpolationTargetTag>
-template <size_t VolumeDim>
 void InterpolationTarget<Metavariables, InterpolationTargetTag>::initialize(
     Parallel::CProxy_ConstGlobalCache<metavariables>& global_cache,
     std::unique_ptr<
-        DomainCreator<VolumeDim, typename Metavariables::domain_frame>>
+        DomainCreator<Metavariables::domain_dim,
+                      typename Metavariables::domain_frame>>
         domain_creator) noexcept {
   auto& my_proxy = Parallel::get_parallel_component<InterpolationTarget>(
       *(global_cache.ckLocalBranch()));

--- a/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Interpolator.hpp
@@ -15,15 +15,15 @@ namespace intrp {
 /// `Element`s and interpolating it onto `InterpolationTarget`s.
 ///
 /// For requirements on Metavariables, see InterpolationTarget
-template <class Metavariables, size_t VolumeDim>
+template <class Metavariables>
 struct Interpolator {
   using chare_type = Parallel::Algorithms::Group;
   using const_global_cache_tag_list = tmpl::list<>;
   using metavariables = Metavariables;
   using action_list = tmpl::list<>;
   using initial_databox =
-      db::compute_databox_type<typename Actions::InitializeInterpolator<
-          VolumeDim>:: template return_tag_list<Metavariables>>;
+      db::compute_databox_type<typename Actions::InitializeInterpolator::
+                                   template return_tag_list<Metavariables>>;
   using options = tmpl::list<>;
   static void initialize(
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache);
@@ -32,8 +32,8 @@ struct Interpolator {
                                      Metavariables>& /*global_cache*/){};
 };
 
-template <class Metavariables, size_t VolumeDim>
-void Interpolator<Metavariables, VolumeDim>::initialize(
+template <class Metavariables>
+void Interpolator<Metavariables>::initialize(
     Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
   auto& my_proxy = Parallel::get_parallel_component<Interpolator>(
       *(global_cache.ckLocalBranch()));

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
@@ -30,7 +30,7 @@ class IdPair;
 namespace intrp {
 namespace Tags {
 struct NumberOfElements;
-template <typename Metavariables, size_t VolumeDim>
+template <typename Metavariables>
 struct InterpolatedVarsHolders;
 }  // namespace Tags
 }  // namespace intrp
@@ -48,14 +48,14 @@ namespace Actions {
 /// Uses:
 /// - Databox:
 ///   - `Tags::NumberOfElements`
-///   - `Tags::InterpolatedVarsHolders<Metavariables,VolumeDim>`
-///   - `Tags::VolumeVarsInfo<Metavariables,VolumeDim>`
+///   - `Tags::InterpolatedVarsHolders<Metavariables>`
+///   - `Tags::VolumeVarsInfo<Metavariables>`
 ///
 /// DataBox changes:
 /// - Adds: nothing
 /// - Removes: nothing
 /// - Modifies:
-///   - `Tags::InterpolatedVarsHolders<Metavariables,VolumeDim>`
+///   - `Tags::InterpolatedVarsHolders<Metavariables>`
 ///
 /// For requirements on InterpolationTargetTag, see InterpolationTarget
 template <typename InterpolationTargetTag>
@@ -75,16 +75,16 @@ struct ReceivePoints {
       std::vector<IdPair<domain::BlockId, tnsr::I<double, VolumeDim,
                                                   typename ::Frame::Logical>>>&&
           block_logical_coords) noexcept {
-    db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>(
+    db::mutate<intrp::Tags::InterpolatedVarsHolders<Metavariables>>(
         make_not_null(&box),
         [
           &temporal_id, &block_logical_coords
-        ](const gsl::not_null<db::item_type<
-              intrp::Tags::InterpolatedVarsHolders<Metavariables, VolumeDim>>*>
+        ](const gsl::not_null<
+            db::item_type<intrp::Tags::InterpolatedVarsHolders<Metavariables>>*>
               vars_holders) noexcept {
           auto& vars_infos =
-              get<intrp::Vars::HolderTag<InterpolationTargetTag, Metavariables,
-                                         VolumeDim>>(*vars_holders)
+              get<intrp::Vars::HolderTag<InterpolationTargetTag,
+                                         Metavariables>>(*vars_holders)
                   .infos;
 
           // Add the target interpolation points at this temporal_id.
@@ -95,7 +95,7 @@ struct ReceivePoints {
                   std::move(block_logical_coords)}));
         });
 
-    try_to_interpolate<InterpolationTargetTag, VolumeDim>(
+    try_to_interpolate<InterpolationTargetTag>(
         make_not_null(&box), make_not_null(&cache), temporal_id);
   }
 };

--- a/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
@@ -16,7 +16,7 @@
 
 /// \cond
 namespace intrp {
-template <typename Metavariables, size_t VolumeDim>
+template <typename Metavariables>
 struct Interpolator;
 namespace Actions {
 template <typename InterpolationTargetTag>
@@ -71,8 +71,7 @@ void send_points_to_interpolator(
       });
 
   auto& receiver_proxy =
-      Parallel::get_parallel_component<Interpolator<Metavariables, VolumeDim>>(
-          cache);
+      Parallel::get_parallel_component<Interpolator<Metavariables>>(cache);
   Parallel::simple_action<
       Actions::ReceivePoints<InterpolationTargetTag>>(
       receiver_proxy, temporal_id, std::move(coords));

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -41,23 +41,22 @@ struct TemporalIds : db::SimpleTag {
 };
 
 /// Volume variables at all `temporal_id`s for all local `Element`s.
-template <typename Metavariables, size_t VolumeDim>
+template <typename Metavariables>
 struct VolumeVarsInfo : db::SimpleTag {
   struct Info {
-    Mesh<VolumeDim> mesh;
+    Mesh<Metavariables::domain_dim> mesh;
     Variables<typename Metavariables::interpolator_source_vars> vars;
   };
-  using type =
-      std::unordered_map<typename Metavariables::temporal_id,
-                         std::unordered_map<ElementId<VolumeDim>, Info>>;
+  using type = std::unordered_map<
+      typename Metavariables::temporal_id,
+      std::unordered_map<
+          ElementId<Metavariables::domain_dim>, Info>>;
   static std::string name() noexcept { return "VolumeVarsInfo"; }
 };
 
 namespace holders_detail {
-template <typename InterpolationTargetTag, typename Metavariables,
-          typename VolumeDimWrapper>
-using WrappedHolderTag = Vars::HolderTag<InterpolationTargetTag, Metavariables,
-                                         VolumeDimWrapper::value>;
+template <typename InterpolationTargetTag, typename Metavariables>
+using WrappedHolderTag = Vars::HolderTag<InterpolationTargetTag, Metavariables>;
 }  // namespace holders_detail
 
 /// `TaggedTuple` containing all local `Vars::Holder`s for
@@ -67,12 +66,11 @@ using WrappedHolderTag = Vars::HolderTag<InterpolationTargetTag, Metavariables,
 /// `TaggedTuple` via a `Vars::HolderTag`.  An `Interpolator` uses the
 /// object in `InterpolatedVarsHolders` to iterate over all of the
 /// `InterpolationTarget`s.
-template <typename Metavariables, size_t VolumeDim>
+template <typename Metavariables>
 struct InterpolatedVarsHolders : db::SimpleTag {
   using type = tuples::tagged_tuple_from_typelist<db::wrap_tags_in<
       holders_detail::WrappedHolderTag,
-      typename Metavariables::interpolation_target_tags, Metavariables,
-      std::integral_constant<size_t, VolumeDim>>>;
+      typename Metavariables::interpolation_target_tags, Metavariables>>;
   static std::string name() noexcept { return "InterpolatedVarsHolders"; }
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -54,7 +54,7 @@ struct mock_interpolation_target {
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
       typename ::intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables, 3>>;
+          InterpolationTargetTag>::template return_tag_list<Metavariables>>;
 };
 
 struct MockComputeTargetPoints {
@@ -91,6 +91,7 @@ struct MockMetavariables {
   };
   using temporal_id = Time;
   using domain_frame = Frame::Inertial;
+  static constexpr size_t domain_dim = 3;
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -33,7 +33,7 @@ namespace intrp {
 
 namespace {
 
-template <typename Metavariables, size_t VolumeDim>
+template <typename Metavariables>
 struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
@@ -41,8 +41,8 @@ struct mock_interpolator {
   using const_global_cache_tag_list = tmpl::list<>;
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
-      typename ::intrp::Actions::InitializeInterpolator<
-          VolumeDim>::template return_tag_list<Metavariables>>;
+      typename ::intrp::Actions::InitializeInterpolator::
+          template return_tag_list<Metavariables>>;
 };
 
 struct MockMetavariables {
@@ -59,11 +59,12 @@ struct MockMetavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
   using temporal_id = Time;
+  static constexpr size_t domain_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags =
       tmpl::list<InterpolationTagA, InterpolationTagB, InterpolationTagC>;
 
-  using component_list = tmpl::list<mock_interpolator<MockMetavariables, 3>>;
+  using component_list = tmpl::list<mock_interpolator<MockMetavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialize, Exit };
 };
@@ -76,7 +77,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
   TupleOfMockDistributedObjects dist_objects{};
   using MockDistributedObjectsTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<
-          mock_interpolator<metavars, 3>>;
+          mock_interpolator<metavars>>;
 
   Slab slab(0.0, 1.0);
   Time temporal_id(slab, Rational(12, 13));
@@ -86,121 +87,120 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
   std::unordered_map<
       typename metavars::temporal_id,
       std::unordered_map<ElementId<3>,
-                         intrp::Tags::VolumeVarsInfo<metavars, 3>::Info>>
+                         intrp::Tags::VolumeVarsInfo<metavars>::Info>>
       volume_vars_info{{temporal_id, {}}};
 
   tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(
-          0,
-          ActionTesting::MockDistributedObject<mock_interpolator<metavars, 3>>{
-              db::create<
-                  db::get_items<typename intrp::Actions::InitializeInterpolator<
-                      3>::template return_tag_list<metavars>>>(
-                  0_st,
-                  db::item_type<intrp::Tags::VolumeVarsInfo<metavars, 3>>{
-                      std::move(volume_vars_info)},
-                  db::item_type<
-                      intrp::Tags::InterpolatedVarsHolders<metavars, 3>>{})});
+          0, ActionTesting::MockDistributedObject<mock_interpolator<metavars>>{
+                 db::create<db::get_items<
+                     typename intrp::Actions::InitializeInterpolator::
+                         template return_tag_list<metavars>>>(
+                     0_st,
+                     db::item_type<intrp::Tags::VolumeVarsInfo<metavars>>{
+                         std::move(volume_vars_info)},
+                     db::item_type<
+                         intrp::Tags::InterpolatedVarsHolders<metavars>>{})});
 
   MockRuntimeSystem runner{{}, std::move(dist_objects)};
 
   const auto& box =
-      runner.template algorithms<mock_interpolator<metavars, 3>>()
+      runner.template algorithms<mock_interpolator<metavars>>()
           .at(0)
           .template get_databox<
-              typename mock_interpolator<metavars, 3>::initial_databox>();
+              typename mock_interpolator<metavars>::initial_databox>();
 
   // There should be one temporal_id in VolumeVarsInfo.
-  CHECK(db::get<intrp::Tags::VolumeVarsInfo<metavars, 3>>(box).size() == 1);
+  CHECK(db::get<intrp::Tags::VolumeVarsInfo<metavars>>(box).size() == 1);
 
   // temporal_ids_when_data_has_been_interpolated should be empty for each tag.
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.empty());
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.empty());
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.empty());
 
   // Call the action on InterpolationTagA
   runner.simple_action<
-      mock_interpolator<metavars, 3>,
-      intrp::Actions::CleanUpInterpolator<metavars::InterpolationTagA, 3>>(
+      mock_interpolator<metavars>,
+      intrp::Actions::CleanUpInterpolator<metavars::InterpolationTagA>>(
       0, temporal_id);
 
   // There should still be one temporal_id in VolumeVarsInfo.
-  CHECK(db::get<intrp::Tags::VolumeVarsInfo<metavars, 3>>(box).size() == 1);
+  CHECK(db::get<intrp::Tags::VolumeVarsInfo<metavars>>(box).size() == 1);
 
   // temporal_ids_when_data_has_been_interpolated should be empty for B and C,
   // but should contain the correct temporal_id for A.
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.size() == 1);
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.count(temporal_id) ==
         1);
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.empty());
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.empty());
 
   // Call the action on InterpolationTagC
   runner.simple_action<
-      mock_interpolator<metavars, 3>,
-      intrp::Actions::CleanUpInterpolator<metavars::InterpolationTagC, 3>>(
+      mock_interpolator<metavars>,
+      intrp::Actions::CleanUpInterpolator<metavars::InterpolationTagC>>(
       0, temporal_id);
 
   // There should still be one temporal_id in VolumeVarsInfo.
-  CHECK(db::get<intrp::Tags::VolumeVarsInfo<metavars, 3>>(box).size() == 1);
+  CHECK(db::get<intrp::Tags::VolumeVarsInfo<metavars>>(box).size() == 1);
 
   // temporal_ids_when_data_has_been_interpolated should be empty for B,
   // but should contain the correct temporal_id for A and C.
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.size() == 1);
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.count(temporal_id) ==
         1);
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.size() == 1);
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.count(temporal_id) ==
         1);
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.empty());
 
   // Call the action on InterpolationTagB. This will clean up everything
   // since all the tags have now cleaned up.
   runner.simple_action<
-      mock_interpolator<metavars, 3>,
-      intrp::Actions::CleanUpInterpolator<metavars::InterpolationTagB, 3>>(
+      mock_interpolator<metavars>,
+      intrp::Actions::CleanUpInterpolator<metavars::InterpolationTagB>>(
       0, temporal_id);
 
   // There should be no temporal_ids in VolumeVarsInfo.
-  CHECK(db::get<intrp::Tags::VolumeVarsInfo<metavars, 3>>(box).empty());
+  CHECK(db::get<intrp::Tags::VolumeVarsInfo<metavars>>(box).empty());
 
   // temporal_ids_when_data_has_been_interpolated should be empty for each tag.
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagA, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.empty());
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagB, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.empty());
-  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars, 3>>(
-            db::get<intrp::Tags::InterpolatedVarsHolders<metavars, 3>>(box))
+  CHECK(get<intrp::Vars::HolderTag<metavars::InterpolationTagC, metavars>>(
+            db::get<intrp::Tags::InterpolatedVarsHolders<metavars>>(box))
             .temporal_ids_when_data_has_been_interpolated.empty());
 
   // There should be no queued actions; verify this.
-  CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars, 3>>(0));
+  CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars>>(0));
 }
 
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -43,7 +43,7 @@ struct mock_interpolation_target {
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
       typename ::intrp::Actions::InitializeInterpolationTarget<
-          InterpolationTargetTag>::template return_tag_list<Metavariables, 3>>;
+          InterpolationTargetTag>::template return_tag_list<Metavariables>>;
 };
 
 struct MockMetavariables {
@@ -53,6 +53,7 @@ struct MockMetavariables {
   };
   using temporal_id = Time;
   using domain_frame = Frame::Inertial;
+  static constexpr size_t domain_dim = 3;
 
   using component_list = tmpl::list<
       mock_interpolation_target<MockMetavariables, InterpolationTargetA>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -30,13 +30,14 @@ struct MockMetavariables {
   };
   using temporal_id = Time;
   using domain_frame = Frame::Inertial;
+  static constexpr size_t domain_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
 
   using component_list = tmpl::list<
       InterpTargetTestHelpers::mock_interpolation_target<MockMetavariables,
                                                          InterpolationTargetA>,
-      InterpTargetTestHelpers::mock_interpolator<MockMetavariables, 3>>;
+      InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialize, Exit };
 };

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -32,13 +32,14 @@ struct MockMetavariables {
   };
   using temporal_id = Time;
   using domain_frame = Frame::Inertial;
+  static constexpr size_t domain_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
 
   using component_list = tmpl::list<
       InterpTargetTestHelpers::mock_interpolation_target<MockMetavariables,
                                                          InterpolationTargetA>,
-      InterpTargetTestHelpers::mock_interpolator<MockMetavariables, 3>>;
+      InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialize, Exit };
 };

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -28,7 +28,7 @@ struct NumberOfElements;
 
 namespace {
 
-template <typename Metavariables, size_t VolumeDim>
+template <typename Metavariables>
 struct mock_interpolator {
   using metavariables = Metavariables;
   using chare_type = ActionTesting::MockArrayChare;
@@ -36,8 +36,8 @@ struct mock_interpolator {
   using const_global_cache_tag_list = tmpl::list<>;
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<
-      typename ::intrp::Actions::InitializeInterpolator<
-          VolumeDim>::template return_tag_list<Metavariables>>;
+      typename ::intrp::Actions::InitializeInterpolator::
+          template return_tag_list<Metavariables>>;
 };
 
 struct MockMetavariables {
@@ -46,10 +46,11 @@ struct MockMetavariables {
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
   using temporal_id = Time;
+  static constexpr size_t domain_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;
 
-  using component_list = tmpl::list<mock_interpolator<MockMetavariables, 3>>;
+  using component_list = tmpl::list<mock_interpolator<MockMetavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
   enum class Phase { Initialize, Exit };
 };
@@ -63,29 +64,29 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.RegisterElement",
   TupleOfMockDistributedObjects dist_objects{};
   using MockDistributedObjectsTag =
       typename MockRuntimeSystem::template MockDistributedObjectsTag<
-          mock_interpolator<metavars, 3>>;
+          mock_interpolator<metavars>>;
   tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(0, ActionTesting::MockDistributedObject<
-                      mock_interpolator<metavars, 3>>{});
+                      mock_interpolator<metavars>>{});
   MockRuntimeSystem runner{{}, std::move(dist_objects)};
 
-  runner.simple_action<mock_interpolator<metavars, 3>,
-                       ::intrp::Actions::InitializeInterpolator<3>>(0);
+  runner.simple_action<mock_interpolator<metavars>,
+                       ::intrp::Actions::InitializeInterpolator>(0);
 
   const auto& box =
-      runner.template algorithms<mock_interpolator<metavars, 3>>()
+      runner.template algorithms<mock_interpolator<metavars>>()
           .at(0)
           .template get_databox<
-              typename mock_interpolator<metavars, 3>::initial_databox>();
+              typename mock_interpolator<metavars>::initial_databox>();
 
   CHECK(db::get<::intrp::Tags::NumberOfElements>(box) == 0);
 
-  runner.simple_action<mock_interpolator<metavars, 3>,
+  runner.simple_action<mock_interpolator<metavars>,
                        ::intrp::Actions::RegisterElement>(0);
 
   CHECK(db::get<::intrp::Tags::NumberOfElements>(box) == 1);
 
-  runner.simple_action<mock_interpolator<metavars, 3>,
+  runner.simple_action<mock_interpolator<metavars>,
                        ::intrp::Actions::RegisterElement>(0);
 
   CHECK(db::get<::intrp::Tags::NumberOfElements>(box) == 2);


### PR DESCRIPTION
Add a Metavariables constexpr static member `domain_dim`
which gives the dimension of the Domain.  This eliminates a VolumeDim
template parameter for many Actions, many of which don't use VolumeDim
but need it as a template parameter so that they can call an Action
that calls an Action that needs the VolumeDim.

The Actions that provide `compute_target_points` might still have a
VolumeDim template parameter.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
