### PR TITLE
Add KomissarovShock analytic solution

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -45,6 +45,17 @@ url = "http://www.sciencedirect.com/science/article/pii/S0021999117300098",
 author = "Lawrence E. Kidder and Scott E. Field and Francois Foucart and Erik Schnetter and Saul A. Teukolsky and Andy Bohn and Nils Deppe and Peter Diener and Fran\c{c}ois H\'ebert and Jonas Lippuner and Jonah Miller and Christian D. Ott and Mark A. Scheel and Trevor Vincent",
 }
 
+@article{Komissarov1999,
+ author    = "Komissarov, S. S.",
+ title     = "A Godunov-type scheme for relativistic magnetohydrodynamics",
+ journal   = "Monthly Notices of the Royal Astronomical Society",
+ volume    = "303",
+ number    = "2",
+ pages     = "343-366",
+ year      = "1999",
+ url       = "https://doi.org/10.1046/j.1365-8711.1999.02244.x"
+}
+
 @Book{Kopriva,
  author    = "David A. {Kopriva}",
  title     = "Implementing Spectral Methods for Partial Differential Equations",

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY GrMhdSolutions)
 set(LIBRARY_SOURCES
     AlfvenWave.cpp
     BondiMichel.cpp
+    KomissarovShock.cpp
     SmoothFlow.cpp
     )
 

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.cpp
@@ -1,0 +1,222 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp"
+
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Parallel/PupStlCpp11.hpp"
+#include "PointwiseFunctions/Hydro/LorentzFactor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp"  // IWYU pragma: keep
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+template <typename DataType>
+Scalar<DataType> compute_piecewise(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double shock_position,
+    const double left_value, const double right_value) noexcept {
+  return Scalar<DataType>(left_value -
+                          (left_value - right_value) *
+                              step_function(get<0>(x) - shock_position));
+}
+
+template <typename DataType>
+tnsr::I<DataType, 3, Frame::Inertial> compute_piecewise_vector(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double shock_position,
+    const std::array<double, 3>& left_value,
+    const std::array<double, 3>& right_value) noexcept {
+  return tnsr::I<DataType, 3, Frame::Inertial>{
+      {{left_value[0] - (left_value[0] - right_value[0]) *
+                            step_function(get<0>(x) - shock_position),
+        left_value[1] - (left_value[1] - right_value[1]) *
+                            step_function(get<0>(x) - shock_position),
+        left_value[2] - (left_value[2] - right_value[2]) *
+                            step_function(get<0>(x) - shock_position)}}};
+}
+}  // namespace
+
+/// \cond
+namespace grmhd {
+namespace Solutions {
+
+KomissarovShock::KomissarovShock(
+    AdiabaticIndex::type adiabatic_index,
+    LeftRestMassDensity::type left_rest_mass_density,
+    RightRestMassDensity::type right_rest_mass_density,
+    LeftPressure::type left_pressure, RightPressure::type right_pressure,
+    LeftSpatialVelocity::type left_spatial_velocity,
+    RightSpatialVelocity::type right_spatial_velocity,
+    LeftMagneticField::type left_magnetic_field,
+    RightMagneticField::type right_magnetic_field,
+    ShockSpeed::type shock_speed) noexcept
+    : equation_of_state_(adiabatic_index),
+      adiabatic_index_(adiabatic_index),
+      left_rest_mass_density_(left_rest_mass_density),
+      right_rest_mass_density_(right_rest_mass_density),
+      left_pressure_(left_pressure),
+      right_pressure_(right_pressure),
+      left_spatial_velocity_(left_spatial_velocity),
+      right_spatial_velocity_(right_spatial_velocity),
+      left_magnetic_field_(left_magnetic_field),
+      right_magnetic_field_(right_magnetic_field),
+      shock_speed_(shock_speed) {}
+
+void KomissarovShock::pup(PUP::er& p) noexcept {
+  p | adiabatic_index_;
+  p | left_rest_mass_density_;
+  p | right_rest_mass_density_;
+  p | left_pressure_;
+  p | right_pressure_;
+  p | left_spatial_velocity_;
+  p | right_spatial_velocity_;
+  p | left_magnetic_field_;
+  p | right_magnetic_field_;
+  p | shock_speed_;
+  p | equation_of_state_;
+  p | background_spacetime_;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>
+KomissarovShock::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
+    noexcept {
+  return compute_piecewise(x, t * shock_speed_, left_rest_mass_density_,
+                           right_rest_mass_density_);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
+KomissarovShock::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/) const
+    noexcept {
+  return compute_piecewise_vector(x, t * shock_speed_, left_spatial_velocity_,
+                                  right_spatial_velocity_);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
+KomissarovShock::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
+    noexcept {
+  return equation_of_state_.specific_internal_energy_from_density_and_pressure(
+      get<hydro::Tags::RestMassDensity<DataType>>(variables(
+          x, t, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{})),
+      get<hydro::Tags::Pressure<DataType>>(
+          variables(x, t, tmpl::list<hydro::Tags::Pressure<DataType>>{})));
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::Pressure<DataType>> KomissarovShock::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const noexcept {
+  return compute_piecewise(x, t * shock_speed_, left_pressure_,
+                           right_pressure_);
+  ;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>
+KomissarovShock::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const
+    noexcept {
+  return compute_piecewise_vector(x, t * shock_speed_, left_magnetic_field_,
+                                  right_magnetic_field_);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>
+KomissarovShock::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double /*t*/,
+    tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
+    noexcept {
+  return {make_with_value<
+      db::item_type<hydro::Tags::DivergenceCleaningField<DataType>>>(x, 0.0)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>
+KomissarovShock::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept {
+  const auto spatial_velocity = get<hydro::Tags::SpatialVelocity<DataType, 3>>(
+      variables(x, t, tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>>{}));
+  return {
+      hydro::lorentz_factor(dot_product(spatial_velocity, spatial_velocity))};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>
+KomissarovShock::variables(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t,
+    tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
+    noexcept {
+  return equation_of_state_.specific_enthalpy_from_density_and_energy(
+      get<hydro::Tags::RestMassDensity<DataType>>(variables(
+          x, t, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{})),
+      get<hydro::Tags::SpecificInternalEnergy<DataType>>(variables(
+          x, t, tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>>{})));
+}
+
+bool operator==(const KomissarovShock& lhs,
+                const KomissarovShock& rhs) noexcept {
+  return lhs.adiabatic_index_ == rhs.adiabatic_index_ and
+         lhs.left_rest_mass_density_ == rhs.left_rest_mass_density_ and
+         lhs.right_rest_mass_density_ == rhs.right_rest_mass_density_ and
+         lhs.left_pressure_ == rhs.left_pressure_ and
+         lhs.right_pressure_ == rhs.right_pressure_ and
+         lhs.left_spatial_velocity_ == rhs.left_spatial_velocity_ and
+         lhs.right_spatial_velocity_ == rhs.right_spatial_velocity_ and
+         lhs.left_magnetic_field_ == rhs.left_magnetic_field_ and
+         lhs.right_magnetic_field_ == rhs.right_magnetic_field_ and
+         lhs.shock_speed_ == rhs.shock_speed_;
+}
+
+bool operator!=(const KomissarovShock& lhs,
+                const KomissarovShock& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define TAG(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_SCALARS(_, data)                               \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>>           \
+      KomissarovShock::variables(                                  \
+          const tnsr::I<DTYPE(data), 3, Frame::Inertial>&, double, \
+          tmpl::list<TAG(data) < DTYPE(data)>>) const noexcept;
+
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE_SCALARS, (double, DataVector),
+    (hydro::Tags::RestMassDensity, hydro::Tags::SpecificInternalEnergy,
+     hydro::Tags::Pressure, hydro::Tags::DivergenceCleaningField,
+     hydro::Tags::LorentzFactor, hydro::Tags::SpecificEnthalpy))
+
+#define INSTANTIATE_VECTORS(_, data)                                \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), 3>>         \
+      KomissarovShock::variables(                                   \
+          const tnsr::I<DTYPE(data), 3, Frame::Inertial>&, double,  \
+          tmpl::list<TAG(data) < DTYPE(data), 3, Frame::Inertial>>) \
+          const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
+                        (hydro::Tags::SpatialVelocity,
+                         hydro::Tags::MagneticField))
+
+#undef DTYPE
+#undef TAG
+#undef INSTANTIATE_SCALARS
+#undef INSTANTIATE_VECTORS
+}  // namespace Solutions
+}  // namespace grmhd
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp
@@ -1,0 +1,256 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <limits>
+#include <string>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+// IWYU pragma: no_include <pup.h>
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+namespace grmhd {
+namespace Solutions {
+
+/*!
+ * \brief A one-dimensional shock solution for an ideal fluid in Minkowski
+ * spacetime
+ *
+ * This solution consists of a left state for \f$x<0\f$ and a right state for
+ * \f$x\ge 0\f$, each with constant fluid variables. The interface between these
+ * states moves with the shock speed \f$\mu\f$ as described in
+ * \cite Komissarov1999.
+ *
+ * \note We do not currently support 1D RMHD, so this class provides a 3D
+ * solution with \f$x\f$-dependence only. Therefore the computational domain can
+ * be represented by a single element with periodic boundary conditions in the
+ * \f$y\f$ and \f$z\f$ directions.
+ */
+class KomissarovShock {
+ public:
+  using equation_of_state_type = EquationsOfState::IdealFluid<true>;
+  using background_spacetime_type = gr::Solutions::Minkowski<3>;
+
+  struct AdiabaticIndex {
+    using type = double;
+    static constexpr OptionString help = {
+        "The adiabatic index of the ideal fluid"};
+    static type lower_bound() noexcept { return 1.0; }
+  };
+  struct LeftRestMassDensity {
+    using type = double;
+    static std::string name() noexcept { return "LeftDensity"; };
+    static constexpr OptionString help = {
+        "Fluid rest mass density in the left half-domain"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct RightRestMassDensity {
+    using type = double;
+    static std::string name() noexcept { return "RightDensity"; };
+    static constexpr OptionString help = {
+        "Fluid rest mass density in the right half-domain"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct LeftPressure {
+    using type = double;
+    static constexpr OptionString help = {
+        "Fluid pressure in the left half-domain"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct RightPressure {
+    using type = double;
+    static constexpr OptionString help = {
+        "Fluid pressure in the right half-domain"};
+    static type lower_bound() noexcept { return 0.0; }
+  };
+  struct LeftSpatialVelocity {
+    using type = std::array<double, 3>;
+    static std::string name() noexcept { return "LeftVelocity"; };
+    static constexpr OptionString help = {
+        "Fluid spatial velocity in the left half-domain"};
+  };
+  struct RightSpatialVelocity {
+    using type = std::array<double, 3>;
+    static std::string name() noexcept { return "RightVelocity"; };
+    static constexpr OptionString help = {
+        "Fluid spatial velocity in the right half-domain"};
+  };
+  struct LeftMagneticField {
+    using type = std::array<double, 3>;
+    static constexpr OptionString help = {
+        "Magnetic field in the left half-domain"};
+  };
+  struct RightMagneticField {
+    using type = std::array<double, 3>;
+    static constexpr OptionString help = {
+        "Magnetic field in the right half-domain"};
+  };
+  struct ShockSpeed {
+    using type = double;
+    static constexpr OptionString help = {"Propagation speed of the shock"};
+  };
+
+  using options = tmpl::list<AdiabaticIndex, LeftRestMassDensity,
+                             RightRestMassDensity, LeftPressure, RightPressure,
+                             LeftSpatialVelocity, RightSpatialVelocity,
+                             LeftMagneticField, RightMagneticField, ShockSpeed>;
+
+  static constexpr OptionString help = {
+      "Analytic initial data for a Komissarov shock test. The fluid variables "
+      "are set homogeneously on either half of the domain left and right of "
+      "x=0."};
+
+  KomissarovShock() = default;
+  KomissarovShock(const KomissarovShock& /*rhs*/) = delete;
+  KomissarovShock& operator=(const KomissarovShock& /*rhs*/) = delete;
+  KomissarovShock(KomissarovShock&& /*rhs*/) noexcept = default;
+  KomissarovShock& operator=(KomissarovShock&& /*rhs*/) noexcept = default;
+  ~KomissarovShock() = default;
+
+  KomissarovShock(AdiabaticIndex::type adiabatic_index,
+                  LeftRestMassDensity::type left_rest_mass_density,
+                  RightRestMassDensity::type right_rest_mass_density,
+                  LeftPressure::type left_pressure,
+                  RightPressure::type right_pressure,
+                  LeftSpatialVelocity::type left_spatial_velocity,
+                  RightSpatialVelocity::type right_spatial_velocity,
+                  LeftMagneticField::type left_magnetic_field,
+                  RightMagneticField::type right_magnetic_field,
+                  ShockSpeed::type shock_speed) noexcept;
+
+  explicit KomissarovShock(CkMigrateMessage* /*unused*/) noexcept {}
+
+  // @{
+  /// Retrieve the GRMHD variables at a given position.
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x, double t,
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x, double t,
+      tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x, double t,
+                 tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x, double t,
+                 tmpl::list<hydro::Tags::SpatialVelocity<
+                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<
+          hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x, double t,
+                 tmpl::list<hydro::Tags::MagneticField<
+                     DataType, 3, Frame::Inertial>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<
+          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x, double t,
+      tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
+      noexcept
+      -> tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x, double t,
+      tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x, double t,
+      tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
+  // @}
+
+  /// Retrieve a collection of hydrodynamic variables at position x
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x, double t,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    static_assert(sizeof...(Tags) > 1,
+                  "The generic template will recurse infinitely if only one "
+                  "tag is being retrieved.");
+    return {tuples::get<Tags>(variables(x, t, tmpl::list<Tags>{}))...};
+  }
+
+  /// Retrieve the metric variables
+  template <typename DataType, typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x, double t,
+                                     tmpl::list<Tag> /*meta*/) const noexcept {
+    return background_spacetime_.variables(x, t, tmpl::list<Tag>{});
+  }
+
+  const EquationsOfState::IdealFluid<true>& equation_of_state() const noexcept {
+    return equation_of_state_;
+  }
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
+
+ private:
+  EquationsOfState::IdealFluid<true> equation_of_state_{};
+  gr::Solutions::Minkowski<3> background_spacetime_{};
+
+  AdiabaticIndex::type adiabatic_index_ =
+      std::numeric_limits<double>::signaling_NaN();
+  LeftRestMassDensity::type left_rest_mass_density_ =
+      std::numeric_limits<double>::signaling_NaN();
+  RightRestMassDensity::type right_rest_mass_density_ =
+      std::numeric_limits<double>::signaling_NaN();
+  LeftPressure::type left_pressure_ =
+      std::numeric_limits<double>::signaling_NaN();
+  RightPressure::type right_pressure_ =
+      std::numeric_limits<double>::signaling_NaN();
+  LeftSpatialVelocity::type left_spatial_velocity_ =
+      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN()}};
+  RightSpatialVelocity::type right_spatial_velocity_ =
+      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN()}};
+  LeftMagneticField::type left_magnetic_field_ =
+      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN()}};
+  RightMagneticField::type right_magnetic_field_ =
+      std::array<double, 3>{{std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN(),
+                             std::numeric_limits<double>::signaling_NaN()}};
+  ShockSpeed::type shock_speed_ = std::numeric_limits<double>::signaling_NaN();
+
+  friend bool operator==(const KomissarovShock& lhs,
+                         const KomissarovShock& rhs) noexcept;
+
+  friend bool operator!=(const KomissarovShock& lhs,
+                         const KomissarovShock& rhs) noexcept;
+};
+
+}  // namespace Solutions
+}  // namespace grmhd

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_GrMhdSolutions")
 set(LIBRARY_SOURCES
   Test_AlfvenWave.cpp
   Test_BondiMichel.cpp
+  Test_KomissarovShock.cpp
   Test_SmoothFlow.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.py
@@ -1,0 +1,57 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+# Functions for Test_KomissarovShock.cpp
+
+def parse_vars(*args, **kwargs):
+    assert not kwargs, "Found unexpected labeled arguments:\n{}".format(kwargs)
+    assert len(args) is 10, "Expected 10 arguments, but got {}".format(
+        len(args))
+    return dict(zip(['adiabatic_index', 'left_rest_mass_density',
+            'right_rest_mass_density', 'left_pressure', 'right_pressure',
+            'left_spatial_velocity', 'right_spatial_velocity',
+            'left_magnetic_field', 'right_magnetic_field', 'shock_speed'],
+            args))
+
+def piecewise(x, shock_position, left_value, right_value):
+    return left_value if x[0] < shock_position else right_value
+
+def rest_mass_density(x, t, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    return piecewise(x, t * vars['shock_speed'],
+        vars['left_rest_mass_density'], vars['right_rest_mass_density'])
+
+def spatial_velocity(x, t, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    return np.asarray(piecewise(x, t * vars['shock_speed'],
+        vars['left_spatial_velocity'], vars['right_spatial_velocity']))
+
+def pressure(x, t, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    return piecewise(x, t * vars['shock_speed'],
+        vars['left_pressure'], vars['right_pressure'])
+
+def specific_internal_energy(x, t, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    p = pressure(x, t, *args, **kwargs)
+    rho = rest_mass_density(x, t, *args, **kwargs)
+    return p / ((vars['adiabatic_index'] - 1.0) * rho)
+
+def specific_enthalpy(x, t, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    e = specific_internal_energy(x, t, *args, **kwargs)
+    return 1.0 + vars['adiabatic_index'] * e
+
+def lorentz_factor(x, t, *args, **kwargs):
+    v = spatial_velocity(x, t, *args, **kwargs)
+    return 1.0 / np.sqrt(1.0 - np.sum(v**2))
+
+def magnetic_field(x, t, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    return np.asarray(piecewise(x, t * vars['shock_speed'],
+        vars['left_magnetic_field'], vars['right_magnetic_field']))
+
+def divergence_cleaning_field(x, t, *args, **kwargs):
+    return 0.0

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GrMhd/Test_KomissarovShock.cpp
@@ -1,0 +1,200 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <tuple>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/Options.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/GrMhd/KomissarovShock.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+
+struct KomissarovShockProxy : grmhd::Solutions::KomissarovShock {
+  using grmhd::Solutions::KomissarovShock::KomissarovShock;
+
+  template <typename DataType>
+  using hydro_variables_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>,
+                 hydro::Tags::SpatialVelocity<DataType, 3>,
+                 hydro::Tags::SpecificInternalEnergy<DataType>,
+                 hydro::Tags::Pressure<DataType>,
+                 hydro::Tags::LorentzFactor<DataType>,
+                 hydro::Tags::SpecificEnthalpy<DataType>>;
+
+  template <typename DataType>
+  using grmhd_variables_tags =
+      tmpl::push_back<hydro_variables_tags<DataType>,
+                      hydro::Tags::MagneticField<DataType, 3>,
+                      hydro::Tags::DivergenceCleaningField<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<hydro_variables_tags<DataType>>
+  hydro_variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                  const double t) const noexcept {
+    return variables(x, t, hydro_variables_tags<DataType>{});
+  }
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<grmhd_variables_tags<DataType>>
+  grmhd_variables(const tnsr::I<DataType, 3, Frame::Inertial>& x,
+                  const double t) const noexcept {
+    return variables(x, t, grmhd_variables_tags<DataType>{});
+  }
+};
+
+void test_create_from_options() noexcept {
+  const auto komissarov_shock =
+      test_creation<grmhd::Solutions::KomissarovShock>(
+          "  AdiabaticIndex: 1.33\n"
+          "  LeftDensity: 1.\n"
+          "  RightDensity: 3.323\n"
+          "  LeftPressure: 10.\n"
+          "  RightPressure: 55.36\n"
+          "  LeftVelocity: [0.83, 0., 0.]\n"
+          "  RightVelocity: [0.62, -0.44, 0.]\n"
+          "  LeftMagneticField: [10., 18.28, 0.]\n"
+          "  RightMagneticField: [10., 14.49, 0.]\n"
+          "  ShockSpeed: 0.5\n");
+  CHECK(komissarov_shock == grmhd::Solutions::KomissarovShock(
+                                1.33, 1., 3.323, 10., 55.36,
+                                std::array<double, 3>{{0.83, 0., 0.}},
+                                std::array<double, 3>{{0.62, -0.44, 0.}},
+                                std::array<double, 3>{{10., 18.28, 0.}},
+                                std::array<double, 3>{{10., 14.49, 0.}}, 0.5));
+}
+
+void test_move() noexcept {
+  grmhd::Solutions::KomissarovShock komissarov_shock(
+      4. / 3., 1., 3.323, 10., 55.36,
+      std::array<double, 3>{{0.8370659816473115, 0., 0.}},
+      std::array<double, 3>{{0.6202085442748952, -0.44207111995019704, 0.}},
+      std::array<double, 3>{{10., 18.28, 0.}},
+      std::array<double, 3>{{10., 14.49, 0.}}, 0.5);
+  grmhd::Solutions::KomissarovShock komissarov_shock_copy(
+      4. / 3., 1., 3.323, 10., 55.36,
+      std::array<double, 3>{{0.8370659816473115, 0., 0.}},
+      std::array<double, 3>{{0.6202085442748952, -0.44207111995019704, 0.}},
+      std::array<double, 3>{{10., 18.28, 0.}},
+      std::array<double, 3>{{10., 14.49, 0.}}, 0.5);
+  test_move_semantics(std::move(komissarov_shock),
+                      komissarov_shock_copy);  //  NOLINT
+}
+
+void test_serialize() noexcept {
+  grmhd::Solutions::KomissarovShock komissarov_shock(
+      4. / 3., 1., 3.323, 10., 55.36,
+      std::array<double, 3>{{0.8370659816473115, 0., 0.}},
+      std::array<double, 3>{{0.6202085442748952, -0.44207111995019704, 0.}},
+      std::array<double, 3>{{10., 18.28, 0.}},
+      std::array<double, 3>{{10., 14.49, 0.}}, 0.5);
+  test_serialization(komissarov_shock);
+}
+
+void test_left_and_right_variables() noexcept {
+  grmhd::Solutions::KomissarovShock komissarov_shock(
+      4. / 3., 1., 3.323, 10., 55.36,
+      std::array<double, 3>{{0.8370659816473115, 0., 0.}},
+      std::array<double, 3>{{0.6202085442748952, -0.44207111995019704, 0.}},
+      std::array<double, 3>{{10., 18.28, 0.}},
+      std::array<double, 3>{{10., 14.49, 0.}}, 0.5);
+
+  // Test that the fluid variables are set somewhere to the right and to the
+  // left of the shock interface
+  tnsr::I<double, 3, Frame::Inertial> left_x{0.};
+  get<0>(left_x) = -1.;
+  tnsr::I<double, 3, Frame::Inertial> right_x{0.};
+  get<0>(right_x) = 1.;
+  CHECK(
+      get(get<hydro::Tags::RestMassDensity<double>>(komissarov_shock.variables(
+          left_x, 0., tmpl::list<hydro::Tags::RestMassDensity<double>>{}))) ==
+      1.);
+  CHECK(
+      get(get<hydro::Tags::RestMassDensity<double>>(komissarov_shock.variables(
+          right_x, 0., tmpl::list<hydro::Tags::RestMassDensity<double>>{}))) ==
+      3.323);
+  CHECK(get(get<hydro::Tags::Pressure<double>>(komissarov_shock.variables(
+            left_x, 0., tmpl::list<hydro::Tags::Pressure<double>>{}))) == 10.);
+  CHECK(get(get<hydro::Tags::Pressure<double>>(komissarov_shock.variables(
+            right_x, 0., tmpl::list<hydro::Tags::Pressure<double>>{}))) ==
+        55.36);
+  CHECK(get<0>(get<hydro::Tags::SpatialVelocity<double, 3, Frame::Inertial>>(
+            komissarov_shock.variables(left_x, 0.,
+                                       tmpl::list<hydro::Tags::SpatialVelocity<
+                                           double, 3, Frame::Inertial>>{}))) ==
+        0.8370659816473115);
+  CHECK(get<0>(get<hydro::Tags::SpatialVelocity<double, 3, Frame::Inertial>>(
+            komissarov_shock.variables(right_x, 0.,
+                                       tmpl::list<hydro::Tags::SpatialVelocity<
+                                           double, 3, Frame::Inertial>>{}))) ==
+        0.6202085442748952);
+  CHECK(get(get<hydro::Tags::LorentzFactor<double>>(komissarov_shock.variables(
+            left_x, 0., tmpl::list<hydro::Tags::LorentzFactor<double>>{}))) ==
+        approx(1.827812900709479));
+  CHECK(get(get<hydro::Tags::LorentzFactor<double>>(komissarov_shock.variables(
+            right_x, 0., tmpl::list<hydro::Tags::LorentzFactor<double>>{}))) ==
+        approx(1.5431906071513006));
+}
+
+template <typename DataType>
+void test_variables(const DataType& used_for_size) noexcept {
+  KomissarovShockProxy komissarov_shock(
+      4. / 3., 1., 3.323, 10., 55.36,
+      std::array<double, 3>{{0.8370659816473115, 0., 0.}},
+      std::array<double, 3>{{0.6202085442748952, -0.44207111995019704, 0.}},
+      std::array<double, 3>{{10., 18.28, 0.}},
+      std::array<double, 3>{{10., 14.49, 0.}}, 0.5);
+  const auto member_variables = std::make_tuple(
+      4. / 3., 1., 3.323, 10., 55.36,
+      std::array<double, 3>{{0.8370659816473115, 0., 0.}},
+      std::array<double, 3>{{0.6202085442748952, -0.44207111995019704, 0.}},
+      std::array<double, 3>{{10., 18.28, 0.}},
+      std::array<double, 3>{{10., 14.49, 0.}}, 0.5);
+
+  pypp::check_with_random_values<
+      1, KomissarovShockProxy::hydro_variables_tags<DataType>>(
+      &KomissarovShockProxy::hydro_variables<DataType>, komissarov_shock,
+      "KomissarovShock",
+      {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
+       "pressure", "lorentz_factor", "specific_enthalpy"},
+      {{{-1., 1.}}}, member_variables, used_for_size);
+
+  pypp::check_with_random_values<
+      1, KomissarovShockProxy::grmhd_variables_tags<DataType>>(
+      &KomissarovShockProxy::grmhd_variables<DataType>, komissarov_shock,
+      "KomissarovShock",
+      {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
+       "pressure", "lorentz_factor", "specific_enthalpy", "magnetic_field",
+       "divergence_cleaning_field"},
+      {{{-1., 1.}}}, member_variables, used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Solutions.GrMhd.KomissarovShock",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/GrMhd"};
+
+  test_create_from_options();
+  test_serialize();
+  test_move();
+
+  test_left_and_right_variables();
+  test_variables(std::numeric_limits<double>::signaling_NaN());
+  test_variables(DataVector(5));
+}


### PR DESCRIPTION
## Proposed changes

This PR adds an analytic solution for the shock tests described in [Komissarov 1999](https://academic.oup.com/mnras/article-abstract/303/2/343/1067242), sec. 6 / Fig. 3. These tests were also done in the spectre 2017 paper. In a few preliminary runs comparing limiters I find the follow results in spectre:

![bildschirmfoto 2018-12-05 um 18 49 10](https://user-images.githubusercontent.com/746230/49533123-78dca180-f8be-11e8-87f3-4ed82b39ef8e.png)

The colours indicate the solution at different times t=0 to t=1.9.

- [x] Add test
- [x] Add documentation

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).