### PR TITLE
Add Basic Matrix Wrapper

### DIFF
--- a/src/DataStructures/Python/Bindings.cpp
+++ b/src/DataStructures/Python/Bindings.cpp
@@ -5,9 +5,11 @@
 
 namespace py_bindings {
 void bind_datavector();
+void bind_matrix();
 }  // namespace py_bindings
 
 BOOST_PYTHON_MODULE(_DataStructures) {
   Py_Initialize();
   py_bindings::bind_datavector();
+  py_bindings::bind_matrix();
 }

--- a/src/DataStructures/Python/CMakeLists.txt
+++ b/src/DataStructures/Python/CMakeLists.txt
@@ -5,7 +5,10 @@ set(LIBRARY "PyDataStructures")
 
 spectre_python_add_module(
   DataStructures
-  SOURCES Bindings.cpp DataVector.cpp
+  SOURCES
+  Bindings.cpp
+  DataVector.cpp
+  Matrix.cpp
   )
 
 target_link_libraries(

--- a/src/DataStructures/Python/Matrix.cpp
+++ b/src/DataStructures/Python/Matrix.cpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <boost/python.hpp>
+#include <boost/python/reference_existing_object.hpp>
+#include <boost/python/return_value_policy.hpp>
+#include <boost/python/tuple.hpp>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "DataStructures/Matrix.hpp"
+#include "PythonBindings/BoundChecks.hpp"
+#include "Utilities/MakeString.hpp"
+
+namespace bp = boost::python;
+
+namespace py_bindings {
+void bind_matrix() {
+  // Wrapper for basic Matrix operations
+  bp::class_<Matrix>("Matrix", bp::init<size_t, size_t>())
+      .add_property("shape",
+           +[](const Matrix& self) {
+             bp::tuple a =
+                 bp::make_tuple<size_t, size_t>(self.rows(), self.columns());
+             return a;
+           })
+      // __getitem__ and __setitem__ are the subscript operators (M[*,*]).
+      .def("__getitem__",
+           +[](const Matrix& self, bp::tuple x) -> double {
+             matrix_bounds_check(self, bp::extract<size_t>(x[0]),
+                                 bp::extract<size_t>(x[1]));
+             return self(bp::extract<size_t>(x[0]), bp::extract<size_t>(x[1]));
+           })
+      // Need __str__ for converting to string/printing
+      .def(
+          "__str__",
+          +[](const Matrix& self) { return std::string(MakeString{} << self); })
+      .def("__setitem__", +[](Matrix& self, bp::tuple x, const double val) {
+        matrix_bounds_check(self, bp::extract<size_t>(x[0]),
+                            bp::extract<size_t>(x[1]));
+        self(bp::extract<size_t>(x[0]), bp::extract<size_t>(x[1])) = val;
+      });
+}
+}  // namespace py_bindings

--- a/src/PythonBindings/BoundChecks.hpp
+++ b/src/PythonBindings/BoundChecks.hpp
@@ -23,4 +23,20 @@ void bounds_check(const T& t, const size_t i) {
                              " of size " + std::to_string(t.size())};
   }
 }
+/*!
+ * \ingroup PythonBindingsGroup
+ * \brief Check if a matrix-like object access is in bounds. Throws
+ * std::runtime_error if it is not.
+ */
+template <typename T>
+void matrix_bounds_check(const T& matrix, const size_t row,
+                         const size_t column) {
+  if (row >= matrix.rows() or column >= matrix.columns()) {
+    throw std::runtime_error{"Out of bounds access (" + std::to_string(row) +
+                             ", " + std::to_string(column) +
+                             ") into Matrix of size (" +
+                             std::to_string(matrix.rows()) + ", " +
+                             std::to_string(matrix.columns()) + ")"};
+  }
+}
 }  // namespace py_bindings

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -36,3 +36,7 @@ spectre_add_python_test(
   "Unit.DataStructures.Python.DataVector"
   Test_DataVector.py
   "unit;datastructures;python")
+spectre_add_python_test(
+  "Unit.DataStructures.Python.Matrix"
+  Test_Matrix.py
+  "unit;datastructures;python")

--- a/tests/Unit/DataStructures/Test_Matrix.py
+++ b/tests/Unit/DataStructures/Test_Matrix.py
@@ -1,0 +1,44 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from spectre.DataStructures import Matrix
+import unittest
+import math
+
+class TestMatrix(unittest.TestCase):
+    def test_shape(self):
+        M = Matrix(3, 5)
+        self.assertEqual(M.shape, (3, 5))
+
+
+    def test_getitem(self):
+        M = Matrix(3, 4)
+        M[1, 2] = 3
+        M[0, 0] = 0
+        M[2, 1] = 1
+        self.assertEqual(M[1, 2], 3)
+        self.assertEqual(M[0, 0], 0)
+        self.assertEqual(M[2, 1], 1)
+
+    def test_string(self):
+        M = Matrix(2,2)
+        M[0,0] = 1
+        M[0,1] = 2
+        M[1,0] = 3
+        M[1,1] = 4
+        self.assertEqual(str(M),
+            '(            1            2 )\n(            3            4 )\n')
+
+
+    def test_bounds_check(self):
+        a = Matrix(2, 2)
+        self.assertRaises(RuntimeError, lambda: a[5,2])
+
+        def assignment_test():
+            a[5,2] = 8
+
+        self.assertRaises(RuntimeError, assignment_test)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

<!--
This Pull Request introduces a simple wrapper class for `Matrix`, which will allow accessing H5 data in Python for use in visualizations.  Only a few of the `Matrix` functions are bound, although any suggestions for other functions which may be useful are welcome. 
-->

### Types of changes:

- [ ] Bugfix
- [x ] New feature

### Component:

- [ x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [x ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
Note: This Pull Request Depends on the PR `Finish Python bindings for DataVector`, which is currently being reviewed. 
-->
