### PR TITLE
Small library-compatibility fixes

### DIFF
--- a/src/IO/H5/File.hpp
+++ b/src/IO/H5/File.hpp
@@ -312,6 +312,7 @@ H5File<Access_t>::check_if_object_exists(const std::string& path) const {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
   const bool exists =
+      name_with_extension == "/" or
       H5Lexists(group.id(), name_with_extension.c_str(), H5P_DEFAULT) or
       H5Aexists(group.id(), name_with_extension.c_str());
 #pragma GCC diagnostic pop

--- a/tests/Unit/ControlSystem/Test_FuntionOfTimeUpdater.cpp
+++ b/tests/Unit/ControlSystem/Test_FuntionOfTimeUpdater.cpp
@@ -1,7 +1,6 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "tests/Unit/ControlSystem/FoTUpdater_Helper.hpp"
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <algorithm>
@@ -16,6 +15,7 @@
 #include "ControlSystem/TimescaleTuner.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Utilities/Gsl.hpp"
+#include "tests/Unit/ControlSystem/FoTUpdater_Helper.hpp"
 
 SPECTRE_TEST_CASE("Unit.ControlSystem.FunctionOfTimeUpdater.Translation",
                   "[ControlSystem][Unit]") {

--- a/tests/Unit/DataStructures/Test_VectorImplHelper.cpp
+++ b/tests/Unit/DataStructures/Test_VectorImplHelper.cpp
@@ -1,5 +1,6 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
+
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -561,7 +561,10 @@ SPECTRE_TEST_CASE("Unit.IO.H5.ReadData", "[Unit][IO][H5]") {
 
 // Check that we can insert and open subfiles at the '/' level
 SPECTRE_TEST_CASE("Unit.IO.H5.check_if_object_exists", "[Unit][IO][H5]") {
-  const std::string h5_file_name("Unit.IO.H5.ObjectCheck.h5");
+  const std::string h5_file_name("Unit.IO.H5.check_if_object_exists.h5");
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
   {
     h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
     auto& error_file = my_file.insert<h5::Header>("/");

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -567,13 +567,12 @@ SPECTRE_TEST_CASE("Unit.IO.H5.check_if_object_exists", "[Unit][IO][H5]") {
   }
   {
     h5::H5File<h5::AccessType::ReadWrite> my_file(h5_file_name);
-    auto& error_file = my_file.insert<h5::Header>("/");
+    my_file.insert<h5::Header>("/");
   }
 
   // Reopen the file to check that the subfile '/' can be opened
   h5::H5File<h5::AccessType::ReadWrite> reopened_file(h5_file_name, true);
-  const auto& sample_data =
-      reopened_file.get<h5::Header>("/");
+  reopened_file.get<h5::Header>("/");
   CHECK(file_system::check_if_file_exists(h5_file_name) == true);
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);

--- a/tests/Unit/IO/Test_StellarCollapseEos.cpp
+++ b/tests/Unit/IO/Test_StellarCollapseEos.cpp
@@ -1,6 +1,8 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "tests/Unit/TestingFramework.hpp"
+
 #include <string>
 #include <vector>
 
@@ -10,7 +12,6 @@
 #include "IO/H5/Header.hpp"  // IWYU pragma: keep
 #include "IO/H5/StellarCollapseEos.hpp"
 #include "Informer/InfoFromBuild.hpp"
-#include "tests/Unit/TestingFramework.hpp"
 
 // IWYU pragma: no_include <boost/iterator/iterator_facade.hpp>
 // IWYU pragma: no_include <boost/multi_array.hpp>


### PR DESCRIPTION
## Proposed changes

Fix issues using catch 2.3 and hdf5 1.8.

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
