### PR TITLE
Add elliptic DgElementArray and initializers

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -1,0 +1,150 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "AlgorithmArray.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/InitialElementIds.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/DiscontinuousGalerkin/InitializeElement.hpp"
+#include "IO/Observer/TypeOfObservation.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace observers {
+namespace Actions {
+template <observers::TypeOfObservation TypeOfObservation>
+struct RegisterWithObservers;
+}  // namespace Actions
+}  // namespace observers
+/// \endcond
+
+namespace Elliptic {
+
+/*!
+ * \brief The parallel component responsible for managing the DG elements that
+ * compose the computational domain
+ *
+ * This parallel component will perform the following phases:
+ *
+ * - `Phase::Initialize`: Create the domain and execute
+ * `Elliptic::dg::Actions::InitializeElement` on all elements.
+ * - `Phase::RegisterWithObservers` (optional)
+ * - `Phase::Solve`: Execute the actions in `ActionList` on all elements. Repeat
+ * until an action terminates the algorithm.
+ *
+ * \note This parallel component is nearly identical to
+ * `Evolution/DiscontinuousGalerkin/DgElementArray.hpp` right now, but will
+ * likely diverge in the future, for instance to support a multigrid domain.
+ *
+ * Uses:
+ * - Metavariables:
+ *   - `domain_creator_tag`
+ * - System:
+ *   - `volume_dim`
+ * - ConstGlobalCache:
+ *   - All items required by the actions in `ActionList`
+ */
+template <class Metavariables, class ActionList>
+struct DgElementArray {
+  static constexpr size_t volume_dim = Metavariables::system::volume_dim;
+
+  using chare_type = Parallel::Algorithms::Array;
+  using metavariables = Metavariables;
+  using action_list = ActionList;
+  using array_index = ElementIndex<volume_dim>;
+
+  using const_global_cache_tag_list =
+      Parallel::get_const_global_cache_tags<action_list>;
+
+  using initial_databox = db::compute_databox_type<
+      typename Elliptic::dg::Actions::InitializeElement<
+          volume_dim>::template return_tag_list<Metavariables>>;
+
+  using options = tmpl::list<typename Metavariables::domain_creator_tag>;
+
+  static void initialize(
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+      std::unique_ptr<DomainCreator<volume_dim, Frame::Inertial>>
+          domain_creator) noexcept;
+
+  static void execute_next_phase(
+      const typename Metavariables::Phase next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) {
+    auto& local_cache = *(global_cache.ckLocalBranch());
+    auto& dg_element_array =
+        Parallel::get_parallel_component<DgElementArray>(local_cache);
+    switch (next_phase) {
+      case Metavariables::Phase::Solve:
+        dg_element_array.perform_algorithm();
+        break;
+      default:
+        try_register_with_observers(next_phase, global_cache);
+        break;
+    }
+  }
+
+ private:
+  template <typename PhaseType,
+            Requires<not observers::has_register_with_observer_v<PhaseType>> =
+                nullptr>
+  static void try_register_with_observers(
+      const PhaseType /*next_phase*/,
+      Parallel::CProxy_ConstGlobalCache<
+          Metavariables>& /*global_cache*/) noexcept {}
+
+  template <
+      typename PhaseType,
+      Requires<observers::has_register_with_observer_v<PhaseType>> = nullptr>
+  static void try_register_with_observers(
+      const PhaseType next_phase,
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
+    if (next_phase == Metavariables::Phase::RegisterWithObserver) {
+      auto& local_cache = *(global_cache.ckLocalBranch());
+      // We currently use a fake temporal id when registering observers but in
+      // the future when we start doing load balancing and elements migrate
+      // around the system they will need to register and unregister themselves
+      // at specific times.
+      const size_t fake_temporal_id = 0;
+      Parallel::simple_action<observers::Actions::RegisterWithObservers<
+          observers::TypeOfObservation::ReductionAndVolume>>(
+          Parallel::get_parallel_component<DgElementArray>(local_cache),
+          fake_temporal_id);
+    }
+  }
+};
+
+template <class Metavariables, class ActionList>
+void DgElementArray<Metavariables, ActionList>::initialize(
+    Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
+    const std::unique_ptr<DomainCreator<volume_dim, Frame::Inertial>>
+        domain_creator) noexcept {
+  auto& dg_element_array = Parallel::get_parallel_component<DgElementArray>(
+      *(global_cache.ckLocalBranch()));
+
+  auto domain = domain_creator->create_domain();
+  for (const auto& block : domain.blocks()) {
+    const auto initial_ref_levs =
+        domain_creator->initial_refinement_levels()[block.id()];
+    const std::vector<ElementId<volume_dim>> element_ids =
+        initial_element_ids(block.id(), initial_ref_levs);
+    int which_proc = 0;
+    const int number_of_procs = Parallel::number_of_procs();
+    for (size_t i = 0; i < element_ids.size(); ++i) {
+      dg_element_array(ElementIndex<volume_dim>(element_ids[i]))
+          .insert(global_cache, which_proc);
+      which_proc = which_proc + 1 == number_of_procs ? 0 : which_proc + 1;
+    }
+  }
+  dg_element_array.doneInserting();
+
+  dg_element_array.template simple_action<
+      Elliptic::dg::Actions::InitializeElement<volume_dim>>(
+      std::make_tuple(domain_creator->initial_extents(), std::move(domain)));
+}
+}  // namespace Elliptic

--- a/src/Elliptic/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/InitializeElement.hpp
@@ -1,0 +1,106 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <tuple>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Domain.hpp"
+#include "Elliptic/Initialization/Derivatives.hpp"
+#include "Elliptic/Initialization/DiscontinuousGalerkin.hpp"
+#include "Elliptic/Initialization/Domain.hpp"
+#include "Elliptic/Initialization/Interface.hpp"
+#include "Elliptic/Initialization/LinearSolver.hpp"
+#include "Elliptic/Initialization/System.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+// IWYU pragma: no_forward_declare db::DataBox
+template <size_t VolumeDim>
+class ElementIndex;
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+namespace tuples {
+template <typename... Tags>
+class TaggedTuple;  // IWYU pragma: keep
+}  // namespace tuples
+/// \endcond
+
+namespace Elliptic {
+namespace dg {
+namespace Actions {
+
+/*!
+ * \brief Initializes the DataBox of each element in the DgElementArray
+ *
+ * The following initializers are chained together (in this order):
+ *
+ * - `Elliptic::Initialization::Domain`
+ * - `Elliptic::Initialization::System`
+ * - `Elliptic::Initialization::LinearSolver`
+ * - `Elliptic::Initialization::Derivatives`
+ * - `Elliptic::Initialization::Interface`
+ * - `Elliptic::Initialization::DiscontinuousGalerkin`
+ */
+template <size_t Dim>
+struct InitializeElement {
+  template <class Metavariables>
+  using return_tag_list =
+      tmpl::append<typename Elliptic::Initialization::Domain<Dim>::simple_tags,
+                   typename Elliptic::Initialization::System<
+                       typename Metavariables::system>::simple_tags,
+                   typename Elliptic::Initialization::LinearSolver<
+                       Metavariables>::simple_tags,
+                   typename Elliptic::Initialization::Derivatives<
+                       typename Metavariables::system>::simple_tags,
+                   typename Elliptic::Initialization::Interface<
+                       typename Metavariables::system>::simple_tags,
+                   typename Elliptic::Initialization::DiscontinuousGalerkin<
+                       Metavariables>::simple_tags,
+                   typename Elliptic::Initialization::Domain<Dim>::compute_tags,
+                   typename Elliptic::Initialization::System<
+                       typename Metavariables::system>::compute_tags,
+                   typename Elliptic::Initialization::LinearSolver<
+                       Metavariables>::compute_tags,
+                   typename Elliptic::Initialization::Derivatives<
+                       typename Metavariables::system>::compute_tags,
+                   typename Elliptic::Initialization::Interface<
+                       typename Metavariables::system>::compute_tags,
+                   typename Elliptic::Initialization::DiscontinuousGalerkin<
+                       Metavariables>::compute_tags>;
+
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ElementIndex<Dim>& array_index,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const parallel_component_meta,
+                    std::vector<std::array<size_t, Dim>> initial_extents,
+                    Domain<Dim, Frame::Inertial> domain) noexcept {
+    using system = typename Metavariables::system;
+    auto domain_box = Elliptic::Initialization::Domain<Dim>::initialize(
+        db::DataBox<tmpl::list<>>{}, array_index, initial_extents, domain);
+    auto system_box = Elliptic::Initialization::System<system>::initialize(
+        std::move(domain_box));
+    auto linear_solver_box =
+        Elliptic::Initialization::LinearSolver<Metavariables>::initialize(
+            std::move(system_box), cache, array_index, parallel_component_meta);
+    auto deriv_box =
+        Elliptic::Initialization::Derivatives<typename Metavariables::system>::
+            initialize(std::move(linear_solver_box));
+    auto face_box = Elliptic::Initialization::Interface<system>::initialize(
+        std::move(deriv_box));
+    auto dg_box = Elliptic::Initialization::DiscontinuousGalerkin<
+        Metavariables>::initialize(std::move(face_box), initial_extents);
+    return std::make_tuple(std::move(dg_box));
+  }
+};
+}  // namespace Actions
+}  // namespace dg
+}  // namespace Elliptic

--- a/src/Elliptic/Initialization/Derivatives.hpp
+++ b/src/Elliptic/Initialization/Derivatives.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace Elliptic {
+namespace Initialization {
+/*!
+ * \brief Initializes the DataBox tags related to derivatives of the system
+ * variables
+ *
+ * We have to initialize these separately from
+ * `Elliptic::Initialization::System` since the `variables_tag` is the linear
+ * solver operand, which is added by the linear solver initialization.
+ *
+ * With:
+ * - `inv_jac_tag` = `Tags::InverseJacobian<
+ * Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>`
+ *
+ * Uses:
+ * - System:
+ *   - `volume_dim`
+ *   - `variables_tag`
+ *   - `gradient_tags`
+ *
+ * DataBox:
+ * - Adds:
+ *   - `Tags::DerivCompute<variables_tag, inv_jac_tag, gradient_tags>>`
+ */
+template <typename SystemType>
+struct Derivatives {
+  static constexpr size_t Dim = SystemType::volume_dim;
+  using inv_jac_tag =
+      Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                            Tags::Coordinates<Dim, Frame::Logical>>;
+
+  using simple_tags = db::AddSimpleTags<>;
+  using compute_tags = db::AddComputeTags<
+      Tags::DerivCompute<typename SystemType::variables_tag, inv_jac_tag,
+                         typename SystemType::gradient_tags>>;
+
+  template <typename TagsList>
+  static auto initialize(db::DataBox<TagsList>&& box) noexcept {
+    return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+        std::move(box));
+  }
+};
+}  // namespace Initialization
+}  // namespace Elliptic

