### PR TITLE
Add Lorentzian solution to the Poisson equation

### DIFF
--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -69,7 +69,9 @@ struct Metavariables {
   using reduction_data_tags = tmpl::list<observers::Tags::ReductionData<
       Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
       Parallel::ReductionDatum<size_t, funcl::Plus<>>,
-      Parallel::ReductionDatum<double, funcl::Plus<>, funcl::Sqrt<>>>>;
+      Parallel::ReductionDatum<double, funcl::Plus<>,
+                               funcl::Sqrt<funcl::Divides<>>,
+                               std::index_sequence<1>>>>;
 
   // Specify all parallel components that will execute actions at some point.
   using component_list = tmpl::append<

--- a/src/Elliptic/Systems/Poisson/Actions/Observe.hpp
+++ b/src/Elliptic/Systems/Poisson/Actions/Observe.hpp
@@ -127,7 +127,9 @@ struct Observe {
     using observed_reduction_data = Parallel::ReductionData<
         Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
         Parallel::ReductionDatum<size_t, funcl::Plus<>>,
-        Parallel::ReductionDatum<double, funcl::Plus<>, funcl::Sqrt<>>>;
+        Parallel::ReductionDatum<double, funcl::Plus<>,
+                                 funcl::Sqrt<funcl::Divides<>>,
+                                 std::index_sequence<1>>>;
     Parallel::simple_action<observers::Actions::ContributeReductionData>(
         local_observer, observers::ObservationId(iteration_id),
         std::string{"/element_data"},

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY PoissonSolutions)
 
 set(LIBRARY_SOURCES
+  Lorentzian.cpp
   Moustache.cpp
   ProductOfSinusoids.cpp
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp"
+
+#include <array>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/MakeWithValue.hpp"
+// IWYU pragma: no_forward_declare Tensor
+
+namespace Poisson {
+namespace Solutions {
+
+template <>
+tuples::TaggedTuple<Field> Lorentzian<3>::variables(
+    const tnsr::I<DataVector, 3>& x, tmpl::list<Field> /*meta*/) noexcept {
+  return {Scalar<DataVector>(1. / sqrt(1 + get(dot_product(x, x))))};
+}
+
+template <>
+tuples::TaggedTuple<::Tags::Source<Field>> Lorentzian<3>::variables(
+    const tnsr::I<DataVector, 3>& x,
+    tmpl::list<::Tags::Source<Field>> /*meta*/) noexcept {
+  return {Scalar<DataVector>(3. / pow<5>(sqrt(1. + get(dot_product(x, x)))))};
+}
+
+template <>
+tuples::TaggedTuple<::Tags::Source<AuxiliaryField<3>>> Lorentzian<3>::variables(
+    const tnsr::I<DataVector, 3>& x,
+    tmpl::list<::Tags::Source<AuxiliaryField<3>>> /*meta*/) noexcept {
+  return {make_with_value<tnsr::I<DataVector, 3, Frame::Inertial>>(x, 0.)};
+}
+
+template <size_t Dim>
+void Lorentzian<Dim>::pup(PUP::er& /*p*/) noexcept {}
+
+template <size_t Dim>
+bool operator==(const Lorentzian<Dim>& /*lhs*/,
+                const Lorentzian<Dim>& /*rhs*/) noexcept {
+  return true;
+}
+
+template <size_t Dim>
+bool operator!=(const Lorentzian<Dim>& lhs,
+                const Lorentzian<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+// Explicit template instantiations
+template class Lorentzian<3>;
+template bool operator==(const Lorentzian<3>& lhs,
+                         const Lorentzian<3>& rhs) noexcept;
+template bool operator!=(const Lorentzian<3>& lhs,
+                         const Lorentzian<3>& rhs) noexcept;
+
+}  // namespace Solutions
+}  // namespace Poisson

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp
@@ -1,0 +1,95 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"     // IWYU pragma: keep
+#include "Elliptic/Systems/Poisson/Tags.hpp"    // IWYU pragma: keep
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+/// \cond
+class DataVector;
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Poisson {
+namespace Solutions {
+
+/*!
+ * \brief A Lorentzian solution to the Poisson equation
+ *
+ * \details This implements the Lorentzian solution
+ * \f$u(\boldsymbol{x})=\left(1+r^2\right)^{-\frac{1}{2}}\f$ to the
+ * three-dimensional Poisson equation
+ * \f$-\Delta u(\boldsymbol{x})=f(\boldsymbol{x})\f$, where
+ * \f$r^2=x^2+y^2+z^2\f$. The corresponding source is
+ * \f$f(\boldsymbol{x})=3\left(1+r^2\right)^{-\frac{5}{2}}\f$.
+ *
+ * \note Corresponding 1D and 2D solutions are not implemented yet.
+ */
+template <size_t Dim>
+class Lorentzian {
+  static_assert(
+      Dim == 3,
+      "This solution is currently implemented in 3 spatial dimensions only");
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr OptionString help{
+      "A Lorentzian solution to the Poisson equation."};
+
+  Lorentzian() = default;
+  Lorentzian(const Lorentzian&) noexcept = delete;
+  Lorentzian& operator=(const Lorentzian&) noexcept = delete;
+  Lorentzian(Lorentzian&&) noexcept = default;
+  Lorentzian& operator=(Lorentzian&&) noexcept = default;
+  ~Lorentzian() noexcept = default;
+
+  // @{
+  /// Retrieve variable at coordinates `x`
+  static auto variables(const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+                        tmpl::list<Field> /*meta*/) noexcept
+      -> tuples::TaggedTuple<Field>;
+
+  static auto variables(const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+                        tmpl::list<::Tags::Source<Field>> /*meta*/) noexcept
+      -> tuples::TaggedTuple<::Tags::Source<Field>>;
+
+  static auto variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+      tmpl::list<::Tags::Source<AuxiliaryField<Dim>>> /*meta*/) noexcept
+      -> tuples::TaggedTuple<::Tags::Source<AuxiliaryField<Dim>>>;
+  // @}
+
+  /// Retrieve a collection of variables at coordinates `x`
+  template <typename... Tags>
+  static tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+      tmpl::list<Tags...> /*meta*/) noexcept {
+    static_assert(sizeof...(Tags) > 1,
+                  "The generic template will recurse infinitely if only one "
+                  "tag is being retrieved.");
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  // clang-tidy: no pass by reference
+  void pup(PUP::er& p) noexcept;  // NOLINT
+};
+
+template <size_t Dim>
+bool operator==(const Lorentzian<Dim>& /*lhs*/,
+                const Lorentzian<Dim>& /*rhs*/) noexcept;
+
+template <size_t Dim>
+bool operator!=(const Lorentzian<Dim>& lhs,
+                const Lorentzian<Dim>& rhs) noexcept;
+
+}  // namespace Solutions
+}  // namespace Poisson

--- a/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
@@ -4,7 +4,6 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <array>
-#include <cmath>
 #include <cstddef>
 #include <string>
 #include <utility>
@@ -121,13 +120,15 @@ struct Metavariables {
   using reduction_data_tags = tmpl::list<observers::Tags::ReductionData<
       Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
       Parallel::ReductionDatum<size_t, funcl::Plus<>>,
-      Parallel::ReductionDatum<double, funcl::Plus<>, funcl::Sqrt<>>>>;
+      Parallel::ReductionDatum<double, funcl::Plus<>,
+                               funcl::Sqrt<funcl::Divides<>>,
+                               std::index_sequence<1>>>>;
 
   enum class Phase { Initialize, Exit };
 };
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson.Actions",
+SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson.Actions.Observe",
                   "[Unit][Elliptic][Actions]") {
   using TupleOfMockDistributedObjects =
       typename ActionTesting::MockRuntimeSystem<
@@ -244,7 +245,7 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson.Actions",
     // NumberOfPoints
     CHECK(reduction_data(0, 1) == 18);
     // L2Error
-    CHECK(reduction_data(0, 2) == sqrt(72.));
+    CHECK(reduction_data(0, 2) == approx(2.));
 
     const auto volume_file =
         h5::H5File<h5::AccessType::ReadOnly>(volume_h5_file_name);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_PoissonSolutions")
 
 set(LIBRARY_SOURCES
+  Test_Lorentzian.cpp
   Test_Moustache.cpp
   Test_ProductOfSinusoids.cpp
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.py
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def field(x):
+    return 1. / np.sqrt(1. + np.dot(x, x))
+
+
+def source(x):
+    return 3. / np.sqrt(1. + np.dot(x, x))**5
+
+
+def auxiliary_source(x):
+    return np.zeros(len(x))

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Lorentzian.cpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+
+template <size_t Dim>
+struct LorentzianProxy : Poisson::Solutions::Lorentzian<Dim> {
+  using Poisson::Solutions::Lorentzian<Dim>::Lorentzian;
+
+  using field_tags = tmpl::list<Poisson::Field>;
+  using source_tags = tmpl::list<Tags::Source<Poisson::Field>,
+                                 Tags::Source<Poisson::AuxiliaryField<Dim>>>;
+
+  tuples::tagged_tuple_from_typelist<field_tags> field_variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) const noexcept {
+    return Poisson::Solutions::Lorentzian<Dim>::variables(x, field_tags{});
+  }
+
+  tuples::tagged_tuple_from_typelist<source_tags> source_variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) const noexcept {
+    return Poisson::Solutions::Lorentzian<Dim>::variables(x, source_tags{});
+  }
+};
+
+template <size_t Dim>
+void test_solution() {
+  const LorentzianProxy<Dim> solution{};
+  pypp::check_with_random_values<1, tmpl::list<Poisson::Field>>(
+      &LorentzianProxy<Dim>::field_variables, solution, "Lorentzian", {"field"},
+      {{{-5., 5.}}}, std::make_tuple(), DataVector(5));
+  pypp::check_with_random_values<
+      1, tmpl::list<Tags::Source<Poisson::Field>,
+                    Tags::Source<Poisson::AuxiliaryField<Dim>>>>(
+      &LorentzianProxy<Dim>::source_variables, solution, "Lorentzian",
+      {"source", "auxiliary_source"}, {{{-5., 5.}}}, std::make_tuple(),
+      DataVector(5));
+
+  const Poisson::Solutions::Lorentzian<Dim> check_solution{};
+  const Poisson::Solutions::Lorentzian<Dim> created_solution =
+      test_creation<Poisson::Solutions::Lorentzian<Dim>>("  ");
+  CHECK(created_solution == check_solution);
+  test_serialization(check_solution);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.Poisson.Lorentzian",
+    "[PointwiseFunctions][Unit]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/Poisson"};
+  // 1D and 2D solutions are not implemented yet.
+  test_solution<3>();
+}


### PR DESCRIPTION
## Proposed changes

- A 3D spherically symmetric solution with a Lorentzian profile:
![bildschirmfoto 2019-01-09 um 12 15 32](https://user-images.githubusercontent.com/746230/50896086-44ea2400-1408-11e9-90ff-353253a0cc77.png)
- This solution falls off with the typical `1/r` dependence, which makes it useful to test spherical domains
- It could be generalized to 1D and 2D, e.g. with solutions that scale as `r` and `log(r)`, respectively. But I'm not sure if we'll actually need those so I'd like to defer that but leave the option open.
- I sneaked in another commit that fixes the normalization in the Poisson observe action

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
