### PR TITLE
Add option to disable Minmod limiter for debugging

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -233,14 +233,14 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
 
   /// \brief Data to send to neighbor elements.
   struct PackagedData {
-    tuples::TaggedTuple<Minmod_detail::to_tensor_double<Tags>...> means_;
-    std::array<double, VolumeDim> element_size_ =
+    tuples::TaggedTuple<Minmod_detail::to_tensor_double<Tags>...> means;
+    std::array<double, VolumeDim> element_size =
         make_array<VolumeDim>(std::numeric_limits<double>::signaling_NaN());
 
     // clang-tidy: google-runtime-references
     void pup(PUP::er& p) noexcept {  // NOLINT
-      p | means_;
-      p | element_size_;
+      p | means;
+      p | element_size;
     }
   };
 
@@ -273,12 +273,12 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
         // this avoids the work of reorienting the tensor while giving the same
         // result.
         get<Minmod_detail::to_tensor_double<decltype(tag)>>(
-            packaged_data->means_)[i] = mean_value(tensor[i], mesh);
+            packaged_data->means)[i] = mean_value(tensor[i], mesh);
       }
       return '0';
     };
     expand_pack(wrap_compute_means(Tags{}, tensors)...);
-    packaged_data->element_size_ =
+    packaged_data->element_size =
         orientation_map.permute_from_neighbor(element_size);
   }
 
@@ -348,7 +348,7 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
           result.insert(std::make_pair(
               neighbor_and_data.first,
               make_not_null(get<Minmod_detail::to_tensor_double<decltype(tag)>>(
-                                neighbor_and_data.second.means_)
+                                neighbor_and_data.second.means)
                                 .cbegin())));
         }
         return result;
@@ -362,7 +362,7 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
             result;
         for (const auto& neighbor_and_data : neighbor_data) {
           result.insert(std::make_pair(neighbor_and_data.first,
-                                       neighbor_and_data.second.element_size_));
+                                       neighbor_and_data.second.element_size));
         }
         return result;
       }

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -193,8 +193,8 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
   /// See `SlopeLimiters::Minmod` documentation for details.
   struct TvbmConstant {
     using type = double;
-    static type default_value() { return 0.0; }
-    static type lower_bound() { return 0.0; }
+    static type default_value() noexcept { return 0.0; }
+    static type lower_bound() noexcept { return 0.0; }
     static constexpr OptionString help = {"TVBM constant 'm'"};
   };
   using options = tmpl::list<Type, TvbmConstant>;

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -48,8 +48,11 @@ NumericalFluxParams:
 DampingParameter: 0.0
 
 SlopeLimiterParams:
+  # Uncomment line below to turn off the limiter:
+  # DisableForDebugging: True
   Type: LambdaPiN
-  TvbmConstant: 1000
+  # Recommended value from minmod papers:
+  TvbmConstant: 50.0
 
 VariableFixerParams:
   MinimumValueOfD: 1.0e-12

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -925,28 +925,28 @@ void test_package_data_work(
 
   // Should not normally look inside the package, but we do so here for testing.
   double lhs =
-      get(get<Minmod_detail::to_tensor_double<scalar>>(packaged_data.means_));
+      get(get<Minmod_detail::to_tensor_double<scalar>>(packaged_data.means));
   CHECK(lhs == approx(mean_value(get(input_scalar), mesh)));
   for (size_t d = 0; d < VolumeDim; ++d) {
     lhs = get<Minmod_detail::to_tensor_double<vector<VolumeDim>>>(
-              packaged_data.means_)
+              packaged_data.means)
               .get(d);
     CHECK(lhs == approx(mean_value(modified_vector.get(d), mesh)));
   }
-  CHECK(packaged_data.element_size_ == element_size);
+  CHECK(packaged_data.element_size == element_size);
 
   // Then we test with a reorientation, as if sending the data to another Block
   minmod.package_data(make_not_null(&packaged_data), input_scalar,
                       modified_vector, mesh, element_size, orientation_map);
-  lhs = get(get<Minmod_detail::to_tensor_double<scalar>>(packaged_data.means_));
+  lhs = get(get<Minmod_detail::to_tensor_double<scalar>>(packaged_data.means));
   CHECK(lhs == approx(mean_value(get(input_scalar), mesh)));
   for (size_t d = 0; d < VolumeDim; ++d) {
     lhs = get<Minmod_detail::to_tensor_double<vector<VolumeDim>>>(
-              packaged_data.means_)
+              packaged_data.means)
               .get(d);
     CHECK(lhs == approx(mean_value(modified_vector.get(d), mesh)));
   }
-  CHECK(packaged_data.element_size_ ==
+  CHECK(packaged_data.element_size ==
         orientation_map.permute_from_neighbor(element_size));
 }
 
