### PR TITLE
Work around gcc ICE in elliptic ImposeBoundaryConditions.hpp

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
@@ -101,12 +101,14 @@ struct ImposeHomogeneousDirichletBoundaryConditions {
     db::mutate<Tags::Interface<Tags::BoundaryDirectionsExterior<volume_dim>,
                                typename system::variables_tag>>(
         make_not_null(&box),
-        [](const gsl::not_null<db::item_type<
-               Tags::Interface<Tags::BoundaryDirectionsExterior<volume_dim>,
-                               typename system::variables_tag>>*>
+        // Need to use system::volume_dim below instead of just
+        // volume_dim to avoid an ICE on gcc 7.
+        [](const gsl::not_null<db::item_type<Tags::Interface<
+               Tags::BoundaryDirectionsExterior<system::volume_dim>,
+               typename system::variables_tag>>*>
                exterior_boundary_vars,
            const db::item_type<Tags::Interface<
-               Tags::BoundaryDirectionsInterior<volume_dim>,
+               Tags::BoundaryDirectionsInterior<system::volume_dim>,
                typename system::variables_tag>>& interior_vars) noexcept {
           for (auto& exterior_direction_and_vars : *exterior_boundary_vars) {
             auto& direction = exterior_direction_and_vars.first;


### PR DESCRIPTION
## Proposed changes

This was originally reported on #1228, but also affects current develop.  The ICE does not occur on Travis for some unknown reason, but this change prevented it in the configurations where I could reproduce it locally.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
