### PR TITLE
Reduce build time and fix timeouts on Travis

### DIFF
--- a/.travis/BuildLinux.sh
+++ b/.travis/BuildLinux.sh
@@ -63,7 +63,9 @@ if [ -z "${RUN_CLANG_TIDY}" ] \
 
     if [[ ${TRAVIS_BUILD_STAGE_NAME} = \
           "Build and run tests, clangtidy, iwyu, and doxygen" ]]; then
-        make test-executables -j2
+        make -j2
+        # Build major executables in serial to avoid hitting memory limits.
+        make test-executables -j1
         ctest --output-on-failure -j2
 
         # Build test coverage

--- a/cmake/AddSpectreExecutable.cmake
+++ b/cmake/AddSpectreExecutable.cmake
@@ -37,7 +37,7 @@ function(add_spectre_executable EXECUTABLE_NAME HPP_NAME SUBDIR_NAME METAVARS LI
     "\n"
     "using charmxx_main_component = Parallel::Main<${METAVARS}>;\n"
     "\n"
-    "#include \"Parallel/CharmMain.cpp\"\n"
+    "#include \"Parallel/CharmMain.tpp\"\n"
     )
   configure_file(
     "${BUILD_TARGET_FILENAME}.out"

--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -1091,7 +1091,7 @@ a `std::vector<void (*)()>` called `charm_init_node_funcs` and
 For example,
 \snippet Test_AlgorithmCore.cpp charm_init_funcs_example
 
-Finally, the user must include the `Parallel/CharmMain.cpp` file at the end of
+Finally, the user must include the `Parallel/CharmMain.tpp` file at the end of
 the main executable cpp file. So, the end of an executables main cpp file will
 then typically look as follows:
 \snippet Test_AlgorithmParallel.cpp charm_include_example

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -492,9 +492,7 @@ class DataBox<tmpl::list<Tags...>>
 
   template <typename... TagsInArgsOrder, typename... FullItems,
             typename... ComputeTags, typename... FullComputeItems,
-            typename... Args,
-            Requires<not tmpl2::flat_any_v<
-                db::is_databox<std::decay_t<Args>>::value...>> = nullptr>
+            typename... Args>
   constexpr DataBox(tmpl::list<TagsInArgsOrder...> /*meta*/,
                     tmpl::list<FullItems...> /*meta*/,
                     tmpl::list<ComputeTags...> /*meta*/,
@@ -872,10 +870,9 @@ constexpr int check_argument_type() noexcept {
 
 /// \cond
 template <typename... Tags>
-template <
-    typename... TagsInArgsOrder, typename... FullItems, typename... ComputeTags,
-    typename... FullComputeItems, typename... Args,
-    Requires<not tmpl2::flat_any_v<is_databox<std::decay_t<Args>>::value...>>>
+template <typename... TagsInArgsOrder, typename... FullItems,
+          typename... ComputeTags, typename... FullComputeItems,
+          typename... Args>
 constexpr DataBox<tmpl::list<Tags...>>::DataBox(
     tmpl::list<TagsInArgsOrder...> /*meta*/, tmpl::list<FullItems...> /*meta*/,
     tmpl::list<ComputeTags...> /*meta*/,
@@ -885,6 +882,9 @@ constexpr DataBox<tmpl::list<Tags...>>::DataBox(
       "Must pass in as many (compute) items as there are Tags.");
   DEBUG_STATIC_ASSERT(sizeof...(TagsInArgsOrder) == sizeof...(Args),
                       "Must pass in as many arguments as AddTags");
+  DEBUG_STATIC_ASSERT(
+      not tmpl2::flat_any_v<is_databox<std::decay_t<Args>>::value...>,
+      "Cannot store a DataBox inside a DataBox.");
   expand_pack(
       DataBox_detail::check_argument_type<TagsInArgsOrder,
                                           typename TagsInArgsOrder::type,

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -6,7 +6,7 @@
 // IWYU pragma: no_include <pup.h>
 #include <vector>
 
-#include "Domain/DomainCreators/RegisterDerivedWithCharm.cpp"
+#include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-#include "Domain/DomainCreators/RegisterDerivedWithCharm.cpp"
+#include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -6,7 +6,7 @@
 #include <cstddef>
 #include <vector>
 
-#include "Domain/DomainCreators/RegisterDerivedWithCharm.cpp"
+#include "Domain/DomainCreators/RegisterDerivedWithCharm.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -107,7 +107,7 @@ class AlgorithmImpl;
  * `array_index`, which must be a `const&`.
  *
  * ### Explicit instantiations of entry methods
- * The code in src/Parallel/CharmMain.cpp registers all entry methods, and if
+ * The code in src/Parallel/CharmMain.tpp registers all entry methods, and if
  * one is not properly registered then a static_assert explains how to have it
  * be registered. If there is a bug in the implementation and an entry method
  * isn't being registered or hitting a static_assert then Charm++ will give an

--- a/src/Parallel/CharmMain.tpp
+++ b/src/Parallel/CharmMain.tpp
@@ -5,6 +5,8 @@
 /// Defines functions used by Charm++ to register classes/chares and entry
 /// methods
 
+#pragma once
+
 #include <algorithm>
 #include <string>
 #include <type_traits>

--- a/src/Parallel/CharmRegistration.hpp
+++ b/src/Parallel/CharmRegistration.hpp
@@ -47,7 +47,7 @@ extern size_t charm_register_list_size;
  * Uses the __PRETTY_FUNCTION__ compiler intrinsic to extract the template
  * parameter names in the same form that Charm++ uses to register entry methods.
  * This is used by the generated Singleton, Array, Group and Nodegroup headers,
- * as well as in CharmMain.cpp.
+ * as well as in CharmMain.tpp.
  */
 template <class... Args>
 std::string get_template_parameters_as_string() {
@@ -164,7 +164,7 @@ struct RegisterParallelComponent : RegistrationHelper {
  * Parallel::charmxx::MainChareRegistrationConstructor&` as its only argument.
  * This constructor is only used to trigger the `RegisterChare::registrar` code
  * needed for automatic registration. The main chare is determined by specifying
- * the type alias `charmxx_main_component` before the `Parallel/CharmMain.cpp`
+ * the type alias `charmxx_main_component` before the `Parallel/CharmMain.tpp`
  * include.
  * \snippet Test_AlgorithmCore.cpp charm_main_example
  */

--- a/src/Utilities/TMPL.hpp
+++ b/src/Utilities/TMPL.hpp
@@ -582,5 +582,5 @@ constexpr const bool list_contains_v = list_contains<Sequence, Item>::value;
 /// Obtain the elements of `Sequence1` that are not in `Sequence2`.
 template <typename Sequence1, typename Sequence2>
 using list_difference =
-    remove_if<Sequence1, bind<list_contains, pin<Sequence2>, _1>>;
+    fold<Sequence2, Sequence1, lazy::remove<_state, _element>>;
 }  // namespace brigand

--- a/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
+++ b/tests/Unit/DataStructures/Test_OrientVariablesOnSlice.cpp
@@ -15,7 +15,6 @@
 #include "DataStructures/Variables.hpp"  // IWYU pragma: keep
 #include "DataStructures/VariablesHelpers.hpp"
 #include "Domain/Block.hpp"  // IWYU pragma: keep
-#include "Domain/BlockNeighbor.cpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -56,4 +56,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -57,4 +57,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -56,4 +56,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -55,4 +55,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 
 using charmxx_main_component = Parallel::Main<Metavariables>;
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmBadBoxApply.cpp
@@ -77,4 +77,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_AlgorithmCore.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmCore.cpp
@@ -718,4 +718,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 /// [charm_main_example]
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply1.cpp
@@ -82,4 +82,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNestedApply2.cpp
@@ -90,4 +90,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmNodelock.cpp
@@ -368,4 +368,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmParallel.cpp
@@ -528,5 +528,5 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep
 /// [charm_include_example]

--- a/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
+++ b/tests/Unit/Parallel/Test_AlgorithmReduction.cpp
@@ -307,4 +307,4 @@ static const std::vector<void (*)()> charm_init_proc_funcs{
 
 using charmxx_main_component = Parallel::Main<TestMetavariables>;
 
-#include "Parallel/CharmMain.cpp"
+#include "Parallel/CharmMain.tpp"  // IWYU pragma: keep

--- a/tests/Unit/RunTests.cpp
+++ b/tests/Unit/RunTests.cpp
@@ -42,7 +42,7 @@ RunTests::RunTests(CkArgMsg* msg) {
 #include "tests/Unit/RunTests.def.h"  /// IWYU pragma: keep
 
 // Needed for tests that use the ConstGlobalCache since it registers itself with
-// Charm++. However, since Parallel/CharmMain.cpp isn't included in the RunTests
+// Charm++. However, since Parallel/CharmMain.tpp isn't included in the RunTests
 // executable, no actual registration is done, the ConstGlobalCache is only
 // queued for registration.
 namespace Parallel {

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -360,7 +360,6 @@ enable_if() {
         whitelist "$1" \
                   'src/DataStructures/Tensor/Structure.hpp$' \
                   'src/IO/H5/File.hpp$' \
-                  'src/Parallel/CharmMain.cpp$' \
                   'src/Utilities/PointerVector.hpp$' \
                   'src/Utilities/Requires.hpp$' \
                   'src/Utilities/TMPL.hpp$' \

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -413,6 +413,29 @@ namespace_details_test() {
 }
 standard_checks+=(namespace_details)
 
+# Check for .cpp includes in cpp, hpp, and tpp files
+prevent_cpp_includes() {
+    is_c++ "$1" && staged_grep -q "include .*\.cpp" "$1"
+}
+prevent_cpp_includes_report() {
+    echo "Found cpp files included in cpp, hpp. or tpp files."
+    pretty_grep "include .*\.cpp" "$@"
+}
+prevent_cpp_includes_test() {
+    test_check pass foo.hpp ''
+    test_check pass foo.tpp ''
+    test_check fail foo.hpp '#include "blah/blue/bla.cpp"'
+    test_check fail foo.tpp '#include "blah/blue/bla.cpp"'
+    test_check fail foo.cpp '#include "blah/blue/bla.cpp"'
+    test_check pass foo.hpp '#include "blah/blue/bla.hpp"'
+    test_check pass foo.tpp '#include "blah/blue/bla.hpp"'
+    test_check pass foo.cpp '#include "blah/blue/bla.hpp"'
+    test_check pass foo.hpp '#include "blah/blue/bla.tpp"'
+    test_check pass foo.tpp '#include "blah/blue/bla.tpp"'
+    test_check pass foo.cpp '#include "blah/blue/bla.tpp"'
+}
+standard_checks+=(prevent_cpp_includes)
+
 # if test is enabled: redefines staged_grep to run tests on files that are not in git
 [ "$1" = --test ] && staged_grep() { grep "$@"; } && run_tests "${standard_checks[@]}"
 


### PR DESCRIPTION
## Proposed changes

- Improves build time slightly (~7-8%). I'll push this down more in a future PR but that's already a useful amount, especially when building with GCC.
- Changes TravisCI to build the `Evolve*` executables one at a time to avoid timeouts on release builds.

I'm treating these as "bug fixes" since they aren't really new features.

Marking as priority since it'll reduce developer time spent building executables and reduce the number of times we have to refresh TravisCI builds.

### Types of changes:

- [x] Bugfix

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
