### PR TITLE
Each Observer now defines reduction_data_tags.

### DIFF
--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -28,6 +28,7 @@
 #include "Evolution/VariableFixing/FixToAtmosphere.hpp"
 #include "Evolution/VariableFixing/Tags.hpp"
 #include "IO/Observer/Actions.hpp"
+#include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"
@@ -99,13 +100,9 @@ struct EvolutionMetavars {
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
 
-  // hack this has to be synchronized with the Observe action :(
-  using Redum = Parallel::ReductionDatum<double, funcl::Plus<>,
-                                         funcl::Sqrt<funcl::Divides<>>,
-                                         std::index_sequence<1>>;
-  using reduction_data_tags = tmpl::list<observers::Tags::ReductionData<
-      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
-      Parallel::ReductionDatum<size_t, funcl::Plus<>>, Redum, Redum, Redum>>;
+  using reduction_data_tags =
+      observers::get_reduction_data_tags_from_observing_actions<
+          tmpl::list<grmhd::ValenciaDivClean::Actions::Observe>>;
 
   using compute_rhs = tmpl::flatten<tmpl::list<
       Actions::ComputeVolumeFluxes,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
@@ -12,6 +12,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "IO/Observer/Actions.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/ReductionActions.hpp"
@@ -30,6 +31,18 @@ namespace grmhd {
 namespace ValenciaDivClean {
 
 namespace Actions {
+
+namespace observe_detail {
+using reduction_datum = Parallel::ReductionDatum<double, funcl::Plus<>,
+                                                 funcl::Sqrt<funcl::Divides<>>,
+                                                 std::index_sequence<1>>;
+using reduction_datums =
+    tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+               Parallel::ReductionDatum<size_t, funcl::Plus<>>, reduction_datum,
+               reduction_datum, reduction_datum>;
+
+}  // namespace observe_detail
+
 /*!
  * \brief Temporary action for observing volume and reduction data
  *
@@ -48,6 +61,9 @@ struct Observe {
   };
 
   using const_global_cache_tags = tmpl::list<ObserveNSlabs, ObserveAtT0>;
+
+  using reduction_data_tags =
+      ::observers::make_reduction_data_tags_t<observe_detail::reduction_datums>;
 
   template <typename... DbTags, typename... InboxTags, typename Metavariables,
             size_t Dim, typename ActionList, typename ParallelComponent>
@@ -222,12 +238,9 @@ struct Observe {
           std::move(components), extents);
 
       // Send data to reduction observer
-      using Redum = Parallel::ReductionDatum<double, funcl::Plus<>,
-                                             funcl::Sqrt<funcl::Divides<>>,
-                                             std::index_sequence<1>>;
-      using ReData = Parallel::ReductionData<
-          Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
-          Parallel::ReductionDatum<size_t, funcl::Plus<>>, Redum, Redum, Redum>;
+      using ReData =
+          ::observers::make_reduction_data_t<observe_detail::reduction_datums>;
+
       Parallel::simple_action<observers::Actions::ContributeReductionData>(
           local_observer, observers::ObservationId(time),
           std::string{"/element_data"},

--- a/src/IO/Observer/Helpers.hpp
+++ b/src/IO/Observer/Helpers.hpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "IO/Observer/Tags.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+namespace observers {
+namespace detail {
+template <class ObservingAction, class = cpp17::void_t<>>
+struct get_reduction_data_tags_from_observing_action {
+  using type = tmpl::list<>;
+};
+
+template <class ObservingAction>
+struct get_reduction_data_tags_from_observing_action<
+    ObservingAction,
+    cpp17::void_t<typename ObservingAction::reduction_data_tags>> {
+  using type = typename ObservingAction::reduction_data_tags;
+};
+}  // namespace detail
+
+/// Each Action that sends data to the reduction Observer must specify
+/// a type alias `reduction_data_tags` that describes the data it
+/// sends.  Given a list of such Actions, this metafunction is used to
+/// create `Metavariables::reduction_data_tags` (which is required to
+/// initialize the Observer).
+template <class ObservingActionList>
+using get_reduction_data_tags_from_observing_actions =
+    tmpl::remove_duplicates<tmpl::transform<
+        ObservingActionList,
+        detail::get_reduction_data_tags_from_observing_action<tmpl::_1>>>;
+
+/// Given a tmpl::list of ReductionDatums, makes an
+/// observers::Tags::ReductionData.
+template <typename ReductionDatumList>
+using make_reduction_data_tags_t =
+    tmpl::wrap<ReductionDatumList, ::observers::Tags::ReductionData>;
+
+/// Given a tmpl::list of ReductionDatums, makes a
+/// Parallel::ReductionData.
+template <typename ReductionDatumList>
+using make_reduction_data_t =
+    tmpl::wrap<ReductionDatumList, ::Parallel::ReductionData>;
+}  // namespace observers

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveSurfaceIntegrals.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveSurfaceIntegrals.hpp
@@ -76,11 +76,14 @@ template <typename... Ts>
 struct reduction_data_tag_type<tmpl::list<Ts...>> {
   // The first argument is for Time, the others are for
   // the list of scalars being integrated.
-  using type = tmpl::list<observers::Tags::ReductionData<
+  using type = observers::Tags::ReductionData<
       Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
       Parallel::ReductionDatum<typename Ts::type::type::value_type,
-                               funcl::AssertEqual<>>...>>;
+                               funcl::AssertEqual<>>...>;
 };
+
+template <typename T>
+using reduction_data_tag_type_t = typename reduction_data_tag_type<T>::type;
 
 template <typename List, size_t... Is>
 auto make_reduction_data(const std::array<double, sizeof...(Is)>& a,
@@ -110,6 +113,8 @@ auto make_reduction_data(const std::array<double, N>& a) noexcept {
 template <typename TagsToObserve, typename InterpolationTargetTag,
           typename Frame>
 struct ObserveSurfaceIntegrals {
+  using reduction_data_tags = detail::reduction_data_tag_type_t<TagsToObserve>;
+
   template <typename DbTags, typename Metavariables>
   static void apply(
       const db::DataBox<DbTags>& box,


### PR DESCRIPTION
This makes it easier to add different Observers to the same
executable (even if the Observers observe something of the same type
but different values).

In Observer/Helpers.hpp there are new metafunctions that
assist with building a list of reduction_data_tags and reduction_data
from a list of ReductionDatum, and one for making the list of
reduction_data_tags in Metavariables given a list of Observers.

Also changed Test_ObserveSurfaceIntegrals.cpp to call more than
one observer (including more than one that observes things of
the same type but different values---something that was difficult to
do before this commit).

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
