### PR TITLE
Get derivs of 3-metric from GH variables

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1,3 +1,18 @@
+@article{Lindblom2005qh,
+      author         = "Lindblom, Lee and Scheel, Mark A. and Kidder,
+                        Lawrence E. and Owen, Robert and Rinne, Oliver",
+      title          = "{A New generalized harmonic evolution system}",
+      journal        = "Class. Quant. Grav.",
+      volume         = "23",
+      year           = "2006",
+      pages          = "S447-S462",
+      doi            = "10.1088/0264-9381/23/16/S09",
+      eprint         = "gr-qc/0512093",
+      archivePrefix  = "arXiv",
+      primaryClass   = "gr-qc",
+      SLACcitation   = "%%CITATION = GR-QC/0512093;%%"
+}
+
 @article{Arnold2002,
   author  = {Arnold, Douglas and Brezzi, Franco and Cockburn, Bernardo and L. Marini, Donatella},
   title   = {Unified Analysis of Discontinuous {Galerkin} Methods for Elliptic Problems},

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -890,8 +890,8 @@ struct TempTensor {
 // @{
 /// \ingroup PeoGroup
 /// Variables Tags for temporary tensors inside a function.
-template <size_t N>
-using TempScalar = TempTensor<N, Scalar<DataVector>>;
+template <size_t N, typename DataType = DataVector>
+using TempScalar = TempTensor<N, Scalar<DataType>>;
 
 // Rank 1
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial>
@@ -935,5 +935,11 @@ template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial>
 using Tempii = TempTensor<N, tnsr::ii<DataVector, SpatialDim, Fr>>;
 template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial>
 using TempII = TempTensor<N, tnsr::II<DataVector, SpatialDim, Fr>>;
+
+// Rank 3
+template <size_t N, size_t SpatialDim, typename Fr = Frame::Inertial,
+  typename DataType = DataVector>
+using Tempijj = TempTensor<N, tnsr::ijj<DataType, SpatialDim, Fr>>;
+
 // @}
 }  // namespace Tags

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
@@ -3,10 +3,17 @@
 
 #include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
 
-#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "DataStructures/Variables.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
 
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -21,7 +28,7 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
   tnsr::iaa<DataType, SpatialDim, Frame> phi(
       make_with_value<DataType>(deriv_lapse, 0.));
   for (size_t k = 0; k < SpatialDim; ++k) {
-    phi.get(k, 0, 0) = -2. * lapse.get() * deriv_lapse.get(k);
+    phi.get(k, 0, 0) = -2.0 * get(lapse) * deriv_lapse.get(k);
     for (size_t m = 0; m < SpatialDim; ++m) {
       for (size_t n = 0; n < SpatialDim; ++n) {
         phi.get(k, 0, 0) +=
@@ -56,11 +63,11 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
   tnsr::aa<DataType, SpatialDim, Frame> pi{
       make_with_value<DataType>(lapse, 0.)};
 
-  pi.get(0, 0) = -2. * lapse.get() * dt_lapse.get();
+  get<0, 0>(pi) = -2.0 * get(lapse) * get(dt_lapse);
 
   for (size_t m = 0; m < SpatialDim; ++m) {
     for (size_t n = 0; n < SpatialDim; ++n) {
-      pi.get(0, 0) +=
+      get<0, 0>(pi) +=
           dt_spatial_metric.get(m, n) * shift.get(m) * shift.get(n) +
           2. * spatial_metric.get(m, n) * shift.get(m) * dt_shift.get(n);
     }
@@ -80,7 +87,7 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
       for (size_t i = 0; i < SpatialDim; ++i) {
         pi.get(mu, nu) -= shift.get(i) * phi.get(i, mu, nu);
       }
-      pi.get(mu, nu) /= -lapse.get();
+      pi.get(mu, nu) /= -get(lapse);
     }
   }
   return pi;
@@ -152,18 +159,31 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
 }
 
 template <size_t SpatialDim, typename Frame, typename DataType>
-tnsr::ijj<DataType, SpatialDim, Frame> deriv_spatial_metric(
+void deriv_spatial_metric(
+    const gsl::not_null<tnsr::ijj<DataType, SpatialDim, Frame>*>
+        d_spatial_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
-  auto deriv_spatial_metric =
-      make_with_value<tnsr::ijj<DataType, SpatialDim, Frame>>(phi, 0.);
+  if (UNLIKELY(get_size(get<0, 0, 0>(*d_spatial_metric)) !=
+               get_size(get<0, 0, 0>(phi)))) {
+    *d_spatial_metric =
+        tnsr::ijj<DataType, SpatialDim, Frame>(get_size(get<0, 0, 0>(phi)));
+  }
   for (size_t k = 0; k < SpatialDim; ++k) {
     for (size_t i = 0; i < SpatialDim; ++i) {
       for (size_t j = i; j < SpatialDim; ++j) {
-        deriv_spatial_metric.get(k, i, j) = phi.get(k, i + 1, j + 1);
+        d_spatial_metric->get(k, i, j) = phi.get(k, i + 1, j + 1);
       }
     }
   }
-  return deriv_spatial_metric;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ijj<DataType, SpatialDim, Frame> deriv_spatial_metric(
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  tnsr::ijj<DataType, SpatialDim, Frame> d_spatial_metric{};
+  GeneralizedHarmonic::deriv_spatial_metric<SpatialDim, Frame, DataType>(
+      make_not_null(&d_spatial_metric), phi);
+  return d_spatial_metric;
 }
 
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -172,12 +192,12 @@ tnsr::i<DataType, SpatialDim, Frame> spatial_deriv_of_lapse(
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
   auto deriv_lapse =
-    make_with_value<tnsr::i<DataType, SpatialDim, Frame>>(get(lapse), 0.);
+      make_with_value<tnsr::i<DataType, SpatialDim, Frame>>(get(lapse), 0.);
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t a = 0; a < SpatialDim + 1; ++a) {
       for (size_t b = 0; b < SpatialDim + 1; ++b) {
-        deriv_lapse.get(i) += phi.get(i, a, b)
-          * spacetime_unit_normal.get(a) * spacetime_unit_normal.get(b);
+        deriv_lapse.get(i) += phi.get(i, a, b) * spacetime_unit_normal.get(a) *
+                              spacetime_unit_normal.get(b);
       }
     }
     deriv_lapse.get(i) *= -0.5 * get(lapse);
@@ -196,12 +216,14 @@ Scalar<DataType> time_deriv_of_lapse(
   for (size_t a = 0; a < SpatialDim + 1; ++a) {
     for (size_t b = 0; b < SpatialDim + 1; ++b) {
       // first term
-      get(dt_lapse) += get(lapse) * pi.get(a, b)
-            * spacetime_unit_normal.get(a) * spacetime_unit_normal.get(b);
+      get(dt_lapse) += get(lapse) * pi.get(a, b) *
+                       spacetime_unit_normal.get(a) *
+                       spacetime_unit_normal.get(b);
       // second term
       for (size_t i = 0; i < SpatialDim; ++i) {
-        get(dt_lapse) -= shift.get(i) * phi.get(i, a, b)
-            * spacetime_unit_normal.get(a) * spacetime_unit_normal.get(b);
+        get(dt_lapse) -= shift.get(i) * phi.get(i, a, b) *
+                         spacetime_unit_normal.get(a) *
+                         spacetime_unit_normal.get(b);
       }
     }
   }
@@ -209,6 +231,135 @@ Scalar<DataType> time_deriv_of_lapse(
   return dt_lapse;
 }
 
+template <size_t SpatialDim, typename Frame, typename DataType>
+void time_deriv_of_spatial_metric(
+    const gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*>
+        dt_spatial_metric,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  if (UNLIKELY(get_size(get<0, 0>(*dt_spatial_metric)) !=
+               get_size(get(lapse)))) {
+    *dt_spatial_metric =
+        tnsr::ii<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    for (size_t j = i; j < SpatialDim; ++j) {
+      dt_spatial_metric->get(i, j) = -get(lapse) * pi.get(i + 1, j + 1);
+      for (size_t k = 0; k < SpatialDim; ++k) {
+        dt_spatial_metric->get(i, j) += shift.get(k) * phi.get(k, i + 1, j + 1);
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> time_deriv_of_spatial_metric(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  tnsr::ii<DataType, SpatialDim, Frame> dt_spatial_metric{};
+  GeneralizedHarmonic::time_deriv_of_spatial_metric<SpatialDim, Frame,
+                                                    DataType>(
+      make_not_null(&dt_spatial_metric), lapse, shift, phi, pi);
+  return dt_spatial_metric;
+}
+
+namespace {
+template <size_t SpatialDim, typename Frame, typename DataType>
+struct D4gBuffer;
+
+template <size_t SpatialDim, typename Frame>
+struct D4gBuffer<SpatialDim, Frame, double> {
+  explicit D4gBuffer(const size_t /*size*/) noexcept {}
+
+  tnsr::ijj<double, SpatialDim, Frame> deriv_of_g{};
+  Scalar<double> det_spatial_metric{};
+};
+
+template <size_t SpatialDim, typename Frame>
+struct D4gBuffer<SpatialDim, Frame, DataVector> {
+ private:
+  // We make one giant allocation so that we don't thrash the heap.
+  Variables<tmpl::list<::Tags::Tempijj<0, SpatialDim, Frame, DataVector>,
+                       ::Tags::TempScalar<1, DataVector>>>
+      buffer_;
+
+ public:
+  explicit D4gBuffer(const size_t size) noexcept
+      : buffer_(size),
+        deriv_of_g(
+            get<::Tags::Tempijj<0, SpatialDim, Frame, DataVector>>(buffer_)),
+        det_spatial_metric(get<::Tags::TempScalar<1, DataVector>>(buffer_)) {}
+
+  tnsr::ijj<DataVector, SpatialDim, Frame>& deriv_of_g;
+  Scalar<DataVector>& det_spatial_metric;
+};
+}  // namespace
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_det_spatial_metric(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*>
+        d4_det_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  if (UNLIKELY(get_size(get<0>(*d4_det_spatial_metric)) !=
+               get_size(get(sqrt_det_spatial_metric)))) {
+    *d4_det_spatial_metric = tnsr::a<DataType, SpatialDim, Frame>(
+        get_size(get(sqrt_det_spatial_metric)));
+  }
+  auto& d4_g = *d4_det_spatial_metric;
+  // Use a Variables to reduce total number of allocations. This is especially
+  // important in a multithreaded environment.
+  D4gBuffer<SpatialDim, Frame, DataType> buffer(
+      get_size(get(sqrt_det_spatial_metric)));
+  deriv_spatial_metric<SpatialDim, Frame, DataType>(
+      make_not_null(&buffer.deriv_of_g), phi);
+  get(buffer.det_spatial_metric) = square(get(sqrt_det_spatial_metric));
+  // \f$ \partial_0 g = g g^{jk} \partial_0 g_{jk}\f$
+  get<0>(d4_g) = inverse_spatial_metric.get(0, 0) * dt_spatial_metric.get(0, 0);
+  for (size_t j = 0; j < SpatialDim; ++j) {
+    for (size_t k = 0; k < SpatialDim; ++k) {
+      if (j != 0 or k != 0) {
+        get<0>(d4_g) +=
+            inverse_spatial_metric.get(j, k) * dt_spatial_metric.get(j, k);
+      }
+    }
+  }
+  get<0>(d4_g) *= get(buffer.det_spatial_metric);
+  // \f$ \partial_i g = g g^{jk} \partial_i g_{jk}\f$
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    d4_g.get(i + 1) =
+        inverse_spatial_metric.get(0, 0) * buffer.deriv_of_g.get(i, 0, 0);
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      for (size_t k = 0; k < SpatialDim; ++k) {
+        if (j != 0 or k != 0) {
+          d4_g.get(i + 1) +=
+              inverse_spatial_metric.get(j, k) * buffer.deriv_of_g.get(i, j, k);
+        }
+      }
+    }
+    d4_g.get(i + 1) *= get(buffer.det_spatial_metric);
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_det_spatial_metric(
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  tnsr::a<DataType, SpatialDim, Frame> d4_det_spatial_metric{};
+  GeneralizedHarmonic::spacetime_deriv_of_det_spatial_metric<SpatialDim, Frame,
+                                                             DataType>(
+      make_not_null(&d4_det_spatial_metric), sqrt_det_spatial_metric,
+      inverse_spatial_metric, dt_spatial_metric, phi);
+  return d4_det_spatial_metric;
+}
 }  // namespace GeneralizedHarmonic
 
 /// \cond
@@ -240,20 +391,52 @@ Scalar<DataType> time_deriv_of_lapse(
           spacetime_normal_vector,                                            \
       const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,                \
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
+  template void GeneralizedHarmonic::deriv_spatial_metric(                    \
+      const gsl::not_null<tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          d_spatial_metric,                                                   \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
   template tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>                     \
   GeneralizedHarmonic::deriv_spatial_metric(                                  \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
+  template void GeneralizedHarmonic::time_deriv_of_spatial_metric(            \
+      const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>     \
+          dt_spatial_metric,                                                  \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi) noexcept;      \
+  template tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>                      \
+  GeneralizedHarmonic::time_deriv_of_spatial_metric(                          \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi) noexcept;      \
+  template void GeneralizedHarmonic::spacetime_deriv_of_det_spatial_metric(   \
+      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          d4_det_spatial_metric,                                              \
+      const Scalar<DTYPE(data)>& det_spatial_metric,                          \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \
+  GeneralizedHarmonic::spacetime_deriv_of_det_spatial_metric(                 \
+      const Scalar<DTYPE(data)>& det_spatial_metric,                          \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          inverse_spatial_metric,                                             \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
   template tnsr::i<DTYPE(data), DIM(data), FRAME(data)>                       \
   GeneralizedHarmonic::spatial_deriv_of_lapse(                                \
       const Scalar<DTYPE(data)>& lapse,                                       \
       const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
-        spacetime_unit_normal,                                                \
+          spacetime_unit_normal,                                              \
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
   template Scalar<DTYPE(data)> GeneralizedHarmonic::time_deriv_of_lapse(      \
       const Scalar<DTYPE(data)>& lapse,                                       \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
       const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                     \
-        spacetime_unit_normal,                                                \
+          spacetime_unit_normal,                                              \
       const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,              \
       const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi) noexcept;      \
   template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                       \

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -10,6 +10,13 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
+/// \cond
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
 namespace GeneralizedHarmonic {
 /*!
  * \ingroup GeneralRelativityGroup
@@ -45,7 +52,7 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
  *
  * \details If \f$ N, N^i\f$ are the lapse and shift
  * respectively, and \f$ \Phi_{iab} = \partial_i \psi_{ab} \f$ then
- * \f$\Pi_{\mu\nu} = -(1/N) ( \partial_t \psi_{\mu\nu}  -
+ * \f$\Pi_{\mu\nu} = -\frac{1}{N} ( \partial_t \psi_{\mu\nu}  -
  *      N^m \Phi_{m\mu\nu}) \f$ where \f$ \partial_t \psi_{ab} \f$ is computed
  * as
  *
@@ -112,6 +119,7 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
     const tnsr::aa<DataType, SpatialDim, Frame>& pi,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
 
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes spatial derivatives of the spatial metric from
@@ -120,15 +128,82 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
  * \details If \f$ \Phi_{kab} \f$ is the generalized
  * harmonic spatial derivative variable, then the derivatives of the
  * spatial metric are
- * \f{align}
- *      \partial_k g_{ij} &= \Phi_{kij}
- * \f}
+ * \f[
+ *      \partial_k g_{ij} = \Phi_{kij}
+ * \f]
  *
  * This quantity is needed for computing spatial Christoffel symbols.
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
+void deriv_spatial_metric(
+    gsl::not_null<tnsr::ijj<DataType, SpatialDim, Frame>*> d_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::ijj<DataType, SpatialDim, Frame> deriv_spatial_metric(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes time derivative of the spatial metric.
+ *
+ * \details Let the generalized harmonic conjugate momentum and spatial
+ * derivative variables be \f$\Pi_{ab} = -t^c \partial_c \psi_{ab} \f$ and
+ * \f$\Phi_{iab} = \partial_i \psi_{ab} \f$. As \f$ t_i \equiv 0 \f$. The time
+ * derivative of the spatial metric is given by the time derivative of the
+ * spatial sector of the spacetime metric, i.e.
+ * \f$ \partial_0 g_{ij} = \partial_0 \psi_{ij} \f$.
+ *
+ * To compute the latter, we use the evolution equation for \f$ \psi_{ij} \f$,
+ * c.f. eq.(35) of "A New Generalized Harmonic Evolution System" by
+ * Lindblom et. al \cite Lindblom2005qh (with \f$\gamma_1 = -1\f$):
+ *
+ * \f[
+ * \partial_0 \psi_{ab} = - N \Pi_{ab} + N^k \Phi_{kab}
+ * \f]
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void time_deriv_of_spatial_metric(
+    gsl::not_null<tnsr::ii<DataType, SpatialDim, Frame>*> dt_spatial_metric,
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::ii<DataType, SpatialDim, Frame> time_deriv_of_spatial_metric(
+    const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Computes spacetime derivatives of the determinant of spatial metric,
+ *        using the generalized harmonic variables, spatial metric, and its
+ *        time derivative.
+ *
+ * \details Using the relation \f$ \partial_a g = g g^{jk} \partial_a g_{jk} \f$
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+void spacetime_deriv_of_det_spatial_metric(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> d4_det_spatial_metric,
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_det_spatial_metric(
+    const Scalar<DataType>& sqrt_det_spatial_metric,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+// @}
 
 /*!
  * \ingroup GeneralRelativityGroup

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/TestFunctions.py
@@ -140,6 +140,28 @@ def dt_lapse(lapse, shift, spacetime_unit_normal, phi, pi):
     return 0.5 * lapse * (t1 - t2)
 
 
+def deriv_spatial_metric(phi):
+    return phi[:,1:,1:]
+
+
+def dt_spatial_metric(lapse, shift, phi, pi):
+    return (-lapse * pi + np.einsum('k,kab->ab', shift, phi))[1:,1:]
+
+
+def spacetime_deriv_detg(sqrt_det_spatial_metric, inverse_spatial_metric,
+        dt_spatial_metric, phi):
+    det_spatial_metric = sqrt_det_spatial_metric**2
+    deriv_of_g = deriv_spatial_metric(phi)
+    dtg = np.einsum('jk,jk', inverse_spatial_metric, dt_spatial_metric)
+    dtg *= det_spatial_metric
+    dxg = np.einsum('jk,ijk->i', inverse_spatial_metric, deriv_of_g)
+    dxg *= det_spatial_metric
+    dg     = np.zeros(1  + len(dxg))
+    dg[0]  = dtg
+    dg[1:] = dxg
+    return dg
+
+
 # End tests for Test_ComputeGhQuantities.cpp
 
 # Begin tests for Test_Ricci.cpp


### PR DESCRIPTION
## Proposed changes

- Adds functions to compute derivatives of spatial metric from generalized harmonic variables.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
