### PR TITLE
Add F constraint

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
@@ -16,7 +16,7 @@ namespace {
 // Functions to compute generalized-harmonic 2-index constraint, where
 // function arguments are in the order that each quantity first
 // appears in the corresponding term in Eq. (44) of
-// http://arXiv.org/abs/gr-qc/0512093v3
+// https://arXiv.org/abs/gr-qc/0512093v3
 template <size_t SpatialDim, typename Frame, typename DataType>
 void two_index_constraint_add_term_1_of_11(
     const gsl::not_null<tnsr::ia<DataType, SpatialDim, Frame>*> constraint,
@@ -274,6 +274,650 @@ void two_index_constraint_add_term_11_of_11(
     }
   }
 }
+
+// Functions to compute generalized-harmonic F constraint, where
+// function arguments are in the order that each quantity first
+// appears in the corresponding term in Eq. (43) of
+// https://arXiv.org/abs/gr-qc/0512093v3
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_1_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        if (a > 0) {
+          constraint->get(a) +=
+              0.5 * inverse_spacetime_metric.get(b, c) * d_pi.get(a - 1, b, c);
+        }
+        for (size_t i = 0; i < SpatialDim; ++i) {
+          constraint->get(a) += 0.5 * spacetime_normal_vector.get(i + 1) *
+                                spacetime_normal_one_form.get(a) *
+                                inverse_spacetime_metric.get(b, c) *
+                                d_pi.get(i, b, c);
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_2_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t j = 0; j < SpatialDim; ++j) {
+        constraint->get(a) -=
+            inverse_spatial_metric.get(i, j) * d_pi.get(i, j + 1, a);
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_3_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t j = 0; j < SpatialDim; ++j) {
+        for (size_t b = 0; b < SpatialDim + 1; ++b) {
+          constraint->get(a) -= inverse_spatial_metric.get(i, j) *
+                                spacetime_normal_vector.get(b) *
+                                d_phi.get(i, j, b, a);
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_4_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t i = 0; i < SpatialDim; ++i) {
+          for (size_t j = 0; j < SpatialDim; ++j) {
+            constraint->get(a) += 0.5 * spacetime_normal_one_form.get(a) *
+                                  inverse_spacetime_metric.get(b, c) *
+                                  inverse_spatial_metric.get(i, j) *
+                                  d_phi.get(i, j, b, c);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_5_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t j = 0; j < SpatialDim; ++j) {
+        constraint->get(a) += spacetime_normal_one_form.get(a) *
+                              inverse_spatial_metric.get(i, j) *
+                              d_gauge_function.get(i, j + 1);
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_6_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>&
+        inverse_spacetime_metric) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t d = 0; d < SpatialDim + 1; ++d) {
+          for (size_t j = 0; j < SpatialDim; ++j) {
+            for (size_t k = 0; k < SpatialDim; ++k) {
+              if (a > 0) {
+                constraint->get(a) += phi.get(a - 1, j + 1, b) *
+                                      inverse_spatial_metric.get(j, k) *
+                                      phi.get(k, c, d) *
+                                      inverse_spacetime_metric.get(b, d) *
+                                      spacetime_normal_vector.get(c);
+              }
+              for (size_t i = 0; i < SpatialDim; ++i) {
+                constraint->get(a) +=
+                    spacetime_normal_one_form.get(a) *
+                    spacetime_normal_vector.get(i + 1) * phi.get(i, j + 1, b) *
+                    inverse_spatial_metric.get(j, k) * phi.get(k, c, d) *
+                    inverse_spacetime_metric.get(b, d) *
+                    spacetime_normal_vector.get(c);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_7_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>&
+        inverse_spacetime_metric) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t d = 0; d < SpatialDim + 1; ++d) {
+          for (size_t j = 0; j < SpatialDim; ++j) {
+            for (size_t k = 0; k < SpatialDim; ++k) {
+              if (a > 0) {
+                constraint->get(a) -= 0.5 * phi.get(a - 1, j + 1, b) *
+                                      inverse_spatial_metric.get(j, k) *
+                                      phi.get(k, c, d) *
+                                      inverse_spacetime_metric.get(c, d) *
+                                      spacetime_normal_vector.get(b);
+              }
+              for (size_t i = 0; i < SpatialDim; ++i) {
+                constraint->get(a) -=
+                    0.5 * spacetime_normal_one_form.get(a) *
+                    spacetime_normal_vector.get(i + 1) * phi.get(i, j + 1, b) *
+                    inverse_spatial_metric.get(j, k) * phi.get(k, c, d) *
+                    inverse_spacetime_metric.get(c, d) *
+                    spacetime_normal_vector.get(b);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_8_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      if (a > 0) {
+        constraint->get(a) -=
+            spacetime_normal_vector.get(b) * d_gauge_function.get(a - 1, b);
+      }
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        constraint->get(a) -= spacetime_normal_one_form.get(a) *
+                              spacetime_normal_vector.get(i + 1) *
+                              spacetime_normal_vector.get(b) *
+                              d_gauge_function.get(i, b);
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_9_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>&
+        spacetime_normal_vector) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t d = 0; d < SpatialDim + 1; ++d) {
+          for (size_t i = 0; i < SpatialDim; ++i) {
+            for (size_t j = 0; j < SpatialDim; ++j) {
+              constraint->get(a) += inverse_spatial_metric.get(i, j) *
+                                    phi.get(i, c, d) * phi.get(j, b, a) *
+                                    inverse_spacetime_metric.get(b, c) *
+                                    spacetime_normal_vector.get(d);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_10_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::AA<DataType, SpatialDim, Frame>&
+        inverse_spacetime_metric) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t c = 0; c < SpatialDim + 1; ++c) {
+      for (size_t d = 0; d < SpatialDim + 1; ++d) {
+        for (size_t i = 0; i < SpatialDim; ++i) {
+          for (size_t j = 0; j < SpatialDim; ++j) {
+            for (size_t m = 0; m < SpatialDim; ++m) {
+              for (size_t n = 0; n < SpatialDim; ++n) {
+                constraint->get(a) -=
+                    0.5 * spacetime_normal_one_form.get(a) *
+                    inverse_spatial_metric.get(i, j) *
+                    inverse_spatial_metric.get(m, n) * phi.get(i, m + 1, c) *
+                    phi.get(n, j + 1, d) * inverse_spacetime_metric.get(c, d);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_11_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::AA<DataType, SpatialDim, Frame>&
+        inverse_spacetime_metric) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t d = 0; d < SpatialDim + 1; ++d) {
+          for (size_t e = 0; e < SpatialDim + 1; ++e) {
+            for (size_t i = 0; i < SpatialDim; ++i) {
+              for (size_t j = 0; j < SpatialDim; ++j) {
+                constraint->get(a) -= 0.25 * spacetime_normal_one_form.get(a) *
+                                      inverse_spatial_metric.get(i, j) *
+                                      phi.get(i, c, d) * phi.get(j, b, e) *
+                                      inverse_spacetime_metric.get(c, b) *
+                                      inverse_spacetime_metric.get(d, e);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_12_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::AA<DataType, SpatialDim, Frame>&
+        inverse_spacetime_metric) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t d = 0; d < SpatialDim + 1; ++d) {
+          for (size_t e = 0; e < SpatialDim + 1; ++e) {
+            constraint->get(a) += 0.25 * spacetime_normal_one_form.get(a) *
+                                  pi.get(c, d) * pi.get(b, e) *
+                                  inverse_spacetime_metric.get(c, b) *
+                                  inverse_spacetime_metric.get(d, e);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_13_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      for (size_t j = 0; j < SpatialDim; ++j) {
+        constraint->get(a) -= inverse_spatial_metric.get(i, j) *
+                              gauge_function.get(i + 1) * pi.get(j + 1, a);
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_14_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        for (size_t j = 0; j < SpatialDim; ++j) {
+          constraint->get(a) -= spacetime_normal_vector.get(b) *
+                                inverse_spatial_metric.get(i, j) *
+                                pi.get(b, i + 1) * pi.get(j + 1, a);
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_15_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t d = 0; d < SpatialDim + 1; ++d) {
+          for (size_t e = 0; e < SpatialDim + 1; ++e) {
+            if (a > 0) {
+              constraint->get(a) -=
+                  0.25 * phi.get(a - 1, c, d) * spacetime_normal_vector.get(c) *
+                  spacetime_normal_vector.get(d) * pi.get(b, e) *
+                  inverse_spacetime_metric.get(b, e);
+            }
+            for (size_t i = 0; i < SpatialDim; ++i) {
+              constraint->get(a) -=
+                  0.25 * spacetime_normal_one_form.get(a) *
+                  spacetime_normal_vector.get(i + 1) * phi.get(i, c, d) *
+                  spacetime_normal_vector.get(c) *
+                  spacetime_normal_vector.get(d) * pi.get(b, e) *
+                  inverse_spacetime_metric.get(b, e);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_16_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>&
+        spacetime_normal_vector) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t d = 0; d < SpatialDim + 1; ++d) {
+          for (size_t e = 0; e < SpatialDim + 1; ++e) {
+            constraint->get(a) +=
+                0.5 * spacetime_normal_one_form.get(a) * pi.get(c, d) *
+                pi.get(b, e) * inverse_spacetime_metric.get(c, e) *
+                spacetime_normal_vector.get(d) * spacetime_normal_vector.get(b);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_17_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t d = 0; d < SpatialDim + 1; ++d) {
+          for (size_t e = 0; e < SpatialDim + 1; ++e) {
+            if (a > 0) {
+              constraint->get(a) += phi.get(a - 1, c, d) * pi.get(b, e) *
+                                    spacetime_normal_vector.get(c) *
+                                    spacetime_normal_vector.get(b) *
+                                    inverse_spacetime_metric.get(d, e);
+            }
+            for (size_t i = 0; i < SpatialDim; ++i) {
+              constraint->get(a) += spacetime_normal_one_form.get(a) *
+                                    spacetime_normal_vector.get(i + 1) *
+                                    phi.get(i, c, d) * pi.get(b, e) *
+                                    spacetime_normal_vector.get(c) *
+                                    spacetime_normal_vector.get(b) *
+                                    inverse_spacetime_metric.get(d, e);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_18_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t e = 0; e < SpatialDim + 1; ++e) {
+        for (size_t i = 0; i < SpatialDim; ++i) {
+          for (size_t j = 0; j < SpatialDim; ++j) {
+            constraint->get(a) -=
+                inverse_spatial_metric.get(i, j) * phi.get(i, b, a) *
+                spacetime_normal_vector.get(b) * pi.get(j + 1, e) *
+                spacetime_normal_vector.get(e);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_19_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t c = 0; c < SpatialDim + 1; ++c) {
+      for (size_t d = 0; d < SpatialDim + 1; ++d) {
+        for (size_t i = 0; i < SpatialDim; ++i) {
+          for (size_t j = 0; j < SpatialDim; ++j) {
+            constraint->get(a) -=
+                0.5 * inverse_spatial_metric.get(i, j) * phi.get(i, c, d) *
+                spacetime_normal_vector.get(c) *
+                spacetime_normal_vector.get(d) * pi.get(j + 1, a);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_20_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::A<DataType, SpatialDim, Frame>&
+        spacetime_normal_vector) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        for (size_t j = 0; j < SpatialDim; ++j) {
+          constraint->get(a) -= inverse_spatial_metric.get(i, j) *
+                                gauge_function.get(i + 1) * phi.get(j, b, a) *
+                                spacetime_normal_vector.get(b);
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_21_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::AA<DataType, SpatialDim, Frame>&
+        inverse_spacetime_metric) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t d = 0; d < SpatialDim + 1; ++d) {
+          if (a > 0) {
+            constraint->get(a) += phi.get(a - 1, c, d) * gauge_function.get(b) *
+                                  inverse_spacetime_metric.get(b, c) *
+                                  spacetime_normal_vector.get(d);
+          }
+          for (size_t i = 0; i < SpatialDim; ++i) {
+            constraint->get(a) += spacetime_normal_one_form.get(a) *
+                                  spacetime_normal_vector.get(i + 1) *
+                                  phi.get(i, c, d) * gauge_function.get(b) *
+                                  inverse_spacetime_metric.get(b, c) *
+                                  spacetime_normal_vector.get(d);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_22_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const Scalar<DataType>& gamma2,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& three_index_constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>&
+        spacetime_normal_one_form) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t d = 0; d < SpatialDim + 1; ++d) {
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        constraint->get(a) += get(gamma2) *
+                              inverse_spacetime_metric.get(i + 1, d) *
+                              three_index_constraint.get(i, d, a);
+        constraint->get(a) += get(gamma2) * spacetime_normal_vector.get(i + 1) *
+                              spacetime_normal_vector.get(d) *
+                              three_index_constraint.get(i, d, a);
+      }
+
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        if (a > 0) {
+          constraint->get(a) -= 0.5 * get(gamma2) *
+                                inverse_spacetime_metric.get(c, d) *
+                                three_index_constraint.get(a - 1, c, d);
+        }
+        for (size_t i = 0; i < SpatialDim; ++i) {
+          constraint->get(a) -= 0.5 * get(gamma2) *
+                                spacetime_normal_one_form.get(a) *
+                                spacetime_normal_vector.get(i + 1) *
+                                inverse_spacetime_metric.get(c, d) *
+                                three_index_constraint.get(i, c, d);
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_23_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::A<DataType, SpatialDim, Frame>&
+        spacetime_normal_vector) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t b = 0; b < SpatialDim + 1; ++b) {
+      for (size_t c = 0; c < SpatialDim + 1; ++c) {
+        for (size_t d = 0; d < SpatialDim + 1; ++d) {
+          constraint->get(a) +=
+              0.5 * spacetime_normal_one_form.get(a) * pi.get(c, d) *
+              inverse_spacetime_metric.get(c, d) * gauge_function.get(b) *
+              spacetime_normal_vector.get(b);
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_24_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::AA<DataType, SpatialDim, Frame>&
+        inverse_spacetime_metric) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t c = 0; c < SpatialDim + 1; ++c) {
+      for (size_t d = 0; d < SpatialDim + 1; ++d) {
+        for (size_t i = 0; i < SpatialDim; ++i) {
+          for (size_t j = 0; j < SpatialDim; ++j) {
+            constraint->get(a) -= spacetime_normal_one_form.get(a) *
+                                  inverse_spatial_metric.get(i, j) *
+                                  phi.get(i, j + 1, c) * gauge_function.get(d) *
+                                  inverse_spacetime_metric.get(c, d);
+          }
+        }
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint_add_term_25_of_25(
+    const gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::AA<DataType, SpatialDim, Frame>&
+        inverse_spacetime_metric) noexcept {
+  for (size_t a = 0; a < SpatialDim + 1; ++a) {
+    for (size_t c = 0; c < SpatialDim + 1; ++c) {
+      for (size_t d = 0; d < SpatialDim + 1; ++d) {
+        for (size_t i = 0; i < SpatialDim; ++i) {
+          for (size_t j = 0; j < SpatialDim; ++j) {
+            constraint->get(a) += 0.5 * spacetime_normal_one_form.get(a) *
+                                  inverse_spatial_metric.get(i, j) *
+                                  gauge_function.get(i + 1) * phi.get(j, c, d) *
+                                  inverse_spacetime_metric.get(c, d);
+          }
+        }
+      }
+    }
+  }
+}
 }  // namespace
 
 namespace GeneralizedHarmonic {
@@ -467,6 +1111,117 @@ void four_index_constraint(
     }
   }
 }
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> f_constraint(
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi,
+    const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi,
+    const Scalar<DataType>& gamma2,
+    const tnsr::iaa<DataType, SpatialDim, Frame>&
+        three_index_constraint) noexcept {
+  auto constraint =
+      make_with_value<tnsr::a<DataType, SpatialDim, Frame>>(pi, 0.0);
+  f_constraint<SpatialDim, Frame, DataType>(
+      &constraint, gauge_function, d_gauge_function, spacetime_normal_one_form,
+      spacetime_normal_vector, inverse_spatial_metric, inverse_spacetime_metric,
+      pi, phi, d_pi, d_phi, gamma2, three_index_constraint);
+  return constraint;
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi,
+    const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi,
+    const Scalar<DataType>& gamma2,
+    const tnsr::iaa<DataType, SpatialDim, Frame>&
+        three_index_constraint) noexcept {
+  if (get_size(get<0>(*constraint)) != get_size(get<0, 0>(pi))) {
+    *constraint = tnsr::a<DataType, SpatialDim, Frame>{get<0, 0>(pi)};
+  }
+  std::fill(constraint->begin(), constraint->end(), 0.0);
+
+  f_constraint_add_term_1_of_25(constraint, spacetime_normal_one_form,
+                                spacetime_normal_vector,
+                                inverse_spacetime_metric, d_pi);
+  f_constraint_add_term_2_of_25(constraint, inverse_spatial_metric, d_pi);
+  f_constraint_add_term_3_of_25(constraint, inverse_spatial_metric,
+                                spacetime_normal_vector, d_phi);
+  f_constraint_add_term_4_of_25(constraint, spacetime_normal_one_form,
+                                inverse_spacetime_metric,
+                                inverse_spatial_metric, d_phi);
+  f_constraint_add_term_5_of_25(constraint, spacetime_normal_one_form,
+                                inverse_spatial_metric, d_gauge_function);
+  f_constraint_add_term_6_of_25(
+      constraint, spacetime_normal_one_form, spacetime_normal_vector, phi,
+      inverse_spatial_metric, inverse_spacetime_metric);
+  f_constraint_add_term_7_of_25(
+      constraint, spacetime_normal_one_form, spacetime_normal_vector, phi,
+      inverse_spatial_metric, inverse_spacetime_metric);
+  f_constraint_add_term_8_of_25(constraint, spacetime_normal_one_form,
+                                spacetime_normal_vector, d_gauge_function);
+  f_constraint_add_term_9_of_25(constraint, inverse_spatial_metric, phi,
+                                inverse_spacetime_metric,
+                                spacetime_normal_vector);
+  f_constraint_add_term_10_of_25(constraint, spacetime_normal_one_form,
+                                 inverse_spatial_metric, phi,
+                                 inverse_spacetime_metric);
+  f_constraint_add_term_11_of_25(constraint, spacetime_normal_one_form,
+                                 inverse_spatial_metric, phi,
+                                 inverse_spacetime_metric);
+  f_constraint_add_term_12_of_25(constraint, spacetime_normal_one_form, pi,
+                                 inverse_spacetime_metric);
+  f_constraint_add_term_13_of_25(constraint, inverse_spatial_metric,
+                                 gauge_function, pi);
+  f_constraint_add_term_14_of_25(constraint, spacetime_normal_vector,
+                                 inverse_spatial_metric, pi);
+  f_constraint_add_term_15_of_25(constraint, inverse_spacetime_metric,
+                                 spacetime_normal_one_form,
+                                 spacetime_normal_vector, phi, pi);
+  f_constraint_add_term_16_of_25(constraint, spacetime_normal_one_form, pi,
+                                 inverse_spacetime_metric,
+                                 spacetime_normal_vector);
+  f_constraint_add_term_17_of_25(constraint, inverse_spacetime_metric,
+                                 spacetime_normal_one_form,
+                                 spacetime_normal_vector, phi, pi);
+  f_constraint_add_term_18_of_25(constraint, inverse_spatial_metric, phi,
+                                 spacetime_normal_vector, pi);
+  f_constraint_add_term_19_of_25(constraint, inverse_spatial_metric, phi,
+                                 spacetime_normal_vector, pi);
+  f_constraint_add_term_20_of_25(constraint, inverse_spatial_metric,
+                                 gauge_function, phi, spacetime_normal_vector);
+  f_constraint_add_term_21_of_25(constraint, spacetime_normal_one_form,
+                                 spacetime_normal_vector, phi, gauge_function,
+                                 inverse_spacetime_metric);
+  f_constraint_add_term_22_of_25(
+      constraint, gamma2, inverse_spacetime_metric, spacetime_normal_vector,
+      three_index_constraint, spacetime_normal_one_form);
+  f_constraint_add_term_23_of_25(constraint, spacetime_normal_one_form, pi,
+                                 inverse_spacetime_metric, gauge_function,
+                                 spacetime_normal_vector);
+  f_constraint_add_term_24_of_25(constraint, spacetime_normal_one_form,
+                                 inverse_spatial_metric, phi, gauge_function,
+                                 inverse_spacetime_metric);
+  f_constraint_add_term_25_of_25(constraint, spacetime_normal_one_form,
+                                 inverse_spatial_metric, gauge_function, phi,
+                                 inverse_spacetime_metric);
+}
 }  // namespace GeneralizedHarmonic
 
 // Explicit Instantiations
@@ -535,6 +1290,45 @@ void four_index_constraint(
   template void GeneralizedHarmonic::two_index_constraint(                   \
       const gsl::not_null<tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>*>    \
           constraint,                                                        \
+      const tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_one_form,                                         \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_vector,                                           \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          inverse_spatial_metric,                                            \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          inverse_spacetime_metric,                                          \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,               \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,             \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& d_pi,            \
+      const tnsr::ijaa<DTYPE(data), DIM(data), FRAME(data)>& d_phi,          \
+      const Scalar<DTYPE(data)>& gamma2,                                     \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          three_index_constraint) noexcept;                                  \
+  template tnsr::a<DTYPE(data), DIM(data), FRAME(data)>                      \
+  GeneralizedHarmonic::f_constraint(                                         \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>& gauge_function,    \
+      const tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_one_form,                                         \
+      const tnsr::A<DTYPE(data), DIM(data), FRAME(data)>&                    \
+          spacetime_normal_vector,                                           \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          inverse_spatial_metric,                                            \
+      const tnsr::AA<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          inverse_spacetime_metric,                                          \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& pi,               \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi,             \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& d_pi,            \
+      const tnsr::ijaa<DTYPE(data), DIM(data), FRAME(data)>& d_phi,          \
+      const Scalar<DTYPE(data)>& gamma2,                                     \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>&                  \
+          three_index_constraint) noexcept;                                  \
+  template void GeneralizedHarmonic::f_constraint(                           \
+      const gsl::not_null<tnsr::a<DTYPE(data), DIM(data), FRAME(data)>*>     \
+          constraint,                                                        \
+      const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>& gauge_function,    \
       const tnsr::ia<DTYPE(data), DIM(data), FRAME(data)>& d_gauge_function, \
       const tnsr::a<DTYPE(data), DIM(data), FRAME(data)>&                    \
           spacetime_normal_one_form,                                         \

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -180,4 +180,92 @@ void four_index_constraint(
     gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> constraint,
     const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi) noexcept;
 // @}
+
+// @{
+/*!
+ * \brief Computes the generalized-harmonic F constraint.
+ *
+ * \details Computes the generalized-harmonic F constraint
+ * [Eq. (43) of https://arXiv.org/abs/gr-qc/0512093v3],
+ * \f{eqnarray}{
+ * {\cal F}_a &\equiv&
+ * \frac{1}{2} g_a^i \psi^{bc}\partial_i \Pi_{bc}
+ * - g^{ij} \partial_i \Pi_{ja}
+ * - g^{ij} t^b \partial_i \Phi_{jba}
+ * + \frac{1}{2} t_a \psi^{bc} g^{ij} \partial_i \Phi_{jbc}
+ * \nonumber \\ &&
+ * + t_a g^{ij} \partial_i H_j
+ * + g_a^i \Phi_{ijb} g^{jk}\Phi_{kcd} \psi^{bd} t^c
+ * - \frac{1}{2} g_a^i \Phi_{ijb} g^{jk}
+ *   \Phi_{kcd} \psi^{cd} t^b
+ * \nonumber \\ &&
+ * - g_a^i t^b \partial_i H_b
+ * + g^{ij} \Phi_{icd} \Phi_{jba} \psi^{bc} t^d
+ * - \frac{1}{2} t_a g^{ij} g^{mn} \Phi_{imc} \Phi_{njd}\psi^{cd}
+ * \nonumber \\ &&
+ * - \frac{1}{4}  t_a g^{ij}\Phi_{icd}\Phi_{jbe}
+ *    \psi^{cb}\psi^{de}
+ * + \frac{1}{4}  t_a \Pi_{cd} \Pi_{be}
+ *    \psi^{cb}\psi^{de}
+ * - g^{ij} H_i \Pi_{ja}
+ * \nonumber \\ &&
+ * - t^b g^{ij} \Pi_{b i} \Pi_{ja}
+ * - \frac{1}{4}  g_a^i \Phi_{icd} t^c t^d \Pi_{be}
+ *   \psi^{be}
+ * + \frac{1}{2} t_a \Pi_{cd} \Pi_{be}\psi^{ce}
+ *   t^d t^b
+ * \nonumber \\ &&
+ * + g_a^i \Phi_{icd} \Pi_{be} t^c t^b \psi^{de}
+ * - g^{ij}\Phi_{iba} t^b \Pi_{je} t^e
+ * - \frac{1}{2} g^{ij}\Phi_{icd} t^c t^d \Pi_{ja}
+ * \nonumber \\ &&
+ * - g^{ij} H_i \Phi_{jba} t^b
+ * + g_{a}^i \Phi_{icd} H_b \psi^{bc} t^d
+ * +\gamma_2\bigl(g^{id}{\cal C}_{ida}
+ * -\frac{1}{2}  g_a^i\psi^{cd}{\cal C}_{icd}\bigr)
+ * \nonumber \\ &&
+ * + \frac{1}{2} t_a \Pi_{cd}\psi^{cd} H_b t^b
+ * - t_a g^{ij} \Phi_{ijc} H_d \psi^{cd}
+ * +\frac{1}{2}  t_a g^{ij} H_i \Phi_{jcd}\psi^{cd},
+ * \f}
+ * where \f$H_a\f$ is the gauge function,
+ * \f$\psi_{ab}\f$ is the spacetime metric,
+ * \f$\Pi_{ab}=-t^c\partial_c \psi_{ab}\f$, and
+ * \f$\Phi_{iab} = \partial_i\psi_{ab}\f$; \f$t^a\f$ is the timelike unit
+ * normal vector to the spatial slice, \f$g^{ij}\f$ is the inverse spatial
+ * metric, and \f$g^b_c = \delta^b_c + t^b t_c\f$.
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::a<DataType, SpatialDim, Frame> f_constraint(
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi,
+    const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi,
+    const Scalar<DataType>& gamma2,
+    const tnsr::iaa<DataType, SpatialDim, Frame>&
+        three_index_constraint) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void f_constraint(
+    gsl::not_null<tnsr::a<DataType, SpatialDim, Frame>*> constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_function,
+    const tnsr::ia<DataType, SpatialDim, Frame>& d_gauge_function,
+    const tnsr::a<DataType, SpatialDim, Frame>& spacetime_normal_one_form,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_normal_vector,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::AA<DataType, SpatialDim, Frame>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& d_pi,
+    const tnsr::ijaa<DataType, SpatialDim, Frame>& d_phi,
+    const Scalar<DataType>& gamma2,
+    const tnsr::iaa<DataType, SpatialDim, Frame>&
+        three_index_constraint) noexcept;
+// @}
 }  // namespace GeneralizedHarmonic

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -267,3 +267,332 @@ def evol_field_phi(gamma2, upsi, uzero, uplus, uminus, normal_one_form):
     return np.einsum('i,ab->iab', normal_one_form, udiff) + uzero
 
 # End test functions for characteristic fields
+
+# Test functions for F constraint
+
+
+def f_constraint_term_1_of_25(spacetime_normal_one_form,
+                              spacetime_normal_vector,
+                              inverse_spacetime_metric, d_pi):
+    spacetime_normal_vector_I = spacetime_normal_vector[1:]
+    d_pi_abc = np.pad(d_pi, ((1, 0), (0, 0), (0, 0)), 'constant')
+    term = np.einsum("bc,abc", inverse_spacetime_metric, d_pi_abc)
+    term += np.einsum("a,i,bc,ibc", spacetime_normal_one_form,
+                      spacetime_normal_vector_I, inverse_spacetime_metric, d_pi)
+    return 0.5 * term
+
+
+def f_constraint_term_2_of_25(inverse_spatial_metric, d_pi):
+    d_pi_ija = d_pi[:, 1:, :]
+    return -1.0 * np.einsum("ij,ija", inverse_spatial_metric, d_pi_ija)
+
+
+def f_constraint_term_3_of_25(inverse_spatial_metric, spacetime_normal_vector,
+                              d_phi):
+    return -1.0 * np.einsum("ij,b,ijba", inverse_spatial_metric,
+                            spacetime_normal_vector, d_phi)
+
+
+def f_constraint_term_4_of_25(spacetime_normal_one_form,
+                              inverse_spacetime_metric,
+                              inverse_spatial_metric, d_phi):
+    return 0.5 * np.einsum("a,bc,ij,ijbc", spacetime_normal_one_form,
+                           inverse_spacetime_metric,
+                           inverse_spatial_metric, d_phi)
+
+
+def f_constraint_term_5_of_25(spacetime_normal_one_form, inverse_spatial_metric,
+                              d_gauge_function):
+    d_gauge_function_ij = d_gauge_function[:, 1:]
+    return np.einsum("a,ij,ij", spacetime_normal_one_form,
+                     inverse_spatial_metric,
+                     d_gauge_function_ij)
+
+
+def f_constraint_term_6_of_25(spacetime_normal_one_form,
+                              spacetime_normal_vector,
+                              phi, inverse_spatial_metric,
+                              inverse_spacetime_metric):
+    spacetime_normal_vector_I = spacetime_normal_vector[1:]
+    phi_ijb = phi[:, 1:, :]
+    phi_ajb = np.pad(phi, ((1, 0), (0, 0), (0, 0)), 'constant')[:, 1:, :]
+    term = np.einsum("ajb,jk,kcd,bd,c", phi_ajb, inverse_spatial_metric, phi,
+                     inverse_spacetime_metric,
+                     spacetime_normal_vector)
+    return term + np.einsum("a,i,ijb,jk,kcd,bd,c", spacetime_normal_one_form,
+                            spacetime_normal_vector_I, phi_ijb,
+                            inverse_spatial_metric, phi,
+                            inverse_spacetime_metric, spacetime_normal_vector)
+
+
+def f_constraint_term_7_of_25(spacetime_normal_one_form,
+                              spacetime_normal_vector,
+                              phi, inverse_spatial_metric,
+                              inverse_spacetime_metric):
+    spacetime_normal_vector_I = spacetime_normal_vector[1:]
+    phi_ijb = phi[:, 1:, :]
+    phi_ajb = np.pad(phi, ((1, 0), (0, 0), (0, 0)), 'constant')[:, 1:, :]
+    term = np.einsum("ajb,jk,kcd,cd,b", phi_ajb, inverse_spatial_metric, phi,
+                     inverse_spacetime_metric,
+                     spacetime_normal_vector)
+    return -0.5 * (term + np.einsum("a,i,ijb,jk,kcd,cd,b",
+                                    spacetime_normal_one_form,
+                                    spacetime_normal_vector_I, phi_ijb,
+                                    inverse_spatial_metric, phi,
+                                    inverse_spacetime_metric,
+                                    spacetime_normal_vector))
+
+
+def f_constraint_term_8_of_25(spacetime_normal_one_form,
+                              spacetime_normal_vector,
+                              d_gauge_function):
+    d_gauge_function_ab = np.pad(
+        d_gauge_function, ((1, 0), (0, 0)), 'constant')
+    spacetime_normal_vector_I = spacetime_normal_vector[1:]
+    term = -1.0 * np.einsum("b,ab", spacetime_normal_vector,
+                            d_gauge_function_ab)
+    return term - np.einsum("a,i,b,ib", spacetime_normal_one_form,
+                            spacetime_normal_vector_I,
+                            spacetime_normal_vector, d_gauge_function)
+
+
+def f_constraint_term_9_of_25(inverse_spatial_metric, phi,
+                              inverse_spacetime_metric,
+                              spacetime_normal_vector):
+    return np.einsum("ij,icd,jba,bc,d", inverse_spatial_metric, phi, phi,
+                     inverse_spacetime_metric, spacetime_normal_vector)
+
+
+def f_constraint_term_10_of_25(spacetime_normal_one_form,
+                               inverse_spatial_metric, phi,
+                               inverse_spacetime_metric):
+    phi_imc = phi[:, 1:, :]
+    return -0.5 * np.einsum("a,ij,mn,imc,njd,cd", spacetime_normal_one_form,
+                            inverse_spatial_metric, inverse_spatial_metric,
+                            phi_imc, phi_imc, inverse_spacetime_metric)
+
+
+def f_constraint_term_11_of_25(spacetime_normal_one_form,
+                               inverse_spatial_metric, phi,
+                               inverse_spacetime_metric):
+    return -0.25 * np.einsum("a,ij,icd,jbe,cb,de", spacetime_normal_one_form,
+                             inverse_spatial_metric, phi, phi,
+                             inverse_spacetime_metric, inverse_spacetime_metric)
+
+
+def f_constraint_term_12_of_25(spacetime_normal_one_form, pi,
+                               inverse_spacetime_metric):
+    return 0.25 * np.einsum("a,cd,be,cb,de", spacetime_normal_one_form, pi, pi,
+                            inverse_spacetime_metric, inverse_spacetime_metric)
+
+
+def f_constraint_term_13_of_25(inverse_spatial_metric, gauge_function, pi):
+    gauge_function_i = gauge_function[1:]
+    pi_ja = pi[1:, :]
+    return -1.0 * np.einsum("ij,i,ja", inverse_spatial_metric,
+                            gauge_function_i, pi_ja)
+
+
+def f_constraint_term_14_of_25(spacetime_normal_vector, inverse_spatial_metric,
+                               pi):
+    pi_bi = pi[:, 1:]
+    pi_ja = pi[1:, :]
+    return -1.0 * np.einsum("b,ij,bi,ja", spacetime_normal_vector,
+                            inverse_spatial_metric, pi_bi, pi_ja)
+
+
+def f_constraint_term_15_of_25(inverse_spacetime_metric,
+                               spacetime_normal_one_form,
+                               spacetime_normal_vector, phi, pi):
+    phi_acd = np.pad(phi, ((1, 0), (0, 0), (0, 0)), 'constant')
+    spacetime_normal_vector_I = spacetime_normal_vector[1:]
+    term = np.einsum("acd,c,d,be,be", phi_acd, spacetime_normal_vector,
+                     spacetime_normal_vector, pi, inverse_spacetime_metric)
+    term += np.einsum("a,i,icd,c,d,be,be", spacetime_normal_one_form,
+                      spacetime_normal_vector_I, phi, spacetime_normal_vector,
+                      spacetime_normal_vector, pi, inverse_spacetime_metric)
+    return -0.25 * term
+
+
+def f_constraint_term_16_of_25(spacetime_normal_one_form, pi,
+                               inverse_spacetime_metric,
+                               spacetime_normal_vector):
+    return 0.5 * np.einsum("a,cd,be,ce,d,b", spacetime_normal_one_form,
+                           pi, pi, inverse_spacetime_metric,
+                           spacetime_normal_vector, spacetime_normal_vector)
+
+
+def f_constraint_term_17_of_25(inverse_spacetime_metric,
+                               spacetime_normal_one_form,
+                               spacetime_normal_vector, phi, pi):
+    phi_acd = np.pad(phi, ((1, 0), (0, 0), (0, 0)), 'constant')
+    spacetime_normal_vector_I = spacetime_normal_vector[1:]
+    term = np.einsum("acd,be,c,b,de", phi_acd, pi, spacetime_normal_vector,
+                     spacetime_normal_vector, inverse_spacetime_metric)
+    return term + np.einsum("a,i,icd,be,c,b,de", spacetime_normal_one_form,
+                            spacetime_normal_vector_I, phi, pi,
+                            spacetime_normal_vector, spacetime_normal_vector,
+                            inverse_spacetime_metric)
+
+
+def f_constraint_term_18_of_25(inverse_spatial_metric, phi,
+                               spacetime_normal_vector, pi):
+    pi_je = pi[1:, :]
+    return -1.0 * np.einsum("ij,iba,b,je,e", inverse_spatial_metric, phi,
+                            spacetime_normal_vector, pi_je,
+                            spacetime_normal_vector)
+
+
+def f_constraint_term_19_of_25(inverse_spatial_metric, phi,
+                               spacetime_normal_vector, pi):
+    pi_ja = pi[1:, :]
+    return -0.5 * np.einsum("ij,icd,c,d,ja", inverse_spatial_metric, phi,
+                            spacetime_normal_vector, spacetime_normal_vector,
+                            pi_ja)
+
+
+def f_constraint_term_20_of_25(inverse_spatial_metric, gauge_function, phi,
+                               spacetime_normal_vector):
+    gauge_function_i = gauge_function[1:]
+    return -1.0 * np.einsum("ij,i,jab,b", inverse_spatial_metric,
+                            gauge_function_i, phi, spacetime_normal_vector)
+
+
+def f_constraint_term_21_of_25(spacetime_normal_one_form,
+                               spacetime_normal_vector, phi, gauge_function,
+                               inverse_spacetime_metric):
+    phi_acd = np.pad(phi, ((1, 0), (0, 0), (0, 0)), 'constant')
+    spacetime_normal_vector_I = spacetime_normal_vector[1:]
+    term = np.einsum("acd,b,bc,d", phi_acd, gauge_function,
+                     inverse_spacetime_metric, spacetime_normal_vector)
+    return term + np.einsum("a,i,icd,b,bc,d", spacetime_normal_one_form,
+                            spacetime_normal_vector_I, phi, gauge_function,
+                            inverse_spacetime_metric, spacetime_normal_vector)
+
+
+def f_constraint_term_22_of_25(gamma2, inverse_spacetime_metric,
+                               spacetime_normal_vector, three_index_constraint,
+                               spacetime_normal_one_form):
+    inverse_spacetime_metric_ID = inverse_spacetime_metric[1:, :]
+    spacetime_normal_vector_I = spacetime_normal_vector[1:]
+    three_index_constraint_acd = np.pad(three_index_constraint,
+                                        ((1, 0), (0, 0), (0, 0)), 'constant')
+    term = np.einsum("id,ida", inverse_spacetime_metric_ID,
+                     three_index_constraint)
+    term += np.einsum("i,d,ida", spacetime_normal_vector_I,
+                      spacetime_normal_vector, three_index_constraint)
+    term -= 0.5 * np.einsum("cd,acd", inverse_spacetime_metric,
+                            three_index_constraint_acd)
+    term -= 0.5 * np.einsum("a,i,cd,icd", spacetime_normal_one_form,
+                            spacetime_normal_vector_I, inverse_spacetime_metric,
+                            three_index_constraint)
+    return gamma2 * term
+
+
+def f_constraint_term_23_of_25(spacetime_normal_one_form, pi,
+                               inverse_spacetime_metric, gauge_function,
+                               spacetime_normal_vector):
+    return 0.5 * np.einsum("a,cd,cd,b,b", spacetime_normal_one_form, pi,
+                           inverse_spacetime_metric, gauge_function,
+                           spacetime_normal_vector)
+
+
+def f_constraint_term_24_of_25(spacetime_normal_one_form,
+                               inverse_spatial_metric, phi, gauge_function,
+                               inverse_spacetime_metric):
+    phi_ijc = phi[:, 1:, :]
+    return -1.0 * np.einsum("a,ij,ijc,d,cd", spacetime_normal_one_form,
+                            inverse_spatial_metric, phi_ijc, gauge_function,
+                            inverse_spacetime_metric)
+
+
+def f_constraint_term_25_of_25(spacetime_normal_one_form,
+                               inverse_spatial_metric, gauge_function,
+                               phi, inverse_spacetime_metric):
+    gauge_function_i = gauge_function[1:]
+    return 0.5 * np.einsum("a,ij,i,jcd,cd", spacetime_normal_one_form,
+                           inverse_spatial_metric, gauge_function_i, phi,
+                           inverse_spacetime_metric)
+
+
+def f_constraint(gauge_function, d_gauge_function, spacetime_normal_one_form,
+                 spacetime_normal_vector, inverse_spatial_metric,
+                 inverse_spacetime_metric, pi, phi, d_pi, d_phi, gamma2,
+                 three_index_constraint):
+    constraint = f_constraint_term_1_of_25(spacetime_normal_one_form,
+                                           spacetime_normal_vector,
+                                           inverse_spacetime_metric, d_pi)
+    constraint += f_constraint_term_2_of_25(inverse_spatial_metric, d_pi)
+    constraint += f_constraint_term_3_of_25(inverse_spatial_metric,
+                                            spacetime_normal_vector, d_phi)
+    constraint += f_constraint_term_4_of_25(spacetime_normal_one_form,
+                                            inverse_spacetime_metric,
+                                            inverse_spatial_metric, d_phi)
+    constraint += f_constraint_term_5_of_25(spacetime_normal_one_form,
+                                            inverse_spatial_metric,
+                                            d_gauge_function)
+    constraint += f_constraint_term_6_of_25(spacetime_normal_one_form,
+                                            spacetime_normal_vector,
+                                            phi, inverse_spatial_metric,
+                                            inverse_spacetime_metric)
+    constraint += f_constraint_term_7_of_25(spacetime_normal_one_form,
+                                            spacetime_normal_vector,
+                                            phi, inverse_spatial_metric,
+                                            inverse_spacetime_metric)
+    constraint += f_constraint_term_8_of_25(spacetime_normal_one_form,
+                                            spacetime_normal_vector,
+                                            d_gauge_function)
+    constraint += f_constraint_term_9_of_25(inverse_spatial_metric, phi,
+                                            inverse_spacetime_metric,
+                                            spacetime_normal_vector)
+    constraint += f_constraint_term_10_of_25(spacetime_normal_one_form,
+                                             inverse_spatial_metric, phi,
+                                             inverse_spacetime_metric)
+    constraint += f_constraint_term_11_of_25(spacetime_normal_one_form,
+                                             inverse_spatial_metric, phi,
+                                             inverse_spacetime_metric)
+    constraint += f_constraint_term_12_of_25(spacetime_normal_one_form, pi,
+                                             inverse_spacetime_metric)
+    constraint += f_constraint_term_13_of_25(inverse_spatial_metric,
+                                             gauge_function, pi)
+    constraint += f_constraint_term_14_of_25(spacetime_normal_vector,
+                                             inverse_spatial_metric, pi)
+    constraint += f_constraint_term_15_of_25(inverse_spacetime_metric,
+                                             spacetime_normal_one_form,
+                                             spacetime_normal_vector, phi, pi)
+    constraint += f_constraint_term_16_of_25(spacetime_normal_one_form, pi,
+                                             inverse_spacetime_metric,
+                                             spacetime_normal_vector)
+    constraint += f_constraint_term_17_of_25(inverse_spacetime_metric,
+                                             spacetime_normal_one_form,
+                                             spacetime_normal_vector, phi, pi)
+    constraint += f_constraint_term_18_of_25(inverse_spatial_metric, phi,
+                                             spacetime_normal_vector, pi)
+    constraint += f_constraint_term_19_of_25(inverse_spatial_metric, phi,
+                                             spacetime_normal_vector, pi)
+    constraint += f_constraint_term_20_of_25(inverse_spatial_metric,
+                                             gauge_function, phi,
+                                             spacetime_normal_vector)
+    constraint += f_constraint_term_21_of_25(spacetime_normal_one_form,
+                                             spacetime_normal_vector, phi,
+                                             gauge_function,
+                                             inverse_spacetime_metric)
+    constraint += f_constraint_term_22_of_25(gamma2, inverse_spacetime_metric,
+                                             spacetime_normal_vector,
+                                             three_index_constraint,
+                                             spacetime_normal_one_form)
+    constraint += f_constraint_term_23_of_25(spacetime_normal_one_form, pi,
+                                             inverse_spacetime_metric,
+                                             gauge_function,
+                                             spacetime_normal_vector)
+    constraint += f_constraint_term_24_of_25(spacetime_normal_one_form,
+                                             inverse_spatial_metric,
+                                             phi, gauge_function,
+                                             inverse_spacetime_metric)
+    constraint += f_constraint_term_25_of_25(spacetime_normal_one_form,
+                                             inverse_spatial_metric,
+                                             gauge_function, phi,
+                                             inverse_spacetime_metric)
+    return constraint
+
+# End test functions for F constraint

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -372,6 +372,147 @@ void test_four_index_constraint_analytic(
       make_with_value<decltype(four_index_constraint)>(x, 0.0),
       numerical_approx);
 }
+
+// Test the return-by-value F constraint function using random values
+template <size_t SpatialDim, typename Frame, typename DataType>
+void test_f_constraint_random(const DataType& used_for_size) noexcept {
+  pypp::check_with_random_values<1>(
+      static_cast<tnsr::a<DataType, SpatialDim, Frame> (*)(
+          const tnsr::a<DataType, SpatialDim, Frame>&,
+          const tnsr::ia<DataType, SpatialDim, Frame>&,
+          const tnsr::a<DataType, SpatialDim, Frame>&,
+          const tnsr::A<DataType, SpatialDim, Frame>&,
+          const tnsr::II<DataType, SpatialDim, Frame>&,
+          const tnsr::AA<DataType, SpatialDim, Frame>&,
+          const tnsr::aa<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&,
+          const tnsr::ijaa<DataType, SpatialDim, Frame>&,
+          const Scalar<DataType>&,
+          const tnsr::iaa<DataType, SpatialDim, Frame>&)>(
+          &GeneralizedHarmonic::f_constraint<SpatialDim, Frame, DataType>),
+      "TestFunctions", "f_constraint", {{{-10.0, 10.0}}}, used_for_size,
+      1.0e-10);  // Loosen tolerance to avoid occasional failures of this test
+                 // (suspected accumulated roundoff error)
+}
+
+// Test the return-by-reference F constraint
+// by comparing to a time-independent analytic solution (e.g. Kerr-Schild)
+template <typename Solution>
+void test_f_constraint_analytic(const Solution& solution,
+                                const size_t grid_size_each_dimension,
+                                const std::array<double, 3>& lower_bound,
+                                const std::array<double, 3>& upper_bound,
+                                const double error_tolerance) noexcept {
+  // Shorter names for tags.
+  using SpacetimeMetric = gr::Tags::SpacetimeMetric<3, Frame::Inertial>;
+  using Pi = ::GeneralizedHarmonic::Tags::Pi<3, Frame::Inertial>;
+  using Phi = ::GeneralizedHarmonic::Tags::Phi<3, Frame::Inertial>;
+  using GaugeH = ::GeneralizedHarmonic::Tags::GaugeH<3, Frame::Inertial>;
+  using VariablesTags = tmpl::list<SpacetimeMetric, Pi, Phi, GaugeH>;
+
+  // Check vs. time-independent analytic solution
+  // Set up grid
+  const size_t data_size = pow<3>(grid_size_each_dimension);
+  Mesh<3> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+               Spectral::Quadrature::GaussLobatto};
+
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+          Affine{-1.0, 1.0, lower_bound[0], upper_bound[0]},
+          Affine{-1.0, 1.0, lower_bound[1], upper_bound[1]},
+          Affine{-1.0, 1.0, lower_bound[2], upper_bound[2]},
+      });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  // Arbitrary time for time-independent solution.
+  const double t = std::numeric_limits<double>::signaling_NaN();
+
+  // Evaluate analytic solution
+  const auto vars =
+      solution.variables(x, t, typename Solution::template tags<DataVector>{});
+  const auto& lapse = get<gr::Tags::Lapse<>>(vars);
+  const auto& dt_lapse = get<Tags::dt<gr::Tags::Lapse<>>>(vars);
+  const auto& d_lapse =
+      get<typename Solution::template DerivLapse<DataVector>>(vars);
+  const auto& shift = get<gr::Tags::Shift<3>>(vars);
+  const auto& d_shift =
+      get<typename Solution::template DerivShift<DataVector>>(vars);
+  const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<3>>>(vars);
+  const auto& spatial_metric = get<gr::Tags::SpatialMetric<3>>(vars);
+  const auto& dt_spatial_metric =
+      get<Tags::dt<gr::Tags::SpatialMetric<3>>>(vars);
+  const auto& d_spatial_metric =
+      get<typename Solution::template DerivSpatialMetric<DataVector>>(vars);
+
+  // Compute quantities from variables for the two-index constraint
+  const auto& inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const auto& inverse_spacetime_metric =
+      gr::inverse_spacetime_metric(lapse, shift, inverse_spatial_metric);
+  const auto& normal_one_form =
+      gr::spacetime_normal_one_form<3, Frame::Inertial>(lapse);
+  const auto& normal_vector = gr::spacetime_normal_vector(lapse, shift);
+
+  // Arbitrary choice for gamma2
+  const auto& gamma2 = make_with_value<Scalar<DataVector>>(x, 4.0);
+
+  // Compute derivatives d_psi, d_phi, d_pi, and d_gauge_function numerically
+  Variables<VariablesTags> gh_vars(data_size);
+  auto& spacetime_metric = get<SpacetimeMetric>(gh_vars);
+  auto& pi = get<Pi>(gh_vars);
+  auto& phi = get<Phi>(gh_vars);
+  auto& gauge_function = get<GaugeH>(gh_vars);
+  spacetime_metric = gr::spacetime_metric(lapse, shift, spatial_metric);
+  phi = GeneralizedHarmonic::phi(lapse, d_lapse, shift, d_shift, spatial_metric,
+                                 d_spatial_metric);
+  pi = GeneralizedHarmonic::pi(lapse, dt_lapse, shift, dt_shift, spatial_metric,
+                               dt_spatial_metric, phi);
+  gauge_function = GeneralizedHarmonic::gauge_source(
+      lapse, dt_lapse, d_lapse, shift, dt_shift, d_shift, spatial_metric,
+      trace(gr::extrinsic_curvature(lapse, shift, d_shift, spatial_metric,
+                                    dt_spatial_metric, d_spatial_metric),
+            inverse_spatial_metric),
+      trace_last_indices(gr::christoffel_first_kind(d_spatial_metric),
+                         inverse_spatial_metric));
+
+  // Compute numerical derivatives of psi,pi,phi,H
+  const auto gh_derivs =
+      partial_derivatives<VariablesTags, VariablesTags, 3, Frame::Inertial>(
+          gh_vars, mesh, coord_map.inv_jacobian(x_logical));
+  const auto& d_spacetime_metric =
+      get<Tags::deriv<SpacetimeMetric, tmpl::size_t<3>, Frame::Inertial>>(
+          gh_derivs);
+  const auto& d_pi =
+      get<Tags::deriv<Pi, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
+  const auto& d_phi =
+      get<Tags::deriv<Phi, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
+  const auto& d_gauge_function =
+      get<Tags::deriv<GaugeH, tmpl::size_t<3>, Frame::Inertial>>(gh_derivs);
+
+  // Compute the three-index constraint
+  const auto& three_index_constraint =
+      GeneralizedHarmonic::three_index_constraint(d_spacetime_metric, phi);
+
+  // Get the constraint, and check that it vanishes to error_tolerance
+  auto f_constraint = make_with_value<tnsr::a<DataVector, 3, Frame::Inertial>>(
+      x, std::numeric_limits<double>::signaling_NaN());
+  GeneralizedHarmonic::f_constraint(
+      make_not_null(&f_constraint), gauge_function, d_gauge_function,
+      normal_one_form, normal_vector, inverse_spatial_metric,
+      inverse_spacetime_metric, pi, phi, d_pi, d_phi, gamma2,
+      three_index_constraint);
+
+  Approx numerical_approx =
+      Approx::custom().epsilon(error_tolerance).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(f_constraint,
+                               make_with_value<decltype(f_constraint)>(x, 0.0),
+                               numerical_approx);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE(
@@ -535,5 +676,53 @@ SPECTRE_TEST_CASE(
   test_four_index_constraint_random<3, Frame::Grid, double>(
       std::numeric_limits<double>::signaling_NaN());
   test_four_index_constraint_random<3, Frame::Inertial, double>(
+      std::numeric_limits<double>::signaling_NaN());
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.FConstraint",
+                  "[Unit][Evolution]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/GeneralizedHarmonic/"};
+  // Test the F constraint against Kerr Schild
+  const double mass = 1.4;
+  const std::array<double, 3> dimensionless_spin{{0.4, 0.3, 0.2}};
+  const std::array<double, 3> center{{0.2, 0.3, 0.4}};
+  const gr::Solutions::KerrSchild solution(mass, dimensionless_spin, center);
+
+  const size_t grid_size = 6;
+  const std::array<double, 3> upper_bound{{0.82, 1.24, 1.32}};
+  const std::array<double, 3> lower_bound{{0.8, 1.22, 1.30}};
+
+  // Note: looser numerical tolerance because this check
+  // uses numerical derivatives
+  test_f_constraint_analytic(solution, grid_size, lower_bound, upper_bound,
+                             std::numeric_limits<double>::epsilon() * 1.e6);
+
+  // Test the F constraint with random numbers
+  test_f_constraint_random<1, Frame::Grid, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_f_constraint_random<1, Frame::Inertial, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_f_constraint_random<1, Frame::Grid, double>(
+      std::numeric_limits<double>::signaling_NaN());
+  test_f_constraint_random<1, Frame::Inertial, double>(
+      std::numeric_limits<double>::signaling_NaN());
+
+  test_f_constraint_random<2, Frame::Grid, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_f_constraint_random<2, Frame::Inertial, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_f_constraint_random<2, Frame::Grid, double>(
+      std::numeric_limits<double>::signaling_NaN());
+  test_f_constraint_random<2, Frame::Inertial, double>(
+      std::numeric_limits<double>::signaling_NaN());
+
+  test_f_constraint_random<3, Frame::Grid, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_f_constraint_random<3, Frame::Inertial, DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_f_constraint_random<3, Frame::Grid, double>(
+      std::numeric_limits<double>::signaling_NaN());
+  test_f_constraint_random<3, Frame::Inertial, double>(
       std::numeric_limits<double>::signaling_NaN());
 }


### PR DESCRIPTION
## Proposed changes

Add function to compute the generalized harmonic f constraint. Depends on PR #1245, which fixes issue #1227.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
