### PR TITLE
Do not generate .pyc or __pycache__ files inside tests/*

### DIFF
--- a/tests/Unit/Pypp/SetupLocalPythonEnvironment.cpp
+++ b/tests/Unit/Pypp/SetupLocalPythonEnvironment.cpp
@@ -13,6 +13,7 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <Python.h>
 #include <numpy/arrayobject.h>  // IWYU pragma: keep
+#include <pydebug.h>
 
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Informer/InfoFromBuild.hpp"
@@ -27,6 +28,10 @@ SetupLocalPythonEnvironment::SetupLocalPythonEnvironment(
   // done in the constructor of SetupLocalPythonEnvironment, while finalization
   // is done in the constructor of RunTests.
   if (not initialized) {
+    // Don't produce the __pycache__ dir (python 3.2 and newer) or the .pyc
+    // files (python 2.7) in the tests directory to avoid cluttering the source
+    // tree. The overhead of not having the compile files is <= 0.01s
+    Py_DontWriteBytecodeFlag = 1;
     Py_Initialize();
     // On some python versions init_numpy() can throw an FPE, this occurred at
     // least with python 3.6, numpy 1.14.2.


### PR DESCRIPTION
## Proposed changes

Reduces the number of files that are generated inside the source tree from
running the python tests. Once python 2.7 support is no longer needed and we
require python 3.5 and newer we can remove this change because then a single
__pycache__ directory is used to store the files instead.

There is a proposal (#1199) to split up the `TestFunctions.py` files, but this would add a bunch of `.pyc` files to the source tree when using python 2.7. To make it easier to navigate the tests and not have three files per test unit, this disables the generation of the `pyc` files.

closes #1202 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
