### PR TITLE
Improve ObserveSurfaceIntegrals

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveSurfaceIntegrals.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveSurfaceIntegrals.hpp
@@ -3,17 +3,22 @@
 
 #pragma once
 
-#include <algorithm>
+#include <array>
 #include <cstddef>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "ApparentHorizons/StrahlkorperGr.hpp"
-#include "IO/H5/AccessType.hpp"
-#include "IO/H5/Dat.hpp"
-#include "IO/H5/File.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Functional.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -33,10 +38,61 @@ namespace db {
 template <typename TagsList>
 class DataBox;
 }  // namespace db
+namespace observers {
+namespace ThreadedActions {
+struct WriteReductionData;
+}  // namespace ThreadedActions
+template <class Metavariables>
+struct ObserverWriter;
+}  // namespace observers
 /// \endcond
 
 namespace intrp {
 namespace callbacks {
+
+namespace detail {
+template <typename T>
+struct reduction_data_type;
+
+template <typename... Ts>
+struct reduction_data_type<tmpl::list<Ts...>> {
+  // We use ReductionData because that is what is expected by the
+  // ObserverWriter.  We do a "reduction" that involves only one
+  // processing element (often equivalent to a core),
+  // so AssertEqual is used here as a no-op.
+  //
+  // The first argument is for Time, the others are for
+  // the list of scalars being integrated.
+  using type = Parallel::ReductionData<
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<typename Ts::type::type::value_type,
+                               funcl::AssertEqual<>>...>;
+};
+
+template <typename T>
+struct reduction_data_tag_type;
+
+template <typename... Ts>
+struct reduction_data_tag_type<tmpl::list<Ts...>> {
+  // The first argument is for Time, the others are for
+  // the list of scalars being integrated.
+  using type = tmpl::list<observers::Tags::ReductionData<
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<typename Ts::type::type::value_type,
+                               funcl::AssertEqual<>>...>>;
+};
+
+template <typename List, size_t... Is>
+auto make_reduction_data(const std::array<double, sizeof...(Is)>& a,
+                         std::index_sequence<Is...> /* meta */) noexcept {
+  return typename reduction_data_type<List>::type(gsl::at(a, Is)...);
+}
+
+template <typename List, size_t N>
+auto make_reduction_data(const std::array<double, N>& a) noexcept {
+  return make_reduction_data<List>(a, std::make_index_sequence<N>{});
+}
+}  // namespace detail
 
 /// \brief post_interpolation_callback that outputs
 /// surface integrals on a Strahlkorper.
@@ -44,8 +100,6 @@ namespace callbacks {
 /// Uses:
 /// - Metavariables
 ///   - `temporal_id`
-/// - ConstGlobalCache:
-///   - `FileNameTag`
 /// - DataBox:
 ///   - `StrahlkorperTags::items_tags<Frame>`
 ///   - `StrahlkorperTags::compute_items_tags<Frame>`
@@ -53,13 +107,13 @@ namespace callbacks {
 ///
 /// This is an InterpolationTargetTag::post_interpolation_callback;
 /// see InterpolationTarget for a description of InterpolationTargetTag.
-template <typename TagsToObserve, typename FileNameTag, typename Frame>
+template <typename TagsToObserve, typename InterpolationTargetTag,
+          typename Frame>
 struct ObserveSurfaceIntegrals {
-  using const_global_cache_tags = tmpl::list<FileNameTag>;
   template <typename DbTags, typename Metavariables>
   static void apply(
       const db::DataBox<DbTags>& box,
-      const Parallel::ConstGlobalCache<Metavariables>& cache,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
       const typename Metavariables::temporal_id& temporal_id) noexcept {
     // Do the integrals and construct the legend.
     const auto& strahlkorper = get<StrahlkorperTags::Strahlkorper<Frame>>(box);
@@ -69,32 +123,36 @@ struct ObserveSurfaceIntegrals {
         get<StrahlkorperTags::NormalOneForm<Frame>>(box),
         get<StrahlkorperTags::Radius<Frame>>(box),
         get<StrahlkorperTags::Rhat<Frame>>(box));
-    std::vector<double> time_and_integrals(tmpl::size<TagsToObserve>::value +
-                                           1);
+
+    // The +1 in the sizes below is because `TagsToObserve` contains
+    // only the integrals, but both `legend` and `time_and_integrals` contain
+    // time in addition to the integrals.
     std::vector<std::string> legend(tmpl::size<TagsToObserve>::value + 1);
+    std::array<double, tmpl::size<TagsToObserve>::value + 1>
+        time_and_integrals{};
     time_and_integrals[0] = temporal_id.time().value();
     legend[0] = "Time";
     size_t s = 1;
-    tmpl::for_each<TagsToObserve>([&](auto tag) noexcept {
-      using Tag = typename decltype(tag)::type;
+    tmpl::for_each<TagsToObserve>([&](auto tag_v) noexcept {
+      using Tag = typename decltype(tag_v)::type;
       const auto& scalar = get<Tag>(box);
-      time_and_integrals[s] = StrahlkorperGr::surface_integral_of_scalar(
-          area_element, scalar, strahlkorper);
+      gsl::at(time_and_integrals, s) =
+          StrahlkorperGr::surface_integral_of_scalar(area_element, scalar,
+                                                     strahlkorper);
       legend[s] = Tag::name();
       ++s;
     });
 
-    // Write to a file.
-    // Currently there is no file locking.
-    // When issue #1198 is resolved we will replace the file-writing here with
-    // calls to the observer infrastructure, which takes care of the file
-    // locking.
-    const auto& file_prefix = Parallel::get<FileNameTag>(cache);
-    h5::H5File<h5::AccessType::ReadWrite> h5file(file_prefix + ".h5", true);
-    constexpr size_t version_number = 0;
-    auto& time_series_file = h5file.try_insert<h5::Dat>(
-        "/surface_integrals", std::move(legend), version_number);
-    time_series_file.append(time_and_integrals);
+    auto& proxy = Parallel::get_parallel_component<
+        observers::ObserverWriter<Metavariables>>(cache);
+
+    // We call this on proxy[0] because the 0th element of a NodeGroup is
+    // always guaranteed to be present.
+    Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(
+        proxy[0], observers::ObservationId(temporal_id.time()),
+        std::string{"/" + pretty_type::short_name<InterpolationTargetTag>() +
+                    "_integrals"},
+        legend, detail::make_reduction_data<TagsToObserve>(time_and_integrals));
   }
 };
 }  // namespace callbacks

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -364,6 +364,10 @@ class MockDistributedObject {
     simple_action_queue_.pop_front();
   }
 
+  bool is_threaded_action_queue_empty() noexcept {
+    return threaded_action_queue_.empty();
+  }
+
   void invoke_queued_threaded_action() noexcept {
     if (threaded_action_queue_.empty()) {
       ERROR(
@@ -852,6 +856,16 @@ class MockRuntimeSystem {
   void invoke_queued_simple_action(
       const typename Component::array_index& array_index) noexcept {
     algorithms<Component>().at(array_index).invoke_queued_simple_action();
+  }
+
+  /// Return true if there are no queued threaded actions on the
+  /// `Component` labeled by `array_index`.
+  template <typename Component>
+  bool is_threaded_action_queue_empty(
+      const typename Component::array_index& array_index) noexcept {
+    return algorithms<Component>()
+        .at(array_index)
+        .is_threaded_action_queue_empty();
   }
 
   /// Invoke the next queued threaded action on the `Component` labeled by


### PR DESCRIPTION
## Proposed changes

ObserveSurfaceIntegrals no longer writes its own file, but instead uses the ObserverWriter action
to do it.

Partially solves #1198 

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments
