### PR TITLE
Tidy up Pypp for travis tests

### DIFF
--- a/tests/Unit/Pypp/PyppFundamentals.hpp
+++ b/tests/Unit/Pypp/PyppFundamentals.hpp
@@ -74,9 +74,9 @@ PyObject* make_py_tuple(const Args&... t) {
     entry++;
     return '0';
   };
-  (void)add_entry; // GCC warns that add_entry is unused
+  (void)add_entry;  // GCC warns that add_entry is unused
   (void)std::initializer_list<char>{add_entry(t)...};
-  return  py_tuple;
+  return py_tuple;
 }
 
 ///\cond
@@ -175,8 +175,7 @@ struct ToPyObject<std::array<T, Size>, std::nullptr_t> {
       throw std::runtime_error{"Failed to convert argument."};
     }
     for (size_t i = 0; i < Size; ++i) {
-      PyObject* value =
-          ToPyObject<T>::convert(gsl::at(t, i));
+      PyObject* value = ToPyObject<T>::convert(gsl::at(t, i));
       if (value == nullptr) {
         throw std::runtime_error{"Failed to convert argument."};
       }
@@ -221,7 +220,8 @@ struct FromPyObject<long, std::nullptr_t> {
 #if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
     } else if (not PyInt_Check(t) and not PyLong_Check(t)) {
 #elif PY_MAJOR_VERSION == 3
-    } else if (not PyLong_Check(t)) {
+      // clang-tidy: hicpp-signed-bitwise
+    } else if (not PyLong_Check(t)) {  // NOLINT
 #else
     } else {
       static_assert(false, "Only works on Python 2.7 and 3.x")
@@ -240,7 +240,8 @@ struct FromPyObject<unsigned long, std::nullptr_t> {
 #if PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION == 7
     } else if (not PyInt_Check(t) and not PyLong_Check(t)) {
 #elif PY_MAJOR_VERSION == 3
-    } else if (not PyLong_Check(t)) {
+      // clang-tidy: hicpp-signed-bitwise
+    } else if (not PyLong_Check(t)) {  // NOLINT
 #else
     } else {
       static_assert(false, "Only works on Python 2.7 and 3.x");


### PR DESCRIPTION
## Proposed changes
- Minor changes to pass clang-tidy tests.
- Created following Geoffrey's comment on [1129](https://github.com/sxs-collaboration/spectre/pull/1129#discussion_r245387505)
- Originally code changes were proposed in #1071, which was superseded by #1129.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
