### PR TITLE
Add flake8 and autopep8 to Docker buildenv image

### DIFF
--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -36,7 +36,8 @@ RUN apt-get update -y && apt-get install -y libc++-dev libc++1 libc++abi-dev \
 # Install ccache to cache compilations for reduced compile time, Doxygen
 # and coverxygen to check documentation coverage
 RUN apt-get install -y ccache doxygen python-pip && pip install coverxygen \
-    && pip install numpy && pip install scipy
+        && pip install numpy && pip install scipy \
+        && pip install --upgrade autopep8 flake8
 
 # Add ruby gems and install coveralls using gem
 RUN apt-get update -y && apt-get install -y rubygems && \


### PR DESCRIPTION
## Proposed changes

These are already in the docker image and have been for a while.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
