### PR TITLE
Allow non "element_data" names in reduction

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#include <cstddef>
+#include <string>
+#include <tuple>
+
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
@@ -225,11 +229,12 @@ struct Observe {
           Parallel::ReductionDatum<size_t, funcl::Plus<>>, Redum, Redum, Redum>;
       Parallel::simple_action<observers::Actions::ContributeReductionData>(
           local_observer, observers::ObservationId(time),
+          std::string{"/element_data"},
           std::vector<std::string>{
               "Time", "NumberOfPoints", "RestMassDensityError",
               "SpecificInternalEnergyError", "PressureError"},
           ReData{time.value(),
-                db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points(),
+                 db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points(),
                  rest_mass_density_error, specific_internal_energy_error,
                  pressure_error});
     }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
@@ -215,6 +215,7 @@ struct Observe {
                .ckLocalBranch();
       Parallel::simple_action<observers::Actions::ContributeVolumeData>(
           local_observer, observers::ObservationId(time),
+          std::string{"/element_data"},
           observers::ArrayComponentId(
               std::add_pointer_t<ParallelComponent>{nullptr},
               Parallel::ArrayIndex<ElementIndex<Dim>>(array_index)),

--- a/src/Evolution/Systems/ScalarWave/Actions.hpp
+++ b/src/Evolution/Systems/ScalarWave/Actions.hpp
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#include <cstddef>
+#include <string>
+#include <tuple>
+
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/ScalarWave/Tags.hpp"
@@ -140,6 +144,7 @@ struct Observe {
           Parallel::ReductionDatum<size_t, funcl::Plus<>>, Redum, Redum>;
       Parallel::simple_action<observers::Actions::ContributeReductionData>(
           local_observer, observers::ObservationId(time),
+          std::string{"/element_data"},
           std::vector<std::string>{"Time", "NumberOfPoints", "PsiError",
                                    "PiError"},
           ReData{time.value(),

--- a/src/Evolution/Systems/ScalarWave/Actions.hpp
+++ b/src/Evolution/Systems/ScalarWave/Actions.hpp
@@ -130,6 +130,7 @@ struct Observe {
                .ckLocalBranch();
       Parallel::simple_action<observers::Actions::ContributeVolumeData>(
           local_observer, observers::ObservationId(time),
+          std::string{"/element_data"},
           observers::ArrayComponentId(
               std::add_pointer_t<ParallelComponent>{nullptr},
               Parallel::ArrayIndex<ElementIndex<Dim>>(array_index)),

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -131,7 +131,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
         make_fake_reduction_data(array_id, time.value());
     runner.simple_action<obs_component,
                          observers::Actions::ContributeReductionData>(
-        0, observers::ObservationId(time), legend,
+        0, observers::ObservationId(time), "/element_data", legend,
         std::move(reduction_data_fakes));
   }
   // Invke the threaded action 'WriteReductionData' to write reduction data to

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -144,7 +144,8 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
         make_fake_volume_data(array_id, MakeString{} << id << '/');
     runner
         .simple_action<obs_component, observers::Actions::ContributeVolumeData>(
-            0, observers::ObservationId(TimeId(3)), array_id,
+            0, observers::ObservationId(TimeId(3)),
+            std::string{"/element_data"}, array_id,
             /* get<1> = volume tensor data */
             std::move(std::get<1>(volume_data_fakes)),
             /* get<0> = index of dimensions */


### PR DESCRIPTION
## Proposed changes

Allow specifying the name of the subfile inside reduction and volume HDF5 files so we can have multiple observers going at once.

@markscheel I think this should do what you need!

### Types of changes:

- [x] Bugfix

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
