### PR TITLE
Prevent non ASCII characters from being added to the code base

### DIFF
--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -38,20 +38,20 @@ installation_on_clusters "Installation on clusters" page.
 * [SciPy](https://www.scipy.org)
 
 #### Optional:
-* [Doxygen](http://www.stack.nl/~dimitri/doxygen/index.html) — to generate
+* [Doxygen](http://www.stack.nl/~dimitri/doxygen/index.html) - to generate
   documentation
 * [Google Benchmark](https://github.com/google/benchmark) - to do
   microbenchmarking inside the SpECTRE framework. v1.2 or newer is required
 * [LCOV](http://ltp.sourceforge.net/coverage/lcov.php) and
-  [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) — to check code test
+  [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) - to check code test
   coverage
-* [coverxygen](https://github.com/psycofdj/coverxygen) — to check documentation
+* [coverxygen](https://github.com/psycofdj/coverxygen) - to check documentation
   coverage
-* [PAPI](http://icl.utk.edu/papi/) — to access hardware performance counters
-* [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) — to format C++
+* [PAPI](http://icl.utk.edu/papi/) - to access hardware performance counters
+* [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) - to format C++
   code in a clear and consistent fashion
-* [Clang-Tidy](http://clang.llvm.org/extra/clang-tidy/) — to "lint" C++ code
-* [Cppcheck](http://cppcheck.sourceforge.net/) — to analyze C++ code
+* [Clang-Tidy](http://clang.llvm.org/extra/clang-tidy/) - to "lint" C++ code
+* [Cppcheck](http://cppcheck.sourceforge.net/) - to analyze C++ code
 
 ## Using Docker to obtain a SpECTRE environment
 
@@ -190,7 +190,7 @@ Install Spack by cloning it into `SPACK_DIR` (a directory of your choice),
 then add `SPACK_DIR/bin` to your `PATH`.
 
 For security, it is good practice to make Spack use the system's OpenSSL
-rather than allow it to install a new copy — see Spack's documentation for
+rather than allow it to install a new copy - see Spack's documentation for
 [instructions](https://spack.readthedocs.io/en/latest/getting_started.html#openssl).
 You may need to install the development version of OpenSSL:
 * On Ubuntu (16.04), run `sudo apt-get install libssl-dev`

--- a/external/SPHEREPACK/LICENSE.txt
+++ b/external/SPHEREPACK/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright © 2004 the University Corporation for Atmospheric Research
+Copyright 2004 the University Corporation for Atmospheric Research
 ("UCAR"). All rights reserved. Developed by NCAR's Computational and
 Information Systems Laboratory, UCAR, www2.cisl.ucar.edu.
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Characteristics.hpp
@@ -57,7 +57,7 @@ namespace ValenciaDivClean {
  * c_s^2 \longrightarrow c_s^2 + v_A^2(1 - c_s^2)
  * \f}
  *
- * in the definition of \f$\Lambda^\pm\f$. Here \f$v_A\f$ is the Alfvén
+ * in the definition of \f$\Lambda^\pm\f$. Here \f$v_A\f$ is the Alfven
  * speed. In addition, two more speeds corresponding to the divergence cleaning
  * mode and the longitudinal magnetic field are added,
  *
@@ -69,7 +69,7 @@ namespace ValenciaDivClean {
  * \note The ordering assumed here is such that, in the Newtonian limit,
  * the exact expressions for \f$\lambda_{2, 8}\f$, \f$\lambda_{3, 7}\f$,
  * and \f$\lambda_{4, 6}\f$ should reduce to the
- * corresponding fast modes, Alfvén modes, and slow modes, respectively.
+ * corresponding fast modes, Alfven modes, and slow modes, respectively.
  * See \ref mhd_ref "[2]" for a detailed description of the hyperbolic
  * characterization of Newtonian MHD.  In terms of the primitive variables:
  *
@@ -91,7 +91,7 @@ namespace ValenciaDivClean {
  * the pressure, and \f$B^i\f$ is the spatial magnetic field measured by an
  * Eulerian observer.
 
- * \anchor char_ref [1] C.F Gammie, J.C McKinney, G. Tóth, HARM: A Numerical
+ * \anchor char_ref [1] C.F Gammie, J.C McKinney, G. Toth, HARM: A Numerical
  * Scheme for General Relativistic Magnetohydrodynamics, ApJ.
  * [589 (2003) 444](http://iopscience.iop.org/article/10.1086/374594/meta)
  *

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/BondiHoyleAccretion.hpp
@@ -32,7 +32,7 @@ namespace AnalyticData {
  *
  * In the context of studying Bondi-Hoyle accretion, i.e. non-spherical
  * accretion on to a Kerr black hole moving relative to a gas cloud, this class
- * implements the method proposed by Font & Ibáñez (1998) \ref font_98 "[1]" to
+ * implements the method proposed by Font & Ibanez (1998) \ref font_98 "[1]" to
  * initialize the GRMHD variables. The fluid quantities are initialized with
  * their (constant) values far from the black hole, e.g.
  * \f$\rho = \rho_\infty\f$. Here we assume a
@@ -78,7 +78,7 @@ namespace AnalyticData {
  * where \f$\gamma = \text{det}(\gamma_{ij})\f$. Wald's solution reproduces a
  * uniform magnetic field far from the black hole.
  *
- * \anchor font_98 [1] J.A. Font & J.M. Ibáñez, ApJ
+ * \anchor font_98 [1] J.A. Font & J.M. Ibanez, ApJ
  * [494 (1998) 297](http://esoads.eso.org/abs/1998ApJ...494..297F)
  *
  * \anchor penner_11 [2] A.J. Penner, MNRAS

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -17,7 +17,7 @@ namespace hydro {
 /// %Tags for hydrodynamic systems.
 namespace Tags {
 
-/// The Alfvén speed squared \f$v_A^2\f$.
+/// The Alfven speed squared \f$v_A^2\f$.
 template <typename DataType>
 struct AlfvenSpeedSquared : db::SimpleTag {
   using type = Scalar<DataType>;

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -215,6 +215,23 @@ carriage_returns_test() {
 }
 standard_checks+=(carriage_returns)
 
+# Check for carriage returns
+non_ascii_characters() {
+    whitelist "$1" '.png' 'FileTestDefs.sh' 'octicons.css' &&
+    staged_grep -q -P "[^\x00-\x7F]" "$1"
+}
+non_ascii_characters_report() {
+    echo "Found non-ASCII characters in the following files:"
+    # Skip highlighting because trying to highlight a carriage return
+    # confuses some terminals.
+    pretty_grep ${color_option:+--color=no} -P "[^\x00-\x7F]" "$@"
+}
+non_ascii_characters_test() {
+    test_check pass foo.cpp 'x'
+    test_check fail foo.cpp "Alfvén"
+}
+standard_checks+=(non_ascii_characters)
+
 # Check for license file.
 license() {
     whitelist "$1" \


### PR DESCRIPTION
## Proposed changes

- Remove existing non-ASCII characters outside of `docs/config/icons/octicons.cs`
- Add check to prevent adding non-ASCII characters to the code base


### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
