### PR TITLE
Damped Harmonic gauge function and its spacetime derivatives

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -115,6 +115,24 @@
   SLACcitation   = "%%CITATION = ARXIV:0704.3206;%%"
 }
 
+@article{Deppe2018uye,
+  author         = "Deppe, Nils and Kidder, Lawrence E. and Scheel, Mark A.
+                    and Teukolsky, Saul A.",
+  title          = "{Critical behavior in 3D gravitational collapse of
+                    massless scalar fields}",
+  journal        = "Phys. Rev.",
+  volume         = "D99",
+  year           = "2019",
+  number         = "2",
+  pages          = "024018",
+  doi            = "10.1103/PhysRevD.99.024018",
+  url            = "https://doi.org/10.1103/PhysRevD.99.024018",
+  eprint         = "1802.08682",
+  archivePrefix  = "arXiv",
+  primaryClass   = "gr-qc",
+  SLACcitation   = "%%CITATION = ARXIV:1802.08682;%%"
+}
+
 @article{Fishbone1976apj,
   author   = "Fishbone, L. G. and Moncrief, V.",
   title    = "Relativistic Fluid Disks in Orbit Around {Kerr} Black Holes",
@@ -418,6 +436,22 @@
   journal  = "Mathematics of Computation",
   pages    = "2117--2133",
   volume   = "79",
+}
+
+@article{Szilagyi2009qz,
+  author         = "Szilagyi, Bela and Lindblom, Lee and Scheel, Mark A.",
+  title          = "{Simulations of Binary Black Hole Mergers Using Spectral
+                    Methods}",
+  journal        = "Phys. Rev.",
+  volume         = "D80",
+  year           = "2009",
+  pages          = "124010",
+  doi            = "10.1103/PhysRevD.80.124010",
+  url            = "https://doi.org/10.1103/PhysRevD.80.124010",
+  eprint         = "0909.3557",
+  archivePrefix  = "arXiv",
+  primaryClass   = "gr-qc",
+  SLACcitation   = "%%CITATION = ARXIV:0909.3557;%%"
 }
 
 @article{Teukolsky2015ega,

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -989,5 +989,8 @@ using Tempijj = TempTensor<N, tnsr::ijj<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
 using Tempiaa = TempTensor<N, tnsr::iaa<DataType, SpatialDim, Fr>>;
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+          typename DataType = DataVector>
+using Tempabb = TempTensor<N, tnsr::abb<DataType, SpatialDim, Fr>>;
 // @}
 }  // namespace Tags

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -1,15 +1,11 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-add_subdirectory(GaugeSourceFunctions)
-
-set(LIBRARY GeneralizedHarmonic)
+set(LIBRARY GeneralizedHarmonicGaugeSourceFunctions)
 
 set(LIBRARY_SOURCES
-    Characteristics.cpp
-    Constraints.cpp
-    Equations.cpp
-    )
+  DampedHarmonic.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
@@ -17,4 +13,5 @@ target_link_libraries(
   ${LIBRARY}
   INTERFACE DataStructures
   INTERFACE ErrorHandling
+  INTERFACE GeneralizedHarmonic
   )

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -1,0 +1,915 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TempBuffer.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "Time/Time.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace GeneralizedHarmonic {
+namespace DampedHarmonicGauge_detail {
+// Spatial weight function used in the damped harmonic gauge source
+// function.
+//
+// The spatial weight function is: \f[ W(x^i) = \exp(- (r / \sigma_r)^2) \f]
+// This function can be written with an extra factor inside the exponent in
+// literature, e.g. \cite Deppe2018uye. We absorb that in \f$\sigma_r\f$.
+template <size_t SpatialDim, typename Frame, typename DataType>
+void weight_function(const gsl::not_null<Scalar<DataType>*> weight,
+                     const tnsr::I<DataType, SpatialDim, Frame>& coords,
+                     const double sigma_r) noexcept {
+  if (UNLIKELY(get_size(get(*weight)) != get_size(get<0>(coords)))) {
+    *weight = Scalar<DataType>(get_size(get<0>(coords)));
+  }
+  const auto& r_squared = dot_product(coords, coords);
+  get(*weight) = exp(-get(r_squared) / pow<2>(sigma_r));
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+Scalar<DataType> weight_function(
+    const tnsr::I<DataType, SpatialDim, Frame>& coords,
+    const double sigma_r) noexcept {
+  Scalar<DataType> weight{};
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function(
+      make_not_null(&weight), coords, sigma_r);
+  return weight;
+}
+
+// Spacetime derivatives of the spatial weight function that enters the
+// damped harmonic gauge source function.
+//
+// Compute the derivatives :
+// \partial_a W(x^i)= \partial_a \exp(- (r/\sigma_r)^2)
+//                  = (-2 * x^i / \sigma_r^2) * exp(-(r/\sigma_r)^2)
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_weight_function(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_weight,
+    const tnsr::I<DataType, SpatialDim, Frame>& coords,
+    const double sigma_r) noexcept {
+  if (UNLIKELY(get_size(get<0>(*d4_weight)) != get_size(get<0>(coords)))) {
+    *d4_weight = tnsr::a<DataType, SpatialDim, Frame>(get_size(get<0>(coords)));
+  }
+  const DataType pre_factor =
+      get(weight_function(coords, sigma_r)) * (-2. / pow<2>(sigma_r));
+  // time derivative of weight function is zero
+  get<0>(*d4_weight) = 0.;
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_weight->get(1 + i) = pre_factor * coords.get(i);
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_weight_function(
+    const tnsr::I<DataType, SpatialDim, Frame>& coords,
+    const double sigma_r) noexcept {
+  tnsr::a<DataType, SpatialDim, Frame> d4_weight{};
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_weight_function(make_not_null(&d4_weight), coords,
+                                         sigma_r);
+  return d4_weight;
+}
+
+// Roll-on function for the damped harmonic gauge.
+//
+// For times after \f$t_0\f$, compute the roll-on function
+// \f$ R(t) = 1 - \exp(-((t - t_0)/\sigma_t)^4]) \f$,
+// and return \f$ R(t) = 0\f$ at times before.
+double roll_on_function(const double time, const double t_start,
+                        const double sigma_t) noexcept {
+  if (time < t_start) {
+    return 0.;
+  }
+  return 1. - exp(-pow<4>((time - t_start) / sigma_t));
+}
+
+// Time derivative of the damped harmonic gauge roll-on function.
+//
+// \details Compute the time derivative:
+// \f{align*}
+// \partial_0 R(t) = 4 exp[-((t - t0)/\sigma_t)^4] (t - t0)^3 / sigma_t^4
+double time_deriv_of_roll_on_function(const double time, const double t_start,
+                                      const double sigma_t) noexcept {
+  if (time < t_start) {
+    return 0.;
+  }
+  const double time_since_start_over_sigma = (time - t_start) / sigma_t;
+  return exp(-pow<4>(time_since_start_over_sigma)) * 4. *
+         pow<3>(time_since_start_over_sigma) / sigma_t;
+}
+
+// The log factor that appears in damped harmonic gauge source function.
+//
+// Calculates:  \f$ logF = \mathrm{log}(g^p/N) \f$.
+template <typename DataType>
+void log_factor_metric_lapse(const gsl::not_null<Scalar<DataType>*> logfac,
+                             const Scalar<DataType>& lapse,
+                             const Scalar<DataType>& sqrt_det_spatial_metric,
+                             const double exponent) noexcept {
+  if (UNLIKELY(get_size(get(*logfac)) != get_size(get(lapse)))) {
+    *logfac = Scalar<DataType>(get_size(get(lapse)));
+  }
+  // branching below is to avoid using pow for performance reasons
+  if (exponent == 0.) {
+    get(*logfac) = -log(get(lapse));
+  } else if (exponent == 0.5) {
+    get(*logfac) = log(get(sqrt_det_spatial_metric) / get(lapse));
+  } else {
+    get(*logfac) =
+        2. * exponent * log(get(sqrt_det_spatial_metric)) - log(get(lapse));
+  }
+}
+
+template <typename DataType>
+Scalar<DataType> log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const double exponent) noexcept {
+  Scalar<DataType> logfac{};
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse(
+      make_not_null(&logfac), lapse, sqrt_det_spatial_metric, exponent);
+  return logfac;
+}
+
+// Spacetime derivatives of the log factor that appears in the
+// damped harmonic gauge source function.
+//
+// Computes the spacetime derivatives:
+//  \partial_a logF = (p/g)\partial_a g - (1/N)\partial_a N
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_log_factor_metric_lapse(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_logfac,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const double exponent) noexcept {
+  if (UNLIKELY(get_size(get<0>(*d4_logfac)) != get_size(get(lapse)))) {
+    *d4_logfac = tnsr::a<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  // Use a TempBuffer to reduce total number of allocations. This is especially
+  // important in a multithreaded environment.
+  TempBuffer<tmpl::list<::Tags::Tempa<0, SpatialDim, Frame, DataType>,
+                        ::Tags::Tempi<1, SpatialDim, Frame, DataType>,
+                        ::Tags::Tempa<2, SpatialDim, Frame, DataType>,
+                        ::Tags::TempScalar<3, DataType>,
+                        ::Tags::TempScalar<4, DataType>>>
+      buffer(get_size(get(lapse)));
+  auto& d_g = get<::Tags::Tempa<0, SpatialDim, Frame, DataType>>(buffer);
+  auto& d3_lapse = get<::Tags::Tempi<1, SpatialDim, Frame, DataType>>(buffer);
+  auto& d_lapse = get<::Tags::Tempa<2, SpatialDim, Frame, DataType>>(buffer);
+  auto& dt_lapse = get<::Tags::TempScalar<3, DataType>>(buffer);
+  auto& one_over_lapse = get<::Tags::TempScalar<4, DataType>>(buffer);
+
+  // Get \f$ \partial_a g\f$
+  spacetime_deriv_of_det_spatial_metric<SpatialDim, Frame, DataType>(
+      make_not_null(&d_g), sqrt_det_spatial_metric, inverse_spatial_metric,
+      dt_spatial_metric, phi);
+  // Get \f$ \partial_a N\f$
+  time_deriv_of_lapse<SpatialDim, Frame, DataType>(
+      make_not_null(&dt_lapse), lapse, shift, spacetime_unit_normal, phi, pi);
+  spatial_deriv_of_lapse<SpatialDim, Frame, DataType>(
+      make_not_null(&d3_lapse), lapse, spacetime_unit_normal, phi);
+  get<0>(d_lapse) = get(dt_lapse);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d_lapse.get(1 + i) = d3_lapse.get(i);
+  }
+  // Compute
+  get(one_over_lapse) = 1. / get(lapse);
+  if (exponent == 0.) {
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_logfac->get(a) = -get(one_over_lapse) * d_lapse.get(a);
+    }
+  } else {
+    const auto p_over_g = exponent / square(get(sqrt_det_spatial_metric));
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_logfac->get(a) =
+          p_over_g * d_g.get(a) - get(one_over_lapse) * d_lapse.get(a);
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const double exponent) noexcept {
+  tnsr::a<DataType, SpatialDim, Frame> d4_logfac{};
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_log_factor_metric_lapse(
+          make_not_null(&d4_logfac), lapse, shift, spacetime_unit_normal,
+          inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric,
+          pi, phi, exponent);
+  return d4_logfac;
+}
+
+// Spacetime derivatives of the log factor (that appears in
+// damped harmonic gauge source function), raised to an exponent.
+//
+// Computes the spacetime derivatives:
+//  \partial_a (logF)^q = q (logF)^{q-1} \partial_a (logF)
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_power_log_factor_metric_lapse(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_powlogfac,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
+    const int exponent) noexcept {
+  if (UNLIKELY(get_size(get<0>(*d4_powlogfac)) != get_size(get(lapse)))) {
+    *d4_powlogfac = tnsr::a<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  // Use a TempBuffer to reduce total number of allocations. This is especially
+  // important in a multithreaded environment.
+  TempBuffer<tmpl::list<::Tags::Tempa<0, SpatialDim, Frame, DataType>,
+                        ::Tags::TempScalar<1, DataType>,
+                        ::Tags::TempScalar<2, DataType>>>
+      buffer(get_size(get(lapse)));
+  auto& dlogfac = get<::Tags::Tempa<0, SpatialDim, Frame, DataType>>(buffer);
+  auto& logfac = get<::Tags::TempScalar<1, DataType>>(buffer);
+  auto& prefac = get<::Tags::TempScalar<2, DataType>>(buffer);
+
+  // Compute derivative
+  spacetime_deriv_of_log_factor_metric_lapse<SpatialDim, Frame, DataType>(
+      make_not_null(&dlogfac), lapse, shift, spacetime_unit_normal,
+      inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric, pi,
+      phi, g_exponent);
+  // Apply pre-factor
+  if (UNLIKELY(exponent == 0)) {
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_powlogfac->get(a) = 0.;
+    }
+  } else if (UNLIKELY(exponent == 1)) {
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_powlogfac->get(a) = dlogfac.get(a);
+    }
+  } else {
+    log_factor_metric_lapse<DataType>(make_not_null(&logfac), lapse,
+                                      sqrt_det_spatial_metric, g_exponent);
+    get(prefac) =
+        static_cast<double>(exponent) * pow(get(logfac), exponent - 1);
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_powlogfac->get(a) = get(prefac) * dlogfac.get(a);
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame>
+spacetime_deriv_of_power_log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
+    const int exponent) noexcept {
+  tnsr::a<DataType, SpatialDim, Frame> d4_powlogfac{};
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_power_log_factor_metric_lapse(
+          make_not_null(&d4_powlogfac), lapse, shift, spacetime_unit_normal,
+          inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric,
+          pi, phi, g_exponent, exponent);
+  return d4_powlogfac;
+}
+}  // namespace DampedHarmonicGauge_detail
+
+// Assemble the gauge source function.
+//
+// Recall that its covariant form is:
+// H_a := [1 - R_{H_\mathrm{init}}(t)] H_a^\mathrm{init} +
+//  [\mu_{L1} log(\sqrt{g}/N) + \mu_{L2} log(1/N)] t_a - \mu_S g_{ai} N^i / N
+//
+// where \f$N, N^k\f$ are the lapse and shift, and \f$n_k\f$ is the unit
+// normal one-form to the spatial slice, as above. The pre-factors:
+//
+//  \mu_{L1} = A_{L1} R_{L1}(t) W(x^i) log(\sqrt{g}/N)^{e_{L1}},
+//  \mu_{L2} = A_{L2} R_{L2}(t) W(x^i) log(1/N)^{e_{L2}},
+//  \mu_{S} = A_{S} R_{S}(t) W(x^i) log(\sqrt{g}/N)^{e_{S}},
+//
+// contain the temporal and spatial roll-on functions.
+template <size_t SpatialDim, typename Frame>
+void damped_harmonic_h(
+    const gsl::not_null<
+        typename db::item_type<Tags::GaugeH<SpatialDim, Frame>>*>
+        gauge_h,
+    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+        gauge_h_init,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+    const double time, const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+    const double amp_coef_L1, const double amp_coef_L2, const double amp_coef_S,
+    const int exp_L1, const int exp_L2, const int exp_S,
+    const double t_start_h_init, const double sigma_t_h_init,
+    const double t_start_L1, const double sigma_t_L1, const double t_start_L2,
+    const double sigma_t_L2, const double t_start_S, const double sigma_t_S,
+    const double sigma_r) noexcept {
+  if (UNLIKELY(get_size(get<0>(*gauge_h)) != get_size(get(lapse)))) {
+    *gauge_h = typename db::item_type<Tags::GaugeH<SpatialDim, Frame>>(
+        get_size(get(lapse)));
+  }
+  // Use a TempBuffer to reduce total number of allocations. This is especially
+  // important in a multithreaded environment.
+  TempBuffer<tmpl::list<::Tags::Tempa<0, SpatialDim, Frame>,
+                        ::Tags::TempScalar<1>, ::Tags::TempScalar<2>,
+                        ::Tags::TempScalar<3>, ::Tags::TempScalar<4>,
+                        ::Tags::TempScalar<5>, ::Tags::TempScalar<6>,
+                        ::Tags::TempScalar<7>, ::Tags::TempScalar<8>>>
+      buffer(get_size(get(lapse)));
+  auto& spacetime_unit_normal_one_form =
+      get<::Tags::Tempa<0, SpatialDim, Frame>>(buffer);
+  auto& log_fac_1 = get<::Tags::TempScalar<1>>(buffer);
+  auto& log_fac_2 = get<::Tags::TempScalar<2>>(buffer);
+  auto& weight = get<::Tags::TempScalar<3>>(buffer);
+  auto& mu_L1 = get<::Tags::TempScalar<4>>(buffer);
+  auto& mu_S = get<::Tags::TempScalar<5>>(buffer);
+  auto& mu_L2 = get<::Tags::TempScalar<6>>(buffer);
+  auto& h_prefac1 = get<::Tags::TempScalar<7>>(buffer);
+  auto& h_prefac2 = get<::Tags::TempScalar<8>>(buffer);
+
+  spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame, DataVector>(lapse);
+
+  constexpr double exp_fac_1 = 0.5;
+  constexpr double exp_fac_2 = 0.;
+  DampedHarmonicGauge_detail::log_factor_metric_lapse<DataVector>(
+      make_not_null(&log_fac_1), lapse, sqrt_det_spatial_metric, exp_fac_1);
+  DampedHarmonicGauge_detail::log_factor_metric_lapse<DataVector>(
+      make_not_null(&log_fac_2), lapse, sqrt_det_spatial_metric, exp_fac_2);
+
+  const double roll_on_L1 = DampedHarmonicGauge_detail::roll_on_function(
+      time, t_start_L1, sigma_t_L1);
+  const double roll_on_L2 = DampedHarmonicGauge_detail::roll_on_function(
+      time, t_start_L2, sigma_t_L2);
+  const double roll_on_S =
+      DampedHarmonicGauge_detail::roll_on_function(time, t_start_S, sigma_t_S);
+  DampedHarmonicGauge_detail::weight_function<SpatialDim, Frame, DataVector>(
+      make_not_null(&weight), coords, sigma_r);
+
+  get(mu_L1) =
+      amp_coef_L1 * roll_on_L1 * get(weight) * pow(get(log_fac_1), exp_L1);
+  get(mu_S) = amp_coef_S * roll_on_S * get(weight) * pow(get(log_fac_1), exp_S);
+  get(mu_L2) =
+      amp_coef_L2 * roll_on_L2 * get(weight) * pow(get(log_fac_2), exp_L2);
+  get(h_prefac1) = get(mu_L1) * get(log_fac_1) + get(mu_L2) * get(log_fac_2);
+  get(h_prefac2) = -get(mu_S) / get(lapse);
+
+  const double roll_on_h_init = DampedHarmonicGauge_detail::roll_on_function(
+      time, t_start_h_init, sigma_t_h_init);
+
+  // Calculate H_a
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    gauge_h->get(a) = (1. - roll_on_h_init) * gauge_h_init.get(a) +
+                      get(h_prefac1) * spacetime_unit_normal_one_form.get(a);
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      gauge_h->get(a) +=
+          get(h_prefac2) * spacetime_metric.get(a, i + 1) * shift.get(i);
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame>
+typename db::item_type<Tags::GaugeH<SpatialDim, Frame>>
+DampedHarmonicHCompute<SpatialDim, Frame>::function(
+    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+        gauge_h_init,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+    const Time& time, const double& t_start, const double& sigma_t,
+    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+    const double& sigma_r) noexcept {
+  typename db::item_type<Tags::GaugeH<SpatialDim, Frame>> gauge_h{
+      get_size(get(lapse))};
+  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame>(
+      make_not_null(&gauge_h), gauge_h_init, lapse, shift,
+      sqrt_det_spatial_metric, spacetime_metric, time.value(), coords, 1., 1.,
+      1.,                // amp_coef_{L1, L2, S}
+      4, 4, 4,           // exp_{L1, L2, S}
+      t_start, sigma_t,  // _h_init
+      t_start, sigma_t,  // _L1
+      t_start, sigma_t,  // _L2
+      t_start, sigma_t,  // _S
+      sigma_r);
+  return gauge_h;
+}
+
+// Spacetime derivatives of the damped harmonic gauge source function.
+//
+// The following functions and struct compute spacetime derivatives, i.e.
+// \f$\partial_a H_b\f$, of the damped hamornic source function H. From above:
+//
+// \partial_a H_b = \partial_a T_1 + \partial_a T_2 + \partial_a T_3
+// H_a = T_1 + T_2 + T_3,
+//
+// where:
+//
+// T_1 = [1 - R_{H_\mathrm{init}}(t)] H_a^\mathrm{init},
+// T_2 = [\mu_{L1} log(\sqrt{g}/N) + \mu_{L2} log(1/N)] t_a,
+// T_3 = - \mu_S g_{ai} N^i / N.
+//
+// See the header file for \f$\partial_a T1,2,3 \f$.
+template <size_t SpatialDim, typename Frame>
+void spacetime_deriv_damped_harmonic_h(
+    const gsl::not_null<
+        typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>*>
+        d4_gauge_h,
+    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+        gauge_h_init,
+    const typename db::item_type<
+        Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+    const tnsr::a<DataVector, SpatialDim, Frame>&
+        spacetime_unit_normal_one_form,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double time,
+    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+    const double amp_coef_L1, const double amp_coef_L2, const double amp_coef_S,
+    const int exp_L1, const int exp_L2, const int exp_S,
+    const double t_start_h_init, const double sigma_t_h_init,
+    const double t_start_L1, const double sigma_t_L1, const double t_start_L2,
+    const double sigma_t_L2, const double t_start_S, const double sigma_t_S,
+    const double sigma_r) noexcept {
+  if (UNLIKELY(get_size(get<0, 0>(*d4_gauge_h)) != get_size(get(lapse)))) {
+    *d4_gauge_h =
+        typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>(
+            get(lapse));
+  }
+  // Use a TempBuffer to reduce total number of allocations. This is especially
+  // important in a multithreaded environment.
+  TempBuffer<tmpl::list<
+      ::Tags::TempA<0, SpatialDim, Frame>, ::Tags::Tempii<1, SpatialDim, Frame>,
+      ::Tags::TempAA<2, SpatialDim, Frame>,
+      ::Tags::Tempii<3, SpatialDim, Frame>,
+      ::Tags::Tempijj<4, SpatialDim, Frame>, ::Tags::TempScalar<5>,
+      ::Tags::TempScalar<6>, ::Tags::TempScalar<7>, ::Tags::TempScalar<8>,
+      ::Tags::TempScalar<9>, ::Tags::TempScalar<10>, ::Tags::TempScalar<11>,
+      ::Tags::TempScalar<12>, ::Tags::TempScalar<13>, ::Tags::TempScalar<14>,
+      ::Tags::Tempa<15, SpatialDim, Frame>,
+      ::Tags::Tempa<16, SpatialDim, Frame>,
+      ::Tags::Tempa<17, SpatialDim, Frame>,
+      ::Tags::Tempa<18, SpatialDim, Frame>,
+      ::Tags::Tempa<19, SpatialDim, Frame>,
+      ::Tags::Tempa<20, SpatialDim, Frame>,
+      ::Tags::Tempa<21, SpatialDim, Frame>,
+      ::Tags::Tempa<22, SpatialDim, Frame>,
+      ::Tags::Tempa<23, SpatialDim, Frame>,
+      ::Tags::Tempa<24, SpatialDim, Frame>, ::Tags::TempScalar<25>,
+      ::Tags::Tempi<26, SpatialDim, Frame>,
+      ::Tags::Tempa<27, SpatialDim, Frame>,
+      ::Tags::TempI<28, SpatialDim, Frame>,
+      ::Tags::TempiJ<29, SpatialDim, Frame>,
+      ::Tags::TempaB<30, SpatialDim, Frame>,
+      ::Tags::Tempab<31, SpatialDim, Frame>, ::Tags::TempScalar<32>,
+      ::Tags::Tempa<33, SpatialDim, Frame>,
+      ::Tags::Tempabb<34, SpatialDim, Frame>,
+      ::Tags::Tempab<35, SpatialDim, Frame>,
+      ::Tags::Tempab<36, SpatialDim, Frame>,
+      ::Tags::Tempab<37, SpatialDim, Frame>>>
+      buffer(get_size(get(lapse)));
+  auto& spacetime_unit_normal =
+      get<::Tags::TempA<0, SpatialDim, Frame>>(buffer);
+  auto& spatial_metric = get<::Tags::Tempii<1, SpatialDim, Frame>>(buffer);
+  auto& inverse_spacetime_metric =
+      get<::Tags::TempAA<2, SpatialDim, Frame>>(buffer);
+  auto& d0_spatial_metric = get<::Tags::Tempii<3, SpatialDim, Frame>>(buffer);
+  auto& d3_spatial_metric = get<::Tags::Tempijj<4, SpatialDim, Frame>>(buffer);
+  auto& one_over_lapse = get<::Tags::TempScalar<5>>(buffer);
+  auto& log_fac_1 = get<::Tags::TempScalar<6>>(buffer);
+  auto& log_fac_2 = get<::Tags::TempScalar<7>>(buffer);
+  auto& weight = get<::Tags::TempScalar<8>>(buffer);
+  auto& mu_L1 = get<::Tags::TempScalar<9>>(buffer);
+  auto& mu_S = get<::Tags::TempScalar<10>>(buffer);
+  auto& mu_L2 = get<::Tags::TempScalar<11>>(buffer);
+  auto& mu_S_over_lapse = get<::Tags::TempScalar<12>>(buffer);
+  auto& mu1 = get<::Tags::TempScalar<13>>(buffer);
+  auto& mu2 = get<::Tags::TempScalar<14>>(buffer);
+  auto& d4_weight = get<::Tags::Tempa<15, SpatialDim, Frame>>(buffer);
+  auto& d4_RW_L1 = get<::Tags::Tempa<16, SpatialDim, Frame>>(buffer);
+  auto& d4_RW_S = get<::Tags::Tempa<17, SpatialDim, Frame>>(buffer);
+  auto& d4_RW_L2 = get<::Tags::Tempa<18, SpatialDim, Frame>>(buffer);
+  auto& d4_mu_S = get<::Tags::Tempa<19, SpatialDim, Frame>>(buffer);
+  auto& d4_mu1 = get<::Tags::Tempa<20, SpatialDim, Frame>>(buffer);
+  auto& d4_mu2 = get<::Tags::Tempa<21, SpatialDim, Frame>>(buffer);
+  auto& d4_log_fac_mu1 = get<::Tags::Tempa<22, SpatialDim, Frame>>(buffer);
+  auto& d4_log_fac_muS = get<::Tags::Tempa<23, SpatialDim, Frame>>(buffer);
+  auto& d4_log_fac_mu2 = get<::Tags::Tempa<24, SpatialDim, Frame>>(buffer);
+  auto& dt_lapse = get<::Tags::TempScalar<25>>(buffer);
+  auto& d3_lapse = get<::Tags::Tempi<26, SpatialDim, Frame>>(buffer);
+  auto& d4_lapse = get<::Tags::Tempa<27, SpatialDim, Frame>>(buffer);
+  auto& d0_shift = get<::Tags::TempI<28, SpatialDim, Frame>>(buffer);
+  auto& d3_shift = get<::Tags::TempiJ<29, SpatialDim, Frame>>(buffer);
+  auto& d4_shift = get<::Tags::TempaB<30, SpatialDim, Frame>>(buffer);
+  auto& d4_normal_one_form = get<::Tags::Tempab<31, SpatialDim, Frame>>(buffer);
+  auto& prefac = get<::Tags::TempScalar<32>>(buffer);
+  auto& d4_muS_over_lapse = get<::Tags::Tempa<33, SpatialDim, Frame>>(buffer);
+  auto& d4_psi = get<::Tags::Tempabb<34, SpatialDim, Frame>>(buffer);
+  auto& dT1 = get<::Tags::Tempab<35, SpatialDim, Frame>>(buffer);
+  auto& dT2 = get<::Tags::Tempab<36, SpatialDim, Frame>>(buffer);
+  auto& dT3 = get<::Tags::Tempab<37, SpatialDim, Frame>>(buffer);
+
+  // 3+1 quantities
+  spacetime_unit_normal =
+      gr::spacetime_normal_vector<SpatialDim, Frame, DataVector>(lapse, shift);
+  spatial_metric =
+      gr::spatial_metric<SpatialDim, Frame, DataVector>(spacetime_metric);
+  inverse_spacetime_metric =
+      gr::inverse_spacetime_metric<SpatialDim, Frame, DataVector>(
+          lapse, shift, inverse_spatial_metric);
+  time_deriv_of_spatial_metric<SpatialDim, Frame, DataVector>(
+      make_not_null(&d0_spatial_metric), lapse, shift, phi, pi);
+  deriv_spatial_metric<SpatialDim, Frame, DataVector>(
+      make_not_null(&d3_spatial_metric), phi);
+
+  // commonly used terms
+  constexpr auto exp_fac_1 = 0.5;
+  constexpr auto exp_fac_2 = 0.;
+  get(one_over_lapse) = 1. / get(lapse);
+  DampedHarmonicGauge_detail::log_factor_metric_lapse<DataVector>(
+      make_not_null(&log_fac_1), lapse, sqrt_det_spatial_metric, exp_fac_1);
+  DampedHarmonicGauge_detail::log_factor_metric_lapse<DataVector>(
+      make_not_null(&log_fac_2), lapse, sqrt_det_spatial_metric, exp_fac_2);
+
+  // Tempering functions
+  const auto roll_on_h_init = DampedHarmonicGauge_detail::roll_on_function(
+      time, t_start_h_init, sigma_t_h_init);
+  const auto roll_on_L1 = DampedHarmonicGauge_detail::roll_on_function(
+      time, t_start_L1, sigma_t_L1);
+  const auto roll_on_L2 = DampedHarmonicGauge_detail::roll_on_function(
+      time, t_start_L2, sigma_t_L2);
+  const auto roll_on_S =
+      DampedHarmonicGauge_detail::roll_on_function(time, t_start_S, sigma_t_S);
+  DampedHarmonicGauge_detail::weight_function<SpatialDim, Frame, DataVector>(
+      make_not_null(&weight), coords, sigma_r);
+
+  // coeffs that enter gauge source function
+  get(mu_L1) =
+      amp_coef_L1 * roll_on_L1 * get(weight) * pow(get(log_fac_1), exp_L1);
+  get(mu_S) = amp_coef_S * roll_on_S * get(weight) * pow(get(log_fac_1), exp_S);
+  get(mu_L2) =
+      amp_coef_L2 * roll_on_L2 * get(weight) * pow(get(log_fac_2), exp_L2);
+  get(mu_S_over_lapse) = get(mu_S) * get(one_over_lapse);
+
+  // Calc \f$ \mu_1 = \mu_{L1} log(rootg/N) = R W log(rootg/N)^5\f$
+  get(mu1) = get(mu_L1) * get(log_fac_1);
+
+  // Calc \f$ \mu_2 = \mu_{L2} log(1/N) = R W log(1/N)^5\f$
+  get(mu2) = get(mu_L2) * get(log_fac_2);
+
+  const auto d0_roll_on_h_init =
+      DampedHarmonicGauge_detail::time_deriv_of_roll_on_function(
+          time, t_start_h_init, sigma_t_h_init);
+  const auto d0_roll_on_L1 =
+      DampedHarmonicGauge_detail::time_deriv_of_roll_on_function(
+          time, t_start_L1, sigma_t_L1);
+  const auto d0_roll_on_S =
+      DampedHarmonicGauge_detail::time_deriv_of_roll_on_function(
+          time, t_start_S, sigma_t_S);
+  const auto d0_roll_on_L2 =
+      DampedHarmonicGauge_detail::time_deriv_of_roll_on_function(
+          time, t_start_L2, sigma_t_L2);
+
+  // Calc \f$ \partial_a [R W] \f$
+  DampedHarmonicGauge_detail::spacetime_deriv_of_weight_function<
+      SpatialDim, Frame, DataVector>(make_not_null(&d4_weight), coords,
+                                     sigma_r);
+  d4_RW_L1 = d4_weight;
+  d4_RW_S = d4_weight;
+  d4_RW_L2 = d4_weight;
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_RW_L1.get(a) *= roll_on_L1;
+    d4_RW_S.get(a) *= roll_on_S;
+    d4_RW_L2.get(a) *= roll_on_L2;
+  }
+  get<0>(d4_RW_L1) += get(weight) * d0_roll_on_L1;
+  get<0>(d4_RW_S) += get(weight) * d0_roll_on_S;
+  get<0>(d4_RW_L2) += get(weight) * d0_roll_on_L2;
+
+  // \partial_a \mu_{S} = \partial_a(A_S R_S W
+  //                               \log(\sqrt{g}/N)^{c_{S}})
+  // \partial_a \mu_1 = \partial_a(A_L1 R_L1 W
+  //                               \log(\sqrt{g}/N)^{1+c_{L1}})
+  // \partial_a \mu_2 = \partial_a(A_L2 R_L2 W
+  //                               \log(1/N)^{1+c_{L2}})
+  DampedHarmonicGauge_detail::spacetime_deriv_of_power_log_factor_metric_lapse<
+      SpatialDim, Frame, DataVector>(
+      make_not_null(&d4_log_fac_mu1), lapse, shift, spacetime_unit_normal,
+      inverse_spatial_metric, sqrt_det_spatial_metric, d0_spatial_metric, pi,
+      phi, exp_fac_1, exp_L1 + 1);
+  DampedHarmonicGauge_detail::spacetime_deriv_of_power_log_factor_metric_lapse<
+      SpatialDim, Frame, DataVector>(
+      make_not_null(&d4_log_fac_muS), lapse, shift, spacetime_unit_normal,
+      inverse_spatial_metric, sqrt_det_spatial_metric, d0_spatial_metric, pi,
+      phi, exp_fac_1, exp_S);
+  DampedHarmonicGauge_detail::spacetime_deriv_of_power_log_factor_metric_lapse<
+      SpatialDim, Frame, DataVector>(
+      make_not_null(&d4_log_fac_mu2), lapse, shift, spacetime_unit_normal,
+      inverse_spatial_metric, sqrt_det_spatial_metric, d0_spatial_metric, pi,
+      phi, exp_fac_2, exp_L2 + 1);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    // \f$ \partial_a \mu_1 \f$
+    d4_mu1.get(a) =
+        amp_coef_L1 * pow(get(log_fac_1), exp_L1 + 1) * d4_RW_L1.get(a) +
+        amp_coef_L1 * roll_on_L1 * get(weight) * d4_log_fac_mu1.get(a);
+    // \f$ \partial_a \mu_{S} \f$
+    d4_mu_S.get(a) =
+        amp_coef_S * d4_RW_S.get(a) * pow(get(log_fac_1), exp_S) +
+        amp_coef_S * roll_on_S * get(weight) * d4_log_fac_muS.get(a);
+    // \f$ \partial_a \mu_2 \f$
+    d4_mu2.get(a) =
+        amp_coef_L2 * pow(get(log_fac_2), exp_L2 + 1) * d4_RW_L2.get(a) +
+        amp_coef_L2 * roll_on_L2 * get(weight) * d4_log_fac_mu2.get(a);
+  }
+
+  // Calc \f$ \partial_a N = {\partial_0 N, \partial_i N} \f$
+  time_deriv_of_lapse<SpatialDim, Frame, DataVector>(
+      make_not_null(&dt_lapse), lapse, shift, spacetime_unit_normal, phi, pi);
+  spatial_deriv_of_lapse<SpatialDim, Frame, DataVector>(
+      make_not_null(&d3_lapse), lapse, spacetime_unit_normal, phi);
+  get<0>(d4_lapse) = get(dt_lapse);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_lapse.get(1 + i) = d3_lapse.get(i);
+  }
+
+  // Calc \f$ \partial_a N^i = {\partial_0 N^i, \partial_j N^i} \f$
+  d0_shift = time_deriv_of_shift<SpatialDim, Frame, DataVector>(
+      lapse, shift, inverse_spatial_metric, spacetime_unit_normal, phi, pi);
+  d3_shift = spatial_deriv_of_shift<SpatialDim, Frame, DataVector>(
+      lapse, inverse_spacetime_metric, spacetime_unit_normal, phi);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_shift.get(0, 1 + i) = d0_shift.get(i);
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      d4_shift.get(1 + j, 1 + i) = d3_shift.get(j, i);
+    }
+  }
+
+  // Calc \f$ \partial_a n_b = {-\partial_a N, 0, 0, 0} \f$
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_normal_one_form.get(a, 0) = -d4_lapse.get(a);
+    for (size_t b = 1; b < SpatialDim + 1; ++b) {
+      d4_normal_one_form.get(a, b) = 0.;
+    }
+  }
+
+  // \f[ \partial_a (\mu_S/N) = (1/N) \partial_a \mu_{S}
+  //         - (\mu_{S}/N^2) \partial_a N
+  // \f]
+  get(prefac) = -get(mu_S) * square(get(one_over_lapse));
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_muS_over_lapse.get(a) =
+        get(one_over_lapse) * d4_mu_S.get(a) + get(prefac) * d4_lapse.get(a);
+  }
+
+  // We need \f$ \partial_a g_{bi} = \partial_a \psi_{bi} \f$. Here we
+  // use `derivatives_of_spacetime_metric` to get \f$ \partial_a g_{bc}\f$
+  // instead, and use only the derivatives of \f$ g_{bi}\f$.
+  d4_psi = gr::derivatives_of_spacetime_metric<SpatialDim, Frame, DataVector>(
+      lapse, dt_lapse, d3_lapse, shift, d0_shift, d3_shift, spatial_metric,
+      d0_spatial_metric, d3_spatial_metric);
+
+  // Calc \f$ \partial_a T1 \f$
+  for (size_t b = 0; b < SpatialDim + 1; ++b) {
+    dT1.get(0, b) = -gauge_h_init.get(b) * d0_roll_on_h_init;
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      if (a != 0) {
+        dT1.get(a, b) = (1. - roll_on_h_init) * dgauge_h_init.get(a, b);
+      } else {
+        dT1.get(a, b) += (1. - roll_on_h_init) * dgauge_h_init.get(a, b);
+      }
+    }
+  }
+
+  // Calc \f$ \partial_a T2 \f$
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      dT2.get(a, b) = (get(mu1) + get(mu2)) * d4_normal_one_form.get(a, b) +
+                      (d4_mu1.get(a) + d4_mu2.get(a)) *
+                          spacetime_unit_normal_one_form.get(b);
+    }
+  }
+
+  // Calc \f$ \partial_a T3 \f$ (note minus sign)
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      dT3.get(a, b) = -d4_muS_over_lapse.get(a) * get<0>(shift) *
+                      spacetime_metric.get(b, 1);
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        if (i != 0) {
+          dT3.get(a, b) -= d4_muS_over_lapse.get(a) * shift.get(i) *
+                           spacetime_metric.get(b, i + 1);
+        }
+        dT3.get(a, b) -=
+            get(mu_S_over_lapse) * shift.get(i) * d4_psi.get(a, b, i + 1);
+        dT3.get(a, b) -= get(mu_S_over_lapse) * spacetime_metric.get(b, i + 1) *
+                         d4_shift.get(a, i + 1);
+      }
+    }
+  }
+
+  // Calc \f$ \partial_a H_b = dT1_{ab} + dT2_{ab} + dT3_{ab} \f$
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      d4_gauge_h->get(a, b) = dT1.get(a, b) + dT2.get(a, b) + dT3.get(a, b);
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame>
+typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
+SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>::function(
+    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+        gauge_h_init,
+    const typename db::item_type<
+        Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+    const tnsr::a<DataVector, SpatialDim, Frame>&
+        spacetime_unit_normal_one_form,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const Time& time,
+    const double& t_start, const double& sigma_t,
+    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+    const double& sigma_r) noexcept {
+  typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
+      d4_gauge_h{get_size(get(lapse))};
+  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h(
+      make_not_null(&d4_gauge_h), gauge_h_init, dgauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, time.value(), coords,
+      1., 1., 1.,        // amp_coef_{L1, L2, S}
+      4, 4, 4,           // exp_{L1, L2, S}
+      t_start, sigma_t,  // _h_init
+      t_start, sigma_t,  // _L1
+      t_start, sigma_t,  // _L2
+      t_start, sigma_t,  // _S
+      sigma_r);
+  return d4_gauge_h;
+}
+}  // namespace GeneralizedHarmonic
+
+// Explicit Instantiations
+/// \cond
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+#define DTYPE_SCAL(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                  \
+  template void                                                               \
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function(           \
+      const gsl::not_null<Scalar<DTYPE(data)>*> weight,                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
+      const double sigma_r) noexcept;                                         \
+  template Scalar<DTYPE(data)>                                                \
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function(           \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,             \
+      const double sigma_r) noexcept;                                         \
+  template void GeneralizedHarmonic::DampedHarmonicGauge_detail::             \
+      spacetime_deriv_of_weight_function(                                     \
+          const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>  \
+              d4_weight,                                                      \
+          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,         \
+          const double sigma_r) noexcept;                                     \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)> GeneralizedHarmonic:: \
+      DampedHarmonicGauge_detail::spacetime_deriv_of_weight_function(         \
+          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& coords,         \
+          const double sigma_r) noexcept;                                     \
+  template void GeneralizedHarmonic::DampedHarmonicGauge_detail::             \
+      spacetime_deriv_of_log_factor_metric_lapse(                             \
+          const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>  \
+              d4_logfac,                                                      \
+          const Scalar<DTYPE(data)>& lapse,                                   \
+          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,          \
+          const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                 \
+              spacetime_unit_normal,                                          \
+          const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
+              inverse_spatial_metric,                                         \
+          const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
+          const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
+              dt_spatial_metric,                                              \
+          const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,            \
+          const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
+          const double exponent) noexcept;                                    \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)> GeneralizedHarmonic:: \
+      DampedHarmonicGauge_detail::spacetime_deriv_of_log_factor_metric_lapse( \
+          const Scalar<DTYPE(data)>& lapse,                                   \
+          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,          \
+          const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                 \
+              spacetime_unit_normal,                                          \
+          const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
+              inverse_spatial_metric,                                         \
+          const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
+          const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
+              dt_spatial_metric,                                              \
+          const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,            \
+          const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
+          const double exponent) noexcept;                                    \
+  template void GeneralizedHarmonic::DampedHarmonicGauge_detail::             \
+      spacetime_deriv_of_power_log_factor_metric_lapse(                       \
+          const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>  \
+              d4_powlogfac,                                                   \
+          const Scalar<DTYPE(data)>& lapse,                                   \
+          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,          \
+          const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                 \
+              spacetime_unit_normal,                                          \
+          const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
+              inverse_spatial_metric,                                         \
+          const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
+          const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
+              dt_spatial_metric,                                              \
+          const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,            \
+          const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
+          const double g_exponent, const int exponent) noexcept;              \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::                           \
+      spacetime_deriv_of_power_log_factor_metric_lapse(                       \
+          const Scalar<DTYPE(data)>& lapse,                                   \
+          const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,          \
+          const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                 \
+              spacetime_unit_normal,                                          \
+          const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                \
+              inverse_spatial_metric,                                         \
+          const Scalar<DTYPE(data)>& sqrt_det_spatial_metric,                 \
+          const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                \
+              dt_spatial_metric,                                              \
+          const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,            \
+          const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,          \
+          const double g_exponent, const int exponent) noexcept;
+
+#define INSTANTIATE_SCALAR_FUNC(_, data)                                    \
+  template void                                                             \
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse( \
+      const gsl::not_null<Scalar<DTYPE_SCAL(data)>*> logfac,                \
+      const Scalar<DTYPE_SCAL(data)>& lapse,                                \
+      const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric,              \
+      const double exponent) noexcept;                                      \
+  template Scalar<DTYPE_SCAL(data)>                                         \
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse( \
+      const Scalar<DTYPE_SCAL(data)>& lapse,                                \
+      const Scalar<DTYPE_SCAL(data)>& sqrt_det_spatial_metric,              \
+      const double exponent) noexcept;
+
+#define INSTANTIATE_COMPUTE_ITEM(_, data)                                    \
+  template struct GeneralizedHarmonic::DampedHarmonicHCompute<DIM(data),     \
+                                                              FRAME(data)>;  \
+  template struct GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute< \
+      DIM(data), FRAME(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
+                        (Frame::Inertial))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALAR_FUNC, (double, DataVector))
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_COMPUTE_ITEM, (1, 2, 3), (DataVector),
+                        (Frame::Inertial))
+
+#undef DIM
+#undef DTYPE
+#undef FRAME
+#undef DTYPE_SCAL
+#undef INSTANTIATE
+#undef INSTANTIATE_SCALAR_FUNC
+#undef INSTANTIATE_COMPUTE_ITEM
+/// \endcond

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -1,0 +1,288 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+///\file
+/// Defines Functions for calculating damped harmonic gauge quantities from
+/// 3+1 quantities
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+class Time;
+/// \endcond
+
+// IWYU pragma: no_forward_declare Tags::Time
+// IWYU pragma: no_forward_declare Tags::Coordinates
+// IWYU pragma: no_forward_declare Tags::deriv
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare db::ComputeTag
+// IWYU pragma: no_forward_declare gr::InverseSpatialMetric
+// IWYU pragma: no_forward_declare gr::Tags::Lapse
+// IWYU pragma: no_forward_declare gr::Tags::Shift
+// IWYU pragma: no_forward_declare gr::Tags::SpacetimeMetric
+// IWYU pragma: no_forward_declare gr::Tags::SpacetimeNormalOneForm
+// IWYU pragma: no_forward_declare gr::Tags::SpacetimeNormalVector
+// IWYU pragma: no_forward_declare gr::Tags::InverseSpatialMetric
+// IWYU pragma: no_forward_declare gr::Tags::SqrtDetSpatialMetric
+
+namespace GeneralizedHarmonic {
+/*!
+ * \brief Damped harmonic gauge source function.
+ *
+ * \details See damped_harmonic_h() for details.
+ */
+template <size_t SpatialDim, typename Frame>
+struct DampedHarmonicHCompute : Tags::GaugeH<SpatialDim, Frame>,
+                                db::ComputeTag {
+  using argument_tags = tmpl::list<
+      Tags::InitialGaugeH<SpatialDim, Frame>, ::gr::Tags::Lapse<DataVector>,
+      ::gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+      ::gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>, ::Tags::Time,
+      OptionTags::GaugeHRollOnStartTime, OptionTags::GaugeHRollOnTimeWindow,
+      ::Tags::Coordinates<SpatialDim, Frame>,
+      OptionTags::GaugeHSpatialWeightDecayWidth<Frame>>;
+
+  static typename db::item_type<Tags::GaugeH<SpatialDim, Frame>> function(
+      const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+          gauge_h_init,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+      const Time& time, const double& t_start, const double& sigma_t,
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+      const double& sigma_r) noexcept;
+};
+
+/*!
+ * \brief Damped harmonic gauge source function.
+ *
+ * \details Computes the gauge source function designed for binary black hole
+ * evolutions. These have been taken from \cite Szilagyi2009qz and
+ * \cite Deppe2018uye.
+ *
+ * The covariant form of the source function \f$H_a\f$ is written as:
+ *
+ * \f{align*}
+ * H_a :=  [1 - R_{H_\mathrm{init}}(t)] H_a^\mathrm{init} +
+ *  [\mu_{L1} \mathrm{log}(\sqrt{g}/N) + \mu_{L2} \mathrm{log}(1/N)] t_a
+ *   - \mu_S g_{ai} N^i / N
+ * \f}
+ *
+ * where \f$N, N^k\f$ are the lapse and shift respectively, \f$t_a\f$ is the
+ * unit normal one-form to the spatial slice, and \f$g_{ab}\f$ is
+ * the spatial metric (obtained by projecting the spacetime metric onto the
+ * 3-slice, i.e. \f$g_{ab} = \psi_{ab} + t_a t_b\f$). The prefactors are:
+ *
+ * \f{align*}
+ *  \mu_{L1} &= A_{L1} R_{L1}(t) W(x^i) \mathrm{log}(\sqrt{g}/N)^{e_{L1}}, \\
+ *  \mu_{L2} &= A_{L2} R_{L2}(t) W(x^i) \mathrm{log}(1/N)^{e_{L2}}, \\
+ *  \mu_{S} &= A_{S} R_{S}(t) W(x^i) \mathrm{log}(\sqrt{g}/N)^{e_{S}},
+ * \f}
+ *
+ * temporal roll-on functions \f$ R_X(t)\f$ (with label \f$ X\f$) are:
+ *
+ * \f{align*}
+ * \begin{array}{ll}
+ *     R_X(t) & = 1 - \exp[-((t - t_{0,X})/ \sigma_t^X)^4], & t\geq t_{0,X} \\
+ *     & = 0, & t< t_{0,X} \\
+ * \end{array}
+ * \f}
+ *
+ * and the spatial weight function is:
+ *
+ * \f{align*}
+ * W(x^i) = \exp[-(r/\sigma_r)^2].
+ * \f}
+ * This weight function can be written with multiple constant factors in the
+ * exponent in literature \cite Deppe2018uye, but we absorb them all into
+ * \f$ \sigma_r\f$ here. The coordinate \f$ r\f$ is the Euclidean radius
+ * in Inertial coordinates.
+ *
+ * Note:
+ *   - Amplitude factors \f$ A_{X} \f$ are input as amp\_coef\_X
+ *   - \f$ R_{X} \f$ is specified by \f$\{ t_{0,X}, \sigma_t^X\}\f$, which are
+ *     input as \f$\{\f$t\_start\_X, sigma\_t\_X \f$\}\f$.
+ *   - Exponents \f$ e_X\f$ are input as exp\_X.
+ *   - The spatial weight function is specified completely by \f$\{\f$sigma\_r
+ * \f$\}\f$.
+ */
+template <size_t SpatialDim, typename Frame>
+void damped_harmonic_h(
+    gsl::not_null<typename db::item_type<Tags::GaugeH<SpatialDim, Frame>>*>
+        gauge_h,
+    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+        gauge_h_init,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+    double time, const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+    // Scaling coeffs in front of each term
+    double amp_coef_L1, double amp_coef_L2, double amp_coef_S,
+    // exponents
+    int exp_L1, int exp_L2, int exp_S,
+    // roll on function parameters for lapse / shift terms
+    double t_start_h_init, double sigma_t_h_init, double t_start_L1,
+    double sigma_t_L1, double t_start_L2, double sigma_t_L2, double t_start_S,
+    double sigma_t_S,
+    // weight function
+    double sigma_r) noexcept;
+
+/*!
+ * \brief Spacetime derivatives of the damped harmonic gauge source function.
+ *
+ * \details See spacetime_deriv_damped_harmonic_h() for details.
+ */
+template <size_t SpatialDim, typename Frame>
+struct SpacetimeDerivDampedHarmonicHCompute
+    : Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<
+      Tags::InitialGaugeH<SpatialDim, Frame>,
+      Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>,
+      ::gr::Tags::Lapse<DataVector>,
+      ::gr::Tags::Shift<SpatialDim, Frame, DataVector>,
+      ::gr::Tags::SpacetimeNormalOneForm<SpatialDim, Frame, DataVector>,
+      ::gr::Tags::SqrtDetSpatialMetric<DataVector>,
+      ::gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>,
+      ::gr::Tags::SpacetimeMetric<SpatialDim, Frame, DataVector>,
+      Tags::Pi<SpatialDim, Frame>, Tags::Phi<SpatialDim, Frame>, ::Tags::Time,
+      OptionTags::GaugeHRollOnStartTime, OptionTags::GaugeHRollOnTimeWindow,
+      ::Tags::Coordinates<SpatialDim, Frame>,
+      OptionTags::GaugeHSpatialWeightDecayWidth<Frame>>;
+
+  static typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
+  function(
+      const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+          gauge_h_init,
+      const typename db::item_type<
+          Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
+      const Scalar<DataVector>& lapse,
+      const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+      const tnsr::a<DataVector, SpatialDim, Frame>&
+          spacetime_unit_normal_one_form,
+      const Scalar<DataVector>& sqrt_det_spatial_metric,
+      const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+      const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+      const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const Time& time,
+      const double& t_start, const double& sigma_t,
+      const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+      const double& sigma_r) noexcept;
+};
+
+/*!
+ * \brief Spacetime derivatives of the damped harmonic gauge source function.
+ *
+ * \details Compute spacetime derivatives, i.e. \f$\partial_a H_b\f$, of the
+ * damped harmonic source function H. Using notation from damped_harmonic_h(),
+ * we rewrite the same as: \f{align*}
+ * \partial_a H_b =& \partial_a T_1 + \partial_a T_2 + \partial_a T_3, \\
+ * H_a =& T_1 + T_2 + T_3,
+ * \f}
+ *
+ * where:
+ *
+ * \f{align*}
+ * T_1 =& [1 - R_{H_\mathrm{init}}(t)] H_a^\mathrm{init}, \\
+ * T_2 =& [\mu_{L1} \mathrm{log}(\sqrt{g}/N) + \mu_{L2} \mathrm{log}(1/N)] t_a,
+ * \\ T_3 =& - \mu_S g_{ai} N^i / N. \f}
+ *
+ * Derivation:
+ *
+ * \f$\blacksquare\f$ For \f$ T_1 \f$, the derivatives are:
+ * \f{align*}
+ * \partial_a T_1 = (1 - R_{H_\mathrm{init}}(t))
+ * \partial_a H_b^\mathrm{init}
+ *                - H_b^\mathrm{init} \partial_a R_{H_\mathrm{init}}.
+ * \f}
+ *
+ * \f$\blacksquare\f$ Write \f$ T_2 \equiv (\mu_1 + \mu_2) t_b \f$. Then:
+ * \f{align*}
+ * \partial_a T_2 =& (\partial_a \mu_1 + \partial_a \mu_2) t_b \\
+ *               +& (\mu_1 + \mu_2) \partial_a t_b,
+ * \f}
+ * where
+ * \f{align*}
+ * \partial_a t_b =& \left(-\partial_a N, 0, 0, 0\right) \\
+ *
+ * \partial_a \mu_1
+ *  =& \partial_a [A_{L1} R_{L1}(t) W(x^i) \mathrm{log}(\sqrt{g}/N)^{e_{L1} +
+ * 1}], \\
+ *  =& A_{L1} R_{L1}(t) W(x^i) \partial_a [\mathrm{log}(\sqrt{g}/N)^{e_{L1} +
+ * 1}] \\
+ *   +& A_{L1} \mathrm{log}(\sqrt{g}/N)^{e_{L1} + 1} \partial_a [R_{L1}(t)
+ * W(x^i)],\\
+ *
+ * \partial_a \mu_2
+ *  =& \partial_a [A_{L2} R_{L2}(t) W(x^i) \mathrm{log}(1/N)^{e_{L2} + 1}], \\
+ *  =& A_{L2} R_{L2}(t) W(x^i) \partial_a [\mathrm{log}(1/N)^{e_{L2} + 1}] \\
+ *     +& A_{L2} \mathrm{log}(1/N)^{e_{L2} + 1} \partial_a [R_{L2}(t) W(x^i)],
+ * \f}
+ * where \f$\partial_a [R W] = \left(\partial_0 R(t), \partial_i
+ * W(x^j)\right)\f$.
+ *
+ * \f$\blacksquare\f$ Finally, the derivatives of \f$ T_3 \f$ are:
+ * \f[
+ * \partial_a T_3 = -\partial_a(\mu_S/N) g_{bi} N^i
+ *                  -(\mu_S/N) \partial_a(g_{bi}) N^i
+ *                  -(\mu_S/N) g_{bi}\partial_a N^i,
+ * \f]
+ * where
+ * \f{align*}
+ * \partial_a(\mu_S / N) =& (1/N)\partial_a \mu_S
+ *                       - \frac{\mu_S}{N^2}\partial_a N, \,\,\mathrm{and}\\
+ * \partial_a \mu_S =& \partial_a [A_S R_S(t) W(x^i)
+ * \mathrm{log}(\sqrt{g}/N)^{e_S}], \\
+ *                  =& A_S R_S(t) W(x^i) \partial_a
+ * [\mathrm{log}(\sqrt{g}/N)^{e_S}] \\
+ *                  +& A_S \mathrm{log}(\sqrt{g} / N)^{e_S} \partial_a [R_S(t)
+ * W(x^i)]. \f}
+ */
+template <size_t SpatialDim, typename Frame>
+void spacetime_deriv_damped_harmonic_h(
+    gsl::not_null<
+        typename db::item_type<Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>*>
+        d4_gauge_h,
+    const typename db::item_type<Tags::InitialGaugeH<SpatialDim, Frame>>&
+        gauge_h_init,
+    const typename db::item_type<
+        Tags::SpacetimeDerivInitialGaugeH<SpatialDim, Frame>>& dgauge_h_init,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+    const tnsr::a<DataVector, SpatialDim, Frame>&
+        spacetime_unit_normal_one_form,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, double time,
+    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+    // Scaling coeffs in front of each term
+    double amp_coef_L1, double amp_coef_L2, double amp_coef_S,
+    // exponents
+    int exp_L1, int exp_L2, int exp_S,
+    // roll on function parameters for lapse / shift terms
+    double t_start_h_init, double sigma_t_h_init, double t_start_L1,
+    double sigma_t_L1, double t_start_L2, double sigma_t_L2, double t_start_S,
+    double sigma_t_S,
+    // weight function
+    double sigma_r) noexcept;
+}  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
+#include "Options/Options.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 
 class DataVector;
