### PR TITLE
Mutating Interface Compute Tags and Performance Improvements

### DIFF
--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -684,9 +684,9 @@ struct compute_item_function_pointer_type_impl<true> {
 template <typename FullTagList, typename ComputeItem,
           typename... ComputeItemArgumentsTags>
 using compute_item_function_pointer_type =
-    typename compute_item_function_pointer_type_impl<
-        DataBox_detail::has_return_type_member_v<ComputeItem>>::
-        template f<FullTagList, ComputeItem, ComputeItemArgumentsTags...>;
+    typename compute_item_function_pointer_type_impl<has_return_type_member_v<
+        ComputeItem>>::template f<FullTagList, ComputeItem,
+                                  ComputeItemArgumentsTags...>;
 
 template <bool IsComputeTag>
 struct get_argument_list_impl {
@@ -796,7 +796,7 @@ db::DataBox<tmpl::list<Tags...>>::add_compute_item_to_box() noexcept {
                                  tmpl::pin<tmpl::list<Tags...>>, tmpl::_1>>{});
   add_sub_compute_item_tags_to_box<Tag>(
       typename Subitems<tmpl::list<Tags...>, Tag>::type{},
-      typename DataBox_detail::has_return_type_member<
+      typename has_return_type_member<
           Subitems<tmpl::list<Tags...>, Tag>>::type{});
 }
 // End adding compute items
@@ -1009,7 +1009,7 @@ void DataBox<tmpl::list<Tags...>>::pup_impl(
     if (p.isUnpacking()) {
       add_sub_compute_item_tags_to_box<tag>(
           typename Subitems<tmpl::list<Tags...>, tag>::type{},
-          typename DataBox_detail::has_return_type_member<
+          typename has_return_type_member<
               Subitems<tmpl::list<Tags...>, tag>>::type{});
     }
   };

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -282,7 +282,6 @@ template <typename Tag>
 constexpr bool is_base_tag_v = is_base_tag<Tag>::value;
 // @}
 
-namespace DataBox_detail {
 template <class T, class = void>
 struct has_return_type_member : std::false_type {};
 template <class T>
@@ -295,6 +294,7 @@ struct has_return_type_member<T, cpp17::void_t<typename T::return_type>>
 template <class T>
 constexpr bool has_return_type_member_v = has_return_type_member<T>::value;
 
+namespace DataBox_detail {
 template <typename TagList, typename Tag>
 struct item_type_impl;
 

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -479,18 +479,22 @@ template <typename DirectionsTag, typename VarsTag>
 struct Slice : Interface<DirectionsTag, VarsTag>, db::ComputeTag {
   static constexpr size_t volume_dim =
       db::item_type<DirectionsTag>::value_type::volume_dim;
-  static constexpr auto function(
+
+  using return_type =
+      std::unordered_map<::Direction<volume_dim>, db::item_type<VarsTag>>;
+
+  static constexpr void function(
+      const gsl::not_null<
+          std::unordered_map<::Direction<volume_dim>, db::item_type<VarsTag>>*>
+          sliced_vars,
       const ::Mesh<volume_dim>& mesh,
       const std::unordered_set<::Direction<volume_dim>>& directions,
       const db::item_type<VarsTag>& variables) noexcept {
-    std::unordered_map<::Direction<volume_dim>, db::item_type<VarsTag>>
-        sliced_vars{};
     for (const auto& direction : directions) {
-      sliced_vars[direction] =
-          data_on_slice(variables, mesh.extents(), direction.dimension(),
-                        index_to_slice_at(mesh.extents(), direction));
+      data_on_slice(make_not_null(&((*sliced_vars)[direction])), variables,
+                    mesh.extents(), direction.dimension(),
+                    index_to_slice_at(mesh.extents(), direction));
     }
-    return sliced_vars;
   }
   static std::string name() { return "Interface<" + VarsTag::name() + ">"; };
   using argument_tags = tmpl::list<Mesh<volume_dim>, DirectionsTag, VarsTag>;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
@@ -33,6 +33,7 @@ struct Normalized;
 namespace grmhd {
 namespace ValenciaDivClean {
 
+// @{
 /*!
  * \brief Compute the characteristic speeds for the Valencia formulation of
  * GRMHD with divergence cleaning.
@@ -112,6 +113,22 @@ std::array<DataVector, 9> characteristic_speeds(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
         equation_of_state) noexcept;
 
+template <size_t ThermodynamicDim>
+void characteristic_speeds(
+    gsl::not_null<std::array<DataVector, 9>*> result,
+    const Scalar<DataVector>& rest_mass_density,
+    const Scalar<DataVector>& specific_internal_energy,
+    const Scalar<DataVector>& specific_enthalpy,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& spatial_velocity,
+    const Scalar<DataVector>& lorentz_factor,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& magnetic_field,
+    const Scalar<DataVector>& lapse, const tnsr::I<DataVector, 3>& shift,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& spatial_metric,
+    const tnsr::i<DataVector, 3>& unit_normal,
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>&
+        equation_of_state) noexcept;
+// @}
+
 namespace Tags {
 /// \brief Compute the characteristic speeds for the Valencia formulation of
 /// GRMHD with divergence cleaning.
@@ -134,7 +151,10 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds,
   using volume_tags =
       tmpl::list<hydro::Tags::EquationOfState<EquationOfStateType>>;
 
-  static constexpr auto function(
+  using return_type = std::array<DataVector, 9>;
+
+  static constexpr void function(
+      const gsl::not_null<return_type*> result,
       const Scalar<DataVector>& rest_mass_density,
       const Scalar<DataVector>& specific_internal_energy,
       const Scalar<DataVector>& specific_enthalpy,
@@ -147,8 +167,8 @@ struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds,
       const EquationsOfState::EquationOfState<
           true, EquationOfStateType::thermodynamic_dim>&
           equation_of_state) noexcept {
-    return characteristic_speeds<EquationOfStateType::thermodynamic_dim>(
-        rest_mass_density, specific_internal_energy, specific_enthalpy,
+    characteristic_speeds<EquationOfStateType::thermodynamic_dim>(
+        result, rest_mass_density, specific_internal_energy, specific_enthalpy,
         spatial_velocity, lorentz_factor, magnetic_field, lapse, shift,
         spatial_metric, unit_normal, equation_of_state);
   }


### PR DESCRIPTION
## Proposed changes

- Allow interface compute tags to be mutating
- Reduce allocations in GRMHD cons from prim

Commit order:
1. Have compute interface tags wrapper mutate map
2. Make db::has_member_return_type available
3. Add support for mutating interface compute items
4. Add and use not_null variant of data_on_slice
5. Make Valencia Div Clean characteristic_speeds not_null
6. Reduce allocations in GRMHD ConservativeFromPrimitive

Depends on:
- [x] #1160 
- [x] #1137 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
