### PR TITLE
Find apparent horizon

### DIFF
--- a/src/ApparentHorizons/ComputeItems.hpp
+++ b/src/ApparentHorizons/ComputeItems.hpp
@@ -1,0 +1,76 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+class DataVector;
+/// \endcond
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah {
+namespace Tags {
+// @{
+/// These ComputeItems are different from those used in
+/// GeneralizedHarmonic evolution because these live only on the
+/// intrp::Actions::ApparentHorizon DataBox, not in the volume
+/// DataBox.  And these ComputeItems can do fewer allocations than the
+/// volume ones, because (for example) Lapse, SpaceTimeNormalVector,
+/// etc.  can be inlined instead of being allocated as a separate
+/// ComputeItem.
+template <size_t Dim, typename Frame>
+struct InverseSpatialMetricCompute : gr::Tags::InverseSpatialMetric<Dim, Frame>,
+                                     db::ComputeTag {
+  static tnsr::II<DataVector, Dim, Frame> function(
+      const tnsr::aa<DataVector, Dim, Frame>& psi) noexcept {
+    return determinant_and_inverse(gr::spatial_metric(psi)).second;
+  };
+  using argument_tags = tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame>>;
+};
+template <size_t Dim, typename Frame>
+struct ExtrinsicCurvatureCompute : gr::Tags::ExtrinsicCurvature<Dim, Frame>,
+                                   db::ComputeTag {
+  static tnsr::ii<DataVector, Dim, Frame> function(
+      const tnsr::aa<DataVector, Dim, Frame>& psi,
+      const tnsr::aa<DataVector, Dim, Frame>& pi,
+      const tnsr::iaa<DataVector, Dim, Frame>& phi,
+      const tnsr::II<DataVector, Dim, Frame>& inv_g) noexcept {
+    const auto shift = gr::shift(psi, inv_g);
+    return GeneralizedHarmonic::extrinsic_curvature(
+        gr::spacetime_normal_vector(gr::lapse(shift, psi), shift), pi, phi);
+  }
+  using argument_tags = tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame>,
+                                   GeneralizedHarmonic::Tags::Pi<Dim, Frame>,
+                                   GeneralizedHarmonic::Tags::Phi<Dim, Frame>,
+                                   gr::Tags::InverseSpatialMetric<Dim, Frame>>;
+};
+template <size_t Dim, typename Frame>
+struct SpatialChristoffelSecondKindCompute
+    : ::gr::Tags::SpatialChristoffelSecondKind<Dim, Frame>,
+      db::ComputeTag {
+  static tnsr::Ijj<DataVector, Dim, Frame> function(
+      const tnsr::iaa<DataVector, Dim, Frame>& phi,
+      const tnsr::II<DataVector, Dim, Frame>& inv_g) noexcept {
+    return raise_or_lower_first_index(
+        gr::christoffel_first_kind(
+            GeneralizedHarmonic::deriv_spatial_metric(phi)),
+        inv_g);
+  }
+  using argument_tags = tmpl::list<GeneralizedHarmonic::Tags::Phi<Dim, Frame>,
+                                   gr::Tags::InverseSpatialMetric<Dim, Frame>>;
+};
+// }@
+}  // namespace Tags
+}  // namespace ah

--- a/src/ApparentHorizons/Tags.hpp
+++ b/src/ApparentHorizons/Tags.hpp
@@ -16,6 +16,19 @@
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_forward_declare gr::Tags::SpatialMetric
+/// \cond
+class DataVector;
+class FastFlow;
+/// \endcond
+
+namespace ah {
+namespace Tags {
+struct FastFlow : db::SimpleTag {
+  static std::string name() noexcept { return "FastFlow"; }
+  using type = ::FastFlow;
+};
+}  // namespace Tags
+}  // namespace ah
 
 /// \ingroup SurfacesGroup
 /// Holds tags and ComputeItems associated with a `::Strahlkorper`.

