### PR TITLE
Improve Documentation of Tags and DataBox in DevGuide

### DIFF
--- a/docs/DevGuide/Databox.md
+++ b/docs/DevGuide/Databox.md
@@ -1,0 +1,369 @@
+\cond NEVER
+Distributed under the MIT License.
+See LICENSE.txt for details.
+\endcond
+# Motivation for SpECTRE's DataBox {#databox_foundations}
+
+\tableofcontents
+
+# Introduction {#introduction}
+This page walks the user through the iterative process that led to SpECTRE's
+DataBox. At each stage, it discusses the advances and challenges that result
+from each improvement.
+
+# Towards SpECTRE's DataBox {#towards_spectres_databox}
+
+## Working without DataBoxes {#working_without_databoxes}
+In a small C++ program, it is common to use the built-in fundamental types
+(bool, int, double, etc.) in computations, and to give variable names to
+objects of these types. For example, a section of a small program may look like
+this:
+
+\snippet Test_DataBoxDocumentation.cpp working_without_databoxes_small_program_1
+
+What changes as our program's size increases in scale? In SpECTRE, one of our
+driving design goals is modularity. In other words, functionality should be
+easy to swap in and out as desired. These smaller modules are easier to test,
+and keep the code flexible. We could wrap our calculation in such a module,
+which would then allow us to decouple the initial setup of the variables from
+where they are used in calculations:
+
+\snippet Test_DataBoxDocumentation.cpp working_without_databoxes_mass_compute
+
+\snippet Test_DataBoxDocumentation.cpp working_without_databoxes_accel_compute
+
+Our small program can now be written as:
+
+\snippet Test_DataBoxDocumentation.cpp working_without_databoxes_small_program_2
+
+One advantage is immediate: we are free to add other computation modules that
+are independently testable and reusable. As the number of routines grows, we
+can even begin to write routines that work on top of existing ones.
+
+\snippet Test_DataBoxDocumentation.cpp working_without_databoxes_force_compute
+
+While we have made progress, two problems arise. Our first problem is that as
+the number of quantities grows, it becomes more unwieldy to have to specify
+each function argument in our routine. The second problem is worse: the
+arguments passed to functions can be transposed and the program will still
+compile and run, but produce incorrect output. For example, the following two
+lines are equally well-formed from the point of view of the program:
+
+\snippet Test_DataBoxDocumentation.cpp working_without_databoxes_failed_accel
+
+Every time we call `acceleration_compute` we need to make sure we pass in the
+arguments in the correct order. In large programs where `acceleration_compute`
+is called many times, it becomes inevitable that the arguments will be
+accidentally transposed. We can address the two problems described above with a
+`std::map`, the first container we'll consider in this series.
+
+##A std::map DataBox {#a_std_map_databox}
+We can encapsulate the variables we use in a `std::map`, and the first half of
+our small program example now looks like this:
+
+\snippet Test_DataBoxDocumentation.cpp std_map_databox_small_program_1
+
+We have not yet taken full advantage of the encapsulation that `std::map`
+provides. We do so by rewriting our other routines to take only a single
+argument, i.e. the `std::map` itself:
+
+\snippet Test_DataBoxDocumentation.cpp std_map_databox_mass_compute
+
+\snippet Test_DataBoxDocumentation.cpp std_map_databox_accel_compute
+
+Notice that this solves the problem of having to provide the arguments
+in the correct order to every function call of `acceleration_compute`:
+
+\snippet Test_DataBoxDocumentation.cpp std_map_databox_force_compute
+
+
+Our small program now looks like:
+
+\snippet Test_DataBoxDocumentation.cpp std_map_databox_small_program_2
+
+Within each function, we no longer need to worry about passing in the arguments
+in the correct order. This is a great improvement, but our reliance on proper
+names does leave us open to the following mistake:
+
+~~~{.c}
+// returns 0 without emitting an error!
+return naive_databox["MisspelledKey"];
+~~~
+
+In the above example, the map is asked to return a value given a key
+that does not exist! As written, however, the program is well-formed and no
+error is emitted. (In the case of std::map, [a value is created.]
+(https://en.cppreference.com/w/cpp/container/map/operator_at)) Because the keys
+are indistinguishable from their type alone, the mistake cannot be caught at
+compile time. In our example, the mistake won't even be caught at run time. The
+run time portion of a SpECTRE calculation will typically be much longer (up to
+thousands of times longer!) than the compile time portion, so it is critical to
+catch costly mistakes like this as early into the calculation as possible.
+Although names encoded as `std::string` cannot be distinguished by the
+compiler, names encoded as types *can* be. This is possible with C++'s static
+typing, and to take advantage of this we need a container that is
+*heterogeneous*, that is, capable of holding objects of different types.
+
+## A std::tuple DataBox {#a_std_tuple_databox}
+
+A well-documented example of a fixed-size heterogeneous container of types is
+[std::tuple](https://en.cppreference.com/w/cpp/utility/tuple):
+
+\snippet Test_DataBoxDocumentation.cpp std_tuple_databox_1
+
+The contents of the `std_tuple` are obtained using
+[std::get](https://en.cppreference.com/w/cpp/utility/tuple/get):
+
+\snippet Test_DataBoxDocumentation.cpp std_tuple_databox_2
+
+In the above, we can see that we have promoted our keys from different values
+all of type `std::string` to different types entirely. We are not limited to
+fundamental types, we are free to make our own structs that serve as keys.
+These user-created types are called *tags*.
+
+As the sole purpose of the tag is to provide the compiler with a type
+distinguishable from other types, they can be as simple as the following:
+
+\snippet Test_DataBoxDocumentation.cpp std_tuple_tags
+
+Note that we have now promoted `Velocity`, `Radius`, etc. from being *values*
+associated with `std::string`s at run time, to *types* distinguishable from
+other types at compile time. A large portion of SpECTRE is designed with the
+philosophy of enlisting the help of the compiler in assuring the correctness
+of our programs. An example of a `std::tuple` making use of these tags might
+look like:
+
+~~~{.c}
+// Note: This won't work!
+std::tuple<Velocity, Radius, Density, Volume> sophomore_databox =
+  std::make_tuple(4.0, 2.0, 0.5, 10.0);
+~~~
+
+Unfortunately, this will not work. The types passed as template parameters to
+`std::tuple` must also be the types of the arguments passed to
+`std::make_tuple`. Using a `std::pair`, we could write the above as:
+
+\snippet Test_DataBoxDocumentation.cpp std_tuple_small_program_1
+
+What remains is to rewrite our functions to use `std::tuple` instead of
+`std::map`. Note that since we are now using a heterogeneous container of
+potentially unknown type, our functions must be templated on the
+pairs used to create the `sophomore_databox`. Our functions then look like:
+
+\snippet Test_DataBoxDocumentation.cpp std_tuple_mass_compute
+
+\snippet Test_DataBoxDocumentation.cpp std_tuple_acceleration_compute
+
+\snippet Test_DataBoxDocumentation.cpp std_tuple_force_compute
+
+Using all these `std::pair`s to get our `std::tuple` to work is a bit
+cumbersome. There is another way to package together the tagging ability
+of the struct names with the type information of the values we wish to store.
+To do this we need to make modifications to both our tags as well as our
+%Databox implementation. This is what is done in SpECTRE's
+`tuples::TaggedTuple`, which is an improved implementation of `std::tuple` in
+terms of both performance and interface.
+
+##A TaggedTuple DataBox {#a_taggedtuple_databox}
+
+TaggedTuple is an implementation of a compile time container where the keys
+are tags.
+
+Tags that are compatible with SpECTRE's `tuples::TaggedTuple` must have the
+type alias `type` in their structs. This type alias carries the type
+information of the data we wish to store in the databox. `tuples::TaggedTuple`
+is able to make use of this type information so we won't need auxiliary
+constructs such as `std::pair` to package this information together anymore.
+Our new tags now look like:
+
+\snippet Test_DataBoxDocumentation.cpp tagged_tuple_tags
+
+We are now able to create the `junior_databox` below in the same way we
+initially wished to create the `sophomore_databox` above:
+
+\snippet Test_DataBoxDocumentation.cpp tagged_tuple_databox_1
+
+Our functions similarly simplify:
+
+\snippet Test_DataBoxDocumentation.cpp tagged_tuple_mass_compute
+
+\snippet Test_DataBoxDocumentation.cpp tagged_tuple_acceleration_compute
+
+\snippet Test_DataBoxDocumentation.cpp tagged_tuple_force_compute
+
+In each of these iterations of the Databox, we started with initial quantities
+and computed subsequent quantities. Let us consider again `force_compute`, in
+which `mass` and `acceleration` are recomputed for every call to
+`force_compute`. If `Mass` and `Acceleration` were tags somewhow, that is, if we
+could compute them once, place them in the databox, and get them back out
+through the use of tags, we could get around this problem. We are now ready to
+consider SpECTRE's DataBox, which provides the solution to this problem in the
+form of `ComputeTags`.
+
+# SpECTRE's DataBox {#a_proper_databox}
+
+A brief description of SpECTRE's DataBox: a TaggedTuple with compute-on-demand.
+For a detailed description of SpECTRE's DataBox, see the
+\ref DataBoxGroup "DataBox documentation".
+
+## SimpleTags {#documentation_for_simple_tags}
+Just as we needed to modify our tags to make them compatible with
+`TaggedTuple`, we need to again modify them for use with DataBox. Our ordinary
+tags become SpECTRE's SimpleTags:
+
+\snippet Test_DataBoxDocumentation.cpp proper_databox_tags
+
+As seen above, SimpleTags have a `type` and a `name` in their struct.
+When creating tags for use with a DataBox, we must make sure to the tag
+inherits from one of the existing DataBox tag types such as `db::SimpleTag`.
+We now create our first DataBox using these `SimpleTags`:
+
+\snippet Test_DataBoxDocumentation.cpp refined_databox
+
+We can get our quantities out of the DataBox by using `db::get`:
+
+\snippet Test_DataBoxDocumentation.cpp refined_databox_get
+
+So far, the usage of DataBox has been similar to the usage of TaggedTuple. To
+address the desire to combine the functionality of tags with the modularity of
+functions, DataBox provides ComputeTags.
+
+## ComputeTags {#documentation_for_compute_tags}
+ComputeTags are used to tag functions that are used in conjunction with a
+DataBox to produce a new quantity. ComputeTags look like:
+
+\snippet Test_DataBoxDocumentation.cpp compute_tags
+
+ComputeTags inherit from `db::ComputeTag`, and it is convenient to have them
+additionally inherit from an existing SimpleTag (in this case `Mass`) so that
+the quantity `MassCompute` can be obtained through the SimpleTag `Mass`.
+We use the naming convention `TagNameCompute` so that `TagNameCompute` and
+`TagName` appear next to each other in documentation that lists tags in
+alphabetical order.
+
+We have also added the type alias `argument_tags`, which is necessary in order
+to refer to the correct tagged quantities in the DataBox.
+
+\note
+The `tmpl::list` used in the type alias is a contiguous container only
+holding types. That is, there is no variable runtime data associated with it
+like there is for `std::tuple`, which is a container associating types with
+values. `tmpl::list`s are useful in situations when one is working with
+multiple tags at once.
+
+Using nested type aliases to pass around information at compile time is a
+common pattern in SpECTRE. Let us see how we can compute our beloved quantity
+of mass times acceleration:
+
+\snippet Test_DataBoxDocumentation.cpp compute_tags_force_compute
+
+And that's it! `db::get` utilizes the `argument_tags` specified in
+`ForceCompute` to determine which items to get out of the `refined_databox`.
+With the corresponding quantities in hand, `db::get` passes them as arguments
+to the `function` specified in `ForceCompute`. This is why every `ComputeTag`
+must have an `argument_tags` as well as a `function` specified; this is the
+contract with DataBox they must satisfy in order to enjoy the full benefits of
+DataBox's generality.
+
+## Mutating DataBox items {#documentation_for_mutate_tags}
+It is reasonable to expect that in a complicated calculation, we will encounter
+time-dependent or iteration-dependent variables. As a result, in addition to
+adding and retrieving items from our DataBox, we also need a way to *mutate*
+quantities already present in the DataBox. This can be done via
+`db::mutate_apply` and can look like the following:
+
+\note
+There is an alternative to `db::mutate_apply`, `db::mutate`. See the
+\ref DataBoxGroup "DataBox documentation" for more details.
+
+\snippet Test_DataBoxDocumentation.cpp mutate_tags
+\snippet Test_DataBoxDocumentation.cpp time_dep_databox
+
+\note
+The `not_null`s here are used to give us the assurance that the pointers
+`time` and `falling_speed` are not null pointers. Using raw pointers alone, we
+risk running into segmentation faults if we dereference null pointers. With
+`not_null`s we instead run into a run time error that tells us what went wrong.
+For information on the usage of `not_null`, see the documentation for Gsl.hpp.
+
+In the above `db::mutate_apply` example, we are changing two values in the
+DataBox using four values from the DataBox. The mutated quantities must be
+passed in as `gsl::not_null`s to the lambda. The non-mutated quantities are
+passed in as const references to the lambda.
+
+\note
+It is critical to guarantee that there is a strict demarcation between
+pre-`db::mutate` and post-`db::mutate` quantities. `db::mutate` provides this
+guarantee via a locking mechanism; within one mutate call, all initial
+pre-mutated quantities are obtained from the DataBox before performing a single
+mutation.
+
+\note
+The mutate functions described above are the only accepted ways to edit data
+in the Databox. It is technically possible to use pointers or references to
+edit data stored in the Databox, but this bypasses the compute tags
+architecture. All changes to the Databox must be made by the Databox itself
+via mutate functions.
+
+From the above, we can see that the different kinds of tags are provided in two
+different `tmpl::list`s. The `MutateTags`, also called `ReturnTags`, refer to
+the quantities in the DataBox we wish to mutate, and the `ArgumentTags` refer to
+additional quantities we need from the DataBox to complete our computation. We
+now return to the recurring question of how to make this construction more
+modular.
+
+We have now worked our way up to SpECTRE's DataBox, but as we can see in the
+above `db::mutate_apply` example, the lambda used to perform the mutation ends
+up being independent of any tags or template parameters! This means we can
+factor it out and place it in its own module, where it can be tested
+independently of the DataBox.
+
+# Toward SpECTRE's Actions {#towards_actions}
+
+## Mutators {#documentation_for_mutators}
+These constructs that exist independently of the DataBox are the precursors to
+SpECTRE's *Actions*. As they are designed to be used with `db::mutate` and
+`db::mutate_apply`, we give them the name *Mutators*. Here is the above lambda
+written as a Mutator-prototype, a struct-with-void-apply:
+
+\snippet Test_DataBoxDocumentation.cpp intended_mutation
+
+The call to `db::mutate_apply` has now been made much simpler:
+
+\snippet Test_DataBoxDocumentation.cpp time_dep_databox2
+
+There is a key step that we take here after this point, to make our
+struct-with-void-apply into a proper Mutator. As we will see, this addition
+will allow us to entirely divorce the internal details of `IntendedMutation`
+from the mechanism through which we update the DataBox. The key step is to
+add type aliases to `IntendedMutation`:
+
+\snippet Test_DataBoxDocumentation.cpp intended_mutation2
+
+We are now able to write our call to `db::mutate_apply` in the following way:
+
+\snippet Test_DataBoxDocumentation.cpp time_dep_databox3
+
+As we saw earlier with `QuantityCompute`, we found that we were able to imbue
+structs with the ability to "read in" types specified in other structs, through
+the use of templates and member type aliases. This liberated us from having to
+hard-code in specific types. We notice immediately that `IntendedMutation` is a
+hard-coded type that we can factor out in favor of a template parameter:
+
+\snippet Test_DataBoxDocumentation.cpp my_first_action
+
+Note how the `mutate_tags` and `argument_tags` are used as metavariables and
+are resolved by the compiler. Our call to `db::mutate_apply` has been fully
+wrapped and now takes the form:
+
+\snippet Test_DataBoxDocumentation.cpp time_dep_databox4
+
+The details of applying Mutators to the DataBox are entirely handled by
+`MyFirstAction`, with the details of the specific Mutator itself entirely
+encapsulated in `IntendedMutation`.
+
+SpECTRE algorithms are decomposed into Actions which can depend on more
+things than we have considered here. Feel free to look at the
+existing \ref ActionsGroup "actions that have been written." The intricacies of
+Actions at the level that SpECTRE uses them is the subject of a future addition
+to the \ref dev_guide "Developer's Guide."

--- a/docs/DevGuide/DevGuide.md
+++ b/docs/DevGuide/DevGuide.md
@@ -4,23 +4,43 @@ See LICENSE.txt for details.
 \endcond
 # Developer's Guide {#dev_guide}
 
+### Developing and Improving Executables
 - \ref spectre_build_system "Build system" and how to add dependencies,
   unit tests, and executables.
-- \ref code_review_guide "Code review guidelines." All code merged into
-  master must follow these requirements.
-- \ref code_concepts "Concepts" used throughout the code are defined here
-  for reference.
 - \ref dev_guide_creating_executables "Executables and how to add them"
 - \ref dev_guide_option_parsing "Option parsing" to get options from input files
-- \ref ParallelGroup "Parallelization infrastructure" components and usage
 - \ref profiling_with_projections "Profiling With Charm++ Projections" and PAPI
   for optimizing performance
-- \ref template_metaprogramming "Template Metaprogramming"
-- \ref travis_guide "Travis CI"
-- \ref writing_good_dox "Writing good documentation" is key for long term
-  maintainability of the project
 - \ref spectre_writing_python_bindings "Writing Python Bindings" to use
   SpECTRE C++ classes and functions from within python.
-- \ref writing_unit_tests "Writing Unit Tests"
 - \ref implementing_vectors "Implementing SpECTRE vectors" a quick how-to for
   making new generalizations of DataVectors
+
+### Having your Contributions Merged into SpECTRE
+- \ref writing_good_dox "Writing good documentation" is key for long term
+  maintainability of the project.
+- \ref writing_unit_tests "Writing Unit Tests" to catch bugs and to make
+  sure future changes don't cause your code to regress.
+- \ref travis_guide "Travis CI" is used to test every pull request.
+- \ref code_review_guide "Code review guidelines." All code merged into
+  develop must follow these requirements.
+
+### General SpECTRE Terminology
+Terms with SpECTRE-specific meanings are defined here.
+- \ref domain_concepts "Domain Concepts" used throughout the code are defined
+  here for reference.
+
+### Template Metaprogramming (TMP)
+Explanations for TMP concepts and patterns known to the greater C++ community
+can be found here.
+- \ref sfinae "SFINAE"
+
+### Foundational Concepts in SpECTRE
+Designed to give the reader an introduction to SpECTRE's most recurring
+concepts and patterns.
+- \ref databox_foundations "Towards SpECTRE's DataBox"
+
+### Technical Documentation for Fluent Developers
+Assumes a thorough familiarity and fluency in SpECTRE's usage of TMP.
+- \ref DataBoxGroup "DataBox"
+- \ref ParallelGroup "Parallelization infrastructure" components and usage

--- a/docs/DevGuide/DomainConcepts.md
+++ b/docs/DevGuide/DomainConcepts.md
@@ -2,7 +2,7 @@
 Distributed under the MIT License.
 See LICENSE.txt for details.
 \endcond
-# Code Concepts {#code_concepts}
+# Domain Concepts {#domain_concepts}
 
 * Logical Coordinates:<br>
   The coordinate frame of a reference cell.

--- a/docs/DevGuide/Tmp.md
+++ b/docs/DevGuide/Tmp.md
@@ -2,9 +2,7 @@
 Distributed under the MIT License.
 See LICENSE.txt for details.
 \endcond
-# Template Metaprogramming {#template_metaprogramming}
-
-## SFINAE
+# SFINAE {#sfinae}
 
 SFINAE, Substitution Failure Is Not An Error, means that if a deduced template
 substitution fails, compilation must continue. This can be exploited to make

--- a/src/DataStructures/DataBox/DataBox.hpp
+++ b/src/DataStructures/DataBox/DataBox.hpp
@@ -1228,6 +1228,20 @@ using AddSimpleTags = tmpl::flatten<tmpl::list<Tags...>>;
 
 /*!
  * \ingroup DataBoxGroup
+ * \brief List of Tags to mutate in the DataBox
+ */
+template <typename... Tags>
+using MutateTags = tmpl::flatten<tmpl::list<Tags...>>;
+
+/*!
+ * \ingroup DataBoxGroup
+ * \brief List of Tags to get from the DataBox to be used as arguments
+ */
+template <typename... Tags>
+using ArgumentTags = tmpl::flatten<tmpl::list<Tags...>>;
+
+/*!
+ * \ingroup DataBoxGroup
  * \brief List of Compute Item Tags to add to the DataBox
  */
 template <typename... Tags>

--- a/tests/Unit/DataStructures/DataBox/CMakeLists.txt
+++ b/tests/Unit/DataStructures/DataBox/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_DataBox")
 set(LIBRARY_SOURCES
   Test_BaseTags.cpp
   Test_DataBox.cpp
+  Test_DataBoxDocumentation.cpp
   Test_DataBoxPrefixes.cpp
   Test_DataBoxTag.cpp
   Test_Deferred.cpp

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxDocumentation.cpp
@@ -1,0 +1,531 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <map>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace db {
+template <typename TagsList>
+class DataBox;
+}  // namespace db
+
+// We want the code to be nicely formatted for the documentation, not here.
+// clang-format off
+namespace {
+double working_without_databoxes_1() noexcept {
+/// [working_without_databoxes_small_program_1]
+// Set up variables:
+const double velocity = 4.0;
+const double radius = 2.0;
+const double density = 0.5;
+const double volume = 10.0;
+
+// Use variables:
+const double mass = density * volume;
+const double acceleration = velocity * velocity / radius;
+return mass * acceleration;
+/// [working_without_databoxes_small_program_1]
+}
+
+/// [working_without_databoxes_mass_compute]
+double mass_compute(const double density, const double volume) noexcept {
+  return density * volume;
+}
+/// [working_without_databoxes_mass_compute]
+
+/// [working_without_databoxes_accel_compute]
+double acceleration_compute(
+    const double velocity, const double radius) noexcept {
+  return velocity * velocity / radius;
+}
+/// [working_without_databoxes_accel_compute]
+
+double working_without_databoxes_2() noexcept {
+/// [working_without_databoxes_small_program_2]
+// Set up variables:
+const double velocity = 4.0;
+const double radius = 2.0;
+const double density = 0.5;
+const double volume = 10.0;
+
+// Use variables:
+const double mass = mass_compute(density, volume);
+const double acceleration = acceleration_compute(velocity, radius);
+return mass * acceleration;
+/// [working_without_databoxes_small_program_2]
+}
+
+/// [working_without_databoxes_force_compute]
+double force_compute(const double velocity, const double radius,
+                     const double density, const double volume) noexcept {
+  const double mass = mass_compute(density, volume);
+  const double acceleration = acceleration_compute(velocity, radius);
+  return mass *  acceleration;
+}
+/// [working_without_databoxes_force_compute]
+
+void failed_acceleration() noexcept {
+/// [working_without_databoxes_failed_accel]
+const double velocity = 4.0;
+const double radius = 2.0;
+const double acceleration = acceleration_compute(velocity, radius);
+const double failed_acceleration = acceleration_compute(radius, velocity);
+/// [working_without_databoxes_failed_accel]
+  CHECK(not(acceleration == failed_acceleration));
+}
+
+double std_map_databox_1() noexcept {
+/// [std_map_databox_small_program_1]
+// Set up variables:
+const double velocity = 4.0;
+const double radius = 2.0;
+const double density = 0.5;
+const double volume = 10.0;
+
+// Set up databox:
+std::map<std::string, double> naive_databox;
+naive_databox["Velocity"] = velocity;
+naive_databox["Radius"] = radius;
+naive_databox["Density"] = density;
+naive_databox["Volume"] = volume;
+/// [std_map_databox_small_program_1]
+  return naive_databox["Density"] * naive_databox["Volume"] *
+         naive_databox["Velocity"] * naive_databox["Velocity"] /
+         naive_databox["Radius"];
+}
+
+/// [std_map_databox_mass_compute]
+double mass_compute(const std::map<std::string, double>& box) noexcept {
+  return box.at("Density") * box.at("Volume");
+}
+/// [std_map_databox_mass_compute]
+
+/// [std_map_databox_accel_compute]
+double acceleration_compute(const std::map<std::string, double>& box) noexcept {
+  return box.at("Velocity") * box.at("Velocity") / box.at("Radius");
+}
+/// [std_map_databox_accel_compute]
+
+/// [std_map_databox_force_compute]
+double force_compute(const std::map<std::string, double>& box) noexcept {
+  const double mass = mass_compute(box);
+  const double acceleration = acceleration_compute(box);
+  return mass * acceleration;
+}
+/// [std_map_databox_force_compute]
+
+double std_map_databox_2() noexcept {
+/// [std_map_databox_small_program_2]
+// Set up variables:
+const double velocity = 4.0;
+const double radius = 2.0;
+const double density = 0.5;
+const double volume = 10.0;
+
+// Set up databox:
+std::map<std::string, double> naive_databox;
+naive_databox["Velocity"] = velocity;
+naive_databox["Radius"] = radius;
+naive_databox["Density"] = density;
+naive_databox["Volume"] = volume;
+
+// Use variables:
+return force_compute(naive_databox);
+/// [std_map_databox_small_program_2]
+}
+
+bool std_tuple_databox_example() noexcept {
+/// [std_tuple_databox_1]
+std::tuple<double, size_t, bool> sophomore_databox =
+  std::make_tuple(1.2, 8, true);
+/// [std_tuple_databox_1]
+
+/// [std_tuple_databox_2]
+const bool bool_quantity = std::get<bool>(sophomore_databox);
+// value obtained is `true`
+/// [std_tuple_databox_2]
+return bool_quantity;
+}
+
+namespace sophomore {
+/// [std_tuple_tags]
+struct Velocity{};
+struct Radius{};
+struct Density{};
+struct Volume{};
+/// [std_tuple_tags]
+
+double std_tuple_databox_1() noexcept {
+/// [std_tuple_small_program_1]
+std::tuple<std::pair<Velocity,double>,
+           std::pair<Radius, double>, std::pair<Density, double>,
+           std::pair<Volume, double>> sophomore_databox =
+  std::make_tuple(std::make_pair(Velocity{}, 4.0),
+                  std::make_pair(Radius{}, 2.0), std::make_pair(Density{}, 0.5),
+                  std::make_pair(Volume{}, 10.0));
+/// [std_tuple_small_program_1]
+  return std::get<std::pair<Density, double>>(sophomore_databox).second *
+         std::get<std::pair<Volume, double>>(sophomore_databox).second *
+         std::get<std::pair<Velocity, double>>(sophomore_databox).second *
+         std::get<std::pair<Velocity, double>>(sophomore_databox).second /
+         std::get<std::pair<Radius, double>>(sophomore_databox).second;
+}
+
+/// [std_tuple_mass_compute]
+template<typename... Pairs>
+double mass_compute(const std::tuple<Pairs...>& box) noexcept {
+  return std::get<std::pair<Density, double>>(box).second *
+         std::get<std::pair<Volume, double>>(box).second;
+}
+/// [std_tuple_mass_compute]
+
+/// [std_tuple_acceleration_compute]
+template<typename... Pairs>
+double acceleration_compute(const std::tuple<Pairs...>& box) noexcept {
+  return std::get<std::pair<Velocity, double>>(box).second *
+         std::get<std::pair<Velocity, double>>(box).second /
+         std::get<std::pair<Radius, double>>(box).second;
+}
+/// [std_tuple_acceleration_compute]
+
+/// [std_tuple_force_compute]
+template<typename... Pairs>
+double force_compute(const std::tuple<Pairs...>& box) noexcept {
+  const double mass = mass_compute(box);
+  const double acceleration = acceleration_compute(box);
+  return mass * acceleration;
+}
+/// [std_tuple_force_compute]
+
+double std_tuple_databox_2() noexcept {
+/// [std_tuple_small_program_2]
+std::tuple<std::pair<Velocity,double>,
+           std::pair<Radius, double>, std::pair<Density, double>,
+           std::pair<Volume, double>> sophomore_databox =
+  std::make_tuple(std::make_pair(Velocity{}, 4.0),
+                  std::make_pair(Radius{}, 2.0), std::make_pair(Density{}, 0.5),
+                  std::make_pair(Volume{}, 10.0));
+
+/// [std_tuple_small_program_2]
+  return force_compute(sophomore_databox);
+}
+} // namespace sophomore
+
+namespace junior {
+/// [tagged_tuple_tags]
+struct Velocity {
+  using type = double;
+};
+struct Radius {
+  using type = double;
+};
+struct Density {
+  using type = double;
+};
+struct Volume {
+  using type = double;
+};
+/// [tagged_tuple_tags]
+
+double tagged_tuple_databox_1() noexcept {
+/// [tagged_tuple_databox_1]
+tuples::TaggedTuple<Velocity, Radius, Density, Volume> junior_databox{
+  4.0, 2.0, 0.5, 10.0};
+/// [tagged_tuple_databox_1]
+  return tuples::get<Density>(junior_databox) *
+         tuples::get<Volume>(junior_databox) *
+         tuples::get<Velocity>(junior_databox) *
+         tuples::get<Velocity>(junior_databox) /
+         tuples::get<Radius>(junior_databox);
+}
+
+/// [tagged_tuple_mass_compute]
+template<typename... Tags>
+double mass_compute(const tuples::TaggedTuple<Tags...>& box) noexcept {
+  return tuples::get<Density>(box) * tuples::get<Volume>(box);
+}
+/// [tagged_tuple_mass_compute]
+
+/// [tagged_tuple_acceleration_compute]
+template<typename... Tags>
+double acceleration_compute(const tuples::TaggedTuple<Tags...>& box) noexcept {
+  return tuples::get<Velocity>(box) * tuples::get<Velocity>(box) /
+         tuples::get<Radius>(box);
+}
+/// [tagged_tuple_acceleration_compute]
+
+/// [tagged_tuple_force_compute]
+template<typename... Tags>
+double force_compute(const tuples::TaggedTuple<Tags...>& box) noexcept {
+  const double mass = mass_compute(box);
+  const double acceleration = acceleration_compute(box);
+  return mass * acceleration;
+}
+/// [tagged_tuple_force_compute]
+} // namespace junior
+
+namespace proper{
+/// [proper_databox_tags]
+struct Velocity : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "Velocity"; }
+};
+struct Radius : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "Radius"; }
+};
+struct Density : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "Density"; }
+};
+struct Volume : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "Volume"; }
+};
+struct Mass : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "Mass"; }
+};
+/// [proper_databox_tags]
+
+double refined_databox_1() noexcept {
+/// [refined_databox]
+const auto refined_databox = db::create<
+    db::AddSimpleTags<
+      Velocity, Radius, Density, Volume>>(4.0, 2.0, 0.5, 10.0);
+/// [refined_databox]
+/// [refined_databox_get]
+const double velocity = db::get<Velocity>(refined_databox);
+/// [refined_databox_get]
+const double radius = db::get<Radius>(refined_databox);
+const double density = db::get<Density>(refined_databox);
+const double volume = db::get<Volume>(refined_databox);
+return density * volume *  velocity * velocity / radius;
+}
+
+double mass_from_density_and_volume(
+  const double& density, const double& volume) noexcept {
+  return density * volume;
+}
+/// [compute_tags]
+struct MassCompute : db::ComputeTag, Mass {
+  static std::string name() noexcept { return "MassCompute"; }
+  static constexpr auto function = &mass_from_density_and_volume;
+  using argument_tags = tmpl::list<Density, Volume>;
+};
+/// [compute_tags]
+
+double acceleration_from_velocity_and_radius(
+  const double& velocity, const double& radius) noexcept {
+  return velocity * velocity / radius;
+}
+
+struct Acceleration : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "Acceleration"; }
+};
+
+struct AccelerationCompute : db::ComputeTag, Acceleration {
+  static std::string name() noexcept { return "AccelerationCompute"; }
+  static constexpr auto function = &acceleration_from_velocity_and_radius;
+  using argument_tags = tmpl::list<Velocity, Radius>;
+};
+
+/// [compute_tags_force_compute]
+struct Force : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "Force"; }
+};
+
+struct ForceCompute : db::ComputeTag, Force {
+  static std::string name() noexcept { return "ForceCompute"; }
+  static constexpr auto function(
+    const double& mass, const double& acceleration) noexcept {
+    return mass * acceleration; }
+  using argument_tags = tmpl::list<Mass, Acceleration>;
+};
+/// [compute_tags_force_compute]
+} // namespace proper
+
+/// [mutate_tags]
+struct Time : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "Time"; }
+};
+
+struct TimeStep : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "TimeStep"; }
+};
+
+struct EarthGravity : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "EarthGravity"; }
+};
+
+struct FallingSpeed : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "FallingSpeed"; }
+};
+/// [mutate_tags]
+
+/// [intended_mutation]
+struct IntendedMutation {
+  static void apply(const gsl::not_null<double*> time,
+     const gsl::not_null<double*> falling_speed,
+     const double time_step,
+     const double earth_gravity) {
+    *time += time_step;
+    *falling_speed += time_step * earth_gravity;
+  }
+};
+/// [intended_mutation]
+
+/// [intended_mutation2]
+struct IntendedMutation2 {
+  using mutate_tags = tmpl::list<Time, FallingSpeed>;
+  using argument_tags = tmpl::list<TimeStep, EarthGravity>;
+
+  static void apply(const gsl::not_null<double*> time,
+     const gsl::not_null<double*> falling_speed,
+     const double time_step,
+     const double earth_gravity) {
+    *time += time_step;
+    *falling_speed += time_step * earth_gravity;
+  }
+};
+/// [intended_mutation2]
+
+/// [my_first_action]
+template <typename Mutator>
+struct MyFirstAction{
+  template<typename DbTagsList>
+  static void apply(
+    const gsl::not_null<db::DataBox<DbTagsList>*> time_dependent_databox)
+      noexcept {
+    db::mutate_apply<typename Mutator::mutate_tags,
+                     typename Mutator::argument_tags>(
+    Mutator{}, time_dependent_databox);
+  }
+};
+/// [my_first_action]
+
+} // namespace
+// clang-format on
+
+SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Documentation",
+                  "[Unit][DataStructures]") {
+const double velocity = 4.0;
+const double radius = 2.0;
+const double density = 0.5;
+const double volume = 10.0;
+const double mass = mass_compute(density, volume);
+const double acceleration = acceleration_compute(velocity, radius);
+const double force = force_compute(velocity, radius, density, volume);
+CHECK(mass == density*volume);
+CHECK(acceleration == velocity * velocity / radius);
+CHECK(force == mass * acceleration);
+failed_acceleration();
+CHECK(force == working_without_databoxes_1());
+CHECK(force == working_without_databoxes_2());
+CHECK(force == std_map_databox_1());
+CHECK(force == std_map_databox_2());
+std::map<std::string, double> naive_databox;
+naive_databox["Velocity"] = velocity;
+naive_databox["Radius"] = radius;
+naive_databox["Density"] = density;
+naive_databox["Volume"] = volume;
+CHECK(mass == mass_compute(naive_databox));
+CHECK(acceleration == acceleration_compute(naive_databox));
+CHECK(force == force_compute(naive_databox));
+CHECK(std_tuple_databox_example());
+std::tuple<std::pair<sophomore::Velocity, double>,
+           std::pair<sophomore::Radius, double>,
+           std::pair<sophomore::Density, double>,
+           std::pair<sophomore::Volume, double>>
+    sophomore_databox =
+        std::make_tuple(std::make_pair(sophomore::Velocity{}, 4.0),
+                        std::make_pair(sophomore::Radius{}, 2.0),
+                        std::make_pair(sophomore::Density{}, 0.5),
+                        std::make_pair(sophomore::Volume{}, 10.0));
+CHECK(mass == sophomore::mass_compute(sophomore_databox));
+CHECK(acceleration == sophomore::acceleration_compute(sophomore_databox));
+CHECK(force == sophomore::force_compute(sophomore_databox));
+CHECK(force == sophomore::std_tuple_databox_1());
+CHECK(force == sophomore::std_tuple_databox_2());
+tuples::TaggedTuple<junior::Velocity, junior::Radius, junior::Density,
+                    junior::Volume>
+    junior_databox{velocity, radius, density, volume};
+CHECK(mass == junior::mass_compute(junior_databox));
+CHECK(acceleration == junior::acceleration_compute(junior_databox));
+CHECK(force == junior::force_compute(junior_databox));
+CHECK(force == junior::tagged_tuple_databox_1());
+CHECK(force == proper::refined_databox_1());
+const auto refined_databox = db::create<
+    db::AddSimpleTags<proper::Velocity, proper::Radius, proper::Density,
+                      proper::Volume>,
+    db::AddComputeTags<proper::MassCompute, proper::AccelerationCompute,
+                       proper::ForceCompute>>(velocity, radius, density,
+                                              volume);
+CHECK(force == db::get<proper::Force>(refined_databox));
+
+/// [time_dep_databox]
+auto time_dependent_databox = db::create<
+    db::AddSimpleTags<
+      Time, TimeStep, EarthGravity, FallingSpeed>>(0.0, 0.1, -9.8, -10.0);
+db::mutate_apply<
+  //MutateTags
+  tmpl::list<Time, FallingSpeed>,
+  //ArgumentTags
+  tmpl::list<TimeStep, EarthGravity>>(
+  [](const gsl::not_null<double*> time,
+     const gsl::not_null<double*> falling_speed,
+     const double& time_step,
+     const double& earth_gravity) {
+    *time += time_step;
+    *falling_speed += time_step * earth_gravity;
+  },
+  make_not_null(&time_dependent_databox));
+/// [time_dep_databox]
+CHECK(0.0 + 0.1 == approx(db::get<Time>(time_dependent_databox)));
+CHECK(-10.0 + 0.1 * -9.8 ==
+  approx(db::get<FallingSpeed>(time_dependent_databox)));
+
+/// [time_dep_databox2]
+db::mutate_apply<
+  tmpl::list<Time, FallingSpeed>,
+  tmpl::list<TimeStep, EarthGravity>>(
+    IntendedMutation{}, make_not_null(&time_dependent_databox));
+/// [time_dep_databox2]
+CHECK(0.0 + 0.2 == approx(db::get<Time>(time_dependent_databox)));
+CHECK(-10.0 + 0.2 * -9.8 ==
+  approx(db::get<FallingSpeed>(time_dependent_databox)));
+
+/// [time_dep_databox3]
+db::mutate_apply<
+  typename IntendedMutation2::mutate_tags,
+  typename IntendedMutation2::argument_tags>(
+    IntendedMutation2{}, make_not_null(&time_dependent_databox));
+/// [time_dep_databox3]
+CHECK(0.0 + 0.3 == approx(db::get<Time>(time_dependent_databox)));
+CHECK(-10.0 + 0.3 * -9.8 ==
+  approx(db::get<FallingSpeed>(time_dependent_databox)));
+
+/// [time_dep_databox4]
+MyFirstAction<IntendedMutation2>::apply(make_not_null(&time_dependent_databox));
+/// [time_dep_databox4]
+CHECK(0.0 + 0.4 == approx(db::get<Time>(time_dependent_databox)));
+CHECK(-10.0 + 0.4 * -9.8 ==
+  approx(db::get<FallingSpeed>(time_dependent_databox)));
+}


### PR DESCRIPTION
## Proposed changes

Partially addresses the desired changes discussed in #944 

I do not yet have a full understanding of the concepts I discuss in these introductions, but
I am hoping to learn more through writing them as well as through reading your comments.
Please feel free to make many requested additions or improvements. I am hopeful that this
becomes a comprehensive, sequential introduction to the more difficult parts of SpECTRE
that is complementary to the detailed technical documentation we already have. I encourage
those who are less familiar with TMP to ask questions if they find something hard to understand,
and those who are more familiar with TMP to make corrections/clarifications on things I have explained
in an incorrect/misleading manner. Let's learn!

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
