### PR TITLE
Fix line length in Orszag-Tang test functions

### DIFF
--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/TestFunctions.py
@@ -218,13 +218,15 @@ def orszag_tang_rest_mass_density(x):
 
 
 def orszag_tang_spatial_velocity(x):
-    return np.array([-1. / 2. * np.sin(2. * np.pi * x[1]),
-                     1. / 2. * np.sin(2. * np.pi * x[0]),
-                     0.])
+    return np.array([
+        -1. / 2. * np.sin(2. * np.pi * x[1]),
+        1. / 2. * np.sin(2. * np.pi * x[0]), 0.
+    ])
 
 
 def orszag_tang_specific_internal_energy(x):
-    return 1. / (5. / 3. - 1.) * orszag_tang_pressure(x) / orszag_tang_rest_mass_density(x)
+    return (1. / (5. / 3. - 1.) * orszag_tang_pressure(x) /
+            orszag_tang_rest_mass_density(x))
 
 
 def orszag_tang_pressure(x):
@@ -237,16 +239,19 @@ def orszag_tang_lorentz_factor(x):
 
 
 def orszag_tang_specific_enthalpy(x):
-    return 1. + orszag_tang_specific_internal_energy(x) + orszag_tang_pressure(x) / orszag_tang_rest_mass_density(x)
+    return 1. + orszag_tang_specific_internal_energy(
+        x) + orszag_tang_pressure(x) / orszag_tang_rest_mass_density(x)
 
 
 def orszag_tang_magnetic_field(x):
-    return np.array([-1. / np.sqrt(4. * np.pi) * np.sin(2. * np.pi * x[1]),
-                     1. / np.sqrt(4. * np.pi) * np.sin(4. * np.pi * x[0]),
-                     0.])
+    return np.array([
+        -1. / np.sqrt(4. * np.pi) * np.sin(2. * np.pi * x[1]),
+        1. / np.sqrt(4. * np.pi) * np.sin(4. * np.pi * x[0]), 0.
+    ])
 
 
 def orszag_tang_divergence_cleaning_field(x):
     return 0.
+
 
 # End for testing OrszagTangVortex.cpp


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
