### PR TITLE
Support inhomogeneous boundary conditions in elliptic solver

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/InitializeElement.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/InitializeElement.hpp
@@ -8,11 +8,13 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/Domain.hpp"
+#include "Elliptic/Initialization/BoundaryConditions.hpp"
 #include "Elliptic/Initialization/Derivatives.hpp"
 #include "Elliptic/Initialization/DiscontinuousGalerkin.hpp"
 #include "Elliptic/Initialization/Domain.hpp"
 #include "Elliptic/Initialization/Interface.hpp"
 #include "Elliptic/Initialization/LinearSolver.hpp"
+#include "Elliptic/Initialization/Source.hpp"
 #include "Elliptic/Initialization/System.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Utilities/TMPL.hpp"
@@ -41,37 +43,47 @@ namespace Actions {
  *
  * - `Elliptic::Initialization::Domain`
  * - `Elliptic::Initialization::System`
- * - `Elliptic::Initialization::LinearSolver`
+ * - `Elliptic::Initialization::Source`
  * - `Elliptic::Initialization::Derivatives`
  * - `Elliptic::Initialization::Interface`
+ * - `Elliptic::Initialization::BoundaryConditions`
+ * - `Elliptic::Initialization::LinearSolver`
  * - `Elliptic::Initialization::DiscontinuousGalerkin`
  */
 template <size_t Dim>
 struct InitializeElement {
   template <class Metavariables>
-  using return_tag_list =
-      tmpl::append<typename Elliptic::Initialization::Domain<Dim>::simple_tags,
-                   typename Elliptic::Initialization::System<
-                       typename Metavariables::system>::simple_tags,
-                   typename Elliptic::Initialization::LinearSolver<
-                       Metavariables>::simple_tags,
-                   typename Elliptic::Initialization::Derivatives<
-                       typename Metavariables::system>::simple_tags,
-                   typename Elliptic::Initialization::Interface<
-                       typename Metavariables::system>::simple_tags,
-                   typename Elliptic::Initialization::DiscontinuousGalerkin<
-                       Metavariables>::simple_tags,
-                   typename Elliptic::Initialization::Domain<Dim>::compute_tags,
-                   typename Elliptic::Initialization::System<
-                       typename Metavariables::system>::compute_tags,
-                   typename Elliptic::Initialization::LinearSolver<
-                       Metavariables>::compute_tags,
-                   typename Elliptic::Initialization::Derivatives<
-                       typename Metavariables::system>::compute_tags,
-                   typename Elliptic::Initialization::Interface<
-                       typename Metavariables::system>::compute_tags,
-                   typename Elliptic::Initialization::DiscontinuousGalerkin<
-                       Metavariables>::compute_tags>;
+  using return_tag_list = tmpl::append<
+      // Simple tags
+      typename Elliptic::Initialization::Domain<Dim>::simple_tags,
+      typename Elliptic::Initialization::System<
+          typename Metavariables::system>::simple_tags,
+      typename Elliptic::Initialization::Source<Metavariables>::simple_tags,
+      typename Elliptic::Initialization::Derivatives<
+          typename Metavariables::system>::simple_tags,
+      typename Elliptic::Initialization::Interface<
+          typename Metavariables::system>::simple_tags,
+      typename Elliptic::Initialization::BoundaryConditions<
+          Metavariables>::simple_tags,
+      typename Elliptic::Initialization::LinearSolver<
+          Metavariables>::simple_tags,
+      typename Elliptic::Initialization::DiscontinuousGalerkin<
+          Metavariables>::simple_tags,
+      // Compute tags
+      typename Elliptic::Initialization::Domain<Dim>::compute_tags,
+      typename Elliptic::Initialization::System<
+          typename Metavariables::system>::compute_tags,
+      typename Elliptic::Initialization::Source<Metavariables>::compute_tags,
+      typename Elliptic::Initialization::Derivatives<
+          typename Metavariables::system>::compute_tags,
+      typename Elliptic::Initialization::Interface<
+          typename Metavariables::system>::compute_tags,
+      typename Elliptic::Initialization::BoundaryConditions<
+          Metavariables>::compute_tags,
+      typename Elliptic::Initialization::LinearSolver<
+          Metavariables>::compute_tags,
+      typename Elliptic::Initialization::DiscontinuousGalerkin<
+          Metavariables>::compute_tags>;
 
   template <typename... InboxTags, typename Metavariables, typename ActionList,
             typename ParallelComponent>
@@ -88,16 +100,23 @@ struct InitializeElement {
         db::DataBox<tmpl::list<>>{}, array_index, initial_extents, domain);
     auto system_box = Elliptic::Initialization::System<system>::initialize(
         std::move(domain_box));
-    auto linear_solver_box =
-        Elliptic::Initialization::LinearSolver<Metavariables>::initialize(
-            std::move(system_box), cache, array_index, parallel_component_meta);
-    auto deriv_box =
-        Elliptic::Initialization::Derivatives<typename Metavariables::system>::
-            initialize(std::move(linear_solver_box));
+    auto source_box =
+        Elliptic::Initialization::Source<Metavariables>::initialize(
+            std::move(system_box), cache);
+    auto deriv_box = Elliptic::Initialization::Derivatives<
+        typename Metavariables::system>::initialize(std::move(source_box));
     auto face_box = Elliptic::Initialization::Interface<system>::initialize(
         std::move(deriv_box));
+    auto boundary_conditions_box =
+        Elliptic::Initialization::BoundaryConditions<Metavariables>::initialize(
+            std::move(face_box), cache);
+    auto linear_solver_box =
+        Elliptic::Initialization::LinearSolver<Metavariables>::initialize(
+            std::move(boundary_conditions_box), cache, array_index,
+            parallel_component_meta);
     auto dg_box = Elliptic::Initialization::DiscontinuousGalerkin<
-        Metavariables>::initialize(std::move(face_box), initial_extents);
+        Metavariables>::initialize(std::move(linear_solver_box),
+                                   initial_extents);
     return std::make_tuple(std::move(dg_box));
   }
 };

--- a/src/Elliptic/Initialization/BoundaryConditions.hpp
+++ b/src/Elliptic/Initialization/BoundaryConditions.hpp
@@ -1,0 +1,172 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/LiftFlux.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace Elliptic {
+namespace Initialization {
+
+/*!
+ * \brief Adds boundary contributions to the sources
+ *
+ * Imposes boundary conditions by adding contributions to the sources of the
+ * elliptic equations. With the source modified, we may then assume homogeneous
+ * (i.e. zero) Dirichlet boundary conditions throughout the elliptic solve.
+ *
+ * \note Only Dirichlet boundary conditions retrieved from the analytic solution
+ * are currently supported.
+ *
+ * With:
+ * - `sources_tag` = `db::add_tag_prefix<Tags::Source, system::fields_tag>`
+ *
+ * Uses:
+ * - Metavariables:
+ *   - `analytic_solution_tag`
+ *   - `normal_dot_numerical_flux`
+ * - System:
+ *   - `volume_dim`
+ *   - `fields_tag`
+ *   - `impose_boundary_conditions_on_fields`
+ * - DataBox:
+ *   - `Tags::Mesh<volume_dim>`
+ *   - `Tags::Coordinates<volume_dim, Frame::Inertial>`
+ *   - `Tags::BoundaryDirectionsInterior<volume_dim>`
+ *   - `Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>,
+ *   Tags::Coordinates<volume_dim, Frame::Inertial>>`
+ *   - `Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>,
+ *   Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>`
+ *   - `Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>,
+ *   Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>`
+ *
+ * DataBox:
+ * - Modifies:
+ *   - `sources_tag`
+ */
+template <typename Metavariables>
+struct BoundaryConditions {
+  using system = typename Metavariables::system;
+
+  using sources_tag =
+      db::add_tag_prefix<Tags::Source, typename system::fields_tag>;
+
+  using simple_tags = db::AddSimpleTags<>;
+  using compute_tags = db::AddComputeTags<>;
+
+  template <typename NormalDotNumericalFluxComputer,
+            typename... NumericalFluxTags, typename... BoundaryDataTags>
+  static void compute_dirichlet_boundary_normal_dot_numerical_flux(
+      const gsl::not_null<Variables<tmpl::list<NumericalFluxTags...>>*>
+          numerical_fluxes,
+      const NormalDotNumericalFluxComputer& normal_dot_numerical_flux_computer,
+      const Variables<tmpl::list<BoundaryDataTags...>>& boundary_data,
+      const tnsr::i<DataVector, system::volume_dim, Frame::Inertial>&
+          normalized_face_normal) noexcept {
+    normal_dot_numerical_flux_computer.compute_dirichlet_boundary(
+        make_not_null(&get<NumericalFluxTags>(*numerical_fluxes))...,
+        get<BoundaryDataTags>(boundary_data)..., normalized_face_normal);
+  }
+
+  template <typename TagsList>
+  static auto initialize(
+      db::DataBox<TagsList>&& box,
+      const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+    static constexpr const size_t volume_dim = system::volume_dim;
+
+    const auto& analytic_solution =
+        Parallel::get<typename Metavariables::analytic_solution_tag>(cache);
+    const auto& normal_dot_numerical_flux_computer =
+        Parallel::get<typename Metavariables::normal_dot_numerical_flux>(cache);
+
+    db::mutate<sources_tag>(
+        make_not_null(&box),
+        [
+          &analytic_solution, &normal_dot_numerical_flux_computer
+        ](const gsl::not_null<db::item_type<sources_tag>*> sources,
+          const Mesh<volume_dim>& mesh,
+          const db::item_type<Tags::BoundaryDirectionsInterior<volume_dim>>&
+              boundary_directions,
+          const db::item_type<
+              Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>,
+                              Tags::Coordinates<volume_dim, Frame::Inertial>>>&
+              boundary_coordinates,
+          const db::item_type<Tags::Interface<
+              Tags::BoundaryDirectionsInterior<volume_dim>,
+              Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>>&
+              normalized_face_normals,
+          const db::item_type<Tags::Interface<
+              Tags::BoundaryDirectionsInterior<volume_dim>,
+              Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>>&
+              magnitude_of_face_normals) noexcept {
+          // Impose Dirichlet boundary conditions as contributions to the source
+          for (const auto& direction : boundary_directions) {
+            const size_t dimension = direction.dimension();
+            const auto mortar_mesh = mesh.slice_away(dimension);
+            // Compute Dirichlet data on mortar
+            Variables<typename system::impose_boundary_conditions_on_fields>
+                dirichlet_boundary_data{mortar_mesh.number_of_grid_points(),
+                                        0.};
+            dirichlet_boundary_data.assign_subset(analytic_solution.variables(
+                boundary_coordinates.at(direction),
+                typename system::impose_boundary_conditions_on_fields{}));
+            // Compute the numerical flux contribution from the Dirichlet data
+            db::item_type<
+                db::add_tag_prefix<Tags::NormalDotNumericalFlux, sources_tag>>
+                boundary_normal_dot_numerical_fluxes{
+                    mortar_mesh.number_of_grid_points(), 0.};
+            compute_dirichlet_boundary_normal_dot_numerical_flux(
+                make_not_null(&boundary_normal_dot_numerical_fluxes),
+                normal_dot_numerical_flux_computer,
+                std::move(dirichlet_boundary_data),
+                normalized_face_normals.at(direction));
+            // Flip sign of the boundary contributions, making them
+            // contributions to the source
+            db::item_type<sources_tag> lifted_boundary_data{
+                -1. *
+                dg::lift_flux(std::move(boundary_normal_dot_numerical_fluxes),
+                              mesh.extents(dimension),
+                              magnitude_of_face_normals.at(direction))};
+            add_slice_to_data(sources, std::move(lifted_boundary_data),
+                              mesh.extents(), dimension,
+                              index_to_slice_at(mesh.extents(), direction));
+          }
+        },
+        get<Tags::Mesh<volume_dim>>(box),
+        get<Tags::BoundaryDirectionsInterior<volume_dim>>(box),
+        get<Tags::Interface<Tags::BoundaryDirectionsInterior<volume_dim>,
+                            Tags::Coordinates<volume_dim, Frame::Inertial>>>(
+            box),
+        get<Tags::Interface<
+            Tags::BoundaryDirectionsInterior<volume_dim>,
+            Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>>(box),
+        get<Tags::Interface<
+            Tags::BoundaryDirectionsInterior<volume_dim>,
+            Tags::Magnitude<Tags::UnnormalizedFaceNormal<volume_dim>>>>(box));
+
+    return std::move(box);
+  }
+};
+}  // namespace Initialization
+}  // namespace Elliptic