--- a/src/Elliptic/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Elliptic/Initialization/DiscontinuousGalerkin.hpp
@@ -1,0 +1,198 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Neighbors.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/Helpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/FluxCommunicationTypes.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace Elliptic {
+namespace Initialization {
+
+/*!
+ * \brief Initializes DataBox tags related to discontinuous Galerkin fluxes
+ *
+ * With:
+ * - `flux_comm_types` = `dg::FluxCommunicationTypes<Metavariables>`
+ * - `mortar_data_tag` = `flux_comm_types::simple_mortar_data_tag`
+ * - `interface<Tag>` =
+ * `Tags::Interface<Tags::InternalDirections<volume_dim>, Tag>`
+ * - `boundary<Tag>` =
+ * `Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>, Tag>`
+ * - `mortar<Tag>` = `Tags::Mortars<Tag, volume_dim>`
+ *
+ * Uses:
+ * - Metavariables:
+ *   - `temporal_id`
+ *   - Items required by `flux_comm_types`
+ * - System:
+ *   - `volume_dim`
+ * - DataBox:
+ *   - `Tags::Element<volume_dim>`
+ *   - `Tags::Mesh<volume_dim>`
+ *   - `temporal_id`
+ *   - `Tags::InternalDirections<volume_dim>`
+ *   - `Tags::BoundaryDirectionsInterior<volume_dim>`
+ *   - `interface<Tags::Mesh<volume_dim - 1>>`
+ *   - `boundary<Tags::Mesh<volume_dim - 1>>`
+ *
+ * DataBox:
+ * - Adds:
+ *   - `mortar_data_tag`
+ *   - `mortar<Tags::Next<temporal_id>>`
+ *   - `mortar<Tags::Mesh<volume_dim - 1>>`
+ *   - `mortar<Tags::MortarSize<volume_dim - 1>>`
+ *   - `interface<flux_comm_types::normal_dot_fluxes_tag>`
+ *   - `boundary<flux_comm_types::normal_dot_fluxes_tag>`
+ */
+template <typename Metavariables>
+struct DiscontinuousGalerkin {
+  static constexpr size_t volume_dim = Metavariables::system::volume_dim;
+  using temporal_id_tag = typename Metavariables::temporal_id;
+  using flux_comm_types = ::dg::FluxCommunicationTypes<Metavariables>;
+  using mortar_data_tag = typename flux_comm_types::simple_mortar_data_tag;
+
+  template <typename Tag>
+  using interface_tag =
+      Tags::Interface<Tags::InternalDirections<volume_dim>, Tag>;
+  template <typename Tag>
+  using boundary_tag =
+      Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>, Tag>;
+  template <typename Tag>
+  using mortar_tag = Tags::Mortars<Tag, volume_dim>;
+
+  using simple_tags = db::AddSimpleTags<
+      mortar_data_tag, mortar_tag<Tags::Next<temporal_id_tag>>,
+      mortar_tag<Tags::Mesh<volume_dim - 1>>,
+      mortar_tag<Tags::MortarSize<volume_dim - 1>>,
+      interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>,
+      boundary_tag<typename flux_comm_types::normal_dot_fluxes_tag>>;
+
+  using compute_tags = db::AddComputeTags<>;
+
+  // This function is mostly copied from
+  // `Evolution/Initialization/DiscontinuousGalerkin.hpp`.
+  // It could be useful to move some of this functionality into compute items.
+  template <typename TagsList>
+  static auto add_mortar_data(db::DataBox<TagsList>&& box,
+                              const std::vector<std::array<size_t, volume_dim>>&
+                                  initial_extents) noexcept {
+    const auto& element = db::get<Tags::Element<volume_dim>>(box);
+    const auto& mesh = db::get<Tags::Mesh<volume_dim>>(box);
+
+    db::item_type<mortar_data_tag> mortar_data{};
+    db::item_type<mortar_tag<Tags::Next<temporal_id_tag>>>
+        mortar_next_temporal_ids{};
+    db::item_type<mortar_tag<Tags::Mesh<volume_dim - 1>>> mortar_meshes{};
+    db::item_type<mortar_tag<Tags::MortarSize<volume_dim - 1>>> mortar_sizes{};
+    const auto& temporal_id = get<temporal_id_tag>(box);
+    for (const auto& direction_neighbors : element.neighbors()) {
+      const auto& direction = direction_neighbors.first;
+      const auto& neighbors = direction_neighbors.second;
+      for (const auto& neighbor : neighbors) {
+        const auto mortar_id = std::make_pair(direction, neighbor);
+        mortar_data[mortar_id];  // Default initialize data
+        mortar_next_temporal_ids.insert({mortar_id, temporal_id});
+        mortar_meshes.emplace(
+            mortar_id,
+            ::dg::mortar_mesh(
+                mesh.slice_away(direction.dimension()),
+                ::Initialization::element_mesh(initial_extents, neighbor,
+                                               neighbors.orientation())
+                    .slice_away(direction.dimension())));
+        mortar_sizes.emplace(
+            mortar_id,
+            ::dg::mortar_size(element.id(), neighbor, direction.dimension(),
+                              neighbors.orientation()));
+      }
+    }
+    // Add mortars for external boundaries
+    for (const auto& direction : element.external_boundaries()) {
+      const auto mortar_id = std::make_pair(
+          direction, ElementId<volume_dim>::external_boundary_id());
+      mortar_data[mortar_id];  // Default initialize data
+      mortar_next_temporal_ids.insert({mortar_id, temporal_id});
+      mortar_meshes.emplace(mortar_id, mesh.slice_away(direction.dimension()));
+      mortar_sizes.emplace(
+          mortar_id, make_array<volume_dim - 1>(Spectral::MortarSize::Full));
+    }
+
+    return db::create_from<
+        db::RemoveTags<>,
+        db::AddSimpleTags<mortar_data_tag,
+                          mortar_tag<Tags::Next<temporal_id_tag>>,
+                          mortar_tag<Tags::Mesh<volume_dim - 1>>,
+                          mortar_tag<Tags::MortarSize<volume_dim - 1>>>>(
+        std::move(box), std::move(mortar_data),
+        std::move(mortar_next_temporal_ids), std::move(mortar_meshes),
+        std::move(mortar_sizes));
+  }
+
+  template <typename TagsList>
+  static auto initialize(db::DataBox<TagsList>&& box,
+                         const std::vector<std::array<size_t, volume_dim>>&
+                             initial_extents) noexcept {
+    auto mortar_box = add_mortar_data(std::move(box), initial_extents);
+
+    const auto& internal_directions =
+        db::get<Tags::InternalDirections<volume_dim>>(mortar_box);
+    const auto& boundary_directions =
+        db::get<Tags::BoundaryDirectionsInterior<volume_dim>>(mortar_box);
+
+    db::item_type<
+        interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>>
+        normal_dot_fluxes{};
+    for (const auto& direction : internal_directions) {
+      const auto& interface_num_points =
+          db::get<interface_tag<Tags::Mesh<volume_dim - 1>>>(mortar_box)
+              .at(direction)
+              .number_of_grid_points();
+      normal_dot_fluxes[direction].initialize(interface_num_points, 0.);
+    }
+    db::item_type<boundary_tag<typename flux_comm_types::normal_dot_fluxes_tag>>
+        boundary_normal_dot_fluxes{};
+    for (const auto& direction : boundary_directions) {
+      const auto& interface_num_points =
+          db::get<boundary_tag<Tags::Mesh<volume_dim - 1>>>(mortar_box)
+              .at(direction)
+              .number_of_grid_points();
+      boundary_normal_dot_fluxes[direction].initialize(interface_num_points,
+                                                       0.);
+    }
+
+    return db::create_from<
+        db::RemoveTags<>,
+        db::AddSimpleTags<
+            interface_tag<typename flux_comm_types::normal_dot_fluxes_tag>,
+            boundary_tag<typename flux_comm_types::normal_dot_fluxes_tag>>>(
+        std::move(mortar_box), std::move(normal_dot_fluxes),
+        std::move(boundary_normal_dot_fluxes));
+  }
+};
+}  // namespace Initialization
+}  // namespace Elliptic

--- a/src/Elliptic/Initialization/Domain.hpp
+++ b/src/Elliptic/Initialization/Domain.hpp
@@ -1,0 +1,78 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Domain/CreateInitialElement.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/MinimumGridSpacing.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/Helpers.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class ElementIndex;
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace Elliptic {
+namespace Initialization {
+
+/*!
+ * \brief Initializes the DataBox tag related to the computational domain
+ *
+ * DataBox:
+ * - Adds:
+ *   - `Tags::Mesh<Dim>`
+ *   - `Tags::Element<Dim>`
+ *   - `Tags::ElementMap<Dim, Frame::Inertial>`
+ *   - `Tags::Coordinates<Dim, Frame::Logical>`
+ *   - `Tags::Coordinates<Dim, Frame::Inertial>`
+ *   - `Tags::InverseJacobian<
+ *   Tags::ElementMap<Dim>, Tags::Coordinates<Dim, Frame::Logical>>`
+ */
+template <size_t Dim>
+struct Domain {
+  using simple_tags = db::AddSimpleTags<Tags::Mesh<Dim>, Tags::Element<Dim>,
+                                        Tags::ElementMap<Dim, Frame::Inertial>>;
+  using compute_tags = db::AddComputeTags<
+      Tags::LogicalCoordinates<Dim>,
+      Tags::MappedCoordinates<Tags::ElementMap<Dim>,
+                              Tags::Coordinates<Dim, Frame::Logical>>,
+      Tags::InverseJacobian<Tags::ElementMap<Dim>,
+                            Tags::Coordinates<Dim, Frame::Logical>>>;
+
+  template <typename TagsList>
+  static auto initialize(
+      db::DataBox<TagsList>&& box, const ElementIndex<Dim>& array_index,
+      const std::vector<std::array<size_t, Dim>>& initial_extents,
+      const ::Domain<Dim, Frame::Inertial>& domain) noexcept {
+    const ElementId<Dim> element_id{array_index};
+    const auto& my_block = domain.blocks()[element_id.block_id()];
+    Mesh<Dim> mesh =
+        ::Initialization::element_mesh(initial_extents, element_id);
+    Element<Dim> element = create_initial_element(element_id, my_block);
+    ElementMap<Dim, Frame::Inertial> map{element_id,
+                                         my_block.coordinate_map().get_clone()};
+
+    return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+        std::move(box), std::move(mesh), std::move(element), std::move(map));
+  }
+};
+
+}  // namespace Initialization
+}  // namespace Elliptic