@@ -53,19 +54,69 @@ struct ConstraintGamma2 : db::SimpleTag {
   using type = Scalar<DataVector>;
   static std::string name() noexcept { return "ConstraintGamma2"; }
 };
+
+/*!
+ * \brief Gauge source function for the generalized harmonic system.
+ *
+ * \details In the generalized / damped harmonic gauge, unlike the simple
+ * harmonic gauge, the right hand side of the gauge equation
+ * \f$ \square x_a = H_a\f$ is sourced by non-vanishing functions. This variable
+ * stores those functions \f$ H_a\f$.
+ */
 template <size_t Dim, typename Frame>
 struct GaugeH : db::SimpleTag {
   using type = tnsr::a<DataVector, Dim, Frame>;
   static std::string name() noexcept { return "GaugeH"; }
 };
+
+/*!
+ * \brief Spacetime derivatives of the gauge source function for the
+ * generalized harmonic system.
+ *
+ * \details In the generalized / damped harmonic gauge, the right hand side of
+ * the gauge equation \f$ \square x_a = H_a\f$ is sourced by non-vanishing
+ * functions \f$ H_a\f$. This variable stores their spacetime derivatives
+ * \f$ \partial_b H_a\f$.
+ */
 template <size_t Dim, typename Frame>
 struct SpacetimeDerivGaugeH : db::SimpleTag {
   using type = tnsr::ab<DataVector, Dim, Frame>;
   static std::string name() noexcept { return "SpacetimeDerivGaugeH"; }
 };
 
