### PR TITLE
Get derivatives of shift from GH variables

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -958,8 +958,7 @@ template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
           typename DataType = DataVector>
 using Tempijj = TempTensor<N, tnsr::ijj<DataType, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
-  typename DataType = DataVector>
+          typename DataType = DataVector>
 using Tempiaa = TempTensor<N, tnsr::iaa<DataType, SpatialDim, Fr>>;
-
 // @}
 }  // namespace Tags

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
@@ -3,9 +3,11 @@
 
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
 
-#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
 #include "DataStructures/Variables.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -63,7 +65,7 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
   tnsr::aa<DataType, SpatialDim, Frame> pi{
       make_with_value<DataType>(lapse, 0.)};
 
-  get<0, 0>(pi) = -2.0 * get(lapse) * get(dt_lapse);
+  get<0, 0>(pi) = -2. * get(lapse) * get(dt_lapse);
 
   for (size_t m = 0; m < SpatialDim; ++m) {
     for (size_t n = 0; n < SpatialDim; ++n) {
@@ -360,6 +362,296 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_det_spatial_metric(
       inverse_spatial_metric, dt_spatial_metric, phi);
   return d4_det_spatial_metric;
 }
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spatial_deriv_of_shift(
+    const gsl::not_null<tnsr::iJ<DataType, SpatialDim, Frame>*> deriv_shift,
+    const Scalar<DataType>& lapse,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  if (UNLIKELY(get_size(get<0, 0>(*deriv_shift)) != get_size(get(lapse)))) {
+    *deriv_shift = tnsr::iJ<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      deriv_shift->get(i, j) =
+          (inverse_spacetime_metric.get(j + 1, 0) +
+           spacetime_unit_normal.get(j + 1) * spacetime_unit_normal.get(0)) *
+          spacetime_unit_normal.get(0) * phi.get(i, 0, 0);
+      for (size_t a = 0; a < SpatialDim + 1; ++a) {
+        for (size_t b = 0; b < SpatialDim + 1; ++b) {
+          if (a != 0 or b != 0) {
+            deriv_shift->get(i, j) += (inverse_spacetime_metric.get(j + 1, a) +
+                                       spacetime_unit_normal.get(j + 1) *
+                                           spacetime_unit_normal.get(a)) *
+                                      spacetime_unit_normal.get(b) *
+                                      phi.get(i, a, b);
+          }
+        }
+      }
+      deriv_shift->get(i, j) *= get(lapse);
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::iJ<DataType, SpatialDim, Frame> spatial_deriv_of_shift(
+    const Scalar<DataType>& lapse,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  tnsr::iJ<DataType, SpatialDim, Frame> deriv_shift{};
+  GeneralizedHarmonic::spatial_deriv_of_shift<SpatialDim, Frame, DataType>(
+      make_not_null(&deriv_shift), lapse, inverse_spacetime_metric,
+      spacetime_unit_normal, phi);
+  return deriv_shift;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void time_deriv_of_shift(
+    const gsl::not_null<tnsr::I<DataType, SpatialDim, Frame>*> dt_shift,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  if (UNLIKELY(get_size(get<0>(*dt_shift)) != get_size(get(lapse)))) {
+    *dt_shift = tnsr::I<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    dt_shift->get(i) = -get(lapse) * pi.get(1, 0) *
+                       spacetime_unit_normal.get(0) *
+                       inverse_spatial_metric.get(i, 0);
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      for (size_t a = 0; a < SpatialDim + 1; ++a) {
+        if (a != 0 or j != 0) {
+          dt_shift->get(i) -= get(lapse) * pi.get(j + 1, a) *
+                              spacetime_unit_normal.get(a) *
+                              inverse_spatial_metric.get(i, j);
+        }
+        for (size_t k = 0; k < SpatialDim; ++k) {
+          dt_shift->get(i) += shift.get(j) * spacetime_unit_normal.get(a) *
+                              phi.get(j, k + 1, a) *
+                              inverse_spatial_metric.get(i, k);
+        }
+      }
+    }
+    dt_shift->get(i) *= get(lapse);
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::I<DataType, SpatialDim, Frame> time_deriv_of_shift(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  tnsr::I<DataType, SpatialDim, Frame> dt_shift{};
+  GeneralizedHarmonic::time_deriv_of_shift<SpatialDim, Frame, DataType>(
+      make_not_null(&dt_shift), lapse, shift, inverse_spatial_metric,
+      spacetime_unit_normal, phi, pi);
+  return dt_shift;
+}
+
+namespace {
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct D0LowerShiftBuffer;
+
+template <size_t SpatialDim, typename Frame>
+struct D0LowerShiftBuffer<SpatialDim, Frame, double> {
+  explicit D0LowerShiftBuffer(const size_t /*size*/) noexcept {}
+
+  tnsr::I<double, SpatialDim, Frame> dt_shift{};
+  tnsr::ii<double, SpatialDim, Frame> dt_spatial_metric{};
+};
+
+template <size_t SpatialDim, typename Frame>
+struct D0LowerShiftBuffer<SpatialDim, Frame, DataVector> {
+ private:
+  // We make one giant allocation so that we don't thrash the heap.
+  Variables<tmpl::list<::Tags::TempI<0, SpatialDim, Frame, DataVector>,
+                       ::Tags::Tempii<1, SpatialDim, Frame, DataVector>>>
+      buffer_;
+
+ public:
+  explicit D0LowerShiftBuffer(const size_t size) noexcept
+      : buffer_(size),
+        dt_shift(get<::Tags::TempI<0, SpatialDim, Frame, DataVector>>(buffer_)),
+        dt_spatial_metric(
+            get<::Tags::Tempii<1, SpatialDim, Frame, DataVector>>(buffer_)) {}
+
+  tnsr::I<DataVector, SpatialDim, Frame>& dt_shift;
+  tnsr::ii<DataVector, SpatialDim, Frame>& dt_spatial_metric;
+};
+}  // namespace
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void time_deriv_of_lower_shift(
+    const gsl::not_null<tnsr::i<DataType, SpatialDim, Frame>*> dt_lower_shift,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  if (UNLIKELY(get_size(get<0>(*dt_lower_shift)) != get_size(get(lapse)))) {
+    *dt_lower_shift =
+        tnsr::i<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  // Use a Variables to reduce total number of allocations. This is especially
+  // important in a multithreaded environment.
+  D0LowerShiftBuffer<SpatialDim, Frame, DataType> buffer(get_size(get(lapse)));
+  // get \partial_0 N^j
+  const auto inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  GeneralizedHarmonic::time_deriv_of_shift<SpatialDim, Frame, DataType>(
+      make_not_null(&buffer.dt_shift), lapse, shift, inverse_spatial_metric,
+      spacetime_unit_normal, phi, pi);
+  GeneralizedHarmonic::time_deriv_of_spatial_metric<SpatialDim, Frame,
+                                                    DataType>(
+      make_not_null(&buffer.dt_spatial_metric), lapse, shift, phi, pi);
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    dt_lower_shift->get(i) = spatial_metric.get(i, 0) * buffer.dt_shift.get(0) +
+                             shift.get(0) * buffer.dt_spatial_metric.get(i, 0);
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      if (j != 0) {
+        dt_lower_shift->get(i) +=
+            spatial_metric.get(i, j) * buffer.dt_shift.get(j) +
+            shift.get(j) * buffer.dt_spatial_metric.get(i, j);
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::i<DataType, SpatialDim, Frame> time_deriv_of_lower_shift(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  tnsr::i<DataType, SpatialDim, Frame> dt_lower_shift{};
+  GeneralizedHarmonic::time_deriv_of_lower_shift<SpatialDim, Frame, DataType>(
+      make_not_null(&dt_lower_shift), lapse, shift, spatial_metric,
+      spacetime_unit_normal, phi, pi);
+  return dt_lower_shift;
+}
+
+namespace {
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct D4NormOfShiftBuffer;
+
+template <size_t SpatialDim, typename Frame>
+struct D4NormOfShiftBuffer<SpatialDim, Frame, double> {
+  explicit D4NormOfShiftBuffer(const size_t /*size*/) noexcept {}
+
+  tnsr::i<double, SpatialDim, Frame> lower_shift{};
+  tnsr::iJ<double, SpatialDim, Frame> deriv_shift{};
+  tnsr::i<double, SpatialDim, Frame> dt_lower_shift{};
+  tnsr::I<double, SpatialDim, Frame> dt_shift{};
+};
+
+template <size_t SpatialDim, typename Frame>
+struct D4NormOfShiftBuffer<SpatialDim, Frame, DataVector> {
+ private:
+  // We make one giant allocation so that we don't thrash the heap.
+  Variables<tmpl::list<::Tags::Tempi<0, SpatialDim, Frame, DataVector>,
+                       ::Tags::TempiJ<1, SpatialDim, Frame, DataVector>,
+                       ::Tags::Tempi<2, SpatialDim, Frame, DataVector>,
+                       ::Tags::TempI<3, SpatialDim, Frame, DataVector>>>
+      buffer_;
+
+ public:
+  explicit D4NormOfShiftBuffer(const size_t size) noexcept
+      : buffer_(size),
+        lower_shift(
+            get<::Tags::Tempi<0, SpatialDim, Frame, DataVector>>(buffer_)),
+        deriv_shift(
+            get<::Tags::TempiJ<1, SpatialDim, Frame, DataVector>>(buffer_)),
+        dt_lower_shift(
+            get<::Tags::Tempi<2, SpatialDim, Frame, DataVector>>(buffer_)),
+        dt_shift(
+            get<::Tags::TempI<3, SpatialDim, Frame, DataVector>>(buffer_)) {}
+
+  tnsr::i<DataVector, SpatialDim, Frame>& lower_shift;
+  tnsr::iJ<DataVector, SpatialDim, Frame>& deriv_shift;
+  tnsr::i<DataVector, SpatialDim, Frame>& dt_lower_shift;
+  tnsr::I<DataVector, SpatialDim, Frame>& dt_shift;
+};
+}  // namespace
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_norm_of_shift(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_norm_of_shift,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  if (UNLIKELY(get_size(get<0>(*d4_norm_of_shift)) != get_size(get(lapse)))) {
+    *d4_norm_of_shift =
+        tnsr::a<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  // Use a Variables to reduce total number of allocations. This is especially
+  // important in a multithreaded environment.
+  D4NormOfShiftBuffer<SpatialDim, Frame, DataType> buffer(get_size(get(lapse)));
+
+  raise_or_lower_index(make_not_null(&buffer.lower_shift), shift,
+                       spatial_metric);
+  spatial_deriv_of_shift(make_not_null(&buffer.deriv_shift), lapse,
+                         inverse_spacetime_metric, spacetime_unit_normal, phi);
+  time_deriv_of_lower_shift(make_not_null(&buffer.dt_lower_shift), lapse, shift,
+                            spatial_metric, spacetime_unit_normal, phi, pi);
+  time_deriv_of_shift(make_not_null(&buffer.dt_shift), lapse, shift,
+                      inverse_spatial_metric, spacetime_unit_normal, phi, pi);
+  // first term for component 0
+  get<0>(*d4_norm_of_shift) =
+      shift.get(0) * buffer.dt_lower_shift.get(0) +
+      buffer.lower_shift.get(0) * buffer.dt_shift.get(0);
+  for (size_t i = 1; i < SpatialDim; ++i) {
+    get<0>(*d4_norm_of_shift) +=
+        shift.get(i) * buffer.dt_lower_shift.get(i) +
+        buffer.lower_shift.get(i) * buffer.dt_shift.get(i);
+  }
+  // second term for components 1,2,3
+  for (size_t j = 0; j < SpatialDim; ++j) {
+    d4_norm_of_shift->get(1 + j) =
+        shift.get(0) * phi.get(j, 0, 1) +
+        buffer.lower_shift.get(0) * buffer.deriv_shift.get(j, 0);
+    for (size_t i = 1; i < SpatialDim; ++i) {
+      d4_norm_of_shift->get(1 + j) +=
+          shift.get(i) * phi.get(j, 0, i + 1) +
+          buffer.lower_shift.get(i) * buffer.deriv_shift.get(j, i);
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_norm_of_shift(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  tnsr::a<DataType, SpatialDim, Frame> d4_norm_of_shift{};
+  GeneralizedHarmonic::spacetime_deriv_of_norm_of_shift<SpatialDim, Frame,
+                                                        DataType>(
+      make_not_null(&d4_norm_of_shift), lapse, shift, spatial_metric,
+      inverse_spatial_metric, inverse_spacetime_metric, spacetime_unit_normal,
+      phi, pi);
+  return d4_norm_of_shift;
+}
 }  // namespace GeneralizedHarmonic
 
 /// \cond
@@ -435,6 +727,90 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_det_spatial_metric(
   template Scalar<DTYPE(data)> GeneralizedHarmonic::time_deriv_of_lapse(      \
       const Scalar<DTYPE(data)>& lapse,                                       \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi) noexcept;      \
+  template void GeneralizedHarmonic::spatial_deriv_of_shift(                  \
+      const gsl::not_null<tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>*>     \
+          deriv_shift,                                                        \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spacetime_metric,                                           \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
+  template tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>                      \
+  GeneralizedHarmonic::spatial_deriv_of_shift(                                \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spacetime_metric,                                           \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
+  template void GeneralizedHarmonic::time_deriv_of_shift(                     \
+      const gsl::not_null<tnsr::I<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          dt_shift,                                                           \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi) noexcept;      \
+  template tnsr::I<DTYPE(data), DIM(data), FRAME(data)>                       \
+  GeneralizedHarmonic::time_deriv_of_shift(                                   \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi) noexcept;      \
+  template void GeneralizedHarmonic::time_deriv_of_lower_shift(               \
+      const gsl::not_null<tnsr::i<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          dt_lower_shift,                                                     \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi) noexcept;      \
+  template tnsr::i<DTYPE(data), DIM(data), FRAME(data)>                       \
+  GeneralizedHarmonic::time_deriv_of_lower_shift(                             \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi) noexcept;      \
+  template void GeneralizedHarmonic::spacetime_deriv_of_norm_of_shift(        \
+      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          d4_norm_of_shift,                                                   \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spacetime_metric,                                           \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spacetime_unit_normal,                                              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi) noexcept;      \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
+  GeneralizedHarmonic::spacetime_deriv_of_norm_of_shift(                      \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spacetime_metric,                                           \
       const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
           spacetime_unit_normal,                                              \
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -271,4 +271,149 @@ Scalar<DataType> time_deriv_of_lapse(
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes spatial derivatives of the shift vector from
+ *        the generalized harmonic and geometric variables
+ *
+ * \details Spatial derivatives of the shift vector \f$N^i\f$ can be derived
+ * from the following steps:
+ * \f{align*}
+ * \partial_i N^j
+ *  =& g^{jl} g_{kl} \partial_i N^k \\
+ *  =& g^{jl} (N^k \partial_i g_{lk}
+ *             + g_{kl}\partial_i N^k - N^k \partial_i g_{kl}) \\
+ *  =& g^{jl} (\partial_i N_l - N^k \partial_i g_{lk}) (\because g^{j0} = 0) \\
+ *  =& g^{ja} (\partial_i \psi_{a0} - N^k \partial _i \psi_{ak}) \\
+ *  =& N g^{ja} t^b \partial_i \psi_{ab} \\
+ *  =& (g^{ja} - t^j t^a) N t^b \Phi_{iab} - 2 t^j \partial_i N \\
+ *  =& \psi^{ja} N t^b \Phi_{iab} - 2 t^j \partial_i N \\
+ *  =& N (\psi^{ja} + t^j t^a) t^b \Phi_{iab}.
+ * \f}
+ * where we used the equation from \ref spatial_deriv_of_lapse for
+ * \f$\partial_i N\f$.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spatial_deriv_of_shift(
+    gsl::not_null<tnsr::iJ<DataType, SpatialDim, Frame>*> deriv_shift,
+    const Scalar<DataType>& lapse,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::iJ<DataType, SpatialDim, Frame> spatial_deriv_of_shift(
+    const Scalar<DataType>& lapse,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes time derivative of the shift vector from
+ *        the generalized harmonic and geometric variables
+ *
+ * \details The time derivative of \f$ N^i \f$ can be derived from the following
+ * steps:
+ * \f{align*}
+ * \partial_0 N^i
+ *  =& g^{ik} \partial_0 (g_{kj} N^j) - N^j g^{ik} \partial_0 g_{kj} \\
+ *  =& N g^{ik} t^b \partial_0 \psi_{kb} \\
+ *  =& N g^{ik} t^b (\partial_0 - N^j\partial_j) \psi_{kb}
+ *                  + N g^{ik} t^b N^j\partial_j \psi_{kb} \\
+ *  =& -N^2 t^b\Pi_{kb} g^{ik} + N N^j t^b\Phi_{jkb} g^{ik} \\
+ *  =& -N g^{ik} t^b (N \Pi_{kb} - N^j \Phi_{jkb}) \\
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void time_deriv_of_shift(
+    gsl::not_null<tnsr::I<DataType, SpatialDim, Frame>*> dt_shift,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::I<DataType, SpatialDim, Frame> time_deriv_of_shift(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes time derivative of index lowered shift from generalized
+ *        harmonic variables, spatial metric and its time derivative.
+ *
+ * \details The time derivative of \f$ N_i \f$ is given by:
+ * \f{align*}
+ *  \partial_0 N_i = g_{ij} \partial_0 N^j + N^j \partial_0 g_{ij}
+ * \f}
+ * where the first term is obtained from `time_deriv_of_shift()`, and the latter
+ * is a user input.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void time_deriv_of_lower_shift(
+    gsl::not_null<tnsr::i<DataType, SpatialDim, Frame>*> dt_lower_shift,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::i<DataType, SpatialDim, Frame> time_deriv_of_lower_shift(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes spacetime derivatives of the norm of the shift vector.
+ *
+ * \details The same is computed as:
+ * \f{align*}
+ * \partial_a (N^i N_i) = (N_i \partial_0 N^i + N^i \partial_0 N_i,
+ *                               N_i \partial_j N^i + N^i \partial_j N_i)
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_norm_of_shift(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_norm_of_shift,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_norm_of_shift(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+// @}
 }  // namespace GeneralizedHarmonic


### PR DESCRIPTION
## Proposed changes

- Adds functions that compute derivatives of shift from generalized harmonic variables.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