--- a/src/Elliptic/Initialization/Interface.hpp
+++ b/src/Elliptic/Initialization/Interface.hpp
@@ -1,0 +1,139 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Elliptic {
+namespace Initialization {
+
+/*!
+ * \brief Initializes the DataBox tags related to data on the element faces
+ *
+ * With:
+ * - `face<Tag>` =
+ * `Tags::Interface<Tags::InternalDirections<volume_dim>, Tag>` **and**
+ * `Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>, Tag>`
+ * - `ext<Tag>` =
+ * `Tags::Interface<Tags::BoundaryDirectionsExterior<volume_dim>, Tag>`
+ *
+ * Uses:
+ * - System:
+ *   - `volume_dim`
+ *   - `variables_tag`
+ *   - `gradient_tags`
+ *   - `magnitude_tag`
+ * - DataBox:
+ *   - All items needed by the added compute tags
+ *
+ * DataBox:
+ * - Adds:
+ *   - `Tags::InternalDirections<volume_dim>`
+ *   - `Tags::BoundaryDirectionsInterior<volume_dim>`
+ *   - `face<Tags::Direction<volume_dim>>`
+ *   - `face<Tags::Mesh<volume_dim - 1>>`
+ *   - `face<variables_tag>` (as a compute tag)
+ *   - `face<db::add_tag_prefix<Tags::deriv, db::variables_tag_with_tags_list<
+ *   variables_tag, gradient_tags>, tmpl::size_t<volume_dim>, Frame::Inertial>>`
+ *   - `face<Tags::UnnormalizedFaceNormal<volume_dim>>`
+ *   - `face<magnitude_tag<Tags::UnnormalizedFaceNormal<volume_dim>>>`
+ *   - `face<Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>`
+ *   - `Tags::BoundaryDirectionsExterior<volume_dim>`
+ *   - `ext<Tags::Direction<volume_dim>>`
+ *   - `ext<Tags::Mesh<volume_dim - 1>>`
+ *   - `ext<variables_tag>` (as a simple tag)
+ *   - `ext<db::add_tag_prefix<Tags::deriv, db::variables_tag_with_tags_list<
+ *   variables_tag, gradient_tags>, tmpl::size_t<volume_dim>, Frame::Inertial>>`
+ *   - `ext<Tags::UnnormalizedFaceNormal<volume_dim>>`
+ *   - `ext<magnitude_tag<Tags::UnnormalizedFaceNormal<volume_dim>>>`
+ *   - `ext<Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>`
+ */
+template <typename System>
+struct Interface {
+  static constexpr size_t volume_dim = System::volume_dim;
+  template <typename Directions>
+  using face_tags = tmpl::list<
+      Directions,
+      Tags::InterfaceComputeItem<Directions, Tags::Direction<volume_dim>>,
+      Tags::InterfaceComputeItem<Directions, Tags::InterfaceMesh<volume_dim>>,
+      Tags::Slice<Directions, typename System::variables_tag>,
+      Tags::Slice<Directions, db::add_tag_prefix<
+                                  Tags::deriv,
+                                  db::variables_tag_with_tags_list<
+                                      typename System::variables_tag,
+                                      typename System::gradient_tags>,
+                                  tmpl::size_t<volume_dim>, Frame::Inertial>>,
+      Tags::InterfaceComputeItem<Directions,
+                                 Tags::UnnormalizedFaceNormal<volume_dim>>,
+      Tags::InterfaceComputeItem<Directions,
+                                 typename System::template magnitude_tag<
+                                     Tags::UnnormalizedFaceNormal<volume_dim>>>,
+      Tags::InterfaceComputeItem<
+          Directions,
+          Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>>;
+
+  using exterior_face_tags = tmpl::list<
+      Tags::BoundaryDirectionsExterior<volume_dim>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<volume_dim>,
+                                 Tags::Direction<volume_dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<volume_dim>,
+                                 Tags::InterfaceMesh<volume_dim>>,
+      // We slice the gradients to the exterior faces, too. This may need to be
+      // reconsidered when boundary conditions are reworked.
+      Tags::Slice<
+          Tags::BoundaryDirectionsExterior<volume_dim>,
+          db::add_tag_prefix<
+              Tags::deriv,
+              db::variables_tag_with_tags_list<typename System::variables_tag,
+                                               typename System::gradient_tags>,
+              tmpl::size_t<volume_dim>, Frame::Inertial>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<volume_dim>,
+                                 Tags::UnnormalizedFaceNormal<volume_dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<volume_dim>,
+                                 typename System::template magnitude_tag<
+                                     Tags::UnnormalizedFaceNormal<volume_dim>>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<volume_dim>,
+          Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>>;
+
+  using simple_tags = db::AddSimpleTags<
+      // We rely on the variable data on exterior faces being updated manually.
+      // This may need to be reconsidered when boundary conditions are reworked.
+      Tags::Interface<Tags::BoundaryDirectionsExterior<volume_dim>,
+                      typename System::variables_tag>>;
+  using compute_tags =
+      tmpl::append<face_tags<Tags::InternalDirections<volume_dim>>,
+                   face_tags<Tags::BoundaryDirectionsInterior<volume_dim>>,
+                   exterior_face_tags>;
+
+  template <typename TagsList>
+  static auto initialize(db::DataBox<TagsList>&& box) noexcept {
+    const auto& mesh = db::get<Tags::Mesh<volume_dim>>(box);
+    std::unordered_map<Direction<volume_dim>,
+                       db::item_type<typename System::variables_tag>>
+        external_boundary_vars{};
+
+    for (const auto& direction :
+         db::get<Tags::Element<volume_dim>>(box).external_boundaries()) {
+      external_boundary_vars[direction] =
+          db::item_type<typename System::variables_tag>{
+              mesh.slice_away(direction.dimension()).number_of_grid_points()};
+    }
+
+    return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+        std::move(box), std::move(external_boundary_vars));
+  }
+};
+
+}  // namespace Initialization
+}  // namespace Elliptic

--- a/src/Elliptic/Initialization/LinearSolver.hpp
+++ b/src/Elliptic/Initialization/LinearSolver.hpp
@@ -1,0 +1,89 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace Elliptic {
+namespace Initialization {
+
+/*!
+ * \brief Initializes the DataBox tag related to the linear solver
+ *
+ * Uses the analytic solution to compute the linear solver source.
+ * Assumes the system fields are initialized to zero (see
+ * `Elliptic::Initialization::System`) so we don't have to apply the operator to
+ * the initial guess.
+ *
+ * Uses:
+ * - Metavariables:
+ *   - `linear_solver`
+ *   - `analytic_solution_tag`
+ * - System:
+ *   - `volume_dim`
+ *   - `fields_tag`
+ * - DataBox:
+ *   - `Tags::Mesh<volume_dim>`
+ *   - `Tags::Coordinates<volume_dim, Frame::Inertial>`
+ *
+ * DataBox:
+ * - Adds:
+ *   - All items in `linear_solver::tags`
+ */
+template <typename Metavariables>
+struct LinearSolver {
+  using linear_solver_tags = typename Metavariables::linear_solver::tags;
+  using system = typename Metavariables::system;
+
+  using sources_tag =
+      db::add_tag_prefix<Tags::Source, typename system::fields_tag>;
+  using fields_operator_tag =
+      db::add_tag_prefix<::LinearSolver::Tags::OperatorAppliedTo,
+                         typename system::fields_tag>;
+
+  using simple_tags = typename linear_solver_tags::simple_tags;
+  using compute_tags = typename linear_solver_tags::compute_tags;
+
+  template <typename TagsList, typename ArrayIndex, typename ParallelComponent>
+  static auto initialize(
+      db::DataBox<TagsList>&& box,
+      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index,
+      const ParallelComponent* const parallel_component_meta) noexcept {
+    const auto& inertial_coords =
+        get<Tags::Coordinates<system::volume_dim, Frame::Inertial>>(box);
+    const auto num_grid_points =
+        get<Tags::Mesh<system::volume_dim>>(box).number_of_grid_points();
+
+    db::item_type<sources_tag> sources(num_grid_points, 0.);
+    sources.assign_subset(
+        Parallel::get<typename Metavariables::analytic_solution_tag>(cache)
+            .source_variables(inertial_coords));
+
+    // Starting with x_0 = 0 initial guess, so Ax_0=0
+    db::item_type<fields_operator_tag> fields_operator(num_grid_points, 0.);
+
+    return linear_solver_tags::initialize(
+        std::move(box), cache, array_index, parallel_component_meta,
+        std::move(sources), std::move(fields_operator));
+  }
+};
+}  // namespace Initialization
+}  // namespace Elliptic

--- a/src/Elliptic/Initialization/System.hpp
+++ b/src/Elliptic/Initialization/System.hpp
@@ -1,0 +1,65 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace Elliptic {
+namespace Initialization {
+
+/*!
+ * \brief Initializes the DataBox tags related to the system
+ *
+ * The system fields are initially set to zero here.
+ *
+ * Uses:
+ * - System:
+ *   - `volume_dim`
+ *   - `fields_tag`
+ * - DataBox:
+ *   - `Tags::Mesh<volume_dim>`
+ *
+ * DataBox:
+ * - Adds:
+ *   - `fields_tag`
+ */
+template <typename SystemType>
+struct System {
+  static constexpr size_t Dim = SystemType::volume_dim;
+  using simple_tags = db::AddSimpleTags<typename SystemType::fields_tag>;
+  using compute_tags = db::AddComputeTags<>;
+
+  template <typename TagsList>
+  static auto initialize(db::DataBox<TagsList>&& box) noexcept {
+    using FieldsVars = typename SystemType::fields_tag::type;
+
+    const size_t num_grid_points =
+        db::get<Tags::Mesh<Dim>>(box).number_of_grid_points();
+
+    // Set initial data to zero. Non-zero initial data would require the
+    // linear solver initialization to also compute the Ax term.
+    FieldsVars fields{num_grid_points, 0.};
+
+    return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+        std::move(box), std::move(fields));
+  }
+};
+
+}  // namespace Initialization
+}  // namespace Elliptic

--- a/tests/Unit/Elliptic/CMakeLists.txt
+++ b/tests/Unit/Elliptic/CMakeLists.txt
@@ -3,4 +3,5 @@
 
 add_subdirectory(Actions)
 add_subdirectory(DiscontinuousGalerkin)