+/*!
+ * \brief Initial value of the gauge source function for the generalized
+ * harmonic system.
+ *
+ * \details In the generalized / damped harmonic gauge, unlike the simple
+ * harmonic gauge, the right hand side of the gauge equation
+ * \f$ \square x_a = H_a\f$ is sourced by non-vanishing functions. This variable
+ * stores the initial or starting value of those functions \f$ H_a\f$, which
+ * are set by the user (based on the choice of initial data) to begin evolution.
+ */
+template <size_t Dim, typename Frame>
+struct InitialGaugeH : db::SimpleTag {
+  using type = tnsr::a<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "InitialGaugeH"; }
+};
+
+/*!
+ * \brief Initial spacetime derivatives of the gauge source function
+ * for the generalized harmonic system.
+ *
+ * \details In the generalized / damped harmonic gauge, the right hand side of
+ * the gauge equation \f$ \square x_a = H_a\f$ is sourced by non-vanishing
+ * functions \f$ H_a\f$. This variable stores the initial or starting value of
+ * the spacetime derivatives of those functions \f$ \partial_b H_a\f$, which
+ * are set by the user (based on the choice of initial data) to begin evolution.
+ */
+template <size_t Dim, typename Frame>
+struct SpacetimeDerivInitialGaugeH : db::SimpleTag {
+  using type = tnsr::ab<DataVector, Dim, Frame>;
+  static std::string name() noexcept { return "SpacetimeDerivInitialGaugeH"; }
+};
+
 // @{
-/// \ingroup GeneralizedHarmonicGroup
 /// \brief Tags corresponding to the characteristic fields of the generalized
 /// harmonic system.
 ///
@@ -116,4 +167,59 @@ struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
   }
 };
 }  // namespace Tags
