### PR TITLE
Add generalized harmonic constraint energy

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -7,6 +7,7 @@
       year           = "2006",
       pages          = "S447-S462",
       doi            = "10.1088/0264-9381/23/16/S09",
+      url            = {https://doi.org/10.1088/0264-9381/23/16/S09},
       eprint         = "gr-qc/0512093",
       archivePrefix  = "arXiv",
       primaryClass   = "gr-qc",
@@ -95,18 +96,10 @@
   volume  = {79},
 }
 
-@article{Lindblom:2005qh,
-      author         = "Lindblom, Lee and Scheel, Mark A. and Kidder, Lawrence E.
-                        and Owen, Robert and Rinne, Oliver",
-      title          = "{A New generalized harmonic evolution system}",
-      journal        = "Class. Quant. Grav.",
-      volume         = "23",
-      year           = "2006",
-      pages          = "S447-S462",
-      doi            = "10.1088/0264-9381/23/16/S09",
-      eprint         = "gr-qc/0512093",
-      archivePrefix  = "arXiv",
-      primaryClass   = "gr-qc",
-      url            = {https://doi.org/10.1088/0264-9381/23/16/S09},
-      SLACcitation   = "%%CITATION = GR-QC/0512093;%%"
+@book{ThorneBlandford2017,
+  author    = {Kip S.~Thorne and Roger D.~Blandford},
+  title     = {Modern Classical Physics},
+  year      = {2017},
+  url       = {https://press.princeton.edu/titles/10157.html},
+  publisher = {Princeton University Press},
 }

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -24,7 +24,8 @@ namespace GeneralizedHarmonic {
  *
  * \details Computes the generalized-harmonic 3-index constraint,
  * \f$C_{iab} = \partial_i\psi_{ab} - \Phi_{iab},\f$ which is
- * given by Eq. (26) of \cite Lindblom:2005qh
+ * given by Eq. (26) of \cite Lindblom2005qh
+ *
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::iaa<DataType, SpatialDim, Frame> three_index_constraint(
@@ -43,7 +44,8 @@ void three_index_constraint(
  * \brief Computes the generalized-harmonic gauge constraint.
  *
  * \details Computes the generalized-harmonic gauge constraint
- * [Eq. (40) of \cite Lindblom:2005qh],
+ * [Eq. (40) of \cite Lindblom2005qh
+ * ],
  * \f[
  * C_a = H_a + g^{ij} \Phi_{ija} + t^b \Pi_{ba}
  * - \frac{1}{2} g^i_a \psi^{bc} \Phi_{ibc}
@@ -83,7 +85,8 @@ void gauge_constraint(
  * \brief Computes the generalized-harmonic 2-index constraint.
  *
  * \details Computes the generalized-harmonic 2-index constraint
- * [Eq. (44) of \cite Lindblom:2005qh],
+ * [Eq. (44) of \cite Lindblom2005qh
+ * ],
  * \f{eqnarray}{
  * C_{ia} &\equiv& g^{jk}\partial_j \Phi_{ika}
  * - \frac{1}{2} g_a^j\psi^{cd}\partial_j \Phi_{icd}
@@ -151,7 +154,8 @@ void two_index_constraint(
  *
  * \details Computes the independent components of the generalized-harmonic
  * 4-index constraint. The constraint itself is given by Eq. (45) of
- * \cite Lindblom:2005qh,
+ * \cite Lindblom2005qh
+ * ,
  * \f{eqnarray}{
  * C_{ijab} = 2 \partial_{[i}\Phi_{j]ab},
  * \f}
@@ -267,5 +271,225 @@ void f_constraint(
     const Scalar<DataType>& gamma2,
     const tnsr::iaa<DataType, SpatialDim, Frame>&
         three_index_constraint) noexcept;
+// @}
+
+// @{
+/*!
+ * \brief Computes the generalized-harmonic (unnormalized) constraint energy.
+ *
+ * \details Computes the generalized-harmonic unnormalized constraint energy
+ * [Eq. (53) of \cite Lindblom2005qh
+ *  with
+ * \f$m^{ab}=\delta^{ab}\f$ and with each term in the sum scaled by an
+ * arbitrary coefficient],
+ * \f{eqnarray}{
+ * E & = & K_1 C_a C_a + K_2\left(F_a F_a
+     + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+     & + & K_3 C_{iab} C_{jab} g^{ij} + K_4 C_{ikab} C_{jlab}g^{ij} g^{kl}.
+ * \f}
+ * Here \f$C_a\f$ is the gauge constraint, \f$F_a\f$ is the f constraint,
+ * \f$C_{ia}\f$ is the two-index constraint, \f$C_{iab}\f$ is the
+ * three-index constraint, \f$C_{ikab}\f$ is the four-index constraint,
+ * \f$g^{ij}\f$ is the inverse spatial metric, and
+ * \f$K_1\f$, \f$K_2\f$, \f$K_3\f$, and \f$K_4\f$ are constant multipliers
+ * for each term that each default to a value of 1.0. Note that in this
+ * equation, spacetime indices \f$a,b\f$ are raised and lowered with
+ * the Kronecker delta.
+ *
+ * Also note that the argument `four_index_constraint` is a rank-3 tensor.
+ * This is because `GeneralizedHarmonic::four_index_constraint()` takes
+ * advantage of the antisymmetry of the four-index constraint's first two
+ * indices to only compute and return the independent
+ * components of \f$C_{ijab}\f$, which can be written as
+ * \f{eqnarray}{
+ * D_{iab} \equiv \frac{1}{2} \epsilon_{i}{}^{jk} C_{jkab},
+ * \f} where \f$\epsilon_{ijk}\f$ is the flat-space Levi-Civita tensor,
+ * whose inidces are raised and lowered with the Kronecker delta.
+ * The result is
+ * \f{eqnarray}{
+ * E & = & K_1 C_a C_a + K_2\left(F_a F_a
+ *       + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+ *   & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+     & + & 2 K_4 g D_{iab} D_{jab} g^{ij},
+ * \f} where \f$g\f$ is the determinant of the spatial metric.
+ *
+ * To derive this expression for the constraint energy implemented here,
+ * Eq.~(53) of \cite Lindblom2005qh
+ *  is
+ * \f{eqnarray}{
+ * S_{AB} dc^A dc^B &=&
+ *      m^{ab}\Bigl[d F_ad F_b
+ *      +g^{ij}\bigl(d C_{ia}d C_{jb}
+ *      +g^{kl}m^{cd}d C_{ikac}d C_{jlbd}\bigr)
+ * \nonumber\\
+ *      & + & \Lambda^2\bigl(d C_ad C_b
+ *      +g^{ij}m^{cd}d C_{iac}d C_{jbd}\bigr)
+ * \Bigr].
+ * \f} Replace \f$dc^A\rightarrow c^A\f$ to get
+ * \f{eqnarray}{
+ * E&=&
+ *      m^{ab}\Bigl[ F_a F_b
+ *      +g^{ij}\bigl( C_{ia} C_{jb}
+ *      +g^{kl}m^{cd} C_{ikac} C_{jlbd}\bigr)
+ * \nonumber\\
+ *      & + & \Lambda^2\bigl( C_a C_b
+ *      +g^{ij}m^{cd} C_{iac} C_{jbd}\bigr)
+ * \Bigr]\nonumber\\
+ * &=&
+ *      m^{ab} F_a F_b
+ *      +m^{ab}g^{ij} C_{ia} C_{jb}
+ *      +m^{ab}g^{ij} g^{kl}m^{cd} C_{ikac} C_{jlbd}
+ * \nonumber\\
+ *      & + & m^{ab}\Lambda^2 C_a C_b
+ *      +m^{ab}\Lambda^2 g^{ij}m^{cd} C_{iac} C_{jbd}.
+ * \f} Here \f$m^{ab}\f$ is an arbitrary positive-definite matrix, and
+ * \f$\Lambda\f$ is an arbitrary real scalar.
+ * Choose \f$m^{ab} = \delta^{ab}\f$ but allow an arbitrary coefficient to be
+ * placed in front of each term. Then, absorb \f$\Lambda^2\f$ into one of
+ * these coefficients, to get
+ * \f{eqnarray}{ E &=& K_
+ * F\delta^{ab} F_a F_b +K_2\delta^{ab}g^{ij} C_{ia} C_{jb}
+ +K_4\delta^{ab}g^{ij}
+ * g^{kl}\delta^{cd} C_{ikac} C_{jlbd}
+ * \nonumber\\
+ *      & + & K_1\delta^{ab} C_a C_b
+ *      +K_3\delta^{ab} g^{ij}\delta^{cd} C_{iac} C_{jbd}.
+ * \f}
+ * Adopting a Euclidean norm for the constraint space (i.e., choosing to raise
+ and
+ * lower spacetime indices with Kronecker deltas) gives
+ * \f{eqnarray}{ E &=& K_ F
+ * F_a F_a +K_2g^{ij} C_{ia} C_{ja} +K_4 g^{ij} g^{kl} C_{ikac} C_{jlac}
+ * \nonumber\\
+ *      & + & K_1 C_a C_a
+ *      +K_3g^{ij} C_{iac} C_{jac}.
+ * \f} The two-index constraint and f constraint can be viewed as the
+ * time and space components of a combined spacetime constraint. So next
+ * choose
+ * \f$K_ F=K_2\f$, giving \f{eqnarray}{ E&=& K_1 C_a C_a + K_2\left(F_a F_a
+ *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} g^{ij}
+ *      + K_4 C_{ikab} C_{jlab}g^{ij} g^{kl}.
+ * \f}
+ *
+ * Note that \f$C_{ikab}\f$ is antisymmetric on the first two indices. Next,
+ * replace the four-index constraint \f$C_{ijab}\f$ with \f$D_{iab}\f$, which
+ * contains the independent components of \f$C_{ijab}\f$. Specifically,
+ * \f{eqnarray}{
+ * D_{iab} \equiv \frac{1}{2} \epsilon_{i}{}^{jk} C_{jkab}.
+ * \f} The inverse relationship is
+ * \f{eqnarray}{
+ * C_{jkab} = \epsilon^{i}{}_{jk} D_{iab},
+ * \f} where \f$\epsilon_{ijk}\f$ is the flat-space Levi-Civita tensor, whose
+ * indices are raised and lowered with the Kronecker delta. Inserting this
+ relation
+ * to replace \f$C_{jkab}\f$ with \f$D_{iab}\f$ gives \f{eqnarray}{ E &=& K_1
+ C_a
+ * C_a + K_2\left(F_a F_a
+ *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+ *      & + & K_4 D_{mab} D_{nab} \epsilon^{m}{}_{ik}
+ *      \epsilon^{n}{}_{jl} g^{ij} g^{kl}. \f}
+ *
+ * There's a subtle point here: \f$g^{ij}\f$ is the inverse spatial metric,
+ which
+ * is not necessarily flat. But \f$\epsilon^{i}{}_{jk}\f$ is the flat space
+ * Levi-Civita tensor. In order to raise and lower indices of the Levi-Civita
+ * tensor with the inverse spatial metrics, put in the appropriate factors of
+ * \f$\sqrt{g}\f$, where \f$g\f$ is the metric determinant, to make the
+ * curved-space Levi-Civita tensor compatible with \f$g^{ij}\f$. Let
+ * \f$\varepsilon^{ijk}\f$ represent the curved space Levi-Civita tensor
+ compatible
+ * with \f$g^{ij}\f$: \f{eqnarray}{
+ * \varepsilon^{mik} = g^{-1/2} \epsilon^{mik}\\
+ * \varepsilon_{mik} = g^{1/2} \epsilon_{mik}.
+ * \f} Then we can write the constraint energy as
+ * \f{eqnarray}{
+ * E &=& K_1 C_a C_a + K_2\left(F_a F_a
+ *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+ *      & + & K_4 D_{mab} D_{nab} g g^{-1/2}\epsilon^{m}{}_{ik}
+ * g^{-1/2}\epsilon^{n}{}_{jl} g^{ij} g^{kl}. \f} The factors of
+ * \f$g^{-1/2}\f$ make the Levi-Civita tensor compatible with \f$g^{ij}\f$.
+ * Swapping which summed indices are raised and which are lowered gives
+ * \f{eqnarray}{ E &=& K_1 C_a
+ C_a +
+ * K_2\left(F_a F_a
+ *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+ *      & + & K_4 D_{mab} D_{nab} g g^{-1/2}\epsilon^{mik}
+ g^{-1/2}\epsilon^{njl}
+ * g_{ij} g_{kl}, \f} or \f{eqnarray}{ E &=& K_1 C_a C_a + K_2\left(F_a F_a
+ *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+ *      & + & K_4 D_{mab} D_{nab} g \varepsilon^{mik} \varepsilon^{njl} g_{ij}
+ * g_{kl}, \f} or, reversing up and down repeated indices again,
+ * \f{eqnarray}{ E
+ * &=& K_1 C_a C_a + K_2\left(F_a F_a
+ *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+ *      & + & K_4 D_{mab} D_{nab} g \varepsilon^{m}{}_{ik}
+ \varepsilon^{n}{}_{jl}
+ * g^{ij} g^{kl}. \f}
+ *
+ * The metric raises and lowers the indices of \f$\varepsilon^{ijk}\f$,
+ * so this can
+ * be written as \f{eqnarray}{ E &=& K_1 C_a C_a + K_2\left(F_a F_a
+ *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+ *      & + & K_4 g D_{mab} D^{n}{}_{ab} \varepsilon^{mjl} \varepsilon_{njl}.
+ * \f}
+ *
+ * Now, in flat space (Eq. (1.23) of \cite ThorneBlandford2017),
+ * \f{eqnarray}{
+ * \epsilon^{mjl} \epsilon_{njl} = \delta^{mj}_{nj} = \delta^m_n \delta^j_j -
+ * \delta^m_j \delta^j_n = 2 \delta^m_n. \f} But this holds for curved space
+ * as well: multiply the left hand side by \f$1 = g^{1/2} g^{-1/2}\f$ to get
+ * \f{eqnarray}{
+ * g^{-1/2}\epsilon^{mjl} g^{1/2}\epsilon_{njl} = \varepsilon^{mjl}
+ * \varepsilon_{njl} = \delta^{mj}_{nj} = \delta^m_n \delta^j_j - \delta^m_j
+ * \delta^j_n = 2 \delta^m_n. \f} So the constraint energy is \f{eqnarray}{ E
+ &=&
+ * K_1 C_a C_a + K_2\left(F_a F_a
+ *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+ *      & + & 2 K_4 D_{mab} D^{n}{}_{ab} \delta^m_n.
+ * \f}
+ * Simplifying gives the formula implemented here:
+ * \f{eqnarray}{
+ * E &=& K_1 C_a C_a + K_2\left(F_a F_a
+ *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+ *      & + & 2 K_4 g D_{iab} D_{jab} g^{ij}.
+ * \f}
+ */
+template <size_t SpatialDim, typename Frame, typename DataType>
+Scalar<DataType> constraint_energy(
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& f_constraint,
+    const tnsr::ia<DataType, SpatialDim, Frame>& two_index_constraint,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& three_index_constraint,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& four_index_constraint,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& spatial_metric_determinant,
+    double gauge_constraint_multiplier = 1.0,
+    double two_index_constraint_multiplier = 1.0,
+    double three_index_constraint_multiplier = 1.0,
+    double four_index_constraint_multiplier = 1.0) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
+void constraint_energy(
+    gsl::not_null<Scalar<DataType>*> energy,
+    const tnsr::a<DataType, SpatialDim, Frame>& gauge_constraint,
+    const tnsr::a<DataType, SpatialDim, Frame>& f_constraint,
+    const tnsr::ia<DataType, SpatialDim, Frame>& two_index_constraint,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& three_index_constraint,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& four_index_constraint,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const Scalar<DataType>& spatial_metric_determinant,
+    double gauge_constraint_multiplier = 1.0,
+    double two_index_constraint_multiplier = 1.0,
+    double three_index_constraint_multiplier = 1.0,
+    double four_index_constraint_multiplier = 1.0) noexcept;
 // @}
 }  // namespace GeneralizedHarmonic

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -596,3 +596,32 @@ def f_constraint(gauge_function, d_gauge_function, spacetime_normal_one_form,
     return constraint
 
 # End test functions for F constraint
+
+# Begin test functions for constraint energy
+
+
+def constraint_energy(gauge_constraint, f_constraint, two_index_constraint,
+                      three_index_constraint, four_index_constraint,
+                      inverse_spatial_metric, spatial_metric_determinant,
+                      gauge_constraint_multiplier,
+                      two_index_constraint_multiplier,
+                      three_index_constraint_multiplier,
+                      four_index_constraint_multiplier):
+    energy = 0.0
+    energy += gauge_constraint_multiplier \
+        * np.einsum("a,a", gauge_constraint, gauge_constraint)
+    energy += two_index_constraint_multiplier \
+        * np.einsum("a,a", f_constraint, f_constraint)
+    energy += two_index_constraint_multiplier \
+        * np.einsum("ia,ja,ij", two_index_constraint, two_index_constraint,
+                    inverse_spatial_metric)
+    energy += three_index_constraint_multiplier \
+        * np.einsum("iab,jab,ij", three_index_constraint,
+                    three_index_constraint, inverse_spatial_metric)
+    energy += 2.0 * four_index_constraint_multiplier \
+        * spatial_metric_determinant \
+        * np.einsum("iab,jab,ij", four_index_constraint,
+                    four_index_constraint, inverse_spatial_metric)
+    return energy
+
+# End test functions for constraint energy


### PR DESCRIPTION
## Proposed changes

Add the generalized harmonic constraint energy (unnormalized). Also update the generalized harmonic constraint documentation to use the new \cite method, instead of just inserting an arXiv URL.

Update: now depends on PR #1246.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->