### PR TITLE
Optimize Bondi-Michel and Kerr-Schild Solutions

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.cpp
@@ -96,7 +96,8 @@ BondiMichel::IntermediateVars<DataType>::IntermediateVars(
     const double in_polytropic_constant, const double in_polytropic_exponent,
     const double in_bernoulli_constant_squared_minus_one,
     const double in_sonic_radius, const double in_sonic_density,
-    const tnsr::I<DataType, 3>& x) noexcept
+    const tnsr::I<DataType, 3>& x, const bool need_spacetime,
+    const gr::Solutions::KerrSchild& background_spacetime) noexcept
     : radius((magnitude(x)).get()),
       rest_mass_density(make_with_value<DataType>(x, 0.0)),
       mass_accretion_rate_over_four_pi(in_mass_accretion_rate_over_four_pi),
@@ -129,6 +130,10 @@ BondiMichel::IntermediateVars<DataType>::IntermediateVars(
                                           : sonic_bound,
             current_radius < sonic_radius ? sonic_bound : sonic_density, 1.e-15,
             1.e-15);
+  }
+  if (need_spacetime) {
+    kerr_schild_soln = background_spacetime.variables(
+        x, 0.0, gr::Solutions::KerrSchild::tags<DataType>{});
   }
 }
 


### PR DESCRIPTION
## Proposed changes

- Reduces the number of allocations in the Bondi-Michel accretion solution
- Reduces the number of allocations in Kerr-Schild
- Clean up Local LF flux.

**Note:** Only last 3 commits are new.

Depends on:
- [x] #1137 
- [x] #1160 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