--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Interpolation)
 
 set(LIBRARY_SOURCES
   BarycentricRational.cpp
+  InterpolationTargetApparentHorizon.cpp
   InterpolationTargetKerrHorizon.cpp
   InterpolationTargetLineSegment.cpp
   InterpolationTargetWedgeSectionTorus.cpp

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/Callbacks.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/Callbacks.hpp
@@ -1,0 +1,12 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace intrp {
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Contains callback functions called by `InterpolationTarget`s.
+ */
+namespace callbacks;
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp
@@ -1,0 +1,200 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <utility>
+
+#include "ApparentHorizons/FastFlow.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Informer/Verbosity.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Printf.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+
+/// \cond
+namespace StrahlkorperTags {
+template <typename Frame>
+struct Strahlkorper;
+}  // namespace StrahlkorperTags
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace intrp {
+template <class Metavariables, typename InterpolationTargetTag>
+struct InterpolationTarget;
+namespace Tags {
+template <typename Metavariables>
+struct TemporalIds;
+}  // namespace Tags
+}  // namespace intrp
+namespace ah {
+namespace Tags {
+struct FastFlow;
+}  // namespace Tags
+}  // namespace ah
+namespace Tags {
+struct Verbosity;
+}  // namespace Tags
+template <typename Frame>
+class Strahlkorper;
+/// \endcond
+
+namespace intrp {
+namespace callbacks {
+
+/// \brief post interpolation callback (see InterpolationTarget)
+/// that does a FastFlow iteration and triggers another one until convergence.
+///
+/// Assumes that InterpolationTargetTag contains an additional
+/// struct called `post_horizon_find_callback`, which has a function
+///```
+///  static void apply(const DataBox<DbTags>&,
+///                    const intrp::ConstGlobalCache<Metavariables>&,
+///                    const Metavariables::temporal_id&) noexcept;
+///```
+/// that is called if the FastFlow iteration has converged.
+///
+/// Uses:
+/// - Metavariables:
+///   - `temporal_id`
+///   - `domain_frame`
+/// - DataBox:
+///   - `::Tags::Verbosity`
+///   - `::gr::Tags::InverseSpatialMetric<3,Frame>`
+///   - `::gr::Tags::ExtrinsicCurvature<3,Frame>`
+///   - `::gr::Tags::SpatialChristoffelSecondKind<3,Frame>`
+///   - `::ah::Tags::FastFlow`
+///   - `StrahlkorperTags::Strahlkorper<Frame>`
+///
+/// Modifies:
+/// - DataBox:
+///   - `::ah::Tags::FastFlow`
+///   - `StrahlkorperTags::Strahlkorper<Frame>`
+///
+/// This is an InterpolationTargetTag::post_interpolation_callback;
+/// see InterpolationTarget for a description of InterpolationTargetTag.
+template <typename InterpolationTargetTag>
+struct FindApparentHorizon {
+  template <typename DbTags, typename Metavariables>
+  static bool apply(
+      const gsl::not_null<db::DataBox<DbTags>*> box,
+      const gsl::not_null<Parallel::ConstGlobalCache<Metavariables>*> cache,
+      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
+    const auto& verbosity = db::get<::Tags::Verbosity>(*box);
+    const auto& inv_g = db::get<::gr::Tags::InverseSpatialMetric<
+        3, typename Metavariables::domain_frame>>(*box);
+    const auto& ex_curv = db::get<::gr::Tags::ExtrinsicCurvature<
+        3, typename Metavariables::domain_frame>>(*box);
+    const auto& christoffel = db::get<::gr::Tags::SpatialChristoffelSecondKind<
+        3, typename Metavariables::domain_frame>>(*box);
+
+    std::pair<FastFlow::Status, FastFlow::IterInfo> status_and_info;
+
+    // Do a FastFlow iteration.
+    db::mutate<::ah::Tags::FastFlow, StrahlkorperTags::Strahlkorper<
+                                     typename Metavariables::domain_frame>>(
+        box, [&inv_g, &ex_curv, &christoffel, &status_and_info ](
+                 const gsl::not_null<::FastFlow*> fast_flow,
+                 const gsl::not_null<
+                     ::Strahlkorper<typename Metavariables::domain_frame>*>
+                     strahlkorper) noexcept {
+          status_and_info = fast_flow->template iterate_horizon_finder<
+              typename Metavariables::domain_frame>(strahlkorper, inv_g,
+                                                    ex_curv, christoffel);
+        });
+
+    // Determine whether we have converged, whether we need another step,
+    // or whether we have encountered an error.
+
+    const auto& status = status_and_info.first;
+    const auto& info = status_and_info.second;
+    const auto has_converged = converged(status);
+
+    if (verbosity > ::Verbosity::Quiet or
+        (verbosity > ::Verbosity::Silent and has_converged)) {
+      //  The things printed out here are:
+      //  its     = current iteration number.
+      //  R       = min and max of residual over all prolonged grid points.
+      // |R|      = L2 norm of residual, counting only L modes solved for.
+      // |R_mesh| = L2 norm of residual over prolonged grid points.
+      // r        = min and max radius of trial horizon surface.
+      //
+      // Difference between |R| and |R_mesh|:
+      //  The horizon is represented in a Y_lm expansion up to l=l_surface;
+      //  the residual |R| represents the failure of that surface to satisfy
+      //  the apparent horizon equation.
+      //
+      //  However, at each iteration we also interpolate the horizon surface
+      //  to a higher resolution ("prolongation").  The prolonged surface
+      //  includes Ylm coefficents up to l=l_mesh, where l_mesh > l_surface.
+      //  The residual computed on this higher-resolution surface is |R_mesh|.
+      //
+      //  As iterations proceed, |R| should decrease until it reaches numerical
+      //  roundoff error, because we are varying all the Y_lm coefficients up to
+      //  l=l_surface to minimize the residual.  However, |R_mesh| should
+      //  eventually stop decreasing as iterations proceed, hitting a
+      //  floor that represents the numerical truncation error of the solution.
+      //
+      //  The convergence criterion looks at both |R| and |R_mesh|:  Once
+      //  |R| is small enough and |R_mesh| has stabilized, it is pointless
+      //  to keep iterating (even though one could iterate until |R| reaches
+      //  roundoff).
+      //
+      //  Problems with convergence of the apparent horizon finder can often
+      //  be diagnosed by looking at the behavior of |R| and |R_mesh| as a
+      //  function of iteration.
+      Parallel::printf(
+          "%s: its=%d: %.1e<R<%.0e, |R|=%.1g, "
+          "|R_grid|=%.1g, %.4g<r<%.4g\n",
+          pretty_type::short_name<InterpolationTargetTag>(), info.iteration,
+          info.min_residual, info.max_residual, info.residual_ylm,
+          info.residual_mesh, info.r_min, info.r_max);
+    }
+
+    if (status == FastFlow::Status::SuccessfulIteration) {
+      // Do another iteration of the same horizon search.
+      const auto& temporal_ids =
+          db::get<intrp::Tags::TemporalIds<Metavariables>>(*box);
+      auto& interpolation_target = Parallel::get_parallel_component<
+          intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>>(
+          *cache);
+      Parallel::simple_action<
+          typename InterpolationTargetTag::compute_target_points>(
+          interpolation_target, temporal_ids.front());
+      // We return false because we don't want this iteration to clean
+      // up the volume data, since we are using it for the next iteration
+      // (i.e. the simple_action that we just called).
+      return false;
+    } else if (not has_converged) {
+      ERROR("Apparent horizon finder "
+            << pretty_type::short_name<InterpolationTargetTag>()
+            << " failed, reason = " << status);
+    }
+    // If we get here, the horizon finder has converged.
+
+    InterpolationTargetTag::post_horizon_find_callback::apply(*box, *cache,
+                                                              temporal_id);
+
+    // Prepare for finding horizon at a new time.
+    // For now, the initial guess for the new
+    // horizon is the result of the old one, so we don't need
+    // to modify the strahlkorper.
+    // Eventually we will hold more than one previous guess and
+    // will do time-extrapolation to set the next guess.
+    db::mutate<::ah::Tags::FastFlow>(
+        box, [](const gsl::not_null<::FastFlow*> fast_flow) noexcept {
+          fast_flow->reset_for_next_find();
+        });
+    // We return true because we are now done with all the volume data
+    // at this temporal_id, so we want it cleaned up.
+    return true;
+  }
+};
+}  // namespace callbacks
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -60,16 +60,26 @@ namespace intrp {
 /// - post_interpolation_callback:   a struct with a type alias
 ///                                  `const_global_cache_tags` (listing tags
 ///                                  that should be read from option parsing)
-///                                  and with a function
+///                                  and with a static function
 ///```
-///       static void apply(const DataBox<DbTags>&,
-///                         const intrp::ConstGlobalCache<Metavariables>&,
-///                         const Metavariables::temporal_id::type&) noexcept;
+///     void apply(const DataBox<DbTags>&,
+///                const intrp::ConstGlobalCache<Metavariables>&,
+///                const Metavariables::temporal_id&) noexcept;
 ///```
-///                                  that will be called when interpolation
-///                                  is complete. `DbTags` includes everything
-///                                  in `vars_to_interpolate_to_target`
-///                                  and `compute_items_on_target`.
+/// or
+///```
+///     bool apply(const gsl::not_null<db::DataBox<DbTags>*>,
+///                const gsl::not_null<intrp::ConstGlobalCache<Metavariables>*>,
+///                const Metavariables::temporal_id&) noexcept;
+///```
+///                            that will be called when interpolation is
+///                            complete.  `DbTags` includes everything in
+///                            `vars_to_interpolate_to_target`, plus everything
+///                            in `compute_items_on_target`.  The second form
+///                            of the `apply` function should return false only
+///                            if it calls another `intrp::Action` that still
+///                            needs the volume data at this temporal_id (such
+///                            as another iteration of the horizon finder).
 ///
 /// `Metavariables` must contain the following type aliases:
 /// - interpolator_source_vars:   a `tmpl::list` of tags that define a

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.cpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp"
+
+#include <algorithm>
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace intrp {
+namespace OptionHolders {
+template <typename Frame>
+ApparentHorizon<Frame>::ApparentHorizon(Strahlkorper<Frame> initial_guess_in,
+                                        ::FastFlow fast_flow_in,
+                                        Verbosity verbosity_in) noexcept
+    : initial_guess(std::move(initial_guess_in)),
+      fast_flow(std::move(fast_flow_in)),    // NOLINT
+      verbosity(std::move(verbosity_in)) {}  // NOLINT
+// clang-tidy std::move of trivially copyable type.
+
+template <typename Frame>
+void ApparentHorizon<Frame>::pup(PUP::er& p) noexcept {
+  p | initial_guess;
+  p | fast_flow;
+  p | verbosity;
+}
+
+template <typename Frame>
+bool operator==(const ApparentHorizon<Frame>& lhs,
+                const ApparentHorizon<Frame>& rhs) noexcept {
+  return lhs.initial_guess == rhs.initial_guess and
+         lhs.fast_flow == rhs.fast_flow and lhs.verbosity == rhs.verbosity;
+}
+
+template <typename Frame>
+bool operator!=(const ApparentHorizon<Frame>& lhs,
+                const ApparentHorizon<Frame>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// So far instantiate for only one frame. But once we
+// have control systems working, we will need this for at
+// least two frames.
+template struct ApparentHorizon<Frame::Inertial>;
+template bool operator==(const ApparentHorizon<Frame::Inertial>& lhs,
+                         const ApparentHorizon<Frame::Inertial>& rhs) noexcept;
+template bool operator!=(const ApparentHorizon<Frame::Inertial>& lhs,
+                         const ApparentHorizon<Frame::Inertial>& rhs) noexcept;
+
+}  // namespace OptionHolders
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -65,7 +65,7 @@ struct ApparentHorizon {
                   Verbosity verbosity_in) noexcept;
 
   ApparentHorizon() = default;
-  ApparentHorizon(const ApparentHorizon& /*rhs*/) = default;
+  ApparentHorizon(const ApparentHorizon& /*rhs*/) = delete;
   ApparentHorizon& operator=(const ApparentHorizon& /*rhs*/) = delete;
   ApparentHorizon(ApparentHorizon&& /*rhs*/) noexcept = default;
   ApparentHorizon& operator=(ApparentHorizon&& /*rhs*/) noexcept = default;

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp
@@ -1,0 +1,188 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "ApparentHorizons/FastFlow.hpp"
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "ApparentHorizons/Tags.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Informer/Verbosity.hpp"
+#include "NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+namespace intrp {
+namespace Tags {
+template <typename Metavariables>
+struct TemporalIds;
+}  // namespace Tags
+}  // namespace intrp
+namespace OptionTags {
+struct Verbosity;
+}  // namespace OptionTags
+namespace Tags {
+struct Verbosity;
+}  // namespace Tags
+/// \endcond
+
+namespace intrp {
+
+namespace OptionHolders {
+/// Options for finding an apparent horizon.
+template <typename Frame>
+struct ApparentHorizon {
+  /// See Strahlkorper for suboptions.
+  struct InitialGuess {
+    static constexpr OptionString help = {"Initial guess"};
+    using type = Strahlkorper<Frame>;
+  };
+  /// See ::FastFlow for suboptions.
+  struct FastFlow {
+    static constexpr OptionString help = {"FastFlow options"};
+    using type = ::FastFlow;
+  };
+  using options = tmpl::list<InitialGuess, FastFlow, ::OptionTags::Verbosity>;
+  static constexpr OptionString help = {
+      "Provide an initial guess for the apparent horizon surface\n"
+      "(Strahlkorper) and apparent-horizon-finding-algorithm (FastFlow)\n"
+      "options."};
+
+  ApparentHorizon(Strahlkorper<Frame> initial_guess_in, ::FastFlow fast_flow_in,
+                  Verbosity verbosity_in) noexcept;
+
+  ApparentHorizon() = default;
+  ApparentHorizon(const ApparentHorizon& /*rhs*/) = default;
+  ApparentHorizon& operator=(const ApparentHorizon& /*rhs*/) = delete;
+  ApparentHorizon(ApparentHorizon&& /*rhs*/) noexcept = default;
+  ApparentHorizon& operator=(ApparentHorizon&& /*rhs*/) noexcept = default;
+  ~ApparentHorizon() = default;
+
+  // clang-tidy non-const reference pointer.
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  Strahlkorper<Frame> initial_guess{};
+  ::FastFlow fast_flow{};
+  Verbosity verbosity{Verbosity::Quiet};
+};
+
+template <typename Frame>
+bool operator==(const ApparentHorizon<Frame>& lhs,
+                const ApparentHorizon<Frame>& rhs) noexcept;
+template <typename Frame>
+bool operator!=(const ApparentHorizon<Frame>& lhs,
+                const ApparentHorizon<Frame>& rhs) noexcept;
+
+}  // namespace OptionHolders
+
+namespace Actions {
+/// \ingroup ActionsGroup
+/// \brief Sends points on a trial apparent horizon to an `Interpolator`.
+///
+/// This differs from `KerrHorizon` in the following ways:
+/// - It supplies points on a prolonged Strahlkorper, at a higher resolution
+///   than the Strahlkorper in the DataBox, as needed for horizon finding.
+/// - It uses a `FastFlow` in the DataBox.
+/// - It has different options (including those for `FastFlow`).
+///
+/// Uses:
+/// - DataBox:
+///   - `::Tags::Domain<VolumeDim, Frame>`
+///   - `::ah::Tags::FastFlow`
+///   - `StrahlkorperTags::CartesianCoords<Frame>`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// DataBox changes:
+/// - Adds: nothing
+/// - Removes: nothing
+/// - Modifies:
+///   - `Tags::IndicesOfFilledInterpPoints`
+///   - `::Tags::Variables<typename
+///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
+///
+/// This Action also has an initialize function that adds to the DataBox:
+/// - `StrahlkorperTags::items_tags<Frame>`
+/// - `StrahlkorperTags::compute_items_tags<Frame>`
+/// - `::ah::Tags::FastFlow`
+/// - `::Tags::Verbosity`
+///
+/// For requirements on InterpolationTargetTag, see InterpolationTarget
+template <typename InterpolationTargetTag, typename Frame>
+struct ApparentHorizon {
+  using options_type = OptionHolders::ApparentHorizon<Frame>;
+  using const_global_cache_tags = tmpl::list<InterpolationTargetTag>;
+  using initialization_tags =
+      tmpl::append<StrahlkorperTags::items_tags<Frame>,
+                   tmpl::list<::ah::Tags::FastFlow, ::Tags::Verbosity>,
+                   StrahlkorperTags::compute_items_tags<Frame>>;
+  template <typename DbTags, typename Metavariables>
+  static auto initialize(
+      db::DataBox<DbTags>&& box,
+      const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+    const auto& options = Parallel::get<InterpolationTargetTag>(cache);
+
+    // Put Strahlkorper and its ComputeItems, FastFlow,
+    // and verbosity into a new DataBox.
+    return db::create_from<
+        db::RemoveTags<>,
+        db::AddSimpleTags<
+            tmpl::push_back<StrahlkorperTags::items_tags<Frame>,
+                            ::ah::Tags::FastFlow, ::Tags::Verbosity>>,
+        db::AddComputeTags<StrahlkorperTags::compute_items_tags<Frame>>>(
+        std::move(box), options.initial_guess, options.fast_flow,
+        options.verbosity);
+  }
+  template <typename DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<tmpl::list_contains_v<
+                DbTags, typename Tags::TemporalIds<Metavariables>>> = nullptr>
+  static void apply(
+      db::DataBox<DbTags>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/,
+      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
+    const auto& fast_flow = db::get<::ah::Tags::FastFlow>(box);
+    const auto& strahlkorper =
+        db::get<StrahlkorperTags::Strahlkorper<Frame>>(box);
+
+    const size_t L_mesh = fast_flow.current_l_mesh(strahlkorper);
+    const auto prolonged_strahlkorper =
+        Strahlkorper<Frame>(L_mesh, L_mesh, strahlkorper);
+
+    const auto prolonged_coords =
+        StrahlkorperTags::CartesianCoords<Frame>::function(
+            prolonged_strahlkorper,
+            StrahlkorperTags::Radius<Frame>::function(prolonged_strahlkorper),
+            StrahlkorperTags::Rhat<Frame>::function(
+                StrahlkorperTags::ThetaPhi<Frame>::function(
+                    prolonged_strahlkorper)));
+
+    // In the future, when we add support for multiple Frames,
+    // the code that transforms coordinates from the Strahlkorper Frame
+    // to `Metavariables::domain_frame` will go here.  That transformation
+    // may depend on `temporal_id`.
+
+    send_points_to_interpolator<InterpolationTargetTag>(
+        box, cache, prolonged_coords, temporal_id);
+  }
+};
+
+}  // namespace Actions
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -67,8 +67,8 @@ struct KerrHorizon {
               const OptionContext& context = {});
 
   KerrHorizon() = default;
-  KerrHorizon(const KerrHorizon& /*rhs*/) = default;
-  KerrHorizon& operator=(const KerrHorizon& /*rhs*/) = default;
+  KerrHorizon(const KerrHorizon& /*rhs*/) = delete;
+  KerrHorizon& operator=(const KerrHorizon& /*rhs*/) = delete;
   KerrHorizon(KerrHorizon&& /*rhs*/) noexcept = default;
   KerrHorizon& operator=(KerrHorizon&& /*rhs*/) noexcept = default;
   ~KerrHorizon() = default;

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -66,8 +66,8 @@ struct LineSegment {
               size_t number_of_points_in) noexcept;
 
   LineSegment() = default;
-  LineSegment(const LineSegment& /*rhs*/) = default;
-  LineSegment& operator=(const LineSegment& /*rhs*/) = default;
+  LineSegment(const LineSegment& /*rhs*/) = delete;
+  LineSegment& operator=(const LineSegment& /*rhs*/) = delete;
   LineSegment(LineSegment&& /*rhs*/) noexcept = default;
   LineSegment& operator=(LineSegment&& /*rhs*/) noexcept = default;
   ~LineSegment() = default;

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -129,8 +129,8 @@ struct WedgeSectionTorus {
                     const OptionContext& context = {});
 
   WedgeSectionTorus() = default;
-  WedgeSectionTorus(const WedgeSectionTorus& /*rhs*/) = default;
-  WedgeSectionTorus& operator=(const WedgeSectionTorus& /*rhs*/) = default;
+  WedgeSectionTorus(const WedgeSectionTorus& /*rhs*/) = delete;
+  WedgeSectionTorus& operator=(const WedgeSectionTorus& /*rhs*/) = delete;
   WedgeSectionTorus(WedgeSectionTorus&& /*rhs*/) noexcept = default;
   WedgeSectionTorus& operator=(WedgeSectionTorus&& /*rhs*/) noexcept = default;
   ~WedgeSectionTorus() = default;

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ApparentHorizons")
 
 set(LIBRARY_SOURCES
   StrahlkorperGrTestHelpers.cpp
+  Test_ApparentHorizonFinder.cpp
   Test_ComputeItems.cpp
   Test_FastFlow.cpp
   Test_SpherepackIterator.cpp

--- a/tests/Unit/ApparentHorizons/CMakeLists.txt
+++ b/tests/Unit/ApparentHorizons/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ApparentHorizons")
 
 set(LIBRARY_SOURCES
   StrahlkorperGrTestHelpers.cpp
+  Test_ComputeItems.cpp
   Test_FastFlow.cpp
   Test_SpherepackIterator.cpp
   Test_Strahlkorper.cpp

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -1,0 +1,374 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+#include <random>
+#include <vector>
+
+#include "ApparentHorizons/ComputeItems.hpp"  // IWYU pragma: keep
+#include "ApparentHorizons/FastFlow.hpp"
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/Creators/Shell.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/InitialElementIds.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Informer/Tags.hpp"  // IWYU pragma: keep
+#include "Informer/Verbosity.hpp"
+#include "NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/Callbacks/FindApparentHorizon.hpp"
+#include "NumericalAlgorithms/Interpolation/CleanUpInterpolator.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
+#include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetReceiveVars.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/ParallelComponentHelpers.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrHorizon.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+namespace StrahlkorperTags {
+template <typename Frame>
+struct Radius;
+template <typename Frame>
+struct Strahlkorper;
+}  // namespace StrahlkorperTags
+namespace Tags {
+template <class TagList>
+struct Variables;
+template <typename Tag, typename Dim, typename Frame, typename>
+struct deriv;
+}  // namespace Tags
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+/// \endcond
+
+namespace {
+
+// Counter to ensure that this function is called
+size_t test_schwarzschild_horizon_called = 0;
+struct TestSchwarzschildHorizon {
+  template <typename DbTags, typename Metavariables>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const typename Metavariables::temporal_id::
+                        type& /*temporal_id*/) noexcept {
+    const auto& horizon_radius =
+        get<StrahlkorperTags::Radius<Frame::Inertial>>(box);
+    const auto expected_radius =
+        make_with_value<DataVector>(horizon_radius, 2.0);
+    // We don't choose many grid points (for speed of test), so we
+    // don't get the horizon radius extremely accurately.
+    Approx custom_approx = Approx::custom().epsilon(1.e-2).scale(1.0);
+    CHECK_ITERABLE_CUSTOM_APPROX(horizon_radius, expected_radius,
+                                 custom_approx);
+    ++test_schwarzschild_horizon_called;
+  }
+};
+
+// Counter to ensure that this function is called
+size_t test_kerr_horizon_called = 0;
+struct TestKerrHorizon {
+  template <typename DbTags, typename Metavariables>
+  static void apply(const db::DataBox<DbTags>& box,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const typename Metavariables::temporal_id::
+                        type& /*temporal_id*/) noexcept {
+    const auto& strahlkorper =
+        get<StrahlkorperTags::Strahlkorper<Frame::Inertial>>(box);
+    // Test actual horizon radius against analytic value at the same
+    // theta,phi points.
+    const auto expected_radius = gr::Solutions::kerr_horizon_radius(
+        strahlkorper.ylm_spherepack().theta_phi_points(), 1.1,
+        {{0.12, 0.23, 0.45}});
+    const auto& horizon_radius =
+        get<StrahlkorperTags::Radius<Frame::Inertial>>(box);
+    // The accuracy is not great because I use only a few grid points
+    // to speed up the test.
+    Approx custom_approx = Approx::custom().epsilon(1.e-3).scale(1.0);
+    CHECK_ITERABLE_CUSTOM_APPROX(horizon_radius, get(expected_radius),
+                                 custom_approx);
+    ++test_kerr_horizon_called;
+  }
+};
+
+template <typename Metavariables, typename InterpolationTargetTag>
+struct mock_interpolation_target {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using action_list = tmpl::list<>;
+  using component_being_mocked =
+      intrp::InterpolationTarget<Metavariables, InterpolationTargetTag>;
+  using initial_databox = db::compute_databox_type<
+      typename intrp::Actions::InitializeInterpolationTarget<
+          InterpolationTargetTag>::template return_tag_list<Metavariables>>;
+
+  using const_global_cache_tag_list = Parallel::get_const_global_cache_tags<
+      tmpl::list<typename InterpolationTargetTag::compute_target_points,
+                 typename InterpolationTargetTag::post_interpolation_callback>>;
+};
+
+template <typename Metavariables>
+struct mock_interpolator {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = size_t;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using component_being_mocked = intrp::Interpolator<Metavariables>;
+  using initial_databox =
+      db::compute_databox_type<typename intrp::Actions::InitializeInterpolator::
+                                   template return_tag_list<Metavariables>>;
+};
+
+template <typename PostHorizonFindCallback>
+struct MockMetavariables {
+  struct AhA {
+    using compute_items_on_source = tmpl::list<
+        ah::Tags::InverseSpatialMetricCompute<3, Frame::Inertial>,
+        ah::Tags::ExtrinsicCurvatureCompute<3, Frame::Inertial>,
+        ah::Tags::SpatialChristoffelSecondKindCompute<3, Frame::Inertial>>;
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::InverseSpatialMetric<3, Frame::Inertial>,
+                   gr::Tags::ExtrinsicCurvature<3, Frame::Inertial>,
+                   gr::Tags::SpatialChristoffelSecondKind<3, Frame::Inertial>>;
+    using compute_items_on_target = tmpl::list<>;
+    using compute_target_points =
+        intrp::Actions::ApparentHorizon<AhA, ::Frame::Inertial>;
+    using post_interpolation_callback =
+        intrp::callbacks::FindApparentHorizon<AhA>;
+    using post_horizon_find_callback = PostHorizonFindCallback;
+    // This `type` is so this tag can be used to read options.
+    using type = typename compute_target_points::options_type;
+  };
+  using interpolator_source_vars =
+      tmpl::list<gr::Tags::SpacetimeMetric<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>,
+                 GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>;
+  using interpolation_target_tags = tmpl::list<AhA>;
+  using temporal_id  = ::Tags::TimeId;
+  using domain_frame = Frame::Inertial;
+  static constexpr size_t domain_dim = 3;
+  using component_list =
+      tmpl::list<mock_interpolation_target<MockMetavariables, AhA>,
+                 mock_interpolator<MockMetavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+};
+
+template <typename PostHorizonFindCallback>
+void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
+                           const size_t l_max,
+                           const size_t grid_points_each_dimension,
+                           const double mass,
+                           const std::array<double, 3>& dimensionless_spin) {
+  using metavars = MockMetavariables<PostHorizonFindCallback>;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  using mock_target_a =
+      mock_interpolation_target<metavars, typename metavars::AhA>;
+  using TupleOfMockDistributedObjects =
+      typename MockRuntimeSystem::TupleOfMockDistributedObjects;
+  TupleOfMockDistributedObjects dist_objects{};
+  using MockDistributedObjectsTagTargetA =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_target_a>;
+  using MockDistributedObjectsTagInterpolator =
+      typename MockRuntimeSystem::template MockDistributedObjectsTag<
+          mock_interpolator<metavars>>;
+
+  // The mocking framework requires an array index to be passed to
+  // many functions, even if the components are singletons.
+  constexpr size_t fake_array_index = 0_st;
+
+  tuples::get<MockDistributedObjectsTagTargetA>(dist_objects)
+      .emplace(fake_array_index,
+               ActionTesting::MockDistributedObject<mock_target_a>{});
+  tuples::get<MockDistributedObjectsTagInterpolator>(dist_objects)
+      .emplace(
+          fake_array_index,
+          ActionTesting::MockDistributedObject<mock_interpolator<metavars>>{});
+
+  // Options for all InterpolationTargets.
+  // The initial guess for the horizon search is a sphere of radius 2.8M.
+  intrp::OptionHolders::ApparentHorizon<Frame::Inertial> apparent_horizon_opts(
+      Strahlkorper<Frame::Inertial>{l_max, 2.8, {{0.0, 0.0, 0.0}}}, FastFlow{},
+      Verbosity::Verbose);
+
+  tuples::TaggedTuple<typename metavars::AhA> tuple_of_opts(
+      apparent_horizon_opts);
+
+  MockRuntimeSystem runner{tuple_of_opts, std::move(dist_objects)};
+
+  // The test finds an apparent horizon for a Schwarzschild or Kerr
+  // metric with M=1.  We choose a spherical shell domain extending
+  // from radius 1.9M to 2.9M; this ensures the horizon is
+  // inside the domain, and it gives a narrow domain so that we don't
+  // need a large number of grid points to resolve the horizon (which
+  // would make the test slower).
+  const auto domain_creator = domain::creators::Shell<Frame::Inertial>(
+      1.9, 2.9, 1, {{grid_points_each_dimension, grid_points_each_dimension}},
+      false);
+
+  runner.template simple_action<
+      mock_target_a,
+      ::intrp::Actions::InitializeInterpolationTarget<typename metavars::AhA>>(
+      fake_array_index, domain_creator.create_domain());
+  runner.template simple_action<mock_interpolator<metavars>,
+                                ::intrp::Actions::InitializeInterpolator>(
+      fake_array_index);
+
+  Slab slab(0.0, 1.0);
+  TimeId temporal_id(true, 0, Time(slab, 0));
+  const auto domain = domain_creator.create_domain();
+
+  // Create element_ids.
+  std::vector<ElementId<3>> element_ids{};
+  for (const auto& block : domain.blocks()) {
+    const auto initial_ref_levs =
+        domain_creator.initial_refinement_levels()[block.id()];
+    auto elem_ids = initial_element_ids(block.id(), initial_ref_levs);
+    element_ids.insert(element_ids.end(), elem_ids.begin(), elem_ids.end());
+  }
+
+  // Tell the interpolator how many elements there are by registering
+  // each one.
+  for (size_t i = 0; i < element_ids.size(); ++i) {
+    runner.template simple_action<mock_interpolator<metavars>,
+                                  intrp::Actions::RegisterElement>(
+        fake_array_index);
+  }
+
+  // Tell the InterpolationTargets that we want to interpolate at
+  // temporal_id.
+  runner.template simple_action<
+      mock_target_a, intrp::Actions::AddTemporalIdsToInterpolationTarget<
+                         typename metavars::AhA>>(
+      fake_array_index, std::vector<TimeId>{temporal_id});
+
+  // Create volume data and send it to the interpolator.
+  for (const auto& element_id : element_ids) {
+    const auto& block = domain.blocks()[element_id.block_id()];
+    ::Mesh<3> mesh{domain_creator.initial_extents()[element_id.block_id()],
+                   Spectral::Basis::Legendre,
+                   Spectral::Quadrature::GaussLobatto};
+    ElementMap<3, Frame::Inertial> map{element_id,
+                                       block.coordinate_map().get_clone()};
+    const auto inertial_coords = map(logical_coordinates(mesh));
+
+    // Compute psi, pi, phi for KerrSchild.
+    gr::Solutions::KerrSchild solution(mass, dimensionless_spin,
+                                       {{0.0, 0.0, 0.0}});
+    const auto solution_vars = solution.variables(
+        inertial_coords, 0.0, gr::Solutions::KerrSchild::tags<DataVector>{});
+    const auto& lapse = get<gr::Tags::Lapse<DataVector>>(solution_vars);
+    const auto& dt_lapse =
+        get<Tags::dt<gr::Tags::Lapse<DataVector>>>(solution_vars);
+    const auto& d_lapse =
+        get<gr::Solutions::KerrSchild::DerivLapse<DataVector>>(solution_vars);
+    const auto& shift =
+        get<gr::Tags::Shift<3, Frame::Inertial, DataVector>>(solution_vars);
+    const auto& d_shift =
+        get<gr::Solutions::KerrSchild::DerivShift<DataVector>>(solution_vars);
+    const auto& dt_shift =
+        get<Tags::dt<gr::Tags::Shift<3, Frame::Inertial, DataVector>>>(
+            solution_vars);
+    const auto& g =
+        get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(
+            solution_vars);
+    const auto& dt_g =
+        get<Tags::dt<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>>(
+            solution_vars);
+    const auto& d_g =
+        get<gr::Solutions::KerrSchild::DerivSpatialMetric<DataVector>>(
+            solution_vars);
+
+    // Fill output variables with solution.
+    db::item_type<
+        ::Tags::Variables<typename metavars::interpolator_source_vars>>
+        output_vars(mesh.number_of_grid_points());
+    get<::gr::Tags::SpacetimeMetric<3, Frame::Inertial>>(output_vars) =
+        gr::spacetime_metric(lapse, shift, g);
+    get<::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(output_vars) =
+        GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift, g, d_g);
+    get<::GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>>(output_vars) =
+        GeneralizedHarmonic::pi(
+            lapse, dt_lapse, shift, dt_shift, g, dt_g,
+            get<::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>>(
+                output_vars));
+
+    // Call the InterpolatorReceiveVolumeData action on each element_id.
+    runner
+        .template simple_action<mock_interpolator<metavars>,
+                                intrp::Actions::InterpolatorReceiveVolumeData>(
+            fake_array_index, temporal_id, element_id, mesh,
+            std::move(output_vars));
+  }
+
+  // Invoke remaining actions in random order.
+  MAKE_GENERATOR(generator);
+  auto index_map = ActionTesting::indices_of_components_with_queued_actions<
+      typename metavars::component_list>(make_not_null(&runner),
+                                         fake_array_index);
+  while (not index_map.empty()) {
+    ActionTesting::invoke_random_queued_action<
+        typename metavars::component_list>(make_not_null(&runner),
+                                           make_not_null(&generator), index_map,
+                                           fake_array_index);
+    index_map = ActionTesting::indices_of_components_with_queued_actions<
+        typename metavars::component_list>(make_not_null(&runner),
+                                           fake_array_index);
+  }
+
+  // Make sure function was called.
+  CHECK(*test_horizon_called == 1);
+}
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ApparentHorizonFinder",
+                  "[Unit]") {
+  test_apparent_horizon<TestSchwarzschildHorizon>(
+      &test_schwarzschild_horizon_called, 4, 5, 1.0, {{0.0, 0.0, 0.0}});
+  test_apparent_horizon<TestKerrHorizon>(&test_kerr_horizon_called, 8, 5, 1.1,
+                                         {{0.12, 0.23, 0.45}});
+}
+}  // namespace

--- a/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ApparentHorizonFinder.cpp
@@ -3,6 +3,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <pup.h>
@@ -236,9 +237,9 @@ void test_apparent_horizon(const gsl::not_null<size_t*> test_horizon_called,
       Verbosity::Verbose);
 
   tuples::TaggedTuple<typename metavars::AhA> tuple_of_opts(
-      apparent_horizon_opts);
+      std::move(apparent_horizon_opts));
 
-  MockRuntimeSystem runner{tuple_of_opts, std::move(dist_objects)};
+  MockRuntimeSystem runner{std::move(tuple_of_opts), std::move(dist_objects)};
 
   // The test finds an apparent horizon for a Schwarzschild or Kerr
   // metric with M=1.  We choose a spherical shell domain extending

--- a/tests/Unit/ApparentHorizons/Test_ComputeItems.cpp
+++ b/tests/Unit/ApparentHorizons/Test_ComputeItems.cpp
@@ -1,0 +1,115 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "ApparentHorizons/ComputeItems.hpp"    // IWYU pragma: keep
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace {
+template <size_t Dim, typename Frame, typename T>
+void test_strahlkorper_compute_items(const T& used_for_size) {
+  // Set up random values for lapse, shift, spatial_metric,
+  // and their derivatives.
+  MAKE_GENERATOR(generator);
+  std::uniform_real_distribution<> dist(-1., 1.);
+  std::uniform_real_distribution<> dist_positive(1., 2.);
+  const auto nn_generator = make_not_null(&generator);
+  const auto nn_dist = make_not_null(&dist);
+  const auto nn_dist_positive = make_not_null(&dist_positive);
+
+  const auto lapse = make_with_random_values<Scalar<T>>(
+      nn_generator, nn_dist_positive, used_for_size);
+  const auto shift = make_with_random_values<tnsr::I<T, Dim>>(
+      nn_generator, nn_dist, used_for_size);
+  const auto spatial_metric = [&]() {
+    auto spatial_metric_l = make_with_random_values<tnsr::ii<T, Dim>>(
+        nn_generator, nn_dist, used_for_size);
+    // Make sure spatial_metric isn't singular by adding
+    // large enough positive diagonal values.
+    for (size_t i = 0; i < Dim; ++i) {
+      spatial_metric_l.get(i, i) += 4.0;
+    }
+    return spatial_metric_l;
+  }();
+  const auto dt_lapse = make_with_random_values<Scalar<T>>(
+      nn_generator, nn_dist_positive, used_for_size);
+  const auto deriv_lapse = make_with_random_values<tnsr::i<T, Dim>>(
+      nn_generator, nn_dist_positive, used_for_size);
+  const auto dt_shift = make_with_random_values<tnsr::I<T, Dim>>(
+      nn_generator, nn_dist, used_for_size);
+  const auto deriv_shift = make_with_random_values<tnsr::iJ<T, Dim>>(
+      nn_generator, nn_dist, used_for_size);
+  const auto deriv_spatial_metric = make_with_random_values<tnsr::ijj<T, Dim>>(
+      nn_generator, nn_dist, used_for_size);
+  const auto dt_spatial_metric = make_with_random_values<tnsr::ii<T, Dim>>(
+      nn_generator, nn_dist, used_for_size);
+
+  // Make spacetime metric, extrinsic curvature, inverse spatial
+  // metric, spatial christoffel of the second kind, and generalized
+  // harmonic pi, psi variables in a way that is already independently
+  // tested.
+  const auto spacetime_metric =
+      gr::spacetime_metric(lapse, shift, spatial_metric);
+  const auto expected_extrinsic_curvature =
+      gr::extrinsic_curvature(lapse, shift, deriv_shift, spatial_metric,
+                              dt_spatial_metric, deriv_spatial_metric);
+  const auto expected_inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto expected_spatial_christoffel_second_kind =
+      raise_or_lower_first_index(
+          gr::christoffel_first_kind(deriv_spatial_metric),
+          expected_inverse_spatial_metric);
+  const auto phi =
+      GeneralizedHarmonic::phi(lapse, deriv_lapse, shift, deriv_shift,
+                               spatial_metric, deriv_spatial_metric);
+  const auto pi = GeneralizedHarmonic::pi(
+      lapse, dt_lapse, shift, dt_shift, spatial_metric, dt_spatial_metric, phi);
+
+  // Now test the ComputeItems.
+  const auto box = db::create<
+      db::AddSimpleTags<tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame>,
+                                   GeneralizedHarmonic::Tags::Pi<Dim, Frame>,
+                                   GeneralizedHarmonic::Tags::Phi<Dim, Frame>>>,
+      db::AddComputeTags<tmpl::list<
+          ah::Tags::InverseSpatialMetricCompute<Dim, Frame>,
+          ah::Tags::ExtrinsicCurvatureCompute<Dim, Frame>,
+          ah::Tags::SpatialChristoffelSecondKindCompute<Dim, Frame>>>>(
+      spacetime_metric, pi, phi);
+
+  const auto& inverse_spatial_metric =
+      db::get<gr::Tags::InverseSpatialMetric<Dim, Frame>>(box);
+  const auto& extrinsic_curvature =
+      db::get<gr::Tags::ExtrinsicCurvature<Dim, Frame>>(box);
+  const auto& spatial_christoffel_second_kind =
+      db::get<gr::Tags::SpatialChristoffelSecondKind<Dim, Frame>>(box);
+  CHECK_ITERABLE_APPROX(inverse_spatial_metric,
+                        expected_inverse_spatial_metric);
+  CHECK_ITERABLE_APPROX(extrinsic_curvature, expected_extrinsic_curvature);
+  CHECK_ITERABLE_APPROX(spatial_christoffel_second_kind,
+                        expected_spatial_christoffel_second_kind);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.ApparentHorizons.ComputeItems",
+                  "[ApparentHorizons][Unit]") {
+  const DataVector used_for_size(20);
+  // Need only Dim=3 and DataVectors for apparent horizons.
+  test_strahlkorper_compute_items<3, Frame::Inertial>(used_for_size);
+}

--- a/tests/Unit/ApparentHorizons/Test_Tags.cpp
+++ b/tests/Unit/ApparentHorizons/Test_Tags.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <string>
 
 #include "ApparentHorizons/SpherepackIterator.hpp"
 #include "ApparentHorizons/Strahlkorper.hpp"
@@ -287,4 +288,5 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizons.StrahlkorperDataBox",
   test_average_radius();
   test_radius_and_derivs();
   test_normals();
+  CHECK(ah::Tags::FastFlow::name() == "FastFlow");
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_CleanUpInterpolator.cpp
   Test_InitializeInterpolationTarget.cpp
   Test_InitializeInterpolator.cpp
+  Test_InterpolationTargetApparentHorizon.cpp
   Test_InterpolationTargetKerrHorizon.cpp
   Test_InterpolationTargetLineSegment.cpp
   Test_InterpolationTargetReceiveVars.cpp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -5,25 +5,18 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <array>
 #include <cstddef>
 #include <utility>
 #include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
-#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/BlockLogicalCoordinates.hpp"
-#include "Domain/Creators/Shell.hpp"
-#include "Domain/Domain.hpp"
 #include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
 #include "NumericalAlgorithms/Interpolation/InitializeInterpolator.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp"
-#include "Options/Options.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
@@ -141,8 +134,7 @@ struct mock_interpolator {
 template <typename MetaVariables, typename DomainCreator,
           typename InterpolationTargetOption, typename BlockCoordHolder>
 void test_interpolation_target(
-    const DomainCreator& domain_creator,
-    const InterpolationTargetOption& options,
+    const DomainCreator& domain_creator, InterpolationTargetOption options,
     const BlockCoordHolder& expected_block_coord_holders) noexcept {
   using metavars = MetaVariables;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
@@ -165,9 +157,9 @@ void test_interpolation_target(
                       mock_interpolator<metavars>>{});
 
   tuples::TaggedTuple<typename metavars::InterpolationTargetA> tuple_of_opts(
-      options);
+      std::move(options));
 
-  MockRuntimeSystem runner{tuple_of_opts, std::move(dist_objects)};
+  MockRuntimeSystem runner{std::move(tuple_of_opts), std::move(dist_objects)};
 
   runner.template simple_action<
       mock_interpolation_target<metavars,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "ApparentHorizons/FastFlow.hpp"
+#include "ApparentHorizons/Strahlkorper.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/BlockLogicalCoordinates.hpp"
+#include "Domain/Creators/Shell.hpp"
+#include "Domain/Domain.hpp"
+#include "Informer/Tags.hpp" // IWYU pragma: keep
+#include "Informer/Verbosity.hpp"
+#include "NumericalAlgorithms/Interpolation/InterpolationTargetApparentHorizon.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Time/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Spherepack.hpp"
+#include "Utilities/TMPL.hpp"
+#include "tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
+#include "tests/Unit/TestCreation.hpp"
+
+namespace {
+struct MockMetavariables {
+  struct InterpolationTargetA {
+    using vars_to_interpolate_to_target =
+        tmpl::list<gr::Tags::Lapse<DataVector>>;
+    using compute_target_points =
+        ::intrp::Actions::ApparentHorizon<InterpolationTargetA,
+                                          ::Frame::Inertial>;
+    using type = compute_target_points::options_type;
+  };
+  using temporal_id = ::Tags::TimeId;
+  using domain_frame = Frame::Inertial;
+  static constexpr size_t domain_dim = 3;
+  using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
+  using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
+
+  using component_list =
+      tmpl::list<InterpTargetTestHelpers::mock_interpolation_target<
+                     MockMetavariables, InterpolationTargetA>,
+                 InterpTargetTestHelpers::mock_interpolator<MockMetavariables>>;
+  using const_global_cache_tag_list = tmpl::list<>;
+};
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.InterpolationTarget.ApparentHorizon", "[Unit]") {
+  // Constants used in this test.
+  // We use l_max=12 to get enough points that the surface is
+  // represented to roundoff error; for smaller l_max we would need to
+  // modify InterpTargetTestHelpers::test_interpolation_target to
+  // handle a custom `approx`.
+  const size_t l_max = 12;
+  const double radius = 2.0;
+  const std::array<double, 3> center = {{0.05, 0.06, 0.07}};
+
+  // Options for ApparentHorizon
+  intrp::OptionHolders::ApparentHorizon<Frame::Inertial> apparent_horizon_opts(
+      Strahlkorper<Frame::Inertial>{l_max, radius, center}, FastFlow{},
+      Verbosity::Verbose);
+
+  // Test creation of options
+  const auto created_opts =
+      test_creation<intrp::OptionHolders::ApparentHorizon<Frame::Inertial>>(
+          "  FastFlow:\n"
+          "  Verbosity: Verbose\n"
+          "  InitialGuess:\n"
+          "    Center: [0.05, 0.06, 0.07]\n"
+          "    Radius: 2.0\n"
+          "    Lmax: 12");
+  CHECK(created_opts == apparent_horizon_opts);
+
+  const auto domain_creator =
+      domain::creators::Shell<Frame::Inertial>(1.8, 2.2, 1, {{5, 5}}, false);
+
+  const auto expected_block_coord_holders =
+      [&domain_creator, &center, &radius ]() noexcept {
+    // How many points are supposed to be in a Strahlkorper,
+    // reproduced here by hand for the test.
+    const auto l_mesh = static_cast<size_t>(std::floor(1.5 * l_max));
+    const size_t n_theta = l_mesh + 1;
+    const size_t n_phi = 2 * l_mesh + 1;
+
+    // The theta points of a Strahlkorper are Gauss-Legendre points.
+    const std::vector<double> theta_points = [&n_theta]() noexcept {
+      std::vector<double> thetas(n_theta);
+      std::vector<double> work(n_theta + 1);
+      std::vector<double> unused_weights(n_theta);
+      int err = 0;
+      gaqd_(static_cast<int>(n_theta), thetas.data(), unused_weights.data(),
+            work.data(), static_cast<int>(n_theta + 1), &err);
+      return thetas;
+    }
+    ();
+
+    const double two_pi_over_n_phi = 2.0 * M_PI / n_phi;
+    tnsr::I<DataVector, 3, Frame::Inertial> points(n_theta * n_phi);
+    size_t s = 0;
+    for (size_t i_phi = 0; i_phi < n_phi; ++i_phi) {
+      const double phi = two_pi_over_n_phi * i_phi;
+      for (size_t i_theta = 0; i_theta < n_theta; ++i_theta) {
+        const double theta = theta_points[i_theta];
+        points.get(0)[s] = radius * sin(theta) * cos(phi) + center[0];
+        points.get(1)[s] = radius * sin(theta) * sin(phi) + center[1],
+        points.get(2)[s] = radius * cos(theta) + center[2];
+        ++s;
+      }
+    }
+    return block_logical_coordinates(domain_creator.create_domain(), points);
+  }
+  ();
+
+  InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
+      domain_creator, apparent_horizon_opts, expected_block_coord_holders);
+}

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetApparentHorizon.cpp
@@ -3,6 +3,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -118,5 +119,6 @@ SPECTRE_TEST_CASE(
   ();
 
   InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, apparent_horizon_opts, expected_block_coord_holders);
+      domain_creator, std::move(apparent_horizon_opts),
+      expected_block_coord_holders);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -3,6 +3,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -130,5 +131,6 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.KerrHorizon",
   ();
 
   InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, kerr_horizon_opts, expected_block_coord_holders);
+      domain_creator, std::move(kerr_horizon_opts),
+      expected_block_coord_holders);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -3,6 +3,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <vector>
@@ -72,5 +73,6 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.LineSegment",
   ();
 
   InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, line_segment_opts, expected_block_coord_holders);
