### PR TITLE
Transplant easily generalized tests to VectorImplTestHelper from Test_DataVector

### DIFF
--- a/tests/Unit/DataStructures/Test_DataVector.cpp
+++ b/tests/Unit/DataStructures/Test_DataVector.cpp
@@ -8,9 +8,8 @@
 #include <cmath>
 #include <cstddef>
 #include <functional>
-#include <numeric>
 
-#include "DataStructures/DataVector.hpp"
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"  // IWYU pragma: keep
@@ -18,194 +17,45 @@
 #include "Utilities/Math.hpp"  // IWYU pragma: keep
 #include "Utilities/Requires.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
-#include "tests/Unit/TestHelpers.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/DataStructures/VectorImplTestHelper.hpp"
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.DataStructures.DataVector.ExpressionAssignError",
+    "[Unit][DataStructures]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<DataVector>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::ExpressionAssign);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.RefDiffSize",
+                               "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<DataVector>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::Copy);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, Must copy into same size]]
+[[noreturn]] SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.MoveRefDiffSize",
+                               "[DataStructures][Unit]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  TestHelpers::VectorImpl::vector_ref_test_size_error<DataVector>(
+      TestHelpers::VectorImpl::RefSizeErrorTestKind::Move);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
 
 namespace {
-void test_main() {
-  DataVector a{2};
-  CHECK(a.size() == 2);
-  DataVector b{2, 10.0};
-  CHECK(b.size() == 2);
-  for (size_t i = 0; i < b.size(); ++i) {
-    INFO(i);
-    CHECK(b[i] == 10.0);
-  }
 
-  DataVector t(5, 10.0);
-  CHECK(t.size() == 5);
-  for (size_t i = 0; i < t.size(); ++i) {
-    INFO(i);
-    CHECK(t[i] == 10.0);
-  }
-  for (const auto& p : t) {
-    CHECK(p == 10.0);
-  }
-  for (auto& p : t) {
-    CHECK(p == 10.0);
-  }
-  DataVector t2{1.43, 2.83, 3.94, 7.85};
-  CHECK(t2.size() == 4);
-  CHECK(t2.is_owning());
-  CHECK(t2[0] == 1.43);
-  CHECK(t2[1] == 2.83);
-  CHECK(t2[2] == 3.94);
-  CHECK(t2[3] == 7.85);
-  test_copy_semantics(t);
-  auto t_copy = t;
-  CHECK(t_copy.is_owning());
-  test_move_semantics(std::move(t), t_copy);
-  DataVector t_move_assignment = std::move(t_copy);
-  CHECK(t_move_assignment.is_owning());
-  DataVector t_move_constructor = std::move(t_move_assignment);
-  CHECK(t_move_constructor.is_owning());
-}
-
-void test_serialization() {
-  const size_t npts = 10;
-  DataVector t(npts), tgood(npts);
-  std::iota(t.begin(), t.end(), 1.2);
-  std::iota(tgood.begin(), tgood.end(), 1.2);
-  CHECK(tgood == t);
-  CHECK(t.is_owning());
-  CHECK(tgood.is_owning());
-  const DataVector serialized = serialize_and_deserialize(t);
-  CHECK(tgood == t);
-  CHECK(serialized == tgood);
-  CHECK(serialized.is_owning());
-  CHECK(serialized.data() != t.data());
-  CHECK(t.is_owning());
-}
-
-void test_serialization_ref() {
-  const size_t npts = 10;
-  DataVector t(npts);
-  std::iota(t.begin(), t.end(), 4.3);
-  DataVector t2;
-  t2.set_data_ref(&t);
-  CHECK(t.is_owning());
-  CHECK_FALSE(t2.is_owning());
-  CHECK(t2 == t);
-  const DataVector serialized = serialize_and_deserialize(t);
-  CHECK(t2 == t);
-  CHECK(serialized == t2);
-  CHECK(serialized.is_owning());
-  CHECK(serialized.data() != t.data());
-  CHECK(t.is_owning());
-  const DataVector serialized2 = serialize_and_deserialize(t2);
-  CHECK(t2 == t);
-  CHECK(serialized2 == t2);
-  CHECK(serialized2.is_owning());
-  CHECK(serialized2.data() != t2.data());
-  CHECK_FALSE(t2.is_owning());
-}
-
-void test_datavector_ref() {
-  DataVector data{1.43, 2.83, 3.94, 7.85};
-  DataVector t;
-  t.set_data_ref(&data);
-  CHECK(not t.is_owning());
-  CHECK(data.is_owning());
-  CHECK(t.data() == data.data());
-  CHECK(t.size() == 4);
-  CHECK(t[0] == 1.43);
-  CHECK(t[1] == 2.83);
-  CHECK(t[2] == 3.94);
-  CHECK(t[3] == 7.85);
-  test_copy_semantics(t);
-  DataVector t_copy;
-  t_copy.set_data_ref(&t);
-  test_move_semantics(std::move(t), t_copy);
-  DataVector t_move_assignment = std::move(t_copy);
-  CHECK(not t_move_assignment.is_owning());
-  DataVector t_move_constructor = std::move(t_move_assignment);
-  CHECK(not t_move_constructor.is_owning());
-  {
-    DataVector data_2{1.43, 2.83, 3.94, 7.85};
-    DataVector data_2_ref;
-    data_2_ref.set_data_ref(&data_2);
-    DataVector data_3{2.43, 3.83, 4.94, 8.85};
-    data_2_ref = std::move(data_3);
-    CHECK(data_2[0] == 2.43);
-    CHECK(data_2[1] == 3.83);
-    CHECK(data_2[2] == 4.94);
-    CHECK(data_2[3] == 8.85);
-// Intentionally testing self-move
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wself-move"
-#endif  // defined(__clang__)
-    data_2_ref = std::move(data_2_ref);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif  // defined(__clang__)
-    CHECK(data_2[0] == 2.43);
-    CHECK(data_2[1] == 3.83);
-    CHECK(data_2[2] == 4.94);
-    CHECK(data_2[3] == 8.85);
-    DataVector owned_data;
-    // clang-tidy: false positive, used after it was moved
-    owned_data = data_2_ref;  // NOLINT
-    CHECK(owned_data[0] == 2.43);
-    CHECK(owned_data[1] == 3.83);
-    CHECK(owned_data[2] == 4.94);
-    CHECK(owned_data[3] == 8.85);
-    // Test operator!=
-    CHECK_FALSE(owned_data != data_2_ref);
-  }
-}
-
-template <typename T1, typename T2>
-void check_vectors(const T1& t1, const T2& t2) {
-  CHECK_ITERABLE_APPROX(t1, t2);
-}
-
-void test_datavector_math_after_move() {
-  DataVector m0(10, 3.0), m1(10, 9.0);
-  {
-    DataVector a(10, 2.0);
-    DataVector b{};
-    b = std::move(a);
-    b = m0 + m1;
-    check_vectors(b, DataVector(10, 12.0));
-    // clang-tidy: use after move (intentional here)
-    CHECK(a.size() == 0);  // NOLINT
-    CHECK(a.is_owning());
-    a = m0 * m1;
-    check_vectors(a, DataVector(10, 27.0));
-    check_vectors(b, DataVector(10, 12.0));
-  }
-
-  {
-    DataVector a(10, 2.0);
-    DataVector b{};
-    b = std::move(a);
-    a = m0 + m1;
-    check_vectors(b, DataVector(10, 2.0));
-    check_vectors(a, DataVector(10, 12.0));
-  }
-
-  {
-    DataVector a(10, 2.0);
-    DataVector b{std::move(a)};
-    b = m0 + m1;
-    CHECK(b.size() == 10);
-    check_vectors(b, DataVector(10, 12.0));
-    // clang-tidy: use after move (intentional here)
-    CHECK(a.size() == 0);  // NOLINT
-    CHECK(a.is_owning());
-    a = m0 * m1;
-    check_vectors(a, DataVector(10, 27.0));
-    check_vectors(b, DataVector(10, 12.0));
-  }
-
-  {
-    DataVector a(10, 2.0);
-    DataVector b{std::move(a)};
-    a = m0 + m1;
-    check_vectors(b, DataVector(10, 2.0));
-    check_vectors(a, DataVector(10, 12.0));
-  }
-}
 enum class UseRefWrap { None, Cref, Ref };
 
 template <UseRefWrap Wrap, class T,
@@ -221,6 +71,12 @@ template <UseRefWrap Wrap, class T,
           Requires<Wrap == UseRefWrap::None> = nullptr>
 decltype(auto) wrap(const T& t) noexcept {
   return t;
+}
+
+// duplicate check vectors needed for math tests until those are updated
+template <typename T1, typename T2>
+void check_vectors(const T1& t1, const T2& t2) {
+  CHECK_ITERABLE_APPROX(t1, t2);
 }
 
 // Wrap is used to wrap values in a std::reference_wrapper using std::cref and
@@ -545,55 +401,26 @@ void test_datavector_math() {
   test_datavector_array_math();
 }
 }  // namespace