--- a/src/Elliptic/Initialization/Interface.hpp
+++ b/src/Elliptic/Initialization/Interface.hpp
@@ -45,6 +45,7 @@ namespace Initialization {
  *   - `face<variables_tag>` (as a compute tag)
  *   - `face<db::add_tag_prefix<Tags::deriv, db::variables_tag_with_tags_list<
  *   variables_tag, gradient_tags>, tmpl::size_t<volume_dim>, Frame::Inertial>>`
+ *   - `face<Tags::Coordinates<volume_dim, Frame::Inertial>>`
  *   - `face<Tags::UnnormalizedFaceNormal<volume_dim>>`
  *   - `face<magnitude_tag<Tags::UnnormalizedFaceNormal<volume_dim>>>`
  *   - `face<Tags::Normalized<Tags::UnnormalizedFaceNormal<volume_dim>>>`
@@ -73,6 +74,8 @@ struct Interface {
                                       typename System::variables_tag,
                                       typename System::gradient_tags>,
                                   tmpl::size_t<volume_dim>, Frame::Inertial>>,
+      Tags::InterfaceComputeItem<
+          Directions, Tags::BoundaryCoordinates<volume_dim, Frame::Inertial>>,
       Tags::InterfaceComputeItem<Directions,
                                  Tags::UnnormalizedFaceNormal<volume_dim>>,
       Tags::InterfaceComputeItem<Directions,

--- a/src/Elliptic/Initialization/LinearSolver.hpp
+++ b/src/Elliptic/Initialization/LinearSolver.hpp
@@ -39,7 +39,6 @@ namespace Initialization {
  * - Metavariables:
  *   - `linear_solver`
  * - System:
- *   - `volume_dim`
  *   - `fields_tag`
  * - DataBox:
  *   - `sources_tag`

--- a/src/Elliptic/Initialization/LinearSolver.hpp
+++ b/src/Elliptic/Initialization/LinearSolver.hpp
@@ -32,16 +32,17 @@ namespace Initialization {
  * `Elliptic::Initialization::System`) so we don't have to apply the operator to
  * the initial guess.
  *
+ * With:
+ * - `sources_tag` = `db::add_tag_prefix<Tags::Source, system::fields_tag>`
+ *
  * Uses:
  * - Metavariables:
  *   - `linear_solver`
- *   - `analytic_solution_tag`
  * - System:
  *   - `volume_dim`
  *   - `fields_tag`
  * - DataBox:
- *   - `Tags::Mesh<volume_dim>`
- *   - `Tags::Coordinates<volume_dim, Frame::Inertial>`
+ *   - `sources_tag`
  *
  * DataBox:
  * - Adds:
@@ -67,22 +68,15 @@ struct LinearSolver {
       const Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& array_index,
       const ParallelComponent* const parallel_component_meta) noexcept {
-    const auto& inertial_coords =
-        get<Tags::Coordinates<system::volume_dim, Frame::Inertial>>(box);
-    const auto num_grid_points =
-        get<Tags::Mesh<system::volume_dim>>(box).number_of_grid_points();
-
-    db::item_type<sources_tag> sources(num_grid_points, 0.);
-    sources.assign_subset(
-        Parallel::get<typename Metavariables::analytic_solution_tag>(cache)
-            .source_variables(inertial_coords));
+    const auto& sources = get<sources_tag>(box);
 
     // Starting with x_0 = 0 initial guess, so Ax_0=0
-    db::item_type<fields_operator_tag> fields_operator(num_grid_points, 0.);
+    auto fields_operator =
+        make_with_value<db::item_type<fields_operator_tag>>(sources, 0.);
 
-    return linear_solver_tags::initialize(
-        std::move(box), cache, array_index, parallel_component_meta,
-        std::move(sources), std::move(fields_operator));
+    return linear_solver_tags::initialize(std::move(box), cache, array_index,
+                                          parallel_component_meta, sources,
+                                          std::move(fields_operator));
   }
 };
 }  // namespace Initialization

--- a/src/Elliptic/Initialization/Source.hpp
+++ b/src/Elliptic/Initialization/Source.hpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
+namespace Elliptic {
+namespace Initialization {
+
+/*!
+ * \brief Computes the sources of the elliptic equations and adds them to the
+ * DataBox
+ *
+ * \note Currently the sources are always retrieved from an analytic solution.
+ *
+ * With:
+ * - `sources_tag` = `db::add_tag_prefix<Tags::Source, system::fields_tag>`
+ *
+ * Uses:
+ * - Metavariables:
+ *   - `analytic_solution_tag`
+ * - ConstGlobalCache:
+ *   - `analytic_solution_tag`
+ * - System:
+ *   - `volume_dim`
+ *   - `fields_tag`
+ * - DataBox:
+ *   - `Tags::Mesh<volume_dim>`
+ *   - `Tags::Coordinates<volume_dim, Frame::Inertial>`
+ *
+ * DataBox:
+ * - Adds:
+ *   - `sources_tag`
+ */
+template <typename Metavariables>
+struct Source {
+  using system = typename Metavariables::system;
+
+  using sources_tag =
+      db::add_tag_prefix<Tags::Source, typename system::fields_tag>;
+
+  using simple_tags = db::AddSimpleTags<sources_tag>;
+  using compute_tags = db::AddComputeTags<>;
+
+  template <typename TagsList>
+  static auto initialize(
+      db::DataBox<TagsList>&& box,
+      const Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+    const auto& inertial_coords =
+        get<Tags::Coordinates<system::volume_dim, Frame::Inertial>>(box);
+    const auto num_grid_points =
+        get<Tags::Mesh<system::volume_dim>>(box).number_of_grid_points();
+
+    db::item_type<sources_tag> sources(num_grid_points, 0.);
+    // This actually sets the complete set of tags in the Variables, but there
+    // is no Variables constructor from a TaggedTuple (yet)
+    sources.assign_subset(
+        Parallel::get<typename Metavariables::analytic_solution_tag>(cache)
+            .variables(inertial_coords,
+                       db::get_variables_tags_list<sources_tag>{}));
+
+    return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+        std::move(box), std::move(sources));
+  }
+};
+}  // namespace Initialization
+}  // namespace Elliptic

--- a/src/Elliptic/Initialization/System.hpp
+++ b/src/Elliptic/Initialization/System.hpp
@@ -13,12 +13,7 @@
 #include "Domain/Mesh.hpp"
 #include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