+add_subdirectory(Initialization)
 add_subdirectory(Systems)

--- a/tests/Unit/Elliptic/Initialization/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Initialization/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_EllipticInitialization")
 
 set(LIBRARY_SOURCES
   Test_Domain.cpp
+  Test_LinearSolver.cpp
   Test_System.cpp
   )
 

--- a/tests/Unit/Elliptic/Initialization/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Initialization/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_EllipticInitialization")
+
+set(LIBRARY_SOURCES
+  Test_Domain.cpp
+  )
+
+add_test_library(
+  ${LIBRARY}
+  "Elliptic/Initialization/"
+  "${LIBRARY_SOURCES}"
+  "DataStructures;Domain;ErrorHandling;LinearOperators;Spectral"
+  )

--- a/tests/Unit/Elliptic/Initialization/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Initialization/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EllipticInitialization")
 
 set(LIBRARY_SOURCES
+  Test_Derivatives.cpp
   Test_Domain.cpp
   Test_LinearSolver.cpp
   Test_System.cpp

--- a/tests/Unit/Elliptic/Initialization/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Initialization/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_EllipticInitialization")
 
 set(LIBRARY_SOURCES
   Test_Derivatives.cpp
+  Test_DiscontinuousGalerkin.cpp
   Test_Domain.cpp
   Test_Interface.cpp
   Test_LinearSolver.cpp

--- a/tests/Unit/Elliptic/Initialization/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Initialization/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_EllipticInitialization")
 set(LIBRARY_SOURCES
   Test_Derivatives.cpp
   Test_Domain.cpp
+  Test_Interface.cpp
   Test_LinearSolver.cpp
   Test_System.cpp
   )

--- a/tests/Unit/Elliptic/Initialization/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Initialization/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_EllipticInitialization")
 
 set(LIBRARY_SOURCES
   Test_Domain.cpp
+  Test_System.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Elliptic/Initialization/Test_Derivatives.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_Derivatives.cpp
@@ -1,0 +1,163 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Domain/Tags.hpp"  // IWYU pragma: keep
+#include "Elliptic/Initialization/Derivatives.hpp"
+#include "Elliptic/Initialization/Domain.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+// IWYU pragma: no_forward_declare Tags::deriv
+
+namespace {
+struct ScalarFieldTag : db::SimpleTag {
+  static std::string name() noexcept { return "ScalarFieldTag"; };
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
+  using gradient_tags = tmpl::list<ScalarFieldTag>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Derivatives",
+                  "[Unit][Elliptic][Actions]") {
+  SECTION("1D") {
+    const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
+    const domain::creators::Interval<Frame::Inertial> domain_creator{
+        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+    auto domain_box = Elliptic::Initialization::Domain<1>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<1>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    const auto& mesh = get<Tags::Mesh<1>>(domain_box);
+    Variables<tmpl::list<ScalarFieldTag>> vars{mesh.number_of_grid_points()};
+    const auto& inertial_coords =
+        get<Tags::Coordinates<1, Frame::Inertial>>(domain_box);
+    get(get<ScalarFieldTag>(vars)) = get<0>(inertial_coords);
+
+    auto argument_box =
+        db::create_from<db::RemoveTags<>,
+                        db::AddSimpleTags<typename System<1>::variables_tag>>(
+            std::move(domain_box), std::move(vars));
+
+    const auto box =
+        Elliptic::Initialization::Derivatives<System<1>>::initialize(
+            std::move(argument_box));
+
+    const tnsr::i<DataVector, 1, Frame::Inertial> expected_derivs{{{{4, 1.}}}};
+    CHECK_ITERABLE_APPROX(
+        get<0>(
+            get<Tags::deriv<ScalarFieldTag, tmpl::size_t<1>, Frame::Inertial>>(
+                box)),
+        get<0>(expected_derivs));
+  }
+  SECTION("2D") {
+    const ElementId<2> element_id{0, {{SegmentId{2, 1}, SegmentId{0, 0}}}};
+    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+        {{-0.5, 0.}}, {{1.5, 1.}}, {{false, false}}, {{2, 0}}, {{4, 2}}};
+    auto domain_box = Elliptic::Initialization::Domain<2>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<2>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    const auto& mesh = get<Tags::Mesh<2>>(domain_box);
+    Variables<tmpl::list<ScalarFieldTag>> vars{mesh.number_of_grid_points()};
+    const auto& inertial_coords =
+        get<Tags::Coordinates<2, Frame::Inertial>>(domain_box);
+    get(get<ScalarFieldTag>(vars)) =
+        get<0>(inertial_coords) + 2. * get<1>(inertial_coords);
+
+    auto argument_box =
+        db::create_from<db::RemoveTags<>,
+                        db::AddSimpleTags<typename System<2>::variables_tag>>(
+            std::move(domain_box), std::move(vars));
+
+    const auto box =
+        Elliptic::Initialization::Derivatives<System<2>>::initialize(
+            std::move(argument_box));
+
+    const tnsr::i<DataVector, 2, Frame::Inertial> expected_derivs{
+        {{{8, 1.}, {8, 2.}}}};
+    CHECK_ITERABLE_APPROX(
+        get<0>(
+            get<Tags::deriv<ScalarFieldTag, tmpl::size_t<2>, Frame::Inertial>>(
+                box)),
+        get<0>(expected_derivs));
+    CHECK_ITERABLE_APPROX(
+        get<1>(
+            get<Tags::deriv<ScalarFieldTag, tmpl::size_t<2>, Frame::Inertial>>(
+                box)),
+        get<1>(expected_derivs));
+  }
+  SECTION("3D") {
+    const ElementId<3> element_id{
+        0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 1}}}};
+    const domain::creators::Brick<Frame::Inertial> domain_creator{
+        {{-0.5, 0., -1.}},
+        {{1.5, 1., 4.}},
+        {{false, false, true}},
+        {{2, 0, 1}},
+        {{4, 2, 3}}};
+    auto domain_box = Elliptic::Initialization::Domain<3>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<3>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    const auto& mesh = get<Tags::Mesh<3>>(domain_box);
+    Variables<tmpl::list<ScalarFieldTag>> vars{mesh.number_of_grid_points()};
+    const auto& inertial_coords =
+        get<Tags::Coordinates<3, Frame::Inertial>>(domain_box);
+    get(get<ScalarFieldTag>(vars)) = get<0>(inertial_coords) +
+                                     2. * get<1>(inertial_coords) +
+                                     3. * get<2>(inertial_coords);
+
+    auto argument_box =
+        db::create_from<db::RemoveTags<>,
+                        db::AddSimpleTags<typename System<3>::variables_tag>>(
+            std::move(domain_box), std::move(vars));
+
+    const auto box =
+        Elliptic::Initialization::Derivatives<System<3>>::initialize(
+            std::move(argument_box));
+
+    const tnsr::i<DataVector, 3, Frame::Inertial> expected_derivs{
+        {{{24, 1.}, {24, 2.}, {24, 3.}}}};
+    CHECK_ITERABLE_APPROX(
+        get<0>(
+            get<Tags::deriv<ScalarFieldTag, tmpl::size_t<3>, Frame::Inertial>>(
+                box)),
+        get<0>(expected_derivs));
+    CHECK_ITERABLE_APPROX(
+        get<1>(
+            get<Tags::deriv<ScalarFieldTag, tmpl::size_t<3>, Frame::Inertial>>(
+                box)),
+        get<1>(expected_derivs));
+    CHECK_ITERABLE_APPROX(
+        get<2>(
+            get<Tags::deriv<ScalarFieldTag, tmpl::size_t<3>, Frame::Inertial>>(
+                box)),
+        get<2>(expected_derivs));
+  }
+}

--- a/tests/Unit/Elliptic/Initialization/Test_DiscontinuousGalerkin.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_DiscontinuousGalerkin.cpp
@@ -1,0 +1,349 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"                  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Domain/Tags.hpp"  // IWYU pragma: keep
+#include "Elliptic/Initialization/DiscontinuousGalerkin.hpp"
+#include "Elliptic/Initialization/Domain.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Spectral/Projection.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/TMPL.hpp"
+// IWYU pragma: no_forward_declare Tags::MortarSize
+// IWYU pragma: no_forward_declare Tags::Mortars
+
+namespace {
+struct TemporalId : db::SimpleTag {
+  static std::string name() noexcept { return "TemporalId"; };
+  using type = int;
+};
+
+struct ScalarFieldTag : db::SimpleTag {
+  static std::string name() noexcept { return "ScalarFieldTag"; };
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using system = System<Dim>;
+  using temporal_id = TemporalId;
+  struct normal_dot_numerical_flux {
+    struct type {
+      using package_tags = tmpl::list<ScalarFieldTag>;
+    };
+  };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.DG",
+                  "[Unit][Elliptic][Actions]") {
+  SECTION("1D") {
+    // Reference element:
+    // [X| | | ] -xi->
+    const ElementId<1> element_id{0, {{SegmentId{2, 0}}}};
+    const domain::creators::Interval<Frame::Inertial> domain_creator{
+        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+    auto domain_box = Elliptic::Initialization::Domain<1>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<1>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    auto arguments_box = db::create_from<
+        db::RemoveTags<>, db::AddSimpleTags<TemporalId>,
+        db::AddComputeTags<
+            Tags::InternalDirections<1>, Tags::BoundaryDirectionsInterior<1>,
+            Tags::InterfaceComputeItem<Tags::InternalDirections<1>,
+                                       Tags::Direction<1>>,
+            Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<1>,
+                                       Tags::Direction<1>>,
+            Tags::InterfaceComputeItem<Tags::InternalDirections<1>,
+                                       Tags::InterfaceMesh<1>>,
+            Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<1>,
+                                       Tags::InterfaceMesh<1>>>>(
+        std::move(domain_box), 0);
+
+    const auto box = Elliptic::Initialization::DiscontinuousGalerkin<
+        Metavariables<1>>::initialize(std::move(arguments_box),
+                                      domain_creator.initial_extents());
+
+    // We are working with 2 mortars here: a domain boundary at lower xi and an
+    // interface at upper xi.
+    const auto boundary_mortar_id = std::make_pair(
+        Direction<1>::lower_xi(), ElementId<1>::external_boundary_id());
+    const auto interface_mortar_id = std::make_pair(
+        Direction<1>::upper_xi(), ElementId<1>(0, {{SegmentId{2, 1}}}));
+    const auto& mortar_next_temporal_ids =
+        get<Tags::Mortars<Tags::Next<TemporalId>, 1>>(box);
+    CHECK(mortar_next_temporal_ids.at(boundary_mortar_id) == 0);
+    CHECK(mortar_next_temporal_ids.at(interface_mortar_id) == 0);
+    const auto& mortar_meshes = get<Tags::Mortars<Tags::Mesh<0>, 1>>(box);
+    CHECK(mortar_meshes.at(boundary_mortar_id) == Mesh<0>());
+    CHECK(mortar_meshes.at(interface_mortar_id) == Mesh<0>());
+    const auto& mortar_sizes = get<Tags::Mortars<Tags::MortarSize<0>, 1>>(box);
+    CHECK(mortar_sizes.at(boundary_mortar_id).empty());
+    CHECK(mortar_sizes.at(interface_mortar_id).empty());
+    const auto& mortar_data = get<Tags::VariablesBoundaryData>(box);
+    // Just make sure this exists, it is not expected to hold any data
+    mortar_data.at(boundary_mortar_id);
+    mortar_data.at(interface_mortar_id);
+
+    // Test that the normal fluxes on the faces have been initialized
+    const auto& boundary_normal_dot_fluxes = get<
+        Tags::Interface<Tags::BoundaryDirectionsInterior<1>,
+                        db::add_tag_prefix<Tags::NormalDotFlux,
+                                           typename System<1>::variables_tag>>>(
+        box);
+    CHECK(boundary_normal_dot_fluxes.at(Direction<1>::lower_xi())
+              .number_of_grid_points() == 1);
+    const auto& interface_normal_dot_fluxes = get<
+        Tags::Interface<Tags::InternalDirections<1>,
+                        db::add_tag_prefix<Tags::NormalDotFlux,
+                                           typename System<1>::variables_tag>>>(
+        box);
+    CHECK(interface_normal_dot_fluxes.at(Direction<1>::upper_xi())
+              .number_of_grid_points() == 1);
+  }
+  SECTION("2D") {
+    // Reference element:
+    // ^ eta
+    // +-+-+> xi
+    // |X| |
+    // +-+-+
+    // | | |
+    // +-+-+
+    const ElementId<2> element_id{0, {{SegmentId{1, 0}, SegmentId{1, 1}}}};
+    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+        {{-0.5, 0.}}, {{1.5, 1.}}, {{false, false}}, {{1, 1}}, {{3, 2}}};
+    auto domain_box = Elliptic::Initialization::Domain<2>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<2>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    auto arguments_box = db::create_from<
+        db::RemoveTags<>, db::AddSimpleTags<TemporalId>,
+        db::AddComputeTags<
+            Tags::InternalDirections<2>, Tags::BoundaryDirectionsInterior<2>,
+            Tags::InterfaceComputeItem<Tags::InternalDirections<2>,
+                                       Tags::Direction<2>>,
+            Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<2>,
+                                       Tags::Direction<2>>,
+            Tags::InterfaceComputeItem<Tags::InternalDirections<2>,
+                                       Tags::InterfaceMesh<2>>,
+            Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<2>,
+                                       Tags::InterfaceMesh<2>>>>(
+        std::move(domain_box), 0);
+
+    const auto box = Elliptic::Initialization::DiscontinuousGalerkin<
+        Metavariables<2>>::initialize(std::move(arguments_box),
+                                      domain_creator.initial_extents());
+
+    // We are working with 4 mortars here: the domain boundary west and north,
+    // and interfaces south and east.
+    const auto boundary_mortar_id_west = std::make_pair(
+        Direction<2>::lower_xi(), ElementId<2>::external_boundary_id());
+    const auto boundary_mortar_id_north = std::make_pair(
+        Direction<2>::upper_eta(), ElementId<2>::external_boundary_id());
+    const auto interface_mortar_id_east =
+        std::make_pair(Direction<2>::upper_xi(),
+                       ElementId<2>(0, {{SegmentId{1, 1}, SegmentId{1, 1}}}));
+    const auto interface_mortar_id_south =
+        std::make_pair(Direction<2>::lower_eta(),
+                       ElementId<2>(0, {{SegmentId{1, 0}, SegmentId{1, 0}}}));
+    const auto& mortar_next_temporal_ids =
+        get<Tags::Mortars<Tags::Next<TemporalId>, 2>>(box);
+    CHECK(mortar_next_temporal_ids.at(boundary_mortar_id_west) == 0);
+    CHECK(mortar_next_temporal_ids.at(boundary_mortar_id_north) == 0);
+    CHECK(mortar_next_temporal_ids.at(interface_mortar_id_east) == 0);
+    CHECK(mortar_next_temporal_ids.at(interface_mortar_id_south) == 0);
+    const auto& mortar_meshes = get<Tags::Mortars<Tags::Mesh<1>, 2>>(box);
+    CHECK(mortar_meshes.at(boundary_mortar_id_west) ==
+          Mesh<1>(2, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto));
+    CHECK(mortar_meshes.at(boundary_mortar_id_north) ==
+          Mesh<1>(3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto));
+    CHECK(mortar_meshes.at(interface_mortar_id_east) ==
+          Mesh<1>(2, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto));
+    CHECK(mortar_meshes.at(interface_mortar_id_south) ==
+          Mesh<1>(3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto));
+    const auto& mortar_sizes = get<Tags::Mortars<Tags::MortarSize<1>, 2>>(box);
+    const std::array<Spectral::MortarSize, 1> expected_mortar_sizes{
+        {Spectral::MortarSize::Full}};
+    CHECK(mortar_sizes.at(boundary_mortar_id_west) == expected_mortar_sizes);
+    CHECK(mortar_sizes.at(boundary_mortar_id_north) == expected_mortar_sizes);
+    CHECK(mortar_sizes.at(interface_mortar_id_east) == expected_mortar_sizes);
+    CHECK(mortar_sizes.at(interface_mortar_id_south) == expected_mortar_sizes);
+    const auto& mortar_data = get<Tags::VariablesBoundaryData>(box);
+    // Just make sure this exists, it is not expected to hold any data
+    mortar_data.at(boundary_mortar_id_west);
+    mortar_data.at(boundary_mortar_id_north);
+    mortar_data.at(interface_mortar_id_east);
+    mortar_data.at(interface_mortar_id_south);
+
+    // Test that the normal fluxes on the faces have been initialized
+    const auto& boundary_normal_dot_fluxes = get<
+        Tags::Interface<Tags::BoundaryDirectionsInterior<2>,
+                        db::add_tag_prefix<Tags::NormalDotFlux,
+                                           typename System<2>::variables_tag>>>(
+        box);
+    CHECK(boundary_normal_dot_fluxes.at(Direction<2>::lower_xi())
+              .number_of_grid_points() == 2);
+    CHECK(boundary_normal_dot_fluxes.at(Direction<2>::upper_eta())
+              .number_of_grid_points() == 3);
+    const auto& interface_normal_dot_fluxes = get<
+        Tags::Interface<Tags::InternalDirections<2>,
+                        db::add_tag_prefix<Tags::NormalDotFlux,
+                                           typename System<2>::variables_tag>>>(
+        box);
+    CHECK(interface_normal_dot_fluxes.at(Direction<2>::upper_xi())
+              .number_of_grid_points() == 2);
+    CHECK(interface_normal_dot_fluxes.at(Direction<2>::lower_eta())
+              .number_of_grid_points() == 3);
+  }
+  SECTION("3D") {
+    const ElementId<3> element_id{
+        0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 0}}}};
+    const domain::creators::Brick<Frame::Inertial> domain_creator{
+        {{-0.5, 0., -1.}},
+        {{1.5, 1., 3.}},
+        {{false, false, false}},
+        {{1, 1, 1}},
+        {{2, 3, 4}}};
+    auto domain_box = Elliptic::Initialization::Domain<3>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<3>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    auto arguments_box = db::create_from<
+        db::RemoveTags<>, db::AddSimpleTags<TemporalId>,
+        db::AddComputeTags<
+            Tags::InternalDirections<3>, Tags::BoundaryDirectionsInterior<3>,
+            Tags::InterfaceComputeItem<Tags::InternalDirections<3>,
+                                       Tags::Direction<3>>,
+            Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<3>,
+                                       Tags::Direction<3>>,
+            Tags::InterfaceComputeItem<Tags::InternalDirections<3>,
+                                       Tags::InterfaceMesh<3>>,
+            Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<3>,
+                                       Tags::InterfaceMesh<3>>>>(
+        std::move(domain_box), 0);
+
+    const auto box = Elliptic::Initialization::DiscontinuousGalerkin<
+        Metavariables<3>>::initialize(std::move(arguments_box),
+                                      domain_creator.initial_extents());
+
+    const auto boundary_mortar_id_left = std::make_pair(
+        Direction<3>::lower_xi(), ElementId<3>::external_boundary_id());
+    const auto boundary_mortar_id_back = std::make_pair(
+        Direction<3>::upper_eta(), ElementId<3>::external_boundary_id());
+    const auto boundary_mortar_id_bottom = std::make_pair(
+        Direction<3>::lower_zeta(), ElementId<3>::external_boundary_id());
+    const auto interface_mortar_id_right = std::make_pair(
+        Direction<3>::upper_xi(),
+        ElementId<3>(0, {{SegmentId{1, 1}, SegmentId{1, 1}, SegmentId{1, 0}}}));
+    const auto interface_mortar_id_front = std::make_pair(
+        Direction<3>::lower_eta(),
+        ElementId<3>(0, {{SegmentId{1, 0}, SegmentId{1, 0}, SegmentId{1, 0}}}));
+    const auto interface_mortar_id_top = std::make_pair(
+        Direction<3>::upper_zeta(),
+        ElementId<3>(0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 1}}}));
+    const auto& mortar_next_temporal_ids =
+        get<Tags::Mortars<Tags::Next<TemporalId>, 3>>(box);
+    CHECK(mortar_next_temporal_ids.at(boundary_mortar_id_left) == 0);
+    CHECK(mortar_next_temporal_ids.at(boundary_mortar_id_back) == 0);
+    CHECK(mortar_next_temporal_ids.at(boundary_mortar_id_bottom) == 0);
+    CHECK(mortar_next_temporal_ids.at(interface_mortar_id_right) == 0);
+    CHECK(mortar_next_temporal_ids.at(interface_mortar_id_front) == 0);
+    CHECK(mortar_next_temporal_ids.at(interface_mortar_id_top) == 0);
+    const auto& mortar_meshes = get<Tags::Mortars<Tags::Mesh<2>, 3>>(box);
+    CHECK(mortar_meshes.at(boundary_mortar_id_left) ==
+          Mesh<2>({{3, 4}}, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto));
+    CHECK(mortar_meshes.at(boundary_mortar_id_back) ==
+          Mesh<2>({{2, 4}}, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto));
+    CHECK(mortar_meshes.at(boundary_mortar_id_bottom) ==
+          Mesh<2>({{2, 3}}, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto));
+    CHECK(mortar_meshes.at(interface_mortar_id_right) ==
+          Mesh<2>({{3, 4}}, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto));
+    CHECK(mortar_meshes.at(interface_mortar_id_front) ==
+          Mesh<2>({{2, 4}}, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto));
+    CHECK(mortar_meshes.at(interface_mortar_id_top) ==
+          Mesh<2>({{2, 3}}, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto));
+    const auto& mortar_sizes = get<Tags::Mortars<Tags::MortarSize<2>, 3>>(box);
+    const std::array<Spectral::MortarSize, 2> expected_mortar_sizes{
+        {Spectral::MortarSize::Full, Spectral::MortarSize::Full}};
+    CHECK(mortar_sizes.at(boundary_mortar_id_left) == expected_mortar_sizes);
+    CHECK(mortar_sizes.at(boundary_mortar_id_back) == expected_mortar_sizes);
+    CHECK(mortar_sizes.at(boundary_mortar_id_bottom) == expected_mortar_sizes);
+    CHECK(mortar_sizes.at(interface_mortar_id_right) == expected_mortar_sizes);
+    CHECK(mortar_sizes.at(interface_mortar_id_front) == expected_mortar_sizes);
+    CHECK(mortar_sizes.at(interface_mortar_id_top) == expected_mortar_sizes);
+    const auto& mortar_data = get<Tags::VariablesBoundaryData>(box);
+    // Just make sure this exists, it is not expected to hold any data
+    mortar_data.at(boundary_mortar_id_left);
+    mortar_data.at(boundary_mortar_id_back);
+    mortar_data.at(boundary_mortar_id_bottom);
+    mortar_data.at(interface_mortar_id_right);
+    mortar_data.at(interface_mortar_id_front);
+    mortar_data.at(interface_mortar_id_top);
+
+    // Test that the normal fluxes on the faces have been initialized
+    const auto& boundary_normal_dot_fluxes = get<
+        Tags::Interface<Tags::BoundaryDirectionsInterior<3>,
+                        db::add_tag_prefix<Tags::NormalDotFlux,
+                                           typename System<3>::variables_tag>>>(
+        box);
+    CHECK(boundary_normal_dot_fluxes.at(Direction<3>::lower_xi())
+              .number_of_grid_points() == 12);
+    CHECK(boundary_normal_dot_fluxes.at(Direction<3>::upper_eta())
+              .number_of_grid_points() == 8);
+    CHECK(boundary_normal_dot_fluxes.at(Direction<3>::lower_zeta())
+              .number_of_grid_points() == 6);
+    const auto& interface_normal_dot_fluxes = get<
+        Tags::Interface<Tags::InternalDirections<3>,
+                        db::add_tag_prefix<Tags::NormalDotFlux,
+                                           typename System<3>::variables_tag>>>(
+        box);
+    CHECK(interface_normal_dot_fluxes.at(Direction<3>::upper_xi())
+              .number_of_grid_points() == 12);
+    CHECK(interface_normal_dot_fluxes.at(Direction<3>::lower_eta())
+              .number_of_grid_points() == 8);
+    CHECK(interface_normal_dot_fluxes.at(Direction<3>::upper_zeta())
+              .number_of_grid_points() == 6);
+  }
+}

