### PR TITLE
Add ComplexModalVector

### DIFF
--- a/src/DataStructures/ComplexDiagonalModalOperator.hpp
+++ b/src/DataStructures/ComplexDiagonalModalOperator.hpp
@@ -1,0 +1,213 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/DiagonalModalOperator.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Utilities/PointerVector.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DiagonalModalOperator;
+class ModalVector;
+/// \endcond
+
+// IWYU pragma: no_include <blaze/math/expressions/DVecMapExpr.h>
+// IWYU pragma: no_include <blaze/math/typetraits/IsVector.h>
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief A class for an element-wise complex multiplier of modal coefficients.
+ *
+ * \details A `ComplexDiagonalModalOperator` holds an array of factors to
+ * multiply by spectral coefficients, and can be either owning (the array is
+ * deleted when the `ComplexDiagonalModalOperator` goes out of scope) or
+ * non-owning, meaning it just has a pointer to an array.
+ *
+ * `ComplexDiagonalModalOperator`s are intended to represent a diagonal matrix
+ * that can operate (via the `*` operator) on spectral coefficients represented
+ * by `ComplexModalVector`s easily. Only basic mathematical operations are
+ * supported with `ComplexDiagonalModalOperator`s.
+ * `ComplexDiagonalModalOperator`s may be added, subtracted, multiplied, or
+ * divided, and all arithmetic operations are similarly supported between
+ * `ComplexDiagonalModalOperator`s and `DiagonalModalOperator`s. In addition,
+ * the following operations with modal data structures are supported:
+ * - multiplication of a `ComplexDiagonalModalOperator` and a
+ *   `ComplexModalVector` resulting in a `ComplexModalVector`
+ * - multiplication of a `ComplexDiagonalModalOperator` and a `ModalVector`
+ *   resulting in a `ComplexModalVector`
+ * - multiplication of a `DiagonalModalOperator` and a `ComplexModalVector`
+ *   resulting in a `ComplexModalVector`
+ * All of these multiplication operations are commutative, supporting the
+ * interpretation of the modal data structure as either a 'row' or a 'column'
+ * vector.
+ *
+ * The following unary operations are supported with
+ * `ComplexDiagonalModalOperator`s:
+ * - conj
+ * - imag (results in a `DiagonalModalOperator`)
+ * - real (results in a `DiagonalModalOperator`)
+ *
+ * Also, addition, subtraction, multiplication and division of
+ * `DiagonalModalOperator`s with `std::complex<double>`s or `double`s is
+ * supported.
+ */
+class ComplexDiagonalModalOperator
+    : public VectorImpl<std::complex<double>, ComplexDiagonalModalOperator> {
+ public:
+  using VectorImpl<std::complex<double>, ComplexDiagonalModalOperator>::
+  operator=;
+  using VectorImpl<std::complex<double>,
+                   ComplexDiagonalModalOperator>::VectorImpl;
+};
+
+namespace blaze {
+VECTOR_BLAZE_TRAIT_SPECIALIZE_ARITHMETIC_TRAITS(ComplexDiagonalModalOperator);
+
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
+                                               DiagonalModalOperator, AddTrait);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
+                                               DiagonalModalOperator, DivTrait);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
+                                               DiagonalModalOperator,
+                                               MultTrait);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
+                                               DiagonalModalOperator, SubTrait);
+
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
+                                               double, AddTrait);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
+                                               double, DivTrait);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
+                                               double, MultTrait);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexDiagonalModalOperator,
+                                               double, SubTrait);
+
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector,
+                                               DiagonalModalOperator,
+                                               MultTrait);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector,
+                                               ComplexDiagonalModalOperator,
+                                               MultTrait);
+template <>
+struct MultTrait<ModalVector, ComplexDiagonalModalOperator> {
+  using Type = ComplexModalVector;
+};
+template <>
+struct MultTrait<ComplexDiagonalModalOperator, ModalVector> {
+  using Type = ComplexModalVector;
+};
+
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+template <typename Operator>
+struct UnaryMapTrait<ComplexDiagonalModalOperator, Operator> {
+  // Selectively allow unary operations for spectral coefficient operators
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<
+              blaze::Conj,
+              // these traits are required for operators acting with doubles
+              blaze::AddScalar<ComplexDiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<ComplexDiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<ComplexDiagonalModalOperator::ElementType>,
+              blaze::DivideScalarByVector<
+                  ComplexDiagonalModalOperator::ElementType>,
+              blaze::AddScalar<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
+              blaze::DivideScalarByVector<
+                  ComplexDiagonalModalOperator::ElementType>>,
+          Operator>,
+      "This unary operation is not permitted on a "
+      "ComplexDiagonalModalOperator");
+  using Type = ComplexDiagonalModalOperator;
+};
+template <>
+struct UnaryMapTrait<ComplexDiagonalModalOperator, blaze::Imag> {
+  using Type = DiagonalModalOperator;
+};
+template <>
+struct UnaryMapTrait<ComplexDiagonalModalOperator, blaze::Real> {
+  using Type = DiagonalModalOperator;
+};
+template <>
+struct UnaryMapTrait<DiagonalModalOperator, blaze::Imag> {
+  using Type = DiagonalModalOperator;
+};
+template <>
+struct UnaryMapTrait<DiagonalModalOperator, blaze::Real> {
+  using Type = DiagonalModalOperator;
+};
+
+template <typename Operator>
+struct BinaryMapTrait<ComplexDiagonalModalOperator,
+                      ComplexDiagonalModalOperator, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // ComplexDiagonalModalOperator that are unlikely to be used on spectral
+  // coefficients. Currently no non-arithmetic binary operations are supported.
+  static_assert(tmpl::list_contains_v<tmpl::list<>, Operator>,
+                "This binary operation is not permitted on a "
+                "ComplexDiagonalModalOperator.");
+  using Type = ComplexDiagonalModalOperator;
+};
+#else
+template <typename Operator>
+struct MapTrait<ComplexDiagonalModalOperator, Operator> {
+  // Selectively allow unary operations for spectral coefficient operators
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<
+              blaze::Conj,
+              // these traits are required for operators acting with doubles
+              blaze::AddScalar<ComplexDiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<ComplexDiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<ComplexDiagonalModalOperator::ElementType>,
+              blaze::DivideScalarByVector<
+                  ComplexDiagonalModalOperator::ElementType>,
+              blaze::AddScalar<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarRhs<DiagonalModalOperator::ElementType>,
+              blaze::SubScalarLhs<DiagonalModalOperator::ElementType>,
+              blaze::DivideScalarByVector<
+                  ComplexDiagonalModalOperator::ElementType>>,
+          Operator>,
+      "This unary operation is not permitted on a "
+      "ComplexDiagonalModalOperator");
+  using Type = ComplexDiagonalModalOperator;
+};
+template <>
+struct MapTrait<ComplexDiagonalModalOperator, blaze::Imag> {
+  using Type = DiagonalModalOperator;
+};
+template <>
+struct MapTrait<ComplexDiagonalModalOperator, blaze::Real> {
+  using Type = DiagonalModalOperator;
+};
+template <>
+struct MapTrait<DiagonalModalOperator, blaze::Imag> {
+  using Type = DiagonalModalOperator;
+};
+template <>
+struct MapTrait<DiagonalModalOperator, blaze::Real> {
+  using Type = DiagonalModalOperator;
+};
+
+template <typename Operator>
+struct MapTrait<ComplexDiagonalModalOperator, ComplexDiagonalModalOperator,
+                Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // ComplexDiagonalModalOperator that are unlikely to be used on spectral
+  // coefficients. Currently no non-arithmetic binary operations are supported.
+  static_assert(tmpl::list_contains_v<tmpl::list<>, Operator>,
+                "This binary operation is not permitted on a "
+                "ComplexDiagonalModalOperator.");
+  using Type = ComplexDiagonalModalOperator;
+};
+#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+}  // namespace blaze
+
+MAKE_STD_ARRAY_VECTOR_BINOPS(ComplexDiagonalModalOperator)
+
+MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(ComplexDiagonalModalOperator)

--- a/src/DataStructures/ComplexModalVector.hpp
+++ b/src/DataStructures/ComplexModalVector.hpp
@@ -1,0 +1,183 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/VectorImpl.hpp"
+#include "Utilities/PointerVector.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_include <blaze/math/expressions/DVecMapExpr.h>
+// IWYU pragma: no_include <blaze/math/typetraits/IsVector.h>
+
+/// \cond
+class ModalVector;
+/// \endcond
+
+/*!
+ * \ingroup DataStructuresGroup
+ * \brief A class for storing complex spectral coefficients on a spectral grid.
+ *
+ * \details A ComplexModalVector holds an array of spectral coefficients
+ * represented as `std::complex<double>`s, and can be either owning (the array
+ * is deleted when the ComplexModalVector goes out of scope) or non-owning,
+ * meaning it just has a pointer to an array.
+ *
+ * Only basic mathematical operations are supported with
+ * `ComplexModalVector`s. `ComplexModalVector`s may be added or subtracted and
+ * may be added or subtracted with `ModalVector`s, and the following unary
+ * operations are supported:
+ * - conj
+ * - imag (which returns a `ModalVector`)
+ * - real (which returns a `ModalVector`)
+ *
+ * Also multiplication is supported with `std::complex<double>`s or doubles and
+ * `ComplexModalVector`s, and `ComplexModalVector`s can be divided by
+ * `std::complex<double>`s or `double`s. Multiplication is supported with
+ * `ComplexDiagonalModalOperator`s and `ComplexModalVector`s.
+ */
+class ComplexModalVector
+    : public VectorImpl<std::complex<double>, ComplexModalVector> {
+ public:
+  using VectorImpl<std::complex<double>, ComplexModalVector>::operator=;
+  using VectorImpl<std::complex<double>, ComplexModalVector>::VectorImpl;
+
+  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(+=, ComplexModalVector)
+  MAKE_MATH_ASSIGN_EXPRESSION_POINTERVECTOR(-=, ComplexModalVector)
+};
+
+namespace blaze {
+template <>
+struct IsVector<ComplexModalVector> : std::true_type {};
+template <>
+struct TransposeFlag<ComplexModalVector>
+    : BoolConstant<ComplexModalVector::transpose_flag> {};
+template <>
+struct AddTrait<ComplexModalVector, ComplexModalVector> {
+  using Type = ComplexModalVector;
+};
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector, ModalVector,
+                                               AddTrait);
+template <>
+struct SubTrait<ComplexModalVector, ComplexModalVector> {
+  using Type = ComplexModalVector;
+};
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector, ModalVector,
+                                               SubTrait);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector,
+                                               std::complex<double>, MultTrait);
+BLAZE_TRAIT_SPECIALIZE_COMPATIBLE_BINARY_TRAIT(ComplexModalVector, double,
+                                               MultTrait);
+template <>
+struct DivTrait<ComplexModalVector, std::complex<double>> {
+  using Type = ComplexModalVector;
+};
+template <>
+struct DivTrait<ComplexModalVector, double> {
+  using Type = ComplexModalVector;
+};
+
+#if ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+template <typename Operator>
+struct UnaryMapTrait<ComplexModalVector, Operator> {
+  // Selectively allow unary operations for spectral coefficients
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<blaze::Conj,
+                     // Following 3 reqd. by operator(+,+=), (-,-=),
+                     // (-) w/doubles
+                     blaze::AddScalar<ComplexModalVector::ElementType>,
+                     blaze::SubScalarRhs<ComplexModalVector::ElementType>,
+                     blaze::SubScalarLhs<ComplexModalVector::ElementType>>,
+          Operator>,
+      "Only unary operations permitted on a ComplexModalVector are:"
+      " conj, imag, and real");
+  using Type = ComplexModalVector;
+};
+template <>
+struct UnaryMapTrait<ComplexModalVector, blaze::Imag> {
+  using Type = ModalVector;
+};
+template <>
+struct UnaryMapTrait<ComplexModalVector, blaze::Real> {
+  using Type = ModalVector;
+};
+// for consistency with the std::imag and std::real, these operations should be
+// supported on real types
+template <>
+struct UnaryMapTrait<ModalVector, blaze::Imag> {
+  using Type = ModalVector;
+};
+template <>
+struct UnaryMapTrait<ModalVector, blaze::Real> {
+  using Type = ModalVector;
+};
+
+template <typename Operator>
+struct BinaryMapTrait<ComplexModalVector, ComplexModalVector, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // ComplexModalVector that are unlikely to be used on spectral coefficients.
+  // Currently no non-arithmetic binary operations are supported.
+  static_assert(
+      tmpl::list_contains_v<tmpl::list<>, Operator>,
+      "This binary operation is not permitted on a ComplexModalVector.");
+  using Type = ComplexModalVector;
+};
+#else
+template <typename Operator>
+struct MapTrait<ComplexModalVector, Operator> {
+  // Selectively allow unary operations for spectral coefficients
+  static_assert(
+      tmpl::list_contains_v<
+          tmpl::list<blaze::Conj,
+                     // Following 3 reqd. by operator(+,+=), (-,-=),
+                     // (-) w/doubles
+                     blaze::AddScalar<ComplexModalVector::ElementType>,
+                     blaze::SubScalarRhs<ComplexModalVector::ElementType>,
+                     blaze::SubScalarLhs<ComplexModalVector::ElementType>>,
+          Operator>,
+      "Only unary operations permitted on a ComplexModalVector are:"
+      " conj, imag, and real");
+  using Type = ComplexModalVector;
+};
+template <>
+struct MapTrait<ComplexModalVector, blaze::Imag> {
+  using Type = ModalVector;
+};
+template <>
+struct MapTrait<ComplexModalVector, blaze::Real> {
+  using Type = ModalVector;
+};
+template <>
+struct MapTrait<ModalVector, blaze::Imag> {
+  using Type = ModalVector;
+};
+template <>
+struct MapTrait<ModalVector, blaze::Real> {
+  using Type = ModalVector;
+};
+
+template <typename Operator>
+struct MapTrait<ComplexModalVector, ComplexModalVector, Operator> {
+  // Forbid math operations in this specialization of BinaryMap traits for
+  // ComplexModalVector that are unlikely to be used on spectral coefficients.
+  // Currently no non-arithmetic binary operations are supported.
+  static_assert(
+      tmpl::list_contains_v<tmpl::list<>, Operator>,
+      "This binary operation is not permitted on a ComplexModalVector.");
+  using Type = ComplexModalVector;
+};
+#endif  // ((BLAZE_MAJOR_VERSION == 3) && (BLAZE_MINOR_VERSION <= 3))
+}  // namespace blaze
+
+/// \cond
+DEFINE_STD_ARRAY_BINOP(ComplexModalVector, ComplexModalVector,
+                       ComplexModalVector, operator+, std::plus<>())
+DEFINE_STD_ARRAY_BINOP(ComplexModalVector, ComplexModalVector,
+                       ComplexModalVector, operator-, std::minus<>())
+DEFINE_STD_ARRAY_INPLACE_BINOP(ComplexModalVector,
+                               ComplexModalVector, operator+=, std::plus<>())
+DEFINE_STD_ARRAY_INPLACE_BINOP(ComplexModalVector,
+                               ComplexModalVector, operator-=, std::minus<>())
+/// \endcond
+MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(ComplexModalVector)

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 
 #include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
 #include "DataStructures/Tensor/Expressions/Contract.hpp"
