### PR TITLE
Give appropriate CMake errors for absent libsharp

### DIFF
--- a/cmake/FindLibsharp.cmake
+++ b/cmake/FindLibsharp.cmake
@@ -29,10 +29,11 @@ find_library(LIBSHARP_LIBCUTILS
 
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(libsharp
-    DEFAULT_MSG LIBSHARP_INCLUDE_DIRS LIBSHARP_LIBRARIES)
-find_package_handle_standard_args(libsharp
-    DEFAULT_MSG LIBSHARP_INCLUDE_DIRS LIBSHARP_LIBFFTPACK)
-find_package_handle_standard_args(libsharp
-    DEFAULT_MSG LIBSHARP_INCLUDE_DIRS LIBSHARP_LIBCUTILS)
-mark_as_advanced(LIBSHARP_INCLUDE_DIRS LIBSHARP_LIBRARIES LIBSHARP_FFTPACK LIBSHARP_LIBCUTILS)
+find_package_handle_standard_args(Libsharp
+    REQUIRED_VARS LIBSHARP_INCLUDE_DIRS
+    LIBSHARP_LIBRARIES LIBSHARP_LIBFFTPACK LIBSHARP_LIBCUTILS)
+
+mark_as_advanced(LIBSHARP_INCLUDE_DIRS)
+mark_as_advanced(LIBSHARP_LIBRARIES)
+mark_as_advanced(LIBSHARP_FFTPACK)
+mark_as_advanced(LIBSHARP_LIBCUTILS)


### PR DESCRIPTION
## Proposed changes

-  Solves [Issue 1181](https://github.com/sxs-collaboration/spectre/issues/1181)

### Types of changes:

- [ ] Bugfix

### Component:

- [ ] Build system

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
