### PR TITLE
Check if Charm++ is SMP and add macro if it is

### DIFF
--- a/cmake/SetupCharm.cmake
+++ b/cmake/SetupCharm.cmake
@@ -33,7 +33,34 @@ configure_file(
 
 include(SetupCharmModuleFunctions)
 
+# Check if Charm++ was built with SMP support
+set(SPECTRE_SHARED_MEMORY_PARALLELISM_BUILD NO)
+if (EXISTS "${CHARM_INCLUDE_DIRS}/conv-mach.h")
+  file(READ "${CHARM_INCLUDE_DIRS}/conv-mach.h" CONV_MACH_HEADER)
+  string(REPLACE "\n" ";" CONV_MACH_HEADER ${CONV_MACH_HEADER})
+  foreach (LINE ${CONV_MACH_HEADER})
+    if (LINE MATCHES "#define[ \t]+CMK_SMP[ \t]+1")
+      set(SPECTRE_SHARED_MEMORY_PARALLELISM_BUILD YES)
+      break()
+    endif()
+  endforeach()
+else()
+  message(FATAL_ERROR
+    "Unable to detect whether or not Charm++ was built with shared "
+    "memory parallelism enabled because the file "
+    "'${CHARM_INCLUDE_DIRS}/conv-mach.h' was not found. Please file "
+    "an issue for support with this error since that file should be "
+    "generated as part of the Charm++ build process.")
+endif()
+if (${SPECTRE_SHARED_MEMORY_PARALLELISM_BUILD})
+  message(STATUS "Charm++ built with shared memory parallelism")
+  add_definitions(-DSPECTRE_SHARED_MEMORY_PARALLELISM_BUILD)
+else()
+  message(STATUS "Charm++ NOT built with shared memory parallelism")
+endif()
+
 file(APPEND
   "${CMAKE_BINARY_DIR}/LibraryVersions.txt"
   "Charm Version:  ${CHARM_VERSION}\n"
+  "Charm SMP:  ${SPECTRE_SHARED_MEMORY_PARALLELISM_BUILD}\n"
   )


### PR DESCRIPTION
## Proposed changes

For storing large datasets like tabulated equations of state we will likely want
to know if Charm++ was built in SMP mode so we know whether we can afford to
store the table in memory.

This came up on the Charm++ mailing list and I figured it would be useful for us to have.

### Types of changes:

- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