+
+namespace OptionTags {
+/*!
+ * \ingroup OptionTagsGroup
+ * \brief Gauge control parameter determining when to start rolling-on the
+ * evolution gauge.
+ *
+ * \details The evolution gauge is gradually transitioned to (or
+ * *rolled-on* to) at the beginning of an evolution. This parameter sets
+ * the coordinate time at which roll-on begins.
+ */
+struct GaugeHRollOnStartTime : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "GaugeHRollOnStartT"; }
+  static constexpr OptionString help{
+      "Simulation time to start rolling-on evolution gauge"};
+};
+
+/*!
+ * \ingroup OptionTagsGroup
+ * \brief Gauge control parameter determining how long the transition to
+ * the evolution gauge should take at the start of an evolution.
+ *
+ * \details The evolution gauge is gradually transitioned to (or
+ * *rolled-on* to) at the beginning of an evolution. This parameter sets
+ * the width of the coordinate time window during which roll-on happens.
+ */
+struct GaugeHRollOnTimeWindow : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "GaugeHRollOnTWindow"; }
+  static constexpr OptionString help{
+      "Duration of gauge roll-on in simulation time"};
+};
+
+/*!
+ * \ingroup OptionTagsGroup
+ * \brief Gauge control parameter to specify the spatial weighting function
+ * that enters damped harmonic gauge source function.
+ *
+ * \details The evolution gauge source function is multiplied by a spatial
+ * weight function which controls where and how much it sources the damped
+ * harmonic gauge equation. The weight function is:
+ * \f$ W(x^i) = \exp[-(r/\sigma_r)^2] \f$.
+ * This weight function can be written with an extra factor inside the exponent
+ * in literature, e.g. \cite Deppe2018uye. We will absorb it here in
+ * \f$\sigma_r\f$. The parameter this tag tags is \f$ \sigma_r \f$.
+ */
+template <typename Frame>
+struct GaugeHSpatialWeightDecayWidth : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "GaugeHDecayWidth"; }
+  static constexpr OptionString help{
+      "Spatial width of weighting factor in evolution gauge"};
+};
+}  // namespace OptionTags
 }  // namespace GeneralizedHarmonic

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -8,6 +8,8 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 
 namespace GeneralizedHarmonic {
+
+/// \brief Tags for the generalized harmonic formulation of Einstein equations
 namespace Tags {
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct Pi;
@@ -18,24 +20,36 @@ struct ConstraintGamma0;
 struct ConstraintGamma1;
 struct ConstraintGamma2;
 template <size_t Dim, typename Frame = Frame::Inertial>
+struct InitialGaugeH;
+template <size_t Dim, typename Frame = Frame::Inertial>
+struct SpacetimeDerivInitialGaugeH;
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct GaugeH;
 template <size_t Dim, typename Frame = Frame::Inertial>
 struct SpacetimeDerivGaugeH;
 
-template<size_t Dim, typename Frame>
+template <size_t Dim, typename Frame>
 struct UPsi;
-template<size_t Dim, typename Frame>
+template <size_t Dim, typename Frame>
 struct UZero;
-template<size_t Dim, typename Frame>
+template <size_t Dim, typename Frame>
 struct UPlus;
-template<size_t Dim, typename Frame>
+template <size_t Dim, typename Frame>
 struct UMinus;
 
-template<size_t Dim, typename Frame>
+template <size_t Dim, typename Frame>
 struct CharacteristicSpeeds;
-template<size_t Dim, typename Frame>
+template <size_t Dim, typename Frame>
 struct CharacteristicFields;
-template<size_t Dim, typename Frame>
+template <size_t Dim, typename Frame>
 struct EvolvedFieldsFromCharacteristicFields;
 }  // namespace Tags
+
+/// \brief Input option tags for the generalized harmonic evolution system
+namespace OptionTags {
+struct GaugeHRollOnStartTime;
+struct GaugeHRollOnTimeWindow;
+template <typename Frame>
+struct GaugeHSpatialWeightDecayWidth;
+}  // namespace OptionTags
 }  // namespace GeneralizedHarmonic

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(GaugeSourceFunctions)
+
 set(LIBRARY "Test_GeneralizedHarmonic")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_GeneralizedHarmonicGaugeSourceFunctions")
