### PR TITLE
Add variable fixer to limit max lorentz factor

### DIFF
--- a/src/Evolution/VariableFixing/CMakeLists.txt
+++ b/src/Evolution/VariableFixing/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY VariableFixing)
 
 set(LIBRARY_SOURCES
   FixToAtmosphere.cpp
+  LimitLorentzFactor.cpp
   RadiallyFallingFloor.cpp
   )
 

--- a/src/Evolution/VariableFixing/LimitLorentzFactor.cpp
+++ b/src/Evolution/VariableFixing/LimitLorentzFactor.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/VariableFixing/LimitLorentzFactor.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace VariableFixing {
+LimitLorentzFactor::LimitLorentzFactor(const double max_density_cutoff,
+                                       const double lorentz_factor_cap) noexcept
+    : max_density_cuttoff_(max_density_cutoff),
+      lorentz_factor_cap_(lorentz_factor_cap) {}
+
+void LimitLorentzFactor::pup(PUP::er& p) noexcept {
+  p | max_density_cuttoff_;
+  p | lorentz_factor_cap_;
+}
+
+void LimitLorentzFactor::operator()(
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        spatial_velocity,
+    const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+    const Scalar<DataVector>& rest_mass_density) const noexcept {
+  constexpr size_t dim = 3;
+  const size_t number_of_grid_points = get(rest_mass_density).size();
+  for (size_t s = 0; s < number_of_grid_points; ++s) {
+    if (get(*lorentz_factor)[s] > lorentz_factor_cap_ and
+        get(rest_mass_density)[s] < max_density_cuttoff_) {
+      const double velocity_renorm_factor =
+          sqrt((1. - 1. / square(lorentz_factor_cap_)) /
+               (1. - 1. / square(get(*lorentz_factor)[s])));
+
+      get(*lorentz_factor)[s] = lorentz_factor_cap_;
+      for (size_t d = 0; d < dim; ++d) {
+        spatial_velocity->get(d)[s] *= velocity_renorm_factor;
+      }
+    }
+  }
+}
+
+bool operator==(const LimitLorentzFactor& lhs,
+                const LimitLorentzFactor& rhs) noexcept {
+  return lhs.max_density_cuttoff_ == rhs.max_density_cuttoff_ and
+         lhs.lorentz_factor_cap_ == rhs.lorentz_factor_cap_;
+}
+
+bool operator!=(const LimitLorentzFactor& lhs,
+                const LimitLorentzFactor& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace VariableFixing

--- a/src/Evolution/VariableFixing/LimitLorentzFactor.hpp
+++ b/src/Evolution/VariableFixing/LimitLorentzFactor.hpp
@@ -1,0 +1,96 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+// IWYU pragma: no_forward_declare hydro::Tags::SpatialVelocity
+// IWYU pragma: no_forward_declare hydro::Tags::LorentzFactor
+// IWYU pragma: no_forward_declare hydro::Tags::RestMassDensity
+// IWYU pragma: no_forward_declare Tensor
+
+namespace VariableFixing {
+/*!
+ *\ingroup VariableFixingGroup
+ * \brief Limit the maximum Lorentz factor to LorentzFactorCap in regions where
+ * the density is below MaxDensityCutoff.
+ *
+ * The Lorentz factor is set to LorentzFactorCap and the spatial velocity is
+ * adjusted according to:
+ * \f{align}
+ * v^i_{(\textrm{new})} = \sqrt{\left(1 - \frac{1}{W_{(\textrm{new})}^2}\right)
+ * \left(1 - \frac{1}{W_{(\textrm{old})}^2}\right)^{-1}} v^i_{(\textrm{old})}
+ * \f}
+ */
+class LimitLorentzFactor {
+ public:
+  /// Do not apply the Lorentz factor cap above this density
+  struct MaxDensityCutoff {
+    using type = double;
+    static type lower_bound() noexcept { return 0.0; }
+    static constexpr OptionString help = {
+        "Do not apply the Lorentz factor cap above this density"};
+  };
+  /// Largest Lorentz factor allowed. If a larger one is found, normalize
+  /// velocity to have the Lorentz factor be this value.
+  struct LorentzFactorCap {
+    using type = double;
+    static type lower_bound() noexcept { return 1.0; }
+    static constexpr OptionString help = {"Largest Lorentz factor allowed."};
+  };
+
+  using options = tmpl::list<MaxDensityCutoff, LorentzFactorCap>;
+  static constexpr OptionString help = {
+      "Limit the maximum Lorentz factor to LorentzFactorCap in regions where "
+      "the\n"
+      "density is below MaxDensityCutoff. The Lorentz factor is set to\n"
+      "LorentzFactorCap and the spatial velocity is adjusted accordingly."};
+
+  LimitLorentzFactor(double max_density_cutoff,
+                     double lorentz_factor_cap) noexcept;
+
+  LimitLorentzFactor() = default;
+  LimitLorentzFactor(const LimitLorentzFactor& /*rhs*/) = default;
+  LimitLorentzFactor& operator=(const LimitLorentzFactor& /*rhs*/) = default;
+  LimitLorentzFactor(LimitLorentzFactor&& /*rhs*/) noexcept = default;
+  LimitLorentzFactor& operator=(LimitLorentzFactor&& /*rhs*/) noexcept =
+      default;
+  ~LimitLorentzFactor() = default;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) noexcept;
+
+  using return_tags = tmpl::list<hydro::Tags::LorentzFactor<DataVector>,
+                                 hydro::Tags::SpatialVelocity<DataVector, 3>>;
+
+  using argument_tags = tmpl::list<hydro::Tags::RestMassDensity<DataVector>>;
+
+  void operator()(
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
+      gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+      const Scalar<DataVector>& rest_mass_density) const noexcept;
+
+ private:
+  friend bool operator==(const LimitLorentzFactor& lhs,
+                         const LimitLorentzFactor& rhs) noexcept;
+
+  double max_density_cuttoff_;
+  double lorentz_factor_cap_;
+};
+
+bool operator!=(const LimitLorentzFactor& lhs,
+                const LimitLorentzFactor& rhs) noexcept;
+}  // namespace VariableFixing

--- a/tests/Unit/Evolution/VariableFixing/CMakeLists.txt
+++ b/tests/Unit/Evolution/VariableFixing/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_VariableFixing")
 set(LIBRARY_SOURCES
   Test_Actions.cpp
   Test_FixToAtmosphere.cpp
+  Test_LimitLorentzFactor.cpp
   Test_RadiallyFallingFloor.cpp
   )
 

--- a/tests/Unit/Evolution/VariableFixing/Test_LimitLorentzFactor.cpp
+++ b/tests/Unit/Evolution/VariableFixing/Test_LimitLorentzFactor.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/VariableFixing/LimitLorentzFactor.hpp"
+#include "PointwiseFunctions/Hydro/LorentzFactor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace VariableFixing {
+namespace {
+void test_variable_fixer(const LimitLorentzFactor& variable_fixer) {
+  const Scalar<DataVector> density{DataVector{1.0, 2.0, 1.0e-5, 1.0e-6}};
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataVector, 3, Frame::Inertial>>(density, 1.0);
+  get<0, 0>(spatial_metric) = 0.2;
+  get<0, 1>(spatial_metric) = 0.3;
+  get<0, 2>(spatial_metric) = 0.4;
+  get<1, 1>(spatial_metric) = 0.5;
+  get<1, 2>(spatial_metric) = 0.6;
+  get<2, 2>(spatial_metric) = 0.7;
+
+  tnsr::I<DataVector, 3, Frame::Inertial> spatial_velocity{
+      {{DataVector{0.4999, 0.4999, 0.4999, 0.4999},
+        DataVector{1.3567, 1.3566, 1.3567, 1.3566},
+        DataVector{-0.200, -0.200, -0.200, -0.200}}}};
+
+  auto lorentz_factor = hydro::lorentz_factor(
+      dot_product(spatial_velocity, spatial_velocity, spatial_metric));
+  const Scalar<DataVector> expected_lorentz_factor{
+      DataVector{get(lorentz_factor)[0], get(lorentz_factor)[1], 50.0,
+                 get(lorentz_factor)[3]}};
+  const double rescale_velocity_factor =
+      sqrt((1.0 - 1.0 / square(get(expected_lorentz_factor)[2])) /
+           (1.0 - 1.0 / square(get(lorentz_factor)[2])));
+  const tnsr::I<DataVector, 3, Frame::Inertial> expected_spatial_velocity{
+      {{DataVector{0.4999, 0.4999, 0.4999 * rescale_velocity_factor, 0.4999},
+        DataVector{1.3567, 1.3566, 1.3567 * rescale_velocity_factor, 1.3566},
+        DataVector{-0.200, -0.200, -0.200 * rescale_velocity_factor, -0.200}}}};
+
+  variable_fixer(make_not_null(&spatial_velocity),
+                 make_not_null(&lorentz_factor), density);
+
+  CHECK(lorentz_factor == expected_lorentz_factor);
+  CHECK(spatial_velocity == expected_spatial_velocity);
+  Approx custom_approx = Approx::custom().epsilon(6.0e-14).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      expected_lorentz_factor,
+      hydro::lorentz_factor(
+          dot_product(spatial_velocity, spatial_velocity, spatial_metric)),
+      custom_approx);
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.VariableFixing.LimitLorentzFactor",
+                  "[VariableFixing][Unit]") {
+  SECTION("operator== and operator!=") {
+    CHECK(LimitLorentzFactor{1.0, 8.0} == LimitLorentzFactor{1.0, 8.0});
+    CHECK_FALSE(LimitLorentzFactor{2., 8.0} == LimitLorentzFactor{1.0, 8.0});
+    CHECK_FALSE(LimitLorentzFactor{1.0, 9.0} == LimitLorentzFactor{1.0, 8.0});
+    CHECK_FALSE(LimitLorentzFactor{1.0, 8.0} != LimitLorentzFactor{1.0, 8.0});
+    CHECK(LimitLorentzFactor{2.0, 8.0} != LimitLorentzFactor{1.0, 8.0});
+    CHECK(LimitLorentzFactor{1.0, 9.0} != LimitLorentzFactor{1.0, 8.0});
+  }
+
+  SECTION("variable fixing") {
+    LimitLorentzFactor variable_fixer{1.0e-4, 50.0};
+    test_variable_fixer(variable_fixer);
+    test_serialization(variable_fixer);
+    test_variable_fixer(serialize_and_deserialize(variable_fixer));
+
+    const auto fixer_from_options = test_creation<LimitLorentzFactor>(
+        "  MaxDensityCutoff: 1.0e-4\n"
+        "  LorentzFactorCap: 50.0\n");
+    test_variable_fixer(fixer_from_options);
+  }
+}
+}  // namespace
+}  // namespace VariableFixing


### PR DESCRIPTION
## Proposed changes

- In disk simulations other groups limit the Lorentz factor to being bounded above. This implements such a variable fixer with the ability to only apply it in low-density regions (e.g. the atmosphere).

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