-
-/// \cond
-namespace Frame {
-struct Inertial;
-}  // namespace Frame
-/// \endcond
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
 
 namespace Elliptic {
 namespace Initialization {
@@ -32,32 +27,49 @@ namespace Initialization {
  * - System:
  *   - `volume_dim`
  *   - `fields_tag`
+ *   - `variables_tag`
  * - DataBox:
  *   - `Tags::Mesh<volume_dim>`
  *
  * DataBox:
  * - Adds:
  *   - `fields_tag`
+ *   - `variables_tag`
+ *   - `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo,
+ *   variables_tag>`
  */
 template <typename SystemType>
 struct System {
   static constexpr size_t Dim = SystemType::volume_dim;
-  using simple_tags = db::AddSimpleTags<typename SystemType::fields_tag>;
+  using simple_tags = db::AddSimpleTags<
+      typename SystemType::fields_tag, typename SystemType::variables_tag,
+      db::add_tag_prefix<::LinearSolver::Tags::OperatorAppliedTo,
+                         typename SystemType::variables_tag>>;
   using compute_tags = db::AddComputeTags<>;
 
   template <typename TagsList>
   static auto initialize(db::DataBox<TagsList>&& box) noexcept {
-    using FieldsVars = typename SystemType::fields_tag::type;
-
     const size_t num_grid_points =
         db::get<Tags::Mesh<Dim>>(box).number_of_grid_points();
 
     // Set initial data to zero. Non-zero initial data would require the
     // linear solver initialization to also compute the Ax term.
-    FieldsVars fields{num_grid_points, 0.};
+    db::item_type<typename SystemType::fields_tag> fields{num_grid_points, 0.};
+
+    // Initialize the variables for the elliptic solve. Their initial value is
+    // determined by the linear solver. The value is also updated by the linear
+    // solver in every step.
+    db::item_type<typename SystemType::variables_tag> vars{num_grid_points};
+
+    // Initialize the linear operator applied to the variables. It needs no
+    // initial value, but is computed in every step of the elliptic solve.
+    db::item_type<db::add_tag_prefix<::LinearSolver::Tags::OperatorAppliedTo,
+                                     typename SystemType::variables_tag>>
+        operator_applied_to_vars{num_grid_points};
 
     return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
-        std::move(box), std::move(fields));
+        std::move(box), std::move(fields), std::move(vars),
+        std::move(operator_applied_to_vars));
   }
 };
 

--- a/src/Elliptic/Systems/Poisson/Actions/Observe.hpp
+++ b/src/Elliptic/Systems/Poisson/Actions/Observe.hpp
@@ -81,7 +81,7 @@ struct Observe {
         db::get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
     const auto field_analytic = get<Poisson::Field>(
         Parallel::get<typename Metavariables::analytic_solution_tag>(cache)
-            .field_variables(inertial_coordinates));
+            .variables(inertial_coordinates, tmpl::list<Poisson::Field>{}));
 
     // Compute error between numeric and analytic solutions
     const DataVector field_error = get(field) - get(field_analytic);

--- a/src/Elliptic/Systems/Poisson/Equations.cpp
+++ b/src/Elliptic/Systems/Poisson/Equations.cpp
@@ -123,6 +123,27 @@ void FirstOrderInternalPenaltyFlux<Dim>::operator()(
       penalty * (get(field_interior) - get(field_exterior));
 }
 
+template <size_t Dim>
+void FirstOrderInternalPenaltyFlux<Dim>::compute_dirichlet_boundary(
+    const gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
+    const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+        numerical_flux_for_auxiliary_field,
+    const Scalar<DataVector>& dirichlet_field,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+    const noexcept {
+  // Need polynomial degress and element size to compute this dynamically
+  const double penalty = penalty_parameter_;
+
+  // The minus sign is to cancel the one in `lift_flux`
+  for (size_t d = 0; d < Dim; d++) {
+    numerical_flux_for_auxiliary_field->get(d) =
+        -interface_unit_normal.get(d) * get(dirichlet_field);
+  }
+
+  // The minus sign in the equation is canceled by the one in `lift_flux`
+  numerical_flux_for_field->get() = 2. * penalty * get(dirichlet_field);
+}
+
 }  // namespace Poisson
 
 // Instantiate needed gradient and divergence templates

--- a/src/Elliptic/Systems/Poisson/Equations.hpp
+++ b/src/Elliptic/Systems/Poisson/Equations.hpp
@@ -187,6 +187,27 @@ struct FirstOrderInternalPenaltyFlux {
       const Scalar<DataVector>& minus_normal_dot_grad_field_exterior) const
       noexcept;
 
+  // This function computes the boundary contributions from Dirichlet boundary
+  // conditions. This data is what remains to be added to the boundaries when
+  // homogeneous (i.e. zero) boundary conditions are assumed in the calculation
+  // of the numerical fluxes, but we wish to impose inhomogeneous (i.e. nonzero)
+  // boundary conditions. Since this contribution does not depend on the
+  // numerical field values, but only on the Dirichlet boundary data, it may be
+  // added as contribution to the source of the elliptic systems. Then, it
+  // remains to solve the homogeneous problem with the modified source.
+  // The first arguments to this function are the boundary contributions to
+  // compute as not-null pointers, in the order they appear in the
+  // `system::fields_tag`. They are followed by the field values of the tags in
+  // `system::impose_boundary_conditions_on_fields`. The last argument is the
+  // normalized unit covector to the element face.
+  void compute_dirichlet_boundary(
+      gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
+      gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          numerical_flux_for_auxiliary_field,
+      const Scalar<DataVector>& dirichlet_field,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal)
+      const noexcept;
+
  private:
   double penalty_parameter_{};
 };

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
@@ -88,13 +88,19 @@ struct ConjugateGradient {
    * - Adds:
    *   * `LinearSolver::Tags::IterationId`
    *   * `Tags::Next<LinearSolver::Tags::IterationId>`
-   *   * `operand_tag`
-   *   * `operator_tag`
    *   * `residual_tag`
    *   * `residual_magnitude_tag`
    *   * `LinearSolver::Tags::HasConverged`
    * - Removes: nothing
-   * - Modifies: nothing
+   * - Modifies:
+   *   * `operand_tag`
+   *
+   * \note The `operand_tag` must already be present in the DataBox and is set
+   * to its initial value here. It is typically added to the DataBox by the
+   * system, which uses it to compute the `operator_tag` in each step. Also the
+   * `operator_tag` is typically added to the DataBox by the system, but does
+   * not need to be initialized until it is computed for the first time in the
+   * first step of the algorithm.
    */
   using tags = cg_detail::InitializeElement<Metavariables>;
 

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -103,14 +103,20 @@ struct Gmres {
    *   * `LinearSolver::Tags::IterationId`
    *   * `Tags::Next<LinearSolver::Tags::IterationId>`
    *   * `initial_fields_tag`
-   *   * `operand_tag`
-   *   * `operator_tag`
    *   * `orthogonalization_iteration_id_tag`
    *   * `basis_history_tag`
    *   * `residual_magnitude_tag`
    *   * `LinearSolver::Tags::HasConverged`
    * - Removes: nothing
-   * - Modifies: nothing
+   * - Modifies:
+   *   * `operand_tag`
+   *
+   * \note The `operand_tag` must already be present in the DataBox and is set
+   * to its initial value here. It is typically added to the DataBox by the
+   * system, which uses it to compute the `operator_tag` in each step. Also the
+   * `operator_tag` is typically added to the DataBox by the system, but does
+   * not need to be initialized until it is computed for the first time in the
+   * first step of the algorithm.
    */
   using tags = gmres_detail::InitializeElement<Metavariables>;
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.cpp
@@ -17,38 +17,11 @@
 namespace Poisson {
 namespace Solutions {
 
-namespace {
-
-tnsr::I<DataVector, 1> auxiliary_field(
-    const tnsr::I<DataVector, 1>& x,
-    const DataVector& precomputed_norm_square) noexcept {
-  auto result = make_with_value<tnsr::I<DataVector, 1>>(x, 0.);
-  const auto& x_d = get<0>(x);
-  get<0>(result) = sqrt(precomputed_norm_square) *
-                   evaluate_polynomial<double>({0.25, -3., 7.5, -5.}, x_d);
-  return result;
-}
-
-tnsr::I<DataVector, 2> auxiliary_field(
-    const tnsr::I<DataVector, 2>& x,
-    const DataVector& precomputed_norm_square) noexcept {
-  auto result = make_with_value<tnsr::I<DataVector, 2>>(x, 0.);
-  for (size_t d = 0; d < 2; d++) {
-    const auto& x_d = x.get(d);
-    const auto& x_p = x.get((d + 1) % 2);
-    result.get(d) = sqrt(precomputed_norm_square) * x_p * (1. - x_p) *
-                    (evaluate_polynomial<double>({0.25, -3.5, 7.5, -5.}, x_d) +
-                     evaluate_polynomial<double>({0.25, -1., 1.}, x_p) +
-                     2. * x_d * x_p - 2. * x_d * square(x_p));
-  }
-  return result;
-}
-
-}  // namespace
-
+/// \cond
 template <size_t Dim>
-tuples::TaggedTuple<Field, AuxiliaryField<Dim>> Moustache<Dim>::field_variables(
-    const tnsr::I<DataVector, Dim>& x) const noexcept {
+tuples::TaggedTuple<Field> Moustache<Dim>::variables(
+    const tnsr::I<DataVector, Dim>& x, tmpl::list<Field> /*meta*/) const
+    noexcept {
   auto field = make_with_value<Scalar<DataVector>>(x, 1.);
   for (size_t d = 0; d < Dim; d++) {
     get(field) *= x.get(d) * (1. - x.get(d));
@@ -58,23 +31,51 @@ tuples::TaggedTuple<Field, AuxiliaryField<Dim>> Moustache<Dim>::field_variables(
     norm_square += square(x.get(d) - 0.5);
   }
   get(field) *= pow(norm_square, 3. / 2.);
-  return {std::move(field), auxiliary_field(x, norm_square)};
+  return {std::move(field)};
 }
 
-/// \cond
 template <>
-tuples::TaggedTuple<::Tags::Source<Field>, ::Tags::Source<AuxiliaryField<1>>>
-Moustache<1>::source_variables(const tnsr::I<DataVector, 1>& x) const noexcept {
+tuples::TaggedTuple<AuxiliaryField<1>> Moustache<1>::variables(
+    const tnsr::I<DataVector, 1>& x,
+    tmpl::list<AuxiliaryField<1>> /*meta*/) const noexcept {
+  const auto& x_d = get<0>(x);
+  tnsr::I<DataVector, 1> auxiliary_field{
+      abs(x_d - 0.5) * evaluate_polynomial<double>({0.25, -3., 7.5, -5.}, x_d)};
+  return {std::move(auxiliary_field)};
+}
+
+template <>
+tuples::TaggedTuple<AuxiliaryField<2>> Moustache<2>::variables(
+    const tnsr::I<DataVector, 2>& x,
+    tmpl::list<AuxiliaryField<2>> /*meta*/) const noexcept {
+  auto auxiliary_field = make_with_value<tnsr::I<DataVector, 2>>(x, 0.);
+  auto norm_square = square(get<0>(x) - 0.5) + square(get<1>(x) - 0.5);
+  for (size_t d = 0; d < 2; d++) {
+    const auto& x_d = x.get(d);
+    const auto& x_p = x.get((d + 1) % 2);
+    auxiliary_field.get(d) =
+        sqrt(norm_square) * x_p * (1. - x_p) *
+        (evaluate_polynomial<double>({0.25, -3.5, 7.5, -5.}, x_d) +
+         evaluate_polynomial<double>({0.25, -1., 1.}, x_p) + 2. * x_d * x_p -
+         2. * x_d * square(x_p));
+  }
+  return {std::move(auxiliary_field)};
+}
+
+template <>
+tuples::TaggedTuple<::Tags::Source<Field>> Moustache<1>::variables(
+    const tnsr::I<DataVector, 1>& x,
+    tmpl::list<::Tags::Source<Field>> /*meta*/) const noexcept {
   const auto& x1 = get<0>(x) - 0.5;
   // This polynomial is minus the laplacian of the 1D solution
   Scalar<DataVector> field_source(abs(x1) * (20. * square(x1) - 1.5));
-  return {std::move(field_source),
-          make_with_value<tnsr::I<DataVector, 1, Frame::Inertial>>(x, 0.)};
+  return {std::move(field_source)};
 }
 
 template <>
-tuples::TaggedTuple<::Tags::Source<Field>, ::Tags::Source<AuxiliaryField<2>>>
-Moustache<2>::source_variables(const tnsr::I<DataVector, 2>& x) const noexcept {
+tuples::TaggedTuple<::Tags::Source<Field>> Moustache<2>::variables(
+    const tnsr::I<DataVector, 2>& x,
+    tmpl::list<::Tags::Source<Field>> /*meta*/) const noexcept {
   const auto& x1 = get<0>(x) - 0.5;
   const auto& x2 = get<1>(x) - 0.5;
   const auto x1_square = square(x1);
@@ -86,8 +87,15 @@ Moustache<2>::source_variables(const tnsr::I<DataVector, 2>& x) const noexcept {
       (-0.5625 + 6.25 * norm_square - 6.125 * square(norm_square) +
        4.125 * square(x1_square) - 24.75 * x1_square * x2_square +
        4.125 * square(x2_square)));
-  return {std::move(field_source),
-          make_with_value<tnsr::I<DataVector, 2, Frame::Inertial>>(x, 0.)};
+  return {std::move(field_source)};
+}
+
+template <size_t Dim>
+tuples::TaggedTuple<::Tags::Source<AuxiliaryField<Dim>>>
+Moustache<Dim>::variables(
+    const tnsr::I<DataVector, Dim>& x,
+    tmpl::list<::Tags::Source<AuxiliaryField<Dim>>> /*meta*/) const noexcept {
+  return {make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(x, 0.)};
 }
 /// \endcond
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
@@ -59,12 +59,35 @@ class Moustache {
   Moustache& operator=(Moustache&&) noexcept = default;
   ~Moustache() noexcept = default;
 
-  auto field_variables(const tnsr::I<DataVector, Dim>& x) const noexcept
-      -> tuples::TaggedTuple<Field, AuxiliaryField<Dim>>;
+  // @{
+  /// Retrieve variable at coordinates `x`
+  auto variables(const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+                 tmpl::list<Field> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Field>;
 
-  auto source_variables(const tnsr::I<DataVector, Dim>& x) const noexcept
-      -> tuples::TaggedTuple<::Tags::Source<Field>,
-                             ::Tags::Source<AuxiliaryField<Dim>>>;
+  auto variables(const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+                 tmpl::list<AuxiliaryField<Dim>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<AuxiliaryField<Dim>>;
+
+  auto variables(const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+                 tmpl::list<::Tags::Source<Field>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<::Tags::Source<Field>>;
+
+  auto variables(const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+                 tmpl::list<::Tags::Source<AuxiliaryField<Dim>>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<::Tags::Source<AuxiliaryField<Dim>>>;
+  // @}
+
+  /// Retrieve a collection of variables at coordinates `x`
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    static_assert(sizeof...(Tags) > 1,
+                  "The generic template will recurse infinitely if only one "
+                  "tag is being retrieved.");
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
 
   // clang-tidy: no pass by reference
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.cpp
@@ -24,13 +24,20 @@ ProductOfSinusoids<Dim>::ProductOfSinusoids(
     : wave_numbers_(wave_numbers) {}
 
 template <size_t Dim>
-tuples::TaggedTuple<Field, AuxiliaryField<Dim>>
-ProductOfSinusoids<Dim>::field_variables(
-    const tnsr::I<DataVector, Dim>& x) const noexcept {
+tuples::TaggedTuple<Field> ProductOfSinusoids<Dim>::variables(
+    const tnsr::I<DataVector, Dim>& x, tmpl::list<Field> /*meta*/) const
+    noexcept {
   auto field = make_with_value<Scalar<DataVector>>(x, 1.);
   for (size_t d = 0; d < Dim; d++) {
     field.get() *= sin(gsl::at(wave_numbers_, d) * x.get(d));
   }
+  return {std::move(field)};
+}
+
+template <size_t Dim>
+tuples::TaggedTuple<AuxiliaryField<Dim>> ProductOfSinusoids<Dim>::variables(
+    const tnsr::I<DataVector, Dim>& x,
+    tmpl::list<AuxiliaryField<Dim>> /*meta*/) const noexcept {
   auto auxiliary_field =
       make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(x, 1.);
   for (size_t d = 0; d < Dim; d++) {
@@ -43,17 +50,24 @@ ProductOfSinusoids<Dim>::field_variables(
       }
     }
   }
-  return {std::move(field), std::move(auxiliary_field)};
+  return {std::move(auxiliary_field)};
 }
 
 template <size_t Dim>
-tuples::TaggedTuple<::Tags::Source<Field>, ::Tags::Source<AuxiliaryField<Dim>>>
-ProductOfSinusoids<Dim>::source_variables(
-    const tnsr::I<DataVector, Dim>& x) const noexcept {
-  auto field_source = get<Field>(field_variables(x));
+tuples::TaggedTuple<::Tags::Source<Field>> ProductOfSinusoids<Dim>::variables(
+    const tnsr::I<DataVector, Dim>& x,
+    tmpl::list<::Tags::Source<Field>> /*meta*/) const noexcept {
+  auto field_source = get<Field>(variables(x, tmpl::list<Field>{}));
   field_source.get() *= square(magnitude(wave_numbers_));
-  return {std::move(field_source),
-          make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(x, 0.)};
+  return {std::move(field_source)};
+}
+
+template <size_t Dim>
+tuples::TaggedTuple<::Tags::Source<AuxiliaryField<Dim>>>
+ProductOfSinusoids<Dim>::variables(
+    const tnsr::I<DataVector, Dim>& x,
+    tmpl::list<::Tags::Source<AuxiliaryField<Dim>>> /*meta*/) const noexcept {
+  return {make_with_value<tnsr::I<DataVector, Dim, Frame::Inertial>>(x, 0.)};
 }
 
 template <size_t Dim>

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
@@ -52,12 +52,35 @@ class ProductOfSinusoids {
   explicit ProductOfSinusoids(
       const std::array<double, Dim>& wave_numbers) noexcept;
 
-  tuples::TaggedTuple<Field, AuxiliaryField<Dim>> field_variables(
-      const tnsr::I<DataVector, Dim>& x) const noexcept;
+  // @{
+  /// Retrieve variable at coordinates `x`
+  auto variables(const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+                 tmpl::list<Field> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<Field>;
 
-  tuples::TaggedTuple<::Tags::Source<Field>,
-                      ::Tags::Source<AuxiliaryField<Dim>>>
-  source_variables(const tnsr::I<DataVector, Dim>& x) const noexcept;
+  auto variables(const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+                 tmpl::list<AuxiliaryField<Dim>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<AuxiliaryField<Dim>>;
+
+  auto variables(const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+                 tmpl::list<::Tags::Source<Field>> /*meta*/) const noexcept
+      -> tuples::TaggedTuple<::Tags::Source<Field>>;
+
+  auto variables(const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+                 tmpl::list<::Tags::Source<AuxiliaryField<Dim>>> /*meta*/) const
+      noexcept -> tuples::TaggedTuple<::Tags::Source<AuxiliaryField<Dim>>>;
+  // @}
+
+  /// Retrieve a collection of variables at coordinates `x`
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x,
+      tmpl::list<Tags...> /*meta*/) const noexcept {
+    static_assert(sizeof...(Tags) > 1,
+                  "The generic template will recurse infinitely if only one "
+                  "tag is being retrieved.");
+    return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
 
   // clang-tidy: no pass by reference
   void pup(PUP::er& p) noexcept;  // NOLINT

--- a/tests/Unit/Elliptic/Initialization/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Initialization/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
   Test_Domain.cpp
   Test_Interface.cpp
   Test_LinearSolver.cpp
+  Test_Source.cpp
   Test_System.cpp
   )
 

--- a/tests/Unit/Elliptic/Initialization/CMakeLists.txt
+++ b/tests/Unit/Elliptic/Initialization/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_EllipticInitialization")
 
 set(LIBRARY_SOURCES
+  Test_BoundaryConditions.cpp
   Test_Derivatives.cpp
   Test_DiscontinuousGalerkin.cpp
   Test_Domain.cpp

--- a/tests/Unit/Elliptic/Initialization/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_BoundaryConditions.cpp
@@ -1,0 +1,257 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Brick.hpp"
+#include "Domain/Creators/Interval.hpp"
+#include "Domain/Creators/Rectangle.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Domain/SegmentId.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Initialization/BoundaryConditions.hpp"
+#include "Elliptic/Initialization/Domain.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+struct ScalarFieldTag : db::SimpleTag {
+  static std::string name() noexcept { return "ScalarFieldTag"; };
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using fields_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
+  using impose_boundary_conditions_on_fields = tmpl::list<ScalarFieldTag>;
+};
+
+template <size_t Dim>
+struct AnalyticSolution {
+  tuples::TaggedTuple<ScalarFieldTag> variables(
+      const tnsr::I<DataVector, Dim>& x,
+      tmpl::list<ScalarFieldTag> /*meta*/) const noexcept {
+    return {Scalar<DataVector>(get<0>(x))};
+  }
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+template <size_t Dim>
+struct NumericalFlux {
+  void compute_dirichlet_boundary(
+      gsl::not_null<Scalar<DataVector>*> numerical_flux_for_field,
+      const Scalar<DataVector>& field,
+      const tnsr::i<DataVector, Dim,
+                    Frame::Inertial>& /*interface_unit_normal*/) const
+      noexcept {
+    numerical_flux_for_field->get() = 2. * get(field);
+  }
+
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using system = System<Dim>;
+  using analytic_solution_tag =
+      OptionTags::AnalyticSolution<AnalyticSolution<Dim>>;
+  using normal_dot_numerical_flux =
+      OptionTags::NumericalFluxParams<NumericalFlux<Dim>>;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tag_list =
+      tmpl::list<analytic_solution_tag, normal_dot_numerical_flux>;
+};
+
+struct MockParallelComponent {};
+
+template <size_t Dim>
+using arguments_compute_tags = db::AddComputeTags<
+    Tags::BoundaryDirectionsInterior<Dim>,
+    Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<Dim>,
+                               Tags::Direction<Dim>>,
+    Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<Dim>,
+                               Tags::InterfaceMesh<Dim>>,
+    Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<Dim>,
+                               Tags::BoundaryCoordinates<Dim, Frame::Inertial>>,
+    Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<Dim>,
+                               Tags::UnnormalizedFaceNormal<Dim>>,
+    Tags::InterfaceComputeItem<
+        Tags::BoundaryDirectionsInterior<Dim>,
+        Tags::EuclideanMagnitude<Tags::UnnormalizedFaceNormal<Dim>>>,
+    Tags::InterfaceComputeItem<
+        Tags::BoundaryDirectionsInterior<Dim>,
+        Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>>;
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.BoundaryConditions",
+                  "[Unit][Elliptic][Actions]") {
+  {
+    INFO("1D");
+    // Reference element:
+    //    [X| | | ] -xi->
+    //    ^       ^
+    // -0.5       1.5
+    const ElementId<1> element_id{0, {{SegmentId{2, 0}}}};
+    const domain::creators::Interval<Frame::Inertial> domain_creator{
+        {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
+    auto domain_box = Elliptic::Initialization::Domain<1>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<1>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    db::item_type<
+        db::add_tag_prefix<Tags::Source, typename System<1>::fields_tag>>
+        sources{4, 0.};
+    auto arguments_box =
+        db::create_from<db::RemoveTags<>,
+                        db::AddSimpleTags<db::add_tag_prefix<
+                            Tags::Source, typename System<1>::fields_tag>>,
+                        arguments_compute_tags<1>>(std::move(domain_box),
+                                                   std::move(sources));
+
+    ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{
+        {AnalyticSolution<1>{}, NumericalFlux<1>{}}, {}};
+
+    const auto box = Elliptic::Initialization::BoundaryConditions<
+        Metavariables<1>>::initialize(std::move(arguments_box), runner.cache());
+
+    // Expected boundary contribution to source in element X:
+    // [ -24 0 0 0 | -xi->
+    // -0.5 (field) * 2. (num. flux) * 6. (inverse logical mass) * 4. (jacobian
+    // for mass) = -24.
+    // This expectation assumes the diagonal mass matrix approximation.
+    const DataVector source_expected{-24., 0., 0., 0.};
+    CHECK(get<Tags::Source<ScalarFieldTag>>(box) ==
+          Scalar<DataVector>(source_expected));
+  }
+  {
+    INFO("2D");
+    // Reference element:
+    //   eta ^
+    // 1.0 > +-+-+
+    //       |X| |
+    //       +-+-+
+    //       | | |
+    // 0.0 > +-+-+> xi
+    //       ^   ^
+    //    -0.5   1.5
+    const ElementId<2> element_id{0, {{SegmentId{1, 0}, SegmentId{1, 1}}}};
+    const domain::creators::Rectangle<Frame::Inertial> domain_creator{
+        {{-0.5, 0.}}, {{1.5, 1.}}, {{false, false}}, {{1, 1}}, {{3, 3}}};
+    auto domain_box = Elliptic::Initialization::Domain<2>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<2>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    db::item_type<
+        db::add_tag_prefix<Tags::Source, typename System<3>::fields_tag>>
+        sources{9, 0.};
+    auto arguments_box =
+        db::create_from<db::RemoveTags<>,
+                        db::AddSimpleTags<db::add_tag_prefix<
+                            Tags::Source, typename System<2>::fields_tag>>,
+                        arguments_compute_tags<2>>(std::move(domain_box),
+                                                   std::move(sources));
+
+    ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
+        {AnalyticSolution<2>{}, NumericalFlux<2>{}}, {}};
+
+    const auto box = Elliptic::Initialization::BoundaryConditions<
+        Metavariables<2>>::initialize(std::move(arguments_box), runner.cache());
+
+    // Expected boundary contribution to source in element X:
+    //   ^ eta
+    // -18 0 12
+    //  -6 0  0
+    //  -6 0  0 > xi
+    // This is the sum of contributions from the following faces (see 1D):
+    // - upper eta: [ -12 0 12 | -xi->
+    // - lower xi: | -6 -6 -6 ] -eta->
+    // This expectation assumes the diagonal mass matrix approximation.
+    const DataVector source_expected{-6., 0., 0., -6., 0., 0., -18., 0., 12.};
+    CHECK(get<Tags::Source<ScalarFieldTag>>(box) ==
+          Scalar<DataVector>(source_expected));
+  }
+  {
+    INFO("3D");
+    const ElementId<3> element_id{
+        0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 0}}}};
+    const domain::creators::Brick<Frame::Inertial> domain_creator{
+        {{-0.5, 0., -1.}},
+        {{1.5, 1., 3.}},
+        {{false, false, false}},
+        {{1, 1, 1}},
+        {{2, 2, 2}}};
+    auto domain_box = Elliptic::Initialization::Domain<3>::initialize(
+        db::DataBox<tmpl::list<>>{}, ElementIndex<3>{element_id},
+        domain_creator.initial_extents(), domain_creator.create_domain());
+
+    db::item_type<
+        db::add_tag_prefix<Tags::Source, typename System<3>::fields_tag>>
+        sources{8, 0.};
+    auto arguments_box =
+        db::create_from<db::RemoveTags<>,
+                        db::AddSimpleTags<db::add_tag_prefix<
+                            Tags::Source, typename System<3>::fields_tag>>,
+                        arguments_compute_tags<3>>(std::move(domain_box),
+                                                   std::move(sources));
+
+    ActionTesting::MockRuntimeSystem<Metavariables<3>> runner{
+        {AnalyticSolution<3>{}, NumericalFlux<3>{}}, {}};
+
+    const auto box = Elliptic::Initialization::BoundaryConditions<
+        Metavariables<3>>::initialize(std::move(arguments_box), runner.cache());
+
+    // Expected boundary contribution to source in reference element (0, 1, 0):
+    //                   7 eta
+    //         -6 ---- 4
+    // zeta ^ / |    / |
+    //     -2 ---- 0   |
+    //      |  -7 -|-- 5
+    //      | /    | /
+    //     -3 ---- 1 > xi
+    // This is the sum of contributions from the following faces (see 1D):
+    // - lower xi:
+    //   -2 -2 > zeta
+    //   -2 -2
+    //    v eta
+    // - upper eta:
+    //   -4 4 > xi
+    //   -4 4
+    //    v zeta
+    // - lower zeta:
+    //   -1 1 > xi
+    //   -1 1
+    //    v eta
+    // This expectation assumes the diagonal mass matrix approximation.
+    const DataVector source_expected{-3., 1., -7., 5., -2., 0., -6., 4.};
+    CHECK(get<Tags::Source<ScalarFieldTag>>(box) ==
+          Scalar<DataVector>(source_expected));
+  }
+}

--- a/tests/Unit/Elliptic/Initialization/Test_Derivatives.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_Derivatives.cpp
@@ -45,7 +45,8 @@ struct System {
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Derivatives",
                   "[Unit][Elliptic][Actions]") {
-  SECTION("1D") {
+  {
+    INFO("1D");
     const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
     const domain::creators::Interval<Frame::Inertial> domain_creator{
         {{-0.5}}, {{1.5}}, {{false}}, {{2}}, {{4}}};
@@ -75,7 +76,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Derivatives",
                 box)),
         get<0>(expected_derivs));
   }
-  SECTION("2D") {
+  {
+    INFO("2D");
     const ElementId<2> element_id{0, {{SegmentId{2, 1}, SegmentId{0, 0}}}};
     const domain::creators::Rectangle<Frame::Inertial> domain_creator{
         {{-0.5, 0.}}, {{1.5, 1.}}, {{false, false}}, {{2, 0}}, {{4, 2}}};
@@ -112,7 +114,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Derivatives",
                 box)),
         get<1>(expected_derivs));
   }
-  SECTION("3D") {
+  {
+    INFO("3D");
     const ElementId<3> element_id{
         0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 1}}}};
     const domain::creators::Brick<Frame::Inertial> domain_creator{

--- a/tests/Unit/Elliptic/Initialization/Test_DiscontinuousGalerkin.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_DiscontinuousGalerkin.cpp
@@ -68,7 +68,8 @@ struct Metavariables {
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.DG",
                   "[Unit][Elliptic][Actions]") {
-  SECTION("1D") {
+  {
+    INFO("1D");
     // Reference element:
     // [X| | | ] -xi->
     const ElementId<1> element_id{0, {{SegmentId{2, 0}}}};
@@ -133,7 +134,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.DG",
     CHECK(interface_normal_dot_fluxes.at(Direction<1>::upper_xi())
               .number_of_grid_points() == 1);
   }
-  SECTION("2D") {
+  {
+    INFO("2D");
     // Reference element:
     // ^ eta
     // +-+-+> xi
@@ -231,7 +233,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.DG",
     CHECK(interface_normal_dot_fluxes.at(Direction<2>::lower_eta())
               .number_of_grid_points() == 3);
   }
-  SECTION("3D") {
+  {
+    INFO("3D");
     const ElementId<3> element_id{
         0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{1, 0}}}};
     const domain::creators::Brick<Frame::Inertial> domain_creator{

--- a/tests/Unit/Elliptic/Initialization/Test_Domain.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_Domain.cpp
@@ -28,7 +28,8 @@
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Domain",
                   "[Unit][Elliptic][Actions]") {
-  SECTION("1D") {
+  {
+    INFO("1D");
     // Reference element:
     // [ |X| | ] -xi->
     const ElementId<1> element_id{0, {{SegmentId{2, 1}}}};
@@ -68,7 +69,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Domain",
                                     Tags::Coordinates<1, Frame::Logical>>>(
               box) == element_map.inv_jacobian(logical_coords));
   }
-  SECTION("2D") {
+  {
+    INFO("2D");
     // Reference element:
     // ^ eta
     // +-+-+-+-+> xi
@@ -114,7 +116,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Domain",
                                     Tags::Coordinates<2, Frame::Logical>>>(
               box) == element_map.inv_jacobian(logical_coords));
   }
-  SECTION("3D") {
+  {
+    INFO("3D");
     const ElementId<3> element_id{
         0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{1, 1}}}};
     const domain::creators::Brick<Frame::Inertial> domain_creator{

--- a/tests/Unit/Elliptic/Initialization/Test_Interface.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_Interface.cpp
@@ -51,7 +51,8 @@ struct System {
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Interface",
                   "[Unit][Elliptic][Actions]") {
-  SECTION("1D") {
+  {
+    INFO("1D");
     // Reference element:
     // [X| | | ] -xi->
     const ElementId<1> element_id{0, {{SegmentId{2, 0}}}};
@@ -137,7 +138,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Interface",
                 exterior_derivs.at(Direction<1>::lower_xi()))) ==
         expected_deriv_lower_xi);
   }
-  SECTION("2D") {
+  {
+    INFO("2D");
     // Reference element:
     // ^ eta
     // +-+-+> xi
@@ -209,7 +211,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Interface",
     CHECK(exterior_vars.at(Direction<2>::upper_eta()).number_of_grid_points() ==
           3);
   }
-  SECTION("3D") {
+  {
+    INFO("3D");
     const ElementId<3> element_id{
         0, {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{2, 0}}}};
     const domain::creators::Brick<Frame::Inertial> domain_creator{

--- a/tests/Unit/Elliptic/Initialization/Test_LinearSolver.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_LinearSolver.cpp
@@ -4,7 +4,6 @@
 #include "tests/Unit/TestingFramework.hpp"
 
 #include <algorithm>
-#include <cstddef>
 #include <string>
 
 #include "DataStructures/DataBox/DataBox.hpp"
@@ -13,24 +12,16 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
-#include "Domain/Mesh.hpp"
-#include "Domain/Tags.hpp"
 #include "Elliptic/Initialization/LinearSolver.hpp"
-#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"
-#include "NumericalAlgorithms/Spectral/Spectral.hpp"
-#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
 
-namespace PUP {
-class er;
-}  // namespace PUP
 namespace Parallel {
 template <typename Metavariables>
 class ConstGlobalCache;
 }  // namespace Parallel
+// IWYU pragma: no_forward_declare Variables
 
 namespace {
 struct ScalarFieldTag : db::SimpleTag {
@@ -48,15 +39,12 @@ struct LinearSolverAxTag : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
-template <size_t Dim>
 struct System {
-  static constexpr size_t volume_dim = Dim;
   using fields_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
 };
 
-template <size_t Dim>
 struct Metavariables {
-  using system = System<Dim>;
+  using system = System;
   using component_list = tmpl::list<>;
   using const_global_cache_tag_list = tmpl::list<>;
   struct linear_solver {
@@ -90,76 +78,22 @@ struct MockParallelComponent {};
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.LinearSolver",
                   "[Unit][Elliptic][Actions]") {
-  SECTION("1D") {
-    db::item_type<
-        db::add_tag_prefix<Tags::Source, typename System<1>::fields_tag>>
-        sources{3, 0.};
-    get<Tags::Source<ScalarFieldTag>>(sources) =
-        Scalar<DataVector>{{{{1., 2., 3.}}}};
-    auto arguments_box = db::create<db::AddSimpleTags<
-        db::add_tag_prefix<Tags::Source, typename System<1>::fields_tag>>>(
-        std::move(sources));
+  db::item_type<db::add_tag_prefix<Tags::Source, typename System::fields_tag>>
+      sources{3, 0.};
+  get<Tags::Source<ScalarFieldTag>>(sources) =
+      Scalar<DataVector>{{{{1., 2., 3.}}}};
+  auto arguments_box = db::create<db::AddSimpleTags<
+      db::add_tag_prefix<Tags::Source, typename System::fields_tag>>>(
+      std::move(sources));
 
-    ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{{}, {}};
-    MockParallelComponent component{};
-    const auto box =
-        Elliptic::Initialization::LinearSolver<Metavariables<1>>::initialize(
-            std::move(arguments_box), runner.cache(), 0, &component);
+  ActionTesting::MockRuntimeSystem<Metavariables> runner{{}, {}};
+  MockParallelComponent component{};
+  const auto box =
+      Elliptic::Initialization::LinearSolver<Metavariables>::initialize(
+          std::move(arguments_box), runner.cache(), 0, &component);
 
-    const DataVector b_expected{1., 2., 3.};
-    CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
-    const DataVector Ax_expected(3, 0.);
-    CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
-  }
-//   SECTION("2D") {
-//     Mesh<2> mesh{{{3, 2}},
-//                  Spectral::Basis::Legendre,
-//                  Spectral::Quadrature::GaussLobatto};
-//     tnsr::I<DataVector, 2, Frame::Inertial> inertial_coords{
-//         {{{1., 2., 3., 4., 5., 6.}, {6, 0.}}}};
-//     auto arguments_box =
-//         db::create<db::AddSimpleTags<Tags::Mesh<2>,
-//                                      Tags::Coordinates<2, Frame::Inertial>>>(
-//             mesh, std::move(inertial_coords));
-
-//     ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
-//         {AnalyticSolution<2>{}}, {}};
-
-//     MockParallelComponent component{};
-//     const auto box =
-//         Elliptic::Initialization::LinearSolver<Metavariables<2>>::initialize(
-//             std::move(arguments_box), runner.cache(), 0, &component);
-
-//     const DataVector b_expected{1., 2., 3., 4., 5., 6.};
-//     CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
-//     const DataVector Ax_expected(6, 0.);
-//     CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
-//   }
-//   SECTION("3D") {
-//     Mesh<3> mesh{{{3, 2, 2}},
-//                  Spectral::Basis::Legendre,
-//                  Spectral::Quadrature::GaussLobatto};
-//     tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{
-//         {{{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.},
-//           {12, 0.},
-//           {12, 0.}}}};
-//     auto arguments_box =
-//         db::create<db::AddSimpleTags<Tags::Mesh<3>,
-//                                      Tags::Coordinates<3, Frame::Inertial>>>(
-//             mesh, std::move(inertial_coords));
-
-//     ActionTesting::MockRuntimeSystem<Metavariables<3>> runner{
-//         {AnalyticSolution<3>{}}, {}};
-
-//     MockParallelComponent component{};
-//     const auto box =
-//         Elliptic::Initialization::LinearSolver<Metavariables<3>>::initialize(
-//             std::move(arguments_box), runner.cache(), 0, &component);
-
-//     const DataVector b_expected{1., 2., 3., 4.,  5.,  6.,
-//                                 7., 8., 9., 10., 11., 12.};
-//     CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
-//     const DataVector Ax_expected(12, 0.);
-//     CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
-//   }
+  const DataVector b_expected{1., 2., 3.};
+  CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
+  const DataVector Ax_expected(3, 0.);
+  CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
 }

--- a/tests/Unit/Elliptic/Initialization/Test_LinearSolver.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_LinearSolver.cpp
@@ -16,6 +16,7 @@
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/Initialization/LinearSolver.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
@@ -54,22 +55,10 @@ struct System {
 };
 
 template <size_t Dim>
-struct AnalyticSolution {
-  tuples::TaggedTuple<Tags::Source<ScalarFieldTag>> source_variables(
-      const tnsr::I<DataVector, Dim>& x) const noexcept {
-    return {Scalar<DataVector>(get<0>(x))};
-  }
-  // clang-tidy: do not use references
-  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
-};
-
-template <size_t Dim>
 struct Metavariables {
   using system = System<Dim>;
-  using analytic_solution_tag =
-      OptionTags::AnalyticSolution<AnalyticSolution<Dim>>;
   using component_list = tmpl::list<>;
-  using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
+  using const_global_cache_tag_list = tmpl::list<>;
   struct linear_solver {
     struct tags {
       using simple_tags =
@@ -102,17 +91,16 @@ struct MockParallelComponent {};
 SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.LinearSolver",
                   "[Unit][Elliptic][Actions]") {
   SECTION("1D") {
-    Mesh<1> mesh{3, Spectral::Basis::Legendre,
-                 Spectral::Quadrature::GaussLobatto};
-    tnsr::I<DataVector, 1, Frame::Inertial> inertial_coords{{{{1., 2., 3.}}}};
-    auto arguments_box =
-        db::create<db::AddSimpleTags<Tags::Mesh<1>,
-                                     Tags::Coordinates<1, Frame::Inertial>>>(
-            mesh, std::move(inertial_coords));
+    db::item_type<
+        db::add_tag_prefix<Tags::Source, typename System<1>::fields_tag>>
+        sources{3, 0.};
+    get<Tags::Source<ScalarFieldTag>>(sources) =
+        Scalar<DataVector>{{{{1., 2., 3.}}}};
+    auto arguments_box = db::create<db::AddSimpleTags<
+        db::add_tag_prefix<Tags::Source, typename System<1>::fields_tag>>>(
+        std::move(sources));
 
-    ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{
-        {AnalyticSolution<1>{}}, {}};
-
+    ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{{}, {}};
     MockParallelComponent component{};
     const auto box =
         Elliptic::Initialization::LinearSolver<Metavariables<1>>::initialize(
@@ -123,55 +111,55 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.LinearSolver",
     const DataVector Ax_expected(3, 0.);
     CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
   }
-  SECTION("2D") {
-    Mesh<2> mesh{{{3, 2}},
-                 Spectral::Basis::Legendre,
-                 Spectral::Quadrature::GaussLobatto};
-    tnsr::I<DataVector, 2, Frame::Inertial> inertial_coords{
-        {{{1., 2., 3., 4., 5., 6.}, {6, 0.}}}};
-    auto arguments_box =
-        db::create<db::AddSimpleTags<Tags::Mesh<2>,
-                                     Tags::Coordinates<2, Frame::Inertial>>>(
-            mesh, std::move(inertial_coords));
+//   SECTION("2D") {
+//     Mesh<2> mesh{{{3, 2}},
+//                  Spectral::Basis::Legendre,
+//                  Spectral::Quadrature::GaussLobatto};
+//     tnsr::I<DataVector, 2, Frame::Inertial> inertial_coords{
+//         {{{1., 2., 3., 4., 5., 6.}, {6, 0.}}}};
+//     auto arguments_box =
+//         db::create<db::AddSimpleTags<Tags::Mesh<2>,
+//                                      Tags::Coordinates<2, Frame::Inertial>>>(
+//             mesh, std::move(inertial_coords));
 
-    ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
-        {AnalyticSolution<2>{}}, {}};
+//     ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
+//         {AnalyticSolution<2>{}}, {}};
 
-    MockParallelComponent component{};
-    const auto box =
-        Elliptic::Initialization::LinearSolver<Metavariables<2>>::initialize(
-            std::move(arguments_box), runner.cache(), 0, &component);
+//     MockParallelComponent component{};
+//     const auto box =
+//         Elliptic::Initialization::LinearSolver<Metavariables<2>>::initialize(
+//             std::move(arguments_box), runner.cache(), 0, &component);
 
-    const DataVector b_expected{1., 2., 3., 4., 5., 6.};
-    CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
-    const DataVector Ax_expected(6, 0.);
-    CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
-  }
-  SECTION("3D") {
-    Mesh<3> mesh{{{3, 2, 2}},
-                 Spectral::Basis::Legendre,
-                 Spectral::Quadrature::GaussLobatto};
-    tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{
-        {{{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.},
-          {12, 0.},
-          {12, 0.}}}};
-    auto arguments_box =
-        db::create<db::AddSimpleTags<Tags::Mesh<3>,
-                                     Tags::Coordinates<3, Frame::Inertial>>>(
-            mesh, std::move(inertial_coords));
+//     const DataVector b_expected{1., 2., 3., 4., 5., 6.};
+//     CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
+//     const DataVector Ax_expected(6, 0.);
+//     CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
+//   }
+//   SECTION("3D") {
+//     Mesh<3> mesh{{{3, 2, 2}},
+//                  Spectral::Basis::Legendre,
+//                  Spectral::Quadrature::GaussLobatto};
+//     tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{
+//         {{{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.},
+//           {12, 0.},
+//           {12, 0.}}}};
+//     auto arguments_box =
+//         db::create<db::AddSimpleTags<Tags::Mesh<3>,
+//                                      Tags::Coordinates<3, Frame::Inertial>>>(
+//             mesh, std::move(inertial_coords));
 
-    ActionTesting::MockRuntimeSystem<Metavariables<3>> runner{
-        {AnalyticSolution<3>{}}, {}};
+//     ActionTesting::MockRuntimeSystem<Metavariables<3>> runner{
+//         {AnalyticSolution<3>{}}, {}};
 
-    MockParallelComponent component{};
-    const auto box =
-        Elliptic::Initialization::LinearSolver<Metavariables<3>>::initialize(
-            std::move(arguments_box), runner.cache(), 0, &component);
+//     MockParallelComponent component{};
+//     const auto box =
+//         Elliptic::Initialization::LinearSolver<Metavariables<3>>::initialize(
+//             std::move(arguments_box), runner.cache(), 0, &component);
 
-    const DataVector b_expected{1., 2., 3., 4.,  5.,  6.,
-                                7., 8., 9., 10., 11., 12.};
-    CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
-    const DataVector Ax_expected(12, 0.);
-    CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
-  }
+//     const DataVector b_expected{1., 2., 3., 4.,  5.,  6.,
+//                                 7., 8., 9., 10., 11., 12.};
+//     CHECK(get<LinearSolverSourceTag>(box) == Scalar<DataVector>(b_expected));
+//     const DataVector Ax_expected(12, 0.);
+//     CHECK(get<LinearSolverAxTag>(box) == Scalar<DataVector>(Ax_expected));
+//   }
 }

--- a/tests/Unit/Elliptic/Initialization/Test_Source.cpp
+++ b/tests/Unit/Elliptic/Initialization/Test_Source.cpp
@@ -1,0 +1,139 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Elliptic/Initialization/Source.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+
+namespace PUP {
+class er;
+}  // namespace PUP
+
+namespace {
+struct ScalarFieldTag : db::SimpleTag {
+  static std::string name() noexcept { return "ScalarFieldTag"; };
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr size_t volume_dim = Dim;
+  using fields_tag = Tags::Variables<tmpl::list<ScalarFieldTag>>;
+};
+
+template <size_t Dim>
+struct AnalyticSolution {
+  tuples::TaggedTuple<Tags::Source<ScalarFieldTag>> variables(
+      const tnsr::I<DataVector, Dim>& x,
+      tmpl::list<Tags::Source<ScalarFieldTag>> /*meta*/) const noexcept {
+    return {Scalar<DataVector>(get<0>(x))};
+  }
+  // clang-tidy: do not use references
+  void pup(PUP::er& /*p*/) noexcept {}  // NOLINT
+};
+
+template <size_t Dim>
+struct Metavariables {
+  using system = System<Dim>;
+  using analytic_solution_tag =
+      OptionTags::AnalyticSolution<AnalyticSolution<Dim>>;
+  using component_list = tmpl::list<>;
+  using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
+};
+
+struct MockParallelComponent {};
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Elliptic.Initialization.Source",
+                  "[Unit][Elliptic][Actions]") {
+  {
+    INFO("1D");
+    Mesh<1> mesh{3, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+    tnsr::I<DataVector, 1, Frame::Inertial> inertial_coords{{{{1., 2., 3.}}}};
+    auto arguments_box =
+        db::create<db::AddSimpleTags<Tags::Mesh<1>,
+                                     Tags::Coordinates<1, Frame::Inertial>>>(
+            mesh, std::move(inertial_coords));
+
+    ActionTesting::MockRuntimeSystem<Metavariables<1>> runner{
+        {AnalyticSolution<1>{}}, {}};
+
+    MockParallelComponent component{};
+    const auto box =
+        Elliptic::Initialization::Source<Metavariables<1>>::initialize(
+            std::move(arguments_box), runner.cache());
+
+    const DataVector source_expected{1., 2., 3.};
+    CHECK(get<Tags::Source<ScalarFieldTag>>(box) ==
+          Scalar<DataVector>(source_expected));
+  }
+  {
+    INFO("2D");
+    Mesh<2> mesh{{{3, 2}},
+                 Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+    tnsr::I<DataVector, 2, Frame::Inertial> inertial_coords{
+        {{{1., 2., 3., 4., 5., 6.}, {6, 0.}}}};
+    auto arguments_box =
+        db::create<db::AddSimpleTags<Tags::Mesh<2>,
+                                     Tags::Coordinates<2, Frame::Inertial>>>(
+            mesh, std::move(inertial_coords));
+
+    ActionTesting::MockRuntimeSystem<Metavariables<2>> runner{
+        {AnalyticSolution<2>{}}, {}};
+
+    MockParallelComponent component{};
+    const auto box =
+        Elliptic::Initialization::Source<Metavariables<2>>::initialize(
+            std::move(arguments_box), runner.cache());
+
+    const DataVector source_expected{1., 2., 3., 4., 5., 6.};
+    CHECK(get<Tags::Source<ScalarFieldTag>>(box) ==
+          Scalar<DataVector>(source_expected));
+  }
+  {
+    INFO("3D");
+    Mesh<3> mesh{{{3, 2, 2}},
+                 Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+    tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{
+        {{{1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.},
+          {12, 0.},
+          {12, 0.}}}};
+    auto arguments_box =
+        db::create<db::AddSimpleTags<Tags::Mesh<3>,
+                                     Tags::Coordinates<3, Frame::Inertial>>>(
+            mesh, std::move(inertial_coords));
+
+    ActionTesting::MockRuntimeSystem<Metavariables<3>> runner{
+        {AnalyticSolution<3>{}}, {}};
+
+    MockParallelComponent component{};
+    const auto box =
+        Elliptic::Initialization::Source<Metavariables<3>>::initialize(
+            std::move(arguments_box), runner.cache());
+
+    const DataVector source_expected{1., 2., 3., 4.,  5.,  6.,
+                                     7., 8., 9., 10., 11., 12.};
+    CHECK(get<Tags::Source<ScalarFieldTag>>(box) ==
+          Scalar<DataVector>(source_expected));
+  }
+}

--- a/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
@@ -97,8 +97,9 @@ struct MockObserverWriterComponent {
 };
 
 struct AnalyticSolution {
-  tuples::TaggedTuple<Poisson::Field> field_variables(
-      const tnsr::I<DataVector, 2>& x) const noexcept {
+  tuples::TaggedTuple<Poisson::Field> variables(
+      const tnsr::I<DataVector, 2>& x,
+      tmpl::list<Poisson::Field> /*meta*/) const noexcept {
     return {Scalar<DataVector>(2. * get<0>(x) + get<1>(x))};
   }
   // clang-tidy: do not use references

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -50,10 +50,11 @@ void test_first_order_operator_action(db::DataBox<DbTagsList>&& domain_box) {
 
   const Poisson::Solutions::ProductOfSinusoids<Dim> solution(
       make_array<Dim>(1.));
-  const auto field_variables = solution.field_variables(inertial_coords);
+  const auto auxiliary_field =
+      get<Poisson::AuxiliaryField<Dim>>(solution.variables(
+          inertial_coords,
+          tmpl::list<Poisson::Field, Poisson::AuxiliaryField<Dim>>{}));
 
-  const auto& auxiliary_field =
-      get<Poisson::AuxiliaryField<Dim>>(field_variables);
   auto grad_field = make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(
       inertial_coords, 0.);
   for (size_t d = 0; d < Dim; d++) {
@@ -86,7 +87,10 @@ void test_first_order_operator_action(db::DataBox<DbTagsList>&& domain_box) {
       typename Poisson::ComputeFirstOrderOperatorAction<Dim>::argument_tags>(
       Poisson::ComputeFirstOrderOperatorAction<Dim>{}, make_not_null(&box));
 
-  const auto source_variables = solution.source_variables(inertial_coords);
+  const auto auxiliary_source =
+      get<Tags::Source<Poisson::AuxiliaryField<Dim>>>(solution.variables(
+          inertial_coords,
+          tmpl::list<Tags::Source<Poisson::AuxiliaryField<Dim>>>{}));
 
   // Field volume contribution should be -div(v), which is not exactly the
   // source f because of discretization error
@@ -109,7 +113,7 @@ void test_first_order_operator_action(db::DataBox<DbTagsList>&& domain_box) {
   CHECK_ITERABLE_APPROX(
       get<LinearSolver::Tags::OperatorAppliedTo<
           LinearSolver::Tags::Operand<Poisson::AuxiliaryField<Dim>>>>(box),
-      get<Tags::Source<Poisson::AuxiliaryField<Dim>>>(source_variables));
+      auxiliary_source);
 }
 
 template <size_t Dim, typename DbTagsList>
@@ -123,7 +127,9 @@ void test_first_order_normal_dot_fluxes(
 
   const Poisson::Solutions::ProductOfSinusoids<Dim> solution(
       make_array<Dim>(1.));
-  const auto field_variables = solution.field_variables(inertial_coords);
+  const auto field_variables = solution.variables(
+      inertial_coords,
+      tmpl::list<Poisson::Field, Poisson::AuxiliaryField<Dim>>{});
 
   // Any numbers are fine, doesn't have anything to do with unit normal
   tnsr::i<DataVector, Dim, Frame::Inertial> unit_normal(num_points, 0.0);
@@ -181,7 +187,9 @@ void test_first_order_internal_penalty_flux(
 
   const Poisson::Solutions::ProductOfSinusoids<Dim> solution(
       make_array<Dim>(1.));
-  const auto field_variables = solution.field_variables(inertial_coords);
+  const auto field_variables = solution.variables(
+      inertial_coords,
+      tmpl::list<Poisson::Field, Poisson::AuxiliaryField<Dim>>{});
 
   // Any numbers are fine, doesn't have anything to do with unit normal
   tnsr::i<DataVector, Dim, Frame::Inertial> unit_normal(num_points, 0.0);

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_Moustache.cpp
@@ -6,11 +6,14 @@
 #include <cstddef>
 #include <tuple>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestCreation.hpp"
@@ -19,19 +22,37 @@
 namespace {
 
 template <size_t Dim>
+struct MoustacheProxy : Poisson::Solutions::Moustache<Dim> {
+  using Poisson::Solutions::Moustache<Dim>::Moustache;
+
+  using field_tags = tmpl::list<Poisson::Field, Poisson::AuxiliaryField<Dim>>;
+  using source_tags = db::wrap_tags_in<Tags::Source, field_tags>;
+
+  tuples::tagged_tuple_from_typelist<field_tags> field_variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) const noexcept {
+    return Poisson::Solutions::Moustache<Dim>::variables(x, field_tags{});
+  }
+
+  tuples::tagged_tuple_from_typelist<source_tags> source_variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) const noexcept {
+    return Poisson::Solutions::Moustache<Dim>::variables(x, source_tags{});
+  }
+};
+
+template <size_t Dim>
 void test_solution() {
-  const Poisson::Solutions::Moustache<Dim> solution{};
+  const MoustacheProxy<Dim> solution{};
   pypp::check_with_random_values<
       1, tmpl::list<Poisson::Field, Poisson::AuxiliaryField<Dim>>>(
-      &Poisson::Solutions::Moustache<Dim>::field_variables, solution,
-      "Moustache", {"field", "auxiliary_field"}, {{{0., 1.}}},
-      std::make_tuple(), DataVector(5));
+      &MoustacheProxy<Dim>::field_variables, solution, "Moustache",
+      {"field", "auxiliary_field"}, {{{0., 1.}}}, std::make_tuple(),
+      DataVector(5));
   pypp::check_with_random_values<
       1, tmpl::list<Tags::Source<Poisson::Field>,
                     Tags::Source<Poisson::AuxiliaryField<Dim>>>>(
-      &Poisson::Solutions::Moustache<Dim>::source_variables, solution,
-      "Moustache", {"source", "auxiliary_source"}, {{{0., 1.}}},
-      std::make_tuple(), DataVector(5));
+      &MoustacheProxy<Dim>::source_variables, solution, "Moustache",
+      {"source", "auxiliary_source"}, {{{0., 1.}}}, std::make_tuple(),
+      DataVector(5));
 
   Poisson::Solutions::Moustache<Dim> created_solution =
       test_creation<Poisson::Solutions::Moustache<Dim>>("  ");

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Poisson/Test_ProductOfSinusoids.cpp
@@ -9,11 +9,14 @@
 #include <string>
 #include <tuple>
 
+#include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"  // IWYU pragma: keep
 #include "PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestCreation.hpp"
@@ -22,18 +25,38 @@
 namespace {
 
 template <size_t Dim>
+struct ProductOfSinusoidsProxy : Poisson::Solutions::ProductOfSinusoids<Dim> {
+  using Poisson::Solutions::ProductOfSinusoids<Dim>::ProductOfSinusoids;
+
+  using field_tags = tmpl::list<Poisson::Field, Poisson::AuxiliaryField<Dim>>;
+  using source_tags = db::wrap_tags_in<Tags::Source, field_tags>;
+
+  tuples::tagged_tuple_from_typelist<field_tags> field_variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) const noexcept {
+    return Poisson::Solutions::ProductOfSinusoids<Dim>::variables(x,
+                                                                  field_tags{});
+  }
+
+  tuples::tagged_tuple_from_typelist<source_tags> source_variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x) const noexcept {
+    return Poisson::Solutions::ProductOfSinusoids<Dim>::variables(
+        x, source_tags{});
+  }
+};
+
+template <size_t Dim>
 void test_solution(const std::array<double, Dim>& wave_numbers,
                    const std::string& options) {
-  const Poisson::Solutions::ProductOfSinusoids<Dim> solution(wave_numbers);
+  const ProductOfSinusoidsProxy<Dim> solution(wave_numbers);
   pypp::check_with_random_values<
       1, tmpl::list<Poisson::Field, Poisson::AuxiliaryField<Dim>>>(
-      &Poisson::Solutions::ProductOfSinusoids<Dim>::field_variables, solution,
+      &ProductOfSinusoidsProxy<Dim>::field_variables, solution,
       "ProductOfSinusoids", {"field", "auxiliary_field"}, {{{0., 2. * M_PI}}},
       std::make_tuple(wave_numbers), DataVector(5));
   pypp::check_with_random_values<
       1, tmpl::list<Tags::Source<Poisson::Field>,
                     Tags::Source<Poisson::AuxiliaryField<Dim>>>>(
-      &Poisson::Solutions::ProductOfSinusoids<Dim>::source_variables, solution,
+      &ProductOfSinusoidsProxy<Dim>::source_variables, solution,
       "ProductOfSinusoids", {"source", "auxiliary_source"}, {{{0., 2. * M_PI}}},
       std::make_tuple(wave_numbers), DataVector(5));
 


### PR DESCRIPTION
## Proposed changes

This PR adds support for inhomogeneous (i.e. nonzero) Dirichlet boundary conditions for the elliptic solver. This requires reordering the initialisation procedure, so that these boundary contributions can be added to the source term. Then, it remains to solve the homogeneous problem with the modified source.

To be able to retrieve the Dirichlet boundary data from the analytic solution, this PR also moves the elliptic analytic solutions to the same architecture as employed in the evolution code, i.e. provide many overloads of a `variables` function.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [x] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
