### PR TITLE
Remove const from types used to construct random values

### DIFF
--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -580,6 +580,10 @@ struct get_vector_element_type<T, true> {
   using type = T;
 };
 template <typename T>
+struct get_vector_element_type<const T, false> {
+  using type = typename get_vector_element_type<T>::type;
+};
+template <typename T>
 struct get_vector_element_type<T, false> {
   using type = typename get_vector_element_type<
       typename T::ResultType::ElementType>::type;

--- a/src/Utilities/MakeWithValue.hpp
+++ b/src/Utilities/MakeWithValue.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <array>
+#include <type_traits>
 
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -38,9 +39,10 @@ struct MakeWithValueImpl {
 ///
 /// \see MakeWithValueImpls
 template <typename R, typename T, typename ValueType>
-SPECTRE_ALWAYS_INLINE R make_with_value(const T& input,
-                                        const ValueType value) noexcept {
-  return MakeWithValueImpls::MakeWithValueImpl<R, T>::apply(input, value);
+SPECTRE_ALWAYS_INLINE std::remove_const_t<R> make_with_value(
+    const T& input, const ValueType& value) noexcept {
+  return MakeWithValueImpls::MakeWithValueImpl<std::remove_const_t<R>,
+                                               T>::apply(input, value);
 }
 
 namespace MakeWithValueImpls {

--- a/tests/Utilities/MakeWithRandomValues.hpp
+++ b/tests/Utilities/MakeWithRandomValues.hpp
@@ -110,12 +110,14 @@ struct FillWithRandomValuesImpl<Variables<tmpl::list<Tags...>>,
 /// floating point or int distributions.
 template <typename T>
 class UniformCustomDistribution
-    : public tmpl::conditional_t<cpp17::is_integral_v<T>,
-                                std::uniform_int_distribution<T>,
-                                std::uniform_real_distribution<T>> {
-  using base = tmpl::conditional_t<cpp17::is_integral_v<T>,
-                                  std::uniform_int_distribution<T>,
-                                  std::uniform_real_distribution<T>>;
+    : public tmpl::conditional_t<
+          cpp17::is_integral_v<T>,
+          std::uniform_int_distribution<std::remove_const_t<T>>,
+          std::uniform_real_distribution<std::remove_const_t<T>>> {
+  using base = tmpl::conditional_t<
+      cpp17::is_integral_v<T>,
+      std::uniform_int_distribution<std::remove_const_t<T>>,
+      std::uniform_real_distribution<std::remove_const_t<T>>>;
   static_assert(cpp17::is_integral_v<T> or cpp17::is_floating_point_v<T>,
                 "UniformCustomDistribution currently supports only floating"
                 "point and integral values");


### PR DESCRIPTION
The changes are needed in order to compile with AppleClang 10.0.0.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