--- a/tests/Unit/Elliptic/Initialization/Test_Domain.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_Domain.cpp
@@ -1,0 +1,176 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <functional>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Initialization/Domain.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/TMPL.hpp"
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Domain",
+                  "[Unit][Elliptic][Actions]") {
+  SECTION("1D") {
+    // Reference element:
+    // [ |X| | ] -xi->
+    const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
+    const domain::creators::Interval<Frame::Inertial> domain_creator{
+        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+
+    const auto box = Elliptic::Initialization::Domain<1>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<1>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    CHECK(get<Tags::Mesh<1>>(box) ==
+          Mesh<1>{4, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto});
+    CHECK(get<Tags::Element<1>>(box) ==
+          Element<1>{element_id,
+                     {{Direction<1>::lower_xi(),
+                       {{{ElementId<1>{0, {{SegmentId{2, 0}}}}}}, {}}},
+                      {Direction<1>::upper_xi(),
+                       {{{ElementId<1>{0, {{SegmentId{2, 2}}}}}}, {}}}}});
+    const auto& element_map = get<Tags::ElementMap<1>>(box);
+    const tnsr::I<DataVector, 1, Frame::Logical> logical_coords_for_element_map{
+        {{{-1., -0.5, 0., 0.1, 1.}}}};
+    const auto inertial_coords_from_element_map =
+        element_map(logical_coords_for_element_map);
+    const tnsr::I<DataVector, 1, Frame::Logical> expected_inertial_coords{
+        {{{0., 0.125, 0.25, 0.275, 0.5}}}};
+    CHECK_ITERABLE_APPROX(get<0>(inertial_coords_from_element_map),
+                          get<0>(expected_inertial_coords));
+    const auto& logical_coords = get<Tags::Coordinates<1, Frame::Logical>>(box);
+    CHECK(get<0>(logical_coords) ==
+          Spectral::collocation_points<Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::GaussLobatto>(4));
+    const auto& inertial_coords =
+        get<Tags::Coordinates<1, Frame::Inertial>>(box);
+    CHECK(inertial_coords == element_map(logical_coords));
+    CHECK(get<Tags::InverseJacobian<Tags::ElementMap<1>,
+                                    Tags::Coordinates<1, Frame::Logical>>>(
+              box) == element_map.inv_jacobian(logical_coords));
+  }
+  SECTION("2D") {
+    // Reference element:
+    // ^ eta
+    // +-+-+-+-+> xi
+    // | |X| | |
+    // +-+-+-+-+
+    const ElementId<2> element_id{0, {{SegmentId{2, 1}, SegmentId{0, 0}}}};
+    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+        {{-0.5, 0.}}, {{1.5, 2.}}, {{false, false}}, {{2, 0}}, {{4, 3}}};
+
+    const auto box = Elliptic::Initialization::Domain<2>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<2>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    CHECK(get<Tags::Mesh<2>>(box) ==
+          Mesh<2>{{{4, 3}},
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto});
+    CHECK(
+        get<Tags::Element<2>>(box) ==
+        Element<2>{
+            element_id,
+            {{Direction<2>::lower_xi(),
+              {{{ElementId<2>{0, {{SegmentId{2, 0}, SegmentId{0, 0}}}}}}, {}}},
+             {Direction<2>::upper_xi(),
+              {{{ElementId<2>{0, {{SegmentId{2, 2}, SegmentId{0, 0}}}}}},
+               {}}}}});
+    const auto& element_map = get<Tags::ElementMap<2>>(box);
+    const tnsr::I<DataVector, 2, Frame::Logical> logical_coords_for_element_map{
+        {{{-1., -0.5, 0., 0.1, 1.}, {-1., -0.5, 0., 0.1, 1.}}}};
+    const auto inertial_coords_from_element_map =
+        element_map(logical_coords_for_element_map);
+    const tnsr::I<DataVector, 2, Frame::Logical> expected_inertial_coords{
+        {{{0., 0.125, 0.25, 0.275, 0.5}, {0., 0.5, 1., 1.1, 2.}}}};
+    CHECK_ITERABLE_APPROX(get<0>(inertial_coords_from_element_map),
+                          get<0>(expected_inertial_coords));
+    CHECK_ITERABLE_APPROX(get<1>(inertial_coords_from_element_map),
+                          get<1>(expected_inertial_coords));
+    const auto& logical_coords = get<Tags::Coordinates<2, Frame::Logical>>(box);
+    const auto& inertial_coords =
+        get<Tags::Coordinates<2, Frame::Inertial>>(box);
+    CHECK(inertial_coords == element_map(logical_coords));
+    CHECK(get<Tags::InverseJacobian<Tags::ElementMap<2>,
+                                    Tags::Coordinates<2, Frame::Logical>>>(
+              box) == element_map.inv_jacobian(logical_coords));
+  }
+  SECTION("3D") {
+    const ElementId<3> element_id{
+        0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 1}}}};
+    const domain::creators::Brick<Frame::Inertial> domain_creator{
+        {{-0.5, 0., -1.}},
+        {{1.5, 2., 3.}},
+        {{false, false, false}},
+        {{2, 0, 1}},
+        {{4, 3, 2}}};
+
+    const auto box = Elliptic::Initialization::Domain<3>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<3>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    CHECK(get<Tags::Mesh<3>>(box) ==
+          Mesh<3>{{{4, 3, 2}},
+                  Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto});
+    CHECK(
+        get<Tags::Element<3>>(box) ==
+        Element<3>{
+            element_id,
+            {{Direction<3>::lower_xi(),
+              {{{ElementId<3>{
+                   0, {{SegmentId{2, 0}, SegmentId{0, 0}, SegmentId{1, 1}}}}}},
+               {}}},
+             {Direction<3>::upper_xi(),
+              {{{ElementId<3>{
+                   0, {{SegmentId{2, 2}, SegmentId{0, 0}, SegmentId{1, 1}}}}}},
+               {}}},
+             {Direction<3>::lower_zeta(),
+              {{{ElementId<3>{
+                   0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 0}}}}}},
+               {}}}}});
+    const auto& element_map = get<Tags::ElementMap<3>>(box);
+    const tnsr::I<DataVector, 3, Frame::Logical> logical_coords_for_element_map{
+        {{{-1., -0.5, 0., 0.1, 1.},
+          {-1., -0.5, 0., 0.1, 1.},
+          {-1., -0.5, 0., 0.1, 1.}}}};
+    const auto inertial_coords_from_element_map =
+        element_map(logical_coords_for_element_map);
+    const tnsr::I<DataVector, 3, Frame::Logical> expected_inertial_coords{
+        {{{0., 0.125, 0.25, 0.275, 0.5},
+          {0., 0.5, 1., 1.1, 2.},
+          {1., 1.5, 2., 2.1, 3.}}}};
+    CHECK_ITERABLE_APPROX(get<0>(inertial_coords_from_element_map),
+                          get<0>(expected_inertial_coords));
+    CHECK_ITERABLE_APPROX(get<1>(inertial_coords_from_element_map),
+                          get<1>(expected_inertial_coords));
+    CHECK_ITERABLE_APPROX(get<2>(inertial_coords_from_element_map),
+                          get<2>(expected_inertial_coords));
+    const auto& logical_coords = get<Tags::Coordinates<3, Frame::Logical>>(box);
+    const auto& inertial_coords =
+        get<Tags::Coordinates<3, Frame::Inertial>>(box);
+    CHECK(inertial_coords == element_map(logical_coords));
+    CHECK(get<Tags::InverseJacobian<Tags::ElementMap<3>,
+                                    Tags::Coordinates<3, Frame::Logical>>>(
+              box) == element_map.inv_jacobian(logical_coords));
+  }
+}

