### PR TITLE
Remove locale-dependent text from test regexes

### DIFF
--- a/tests/Unit/TestCompilationFramework.cpp
+++ b/tests/Unit/TestCompilationFramework.cpp
@@ -5,12 +5,10 @@
 #ifdef COMPILATION_TEST_TEST_DIFFERENT_COMPILERS
 // [[TAGS: unit, CompilationTest]]
 
-// [[COMPILER: GNU:0.0.0 REGEX: static assertion failed: assert with GCC 5]]
-// [[COMPILER: GNU:6.0.0 REGEX: static assertion failed: assert with GCC 6 or
-// newer]]
-// [[COMPILER: Clang REGEX: static_assert failed \"assert with Clang\"]]
-// [[COMPILER: AppleClang REGEX: static_assert failed \"assert with
-// AppleClang\"]]
+// [[COMPILER: GNU:0.0.0 REGEX: assert with GCC 5]]
+// [[COMPILER: GNU:6.0.0 REGEX: assert with GCC 6 or newer]]
+// [[COMPILER: Clang REGEX: assert with Clang]]
+// [[COMPILER: AppleClang REGEX: assert with AppleClang]]
 
 #ifdef __APPLE__
 static_assert(false, "assert with AppleClang");


### PR DESCRIPTION
Only GCC was affected because Clang is not currently localized, but
similar changes were made for all compilers for future-proofing
purposes.

Fixes #1250

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