@@ -84,12 +85,14 @@ class Tensor<X, Symm, IndexList<Indices...>> {
       cpp17::is_same_v<X, double> or cpp17::is_same_v<X, DataVector> or
           cpp17::is_same_v<X, ModalVector> or
           cpp17::is_same_v<X, std::complex<double>> or
-          cpp17::is_same_v<X, ComplexDataVector>,
+          cpp17::is_same_v<X, ComplexDataVector> or
+          cpp17::is_same_v<X, ComplexModalVector>,
       "Only a Tensor<double>, Tensor<DataVector>, Tensor<ModalVector>, "
-      "Tensor<std::complex<double>>, or Tensor<ComplexDataVector> is currently "
-      "allowed. While other types are technically possible it is not "
-      "clear that Tensor is the correct container for them. Please "
-      "seek advice on the topic by discussing with the SpECTRE developers.");
+      "Tensor<std::complex<double>>, Tensor<ComplexDataVector>, or "
+      "Tensor<ComplexModalVector> is currently allowed. While other types are "
+      "technically possible it is not clear that Tensor is the correct "
+      "container for them. Please seek advice on the topic by discussing with "
+      "the SpECTRE developers.");
   /// The Tensor_detail::Structure for the particular tensor index structure
   ///
   /// Each tensor index structure, e.g. \f$T_{ab}\f$, \f$T_a{}^b\f$ or

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_DataStructures")
 
 set(LIBRARY_SOURCES
   Test_ComplexDataVector.cpp
+  Test_ComplexModalVector.cpp
   Test_DataVector.cpp
   Test_DenseMatrix.cpp
   Test_DenseVector.cpp

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_DataStructures")
 
 set(LIBRARY_SOURCES
   Test_ComplexDataVector.cpp
+  Test_ComplexDiagonalModalOperator.cpp
   Test_ComplexModalVector.cpp
   Test_DataVector.cpp
   Test_DenseMatrix.cpp

--- a/tests/Unit/DataStructures/Test_ComplexDiagonalModalOperator.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexDiagonalModalOperator.cpp
@@ -1,0 +1,172 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <complex>
+#include <tuple>
+
+#include "DataStructures/ComplexDiagonalModalOperator.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DiagonalModalOperator.hpp"
+#include "DataStructures/ModalVector.hpp"  // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"         // IWYU pragma: keep
+#include "Utilities/Functional.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// IWYU pragma: no_include <algorithm>
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.ComplexDiagonalModalOperator.ExpressionAssignError",
+    "[Unit][DataStructures]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<
+      ComplexDiagonalModalOperator>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::ExpressionAssign);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+        "Unit.DataStructures.ComplexDiagonalModalOperator.RefDiffSize",
+        "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<
+      ComplexDiagonalModalOperator>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::Copy);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.ComplexDiagonalModalOperator.MoveRefDiffSize",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<
+      ComplexDiagonalModalOperator>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::Move);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+void test_complex_diagonal_modal_operator_math() noexcept {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+
+  const auto unary_ops = std::make_tuple(
+      std::make_tuple(funcl::Conj<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Imag<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Real<>{}, std::make_tuple(generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, ComplexDiagonalModalOperator>(
+      unary_ops);
+
+  const auto binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, ComplexDiagonalModalOperator>(
+      binary_ops);
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, ComplexDiagonalModalOperator,
+      DiagonalModalOperator>(binary_ops);
+
+  const auto inplace_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::DivAssign<>{}, std::make_tuple(generic, positive)),
+      std::make_tuple(funcl::MinusAssign<>{},
+                      std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::MultAssign<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::PlusAssign<>{},
+                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Inplace, ComplexDiagonalModalOperator,
+      DiagonalModalOperator>(inplace_binary_ops);
+
+  const auto acting_on_modal_vector = std::make_tuple(std::make_tuple(
+      funcl::Multiplies<>{}, std::make_tuple(generic, generic)));
+
+  // the operation isn't really "inplace", but we carefully forbid the operation
+  // between two ModalVectors, which will be avoided in the inplace test case,
+  // which checks only combinations with the ComplexDiagonalModalOperator as the
+  // first argument.
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Inplace, ComplexDiagonalModalOperator,
+      ModalVector, ComplexModalVector>(acting_on_modal_vector);
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      DiagonalModalOperator, ComplexModalVector>(acting_on_modal_vector);
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, DiagonalModalOperator>(acting_on_modal_vector);
+  // testing the other ordering
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, ModalVector,
+      ComplexDiagonalModalOperator>(acting_on_modal_vector);
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, ComplexDiagonalModalOperator>(acting_on_modal_vector);
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, DiagonalModalOperator>(acting_on_modal_vector);
+
+  const auto cascaded_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)),
+      std::make_tuple(funcl::Minus<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, ComplexDiagonalModalOperator,
+      DiagonalModalOperator>(cascaded_ops);
+
+  const auto array_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict,
+      std::array<ComplexDiagonalModalOperator, 2>>(array_binary_ops);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.ComplexDiagonalModalOperator",
+                  "[DataStructures][Unit]") {
+  {
+    INFO("test construct and assign");
+    TestHelpers::VectorImpl::vector_test_construct_and_assign<
+        ComplexDiagonalModalOperator, std::complex<double>>();
+  }
+  {
+    INFO("test serialize and deserialize");
+    TestHelpers::VectorImpl::vector_test_serialize<ComplexDiagonalModalOperator,
+                                                   std::complex<double>>();
+  }
+  {
+    INFO("test set_data_ref functionality");
+    TestHelpers::VectorImpl::vector_test_ref<ComplexDiagonalModalOperator,
+                                             std::complex<double>>();
+  }
+  {
+    INFO("test math after move");
+    TestHelpers::VectorImpl::vector_test_math_after_move<
+        ComplexDiagonalModalOperator, std::complex<double>>();
+  }
+  {
+    INFO("test ComplexDiagonalModalOperator math operations");
+    test_complex_diagonal_modal_operator_math();
+  }
+}

--- a/tests/Unit/DataStructures/Test_ComplexModalVector.cpp
+++ b/tests/Unit/DataStructures/Test_ComplexModalVector.cpp
@@ -1,0 +1,168 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <complex>
+#include <tuple>
+
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "ErrorHandling/Error.hpp"           // IWYU pragma: keep
+#include "Utilities/DereferenceWrapper.hpp"  // IWYU pragma: keep
+#include "Utilities/Functional.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/TypeTraits.hpp"  // IWYU pragma: keep
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// IWYU pragma: no_include <algorithm>
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.ComplexModalVector.ExpressionAssignError",
+    "[Unit][DataStructures]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<ComplexModalVector>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::ExpressionAssign);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+        "Unit.DataStructures.ComplexModalVector.RefDiffSize",
+        "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<ComplexModalVector>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::Copy);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.ComplexModalVector.MoveRefDiffSize",
+    "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<ComplexModalVector>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::Move);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+void test_complex_modal_vector_math() noexcept {
+  const TestHelpers::VectorImpl::Bound generic{{-100.0, 100.0}};
+  const TestHelpers::VectorImpl::Bound positive{{0.01, 100.0}};
+
+  const auto unary_ops = std::make_tuple(
+      std::make_tuple(funcl::Conj<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Imag<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Real<>{}, std::make_tuple(generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, ComplexModalVector>(unary_ops);
+
+  const auto real_unary_ops = std::make_tuple(
+      std::make_tuple(funcl::Imag<>{}, std::make_tuple(generic)),
+      std::make_tuple(funcl::Real<>{}, std::make_tuple(generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Normal, ModalVector>(real_unary_ops);
+
+  const auto binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, ComplexModalVector,
+      ModalVector>(binary_ops);
+
+  const auto cascaded_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<funcl::Plus<>, funcl::Identity>{},
+                      std::make_tuple(generic, generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict, ComplexModalVector,
+      ModalVector>(cascaded_ops);
+
+  const auto array_binary_ops = std::make_tuple(
+      std::make_tuple(funcl::Minus<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Plus<>{}, std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::Strict,
+      std::array<ComplexModalVector, 2>>(array_binary_ops);
+
+  const auto just_element_with_modal_vector_ops =
+      std::make_tuple(std::make_tuple(funcl::Multiplies<>{},
+                                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly, double,
+      ComplexModalVector>(just_element_with_modal_vector_ops);
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      std::complex<double>, ComplexModalVector>(
+      just_element_with_modal_vector_ops);
+
+  const auto just_modal_vector_with_element_ops = std::make_tuple(
+      std::make_tuple(funcl::Multiplies<>{}, std::make_tuple(generic, generic)),
+      std::make_tuple(funcl::Divides<>{}, std::make_tuple(generic, positive)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, double>(just_modal_vector_with_element_ops);
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, std::complex<double>>(
+      just_modal_vector_with_element_ops);
+
+  const auto just_modal_vector_with_modal_vector_ops =
+      std::make_tuple(std::make_tuple(funcl::MinusAssign<>{},
+                                      std::make_tuple(generic, generic)),
+                      std::make_tuple(funcl::PlusAssign<>{},
+                                      std::make_tuple(generic, generic)));
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, ComplexModalVector>(
+      just_modal_vector_with_modal_vector_ops);
+
+  TestHelpers::VectorImpl::test_functions_with_vector_arguments<
+      TestHelpers::VectorImpl::TestKind::GivenOrderOfArgumentsOnly,
+      ComplexModalVector, ModalVector>(just_modal_vector_with_modal_vector_ops);
+}
+
+SPECTRE_TEST_CASE("Unit.DataStructures.ComplexModalVector",
+                  "[DataStructures][Unit]") {
+  {
+    INFO("test construct and assign");
+    TestHelpers::VectorImpl::vector_test_construct_and_assign<
+        ComplexModalVector, std::complex<double>>();
+  }
+  {
+    INFO("test serialize and deserialize");
+    TestHelpers::VectorImpl::vector_test_serialize<ComplexModalVector,
+                                                   std::complex<double>>();
+  }
+  {
+    INFO("test set_data_ref functionality");
+    TestHelpers::VectorImpl::vector_test_ref<ComplexModalVector,
+                                             std::complex<double>>();
+  }
+  {
+    INFO("test math after move");
+    TestHelpers::VectorImpl::vector_test_math_after_move<
+        ComplexModalVector, std::complex<double>>();
+  }
+  {
+    INFO("test ComplexModalVector math operations");
+    test_complex_modal_vector_math();
+  }
+}

--- a/tests/Unit/DataStructures/Test_Variables.cpp
+++ b/tests/Unit/DataStructures/Test_Variables.cpp
@@ -11,6 +11,7 @@
 #include <tuple>
 
 #include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
@@ -915,49 +916,57 @@ void test_variables_add_slice_to_data() noexcept {
 
 SPECTRE_TEST_CASE("Unit.DataStructures.Variables", "[DataStructures][Unit]") {
   SECTION("Test Variables construction, access, and assignment") {
-    test_variables_construction_and_access<DataVector>();
     test_variables_construction_and_access<ComplexDataVector>();
+    test_variables_construction_and_access<ComplexModalVector>();
+    test_variables_construction_and_access<DataVector>();
     test_variables_construction_and_access<ModalVector>();
   }
   SECTION("Test Variables move operations") {
-    test_variables_move<DataVector>();
     test_variables_move<ComplexDataVector>();
+    test_variables_move<ComplexModalVector>();
+    test_variables_move<DataVector>();
     test_variables_move<ModalVector>();
   }
   SECTION("Test Variables arithmetic operations") {
     test_variables_math<DataVector>();
     test_variables_math<ComplexDataVector>();
-    // test for ModalVector omitted due to limited arithmetic operation support
-    // for ModalVectors
+    // tests for ModalVector and ComplexModalVector omitted due to limited
+    // arithmetic operation support for ModalVectors
   }
   SECTION("Test Prefix Variables move and copy semantics") {
-    test_variables_prefix_semantics<DataVector>();
     test_variables_prefix_semantics<ComplexDataVector>();
+    test_variables_prefix_semantics<ComplexModalVector>();
+    test_variables_prefix_semantics<DataVector>();
     test_variables_prefix_semantics<ModalVector>();
   }
   SECTION("Test Prefix Variables arithmetic operations") {
-    test_variables_prefix_math<DataVector>();
     test_variables_prefix_math<ComplexDataVector>();
+    test_variables_prefix_math<ComplexModalVector>();
+    test_variables_prefix_math<DataVector>();
     test_variables_prefix_math<ModalVector>();
   }
   SECTION("Test Variables serialization") {
-    test_variables_serialization<DataVector>();
     test_variables_serialization<ComplexDataVector>();
+    test_variables_serialization<ComplexModalVector>();
+    test_variables_serialization<DataVector>();
     test_variables_serialization<ModalVector>();
   }
   SECTION("Test Variables assign subset") {
-    test_variables_assign_subset<DataVector>();
     test_variables_assign_subset<ComplexDataVector>();
+    test_variables_assign_subset<ComplexModalVector>();
+    test_variables_assign_subset<DataVector>();
     test_variables_assign_subset<ModalVector>();
   }
   SECTION("Test Variables slice utilities") {
-    test_variables_slice<DataVector>();
     test_variables_slice<ComplexDataVector>();
+    test_variables_slice<ComplexModalVector>();
+    test_variables_slice<DataVector>();
     test_variables_slice<ModalVector>();
   }
   SECTION("Test adding slice values to Variables") {
-    test_variables_add_slice_to_data<DataVector>();
     test_variables_add_slice_to_data<ComplexDataVector>();
+    test_variables_add_slice_to_data<ComplexModalVector>();
+    test_variables_add_slice_to_data<DataVector>();
     test_variables_add_slice_to_data<ModalVector>();
   }
 }


### PR DESCRIPTION
## Proposed changes

ComplexModalVector is similar to ModalVector, but for complex values. It is suggested to be used for storing the (complex) Ylm coefficients for spin-weighted spherical harmonic transforms.


### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] [PR1080](https://github.com/sxs-collaboration/spectre/pull/1080)
- [x] [PR970](https://github.com/sxs-collaboration/spectre/pull/970)
- [x] [PR935](https://github.com/sxs-collaboration/spectre/pull/935)
- [x] [PR1139](https://github.com/sxs-collaboration/spectre/pull/1139)