-
 SPECTRE_TEST_CASE("Unit.DataStructures.DataVector", "[DataStructures][Unit]") {
-  test_main();
-  test_serialization();
-  test_serialization_ref();
-  test_datavector_ref();
-  test_datavector_math_after_move();
-  test_datavector_math();
-}
-
-// [[OutputRegex, Must copy into same size]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.DataStructures.DataVector.ExpressionAssignError",
-    "[Unit][DataStructures]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  DataVector one(10, 1.0);
-  DataVector one_ref(one.data(), one.size());
-  DataVector one_b(2, 1.0);
-  one_ref = (one_b * one_b);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Must copy into same size]]
-[[noreturn]] SPECTRE_TEST_CASE("Unit.DataStructures.DataVector.ref_diff_size",
-                               "[DataStructures][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  DataVector data{1.43, 2.83, 3.94, 7.85};
-  DataVector data_ref;
-  data_ref.set_data_ref(&data);
-  DataVector data2{1.43, 2.83, 3.94};
-  data_ref = data2;
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Must copy into same size]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.DataStructures.DataVector.move_ref_diff_size",
-    "[DataStructures][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  DataVector data{1.43, 2.83, 3.94, 7.85};
-  DataVector data_ref;
-  data_ref.set_data_ref(&data);
-  DataVector data2{1.43, 2.83, 3.94};
-  data_ref = std::move(data2);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
+  {
+    INFO("test construct and assign");
+    TestHelpers::VectorImpl::vector_test_construct_and_assign<DataVector,
+                                                              double>();
+  }
+  {
+    INFO("test serialize and deserialize");
+    TestHelpers::VectorImpl::vector_test_serialize<DataVector, double>();
+  }
+  {
+    INFO("test set_data_ref functionality");
+    TestHelpers::VectorImpl::vector_test_ref<DataVector, double>();
+  }
+  {
+    INFO("test math after move");
+    TestHelpers::VectorImpl::vector_test_math_after_move<DataVector, double>();
+  }
+  {
+    INFO("test DataVector math operations");
+    test_datavector_math();
+  }
 }