+      domain_creator, std::move(line_segment_opts),
+      expected_block_coord_holders);
 }

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -3,6 +3,7 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -87,7 +88,8 @@ void test_r_theta_lgl() noexcept {
   ();
 
   InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, wedge_section_torus_opts, expected_block_coord_holders);
+      domain_creator, std::move(wedge_section_torus_opts),
+      expected_block_coord_holders);
 }
 
 void test_r_theta_uniform() noexcept {
@@ -124,7 +126,8 @@ void test_r_theta_uniform() noexcept {
   ();
 
   InterpTargetTestHelpers::test_interpolation_target<MockMetavariables>(
-      domain_creator, wedge_section_torus_opts, expected_block_coord_holders);
+      domain_creator, std::move(wedge_section_torus_opts),
+      expected_block_coord_holders);
 }
 }  // namespace
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -293,10 +293,11 @@ SPECTRE_TEST_CASE(
   tuples::TaggedTuple<observers::OptionTags::ReductionFileName,
                       metavars::SurfaceA, metavars::SurfaceB,
                       metavars::SurfaceC>
-      tuple_of_opts(h5_file_prefix, kerr_horizon_opts_A, kerr_horizon_opts_B,
-                    kerr_horizon_opts_C);
+      tuple_of_opts(h5_file_prefix, std::move(kerr_horizon_opts_A),
+                    std::move(kerr_horizon_opts_B),
+                    std::move(kerr_horizon_opts_C));
 
-  MockRuntimeSystem runner{tuple_of_opts, std::move(dist_objects)};
+  MockRuntimeSystem runner{std::move(tuple_of_opts), std::move(dist_objects)};
 
   const auto domain_creator =
       domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -295,10 +295,11 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
   tuples::TaggedTuple<metavars::InterpolationTargetA,
                       metavars::InterpolationTargetB,
                       metavars::InterpolationTargetC>
-      tuple_of_opts(line_segment_opts_A, line_segment_opts_B,
-                    kerr_horizon_opts_C);
+      tuple_of_opts(std::move(line_segment_opts_A),
+                    std::move(line_segment_opts_B),
+                    std::move(kerr_horizon_opts_C));
 
-  MockRuntimeSystem runner{tuple_of_opts, std::move(dist_objects)};
+  MockRuntimeSystem runner{std::move(tuple_of_opts), std::move(dist_objects)};
 
   const auto domain_creator =
       domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{5, 5}}, false);


### PR DESCRIPTION
## Proposed changes

Adds parallel horizon finder to Interpolator infrastructure.
This is done in several commits:

- Adds a new compute_target_points ("intrp::Actions::ApparentHorizon")
- Adds a new post_interpolation_callback ("intrp::callbacks::FindHorizon")
- Overloads the function arguments allowed in post_interpolation_callback::apply
- Puts ComputeItems for the HorizonFinder in one place (as opposed to hardcoding them in the test).
- Adds a test that finds the horizon given metric data on a Domain.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