--- a/tests/Unit/Elliptic/Initialization/Test_Interface.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_Interface.cpp
@@ -1,0 +1,296 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Domain/Tags.hpp"  // IWYU pragma: keep
+#include "Elliptic/Initialization/Domain.hpp"
+#include "Elliptic/Initialization/Interface.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/TMPL.hpp"
+// IWYU pragma: no_forward_declare Tags::deriv
+
+namespace {
+struct ScalarFieldTag : db::SimpleTag {
+  static std::string name() noexcept { return "ScalarFieldTag"; };
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using variables_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
+  using gradient_tags = tmpl::list<ScalarFieldTag>;
+  template <typename Tag>
+  using magnitude_tag = Tags::EuclideanMagnitude<Tag>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Interface",
+                  "[Unit][Elliptic][Actions]") {
+  SECTION("1D") {
+    // Reference element:
+    // [X| | | ] -xi->
+    const ElementId<1> element_id{0, {{SegmentId{2, 0}}}};
+    const domain::creators::Interval<Frame::Inertial> domain_creator{
+        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+    auto domain_box = Elliptic::Initialization::Domain<1>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<1>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    using variables_tag = typename System<1>::variables_tag;
+    using derivs_tag = db::add_tag_prefix<
+        Tags::deriv,
+        db::variables_tag_with_tags_list<variables_tag,
+                                         typename System<1>::gradient_tags>,
+        tmpl::size_t<1>, Frame::Inertial>;
+    db::item_type<variables_tag> vars(DataVector{1., 2., 3., 4.});
+    db::item_type<derivs_tag> derivs(DataVector{-1., -2., -3., -4.});
+    auto arguments_box =
+        db::create_from<db::RemoveTags<>,
+                        db::AddSimpleTags<variables_tag, derivs_tag>>(
+            std::move(domain_box), std::move(vars), std::move(derivs));
+
+    const auto box = Elliptic::Initialization::Interface<System<1>>::initialize(
+        std::move(arguments_box));
+
+    const auto& internal_directions = get<Tags::InternalDirections<1>>(box);
+    const std::unordered_set<Direction<1>> expected_internal_directions{
+        Direction<1>::upper_xi()};
+    CHECK(internal_directions == expected_internal_directions);
+    const auto& external_directions =
+        get<Tags::BoundaryDirectionsInterior<1>>(box);
+    const std::unordered_set<Direction<1>> expected_external_directions{
+        Direction<1>::lower_xi()};
+    CHECK(external_directions == expected_external_directions);
+    const auto& exterior_directions =
+        get<Tags::BoundaryDirectionsExterior<1>>(box);
+    const std::unordered_set<Direction<1>> expected_exterior_directions{
+        Direction<1>::lower_xi()};
+    CHECK(exterior_directions == expected_exterior_directions);
+
+    const auto& interface_vars =
+        get<Tags::Interface<Tags::InternalDirections<1>, variables_tag>>(box);
+    const DataVector expected_field_upper_xi{4.};
+    CHECK(get(get<ScalarFieldTag>(interface_vars.at(
+              Direction<1>::upper_xi()))) == expected_field_upper_xi);
+    const auto& external_vars = get<
+        Tags::Interface<Tags::BoundaryDirectionsInterior<1>, variables_tag>>(
+        box);
+    const DataVector expected_field_lower_xi{1.};
+    CHECK(get(get<ScalarFieldTag>(external_vars.at(
+              Direction<1>::lower_xi()))) == expected_field_lower_xi);
+    const auto& exterior_vars = get<
+        Tags::Interface<Tags::BoundaryDirectionsExterior<1>, variables_tag>>(
+        box);
+    // Exterior vars are not computed, but only initialized
+    CHECK(exterior_vars.at(Direction<1>::lower_xi()).number_of_grid_points() ==
+          1);
+
+    const auto& interface_derivs =
+        get<Tags::Interface<Tags::InternalDirections<1>, derivs_tag>>(box);
+    const DataVector expected_deriv_upper_xi{-4.};
+    CHECK(
+        get<0>(
+            get<Tags::deriv<ScalarFieldTag, tmpl::size_t<1>, Frame::Inertial>>(
+                interface_derivs.at(Direction<1>::upper_xi()))) ==
+        expected_deriv_upper_xi);
+    const auto& external_derivs =
+        get<Tags::Interface<Tags::BoundaryDirectionsInterior<1>, derivs_tag>>(
+            box);
+    const DataVector expected_deriv_lower_xi{-1.};
+    CHECK(
+        get<0>(
+            get<Tags::deriv<ScalarFieldTag, tmpl::size_t<1>, Frame::Inertial>>(
+                external_derivs.at(Direction<1>::lower_xi()))) ==
+        expected_deriv_lower_xi);
+    const auto& exterior_derivs =
+        get<Tags::Interface<Tags::BoundaryDirectionsExterior<1>, derivs_tag>>(
+            box);
+    // Exterior derivs are the same as the interior
+    CHECK(
+        get<0>(
+            get<Tags::deriv<ScalarFieldTag, tmpl::size_t<1>, Frame::Inertial>>(
+                exterior_derivs.at(Direction<1>::lower_xi()))) ==
+        expected_deriv_lower_xi);
+  }
+  SECTION("2D") {
+    // Reference element:
+    // ^ eta
+    // +-+-+> xi
+    // |X| |
+    // +-+-+
+    // | | |
+    // +-+-+
+    const ElementId<2> element_id{0, {{SegmentId{1, 0}, SegmentId{1, 1}}}};
+    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+        {{-0.5, 0.}}, {{1.5, 2.}}, {{false, false}}, {{1, 1}}, {{3, 2}}};
+    auto domain_box = Elliptic::Initialization::Domain<2>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<2>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    using variables_tag = typename System<2>::variables_tag;
+    using derivs_tag = db::add_tag_prefix<
+        Tags::deriv,
+        db::variables_tag_with_tags_list<variables_tag,
+                                         typename System<2>::gradient_tags>,
+        tmpl::size_t<2>, Frame::Inertial>;
+    db::item_type<variables_tag> vars(DataVector{1., 2., 3., 4., 5., 6.});
+    db::item_type<derivs_tag> derivs(DataVector{-1., -2., -3., -4., -5., -6.});
+    auto arguments_box =
+        db::create_from<db::RemoveTags<>,
+                        db::AddSimpleTags<variables_tag, derivs_tag>>(
+            std::move(domain_box), std::move(vars), std::move(derivs));
+
+    const auto box = Elliptic::Initialization::Interface<System<2>>::initialize(
+        std::move(arguments_box));
+
+    const auto& internal_directions = get<Tags::InternalDirections<2>>(box);
+    const std::unordered_set<Direction<2>> expected_internal_directions{
+        Direction<2>::upper_xi(), Direction<2>::lower_eta()};
+    CHECK(internal_directions == expected_internal_directions);
+    const auto& external_directions =
+        get<Tags::BoundaryDirectionsInterior<2>>(box);
+    const std::unordered_set<Direction<2>> expected_external_directions{
+        Direction<2>::lower_xi(), Direction<2>::upper_eta()};
+    CHECK(external_directions == expected_external_directions);
+    const auto& exterior_directions =
+        get<Tags::BoundaryDirectionsExterior<2>>(box);
+    const std::unordered_set<Direction<2>> expected_exterior_directions{
+        Direction<2>::lower_xi(), Direction<2>::upper_eta()};
+    CHECK(exterior_directions == expected_exterior_directions);
+
+    const auto& interface_vars =
+        get<Tags::Interface<Tags::InternalDirections<2>, variables_tag>>(box);
+    const DataVector expected_field_upper_xi{3., 6.};
+    CHECK(get(get<ScalarFieldTag>(interface_vars.at(
+              Direction<2>::upper_xi()))) == expected_field_upper_xi);
+    const DataVector expected_field_lower_eta{1., 2., 3.};
+    CHECK(get(get<ScalarFieldTag>(interface_vars.at(
+              Direction<2>::lower_eta()))) == expected_field_lower_eta);
+    const auto& external_vars = get<
+        Tags::Interface<Tags::BoundaryDirectionsInterior<2>, variables_tag>>(
+        box);
+    const DataVector expected_field_lower_xi{1., 4.};
+    CHECK(get(get<ScalarFieldTag>(external_vars.at(
+              Direction<2>::lower_xi()))) == expected_field_lower_xi);
+    const DataVector expected_field_upper_eta{4., 5., 6.};
+    CHECK(get(get<ScalarFieldTag>(external_vars.at(
+              Direction<2>::upper_eta()))) == expected_field_upper_eta);
+    const auto& exterior_vars = get<
+        Tags::Interface<Tags::BoundaryDirectionsExterior<2>, variables_tag>>(
+        box);
+    // Exterior vars are not computed, but only initialized
+    CHECK(exterior_vars.at(Direction<2>::lower_xi()).number_of_grid_points() ==
+          2);
+    CHECK(exterior_vars.at(Direction<2>::upper_eta()).number_of_grid_points() ==
+          3);
+  }
+  SECTION("3D") {
+    const ElementId<3> element_id{
+        0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{2, 0}}}};
+    const domain::creators::Brick<Frame::Inertial> domain_creator{
+        {{-0.5, 0., -1.}},
+        {{1.5, 2., 4.}},
+        {{false, false, false}},
+        {{1, 1, 2}},
+        {{3, 2, 2}}};
+    auto domain_box = Elliptic::Initialization::Domain<3>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<3>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    using variables_tag = typename System<3>::variables_tag;
+    using derivs_tag = db::add_tag_prefix<
+        Tags::deriv,
+        db::variables_tag_with_tags_list<variables_tag,
+                                         typename System<3>::gradient_tags>,
+        tmpl::size_t<3>, Frame::Inertial>;
+    db::item_type<variables_tag> vars(
+        DataVector{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.});
+    db::item_type<derivs_tag> derivs(DataVector{
+        -1., -2., -3., -4., -5., -6., -7., -8., -9., -10., -11., -12.});
+    auto arguments_box =
+        db::create_from<db::RemoveTags<>,
+                        db::AddSimpleTags<variables_tag, derivs_tag>>(
+            std::move(domain_box), std::move(vars), std::move(derivs));
+
+    const auto box = Elliptic::Initialization::Interface<System<3>>::initialize(
+        std::move(arguments_box));
+
+    const auto& internal_directions = get<Tags::InternalDirections<3>>(box);
+    const std::unordered_set<Direction<3>> expected_internal_directions{
+        Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+        Direction<3>::upper_zeta()};
+    CHECK(internal_directions == expected_internal_directions);
+    const auto& external_directions =
+        get<Tags::BoundaryDirectionsInterior<3>>(box);
+    const std::unordered_set<Direction<3>> expected_external_directions{
+        Direction<3>::lower_xi(), Direction<3>::upper_eta(),
+        Direction<3>::lower_zeta()};
+    CHECK(external_directions == expected_external_directions);
+    const auto& exterior_directions =
+        get<Tags::BoundaryDirectionsExterior<3>>(box);
+    const std::unordered_set<Direction<3>> expected_exterior_directions{
+        Direction<3>::lower_xi(), Direction<3>::upper_eta(),
+        Direction<3>::lower_zeta()};
+    CHECK(exterior_directions == expected_exterior_directions);
+
+    const auto& interface_vars =
+        get<Tags::Interface<Tags::InternalDirections<3>, variables_tag>>(box);
+    const DataVector expected_field_upper_xi{3., 6., 9., 12.};
+    CHECK(get(get<ScalarFieldTag>(interface_vars.at(
+              Direction<3>::upper_xi()))) == expected_field_upper_xi);
+    const DataVector expected_field_lower_eta{1., 2., 3., 7., 8., 9.};
+    CHECK(get(get<ScalarFieldTag>(interface_vars.at(
+              Direction<3>::lower_eta()))) == expected_field_lower_eta);
+    const DataVector expected_field_upper_zeta{7., 8., 9., 10., 11., 12.};
+    CHECK(get(get<ScalarFieldTag>(interface_vars.at(
+              Direction<3>::upper_zeta()))) == expected_field_upper_zeta);
+    const auto& external_vars = get<
+        Tags::Interface<Tags::BoundaryDirectionsInterior<3>, variables_tag>>(
+        box);
+    const DataVector expected_field_lower_xi{1., 4., 7., 10.};
+    CHECK(get(get<ScalarFieldTag>(external_vars.at(
+              Direction<3>::lower_xi()))) == expected_field_lower_xi);
+    const DataVector expected_field_upper_eta{4., 5., 6., 10., 11., 12.};
+    CHECK(get(get<ScalarFieldTag>(external_vars.at(
+              Direction<3>::upper_eta()))) == expected_field_upper_eta);
+    const DataVector expected_field_lower_zeta{1., 2., 3., 4., 5., 6.};
+    CHECK(get(get<ScalarFieldTag>(external_vars.at(
+              Direction<3>::lower_zeta()))) == expected_field_lower_zeta);
+    const auto& exterior_vars = get<
+        Tags::Interface<Tags::BoundaryDirectionsExterior<3>, variables_tag>>(
+        box);
+    // Exterior vars are not computed, but only initialized
+    CHECK(exterior_vars.at(Direction<3>::lower_xi()).number_of_grid_points() ==
+          4);
+    CHECK(exterior_vars.at(Direction<3>::upper_eta()).number_of_grid_points() ==
+          6);
+    CHECK(
+        exterior_vars.at(Direction<3>::lower_zeta()).number_of_grid_points() ==
+        6);
+  }
+}

