### PR TITLE
Fix gcc8 issues

### DIFF
--- a/external/SPHEREPACK/CMakeLists.txt
+++ b/external/SPHEREPACK/CMakeLists.txt
@@ -19,4 +19,19 @@ set(LIBRARY_SOURCES
     vtsgs.f
     )
 
+# Starting in gcc8, gfortran warns about instances of Fortran77 coding style in
+# certain SPHEREPACK files. The warning is:
+#   Warning: Array reference at ... out of bounds ... in loop beginning ...
+#
+# Attempts to silence the warning by use of individual flags were unsuccessful,
+# so instead we silence all warnings for the problematic files.
+file(GLOB FILES_WITH_WARNINGS
+    alf.f
+    sphcom.f
+    vhags.f
+    vhsgs.f
+    vtsgs.f
+    )
+set_source_files_properties(${FILES_WITH_WARNINGS} PROPERTIES COMPILE_FLAGS -w)
+
 add_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Utilities/Gsl.hpp
+++ b/src/Utilities/Gsl.hpp
@@ -844,12 +844,6 @@ constexpr ElementType& at(span<ElementType, Extent> s,
   return s[i];
 }
 
-template <class ElementType, std::ptrdiff_t Extent>
-constexpr ElementType& at(span<ElementType, Extent> s, size_t i) {
-  // No bounds checking here because it is done in span::operator[] called below
-  return s[i];
-}
-
 #if __GNUC__ > 6
 #pragma GCC diagnostic pop
 #endif  // __GNUC__ > 6


### PR DESCRIPTION
Work around a `g++` issue, and silence `gfortran` warnings

Edit by @nilsdeppe:
closes #1026

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
