### PR TITLE
Add SlabJet analytic data

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -140,3 +140,9 @@ add_grmhd_executable(
   RelativisticEuler::Solutions::RotatingStar
   "${LIBS_TO_LINK}"
   )
+
+add_grmhd_executable(
+  SlabJet
+  grmhd::AnalyticData::SlabJet
+  "${LIBS_TO_LINK}"
+  )

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -141,6 +141,7 @@
 #include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedTovStar.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/OrszagTangVortex.hpp"
 #include "PointwiseFunctions/AnalyticData/GrMhd/RiemannProblem.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/SlabJet.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/AlfvenWave.hpp"

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivCleanFwd.hpp
@@ -30,6 +30,7 @@ class MagnetizedFmDisk;
 class MagnetizedTovStar;
 class OrszagTangVortex;
 class RiemannProblem;
+class SlabJet;
 }  // namespace AnalyticData
 }  // namespace grmhd
 

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -18,6 +18,7 @@ spectre_target_sources(
   MagnetizedTovStar.cpp
   OrszagTangVortex.cpp
   RiemannProblem.cpp
+  SlabJet.cpp
   )
 
 spectre_target_headers(
@@ -35,6 +36,7 @@ spectre_target_headers(
   MagnetizedTovStar.hpp
   OrszagTangVortex.hpp
   RiemannProblem.hpp
+  SlabJet.hpp
   )
 
 target_link_libraries(

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/SlabJet.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/SlabJet.cpp
@@ -1,0 +1,236 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/GrMhd/SlabJet.hpp"
+
+#include <cmath>
+#include <ostream>
+#include <pup.h>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "PointwiseFunctions/Hydro/LorentzFactor.hpp"
+#include "PointwiseFunctions/Hydro/SpecificEnthalpy.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp"
+
+namespace {
+template <typename DataType>
+Scalar<DataType> compute_piecewise(const tnsr::I<DataType, 3>& x,
+                                   const double inlet_radius,
+                                   const double ambient_value,
+                                   const double jet_value) {
+  auto result = make_with_value<Scalar<DataType>>(x, ambient_value);
+  for (size_t i = 0; i < get_size(get(result)); ++i) {
+    if (get_element(get<0>(x), i) <= 0. and
+        abs(get_element(get<1>(x), i)) <= inlet_radius) {
+      get_element(get(result), i) = jet_value;
+    }
+  }
+  return result;
+}
+
+template <typename DataType>
+tnsr::I<DataType, 3> compute_piecewise_vector(
+    const tnsr::I<DataType, 3>& x, const double inlet_radius,
+    const std::array<double, 3>& ambient_value,
+    const std::array<double, 3>& jet_value) {
+  auto result = make_with_value<tnsr::I<DataType, 3>>(x, 0.);
+  for (size_t i = 0; i < get_size(get<0>(result)); ++i) {
+    if (get_element(get<0>(x), i) <= 0. and
+        abs(get_element(get<1>(x), i)) <= inlet_radius) {
+      get_element(get<0>(result), i) = jet_value[0];
+      get_element(get<1>(result), i) = jet_value[1];
+      get_element(get<2>(result), i) = jet_value[2];
+    } else {
+      get_element(get<0>(result), i) = ambient_value[0];
+      get_element(get<1>(result), i) = ambient_value[1];
+      get_element(get<2>(result), i) = ambient_value[2];
+    }
+  }
+  return result;
+}
+}  // namespace
+
+namespace grmhd::AnalyticData {
+
+SlabJet::SlabJet(double adiabatic_index, double ambient_density,
+                 double ambient_pressure, double ambient_electron_fraction,
+                 double jet_density, double jet_pressure,
+                 double jet_electron_fraction,
+                 std::array<double, 3> jet_velocity, double inlet_radius,
+                 std::array<double, 3> magnetic_field)
+    : equation_of_state_(adiabatic_index),
+      ambient_density_(ambient_density),
+      ambient_pressure_(ambient_pressure),
+      ambient_electron_fraction_(ambient_electron_fraction),
+      jet_density_(jet_density),
+      jet_pressure_(jet_pressure),
+      jet_electron_fraction_(jet_electron_fraction),
+      jet_velocity_(jet_velocity),
+      inlet_radius_(inlet_radius),
+      magnetic_field_(magnetic_field) {}
+
+std::unique_ptr<evolution::initial_data::InitialData> SlabJet::get_clone()
+    const {
+  return std::make_unique<SlabJet>(*this);
+}
+
+SlabJet::SlabJet(CkMigrateMessage* msg) : InitialData(msg) {}
+
+void SlabJet::pup(PUP::er& p) {
+  InitialData::pup(p);
+  p | equation_of_state_;
+  p | background_spacetime_;
+  p | ambient_density_;
+  p | ambient_pressure_;
+  p | ambient_electron_fraction_;
+  p | jet_density_;
+  p | jet_pressure_;
+  p | jet_electron_fraction_;
+  p | jet_velocity_;
+  p | inlet_radius_;
+  p | magnetic_field_;
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>> SlabJet::variables(
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/) const {
+  return compute_piecewise(x, inlet_radius_, ambient_density_, jet_density_);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::ElectronFraction<DataType>> SlabJet::variables(
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<hydro::Tags::ElectronFraction<DataType>> /*meta*/) const {
+  return compute_piecewise(x, inlet_radius_, ambient_electron_fraction_,
+                           jet_electron_fraction_);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>
+SlabJet::variables(
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/) const {
+  return compute_piecewise_vector(
+      x, inlet_radius_, std::array<double, 3>{{0., 0., 0.}}, jet_velocity_);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>
+SlabJet::variables(
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const {
+  using density_tag = hydro::Tags::RestMassDensity<DataType>;
+  using pressure_tag = hydro::Tags::Pressure<DataType>;
+  const auto data = variables(x, tmpl::list<density_tag, pressure_tag>{});
+  return equation_of_state_.specific_internal_energy_from_density_and_pressure(
+      get<density_tag>(data), get<pressure_tag>(data));
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::Pressure<DataType>> SlabJet::variables(
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const {
+  return compute_piecewise(x, inlet_radius_, ambient_pressure_, jet_pressure_);
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>> SlabJet::variables(
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/) const {
+  auto magnetic_field = make_with_value<tnsr::I<DataType, 3>>(x, 0.);
+  get<0>(magnetic_field) = magnetic_field_[0];
+  get<1>(magnetic_field) = magnetic_field_[1];
+  get<2>(magnetic_field) = magnetic_field_[2];
+  return {std::move(magnetic_field)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>
+SlabJet::variables(
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const {
+  return {make_with_value<Scalar<DataType>>(x, 0.)};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>> SlabJet::variables(
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/) const {
+  const auto spatial_velocity = get<hydro::Tags::SpatialVelocity<DataType, 3>>(
+      variables(x, tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>>{}));
+  return {
+      hydro::lorentz_factor(dot_product(spatial_velocity, spatial_velocity))};
+}
+
+template <typename DataType>
+tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>> SlabJet::variables(
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/) const {
+  using density_tag = hydro::Tags::RestMassDensity<DataType>;
+  using energy_tag = hydro::Tags::SpecificInternalEnergy<DataType>;
+  using pressure_tag = hydro::Tags::Pressure<DataType>;
+  const auto data =
+      variables(x, tmpl::list<density_tag, energy_tag, pressure_tag>{});
+  return hydro::relativistic_specific_enthalpy(
+      get<density_tag>(data), get<energy_tag>(data), get<pressure_tag>(data));
+}
+
+PUP::able::PUP_ID SlabJet::my_PUP_ID = 0;
+
+bool operator==(const SlabJet& lhs, const SlabJet& rhs) {
+  return lhs.equation_of_state_ == rhs.equation_of_state_ and
+         lhs.ambient_density_ == rhs.ambient_density_ and
+         lhs.ambient_pressure_ == rhs.ambient_pressure_ and
+         lhs.ambient_electron_fraction_ == rhs.ambient_electron_fraction_ and
+         lhs.jet_density_ == rhs.jet_density_ and
+         lhs.jet_pressure_ == rhs.jet_pressure_ and
+         lhs.jet_electron_fraction_ == rhs.jet_electron_fraction_ and
+         lhs.jet_velocity_ == rhs.jet_velocity_ and
+         lhs.inlet_radius_ == rhs.inlet_radius_ and
+         lhs.magnetic_field_ == rhs.magnetic_field_;
+}
+
+bool operator!=(const SlabJet& lhs, const SlabJet& rhs) {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define TAG(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_SCALARS(_, data)                        \
+  template tuples::TaggedTuple < TAG(data) < DTYPE(data) >> \
+      SlabJet::variables(const tnsr::I<DTYPE(data), 3>&,    \
+                         tmpl::list < TAG(data) < DTYPE(data) >>) const;
+
+GENERATE_INSTANTIATIONS(
+    INSTANTIATE_SCALARS, (double, DataVector),
+    (hydro::Tags::RestMassDensity, hydro::Tags::ElectronFraction,
+     hydro::Tags::SpecificInternalEnergy, hydro::Tags::Pressure,
+     hydro::Tags::DivergenceCleaningField, hydro::Tags::LorentzFactor,
+     hydro::Tags::SpecificEnthalpy))
+
+#define INSTANTIATE_VECTORS(_, data)                                   \
+  template tuples::TaggedTuple < TAG(data) < DTYPE(data),              \
+      3 >> SlabJet::variables(const tnsr::I<DTYPE(data), 3>&,          \
+                              tmpl::list < TAG(data) < DTYPE(data), 3, \
+                              Frame::Inertial >>) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_VECTORS, (double, DataVector),
+                        (hydro::Tags::SpatialVelocity,
+                         hydro::Tags::MagneticField))
+
+#undef DTYPE
+#undef TAG
+#undef INSTANTIATE_SCALARS
+#undef INSTANTIATE_VECTORS
+}  // namespace grmhd::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/SlabJet.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/SlabJet.hpp
@@ -1,0 +1,260 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <limits>
+#include <memory>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "Parallel/CharmPupable.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/IdealFluid.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace grmhd::AnalyticData {
+
+/*!
+ * \brief Analytic initial data for a slab jet
+ *
+ * This test problem is described in \cite Komissarov1999, Section 7.4 and
+ * Fig. 13. It involves a high Lorentz factor jet injected into an ambient fluid
+ * with an initially uniform magnetic field.
+ *
+ * The parameters used in \cite Komissarov1999 are:
+ *
+ * ```yaml
+ * AdiabaticIndex: 4. / 3.
+ * AmbientDensity: 10.
+ * AmbientPressure: 0.01
+ * JetDensity: 0.1
+ * JetPressure: 0.01
+ * # u^i = [20, 0, 0] or W = sqrt(401)
+ * JetVelocity: [0.9987523388778445, 0., 0.]
+ * InletRadius: 1.
+ * MagneticField: [1., 0., 0.]
+ * ```
+ *
+ * In \cite Komissarov1999 an artificial dissipation of $\eta_u=0.2$ and
+ * $\eta_b=0.15$ is used, which we don't use here (yet).
+ *
+ * \note The inlet is currently modeled as the region of the domain where
+ * $x <= 0$ and $|y| <= \mathrm{inlet_radius}$. Since this class only sets
+ * the initial data, no fluid will flow into the domain during the evolution.
+ * This has to be modeled as a boundary condition and is not implemented yet.
+ */
+class SlabJet : public evolution::initial_data::InitialData,
+                public MarkAsAnalyticData,
+                public AnalyticDataBase {
+ public:
+  using equation_of_state_type = EquationsOfState::IdealFluid<true>;
+
+  struct AdiabaticIndex {
+    using type = double;
+    static constexpr Options::String help = {
+        "The adiabatic index of the ideal fluid"};
+    static double lower_bound() { return 1.; }
+  };
+  struct AmbientDensity {
+    using type = double;
+    static constexpr Options::String help = {
+        "Fluid rest mass density outside the jet"};
+    static double lower_bound() { return 0.; }
+    static double suggested_value() { return 10.; }
+  };
+  struct AmbientPressure {
+    using type = double;
+    static constexpr Options::String help = {"Fluid pressure outside the jet"};
+    static double lower_bound() { return 0.; }
+    static double suggested_value() { return 0.01; }
+  };
+  struct AmbientElectronFraction {
+    using type = double;
+    static constexpr Options::String help = {
+        "Electron fraction outside the jet"};
+    static double lower_bound() { return 0.; }
+    static double upper_bound() { return 1.; }
+  };
+  struct JetDensity {
+    using type = double;
+    static constexpr Options::String help = {
+        "Fluid rest mass density of the jet inlet"};
+    static double lower_bound() { return 0.; }
+    static double suggested_value() { return 0.1; }
+  };
+  struct JetPressure {
+    using type = double;
+    static constexpr Options::String help = {"Fluid pressure of the jet inlet"};
+    static double lower_bound() { return 0.; }
+    static double suggested_value() { return 0.01; }
+  };
+  struct JetElectronFraction {
+    using type = double;
+    static constexpr Options::String help = {
+        "Electron fraction of the jet inlet"};
+    static double lower_bound() { return 0.; }
+    static double upper_bound() { return 1.; }
+  };
+  struct JetVelocity {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "Fluid spatial velocity of the jet inlet"};
+  };
+  struct InletRadius {
+    using type = double;
+    static constexpr Options::String help = {
+        "Radius of the jet inlet around y=0"};
+    static double lower_bound() { return 0.; }
+    static double suggested_value() { return 1.; }
+  };
+  struct MagneticField {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "Initially uniform magnetic field"};
+    static std::array<double, 3> suggested_value() { return {{1., 0., 0.}}; }
+  };
+
+  using options =
+      tmpl::list<AdiabaticIndex, AmbientDensity, AmbientPressure,
+                 AmbientElectronFraction, JetDensity, JetPressure,
+                 JetElectronFraction, JetVelocity, InletRadius, MagneticField>;
+
+  static constexpr Options::String help = {
+      "Analytic initial data for a jet test."};
+
+  SlabJet() = default;
+  SlabJet(const SlabJet& /*rhs*/) = default;
+  SlabJet& operator=(const SlabJet& /*rhs*/) = default;
+  SlabJet(SlabJet&& /*rhs*/) = default;
+  SlabJet& operator=(SlabJet&& /*rhs*/) = default;
+  ~SlabJet() = default;
+
+  SlabJet(double adiabatic_index, double ambient_density,
+          double ambient_pressure, double ambient_electron_fraction,
+          double jet_density, double jet_pressure, double jet_electron_fraction,
+          std::array<double, 3> jet_velocity, double inlet_radius,
+          std::array<double, 3> magnetic_field);
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
+  /// \cond
+  explicit SlabJet(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(SlabJet);
+  /// \endcond
+
+  /// @{
+  /// Retrieve the GRMHD variables at a given position.
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/)
+      const -> tuples::TaggedTuple<hydro::Tags::RestMassDensity<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::ElectronFraction<DataType>> /*meta*/)
+      const -> tuples::TaggedTuple<hydro::Tags::ElectronFraction<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::SpecificInternalEnergy<DataType>> /*meta*/) const
+      -> tuples::TaggedTuple<hydro::Tags::SpecificInternalEnergy<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::Pressure<DataType>> /*meta*/) const
+      -> tuples::TaggedTuple<hydro::Tags::Pressure<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3>> /*meta*/)
+      const -> tuples::TaggedTuple<hydro::Tags::SpatialVelocity<DataType, 3>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::MagneticField<DataType, 3>> /*meta*/)
+      const -> tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>> /*meta*/) const
+      -> tuples::TaggedTuple<hydro::Tags::DivergenceCleaningField<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::LorentzFactor<DataType>> /*meta*/)
+      const -> tuples::TaggedTuple<hydro::Tags::LorentzFactor<DataType>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, 3>& x,
+                 tmpl::list<hydro::Tags::SpecificEnthalpy<DataType>> /*meta*/)
+      const -> tuples::TaggedTuple<hydro::Tags::SpecificEnthalpy<DataType>>;
+  /// @}
+
+  /// Retrieve a collection of hydrodynamic variables at position x
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, 3>& x,
+                                         tmpl::list<Tags...> /*meta*/) const {
+    static_assert(sizeof...(Tags) > 1, "The requested tag is not implemented.");
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  /// Retrieve the metric variables
+  template <typename DataType, typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x,
+                                     tmpl::list<Tag> /*meta*/) const {
+    return background_spacetime_.variables(
+        x, std::numeric_limits<double>::signaling_NaN(), tmpl::list<Tag>{});
+  }
+
+  const EquationsOfState::IdealFluid<true>& equation_of_state() const {
+    return equation_of_state_;
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& /*p*/) override;
+
+ private:
+  EquationsOfState::IdealFluid<true> equation_of_state_{};
+  gr::Solutions::Minkowski<3> background_spacetime_{};
+
+  double ambient_density_ = std::numeric_limits<double>::signaling_NaN();
+  double ambient_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double ambient_electron_fraction_ =
+      std::numeric_limits<double>::signaling_NaN();
+  double jet_density_ = std::numeric_limits<double>::signaling_NaN();
+  double jet_pressure_ = std::numeric_limits<double>::signaling_NaN();
+  double jet_electron_fraction_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> jet_velocity_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+  double inlet_radius_ = std::numeric_limits<double>::signaling_NaN();
+  std::array<double, 3> magnetic_field_{
+      {std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN(),
+       std::numeric_limits<double>::signaling_NaN()}};
+
+  friend bool operator==(const SlabJet& lhs, const SlabJet& rhs);
+
+  friend bool operator!=(const SlabJet& lhs, const SlabJet& rhs);
+};
+
+}  // namespace grmhd::AnalyticData

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -16,11 +16,23 @@ set(LIBRARY_SOURCES
   Test_MagnetizedTovStar.cpp
   Test_OrszagTangVortex.cpp
   Test_RiemannProblem.cpp
+  Test_SlabJet.cpp
   )
 
 add_test_library(
   ${LIBRARY}
   "PointwiseFunctions/AnalyticData/GrMhd"
   "${LIBRARY_SOURCES}"
-  "GrMhdAnalyticData;Options;Utilities"
+  ""
   )
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  ErrorHandling
+  GrMhdAnalyticData
+  Hydro
+  Options
+  Utilities
+)

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/SlabJet.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/SlabJet.py
@@ -1,0 +1,82 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def piecewise(x, inlet_radius, ambient_value, jet_value):
+    return (jet_value
+            if x[0] <= 0. and abs(x[1]) <= inlet_radius else ambient_value)
+
+
+def piecewise_vector(x, inlet_radius, ambient_value, jet_value):
+    return np.array([
+        jet_value[d]
+        if x[0] <= 0. and abs(x[1]) <= inlet_radius else ambient_value[d]
+        for d in range(3)
+    ])
+
+
+def parse_vars(*args, **kwargs):
+    assert not kwargs, "Found unexpected labeled arguments:\n{}".format(kwargs)
+    assert len(args) == 10, "Expected 10 arguments, but got {}".format(
+        len(args))
+    return dict(
+        zip([
+            "adiabatic_index", "ambient_density", "ambient_pressure",
+            "ambient_electron_fraction", "jet_density", "jet_pressure",
+            "jet_electron_fraction", "jet_velocity", "inlet_radius",
+            "magnetic_field"
+        ], args))
+
+
+def rest_mass_density(x, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    return piecewise(x, vars["inlet_radius"], vars["ambient_density"],
+                     vars["jet_density"])
+
+
+def electron_fraction(x, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    return piecewise(x, vars["inlet_radius"],
+                     vars["ambient_electron_fraction"],
+                     vars["jet_electron_fraction"])
+
+
+def spatial_velocity(x, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    return piecewise_vector(x, vars["inlet_radius"], [0., 0., 0.],
+                            vars["jet_velocity"])
+
+
+def specific_internal_energy(x, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    p = pressure(x, *args, **kwargs)
+    rho = rest_mass_density(x, *args, **kwargs)
+    return p / ((vars["adiabatic_index"] - 1.0) * rho)
+
+
+def pressure(x, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    return piecewise(x, vars["inlet_radius"], vars["ambient_pressure"],
+                     vars["jet_pressure"])
+
+
+def specific_enthalpy(x, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    e = specific_internal_energy(x, *args, **kwargs)
+    return 1.0 + vars["adiabatic_index"] * e
+
+
+def lorentz_factor(x, *args, **kwargs):
+    v = spatial_velocity(x, *args, **kwargs)
+    return 1.0 / np.sqrt(1.0 - np.sum(v**2))
+
+
+def magnetic_field(x, *args, **kwargs):
+    vars = parse_vars(*args, **kwargs)
+    return np.array(vars["magnetic_field"])
+
+
+def divergence_cleaning_field(x, *args, **kwargs):
+    return 0.0

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_SlabJet.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_SlabJet.cpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <memory>
+
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/SlabJet.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+
+namespace {
+struct SlabJetProxy : public ::grmhd::AnalyticData::SlabJet {
+  using grmhd::AnalyticData::SlabJet::SlabJet;
+
+  template <typename DataType>
+  using variables_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>,
+                 hydro::Tags::ElectronFraction<DataType>,
+                 hydro::Tags::SpatialVelocity<DataType, 3>,
+                 hydro::Tags::SpecificInternalEnergy<DataType>,
+                 hydro::Tags::Pressure<DataType>,
+                 hydro::Tags::LorentzFactor<DataType>,
+                 hydro::Tags::SpecificEnthalpy<DataType>,
+                 hydro::Tags::MagneticField<DataType, 3>,
+                 hydro::Tags::DivergenceCleaningField<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<variables_tags<DataType>>
+  primitive_variables(const tnsr::I<DataType, 3, Frame::Inertial>& x) const {
+    return this->variables(x, variables_tags<DataType>{});
+  }
+};
+
+template <typename DataType>
+void test(const DataType& used_for_size) {
+  const double adiabatic_index = 1.33333333333333;
+  const double ambient_density = 10.;
+  const double ambient_pressure = 0.01;
+  const double ambient_electron_fraction = 0.;
+  const double jet_density = 0.1;
+  const double jet_pressure = 0.01;
+  const double jet_electron_fraction = 0.;
+  const std::array<double, 3> jet_velocity{{0.9987523388778445, 0., 0.}};
+  const double inlet_radius = 1.;
+  const std::array<double, 3> magnetic_field{{1., 0., 0.}};
+  const auto members = std::make_tuple(
+      adiabatic_index, ambient_density, ambient_pressure,
+      ambient_electron_fraction, jet_density, jet_pressure,
+      jet_electron_fraction, jet_velocity, inlet_radius, magnetic_field);
+
+  Parallel::register_classes_with_charm<grmhd::AnalyticData::SlabJet>();
+  const std::unique_ptr<evolution::initial_data::InitialData> option_solution =
+      TestHelpers::test_option_tag_factory_creation<
+          evolution::initial_data::OptionTags::InitialData,
+          grmhd::AnalyticData::SlabJet>(
+          "SlabJet:\n"
+          "  AdiabaticIndex: 1.33333333333333\n"
+          "  AmbientDensity: 10.\n"
+          "  AmbientPressure: 0.01\n"
+          "  AmbientElectronFraction: 0.\n"
+          "  JetDensity: 0.1\n"
+          "  JetPressure: 0.01\n"
+          "  JetElectronFraction: 0.\n"
+          "  JetVelocity: [0.9987523388778445, 0., 0.]\n"
+          "  InletRadius: 1.\n"
+          "  MagneticField: [1., 0., 0.]\n")
+          ->get_clone();
+  const auto deserialized_option_solution =
+      serialize_and_deserialize(option_solution);
+  const auto& slab_jet = dynamic_cast<const grmhd::AnalyticData::SlabJet&>(
+      *deserialized_option_solution);
+
+  CHECK(slab_jet == grmhd::AnalyticData::SlabJet(
+                        adiabatic_index, ambient_density, ambient_pressure,
+                        ambient_electron_fraction, jet_density, jet_pressure,
+                        jet_electron_fraction, jet_velocity, inlet_radius,
+                        magnetic_field));
+
+  {
+    INFO("Semantics");
+    auto to_move = slab_jet;
+    test_move_semantics(std::move(to_move), slab_jet);
+  }
+
+  const SlabJetProxy proxy{adiabatic_index,       ambient_density,
+                           ambient_pressure,      ambient_electron_fraction,
+                           jet_density,           jet_pressure,
+                           jet_electron_fraction, jet_velocity,
+                           inlet_radius,          magnetic_field};
+  pypp::check_with_random_values<1>(
+      &SlabJetProxy::template primitive_variables<DataType>, proxy, "SlabJet",
+      {"rest_mass_density", "electron_fraction", "spatial_velocity",
+       "specific_internal_energy", "pressure", "lorentz_factor",
+       "specific_enthalpy", "magnetic_field", "divergence_cleaning_field"},
+      {{{0.0, 1.0}}}, members, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.GrMhd.SlabJet",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticData/GrMhd"};
+
+  test(std::numeric_limits<double>::signaling_NaN());
+  test(DataVector(5));
+}


### PR DESCRIPTION
## Proposed changes

This PR adds the analytic data for evolving a jet such as the one described in [Komissarov 1999](https://academic.oup.com/mnras/article-abstract/303/2/343/1067242), section 7.4 / Fig. 13.

- [x] Depends on the WENO limiter (cherry-picked from @fmahebert)

A sample run at t=30:

![jet](https://user-images.githubusercontent.com/746230/49591937-16dc7480-f970-11e8-9cb0-2f82ccc6d2a2.png)

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`. For
  instructions on how to perform the CI checks locally refer to the [Dev guide
  on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run `make doc`
  to generate the documentation locally into `BUILD_DIR/docs/html`. Then open
  `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
