### PR TITLE
Write volume data as rank1 dataset

### DIFF
--- a/src/IO/H5/Helpers.hpp
+++ b/src/IO/H5/Helpers.hpp
@@ -21,15 +21,6 @@ class DataVector;
 namespace h5 {
 /*!
  * \ingroup HDF5Group
- * \brief Write a DataVector named `name` to the group `group_id`
- */
-template <size_t Dim>
-void write_data(hid_t group_id, const DataVector& data,
-                const Index<Dim>& extents,
-                const std::string& name = "scalar") noexcept;
-
-/*!
- * \ingroup HDF5Group
  * \brief Write a std::vector named `name` to the group `group_id`
  */
 template <typename T>
@@ -42,8 +33,7 @@ void write_data(hid_t group_id, const std::vector<T>& data,
  * \brief Write a DataVector named `name` to the group `group_id`
  */
 void write_data(hid_t group_id, const DataVector& data,
-                const std::vector<size_t>& extents,
-                const std::string& name = "scalar") noexcept;
+                const std::string& name) noexcept;
 
 /*!
  * \ingroup HDF5Group

--- a/src/IO/H5/VolumeData.cpp
+++ b/src/IO/H5/VolumeData.cpp
@@ -106,8 +106,7 @@ void VolumeData::insert_tensor_data(
         tensor_component.name.find_last_of('/') + 1);
     if (not h5::contains_dataset_or_group(spatial_group.id(), "",
                                           component_name)) {
-      h5::write_data(spatial_group.id(), tensor_component.data, extents,
-                     component_name);
+      h5::write_data(spatial_group.id(), tensor_component.data, component_name);
     } else {
       ERROR("Trying to write tensor component '"
             << component_name


### PR DESCRIPTION
## Proposed changes

Since our data is x-varying fastest and HDF5 uses z-varying fastest there's no
benefit to using the rank-3 representations since it ends up being in the wrong
order anyway. See issue #1141.

I'll be building on this to improve IO time in a future PR. I figure getting this in as a small PR would be easiest for now.

closes #1141 

### Types of changes:

- [x] Bugfix

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
