### PR TITLE
Terminate linear solver algorithm based on convergence flag in DataBox

### DIFF
--- a/src/NumericalAlgorithms/LinearSolver/Actions/TerminateIfConverged.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Actions/TerminateIfConverged.hpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+
+/// \cond
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+namespace Parallel {
+template <typename>
+struct ConstGlobalCache;
+}  // namespace Parallel
+/// \endcond
+
+namespace LinearSolver {
+namespace Actions {
+
+/*!
+ * \brief Terminate the algorithm if the linear solver has converged.
+ *
+ * Uses:
+ * - DataBox:
+ *   - `LinearSolver::Tags::HasConverged`
+ */
+struct TerminateIfConverged {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(db::DataBox<DbTagsList>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    return std::tuple<db::DataBox<DbTagsList>&&, bool>(
+        std::move(box), db::get<LinearSolver::Tags::HasConverged>(box));
+  }
+};
+
+}  // namespace Actions
+}  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
@@ -50,8 +50,7 @@ namespace LinearSolver {
  * broadcast the ratio of the new and old \f$r^2\f$, as well as a termination
  * flag if the residual vanishes to a precision determined by
  * `equal_within_roundoff`.
- * 5. `UpdateOperand` (on elements): Update \f$p\f$. Stop if termination flag
- * was received.
+ * 5. `UpdateOperand` (on elements): Update \f$p\f$.
  *
  * \see Gmres for a linear solver that can invert nonsymmetric operators
  * \f$A\f$.
@@ -82,6 +81,8 @@ struct ConjugateGradient {
    * `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>`
    * - `residual_tag` =
    * `db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>`
+   * - `residual_magnitude_tag` =
+   * `db::add_tag_prefix<LinearSolver::Tags::Magnitude, residual_tag>`
    *
    * DataBox changes:
    * - Adds:
@@ -90,6 +91,8 @@ struct ConjugateGradient {
    *   * `operand_tag`
    *   * `operator_tag`
    *   * `residual_tag`
+   *   * `residual_magnitude_tag`
+   *   * `LinearSolver::Tags::HasConverged`
    * - Removes: nothing
    * - Modifies: nothing
    */
@@ -108,6 +111,8 @@ struct ConjugateGradient {
    * `db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>`
    * - `residual_tag` =
    * `db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>`
+   * - `residual_magnitude_tag` =
+   * `db::add_tag_prefix<LinearSolver::Tags::Magnitude, residual_tag>`
    *
    * DataBox changes:
    * - Adds: nothing
@@ -116,8 +121,10 @@ struct ConjugateGradient {
    *   * `LinearSolver::Tags::IterationId`
    *   * `Tags::Next<LinearSolver::Tags::IterationId>`
    *   * `fields_tag`
-   *   * `residual_tag`
    *   * `operand_tag`
+   *   * `residual_tag`
+   *   * `residual_magnitude_tag`
+   *   * `LinearSolver::Tags::HasConverged`
    */
   using perform_step = cg_detail::PerformStep;
 };

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -22,7 +22,7 @@ class TaggedTuple;
 }  // namespace tuples
 namespace LinearSolver {
 namespace cg_detail {
-template <typename>
+template <typename Metavariables>
 struct InitializeResidualMonitor;
 }  // namespace cg_detail
 }  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ElementActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ElementActions.hpp
@@ -27,7 +27,7 @@ class TaggedTuple;
 }  // namespace tuples
 namespace LinearSolver {
 namespace gmres_detail {
-template <typename>
+template <typename Metavariables>
 struct ResidualMonitor;
 }  // namespace gmres_detail
 }  // namespace LinearSolver
@@ -56,15 +56,20 @@ struct NormalizeInitialOperand {
         db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
     using basis_history_tag =
         LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>;
+    using residual_magnitude_tag = db::add_tag_prefix<
+        LinearSolver::Tags::Magnitude,
+        db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>;
 
-    db::mutate<operand_tag, basis_history_tag>(
+    db::mutate<operand_tag, basis_history_tag, residual_magnitude_tag>(
         make_not_null(&box),
         [residual_magnitude](
             const gsl::not_null<db::item_type<operand_tag>*> operand,
             const gsl::not_null<db::item_type<basis_history_tag>*>
-                basis_history) noexcept {
+                basis_history,
+            const gsl::not_null<double*> local_residual_magnitude) noexcept {
           *operand /= residual_magnitude;
           basis_history->push_back(*operand);
+          *local_residual_magnitude = residual_magnitude;
         });
   }
 };
@@ -174,7 +179,7 @@ struct OrthogonalizeOperand {
   }
 };
 
-struct NormalizeOperand {
+struct NormalizeOperandAndUpdateField {
   template <typename... DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent,
@@ -187,8 +192,13 @@ struct NormalizeOperand {
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index, const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/,
-                    const double normalization) noexcept {
+                    const double normalization,
+                    const DenseVector<double>& minres,
+                    const double residual_magnitude,
+                    const bool has_converged) noexcept {
     using fields_tag = typename Metavariables::system::fields_tag;
+    using initial_fields_tag =
+        db::add_tag_prefix<LinearSolver::Tags::Initial, fields_tag>;
     using operand_tag =
         db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
     using orthogonalization_iteration_id_tag =
@@ -196,25 +206,40 @@ struct NormalizeOperand {
                            LinearSolver::Tags::IterationId>;
     using basis_history_tag =
         LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>;
+    using residual_magnitude_tag = db::add_tag_prefix<
+        LinearSolver::Tags::Magnitude,
+        db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>;
 
     db::mutate<LinearSolver::Tags::IterationId,
                ::Tags::Next<LinearSolver::Tags::IterationId>,
                orthogonalization_iteration_id_tag, operand_tag,
-               basis_history_tag>(
+               basis_history_tag, fields_tag, residual_magnitude_tag,
+               LinearSolver::Tags::HasConverged>(
         make_not_null(&box),
-        [normalization](
-            const gsl::not_null<IterationId*> iteration_id,
-            const gsl::not_null<IterationId*> next_iteration_id,
-            const gsl::not_null<IterationId*> orthogonalization_iteration_id,
-            const gsl::not_null<db::item_type<operand_tag>*> operand,
-            const gsl::not_null<db::item_type<basis_history_tag>*>
-                basis_history) noexcept {
+        [
+          normalization, minres, residual_magnitude, has_converged
+        ](const gsl::not_null<IterationId*> iteration_id,
+          const gsl::not_null<IterationId*> next_iteration_id,
+          const gsl::not_null<IterationId*> orthogonalization_iteration_id,
+          const gsl::not_null<db::item_type<operand_tag>*> operand,
+          const gsl::not_null<db::item_type<basis_history_tag>*> basis_history,
+          const gsl::not_null<db::item_type<fields_tag>*> field,
+          const gsl::not_null<double*> local_residual_magnitude,
+          const gsl::not_null<bool*> local_has_converged,
+          const db::item_type<initial_fields_tag>& initial_field) noexcept {
           iteration_id->step_number++;
           next_iteration_id->step_number = iteration_id->step_number + 1;
           orthogonalization_iteration_id->step_number = 0;
           *operand /= normalization;
           basis_history->push_back(*operand);
-        });
+          *field = initial_field;
+          for (size_t i = 0; i < minres.size(); i++) {
+            *field += minres[i] * gsl::at(*basis_history, i);
+          }
+          *local_residual_magnitude = residual_magnitude;
+          *local_has_converged = has_converged;
+        },
+        get<initial_fields_tag>(box));
 
     // Proceed with algorithm
     // We use `ckLocal()` here since this is essentially retrieving "self",
@@ -225,44 +250,6 @@ struct NormalizeOperand {
         ->set_terminate(false);
     Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
         .perform_algorithm();
-  }
-};
-
-struct UpdateFieldAndTerminate {
-  template <typename... DbTags, typename... InboxTags, typename Metavariables,
-            typename ArrayIndex, typename ActionList,
-            typename ParallelComponent,
-            Requires<tmpl2::flat_any_v<cpp17::is_same_v<
-                typename Metavariables::system::fields_tag,
-                DbTags>...>> = nullptr>
-  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
-                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    Parallel::ConstGlobalCache<Metavariables>& cache,
-                    const ArrayIndex& array_index, const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/,
-                    const DenseVector<double>& minres) noexcept {
-    using fields_tag = typename Metavariables::system::fields_tag;
-    using basis_history_tag =
-        LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>;
-
-    db::mutate<fields_tag>(
-        make_not_null(&box),
-        [minres](
-            const gsl::not_null<db::item_type<fields_tag>*> field,
-            const db::item_type<basis_history_tag>& basis_history) noexcept {
-          for (size_t i = 0; i < minres.size(); i++) {
-            *field += minres[i] * gsl::at(basis_history, i);
-          }
-        },
-        get<basis_history_tag>(box));
-
-    // Terminate algorithm
-    // We use `ckLocal()` here since this is essentially retrieving "self",
-    // which is guaranteed to be on the local processor. This ensures the calls
-    // are evaluated in order.
-    Parallel::get_parallel_component<ParallelComponent>(cache)[array_index]
-        .ckLocal()
-        ->set_terminate(true);
   }
 };
 

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -55,12 +55,9 @@ namespace LinearSolver {
  * Broadcast to `UpdateFieldAndTerminate` if the residual vanishes to a
  * precision determined by `equal_within_roundoff`, else broadcast to
  * `NormalizeOperand`.
- * 5. `NormalizeOperand` (on elements): Set the operand \f$q\f$ as the new
- * orthogonal vector and normalize. `UpdateFieldAndTerminate`: Use the residual
- * vector and the set of orthogonal vectors to determine the solution \f$x\f$.
- *
- * \note that the field \f$x\f$ is not updated in every step, but only set to
- * the solution when the algorithm has decided to terminate.
+ * 5. `NormalizeOperandAndUpdateField` (on elements): Set the operand \f$q\f$ as
+ * the new orthogonal vector and normalize. Use the residual vector and the set
+ * of orthogonal vectors to determine the solution \f$x\f$.
  *
  * \see ConjugateGradient for a linear solver that is more efficient when the
  * linear operator \f$A\f$ is symmetric.
@@ -86,6 +83,8 @@ struct Gmres {
    * - ConstGlobalCache: nothing
    *
    * With:
+   * - `initial_fields_tag` =
+   * `db::add_tag_prefix<LinearSolver::Tags::Initial, fields_tag>`
    * - `operand_tag` =
    * `db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>`
    * - `operator_tag` =
@@ -95,15 +94,21 @@ struct Gmres {
    * LinearSolver::Tags::IterationId>`
    * - `basis_history_tag` =
    * `LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>`
+   * - `residual_magnitude_tag` =
+   * `db::add_tag_prefix<LinearSolver::Tags::Magnitude,
+   * db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>`
    *
    * DataBox changes:
    * - Adds:
    *   * `LinearSolver::Tags::IterationId`
    *   * `Tags::Next<LinearSolver::Tags::IterationId>`
+   *   * `initial_fields_tag`
    *   * `operand_tag`
    *   * `operator_tag`
    *   * `orthogonalization_iteration_id_tag`
    *   * `basis_history_tag`
+   *   * `residual_magnitude_tag`
+   *   * `LinearSolver::Tags::HasConverged`
    * - Removes: nothing
    * - Modifies: nothing
    */
@@ -125,6 +130,9 @@ struct Gmres {
    * LinearSolver::Tags::IterationId>`
    * - `basis_history_tag` =
    * `LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>`
+   * - `residual_magnitude_tag` =
+   * `db::add_tag_prefix<LinearSolver::Tags::Magnitude,
+   * db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>`
    *
    * DataBox changes:
    * - Adds: nothing
@@ -133,9 +141,11 @@ struct Gmres {
    *   * `LinearSolver::Tags::IterationId`
    *   * `Tags::Next<LinearSolver::Tags::IterationId>`
    *   * `fields_tag`
+   *   * `operand_tag`
    *   * `orthogonalization_iteration_id_tag`
    *   * `basis_history_tag`
-   *   * `operand_tag`
+   *   * `residual_magnitude_tag`
+   *   * `LinearSolver::Tags::HasConverged`
    */
   using perform_step = gmres_detail::PerformStep;
 };

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -23,7 +23,7 @@ class TaggedTuple;
 }  // namespace tuples
 namespace LinearSolver {
 namespace gmres_detail {
-template <typename>
+template <typename Metavariables>
 struct InitializeResidualMonitor;
 }  // namespace gmres_detail
 }  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Tags.hpp
@@ -69,6 +69,16 @@ struct IterationId : db::SimpleTag {
 };
 
 /*!
+ * \brief Holds a flag that signals the linear solver has converged
+ */
+struct HasConverged : db::SimpleTag {
+  static std::string name() noexcept {
+    return "LinearSolverHasConverged";
+  }
+  using type = bool;
+};
+
+/*!
  * \brief The residual \f$r=b - Ax\f$
  */
 template <typename Tag>
@@ -77,6 +87,13 @@ struct Residual : db::PrefixTag, db::SimpleTag {
     // Add "Linear" prefix to abbreviate the namespace for uniqueness
     return "LinearResidual(" + Tag::name() + ")";
   }
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+
+template <typename Tag>
+struct Initial : db::PrefixTag, db::SimpleTag {
+  static std::string name() noexcept { return "Initial(" + Tag::name() + ")"; }
   using type = typename Tag::type;
   using tag = Tag;
 };

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Actions/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Actions/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_LinearSolverActions")
+
+set(LIBRARY_SOURCES
+  Test_TerminateIfConverged.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "NumericalAlgorithms/LinearSolver/Actions"
+  "${LIBRARY_SOURCES}"
+  "DataStructures;LinearSolver"
+  )

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Actions/Test_TerminateIfConverged.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Actions/Test_TerminateIfConverged.cpp
@@ -1,0 +1,85 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "NumericalAlgorithms/LinearSolver/Actions/TerminateIfConverged.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace {
+
+using simple_tags = db::AddSimpleTags<LinearSolver::Tags::HasConverged>;
+
+template <typename Metavariables>
+struct ElementArray {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<LinearSolver::Actions::TerminateIfConverged>;
+  using initial_databox = db::compute_databox_type<simple_tags>;
+};
+
+struct Metavariables {
+  using component_list = tmpl::list<ElementArray<Metavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+};
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Actions.TerminateIfConverged",
+                  "[Unit][NumericalAlgorithms][LinearSolver][Actions]") {
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+  using MockDistributedObjectsTag =
+      MockRuntimeSystem::MockDistributedObjectsTag<ElementArray<Metavariables>>;
+
+  const int self_id{0};
+
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+
+  SECTION("ProceedIfNotConverged") {
+    tuples::get<MockDistributedObjectsTag>(dist_objects)
+        .emplace(self_id, db::create<simple_tags>(false));
+    MockRuntimeSystem runner{{}, std::move(dist_objects)};
+    const auto get_box = [&runner, &self_id]() -> decltype(auto) {
+      return runner.algorithms<ElementArray<Metavariables>>()
+          .at(self_id)
+          .get_databox<ElementArray<Metavariables>::initial_databox>();
+    };
+    CHECK_FALSE(db::get<LinearSolver::Tags::HasConverged>(get_box()));
+
+    // This should do nothing
+    runner.next_action<ElementArray<Metavariables>>(self_id);
+
+    CHECK_FALSE(db::get<LinearSolver::Tags::HasConverged>(get_box()));
+    CHECK_FALSE(runner.algorithms<ElementArray<Metavariables>>()
+                    .at(self_id)
+                    .get_terminate());
+  }
+  SECTION("TerminateIfConverged") {
+    tuples::get<MockDistributedObjectsTag>(dist_objects)
+        .emplace(self_id, db::create<simple_tags>(true));
+    MockRuntimeSystem runner{{}, std::move(dist_objects)};
+    const auto get_box = [&runner, &self_id]() -> decltype(auto) {
+      return runner.algorithms<ElementArray<Metavariables>>()
+          .at(self_id)
+          .get_databox<ElementArray<Metavariables>::initial_databox>();
+    };
+    CHECK(db::get<LinearSolver::Tags::HasConverged>(get_box()));
+
+    // This should terminate the algorithm
+    runner.next_action<ElementArray<Metavariables>>(self_id);
+
+    CHECK(db::get<LinearSolver::Tags::HasConverged>(get_box()));
+    CHECK(runner.algorithms<ElementArray<Metavariables>>()
+              .at(self_id)
+              .get_terminate());
+  }
+}

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_Tags.cpp
   )
 
+add_subdirectory(Actions)
 add_subdirectory(ConjugateGradient)
 add_subdirectory(Gmres)
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -22,6 +22,7 @@
 #include "DataStructures/Variables.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "NumericalAlgorithms/LinearSolver/Actions/TerminateIfConverged.hpp"
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
@@ -210,7 +211,8 @@ struct ElementArray {
   using chare_type = Parallel::Algorithms::Array;
   using metavariables = Metavariables;
   using action_list =
-      tmpl::list<ComputeOperatorAction,
+      tmpl::list<LinearSolver::Actions::TerminateIfConverged,
+                 ComputeOperatorAction,
                  typename Metavariables::linear_solver::perform_step>;
   using initial_databox = db::compute_databox_type<
       typename InitializeElement::return_tag_list<Metavariables>>;

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -18,8 +18,7 @@
 #include "DataStructures/DenseVector.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
-#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp"
-#include "NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp"
+#include "NumericalAlgorithms/LinearSolver/Actions/TerminateIfConverged.hpp"
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
@@ -131,7 +130,8 @@ struct ElementArray {
   // magnitude and the iteration step number.
   /// [action_list]
   using action_list =
-      tmpl::list<ComputeOperatorAction,
+      tmpl::list<LinearSolver::Actions::TerminateIfConverged,
+                 ComputeOperatorAction,
                  typename Metavariables::linear_solver::perform_step>;
   /// [action_list]
   using initial_databox = db::compute_databox_type<

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_IterationId.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_IterationId.cpp
@@ -27,7 +27,5 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.IterationId",
   test_serialization(id);
   test_copy_semantics(id);
 
-  SECTION("Tag") {
-    CHECK(LinearSolver::Tags::IterationId::name() == "LinearIterationId");
-  }
+  CHECK(LinearSolver::Tags::IterationId::name() == "LinearIterationId");
 }

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Tags.cpp
@@ -20,7 +20,9 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Tags",
   CHECK(LinearSolver::Tags::Operand<Tag>::name() == "LinearOperand(Tag)");
   CHECK(LinearSolver::Tags::OperatorAppliedTo<Tag>::name() ==
         "LinearOperatorAppliedTo(Tag)");
+  CHECK(LinearSolver::Tags::HasConverged::name() == "LinearSolverHasConverged");
   CHECK(LinearSolver::Tags::Residual<Tag>::name() == "LinearResidual(Tag)");
+  CHECK(LinearSolver::Tags::Initial<Tag>::name() == "Initial(Tag)");
   CHECK(LinearSolver::Tags::MagnitudeSquare<Tag>::name() ==
         "LinearMagnitudeSquare(Tag)");
   CHECK(LinearSolver::Tags::Magnitude<Tag>::name() == "LinearMagnitude(Tag)");


### PR DESCRIPTION
## Proposed changes

This PR changes the termination behaviour of the linear solvers (CG and GMRES). Instead of terminating the algorithm directly when they have converged, they now set a flag in `LinearSolver::Tags::HasConverged`. A new action `LinerSolver::Actions::TerminateIfConverged` handles the termination of the algorithm. This is necessary to do observations also after convergence, as well as to embed the linear solver into the (not yet implemented) non-linear solver.

I also add a `LinearSolver::Tags::Initial` prefix that is used to store the initial guess. This allows GMRES to update the solution in every step, as opposed to only after convergence, which is useful for observations. The `LinearSolver::Tags::Residual` magnitude is also stored on the elements so that it can be observed (it was stored only in the residual monitor before).

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