--- a/tests/Unit/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/DataStructures/VectorImplTestHelper.hpp
@@ -9,10 +9,13 @@
 #include <utility>
 
 #include "DataStructures/VectorImpl.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/Tuple.hpp"
+#include "tests/Unit/TestHelpers.hpp"
 #include "tests/Unit/TestingFramework.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
 
 namespace TestHelpers {
 namespace VectorImpl {
@@ -71,7 +74,7 @@ template <typename T1, typename T2, size_t S>
 void check_vectors(const T1& t1, const std::array<T2, S>& t2) noexcept {
   check_vectors(t2, t1);
 }
-} // namespace detail
+}  // namespace detail
 
 // @{
 /*!
@@ -116,8 +119,8 @@ template <size_t ArgLength, typename T, typename... Elements, typename... Args,
 constexpr inline void apply_tuple_combinations(
     const std::tuple<Elements...>& set, const T& function,
     const Args&... args) noexcept {
-  tuple_fold(set, [&function, &set, &args...](const auto& x) noexcept {
-      apply_tuple_combinations<ArgLength>(set, function, x, args...);
+  tuple_fold(set, [&function, &set, &args... ](const auto& x) noexcept {
+    apply_tuple_combinations<ArgLength>(set, function, x, args...);
   });
 }
 // @}
@@ -159,6 +162,348 @@ auto remove_nth(const std::tuple<ValueTypes...>& tup) noexcept {
   return detail::remove_nth_impl<N>(
       tup, std::make_index_sequence<N>(),
       std::make_index_sequence<sizeof...(ValueTypes) - N - 1>());
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief test construction and assignment of a `VectorType` with a `ValueType`
+template <typename VectorType, typename ValueType>
+void vector_test_construct_and_assign(
+    typename tt::get_fundamental_type_t<ValueType> low =
+        typename tt::get_fundamental_type_t<ValueType>{-100.0},
+    typename tt::get_fundamental_type_t<ValueType> high =
+        typename tt::get_fundamental_type_t<ValueType>{100.0}) noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<typename tt::get_fundamental_type_t<ValueType>>
+      dist{low, high};
+  UniformCustomDistribution<size_t> sdist{2, 20};
+
+  const size_t size = sdist(gen);
+
+  const VectorType size_constructed{size};
+  CHECK(size_constructed.size() == size);
+  const auto generated_value1 = make_with_random_values<ValueType>(
+      make_not_null(&gen), make_not_null(&dist));
+
+  const VectorType value_size_constructed{size, generated_value1};
+  CHECK(value_size_constructed.size() == size);
+  alg::for_each(value_size_constructed, [
+    generated_value1, &value_size_constructed
+  ](typename VectorType::value_type element) noexcept {
+    CAPTURE_PRECISE(value_size_constructed);
+    CHECK(element == generated_value1);
+  });
+
+  // random generation must use `make_with_random_values`, because stored value
+  // in vector type might be a non-fundamental type.
+  const auto generated_value2 = make_with_random_values<ValueType>(
+      make_not_null(&gen), make_not_null(&dist));
+  const auto generated_value3 = make_with_random_values<ValueType>(
+      make_not_null(&gen), make_not_null(&dist));
+
+  VectorType initializer_list_constructed{
+      {static_cast<typename VectorType::value_type>(generated_value2),
+       static_cast<typename VectorType::value_type>(generated_value3)}};
+  CHECK(initializer_list_constructed.size() == 2);
+  CHECK(initializer_list_constructed.is_owning());
+  CHECK(gsl::at(initializer_list_constructed, 0) == generated_value2);
+  CHECK(gsl::at(initializer_list_constructed, 1) == generated_value3);
+
+  typename VectorType::value_type raw_ptr[2] = {generated_value2,
+                                                generated_value3};
+  const VectorType pointer_size_constructed{
+      static_cast<typename VectorType::value_type*>(raw_ptr), 2};
+  CHECK(initializer_list_constructed == pointer_size_constructed);
+  CHECK_FALSE(initializer_list_constructed != pointer_size_constructed);
+
+  test_copy_semantics(initializer_list_constructed);
+  auto initializer_list_constructed_copy = initializer_list_constructed;
+  CHECK(initializer_list_constructed_copy.is_owning());
+  CHECK(initializer_list_constructed_copy == pointer_size_constructed);
+  test_move_semantics(std::move(initializer_list_constructed),
+                      initializer_list_constructed_copy);
+
+  VectorType move_assignment_initialized;
+  move_assignment_initialized = std::move(initializer_list_constructed_copy);
+  CHECK(move_assignment_initialized.is_owning());
+
+  const VectorType move_constructed{std::move(move_assignment_initialized)};
+  CHECK(move_constructed.is_owning());
+  CHECK(move_constructed == pointer_size_constructed);
+
+  // clang-tidy has performance complaints, and we're checking functionality
+  const VectorType copy_constructed{move_constructed};  // NOLINT
+  CHECK(copy_constructed.is_owning());
+  CHECK(copy_constructed == pointer_size_constructed);
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief test the serialization of a `VectorType` constructed with a
+/// `ValueType`
+template <typename VectorType, typename ValueType>
+void vector_test_serialize(
+    typename tt::get_fundamental_type_t<ValueType> low =
+        typename tt::get_fundamental_type_t<ValueType>{-100.0},
+    typename tt::get_fundamental_type_t<ValueType> high =
+        typename tt::get_fundamental_type_t<ValueType>{100.0}) noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<typename tt::get_fundamental_type_t<ValueType>>
+      dist{low, high};
+  UniformCustomDistribution<size_t> sdist{2, 20};
+
+  const size_t size = sdist(gen);
+  VectorType vector_test{size}, vector_control{size};
+  VectorType vector_ref;
+  const auto start_value = make_with_random_values<ValueType>(
+      make_not_null(&gen), make_not_null(&dist));
+  const auto value_difference = make_with_random_values<ValueType>(
+      make_not_null(&gen), make_not_null(&dist));
+  // generate_series is used to generate a pair of equivalent, but independently
+  // constructed, data sets to fill the vectors with.
+  ValueType current_value = start_value;
+  const auto generate_series = [&current_value, value_difference ]() noexcept {
+    return current_value += value_difference;
+  };
+  std::generate(vector_test.begin(), vector_test.end(), generate_series);
+  current_value = start_value;
+  std::generate(vector_control.begin(), vector_control.end(), generate_series);
+  // checks the vectors have been constructed as expected
+  CHECK(vector_control == vector_test);
+  CHECK(vector_test.is_owning());
+  CHECK(vector_control.is_owning());
+  const VectorType serialized_vector_test =
+      serialize_and_deserialize(vector_test);
+  // check that the vector is unaltered by serialize_and_deserialize
+  CHECK(vector_control == vector_test);
+  CHECK(serialized_vector_test == vector_control);
+  CHECK(serialized_vector_test.is_owning());
+  CHECK(serialized_vector_test.data() != vector_test.data());
+  CHECK(vector_test.is_owning());
+  // checks serialization for reference
+  vector_ref.set_data_ref(&vector_test);
+  CHECK(vector_test.is_owning());
+  CHECK_FALSE(vector_ref.is_owning());
+  CHECK(vector_ref == vector_test);
+  const VectorType serialized_vector_ref =
+      serialize_and_deserialize(vector_ref);
+  CHECK(vector_test.is_owning());
+  CHECK(vector_test == vector_control);
+  CHECK(vector_ref == vector_test);
+  CHECK(serialized_vector_ref == vector_test);
+  CHECK(serialized_vector_ref.is_owning());
+  CHECK(serialized_vector_ref.data() != vector_ref.data());
+  CHECK_FALSE(vector_ref.is_owning());
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief test the construction and move of a reference `VectorType`
+/// constructed with a `ValueType`
+template <typename VectorType, typename ValueType>
+void vector_test_ref(typename tt::get_fundamental_type_t<ValueType> low =
+                         typename tt::get_fundamental_type_t<ValueType>{-100.0},
+                     typename tt::get_fundamental_type_t<ValueType> high =
+                         typename tt::get_fundamental_type_t<ValueType>{
+                             100.0}) noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<typename tt::get_fundamental_type_t<ValueType>>
+      dist{low, high};
+  UniformCustomDistribution<size_t> sdist{2, 20};
+
+  const size_t size = sdist(gen);
+  VectorType original_vector = make_with_random_values<VectorType>(
+      make_not_null(&gen), make_not_null(&dist), VectorType{size});
+
+  {
+    INFO("Check construction, copy, move, and ownership of reference vectors")
+    VectorType ref_vector;
+    ref_vector.set_data_ref(&original_vector);
+    CHECK_FALSE(ref_vector.is_owning());
+    CHECK(original_vector.is_owning());
+    CHECK(ref_vector.data() == original_vector.data());
+
+    const VectorType data_check{original_vector};
+    CHECK(ref_vector.size() == size);
+    CHECK(ref_vector == data_check);
+    test_copy_semantics(ref_vector);
+
+    VectorType ref_vector_copy;
+    ref_vector_copy.set_data_ref(&ref_vector);
+    test_move_semantics(std::move(ref_vector), ref_vector_copy);
+    VectorType move_assignment_initialized;
+    move_assignment_initialized = std::move(ref_vector_copy);
+    CHECK(not move_assignment_initialized.is_owning());
+    const VectorType move_constructed{std::move(move_assignment_initialized)};
+    CHECK(not move_constructed.is_owning());
+  }
+  {
+    INFO("Check move acts appropriately on both source and target refs")
+    VectorType ref_original_vector;
+    ref_original_vector.set_data_ref(&original_vector);
+    VectorType generated_vector = make_with_random_values<VectorType>(
+        make_not_null(&gen), make_not_null(&dist), VectorType{size});
+    const VectorType generated_vector_copy = generated_vector;
+    ref_original_vector = std::move(generated_vector);
+    // clang-tidy : Intentionally testing use after move
+    CHECK(original_vector != generated_vector);  // NOLINT
+    CHECK(original_vector == generated_vector_copy);
+// Intentionally testing self-move
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+#endif  // defined(__clang__)
+    ref_original_vector = std::move(ref_original_vector);
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif  // defined(__clang__)
+    CHECK(original_vector == generated_vector_copy);
+    // clang-tidy: false positive, used after it was moved
+    const VectorType data_check_vector = ref_original_vector;  // NOLINT
+    CHECK(data_check_vector == generated_vector_copy);
+  }
+  {
+    INFO("Check math affects both data vectors which share a ref")
+    const auto generated_value1 = make_with_random_values<ValueType>(
+        make_not_null(&gen), make_not_null(&dist));
+    const auto generated_value2 = make_with_random_values<ValueType>(
+        make_not_null(&gen), make_not_null(&dist));
+    const auto sum_generated_values = generated_value1 + generated_value2;
+    VectorType sharing_vector{size, generated_value1};
+    VectorType owning_vector{size, generated_value2};
+    sharing_vector.set_data_ref(&owning_vector);
+    sharing_vector = sharing_vector + generated_value1;
+    detail::check_vectors(owning_vector, sum_generated_values);
+    detail::check_vectors(sharing_vector, sum_generated_values);
+  }
+}
+
+enum RefSizeErrorTestKind { Copy, ExpressionAssign, Move };
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Test that assigning to a non-owning `VectorType` of the wrong size
+/// appropriately generates an error.
+///
+/// \details a calling function should be an `ASSERTION_TEST()` and check for
+/// the string "Must copy into same size".
+/// Three types of tests are provided and one must be provided as the first
+/// function argument:
+/// - `RefSizeErrorTestKind::Copy`: Checks that copy-assigning to a non-owning
+/// `VectorType` from a `VectorType` with the wrong size generates an error.
+/// - `RefSizeErrorTestKind::ExpressionAssign`: Checks that assigning to a
+/// non-owning `VectorType` from an expression with alias `ResultType` of
+/// `VectorType` with the wrong size generates an error
+/// - `RefSizeErrorTestKind::Move`: Checks that move-assigning to a non-owning
+/// `VectorType` from a `VectorType` with the wrong size generates an error.
+template <typename VectorType,
+          typename ValueType = typename VectorType::ElementType>
+void vector_ref_test_size_error(
+    RefSizeErrorTestKind test_kind,
+    typename tt::get_fundamental_type_t<ValueType> low =
+        typename tt::get_fundamental_type_t<ValueType>{-100.0},
+    typename tt::get_fundamental_type_t<ValueType> high =
+        typename tt::get_fundamental_type_t<ValueType>{100.0}) noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<typename tt::get_fundamental_type_t<ValueType>>
+      dist{low, high};
+  UniformCustomDistribution<size_t> sdist{2, 20};
+
+  const size_t size = sdist(gen);
+  VectorType generated_vector = make_with_random_values<VectorType>(
+      make_not_null(&gen), make_not_null(&dist), VectorType{size});
+  VectorType ref_generated_vector;
+  ref_generated_vector.set_data_ref(&generated_vector);
+  const VectorType larger_generated_vector =
+      make_with_random_values<VectorType>(
+          make_not_null(&gen), make_not_null(&dist), VectorType{size + 1});
+  // each of the following options should error, the reference should have
+  // received the wrong size
+  if (test_kind == RefSizeErrorTestKind::Copy) {
+    ref_generated_vector = larger_generated_vector;
+  }
+  if (test_kind == RefSizeErrorTestKind::ExpressionAssign) {
+    ref_generated_vector = (larger_generated_vector + larger_generated_vector);
+  }
+  if (test_kind == RefSizeErrorTestKind::Move) {
+    ref_generated_vector = std::move(larger_generated_vector);
+  }
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief tests a small sample of math functions after a move of a
+/// `VectorType` initialized with `ValueType`
+template <typename VectorType, typename ValueType>
+void vector_test_math_after_move(
+    typename tt::get_fundamental_type_t<ValueType> low =
+        typename tt::get_fundamental_type_t<ValueType>{-100.0},
+    typename tt::get_fundamental_type_t<ValueType> high =
+        typename tt::get_fundamental_type_t<ValueType>{100.0}) noexcept {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<typename tt::get_fundamental_type_t<ValueType>>
+      dist{low, high};
+  UniformCustomDistribution<size_t> sdist{2, 20};
+
+  const size_t size = sdist(gen);
+  const auto generated_value1 = make_with_random_values<ValueType>(
+      make_not_null(&gen), make_not_null(&dist));
+  const auto generated_value2 = make_with_random_values<ValueType>(
+      make_not_null(&gen), make_not_null(&dist));
+  const auto sum_generated_values = generated_value1 + generated_value2;
+  const auto difference_generated_values = generated_value1 - generated_value2;
+
+  const VectorType vector_math_lhs{size, generated_value1},
+      vector_math_rhs{size, generated_value2};
+  {
+    INFO("Check move assignment and use after move");
+    VectorType from_vector = make_with_random_values<VectorType>(
+        make_not_null(&gen), make_not_null(&dist), VectorType{size});
+    VectorType to_vector{};
+    to_vector = std::move(from_vector);
+    to_vector = vector_math_lhs + vector_math_rhs;
+    detail::check_vectors(to_vector, VectorType{size, sum_generated_values});
+    // clang-tidy: use after move (intentional here)
+    CHECK(from_vector.size() == 0);  // NOLINT
+    CHECK(from_vector.is_owning());
+    from_vector = vector_math_lhs - vector_math_rhs;
+    detail::check_vectors(from_vector,
+                          VectorType{size, difference_generated_values});
+    detail::check_vectors(to_vector, sum_generated_values);
+  }
+  {
+    INFO("Check move assignment and value of target")
+    auto from_value = make_with_random_values<ValueType>(make_not_null(&gen),
+                                                         make_not_null(&dist));
+    VectorType from_vector{size, from_value};
+    VectorType to_vector{};
+    to_vector = std::move(from_vector);
+    from_vector = vector_math_lhs + vector_math_rhs;
+    detail::check_vectors(to_vector, from_value);
+    detail::check_vectors(from_vector, sum_generated_values);
+  }
+  {
+    INFO("Check move constructor and use after move")
+    VectorType from_vector = make_with_random_values<VectorType>(
+        make_not_null(&gen), make_not_null(&dist), VectorType{size});
+    VectorType to_vector{std::move(from_vector)};
+    to_vector = vector_math_lhs + vector_math_rhs;
+    CHECK(to_vector.size() == size);
+    detail::check_vectors(to_vector, sum_generated_values);
+    // clang-tidy: use after move (intentional here)
+    CHECK(from_vector.size() == 0);  // NOLINT
+    CHECK(from_vector.is_owning());
+    from_vector = vector_math_lhs - vector_math_rhs;
+    detail::check_vectors(from_vector,
+                          VectorType{size, difference_generated_values});
+    detail::check_vectors(to_vector, VectorType{size, sum_generated_values});
+  }
+
+  {
+    INFO("Check move constructor and value of target")
+    auto from_value = make_with_random_values<ValueType>(make_not_null(&gen),
+                                                         make_not_null(&dist));
+    VectorType from_vector{size, from_value};
+    const VectorType to_vector{std::move(from_vector)};
+    from_vector = vector_math_lhs + vector_math_rhs;
+    detail::check_vectors(to_vector, VectorType{size, from_value});
+    detail::check_vectors(from_vector, VectorType{size, sum_generated_values});
+  }
 }
 }  // namespace VectorImpl
 }  // namespace TestHelpers


### PR DESCRIPTION
## Proposed changes

Move tests which are easy to reformulate as general template tests from `Test_DataVector.cpp` to `VectorImplTestHelper.hpp`, and make use of the new test utilities instead. Also, the tests have been modernized to use random values and variable names and structure of the tests have been adjusted for clarity.
This is the 6th commit from #935.

### Depends on:
- [x] #1225 

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