--- a/tests/Unit/Elliptic/Initialization/Test_LinearSolver.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_LinearSolver.cpp
@@ -1,0 +1,177 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Initialization/LinearSolver.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+
+namespace {
+struct ScalarFieldTag : db::SimpleTag {
+  static std::string name() noexcept { return "ScalarFieldTag"; };
+  using type = Scalar<DataVector>;
+};
+
+struct LinearSolverSourceTag : db::SimpleTag {
+  static std::string name() noexcept { return "LinearSolverSourceTag"; };
+  using type = Scalar<DataVector>;
+};
+
+struct LinearSolverAxTag : db::SimpleTag {
+  static std::string name() noexcept { return "LinearSolverAxTag"; };
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using fields_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
+};
+
+template <size_t Dim>
+struct AnalyticSolution {
+  tuples::TaggedTuple<Tags::Source<ScalarFieldTag>> source_variables(
+      const tnsr::I<DataVector, Dim>& x) const noexcept {
+    return {Scalar<DataVector>(get<0>(x))};
+  }
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using system = System<Dim>;
+  using analytic_solution_tag =
+      OptionTags::AnalyticSolution<AnalyticSolution<Dim>>;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
+  struct linear_solver {
+    struct tags {
+      using simple_tags =
+          db::AddSimpleTags<LinearSolverSourceTag, LinearSolverAxTag>;
+      using compute_tags = db::AddComputeTags<>;
+      template <typename TagsList, typename ArrayIndex,
+                typename ParallelComponent>
+      static auto initialize(
+          db::DataBox<TagsList>&& box,
+          const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+          const ArrayIndex& /*array_index*/,
+          const ParallelComponent* const /*meta*/,
+          const db::item_type<
+              db::add_tag_prefix<::Tags::Source, typename system::fields_tag>>&
+              b,
+          const db::item_type<
+              db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
+                                 typename system::fields_tag>>& Ax) noexcept {
+        return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+            std::move(box), get<::Tags::Source<ScalarFieldTag>>(b),
+            get<LinearSolver::Tags::OperatorAppliedTo<ScalarFieldTag>>(Ax));
+      }
+    };
+  };
+};
+
+struct MockParallelComponent {};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.LinearSolver",
+                  "[Unit][Elliptic][Actions]") {
+  SECTION("1D") {
+    Mesh<1> mesh{3, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+    tnsr::I<DataVector, 1, Frame::Inertial> inertial_coords{{{{1., 2., 3.}}}};
+    auto arguments_box =
+        db::create<db::AddSimpleTags<Tags::Mesh<1>,
+                                     Tags::Coordinates<1, Frame::Inertial>>>(
+            mesh, std::move(inertial_coords));
+
+    ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{
+        {AnalyticSolution<1>{}}, {}};
+
+    MockParallelComponent component{};
+    const auto box =
+        Elliptic::Initialization::LinearSolver<Metavariables<1>>::initialize(
+            std::move(arguments_box), runner.cache(), 0, &component);
+
+    const DataVector b_expected{1., 2., 3.};
+    CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
+    const DataVector Ax_expected(3, 0.);
+    CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
+  }
+  SECTION("2D") {
+    Mesh<2> mesh{{{3, 2}},
+                 Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+    tnsr::I<DataVector, 2, Frame::Inertial> inertial_coords{
+        {{{1., 2., 3., 4., 5., 6.}, {6, 0.}}}};
+    auto arguments_box =
+        db::create<db::AddSimpleTags<Tags::Mesh<2>,
+                                     Tags::Coordinates<2, Frame::Inertial>>>(
+            mesh, std::move(inertial_coords));
+
+    ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
+        {AnalyticSolution<2>{}}, {}};
+
+    MockParallelComponent component{};
+    const auto box =
+        Elliptic::Initialization::LinearSolver<Metavariables<2>>::initialize(
+            std::move(arguments_box), runner.cache(), 0, &component);
+
+    const DataVector b_expected{1., 2., 3., 4., 5., 6.};
+    CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
+    const DataVector Ax_expected(6, 0.);
+    CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
+  }
+  SECTION("3D") {
+    Mesh<3> mesh{{{3, 2, 2}},
+                 Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+    tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{
+        {{{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.},
+          {12, 0.},
+          {12, 0.}}}};
+    auto arguments_box =
+        db::create<db::AddSimpleTags<Tags::Mesh<3>,
+                                     Tags::Coordinates<3, Frame::Inertial>>>(
+            mesh, std::move(inertial_coords));
+
+    ActionTesting::MockRuntimeSystem<Metavariables<3>> runner{
+        {AnalyticSolution<3>{}}, {}};
+
+    MockParallelComponent component{};
+    const auto box =
+        Elliptic::Initialization::LinearSolver<Metavariables<3>>::initialize(
+            std::move(arguments_box), runner.cache(), 0, &component);
+
+    const DataVector b_expected{1., 2., 3., 4.,  5.,  6.,
+                                7., 8., 9., 10., 11., 12.};
+    CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
+    const DataVector Ax_expected(12, 0.);
+    CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
+  }
+}

--- a/tests/Unit/Elliptic/Initialization/Test_System.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_System.cpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Initialization/System.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+struct ScalarFieldTag : db::SimpleTag {
+  static std::string name() noexcept { return "ScalarFieldTag"; };
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using fields_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.System",
+                  "[Unit][Elliptic][Actions]") {
+  SECTION("1D") {
+    Mesh<1> mesh{4, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+    const auto box = Elliptic::Initialization::System<System<1>>::initialize(
+        db::create<db::AddSimpleTags<Tags::Mesh<1>>>(mesh));
+
+    const Scalar<DataVector> expected_initial_field{{{{4, 0.}}}};
+    CHECK(get<ScalarFieldTag>(box) == expected_initial_field);
+  }
+  SECTION("2D") {
+    Mesh<2> mesh{{{3, 4}},
+                 Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+    const auto box = Elliptic::Initialization::System<System<2>>::initialize(
+        db::create<db::AddSimpleTags<Tags::Mesh<2>>>(mesh));
+
+    const Scalar<DataVector> expected_initial_field{{{{12, 0.}}}};
+    CHECK(get<ScalarFieldTag>(box) == expected_initial_field);
+  }
+  SECTION("3D") {
+    Mesh<3> mesh{{{3, 4, 2}},
+                 Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+    const auto box = Elliptic::Initialization::System<System<3>>::initialize(
+        db::create<db::AddSimpleTags<Tags::Mesh<3>>>(mesh));
+
+    const Scalar<DataVector> expected_initial_field{{{{24, 0.}}}};
+    CHECK(get<ScalarFieldTag>(box) == expected_initial_field);
+  }
+}


### PR DESCRIPTION
## Proposed changes

This PR adds the DgElementArray parallel component for elliptic system, as well as its element DataBox initialisers. The DgElementArray is mostly the same as the one for evolution systems, but kept separately because it will presumable diverge in the future, for instance when we add multigrid infrastructure. The `InitializeElement` action chains together a number of initialisers that all follow the same structure and are tested individually.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