+
+set(LIBRARY_SOURCES
+  Test_DampedHarmonicGaugeQuantities.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/"
+  "${LIBRARY_SOURCES}"
+  "GeneralizedHarmonicGaugeSourceFunctions"
+  )

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.py
@@ -1,0 +1,201 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+import os
+import sys
+from PointwiseFunctions.GeneralRelativity.ComputeGhQuantities import (
+    spacetime_deriv_detg, deriv_lapse, dt_lapse, deriv_spatial_metric,
+    dt_spatial_metric, deriv_shift, dt_shift
+)
+from PointwiseFunctions.GeneralRelativity.ComputeSpacetimeQuantities import (
+    derivatives_of_spacetime_metric, inverse_spacetime_metric,
+    spacetime_normal_vector
+)
+
+
+def weight_function(coords, r_max):
+    r2 = np.sum([coords[i]**2 for i in range(len(coords))])
+    return np.exp(- r2 / r_max / r_max)
+
+
+def spacetime_deriv_weight_function(coords, r_max):
+    W = weight_function(coords, r_max)
+    DW = np.zeros(len(coords) + 1)
+    DW[1:] = -2. * W / r_max / r_max * coords
+    return DW
+
+
+def roll_on_function(time, t_start, sigma_t):
+    if time < t_start:
+        return 0.
+    return 1. - np.exp(- ((time - t_start) / sigma_t)**4)
+
+
+def time_deriv_roll_on_function(time, t_start, sigma_t):
+    if time < t_start:
+        return 0.
+    tnrm = (time - t_start) / sigma_t
+    return np.exp(- tnrm**4) * 4 * tnrm**3 / sigma_t
+
+
+def log_fac(lapse, sqrt_det_spatial_metric, exponent):
+    # if exponent == 0, the first term automatically vanishes
+    return exponent * np.log(sqrt_det_spatial_metric**2) - np.log(lapse)
+
+
+def spacetime_deriv_log_fac(lapse, shift, spacetime_unit_normal,
+                            inverse_spatial_metric, sqrt_det_spatial_metric,
+                            dt_spatial_metric, pi, phi, exponent):
+    spatial_dim = len(shift)
+    detg = sqrt_det_spatial_metric**2
+    dg = spacetime_deriv_detg(sqrt_det_spatial_metric,
+                                   inverse_spatial_metric, dt_spatial_metric,
+                                   phi)
+    d0N = dt_lapse(lapse, shift, spacetime_unit_normal, phi, pi)
+    d3N = deriv_lapse(lapse, spacetime_unit_normal, phi)
+    d4N = np.zeros(1 + spatial_dim)
+    d4N[0] = d0N
+    d4N[1:] = d3N
+    # if exponent == 0, the first term automatically vanishes
+    d_logfac = (exponent / detg) * dg - (1. / lapse) * d4N
+    return d_logfac
+
+
+def spacetime_deriv_pow_log_fac(lapse, shift, spacetime_unit_normal,
+                                inverse_spatial_metric, sqrt_det_spatial_metric,
+                                dt_spatial_metric,
+                                pi, phi, g_exponent, exponent):
+    exponent = int(exponent)
+    dlogfac = spacetime_deriv_log_fac(lapse, shift, spacetime_unit_normal,
+                                      inverse_spatial_metric,
+                                      sqrt_det_spatial_metric,
+                                      dt_spatial_metric,
+                                      pi, phi, g_exponent)
+    logfac = log_fac(lapse, sqrt_det_spatial_metric, g_exponent)
+    return exponent * np.power(logfac, exponent - 1) * dlogfac
+
+
+def spatial_metric_from_spacetime_metric(spacetime_metric):
+    return spacetime_metric[1:, 1:]
+
+
+# In the next two functions, assume that amplitude pre-factors and exponents
+# have the following values:
+#      amp_coef_{h_init, L1, L2, S} = 1., 1., 1., 1.
+#      exp_{L1, L2, S}              = 4, 4, 4
+# and that the roll-on function associated with each term has identical config:
+#      t_start, sigma_t  for {_h_init, _L1, _L2, _S}.
+def damped_harmonic_gauge_source_function(gauge_h_init, lapse, shift,
+                                          sqrt_det_spatial_metric,
+                                          spacetime_metric, time, t_start,
+                                          sigma_t, coords, r_max):
+    unit_normal_one_form = np.zeros(1 + len(shift))
+    unit_normal_one_form[0] -= lapse
+    log_sqrtg_over_lapse = log_fac(lapse, sqrt_det_spatial_metric, 0.5)
+    log_one_over_lapse = log_fac(lapse, sqrt_det_spatial_metric, 0.)
+    R = roll_on_function(time, t_start, sigma_t)
+    W = weight_function(coords, r_max)
+    muL1 = R * W * log_sqrtg_over_lapse**4
+    muL2 = R * W * log_one_over_lapse**4
+    muS = muL1
+    h_pre1 = muL1 * log_sqrtg_over_lapse + muL2 * log_one_over_lapse
+    h_pre2 = muS / lapse
+    return (1. - R) * gauge_h_init + h_pre1 * unit_normal_one_form - h_pre2 * \
+        np.einsum('ai,i->a', spacetime_metric[:, 1:], shift)
+
+
+def spacetime_deriv_damped_harmonic_gauge_source_function(gauge_h_init,
+                                                dgauge_h_init, lapse, shift,
+                                                spacetime_unit_normal_one_form,
+                                                sqrt_det_spatial_metric,
+                                                inverse_spatial_metric,
+                                                spacetime_metric, pi, phi, time,
+                                                t_start, sigma_t, coords,
+                                                r_max):
+    spatial_dim = len(shift)
+    spacetime_unit_normal = spacetime_normal_vector(lapse, shift)
+    spatial_metric = spatial_metric_from_spacetime_metric(spacetime_metric)
+    det_spatial_metric = sqrt_det_spatial_metric**2
+    d3_spatial_metric = deriv_spatial_metric(phi)
+    inv_spacetime_metric = inverse_spacetime_metric(lapse, shift,
+                                                    inverse_spatial_metric)
+    d0_spatial_metric = dt_spatial_metric(lapse, shift, phi, pi)
+
+    log_sqrtg_over_lapse = np.log(sqrt_det_spatial_metric / lapse)
+    log_sqrtg_over_lapse_pow3 = log_sqrtg_over_lapse**3
+    log_sqrtg_over_lapse_pow4 = log_sqrtg_over_lapse * log_sqrtg_over_lapse_pow3
+    log_sqrtg_over_lapse_pow5 = log_sqrtg_over_lapse * log_sqrtg_over_lapse_pow4
+    one_over_lapse = 1. / lapse
+    log_one_over_lapse = np.log(one_over_lapse)
+    log_one_over_lapse_pow4 = log_one_over_lapse**4
+    log_one_over_lapse_pow5 = log_one_over_lapse * log_one_over_lapse_pow4
+
+    R = roll_on_function(time, t_start, sigma_t)
+    W = weight_function(coords, r_max)
+
+    muL1 = R * W * log_sqrtg_over_lapse_pow4
+    muS_over_N = muL1 / lapse
+
+    mu1 = muL1 * log_sqrtg_over_lapse
+    mu2 = R * W * log_one_over_lapse_pow5
+
+    d4_W = spacetime_deriv_weight_function(coords, r_max)
+    d0_R = time_deriv_roll_on_function(time, t_start, sigma_t)
+    d4_RW = R * d4_W
+    d4_RW[0] += W * d0_R
+
+    d4_g = spacetime_deriv_detg(sqrt_det_spatial_metric, inverse_spatial_metric,
+                                d0_spatial_metric, phi)
+
+    d0_N = dt_lapse(lapse, shift, spacetime_unit_normal, phi, pi)
+    d3_N = deriv_lapse(lapse, spacetime_unit_normal, phi)
+    d4_N = np.zeros(1 + spatial_dim)
+    d4_N[0] = d0_N
+    d4_N[1:] = d3_N
+
+    d0_shift = dt_shift(lapse, shift, inverse_spatial_metric,
+                             spacetime_unit_normal, phi, pi)
+    d3_shift = deriv_shift(lapse, inv_spacetime_metric,
+                                spacetime_unit_normal, phi)
+    d4_shift = np.einsum('a,b->ab',
+                         np.zeros(spatial_dim + 1), np.zeros(spatial_dim + 1))
+    d4_shift[0, 1:] = d0_shift
+    d4_shift[1:, 1:] = d3_shift
+
+    prefac0 = 2. * R * W * log_sqrtg_over_lapse_pow3
+    prefac1 = 2.5 * R * W * log_sqrtg_over_lapse_pow4
+    prefac2 = -5. * R * W * log_one_over_lapse_pow4 * one_over_lapse
+    d4_muL1 = log_sqrtg_over_lapse_pow4 * d4_RW +\
+        prefac0 * (d4_g / det_spatial_metric - 2. * one_over_lapse * d4_N)
+    d4_mu1 = log_sqrtg_over_lapse_pow5 * d4_RW +\
+        prefac1 * (d4_g / det_spatial_metric - 2. * one_over_lapse * d4_N)
+    d4_mu2 = log_one_over_lapse_pow5 * d4_RW + prefac2 * d4_N
+
+    d4_normal_one_form = np.einsum('a,b->ab',
+                                   np.zeros(spatial_dim + 1),
+                                   np.zeros(spatial_dim + 1))
+    d4_normal_one_form[:, 0] = -d4_N
+
+    d4_muS_over_N = one_over_lapse * d4_muL1 - muL1 * one_over_lapse**2 * d4_N
+
+    d4_psi = derivatives_of_spacetime_metric(lapse, d0_N, d3_N,
+                                             shift, d0_shift, d3_shift,
+                                             spatial_metric,
+                                             d0_spatial_metric,
+                                             d3_spatial_metric)
+
+    dT1 = (1. - R) * dgauge_h_init
+    dT1[0, :] -= d0_R * gauge_h_init
+
+    dT2 = (mu1 + mu2) * d4_normal_one_form +\
+        np.einsum('a,b->ab', d4_mu1 + d4_mu2, spacetime_unit_normal_one_form)
+
+    dT3 = np.einsum('a,b->ab',
+                    np.zeros(spatial_dim + 1), np.zeros(spatial_dim + 1))
+    dT3 -= np.einsum('a,b->ab', d4_muS_over_N,
+                     np.einsum('bi,i->b', spacetime_metric[:, 1:], shift))
+    dT3 -= muS_over_N * np.einsum('abi,i->ab', d4_psi[:, :, 1:], shift)
+    dT3 -= muS_over_N * np.einsum('ai,bi->ab', d4_shift[:, 1:],
+                                  spacetime_metric[:, 1:])
+    return dT1 + dT2 + dT3

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_DampedHarmonicGaugeQuantities.cpp
@@ -1,0 +1,3155 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+#include <random>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Rational.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+namespace Tags {
+template <typename Tag>
+struct dt;
+}  // namespace Tags
+/// \endcond
+
+namespace GeneralizedHarmonic {
+namespace DampedHarmonicGauge_detail {
+// The `detail` functions below are forward-declared to enable their independent
+// testing
+template <size_t SpatialDim, typename Frame, typename DataType>
+Scalar<DataType> weight_function(
+    const tnsr::I<DataType, SpatialDim, Frame>& coords,
+    double sigma_r) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_weight_function(
+    const tnsr::I<DataType, SpatialDim, Frame>& coords,
+    double sigma_r) noexcept;
+
+double roll_on_function(double time, double t_start, double sigma_t) noexcept;
+
+double time_deriv_of_roll_on_function(double time, double t_start,
+                                      double sigma_t) noexcept;
+
+template <typename DataType>
+Scalar<DataType> log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const Scalar<DataType>& sqrt_det_spatial_metric, double exponent) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    double exponent) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_power_log_factor_metric_lapse(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_powlogfac,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, double g_exponent,
+    int exponent) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame>
+spacetime_deriv_of_power_log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, double g_exponent,
+    int exponent) noexcept;
+}  // namespace DampedHarmonicGauge_detail
+}  // namespace GeneralizedHarmonic
+
+// Wrap `wrap_spacetime_deriv_of_power_log_factor_metric_lapse` here to make its
+// last argument a double, allowing for `pypp::check_with_random_values` to
+// work.
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame>
+wrap_spacetime_deriv_of_power_log_factor_metric_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi, const double g_exponent,
+    const double d_exponent) noexcept {
+  const auto exponent = static_cast<int>(d_exponent);
+  tnsr::a<DataType, SpatialDim, Frame> d4_powlogfac{};
+  GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_power_log_factor_metric_lapse(
+          make_not_null(&d4_powlogfac), lapse, shift, spacetime_unit_normal,
+          inverse_spatial_metric, sqrt_det_spatial_metric, dt_spatial_metric,
+          pi, phi, g_exponent, exponent);
+  return d4_powlogfac;
+}
+
+namespace {
+using Affine = domain::CoordinateMaps::Affine;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
+template <typename Frame>
+void test_options() noexcept {
+  Options<tmpl::list<
+      GeneralizedHarmonic::OptionTags::GaugeHRollOnStartTime,
+      GeneralizedHarmonic::OptionTags::GaugeHRollOnTimeWindow,
+      GeneralizedHarmonic::OptionTags::GaugeHSpatialWeightDecayWidth<Frame>>>
+      opts("");
+  opts.parse(
+      "GaugeHRollOnStartT : 0.\n"
+      "GaugeHRollOnTWindow : 100.\n"
+      "GaugeHDecayWidth : 50.\n");
+  CHECK(opts.template get<
+            GeneralizedHarmonic::OptionTags::GaugeHRollOnStartTime>() == 0.);
+  CHECK(opts.template get<
+            GeneralizedHarmonic::OptionTags::GaugeHRollOnTimeWindow>() == 100.);
+  CHECK(opts.template get<GeneralizedHarmonic::OptionTags::
+                              GaugeHSpatialWeightDecayWidth<Frame>>() == 50.);
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void test_detail_functions(const DataType& used_for_size) noexcept {
+  // weight_function
+  pypp::check_with_random_values<2>(
+      static_cast<Scalar<DataType> (*)(
+          const tnsr::I<DataType, SpatialDim, Frame>&, const double)>(
+          &::GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+              SpatialDim, Frame, DataType>),
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedHarmonic",
+      "weight_function",
+      {{{-10., 10.}, {std::numeric_limits<double>::denorm_min(), 10.}}},
+      used_for_size);
+  // spacetime_deriv_of_weight_function
+  pypp::check_with_random_values<2>(
+      static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
+          const tnsr::I<DataType, SpatialDim, Frame>&, const double)>(
+          &::GeneralizedHarmonic::DampedHarmonicGauge_detail::
+              spacetime_deriv_of_weight_function<SpatialDim, Frame, DataType>),
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedHarmonic",
+      "spacetime_deriv_weight_function",
+      {{{-10., 10.}, {std::numeric_limits<double>::denorm_min(), 10.}}},
+      used_for_size);
+  // roll_on_function
+  pypp::check_with_random_values<1>(
+      &::GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function,
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedHarmonic",
+      "roll_on_function", {{{std::numeric_limits<double>::denorm_min(), 10.}}},
+      used_for_size);
+  // time_deriv_of_roll_on_function
+  pypp::check_with_random_values<1>(
+      &::GeneralizedHarmonic::DampedHarmonicGauge_detail::
+          time_deriv_of_roll_on_function,
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedHarmonic",
+      "time_deriv_roll_on_function",
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size);
+  // log_factor_metric_lapse
+  pypp::check_with_random_values<1>(
+      static_cast<Scalar<DataType> (*)(const Scalar<DataType>&,
+                                       const Scalar<DataType>&, const double)>(
+          &::GeneralizedHarmonic::DampedHarmonicGauge_detail::
+              log_factor_metric_lapse<DataType>),
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedHarmonic",
+      "log_fac", {{{std::numeric_limits<double>::denorm_min(), 10.}}},
+      used_for_size);
+  // spacetime_deriv_of_log_factor_metric_lapse
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
+          const Scalar<DataType>&, const tnsr::I<DataType, SpatialDim, Frame>&,
+          const tnsr::A<DataType, SpatialDim, Frame>&,
+          const tnsr::II<DataType, SpatialDim, Frame>&, const Scalar<DataType>&,
+          const tnsr::ii<DataType, SpatialDim, Frame>&,
+          const tnsr::aa<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&, const double)>(
+          &::GeneralizedHarmonic::DampedHarmonicGauge_detail::
+              spacetime_deriv_of_log_factor_metric_lapse<SpatialDim, Frame,
+                                                         DataType>),
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedHarmonic",
+      "spacetime_deriv_log_fac",
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size);
+  // spacetime_deriv_of_power_log_factor_metric_lapse
+  pypp::check_with_random_values<1>(
+      &wrap_spacetime_deriv_of_power_log_factor_metric_lapse<SpatialDim, Frame,
+                                                             DataType>,
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedHarmonic",
+      "spacetime_deriv_pow_log_fac",
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size,
+      1.e-11);
+}
+
+//
+//  Tests of the damped harmonic gauge source function
+//
+// Wrap `DampedHarmonicHCompute::function` here to make its time
+// argument a double, allowing for `pypp::check_with_random_values` to work.
+template <size_t SpatialDim, typename Frame>
+typename db::item_type<GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame>>
+wrap_DampedHarmonicHCompute(
+    const typename db::item_type<GeneralizedHarmonic::Tags::InitialGaugeH<
+        SpatialDim, Frame>>& gauge_h_init,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+    const double t, const double t_start, const double sigma_t,
+    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+    const double sigma_r) noexcept {
+  const Slab slab(0, t);
+  const Rational frac(1);
+  const Time current_time(slab, frac);
+  return GeneralizedHarmonic::DampedHarmonicHCompute<
+      SpatialDim, Frame>::function(gauge_h_init, lapse, shift,
+                                   sqrt_det_spatial_metric, spacetime_metric,
+                                   current_time, t_start, sigma_t, coords,
+                                   sigma_r);
+}
+
+// Compare with Python implementation
+template <size_t SpatialDim, typename Frame>
+void test_damped_harmonic_h_function(const DataVector& used_for_size) noexcept {
+  // H_a
+  pypp::check_with_random_values<1>(
+      static_cast<typename db::item_type<
+          GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame>> (*)(
+          const typename db::item_type<
+              GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame>>&,
+          const Scalar<DataVector>&,
+          const tnsr::I<DataVector, SpatialDim, Frame>&,
+          const Scalar<DataVector>&,
+          const tnsr::aa<DataVector, SpatialDim, Frame>&, const double,
+          const double, const double,
+          const tnsr::I<DataVector, SpatialDim, Frame>&, const double)>(
+          &wrap_DampedHarmonicHCompute<SpatialDim, Frame>),
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedHarmonic",
+      "damped_harmonic_gauge_source_function",
+      {{{std::numeric_limits<double>::denorm_min(), 10.}}}, used_for_size);
+}
+
+// Test term 1/4 of gauge source function for Kerr-Schild
+void test_damped_harmonic_h_function_term_1_of_4(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> rdist(0.1, 1.);
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Randomized 3 + 1 quantities
+  std::uniform_real_distribution<> dist(0.9, 1.);
+  const DataVector& used_for_size = get<0>(x);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  get<0, 0>(spatial_metric) = get<1, 1>(spatial_metric) =
+      get<2, 2>(spatial_metric) = 1.;
+  std::uniform_real_distribution<> dist2(0., 0.12);
+  const auto dspatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      spatial_metric.get(i, j) += dspatial_metric.get(i, j);
+    }
+  }
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+
+  // Initialize settings
+  const double t_start_HI = pdist(generator) * 0.1;
+  const double sigma_t_HI = pdist(generator) * 0.2;
+
+  // Initialize initial gauge function and its roll-off function
+  const auto gauge_h_init = make_with_random_values<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      make_not_null(&generator), make_not_null(&rdist), x);
+  const double roll_on_HI =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_HI, sigma_t_HI);
+
+  // local H_a
+  auto gauge_h_expected = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    gauge_h_expected.get(a) = (1. - roll_on_HI) * gauge_h_init.get(a);
+  }
+
+  // Check that locally computed H_a matches the returned one
+  typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
+      gauge_h{};
+  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+      make_not_null(&gauge_h), gauge_h_init, lapse, shift,
+      sqrt_det_spatial_metric, spacetime_metric, t, x, 0., 0., 0., 0, 0,
+      0,  // exponents
+      // roll on function parameters for lapse / shift terms
+      t_start_HI, sigma_t_HI, -1., -1., -1., -1., -1., -1.,
+      -1. /* weight function */);
+
+  CHECK_ITERABLE_APPROX(gauge_h_expected, gauge_h);
+}
+
+// Test term 2/4 of gauge source function for Kerr-Schild
+void test_damped_harmonic_h_function_term_2_of_4(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Randomized 3 + 1 quantities
+  std::uniform_real_distribution<> dist(0.9, 1.);
+  const DataVector& used_for_size = get<0>(x);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  get<0, 0>(spatial_metric) = get<1, 1>(spatial_metric) =
+      get<2, 2>(spatial_metric) = 1.;
+  std::uniform_real_distribution<> dist2(0., 0.12);
+  const auto dspatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      spatial_metric.get(i, j) += dspatial_metric.get(i, j);
+    }
+  }
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+
+  // Initialize settings
+  const double amp_coef_L1 = pdist(generator);
+  const int exp_L1 = idist(generator);
+  // roll on function parameters for lapse / shift terms
+  const double t_start_L1 = pdist(generator) * 0.1;
+  const double sigma_t_L1 = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+
+  const auto& log_fac_1 = log(get(sqrt_det_spatial_metric) / get(lapse));
+  const double roll_on_L1 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_L1, sigma_t_L1);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+
+  const auto h_prefac1 = amp_coef_L1 * roll_on_L1 * get(weight) *
+                         pow(log_fac_1, exp_L1) * log_fac_1;
+
+  // local H_a
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  auto gauge_h_expected = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    gauge_h_expected.get(a) = h_prefac1 * spacetime_unit_normal_one_form.get(a);
+  }
+
+  // Check that locally computed H_a matches the returned one
+  typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
+      gauge_h{};
+  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+      make_not_null(&gauge_h), gauge_h_init, lapse, shift,
+      sqrt_det_spatial_metric, spacetime_metric, t, x, amp_coef_L1, 0., 0.,
+      exp_L1, 0, 0,  // exponents
+      // roll on function parameters for lapse / shift terms
+      -1., -1., t_start_L1, sigma_t_L1, -1., -1., -1., -1.,
+      r_max /* weight function */);
+
+  CHECK_ITERABLE_APPROX(gauge_h_expected, gauge_h);
+}
+
+// Test term 3/4 of gauge source function for Kerr-Schild
+void test_damped_harmonic_h_function_term_3_of_4(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Randomized 3 + 1 quantities
+  std::uniform_real_distribution<> dist(0.9, 1.);
+  const DataVector& used_for_size = get<0>(x);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  get<0, 0>(spatial_metric) = get<1, 1>(spatial_metric) =
+      get<2, 2>(spatial_metric) = 1.;
+  std::uniform_real_distribution<> dist2(0., 0.12);
+  const auto dspatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      spatial_metric.get(i, j) += dspatial_metric.get(i, j);
+    }
+  }
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+
+  // Initialize settings
+  const double amp_coef_L2 = pdist(generator);
+  const int exp_L2 = idist(generator);
+  const double t_start_L2 = pdist(generator) * 0.1;
+  const double sigma_t_L2 = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+
+  const double roll_on_L2 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_L2, sigma_t_L2);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+
+  const auto& log_fac_2 = log(1. / get(lapse));
+  const auto h_prefac1 = amp_coef_L2 * roll_on_L2 * get(weight) *
+                         pow(log_fac_2, exp_L2) * log_fac_2;
+
+  // local H_a
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  auto gauge_h_expected = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    gauge_h_expected.get(a) = h_prefac1 * spacetime_unit_normal_one_form.get(a);
+  }
+
+  // Check that locally computed H_a matches the returned one
+  typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
+      gauge_h{};
+  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+      make_not_null(&gauge_h), gauge_h_init, lapse, shift,
+      sqrt_det_spatial_metric, spacetime_metric, t, x, 0., amp_coef_L2, 0., 0,
+      exp_L2, 0,  // exponents
+      // roll on function parameters for lapse / shift terms
+      -1., -1., -1., -1., t_start_L2, sigma_t_L2, -1., -1.,
+      r_max /* weight function */);
+
+  CHECK_ITERABLE_APPROX(gauge_h_expected, gauge_h);
+}
+
+// Test term 4/4 of gauge source function for Kerr-Schild
+void test_damped_harmonic_h_function_term_4_of_4(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.1, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Randomized 3 + 1 quantities
+  std::uniform_real_distribution<> dist(0.9, 1.);
+  const DataVector& used_for_size = get<0>(x);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  get<0, 0>(spatial_metric) = get<1, 1>(spatial_metric) =
+      get<2, 2>(spatial_metric) = 1.;
+  std::uniform_real_distribution<> dist2(0., 0.12);
+  const auto dspatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      spatial_metric.get(i, j) += dspatial_metric.get(i, j);
+    }
+  }
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+  const auto& one_over_lapse = 1. / get(lapse);
+
+  // Initialize settings
+  const double amp_coef_S = pdist(generator);
+  const int exp_S = idist(generator);
+  const double t_start_S = pdist(generator) * 0.1;
+  const double sigma_t_S = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+
+  const double roll_on_S =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_S, sigma_t_S);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+
+  const auto& log_fac_1 = log(get(sqrt_det_spatial_metric) * one_over_lapse);
+  const auto h_prefac2 = -amp_coef_S * roll_on_S * get(weight) *
+                         pow(log_fac_1, exp_S) * one_over_lapse;
+
+  // local H_a
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  auto gauge_h_expected = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      gauge_h_expected.get(a) +=
+          h_prefac2 * spacetime_metric.get(a, i + 1) * shift.get(i);
+    }
+  }
+
+  // Check that locally computed H_a match returned one
+  typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
+      gauge_h{};
+  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+      make_not_null(&gauge_h), gauge_h_init, lapse, shift,
+      sqrt_det_spatial_metric, spacetime_metric, t, x, 0., 0., amp_coef_S, 0, 0,
+      exp_S,  // exponents
+      // roll on function parameters for lapse / shift terms
+      -1., -1., -1., -1., -1., -1., t_start_S, sigma_t_S,
+      r_max /* weight function */);
+
+  CHECK_ITERABLE_APPROX(gauge_h_expected, gauge_h);
+}
+
+// The next three functions test the gauge source function for
+// Schwarzschild spacetime, in Kerr-Schild coordinates.
+
+// Test term 2/4 of gauge source function for Schwarzschild in Kerr-Schild coord
+template <typename Solution>
+void test_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& shift = get<gr::Tags::Shift<SpatialDim>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+
+  // Initialize settings
+  const double amp_coef_L1 = pdist(generator);
+  const int exp_L1 = idist(generator);
+  // roll on function parameters for lapse / shift terms
+  const double t_start_L1 = pdist(generator) * 0.1;
+  const double sigma_t_L1 = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+  const double roll_on_L1 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_L1, sigma_t_L1);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
+      gauge_h{};
+  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+      make_not_null(&gauge_h), gauge_h_init, lapse, shift,
+      sqrt_det_spatial_metric, spacetime_metric, t, x, amp_coef_L1, 0., 0.,
+      exp_L1, 0, 0,  // exponents
+      // roll on function parameters for lapse / shift terms
+      -1., -1., t_start_L1, sigma_t_L1, -1., -1., -1., -1.,
+      r_max /* weight function */);
+
+  // Evaluate analytic solution for Schwarzschild, ab initio.
+  const double mass = solution.mass();
+  const std::array<double, SpatialDim> center = solution.center();
+  // 1) shift coords with BH at the center
+  auto x_minus_center = x;
+  // DataVector r_squared(get_size(x), 0.);
+  auto r_squared = get<0>(x);
+  r_squared -= get<0>(x);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    x_minus_center.get(i) -= gsl::at(center, i);
+    r_squared += square(x_minus_center.get(i));
+  }
+  const DataVector r_ = sqrt(r_squared);
+  // 2) compute scalar function that defines KerrSchild coords
+  const DataVector H = mass * (1. / r_);
+  const DataVector H2 = H * 2.;
+  // 3) compute lapse
+  const Scalar<DataVector> lapse_ab_initio{sqrt(1. / (1. + H2))};
+  // 4) compute 3-metric
+  auto spatial_metric_ab_initio =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      spatial_metric_ab_initio.get(i, j) =
+          H2 * x_minus_center.get(i) * x_minus_center.get(j) / r_squared;
+      if (i == j) {
+        spatial_metric_ab_initio.get(i, i) += 1.;
+      }
+    }
+  }
+  const auto& spacetime_unit_normal_one_form_ab_initio =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio);
+  const auto& det_spatial_metric_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio).first;
+  Scalar<DataVector> sqrt_det_spatial_metric_ab_initio(
+      sqrt(get(det_spatial_metric_ab_initio)));
+
+  // compute GR dependent terms
+  const auto& log_fac_1 =
+      log(get(sqrt_det_spatial_metric_ab_initio) / get(lapse_ab_initio));
+
+  const auto h_prefac1 = amp_coef_L1 * roll_on_L1 * get(weight) *
+                         pow(log_fac_1, exp_L1) * log_fac_1;
+
+  // local H_a
+  auto gauge_h_expected = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    gauge_h_expected.get(a) =
+        h_prefac1 * spacetime_unit_normal_one_form_ab_initio.get(a);
+  }
+
+  // Check that locally computed H_a matches the returned one
+  CHECK_ITERABLE_APPROX(gauge_h_expected, gauge_h);
+}
+
+// Test term 3/4 of gauge source function for Schwarzschild in Kerr-Schild coord
+template <typename Solution>
+void test_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& shift = get<gr::Tags::Shift<SpatialDim>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+
+  // Initialize settings
+  const double amp_coef_L2 = pdist(generator);
+  const int exp_L2 = idist(generator);
+  const double t_start_L2 = pdist(generator) * 0.1;
+  const double sigma_t_L2 = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+  const double roll_on_L2 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_L2, sigma_t_L2);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
+      gauge_h{};
+  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+      make_not_null(&gauge_h), gauge_h_init, lapse, shift,
+      sqrt_det_spatial_metric, spacetime_metric, t, x, 0., amp_coef_L2, 0., 0,
+      exp_L2, 0,  // exponents
+      // roll on function parameters for lapse / shift terms
+      -1., -1., -1., -1., t_start_L2, sigma_t_L2, -1., -1.,
+      r_max /* weight function */);
+
+  // Evaluate analytic solution for Schwarzschild, ab initio.
+  const double mass = solution.mass();
+  const std::array<double, SpatialDim> center = solution.center();
+  // 1) shift coords with BH at the center
+  auto x_minus_center = x;
+  // DataVector r_squared(get_size(x), 0.);
+  auto r_squared = get<0>(x);
+  r_squared -= get<0>(x);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    x_minus_center.get(i) -= gsl::at(center, i);
+    r_squared += square(x_minus_center.get(i));
+  }
+  const DataVector r_ = sqrt(r_squared);
+  // 2) compute scalar function that defines KerrSchild coords
+  const DataVector H = mass * (1. / r_);
+  const DataVector H2 = H * 2.;
+  // 3) compute lapse
+  const Scalar<DataVector> lapse_ab_initio{sqrt(1. / (1. + H2))};
+
+  const auto& spacetime_unit_normal_one_form_ab_initio =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio);
+
+  // compute GR dependent terms
+  const auto& log_fac_2 = log(1. / get(lapse_ab_initio));
+
+  // compute other terms
+  const auto h_prefac1 = amp_coef_L2 * roll_on_L2 * get(weight) *
+                         pow(log_fac_2, exp_L2) * log_fac_2;
+
+  // local H_a
+  auto gauge_h_expected = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    gauge_h_expected.get(a) =
+        h_prefac1 * spacetime_unit_normal_one_form_ab_initio.get(a);
+  }
+
+  // Check that locally computed H_a matches the returned one
+  CHECK_ITERABLE_APPROX(gauge_h_expected, gauge_h);
+}
+
+// Test term 4/4 of gauge source function for Schwarzschild in Kerr-Schild coord
+template <typename Solution>
+void test_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& shift = get<gr::Tags::Shift<SpatialDim>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+
+  // Initialize settings
+  const double amp_coef_S = pdist(generator);
+  const int exp_S = idist(generator);
+  const double t_start_S = pdist(generator) * 0.1;
+  const double sigma_t_S = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+  const double roll_on_S =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_S, sigma_t_S);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>
+      gauge_h{};
+  GeneralizedHarmonic::damped_harmonic_h<SpatialDim, Frame::Inertial>(
+      make_not_null(&gauge_h), gauge_h_init, lapse, shift,
+      sqrt_det_spatial_metric, spacetime_metric, t, x, 0., 0., amp_coef_S, 0, 0,
+      exp_S,  // exponents
+      // roll on function parameters for lapse / shift terms
+      -1., -1., -1., -1., -1., -1., t_start_S, sigma_t_S,
+      r_max /* weight function */);
+
+  // Evaluate analytic solution for Schwarzschild, ab initio.
+  const double mass = solution.mass();
+  const std::array<double, SpatialDim> center = solution.center();
+  // 1) shift coords with BH at the center
+  auto x_minus_center = x;
+  // DataVector r_squared(get_size(x), 0.);
+  auto r_squared = get<0>(x);
+  r_squared -= get<0>(x);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    x_minus_center.get(i) -= gsl::at(center, i);
+    r_squared += square(x_minus_center.get(i));
+  }
+  const DataVector r_ = sqrt(r_squared);
+  // 2) compute scalar function that defines KerrSchild coords
+  const DataVector H = mass * (1. / r_);
+  const DataVector H2 = H * 2.;
+  // 3) compute lapse
+  const Scalar<DataVector> lapse_ab_initio{sqrt(1. / (1. + H2))};
+  // 4) compute shift
+  auto shift_ab_initio =
+      make_with_value<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    shift_ab_initio.get(i) = (H2 / (1. + H2)) * x_minus_center.get(i) / r_;
+  }
+  // 5) compute 3-metric
+  auto spatial_metric_ab_initio =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      spatial_metric_ab_initio.get(i, j) =
+          H2 * x_minus_center.get(i) * x_minus_center.get(j) / r_squared;
+      if (i == j) {
+        spatial_metric_ab_initio.get(i, i) += 1.;
+      }
+    }
+  }
+  const auto& spacetime_metric_ab_initio = gr::spacetime_metric(
+      lapse_ab_initio, shift_ab_initio, spatial_metric_ab_initio);
+  const auto& spacetime_unit_normal_one_form_ab_initio =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio);
+  const auto& det_spatial_metric_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio).first;
+  Scalar<DataVector> sqrt_det_spatial_metric_ab_initio(
+      sqrt(get(det_spatial_metric_ab_initio)));
+
+  // compute GR dependent terms
+  const auto& log_fac_1 =
+      log(get(sqrt_det_spatial_metric_ab_initio) / get(lapse_ab_initio));
+
+  const auto h_prefac2 = -amp_coef_S * roll_on_S * get(weight) *
+                         pow(log_fac_1, exp_S) / get(lapse_ab_initio);
+
+  // local H_a
+  auto gauge_h_expected = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::GaugeH<SpatialDim, Frame::Inertial>>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      gauge_h_expected.get(a) += h_prefac2 *
+                                 spacetime_metric_ab_initio.get(a, i + 1) *
+                                 shift_ab_initio.get(i);
+    }
+  }
+
+  // Check that locally computed H_a match returned one
+  CHECK_ITERABLE_APPROX(gauge_h_expected, gauge_h);
+}
+
+//
+//  Tests of spacetime derivatives of the damped harmonic gauge source function
+//
+// Wrap `SpacetimeDerivDampedHarmonicHCompute::function` here to make its time
+// argument a double, allowing for `pypp::check_with_random_values` to work.
+template <size_t SpatialDim, typename Frame>
+typename db::item_type<
+    GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<SpatialDim, Frame>>
+wrap_SpacetimeDerivDampedHarmonicHCompute(
+    const typename db::item_type<GeneralizedHarmonic::Tags::InitialGaugeH<
+        SpatialDim, Frame>>& gauge_h_init,
+    const typename db::item_type<
+        GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<
+            SpatialDim, Frame>>& dgauge_h_init,
+    const Scalar<DataVector>& lapse,
+    const tnsr::I<DataVector, SpatialDim, Frame>& shift,
+    const tnsr::a<DataVector, SpatialDim, Frame>&
+        spacetime_unit_normal_one_form,
+    const Scalar<DataVector>& sqrt_det_spatial_metric,
+    const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& spacetime_metric,
+    const tnsr::aa<DataVector, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataVector, SpatialDim, Frame>& phi, const double t,
+    const double t_start, const double sigma_t,
+    const tnsr::I<DataVector, SpatialDim, Frame>& coords,
+    const double sigma_r) noexcept {
+  const Slab slab(0, t);
+  const Rational frac(1);
+  const Time current_time(slab, frac);
+  return GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
+      SpatialDim, Frame>::function(gauge_h_init, dgauge_h_init, lapse, shift,
+                                   spacetime_unit_normal_one_form,
+                                   sqrt_det_spatial_metric,
+                                   inverse_spatial_metric, spacetime_metric, pi,
+                                   phi, current_time, t_start, sigma_t, coords,
+                                   sigma_r);
+}
+// Compare with Python implementation
+template <size_t SpatialDim, typename Frame>
+void test_deriv_damped_harmonic_h_function(
+    const DataVector& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      static_cast<typename db::item_type<
+          GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<SpatialDim,
+                                                          Frame>> (*)(
+          const typename db::item_type<
+              GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame>>&,
+          const typename db::item_type<
+              GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<SpatialDim,
+                                                                     Frame>>&,
+          const Scalar<DataVector>&,
+          const tnsr::I<DataVector, SpatialDim, Frame>&,
+          const tnsr::a<DataVector, SpatialDim, Frame>&,
+          const Scalar<DataVector>&,
+          const tnsr::II<DataVector, SpatialDim, Frame>&,
+          const tnsr::aa<DataVector, SpatialDim, Frame>&,
+          const tnsr::aa<DataVector, SpatialDim, Frame>&,
+          const tnsr::iaa<DataVector, SpatialDim, Frame>&, const double,
+          const double, const double,
+          const tnsr::I<DataVector, SpatialDim, Frame>&, const double)>(
+          &wrap_SpacetimeDerivDampedHarmonicHCompute<SpatialDim, Frame>),
+      "Evolution.Systems.GeneralizedHarmonic.GaugeSourceFunctions."
+      "DampedHarmonic",
+      "spacetime_deriv_damped_harmonic_gauge_source_function", {{{0.1, 10.}}},
+      used_for_size, 1.e-11);
+}
+
+// Test term 1/4 of spacetime deriv of gauge source function
+void test_deriv_damped_harmonic_h_function_term_1_of_4(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> rdist(0.1, 1.);
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Randomized 3 + 1 quantities
+  // Note: Ranges from which random numbers are drawn to populate 3+1 tensors
+  //       below were chosen to not throw FPEs (by trial & error).
+  std::uniform_real_distribution<> dist(0.9, 1.);
+  const DataVector& used_for_size = get<0>(x);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto dt_lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto d_lapse =
+      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto dt_shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto d_shift = make_with_random_values<
+      tnsr::iJ<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  get<0, 0>(spatial_metric) = get<1, 1>(spatial_metric) =
+      get<2, 2>(spatial_metric) = 1.;
+  std::uniform_real_distribution<> dist2(0., 0.12);
+  const auto dspatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      spatial_metric.get(i, j) += dspatial_metric.get(i, j);
+    }
+  }
+  const auto dt_spatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  const auto d_spatial_metric = make_with_random_values<
+      tnsr::ijj<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+
+  // Initialize settings
+  // roll on function parameters
+  const double t_start_HI = pdist(generator) * 0.1;
+  const double sigma_t_HI = pdist(generator) * 0.2;
+
+  // Tempering functions
+  const double roll_on_HI =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_HI, sigma_t_HI);
+  const auto d0_roll_on_HI = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      time_deriv_of_roll_on_function(t, t_start_HI, sigma_t_HI);
+
+  // Initialize initial gauge function and its roll-off function
+  const auto gauge_h_init = make_with_random_values<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      make_not_null(&generator), make_not_null(&rdist), x);
+  const auto d4_gauge_h_init = make_with_random_values<typename db::item_type<
+      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<SpatialDim,
+                                                             Frame::Inertial>>>(
+      make_not_null(&generator), make_not_null(&rdist), x);
+
+  // Calc \f$ \partial_a T1 \f$
+  auto dT1 =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t b = 0; b < SpatialDim + 1; ++b) {
+    dT1.get(0, b) -= gauge_h_init.get(b) * d0_roll_on_HI;
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      dT1.get(a, b) += (1. - roll_on_HI) * d4_gauge_h_init.get(a, b);
+    }
+  }
+
+  // Calc \f$ \partial_a H_b = dT1_{ab} \f$
+  const auto& d4_gauge_h_expected = dT1;
+
+  // Check that locally computed \f$\partial_a H_b\f$ matches returned one
+  typename db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
+      SpatialDim, Frame::Inertial>>
+      d4_gauge_h{};
+  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
+                                                         Frame::Inertial>(
+      make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, x, 0., 0., 0., 0, 0,
+      0,  // exponents
+      // roll on function parameters
+      t_start_HI, sigma_t_HI, -1., -1., -1., -1., -1., -1.,
+      -1. /* weight function */);
+
+  CHECK_ITERABLE_APPROX(d4_gauge_h_expected, d4_gauge_h);
+}
+
+// Test term 2/4 of spacetime deriv of gauge source function
+void test_deriv_damped_harmonic_h_function_term_2_of_4(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Randomized 3 + 1 quantities
+  // Note: Ranges from which random numbers are drawn to populate 3+1 tensors
+  //       below were chosen to not throw FPEs (by trial & error).
+  std::uniform_real_distribution<> dist(0.9, 1.);
+  const DataVector& used_for_size = get<0>(x);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto dt_lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto d_lapse =
+      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto dt_shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto d_shift = make_with_random_values<
+      tnsr::iJ<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  get<0, 0>(spatial_metric) = get<1, 1>(spatial_metric) =
+      get<2, 2>(spatial_metric) = 1.;
+  std::uniform_real_distribution<> dist2(0., 0.12);
+  const auto dspatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      spatial_metric.get(i, j) += dspatial_metric.get(i, j);
+    }
+  }
+  const auto dt_spatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  const auto d_spatial_metric = make_with_random_values<
+      tnsr::ijj<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto spacetime_unit_normal =
+      gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift);
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift, inverse_spatial_metric);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+
+  // commonly used terms
+  const auto exp_fac_1 = 1. / 2.;
+  const auto& log_fac_1 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
+          DataVector>(lapse, sqrt_det_spatial_metric, exp_fac_1);
+
+  // Initialize settings
+  const double amp_coef_L1 = pdist(generator);
+  const int exp_L1 = idist(generator);
+  const double t_start_L1 = pdist(generator) * 0.1;
+  const double sigma_t_L1 = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+
+  // Tempering functions
+  const double roll_on_L1 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_L1, sigma_t_L1);
+  const auto d0_roll_on_L1 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      time_deriv_of_roll_on_function(t, t_start_L1, sigma_t_L1);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
+                                         DataVector>(x, r_max);
+
+  // coeffs that enter gauge source function
+  const auto mu_L1 =
+      amp_coef_L1 * roll_on_L1 * get(weight) * pow(get(log_fac_1), exp_L1);
+
+  // Calc \f$ \mu_1 = \mu_{L1} log(rootg/N) = R W log(rootg/N)^5\f$
+  const auto mu1 = mu_L1 * get(log_fac_1);
+
+  // Calc \f$ \partial_a [R W] \f$
+  auto d4_RW_L1 = d4_weight;
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_RW_L1.get(a) *= roll_on_L1;
+  }
+  d4_RW_L1.get(0) += get(weight) * d0_roll_on_L1;
+
+  // Calc derivs of \f$ \mu_1 \f$
+  auto d4_mu1 =
+      make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse), 0.);
+  {
+    const auto& d4_log_fac_mu1 =
+        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+            spacetime_deriv_of_power_log_factor_metric_lapse<
+                SpatialDim, Frame::Inertial, DataVector>(
+                lapse, shift, spacetime_unit_normal, inverse_spatial_metric,
+                sqrt_det_spatial_metric, dt_spatial_metric, pi, phi, exp_fac_1,
+                exp_L1 + 1);
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      // \f$ \partial_a \mu_1 \f$
+      d4_mu1.get(a) =
+          amp_coef_L1 * pow(get(log_fac_1), exp_L1 + 1) * d4_RW_L1.get(a) +
+          amp_coef_L1 * roll_on_L1 * get(weight) * d4_log_fac_mu1.get(a);
+    }
+  }
+
+  // Calc \f$ \partial_a N = {\partial_0 N, \partial_i N} \f$
+  auto d4_N = make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+      get(lapse), 0.);
+  d4_N.get(0) = get(dt_lapse);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_N.get(1 + i) = d_lapse.get(i);
+  }
+
+  // Calc \f$ \partial_a n_b = {-\partial_a N, 0, 0, 0} \f$
+  auto d4_normal_one_form =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse), 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_normal_one_form.get(a, 0) -= d4_N.get(a);
+  }
+
+  // Calc \f$ \partial_a T2 \f$
+  auto dT2 =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      dT2.get(a, b) += mu1 * d4_normal_one_form.get(a, b) +
+                       d4_mu1.get(a) * spacetime_unit_normal_one_form.get(b);
+    }
+  }
+
+  // Initialize initial gauge function and its roll-off function
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  const auto d4_gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<SpatialDim,
+                                                             Frame::Inertial>>>(
+      x, 0.);
+
+  // Calc \f$ \partial_a H_b = dT2_{ab} \f$
+  const auto& d4_gauge_h_expected = dT2;
+
+  // Check that locally computed \f$\partial_a H_b\f$ matches returned one
+  typename db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
+      SpatialDim, Frame::Inertial>>
+      d4_gauge_h{};
+  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
+                                                         Frame::Inertial>(
+      make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, x, amp_coef_L1, 0.,
+      0., exp_L1, 0, 0,  // exponents
+      // roll on function parameters
+      -1., -1., t_start_L1, sigma_t_L1, -1., -1., -1., -1.,
+      r_max /* weight function */);
+
+  CHECK_ITERABLE_APPROX(d4_gauge_h_expected, d4_gauge_h);
+}
+
+// Test term 3/4 of spacetime deriv of gauge source function
+void test_deriv_damped_harmonic_h_function_term_3_of_4(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Randomized 3 + 1 quantities
+  // Note: Ranges from which random numbers are drawn to populate 3+1 tensors
+  //       below were chosen to not throw FPEs (by trial & error).
+  std::uniform_real_distribution<> dist(0.9, 1.);
+  const DataVector& used_for_size = get<0>(x);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto dt_lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto d_lapse =
+      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto dt_shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto d_shift = make_with_random_values<
+      tnsr::iJ<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  get<0, 0>(spatial_metric) = get<1, 1>(spatial_metric) =
+      get<2, 2>(spatial_metric) = 1.;
+  std::uniform_real_distribution<> dist2(0., 0.12);
+  const auto dspatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      spatial_metric.get(i, j) += dspatial_metric.get(i, j);
+    }
+  }
+  const auto dt_spatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  const auto d_spatial_metric = make_with_random_values<
+      tnsr::ijj<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto spacetime_unit_normal =
+      gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift);
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift, inverse_spatial_metric);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+
+  // commonly used terms
+  const auto exp_fac_2 = 0.;
+  const auto& log_fac_2 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
+          DataVector>(lapse, sqrt_det_spatial_metric, exp_fac_2);
+
+  // Initialize settings
+  const double amp_coef_L2 = pdist(generator);
+  const int exp_L2 = idist(generator);
+  const double t_start_L2 = pdist(generator) * 0.1;
+  const double sigma_t_L2 = pdist(generator) * 0.2;
+  // weight function
+  const double r_max = pdist(generator) * 0.7;
+
+  // Tempering functions
+  const double roll_on_L2 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_L2, sigma_t_L2);
+  const auto d0_roll_on_L2 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      time_deriv_of_roll_on_function(t, t_start_L2, sigma_t_L2);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
+                                         DataVector>(x, r_max);
+
+  // coeffs that enter gauge source function
+  const auto mu_L2 =
+      amp_coef_L2 * roll_on_L2 * get(weight) * pow(get(log_fac_2), exp_L2);
+
+  // Calc \f$ \mu_2 = \mu_{L2} log(1/N) = R W log(1/N)^5\f$
+  const auto mu2 = mu_L2 * get(log_fac_2);
+
+  // Calc \f$ \partial_a [R W] \f$
+  auto d4_RW_L2 = d4_weight;
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_RW_L2.get(a) *= roll_on_L2;
+  }
+  d4_RW_L2.get(0) += get(weight) * d0_roll_on_L2;
+
+  // Calc derivs of \f$ \mu_2 \f$
+  auto d4_mu2 =
+      make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse), 0.);
+  {
+    const auto& d4_log_fac_mu2 =
+        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+            spacetime_deriv_of_power_log_factor_metric_lapse<
+                SpatialDim, Frame::Inertial, DataVector>(
+                lapse, shift, spacetime_unit_normal, inverse_spatial_metric,
+                sqrt_det_spatial_metric, dt_spatial_metric, pi, phi, exp_fac_2,
+                exp_L2 + 1);
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      // \f$ \partial_a \mu_2 \f$
+      d4_mu2.get(a) =
+          amp_coef_L2 * pow(get(log_fac_2), exp_L2 + 1) * d4_RW_L2.get(a) +
+          amp_coef_L2 * roll_on_L2 * get(weight) * d4_log_fac_mu2.get(a);
+    }
+  }
+
+  // Calc \f$ \partial_a N = {\partial_0 N, \partial_i N} \f$
+  auto d4_N = make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+      get(lapse), 0.);
+  d4_N.get(0) = get(dt_lapse);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_N.get(1 + i) = d_lapse.get(i);
+  }
+
+  // Calc \f$ \partial_a n_b = {-\partial_a N, 0, 0, 0} \f$
+  auto d4_normal_one_form =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse), 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_normal_one_form.get(a, 0) -= d4_N.get(a);
+  }
+
+  // Calc \f$ \partial_a T2 \f$
+  auto dT2 =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      dT2.get(a, b) += mu2 * d4_normal_one_form.get(a, b) +
+                       d4_mu2.get(a) * spacetime_unit_normal_one_form.get(b);
+    }
+  }
+
+  // Initialize initial gauge function and its roll-off function
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  const auto d4_gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<SpatialDim,
+                                                             Frame::Inertial>>>(
+      x, 0.);
+
+  // Calc \f$ \partial_a H_b = dT2_{ab} \f$
+  const auto& d4_gauge_h_expected = dT2;
+
+  // Check that locally computed \f$\partial_a H_b\f$ matches returned one
+  typename db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
+      SpatialDim, Frame::Inertial>>
+      d4_gauge_h{};
+  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
+                                                         Frame::Inertial>(
+      make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, x, 0., amp_coef_L2,
+      0., 0, exp_L2, 0,  // exponents
+      // roll on function parameters for lapse / shift terms
+      -1., -1., -1., -1., t_start_L2, sigma_t_L2, -1., -1.,
+      r_max /* weight function */);
+
+  CHECK_ITERABLE_APPROX(d4_gauge_h_expected, d4_gauge_h);
+}
+
+// Test term 4/4 of spacetime deriv of gauge source function
+void test_deriv_damped_harmonic_h_function_term_4_of_4(
+    const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Randomized 3 + 1 quantities
+  // Note: Ranges from which random numbers are drawn to populate 3+1 tensors
+  //       below were chosen to not throw FPEs (by trial & error).
+  std::uniform_real_distribution<> dist(0.9, 1.);
+  const DataVector& used_for_size = get<0>(x);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto dt_lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto d_lapse =
+      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto dt_shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto d_shift = make_with_random_values<
+      tnsr::iJ<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  get<0, 0>(spatial_metric) = get<1, 1>(spatial_metric) =
+      get<2, 2>(spatial_metric) = 1.;
+  std::uniform_real_distribution<> dist2(0., 0.12);
+  const auto dspatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      spatial_metric.get(i, j) += dspatial_metric.get(i, j);
+    }
+  }
+  const auto dt_spatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  const auto d_spatial_metric = make_with_random_values<
+      tnsr::ijj<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto spacetime_unit_normal =
+      gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift);
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift, inverse_spatial_metric);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+  const auto d4_spacetime_metric = gr::derivatives_of_spacetime_metric(
+      lapse, dt_lapse, d_lapse, shift, dt_shift, d_shift, spatial_metric,
+      dt_spatial_metric, d_spatial_metric);
+
+  // commonly used terms
+  const auto exp_fac_1 = 1. / 2.;
+  const auto& one_over_lapse = 1. / get(lapse);
+  const auto& log_fac_1 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
+          DataVector>(lapse, sqrt_det_spatial_metric, exp_fac_1);
+
+  // Initialize settings
+  const double amp_coef_S = pdist(generator);
+  const int exp_S = idist(generator);
+  const double t_start_S = pdist(generator) * 0.1;
+  const double sigma_t_S = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+
+  // Tempering functions
+  const double roll_on_S =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_S, sigma_t_S);
+  const auto d0_roll_on_S = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      time_deriv_of_roll_on_function(t, t_start_S, sigma_t_S);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
+                                         DataVector>(x, r_max);
+
+  // coeffs that enter gauge source function
+  const auto mu_S =
+      amp_coef_S * roll_on_S * get(weight) * pow(get(log_fac_1), exp_S);
+  const auto mu_S_over_N = mu_S * one_over_lapse;
+
+  // Calc \f$ \partial_a [R W] \f$
+  auto d4_RW_S = d4_weight;
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_RW_S.get(a) *= roll_on_S;
+  }
+  d4_RW_S.get(0) += get(weight) * d0_roll_on_S;
+
+  // Calc derivs of \f$ \mu_S \f$
+  auto d4_mu_S =
+      make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse), 0.);
+  {
+    const auto& d4_log_fac_muS =
+        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+            spacetime_deriv_of_power_log_factor_metric_lapse<
+                SpatialDim, Frame::Inertial, DataVector>(
+                lapse, shift, spacetime_unit_normal, inverse_spatial_metric,
+                sqrt_det_spatial_metric, dt_spatial_metric, pi, phi, exp_fac_1,
+                exp_S);
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      // \f$ \partial_a \mu_{L1} \f$
+      d4_mu_S.get(a) =
+          amp_coef_S * d4_RW_S.get(a) * pow(get(log_fac_1), exp_S) +
+          amp_coef_S * roll_on_S * get(weight) * d4_log_fac_muS.get(a);
+    }
+  }
+
+  // Calc \f$ \partial_a N = {\partial_0 N, \partial_i N} \f$
+  auto d4_N = make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+      get(lapse), 0.);
+  d4_N.get(0) = get(dt_lapse);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_N.get(1 + i) = d_lapse.get(i);
+  }
+
+  // Calc \f$ \partial_a N^i = {\partial_0 N^i, \partial_j N^i} \f$
+  auto d4_shift =
+      make_with_value<tnsr::aB<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse), 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_shift.get(0, 1 + i) = dt_shift.get(i);
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      d4_shift.get(1 + j, 1 + i) = d_shift.get(j, i);
+    }
+  }
+
+  // \f[ \partial_a (\mu_S/N) = (1/N) \partial_a \mu_{S}
+  //         - (\mu_{S}/N^2) \partial_a N
+  // \f]
+  auto d4_muS_over_N =
+      make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse), 0.);
+  {
+    auto prefac = -mu_S * one_over_lapse * one_over_lapse;
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_muS_over_N.get(a) +=
+          one_over_lapse * d4_mu_S.get(a) + prefac * d4_N.get(a);
+    }
+  }
+
+  // Calc \f$ \partial_a T3 \f$ (note minus sign)
+  auto dT3 =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        dT3.get(a, b) -= d4_muS_over_N.get(a) * spacetime_metric.get(b, i + 1) *
+                         shift.get(i);
+        dT3.get(a, b) -=
+            mu_S_over_N * d4_spacetime_metric.get(a, b, i + 1) * shift.get(i);
+        dT3.get(a, b) -= mu_S_over_N * spacetime_metric.get(b, i + 1) *
+                         d4_shift.get(a, i + 1);
+      }
+    }
+  }
+
+  // Initialize initial gauge function and its roll-off function
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  const auto d4_gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<SpatialDim,
+                                                             Frame::Inertial>>>(
+      x, 0.);
+
+  // Calc \f$ \partial_a H_b = dT3_{ab} \f$
+  const auto& d4_gauge_h_expected = dT3;
+
+  // Check that locally computed \f$\partial_a H_b\f$ matches returned one
+  typename db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
+      SpatialDim, Frame::Inertial>>
+      d4_gauge_h{};
+  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
+                                                         Frame::Inertial>(
+      make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, x, 0., 0.,
+      amp_coef_S, 0, 0, exp_S,  // exponents
+      // roll on function parameters for lapse / shift terms
+      -1., -1., -1., -1., -1., -1., t_start_S, sigma_t_S,
+      r_max /* weight function */);
+
+  CHECK_ITERABLE_APPROX(d4_gauge_h_expected, d4_gauge_h);
+}
+
+// The next three functions test spacetime derivatives of the gauge source
+// function for Schwarzschild spacetime, in Kerr-Schild coordinates.
+
+// Test term 2/4 of gauge source function for Schwarzschild in Kerr-Schild coord
+template <typename Solution>
+void test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<>>>(vars);
+  const auto& d_lapse =
+      get<typename Solution::template DerivLapse<DataVector>>(vars);
+  const auto& shift = get<gr::Tags::Shift<SpatialDim>>(vars);
+  const auto& d_shift =
+      get<typename Solution::template DerivShift<DataVector>>(vars);
+  const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<SpatialDim>>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
+  const auto& dt_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<SpatialDim>>>(vars);
+  const auto& d_spatial_metric =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto spacetime_unit_normal =
+      gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift);
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift, inverse_spatial_metric);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+
+  // Initialize settings
+  const double amp_coef_L1 = pdist(generator);
+  const int exp_L1 = idist(generator);
+  const double t_start_L1 = pdist(generator) * 0.1;
+  const double sigma_t_L1 = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+
+  // Initialize initial gauge function and its roll-off function
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  const auto d4_gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<SpatialDim,
+                                                             Frame::Inertial>>>(
+      x, 0.);
+
+  // compute d4H using function being tested
+  typename db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
+      SpatialDim, Frame::Inertial>>
+      d4_gauge_h{};
+  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
+                                                         Frame::Inertial>(
+      make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, x, amp_coef_L1, 0.,
+      0., exp_L1, 0, 0,  // exponents
+      // roll on function parameters
+      -1., -1., t_start_L1, sigma_t_L1, -1., -1., -1., -1.,
+      r_max /* weight function */);
+
+  // Tempering functions
+  const double roll_on_L1 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_L1, sigma_t_L1);
+  const auto d0_roll_on_L1 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      time_deriv_of_roll_on_function(t, t_start_L1, sigma_t_L1);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
+                                         DataVector>(x, r_max);
+
+  // Evaluate analytic solution for Schwarzschild, ab initio.
+  const double mass = solution.mass();
+  const std::array<double, SpatialDim> center = solution.center();
+  // 1) shift coords with BH at the center
+  auto x_minus_center = x;
+  // DataVector r_squared(get_size(x), 0.);
+  auto r_squared = get<0>(x);
+  r_squared -= get<0>(x);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    x_minus_center.get(i) -= gsl::at(center, i);
+    r_squared += square(x_minus_center.get(i));
+  }
+  const DataVector r_ = sqrt(r_squared);
+  // 2) compute scalar function that defines KerrSchild coords
+  const DataVector H = mass * (1. / r_);
+  const DataVector H2 = H * 2.;
+  // 3) compute 3D null_one_form and its derivatives
+  tnsr::i<DataVector, SpatialDim, Frame::Inertial> null_one_form{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    null_one_form.get(i) = x_minus_center.get(i) / r_;
+  }
+  auto null_vec = null_one_form;
+  tnsr::ij<DataVector, SpatialDim, Frame::Inertial> deriv_null_one_form{};
+  const DataVector denom = 1. / r_squared;
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      deriv_null_one_form.get(i, j) =
+          -(null_one_form.get(i) * null_one_form.get(j)) / r_;
+      if (i == j) {
+        deriv_null_one_form.get(j, i) += (1. / r_);
+      }
+    }
+  }
+  // 4) compute deriv of H
+  tnsr::i<DataVector, SpatialDim, Frame::Inertial> deriv_H{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    deriv_H.get(i) = -(H / r_squared) * x_minus_center.get(i);
+  }
+  // 5) compute lapse & its derivatives
+  const Scalar<DataVector> lapse_ab_initio{sqrt(1. / (1. + H2))};
+  const auto dt_lapse_ab_initio = make_with_value<Scalar<DataVector>>(x, 0.);
+  auto d_lapse_ab_initio =
+      make_with_value<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d_lapse_ab_initio.get(i) -= (pow<3>(get(lapse_ab_initio)) * deriv_H.get(i));
+  }
+  // 6) compute shift & its derivatives
+  auto shift_ab_initio =
+      make_with_value<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    shift_ab_initio.get(i) = (H2 / (1. + H2)) * null_vec.get(i);
+  }
+  const auto dt_shift_ab_initio =
+      make_with_value<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  auto d_shift_ab_initio =
+      make_with_value<tnsr::iJ<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      d_shift_ab_initio.get(i, j) =
+          2. * pow<4>(get(lapse_ab_initio)) * null_vec.get(j) * deriv_H.get(i) +
+          H2 * square(get(lapse_ab_initio)) * deriv_null_one_form.get(i, j);
+    }
+  }
+  // 7) compute 3-metric & its derivatives
+  auto spatial_metric_ab_initio =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      spatial_metric_ab_initio.get(i, j) =
+          H2 * null_vec.get(i) * null_vec.get(j);
+      if (i == j) {
+        spatial_metric_ab_initio.get(i, i) += 1.;
+      }
+    }
+  }
+  auto dt_spatial_metric_ab_initio =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  auto d_spatial_metric_ab_initio =
+      make_with_value<tnsr::ijj<DataVector, SpatialDim, Frame::Inertial>>(x,
+                                                                          0.);
+  for (size_t k = 0; k < SpatialDim; ++k) {
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t j = i; j < SpatialDim; ++j) {
+        d_spatial_metric_ab_initio.get(k, i, j) =
+            2. * null_vec.get(i) * null_vec.get(j) * deriv_H.get(k) +
+            H2 * (null_one_form.get(i) * deriv_null_one_form.get(k, j) +
+                  null_one_form.get(j) * deriv_null_one_form.get(k, i));
+      }
+    }
+  }
+
+  const auto& spacetime_metric_ab_initio = gr::spacetime_metric(
+      lapse_ab_initio, shift_ab_initio, spatial_metric_ab_initio);
+  const auto& spacetime_unit_normal_one_form_ab_initio =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio);
+  const auto spacetime_unit_normal_ab_initio =
+      gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio, shift_ab_initio);
+  const auto& inverse_spatial_metric_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio).second;
+  const auto inverse_spacetime_metric_ab_initio =
+      gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio, shift_ab_initio, inverse_spatial_metric_ab_initio);
+  const auto& det_spatial_metric_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio).first;
+  Scalar<DataVector> sqrt_det_spatial_metric_ab_initio(
+      sqrt(get(det_spatial_metric_ab_initio)));
+  const auto phi_ab_initio = GeneralizedHarmonic::phi(
+      lapse_ab_initio, d_lapse_ab_initio, shift_ab_initio, d_shift_ab_initio,
+      spatial_metric_ab_initio, d_spatial_metric_ab_initio);
+  const auto pi_ab_initio = GeneralizedHarmonic::pi(
+      lapse_ab_initio, dt_lapse_ab_initio, shift_ab_initio, dt_shift_ab_initio,
+      spatial_metric_ab_initio, dt_spatial_metric_ab_initio, phi_ab_initio);
+
+  // commonly used terms
+  const auto exp_fac_1 = 1. / 2.;
+  const auto& log_fac_1 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
+          DataVector>(lapse_ab_initio, sqrt_det_spatial_metric_ab_initio,
+                      exp_fac_1);
+
+  // compute GR dependent terms
+  // coeffs that enter gauge source function
+  const auto mu_L1 =
+      amp_coef_L1 * roll_on_L1 * get(weight) * pow(get(log_fac_1), exp_L1);
+
+  // Calc \f$ \mu_1 = \mu_{L1} log(rootg/N) = R W log(rootg/N)^5\f$
+  const auto mu1 = mu_L1 * get(log_fac_1);
+
+  // Calc \f$ \partial_a [R W] \f$
+  auto d4_RW_L1 = d4_weight;
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_RW_L1.get(a) *= roll_on_L1;
+  }
+  d4_RW_L1.get(0) += get(weight) * d0_roll_on_L1;
+
+  // Calc derivs of \f$ \mu_1 \f$
+  auto d4_mu1 =
+      make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse), 0.);
+  {
+    const auto& d4_log_fac_mu1 =
+        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+            spacetime_deriv_of_power_log_factor_metric_lapse<
+                SpatialDim, Frame::Inertial, DataVector>(
+                lapse_ab_initio, shift_ab_initio,
+                spacetime_unit_normal_ab_initio,
+                inverse_spatial_metric_ab_initio,
+                sqrt_det_spatial_metric_ab_initio, dt_spatial_metric_ab_initio,
+                pi_ab_initio, phi_ab_initio, exp_fac_1, exp_L1 + 1);
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      // \f$ \partial_a \mu_1 \f$
+      d4_mu1.get(a) =
+          amp_coef_L1 * pow(get(log_fac_1), exp_L1 + 1) * d4_RW_L1.get(a) +
+          amp_coef_L1 * roll_on_L1 * get(weight) * d4_log_fac_mu1.get(a);
+    }
+  }
+
+  // Calc \f$ \partial_a N = {\partial_0 N, \partial_i N} \f$
+  auto d4_N = make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+      get(lapse_ab_initio), 0.);
+  d4_N.get(0) = get(dt_lapse_ab_initio);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_N.get(1 + i) = d_lapse_ab_initio.get(i);
+  }
+
+  // Calc \f$ \partial_a n_b = {-\partial_a N, 0, 0, 0} \f$
+  auto d4_normal_one_form =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse_ab_initio), 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_normal_one_form.get(a, 0) -= d4_N.get(a);
+  }
+
+  // Calc \f$ \partial_a T2 \f$
+  auto dT2 =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      dT2.get(a, b) +=
+          mu1 * d4_normal_one_form.get(a, b) +
+          d4_mu1.get(a) * spacetime_unit_normal_one_form_ab_initio.get(b);
+    }
+  }
+
+  // Calc \f$ \partial_a H_b = dT2_{ab} \f$
+  const auto& d4_gauge_h_expected = dT2;
+
+  // Check that locally computed \f$\partial_a H_b\f$ matches returned one
+  CHECK_ITERABLE_APPROX(d4_gauge_h_expected, d4_gauge_h);
+}
+
+// Test term 3/4 of spacetime deriv of gauge source function for Kerr-Schild
+template <typename Solution>
+void test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<>>>(vars);
+  const auto& d_lapse =
+      get<typename Solution::template DerivLapse<DataVector>>(vars);
+  const auto& shift = get<gr::Tags::Shift<SpatialDim>>(vars);
+  const auto& d_shift =
+      get<typename Solution::template DerivShift<DataVector>>(vars);
+  const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<SpatialDim>>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
+  const auto& dt_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<SpatialDim>>>(vars);
+  const auto& d_spatial_metric =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto spacetime_unit_normal =
+      gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift);
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift, inverse_spatial_metric);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+
+  // Initialize settings
+  const double amp_coef_L2 = pdist(generator);
+  const int exp_L2 = idist(generator);
+  const double t_start_L2 = pdist(generator) * 0.1;
+  const double sigma_t_L2 = pdist(generator) * 0.2;
+  // weight function
+  const double r_max = pdist(generator) * 0.7;
+
+  // Initialize initial gauge function and its roll-off function
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  const auto d4_gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<SpatialDim,
+                                                             Frame::Inertial>>>(
+      x, 0.);
+
+  // compute d4H using function being tested
+  typename db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
+      SpatialDim, Frame::Inertial>>
+      d4_gauge_h{};
+  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
+                                                         Frame::Inertial>(
+      make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, x, 0., amp_coef_L2,
+      0., 0, exp_L2, 0,  // exponents
+      // roll on function parameters for lapse / shift terms
+      -1., -1., -1., -1., t_start_L2, sigma_t_L2, -1., -1.,
+      r_max /* weight function */);
+
+  // Tempering functions
+  const double roll_on_L2 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_L2, sigma_t_L2);
+  const auto d0_roll_on_L2 = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      time_deriv_of_roll_on_function(t, t_start_L2, sigma_t_L2);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
+                                         DataVector>(x, r_max);
+
+  // Evaluate analytic solution for Schwarzschild, ab initio.
+  const double mass = solution.mass();
+  const std::array<double, SpatialDim> center = solution.center();
+  // 1) shift coords with BH at the center
+  auto x_minus_center = x;
+  // DataVector r_squared(get_size(x), 0.);
+  auto r_squared = get<0>(x);
+  r_squared -= get<0>(x);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    x_minus_center.get(i) -= gsl::at(center, i);
+    r_squared += square(x_minus_center.get(i));
+  }
+  const DataVector r_ = sqrt(r_squared);
+  // 2) compute scalar function that defines KerrSchild coords
+  const DataVector H = mass * (1. / r_);
+  const DataVector H2 = H * 2.;
+  // 3) compute 3D null_one_form and its derivatives
+  tnsr::i<DataVector, SpatialDim, Frame::Inertial> null_one_form{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    null_one_form.get(i) = x_minus_center.get(i) / r_;
+  }
+  auto null_vec = null_one_form;
+  tnsr::ij<DataVector, SpatialDim, Frame::Inertial> deriv_null_one_form{};
+  const DataVector denom = 1. / r_squared;
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      deriv_null_one_form.get(i, j) =
+          -(null_one_form.get(i) * null_one_form.get(j)) / r_;
+      if (i == j) {
+        deriv_null_one_form.get(j, i) += (1. / r_);
+      }
+    }
+  }
+  // 4) compute deriv of H
+  tnsr::i<DataVector, SpatialDim, Frame::Inertial> deriv_H{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    deriv_H.get(i) = -(H / r_squared) * x_minus_center.get(i);
+  }
+  // 5) compute lapse & its derivatives
+  const Scalar<DataVector> lapse_ab_initio{sqrt(1. / (1. + H2))};
+  const auto dt_lapse_ab_initio = make_with_value<Scalar<DataVector>>(x, 0.);
+  auto d_lapse_ab_initio =
+      make_with_value<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d_lapse_ab_initio.get(i) -= (pow<3>(get(lapse_ab_initio)) * deriv_H.get(i));
+  }
+  // 6) compute shift & its derivatives
+  auto shift_ab_initio =
+      make_with_value<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    shift_ab_initio.get(i) = (H2 / (1. + H2)) * null_vec.get(i);
+  }
+  const auto dt_shift_ab_initio =
+      make_with_value<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  auto d_shift_ab_initio =
+      make_with_value<tnsr::iJ<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      d_shift_ab_initio.get(i, j) =
+          2. * pow<4>(get(lapse_ab_initio)) * null_vec.get(j) * deriv_H.get(i) +
+          H2 * square(get(lapse_ab_initio)) * deriv_null_one_form.get(i, j);
+    }
+  }
+  // 7) compute 3-metric & its derivatives
+  auto spatial_metric_ab_initio =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      spatial_metric_ab_initio.get(i, j) =
+          H2 * null_vec.get(i) * null_vec.get(j);
+      if (i == j) {
+        spatial_metric_ab_initio.get(i, i) += 1.;
+      }
+    }
+  }
+  auto dt_spatial_metric_ab_initio =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  auto d_spatial_metric_ab_initio =
+      make_with_value<tnsr::ijj<DataVector, SpatialDim, Frame::Inertial>>(x,
+                                                                          0.);
+  for (size_t k = 0; k < SpatialDim; ++k) {
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t j = i; j < SpatialDim; ++j) {
+        d_spatial_metric_ab_initio.get(k, i, j) =
+            2. * null_vec.get(i) * null_vec.get(j) * deriv_H.get(k) +
+            H2 * (null_one_form.get(i) * deriv_null_one_form.get(k, j) +
+                  null_one_form.get(j) * deriv_null_one_form.get(k, i));
+      }
+    }
+  }
+
+  const auto& spacetime_metric_ab_initio = gr::spacetime_metric(
+      lapse_ab_initio, shift_ab_initio, spatial_metric_ab_initio);
+  const auto& spacetime_unit_normal_one_form_ab_initio =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio);
+  const auto spacetime_unit_normal_ab_initio =
+      gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio, shift_ab_initio);
+  const auto& inverse_spatial_metric_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio).second;
+  const auto inverse_spacetime_metric_ab_initio =
+      gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio, shift_ab_initio, inverse_spatial_metric_ab_initio);
+  const auto& det_spatial_metric_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio).first;
+  Scalar<DataVector> sqrt_det_spatial_metric_ab_initio(
+      sqrt(get(det_spatial_metric_ab_initio)));
+  const auto phi_ab_initio = GeneralizedHarmonic::phi(
+      lapse_ab_initio, d_lapse_ab_initio, shift_ab_initio, d_shift_ab_initio,
+      spatial_metric_ab_initio, d_spatial_metric_ab_initio);
+  const auto pi_ab_initio = GeneralizedHarmonic::pi(
+      lapse_ab_initio, dt_lapse_ab_initio, shift_ab_initio, dt_shift_ab_initio,
+      spatial_metric_ab_initio, dt_spatial_metric_ab_initio, phi_ab_initio);
+
+  // commonly used terms
+  const auto exp_fac_2 = 0.;
+  const auto& log_fac_2 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
+          DataVector>(lapse_ab_initio, sqrt_det_spatial_metric_ab_initio,
+                      exp_fac_2);
+
+  // coeffs that enter gauge source function
+  const auto mu_L2 =
+      amp_coef_L2 * roll_on_L2 * get(weight) * pow(get(log_fac_2), exp_L2);
+
+  // Calc \f$ \mu_2 = \mu_{L2} log(1/N) = R W log(1/N)^5\f$
+  const auto mu2 = mu_L2 * get(log_fac_2);
+
+  // Calc \f$ \partial_a [R W] \f$
+  auto d4_RW_L2 = d4_weight;
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_RW_L2.get(a) *= roll_on_L2;
+  }
+  d4_RW_L2.get(0) += get(weight) * d0_roll_on_L2;
+
+  // Calc derivs of \f$ \mu_2 \f$
+  auto d4_mu2 =
+      make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse_ab_initio), 0.);
+  {
+    const auto& d4_log_fac_mu2 =
+        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+            spacetime_deriv_of_power_log_factor_metric_lapse<
+                SpatialDim, Frame::Inertial, DataVector>(
+                lapse_ab_initio, shift_ab_initio,
+                spacetime_unit_normal_ab_initio,
+                inverse_spatial_metric_ab_initio,
+                sqrt_det_spatial_metric_ab_initio, dt_spatial_metric_ab_initio,
+                pi_ab_initio, phi_ab_initio, exp_fac_2, exp_L2 + 1);
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      // \f$ \partial_a \mu_2 \f$
+      d4_mu2.get(a) =
+          amp_coef_L2 * pow(get(log_fac_2), exp_L2 + 1) * d4_RW_L2.get(a) +
+          amp_coef_L2 * roll_on_L2 * get(weight) * d4_log_fac_mu2.get(a);
+    }
+  }
+
+  // Calc \f$ \partial_a N = {\partial_0 N, \partial_i N} \f$
+  auto d4_N = make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+      get(lapse_ab_initio), 0.);
+  d4_N.get(0) = get(dt_lapse);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_N.get(1 + i) = d_lapse_ab_initio.get(i);
+  }
+
+  // Calc \f$ \partial_a n_b = {-\partial_a N, 0, 0, 0} \f$
+  auto d4_normal_one_form =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse_ab_initio), 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_normal_one_form.get(a, 0) -= d4_N.get(a);
+  }
+
+  // Calc \f$ \partial_a T2 \f$
+  auto dT2 =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      dT2.get(a, b) +=
+          mu2 * d4_normal_one_form.get(a, b) +
+          d4_mu2.get(a) * spacetime_unit_normal_one_form_ab_initio.get(b);
+    }
+  }
+
+  // Calc \f$ \partial_a H_b = dT2_{ab} \f$
+  const auto& d4_gauge_h_expected = dT2;
+
+  // Check that locally computed \f$\partial_a H_b\f$ matches returned one
+  CHECK_ITERABLE_APPROX(d4_gauge_h_expected, d4_gauge_h);
+}
+
+// Test term 4/4 of spacetime deriv of gauge source function for Kerr-Schild
+template <typename Solution>
+void test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, 3>& lower_bound,
+    const std::array<double, 3>& upper_bound, std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.01, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<>>>(vars);
+  const auto& d_lapse =
+      get<typename Solution::template DerivLapse<DataVector>>(vars);
+  const auto& shift = get<gr::Tags::Shift<SpatialDim>>(vars);
+  const auto& d_shift =
+      get<typename Solution::template DerivShift<DataVector>>(vars);
+  const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<SpatialDim>>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<SpatialDim>>(vars);
+  const auto& dt_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<SpatialDim>>>(vars);
+  const auto& d_spatial_metric =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto spacetime_unit_normal =
+      gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift);
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift, inverse_spatial_metric);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+  const auto d4_spacetime_metric = gr::derivatives_of_spacetime_metric(
+      lapse, dt_lapse, d_lapse, shift, dt_shift, d_shift, spatial_metric,
+      dt_spatial_metric, d_spatial_metric);
+
+  // Initialize settings
+  const double amp_coef_S = pdist(generator);
+  const int exp_S = idist(generator);
+  const double t_start_S = pdist(generator) * 0.1;
+  const double sigma_t_S = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+
+  // Initialize initial gauge function and its roll-off function
+  const auto gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      x, 0.);
+  const auto d4_gauge_h_init = make_with_value<typename db::item_type<
+      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<SpatialDim,
+                                                             Frame::Inertial>>>(
+      x, 0.);
+
+  // compute d4H using function being tested
+  typename db::item_type<GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<
+      SpatialDim, Frame::Inertial>>
+      d4_gauge_h{};
+  GeneralizedHarmonic::spacetime_deriv_damped_harmonic_h<SpatialDim,
+                                                         Frame::Inertial>(
+      make_not_null(&d4_gauge_h), gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, x, 0., 0.,
+      amp_coef_S, 0, 0, exp_S,  // exponents
+      // roll on function parameters for lapse / shift terms
+      -1., -1., -1., -1., -1., -1., t_start_S, sigma_t_S,
+      r_max /* weight function */);
+
+  // Tempering functions
+  const double roll_on_S =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::roll_on_function(
+          t, t_start_S, sigma_t_S);
+  const auto d0_roll_on_S = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      time_deriv_of_roll_on_function(t, t_start_S, sigma_t_S);
+  const auto& weight =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::weight_function<
+          SpatialDim, Frame::Inertial, DataVector>(x, r_max);
+  auto d4_weight = GeneralizedHarmonic::DampedHarmonicGauge_detail::
+      spacetime_deriv_of_weight_function<SpatialDim, Frame::Inertial,
+                                         DataVector>(x, r_max);
+
+  // Evaluate analytic solution for Schwarzschild, ab initio.
+  const double mass = solution.mass();
+  const std::array<double, SpatialDim> center = solution.center();
+  // 1) shift coords with BH at the center
+  auto x_minus_center = x;
+  // DataVector r_squared(get_size(x), 0.);
+  auto r_squared = get<0>(x);
+  r_squared -= get<0>(x);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    x_minus_center.get(i) -= gsl::at(center, i);
+    r_squared += square(x_minus_center.get(i));
+  }
+  const DataVector r_ = sqrt(r_squared);
+  // 2) compute scalar function that defines KerrSchild coords
+  const DataVector H = mass * (1. / r_);
+  const DataVector H2 = H * 2.;
+  // 3) compute 3D null_one_form and its derivatives
+  tnsr::i<DataVector, SpatialDim, Frame::Inertial> null_one_form{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    null_one_form.get(i) = x_minus_center.get(i) / r_;
+  }
+  auto null_vec = null_one_form;
+  tnsr::ij<DataVector, SpatialDim, Frame::Inertial> deriv_null_one_form{};
+  const DataVector denom = 1. / r_squared;
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      deriv_null_one_form.get(i, j) =
+          -(null_one_form.get(i) * null_one_form.get(j)) / r_;
+      if (i == j) {
+        deriv_null_one_form.get(j, i) += (1. / r_);
+      }
+    }
+  }
+  // 4) compute deriv of H
+  tnsr::i<DataVector, SpatialDim, Frame::Inertial> deriv_H{};
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    deriv_H.get(i) = -(H / r_squared) * x_minus_center.get(i);
+  }
+  // 5) compute lapse & its derivatives
+  const Scalar<DataVector> lapse_ab_initio{sqrt(1. / (1. + H2))};
+  const auto dt_lapse_ab_initio = make_with_value<Scalar<DataVector>>(x, 0.);
+  auto d_lapse_ab_initio =
+      make_with_value<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d_lapse_ab_initio.get(i) -= (pow<3>(get(lapse_ab_initio)) * deriv_H.get(i));
+  }
+  // 6) compute shift & its derivatives
+  auto shift_ab_initio =
+      make_with_value<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    shift_ab_initio.get(i) = (H2 / (1. + H2)) * null_vec.get(i);
+  }
+  const auto dt_shift_ab_initio =
+      make_with_value<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  auto d_shift_ab_initio =
+      make_with_value<tnsr::iJ<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      d_shift_ab_initio.get(i, j) =
+          2. * pow<4>(get(lapse_ab_initio)) * null_vec.get(j) * deriv_H.get(i) +
+          H2 * square(get(lapse_ab_initio)) * deriv_null_one_form.get(i, j);
+    }
+  }
+  // 7) compute 3-metric & its derivatives
+  auto spatial_metric_ab_initio =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      spatial_metric_ab_initio.get(i, j) =
+          H2 * null_vec.get(i) * null_vec.get(j);
+      if (i == j) {
+        spatial_metric_ab_initio.get(i, i) += 1.;
+      }
+    }
+  }
+  auto dt_spatial_metric_ab_initio =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  auto d_spatial_metric_ab_initio =
+      make_with_value<tnsr::ijj<DataVector, SpatialDim, Frame::Inertial>>(x,
+                                                                          0.);
+  for (size_t k = 0; k < SpatialDim; ++k) {
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t j = i; j < SpatialDim; ++j) {
+        d_spatial_metric_ab_initio.get(k, i, j) =
+            2. * null_vec.get(i) * null_vec.get(j) * deriv_H.get(k) +
+            H2 * (null_one_form.get(i) * deriv_null_one_form.get(k, j) +
+                  null_one_form.get(j) * deriv_null_one_form.get(k, i));
+      }
+    }
+  }
+
+  const auto& spacetime_metric_ab_initio = gr::spacetime_metric(
+      lapse_ab_initio, shift_ab_initio, spatial_metric_ab_initio);
+  const auto& spacetime_unit_normal_one_form_ab_initio =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio);
+  const auto spacetime_unit_normal_ab_initio =
+      gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio, shift_ab_initio);
+  const auto& inverse_spatial_metric_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio).second;
+  const auto inverse_spacetime_metric_ab_initio =
+      gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
+          lapse_ab_initio, shift_ab_initio, inverse_spatial_metric_ab_initio);
+  const auto& det_spatial_metric_ab_initio =
+      determinant_and_inverse(spatial_metric_ab_initio).first;
+  Scalar<DataVector> sqrt_det_spatial_metric_ab_initio(
+      sqrt(get(det_spatial_metric_ab_initio)));
+  const auto phi_ab_initio = GeneralizedHarmonic::phi(
+      lapse_ab_initio, d_lapse_ab_initio, shift_ab_initio, d_shift_ab_initio,
+      spatial_metric_ab_initio, d_spatial_metric_ab_initio);
+  const auto pi_ab_initio = GeneralizedHarmonic::pi(
+      lapse_ab_initio, dt_lapse_ab_initio, shift_ab_initio, dt_shift_ab_initio,
+      spatial_metric_ab_initio, dt_spatial_metric_ab_initio, phi_ab_initio);
+
+  // commonly used terms
+  const auto exp_fac_1 = 1. / 2.;
+  const auto& one_over_lapse = 1. / get(lapse_ab_initio);
+  const auto& log_fac_1 =
+      GeneralizedHarmonic::DampedHarmonicGauge_detail::log_factor_metric_lapse<
+          DataVector>(lapse_ab_initio, sqrt_det_spatial_metric_ab_initio,
+                      exp_fac_1);
+
+  // coeffs that enter gauge source function
+  const auto mu_S =
+      amp_coef_S * roll_on_S * get(weight) * pow(get(log_fac_1), exp_S);
+  const auto mu_S_over_N = mu_S * one_over_lapse;
+
+  // Calc \f$ \partial_a [R W] \f$
+  auto d4_RW_S = d4_weight;
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    d4_RW_S.get(a) *= roll_on_S;
+  }
+  d4_RW_S.get(0) += get(weight) * d0_roll_on_S;
+
+  // Calc derivs of \f$ \mu_S \f$
+  auto d4_mu_S =
+      make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse_ab_initio), 0.);
+  {
+    const auto& d4_log_fac_muS =
+        GeneralizedHarmonic::DampedHarmonicGauge_detail ::
+            spacetime_deriv_of_power_log_factor_metric_lapse<
+                SpatialDim, Frame::Inertial, DataVector>(
+                lapse_ab_initio, shift_ab_initio,
+                spacetime_unit_normal_ab_initio,
+                inverse_spatial_metric_ab_initio,
+                sqrt_det_spatial_metric_ab_initio, dt_spatial_metric_ab_initio,
+                pi_ab_initio, phi_ab_initio, exp_fac_1, exp_S);
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      // \f$ \partial_a \mu_{L1} \f$
+      d4_mu_S.get(a) =
+          amp_coef_S * d4_RW_S.get(a) * pow(get(log_fac_1), exp_S) +
+          amp_coef_S * roll_on_S * get(weight) * d4_log_fac_muS.get(a);
+    }
+  }
+
+  // Calc \f$ \partial_a N = {\partial_0 N, \partial_i N} \f$
+  auto d4_N = make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+      get(lapse_ab_initio), 0.);
+  d4_N.get(0) = get(dt_lapse_ab_initio);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_N.get(1 + i) = d_lapse_ab_initio.get(i);
+  }
+
+  // Calc \f$ \partial_a N^i = {\partial_0 N^i, \partial_j N^i} \f$
+  auto d4_shift =
+      make_with_value<tnsr::aB<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse_ab_initio), 0.);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_shift.get(0, 1 + i) = dt_shift_ab_initio.get(i);
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      d4_shift.get(1 + j, 1 + i) = d_shift_ab_initio.get(j, i);
+    }
+  }
+
+  // \f[ \partial_a (\mu_S/N) = (1/N) \partial_a \mu_{S}
+  //         - (\mu_{S}/N^2) \partial_a N
+  // \f]
+  auto d4_muS_over_N =
+      make_with_value<tnsr::a<DataVector, SpatialDim, Frame::Inertial>>(
+          get(lapse_ab_initio), 0.);
+  {
+    auto prefac = -mu_S * one_over_lapse * one_over_lapse;
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d4_muS_over_N.get(a) +=
+          one_over_lapse * d4_mu_S.get(a) + prefac * d4_N.get(a);
+    }
+  }
+
+  // Calc \f$ \partial_a T3 \f$ (note minus sign)
+  auto dT3 =
+      make_with_value<tnsr::ab<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        dT3.get(a, b) -= d4_muS_over_N.get(a) *
+                         spacetime_metric_ab_initio.get(b, i + 1) *
+                         shift.get(i);
+        dT3.get(a, b) -= mu_S_over_N * d4_spacetime_metric.get(a, b, i + 1) *
+                         shift_ab_initio.get(i);
+        dT3.get(a, b) -= mu_S_over_N *
+                         spacetime_metric_ab_initio.get(b, i + 1) *
+                         d4_shift.get(a, i + 1);
+      }
+    }
+  }
+
+  // Calc \f$ \partial_a H_b = dT3_{ab} \f$
+  const auto& d4_gauge_h_expected = dT3;
+
+  // Check that locally computed \f$\partial_a H_b\f$ matches returned one
+  CHECK_ITERABLE_APPROX(d4_gauge_h_expected, d4_gauge_h);
+}
+
+//
+//  Test ComputeTags
+//
+void test_damped_harmonic_compute_tags(const size_t grid_size_each_dimension,
+                                       const std::array<double, 3>& lower_bound,
+                                       const std::array<double, 3>& upper_bound,
+                                       std::mt19937 generator) noexcept {
+  // Initialize random number generation
+  std::uniform_real_distribution<> pdist(0.1, 1.);
+  std::uniform_int_distribution<> idist(2, 7);
+
+  // Setup grid
+  const size_t SpatialDim = 3;
+  Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1., 1., lower_bound[0], upper_bound[0]},
+          Affine{-1., 1., lower_bound[1], upper_bound[1]},
+          Affine{-1., 1., lower_bound[2], upper_bound[2]},
+      });
+
+  // Setup coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = pdist(generator) * 0.4;
+  const Slab slab(0, t);
+  const Rational frac(1);
+  const Time current_time(slab, frac);
+  const TimeId current_time_id(true, 0, current_time);
+
+  // Randomized 3 + 1 quantities
+  // Note: Ranges from which random numbers are drawn to populate 3+1 tensors
+  //       below were chosen to not throw FPEs (by trial & error).
+  std::uniform_real_distribution<> dist(0.9, 1.);
+  const DataVector& used_for_size = get<0>(x);
+  const auto lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto dt_lapse = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto d_lapse =
+      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto dt_shift =
+      make_with_random_values<tnsr::I<DataVector, SpatialDim, Frame::Inertial>>(
+          make_not_null(&generator), make_not_null(&dist), used_for_size);
+  const auto d_shift = make_with_random_values<
+      tnsr::iJ<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist), used_for_size);
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(x, 0.);
+  get<0, 0>(spatial_metric) = get<1, 1>(spatial_metric) =
+      get<2, 2>(spatial_metric) = 1.;
+  std::uniform_real_distribution<> dist2(0., 0.12);
+  const auto dspatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      spatial_metric.get(i, j) += dspatial_metric.get(i, j);
+    }
+  }
+  const auto dt_spatial_metric = make_with_random_values<
+      tnsr::ii<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+  const auto d_spatial_metric = make_with_random_values<
+      tnsr::ijj<DataVector, SpatialDim, Frame::Inertial>>(
+      make_not_null(&generator), make_not_null(&dist2), used_for_size);
+
+  // Get ingredients
+  const auto& spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto& spacetime_unit_normal_one_form =
+      gr::spacetime_normal_one_form<SpatialDim, Frame::Inertial, DataVector>(
+          lapse);
+  const auto spacetime_unit_normal =
+      gr::spacetime_normal_vector<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift);
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto inverse_spacetime_metric =
+      gr::inverse_spacetime_metric<SpatialDim, Frame::Inertial, DataVector>(
+          lapse, shift, inverse_spatial_metric);
+  const auto& det_spatial_metric =
+      determinant_and_inverse(spatial_metric).first;
+  Scalar<DataVector> sqrt_det_spatial_metric(sqrt(get(det_spatial_metric)));
+  const auto phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift,
+                                            spatial_metric, d_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+  const auto d4_spacetime_metric = gr::derivatives_of_spacetime_metric(
+      lapse, dt_lapse, d_lapse, shift, dt_shift, d_shift, spatial_metric,
+      dt_spatial_metric, d_spatial_metric);
+
+  // Initialize settings
+  const double t_start_S = pdist(generator) * 0.1;
+  const double sigma_t_S = pdist(generator) * 0.2;
+  const double r_max = pdist(generator) * 0.7;
+
+  // initial H_a and D4(H_a)
+  const auto gauge_h_init = make_with_random_values<typename db::item_type<
+      GeneralizedHarmonic::Tags::InitialGaugeH<SpatialDim, Frame::Inertial>>>(
+      make_not_null(&generator), make_not_null(&pdist), x);
+  const auto d4_gauge_h_init = make_with_random_values<typename db::item_type<
+      GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<SpatialDim,
+                                                             Frame::Inertial>>>(
+      make_not_null(&generator), make_not_null(&pdist), x);
+  // local H_a
+  const auto gauge_h_expected = wrap_DampedHarmonicHCompute(
+      gauge_h_init, lapse, shift, sqrt_det_spatial_metric, spacetime_metric, t,
+      t_start_S, sigma_t_S, x, r_max);
+  // local D4(H_a)
+  const auto d4_gauge_h_expected = wrap_SpacetimeDerivDampedHarmonicHCompute(
+      gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, t, t_start_S,
+      sigma_t_S, x, r_max);
+
+  //
+  // Check that compute items work correctly in the DataBox
+  //
+  // First, check that the names are correct
+  CHECK(
+      GeneralizedHarmonic::DampedHarmonicHCompute<3, Frame::Inertial>::name() ==
+      "GaugeH");
+  CHECK(GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
+            3, Frame::Inertial>::name() == "SpacetimeDerivGaugeH");
+
+  const auto box = db::create<
+      db::AddSimpleTags<
+          GeneralizedHarmonic::Tags::InitialGaugeH<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::SpacetimeDerivInitialGaugeH<
+              3, Frame::Inertial>,
+          gr::Tags::Lapse<DataVector>,
+          gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+          gr::Tags::SpacetimeNormalOneForm<3, Frame::Inertial, DataVector>,
+          gr::Tags::SqrtDetSpatialMetric<DataVector>,
+          gr::Tags::InverseSpatialMetric<3, Frame::Inertial, DataVector>,
+          gr::Tags::SpacetimeMetric<3, Frame::Inertial, DataVector>,
+          GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+          GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>, ::Tags::TimeId,
+          ::Tags::Coordinates<3, Frame::Inertial>,
+          GeneralizedHarmonic::OptionTags::GaugeHRollOnStartTime,
+          GeneralizedHarmonic::OptionTags::GaugeHRollOnTimeWindow,
+          GeneralizedHarmonic::OptionTags::GaugeHSpatialWeightDecayWidth<
+              Frame::Inertial>>,
+      db::AddComputeTags<
+          ::Tags::Time,
+          GeneralizedHarmonic::DampedHarmonicHCompute<3, Frame::Inertial>,
+          GeneralizedHarmonic::SpacetimeDerivDampedHarmonicHCompute<
+              3, Frame::Inertial>>>(
+      gauge_h_init, d4_gauge_h_init, lapse, shift,
+      spacetime_unit_normal_one_form, sqrt_det_spatial_metric,
+      inverse_spatial_metric, spacetime_metric, pi, phi, current_time_id, x,
+      t_start_S, sigma_t_S, r_max);
+
+  // Verify that locally computed H_a matches the same obtained through its
+  // ComputeTag from databox
+  CHECK(db::get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(box) == shift);
+  CHECK(db::get<::Tags::Time>(box) == current_time);
+  CHECK(db::get<GeneralizedHarmonic::OptionTags::GaugeHRollOnStartTime>(box) ==
+        t_start_S);
+  CHECK(db::get<GeneralizedHarmonic::OptionTags::GaugeHRollOnTimeWindow>(box) ==
+        sigma_t_S);
+  CHECK(db::get<GeneralizedHarmonic::OptionTags::GaugeHSpatialWeightDecayWidth<
+            Frame::Inertial>>(box) == r_max);
+  CHECK(db::get<GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>>(box) ==
+        gauge_h_expected);
+  CHECK(
+      db::get<
+          GeneralizedHarmonic::Tags::SpacetimeDerivGaugeH<3, Frame::Inertial>>(
+          box) == d4_gauge_h_expected);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.Gauge.DampedHarmonic.details",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  const DataVector used_for_size(4);
+
+  test_options<Frame::Inertial>();
+
+  test_detail_functions<1, Frame::Inertial>(used_for_size);
+  test_detail_functions<2, Frame::Inertial>(used_for_size);
+  test_detail_functions<3, Frame::Inertial>(used_for_size);
+
+  test_detail_functions<1, Frame::Inertial>(1.);
+  test_detail_functions<2, Frame::Inertial>(1.);
+  test_detail_functions<3, Frame::Inertial>(1.);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.Gauge.DampedHarmonic.H",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  const DataVector used_for_size(4);
+
+  // Compare with Python implementation
+  test_damped_harmonic_h_function<1, Frame::Inertial>(used_for_size);
+  test_damped_harmonic_h_function<2, Frame::Inertial>(used_for_size);
+  test_damped_harmonic_h_function<3, Frame::Inertial>(used_for_size);
+
+  // Piece-wise tests with random tensors
+  const size_t grid_size = 8;
+  const std::array<double, 3> lower_bound{{0.82, 1.24, 1.32}};
+  const std::array<double, 3> upper_bound{{0.8, 1.22, 1.30}};
+
+  MAKE_GENERATOR(generator);
+  test_damped_harmonic_h_function_term_1_of_4(grid_size, lower_bound,
+                                              upper_bound, generator);
+  test_damped_harmonic_h_function_term_2_of_4(grid_size, lower_bound,
+                                              upper_bound, generator);
+  test_damped_harmonic_h_function_term_3_of_4(grid_size, lower_bound,
+                                              upper_bound, generator);
+  test_damped_harmonic_h_function_term_4_of_4(grid_size, lower_bound,
+                                              upper_bound, generator);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.Gauge.DampedHarmonic.D4H",
+    "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+  const DataVector used_for_size(4);
+
+  // Compare with Python implementation
+  test_deriv_damped_harmonic_h_function<1, Frame::Inertial>(used_for_size);
+  test_deriv_damped_harmonic_h_function<2, Frame::Inertial>(used_for_size);
+  test_deriv_damped_harmonic_h_function<3, Frame::Inertial>(used_for_size);
+
+  // Piece-wise tests with random tensors
+  const size_t grid_size = 8;
+  const std::array<double, 3> lower_bound{{0.82, 1.24, 1.32}};
+  const std::array<double, 3> upper_bound{{0.8, 1.22, 1.30}};
+
+  MAKE_GENERATOR(generator);
+  test_deriv_damped_harmonic_h_function_term_1_of_4(grid_size, lower_bound,
+                                                    upper_bound, generator);
+  test_deriv_damped_harmonic_h_function_term_2_of_4(grid_size, lower_bound,
+                                                    upper_bound, generator);
+  test_deriv_damped_harmonic_h_function_term_3_of_4(grid_size, lower_bound,
+                                                    upper_bound, generator);
+  test_deriv_damped_harmonic_h_function_term_4_of_4(grid_size, lower_bound,
+                                                    upper_bound, generator);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.Gauge.DampedHarmonic.Analytic",
+    "[Unit][Evolution]") {
+  const size_t grid_size = 8;
+  const std::array<double, 3> lower_bound{{0.82, 1.24, 1.32}};
+  const std::array<double, 3> upper_bound{{0.8, 1.22, 1.30}};
+  MAKE_GENERATOR(generator);
+
+  // Analytic spacetime tests
+  const double mass = 2.;
+  const std::array<double, 3> spin{{0., 0., 0.}};
+  const std::array<double, 3> center{{0.2, -0.3, 0.5}};
+  const gr::Solutions::KerrSchild solution(mass, spin, center);
+
+  test_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
+      solution, grid_size, lower_bound, upper_bound, generator);
+  test_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
+      solution, grid_size, lower_bound, upper_bound, generator);
+  test_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
+      solution, grid_size, lower_bound, upper_bound, generator);
+
+  test_deriv_damped_harmonic_h_function_term_2_of_4_analytic_schwarzschild(
+      solution, grid_size, lower_bound, upper_bound, generator);
+  test_deriv_damped_harmonic_h_function_term_3_of_4_analytic_schwarzschild(
+      solution, grid_size, lower_bound, upper_bound, generator);
+  test_deriv_damped_harmonic_h_function_term_4_of_4_analytic_schwarzschild(
+      solution, grid_size, lower_bound, upper_bound, generator);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.GeneralizedHarmonic.Gauge.DampedHarmonic.CompTags",
+    "[Unit][Evolution]") {
+  const size_t grid_size = 8;
+  const std::array<double, 3> lower_bound{{0.82, 1.24, 1.32}};
+  const std::array<double, 3> upper_bound{{0.8, 1.22, 1.30}};
+  MAKE_GENERATOR(generator);
+
+  // ComputeTag tests
+  test_damped_harmonic_compute_tags(grid_size, lower_bound, upper_bound,
+                                    generator);
+}

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/__init__.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/__init__.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/Evolution/Systems/__init__.py
+++ b/tests/Unit/Evolution/Systems/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/Evolution/__init__.py
+++ b/tests/Unit/Evolution/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes

- Adds functionality to compute the source function H for the damped harmonic gauge.
- Adds functionality to also compute the spacetime derivative of this source function.
- This PR depends on #1176 , #1177 , #1179, and #1321. [Edit 02/11: All 4 are merged, and this PR rebased.]


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