@@ -1039,26 +1039,26 @@ SPECTRE_TEST_CASE(
   const std::array<std::pair<Direction<1>, ElementId<1>>, 2> dir_keys = {
       {{Direction<1>::lower_xi(), ElementId<1>(1)},
        {Direction<1>::upper_xi(), ElementId<1>(2)}}};
-  neighbor_data[dir_keys[0]].element_size_ = element_size;
-  neighbor_data[dir_keys[1]].element_size_ = element_size;
+  neighbor_data[dir_keys[0]].element_size = element_size;
+  neighbor_data[dir_keys[1]].element_size = element_size;
 
   // The scalar we treat as a shock: we want the slope to be reduced
   const auto target_scalar_slope = std::array<double, 1>{{1.2}};
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[0]].means_) =
+      neighbor_data[dir_keys[0]].means) =
       Scalar<double>(mean - target_scalar_slope[0]);
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[1]].means_) =
+      neighbor_data[dir_keys[1]].means) =
       Scalar<double>(mean + target_scalar_slope[0]);
 
   // The vector x-component we treat as a smooth function: no limiter action
   const auto target_vector_slope =
       std::array<std::array<double, 1>, 1>{{true_slope}};
   get<Minmod_detail::to_tensor_double<vector<1>>>(
-      neighbor_data[dir_keys[0]].means_) =
+      neighbor_data[dir_keys[0]].means) =
       tnsr::I<double, 1>(mean - 2.0 * true_slope[0]);
   get<Minmod_detail::to_tensor_double<vector<1>>>(
-      neighbor_data[dir_keys[1]].means_) =
+      neighbor_data[dir_keys[1]].means) =
       tnsr::I<double, 1>(mean + 2.0 * true_slope[0]);
 
   test_work(input_scalar, input_vector, neighbor_data, mesh, logical_coords,
@@ -1109,10 +1109,10 @@ SPECTRE_TEST_CASE(
        {Direction<2>::upper_xi(), ElementId<2>(2)},
        {Direction<2>::lower_eta(), ElementId<2>(3)},
        {Direction<2>::upper_eta(), ElementId<2>(4)}}};
-  neighbor_data[dir_keys[0]].element_size_ = element_size;
-  neighbor_data[dir_keys[1]].element_size_ = element_size;
-  neighbor_data[dir_keys[2]].element_size_ = element_size;
-  neighbor_data[dir_keys[3]].element_size_ = element_size;
+  neighbor_data[dir_keys[0]].element_size = element_size;
+  neighbor_data[dir_keys[1]].element_size = element_size;
+  neighbor_data[dir_keys[2]].element_size = element_size;
+  neighbor_data[dir_keys[3]].element_size = element_size;
 
   // The scalar we treat as a 3D shock: we want each slope to be reduced
   const auto target_scalar_slope = std::array<double, 2>{{1.2, -2.2}};
@@ -1121,13 +1121,13 @@ SPECTRE_TEST_CASE(
     return Scalar<double>(mean + sign * gsl::at(target_scalar_slope, dim));
   };
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[0]].means_) = neighbor_scalar_func(0, -1);
+      neighbor_data[dir_keys[0]].means) = neighbor_scalar_func(0, -1);
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[1]].means_) = neighbor_scalar_func(0, 1);
+      neighbor_data[dir_keys[1]].means) = neighbor_scalar_func(0, 1);
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[2]].means_) = neighbor_scalar_func(1, -1);
+      neighbor_data[dir_keys[2]].means) = neighbor_scalar_func(1, -1);
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[3]].means_) = neighbor_scalar_func(1, 1);
+      neighbor_data[dir_keys[3]].means) = neighbor_scalar_func(1, 1);
 
   // The vector we treat differently in each component, to check the limiter
   // acts independently on each:
@@ -1149,13 +1149,13 @@ SPECTRE_TEST_CASE(
           mean + sign * gsl::at(neighbor_vector_slope[1], dim)}}};
   };
   get<Minmod_detail::to_tensor_double<vector<2>>>(
-      neighbor_data[dir_keys[0]].means_) = neighbor_vector_func(0, -1);
+      neighbor_data[dir_keys[0]].means) = neighbor_vector_func(0, -1);
   get<Minmod_detail::to_tensor_double<vector<2>>>(
-      neighbor_data[dir_keys[1]].means_) = neighbor_vector_func(0, 1);
+      neighbor_data[dir_keys[1]].means) = neighbor_vector_func(0, 1);
   get<Minmod_detail::to_tensor_double<vector<2>>>(
-      neighbor_data[dir_keys[2]].means_) = neighbor_vector_func(1, -1);
+      neighbor_data[dir_keys[2]].means) = neighbor_vector_func(1, -1);
   get<Minmod_detail::to_tensor_double<vector<2>>>(
-      neighbor_data[dir_keys[3]].means_) = neighbor_vector_func(1, 1);
+      neighbor_data[dir_keys[3]].means) = neighbor_vector_func(1, 1);
 
   test_work(input_scalar, input_vector, neighbor_data, mesh, logical_coords,
             element_size, target_scalar_slope, target_vector_slope);
@@ -1221,7 +1221,7 @@ SPECTRE_TEST_CASE(
        {Direction<3>::lower_zeta(), ElementId<3>(5)},
        {Direction<3>::upper_zeta(), ElementId<3>(6)}}};
   for (const auto& id_pair : dir_keys) {
-    neighbor_data[id_pair].element_size_ = element_size;
+    neighbor_data[id_pair].element_size = element_size;
   }
 
   // The scalar we treat as a 3D shock: we want each slope to be reduced
@@ -1238,17 +1238,17 @@ SPECTRE_TEST_CASE(
     return Scalar<double>(mean + sign * gsl::at(target_scalar_slope, dim));
   };
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[0]].means_) = neighbor_scalar_func(0, -1);
+      neighbor_data[dir_keys[0]].means) = neighbor_scalar_func(0, -1);
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[1]].means_) = neighbor_scalar_func(0, 1);
+      neighbor_data[dir_keys[1]].means) = neighbor_scalar_func(0, 1);
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[2]].means_) = neighbor_scalar_func(1, -1);
+      neighbor_data[dir_keys[2]].means) = neighbor_scalar_func(1, -1);
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[3]].means_) = neighbor_scalar_func(1, 1);
+      neighbor_data[dir_keys[3]].means) = neighbor_scalar_func(1, 1);
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[4]].means_) = neighbor_scalar_func(2, -1);
+      neighbor_data[dir_keys[4]].means) = neighbor_scalar_func(2, -1);
   get<Minmod_detail::to_tensor_double<scalar>>(
-      neighbor_data[dir_keys[5]].means_) = neighbor_scalar_func(2, 1);
+      neighbor_data[dir_keys[5]].means) = neighbor_scalar_func(2, 1);
 
   // The vector we treat differently in each component, to verify that the
   // limiter acts independently on each:
@@ -1279,17 +1279,17 @@ SPECTRE_TEST_CASE(
           mean - 1.1 - dim - sign}}};  // arbitrary, but smaller than mean
   };
   get<Minmod_detail::to_tensor_double<vector<3>>>(
-      neighbor_data[dir_keys[0]].means_) = neighbor_vector_func(0, -1);
+      neighbor_data[dir_keys[0]].means) = neighbor_vector_func(0, -1);
   get<Minmod_detail::to_tensor_double<vector<3>>>(
-      neighbor_data[dir_keys[1]].means_) = neighbor_vector_func(0, 1);
+      neighbor_data[dir_keys[1]].means) = neighbor_vector_func(0, 1);
   get<Minmod_detail::to_tensor_double<vector<3>>>(
-      neighbor_data[dir_keys[2]].means_) = neighbor_vector_func(1, -1);
+      neighbor_data[dir_keys[2]].means) = neighbor_vector_func(1, -1);
   get<Minmod_detail::to_tensor_double<vector<3>>>(
-      neighbor_data[dir_keys[3]].means_) = neighbor_vector_func(1, 1);
+      neighbor_data[dir_keys[3]].means) = neighbor_vector_func(1, 1);
   get<Minmod_detail::to_tensor_double<vector<3>>>(
-      neighbor_data[dir_keys[4]].means_) = neighbor_vector_func(2, -1);
+      neighbor_data[dir_keys[4]].means) = neighbor_vector_func(2, -1);
   get<Minmod_detail::to_tensor_double<vector<3>>>(
-      neighbor_data[dir_keys[5]].means_) = neighbor_vector_func(2, 1);
+      neighbor_data[dir_keys[5]].means) = neighbor_vector_func(2, 1);
 
   test_work(input_scalar, input_vector, neighbor_data, mesh, logical_coords,
             element_size, target_scalar_slope, target_vector_slope);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -79,6 +79,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.Minmod.Options",
       "  Type: LambdaPiN");
   test_creation<SlopeLimiters::Minmod<3, tmpl::list<scalar, vector<3>>>>(
       "  Type: LambdaPiN");
+
+  test_creation<SlopeLimiters::Minmod<3, tmpl::list<scalar>>>(
+      "  Type: LambdaPiN\n  DisableForDebugging: True");
 }
 
 // [[OutputRegex, Failed to convert "BadType" to MinmodType]]


### PR DESCRIPTION
## Proposed changes

Adds a simple input-file option to turn off the limiter. This way we can hopefully avoid the confusion where users may not know that `TvbmConstant` was set to a large number in the input files as a hack to "almost always turn off" the limiter.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
