### PR TITLE
Observe linear solver residuals

### DIFF
--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -14,6 +14,7 @@
 #include "Elliptic/Systems/Poisson/FirstOrderSystem.hpp"
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "IO/Observer/Actions.hpp"
+#include "IO/Observer/Helpers.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"
@@ -64,14 +65,8 @@ struct Metavariables {
   // Collect all items to store in the cache.
   using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
 
-  // This has to be synchronized with Poisson::Actions::Observe (see also e.g.
-  // EvolveValenciaDivClean)
-  using reduction_data_tags = tmpl::list<observers::Tags::ReductionData<
-      Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
-      Parallel::ReductionDatum<size_t, funcl::Plus<>>,
-      Parallel::ReductionDatum<double, funcl::Plus<>,
-                               funcl::Sqrt<funcl::Divides<>>,
-                               std::index_sequence<1>>>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::list<Poisson::Actions::Observe, linear_solver>>;
 
   // Specify all parallel components that will execute actions at some point.
   using component_list = tmpl::append<

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -75,9 +75,8 @@ struct EvolutionMetavars {
                      local_time_stepping, LtsTimeStepper, TimeStepper>>>;
   using domain_creator_tag = OptionTags::DomainCreator<1, Frame::Inertial>;
 
-  using reduction_data_tags =
-      observers::get_reduction_data_tags_from_observing_actions<
-          tmpl::list<Burgers::Actions::Observe>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::list<Burgers::Actions::Observe>>;
 
   using step_choosers =
       tmpl::list<StepChoosers::Registrars::Cfl<1, Frame::Inertial>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -104,9 +104,8 @@ struct EvolutionMetavars {
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
       grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
 
-  using reduction_data_tags =
-      observers::get_reduction_data_tags_from_observing_actions<
-          tmpl::list<grmhd::ValenciaDivClean::Actions::Observe>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::list<grmhd::ValenciaDivClean::Actions::Observe>>;
 
   using compute_rhs = tmpl::flatten<tmpl::list<
       Actions::ComputeVolumeFluxes,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -16,10 +16,9 @@
 #include "Evolution/Systems/ScalarWave/Equations.hpp"  // IWYU pragma: keep // for UpwindFlux
 #include "Evolution/Systems/ScalarWave/Observe.hpp"    // IWYU pragma: keep
 #include "Evolution/Systems/ScalarWave/System.hpp"
-#include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
-#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/Actions.hpp"            // IWYU pragma: keep
+#include "IO/Observer/Helpers.hpp"            // IWYU pragma: keep
 #include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
-#include "IO/Observer/Tags.hpp"               // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyBoundaryFluxesLocalTimeStepping.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ApplyFluxes.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ComputeNonconservativeBoundaryFluxes.hpp"  // IWYU pragma: keep
@@ -80,9 +79,8 @@ struct EvolutionMetavars {
                      local_time_stepping, LtsTimeStepper, TimeStepper>>>;
   using domain_creator_tag = OptionTags::DomainCreator<Dim, Frame::Inertial>;
 
-  using reduction_data_tags =
-      observers::get_reduction_data_tags_from_observing_actions<
-          tmpl::list<ScalarWave::Actions::Observe>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::list<ScalarWave::Actions::Observe>>;
 
   using step_choosers =
       tmpl::list<StepChoosers::Registrars::Cfl<Dim, Frame::Inertial>,

--- a/src/Evolution/Systems/Burgers/Observe.hpp
+++ b/src/Evolution/Systems/Burgers/Observe.hpp
@@ -30,17 +30,6 @@
 namespace Burgers {
 namespace Actions {
 
-namespace observe_detail {
-using reduction_datum = Parallel::ReductionDatum<double, funcl::Plus<>,
-                                                 funcl::Sqrt<funcl::Divides<>>,
-                                                 std::index_sequence<1>>;
-using reduction_datums =
-    tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
-               Parallel::ReductionDatum<size_t, funcl::Plus<>>,
-               reduction_datum>;
-
-}  // namespace observe_detail
-
 /*!
  * \brief Temporary action for observing volume and reduction data
  *
@@ -49,6 +38,15 @@ using reduction_datums =
  * - The RMS error of \f$U\f$ is written to disk.
  */
 struct Observe {
+ private:
+  using l2_error_datum = Parallel::ReductionDatum<double, funcl::Plus<>,
+                                                  funcl::Sqrt<funcl::Divides<>>,
+                                                  std::index_sequence<1>>;
+  using reduction_data = Parallel::ReductionData<
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<size_t, funcl::Plus<>>, l2_error_datum>;
+
+ public:
   struct ObserveNSlabs {
     using type = size_t;
     static constexpr OptionString help = {"Observe every Nth slab"};
@@ -59,9 +57,8 @@ struct Observe {
   };
 
   using const_global_cache_tags = tmpl::list<ObserveNSlabs, ObserveAtT0>;
-
-  using reduction_data_tags =
-      ::observers::make_reduction_data_tags_t<observe_detail::reduction_datums>;
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<reduction_data>>;
 
   template <typename... DbTags, typename... InboxTags, typename Metavariables,
             size_t Dim, typename ActionList, typename ParallelComponent>
@@ -127,15 +124,14 @@ struct Observe {
           std::move(components), extents);
 
       // Send data to reduction observer
-      using ReData =
-          ::observers::make_reduction_data_t<observe_detail::reduction_datums>;
       Parallel::simple_action<observers::Actions::ContributeReductionData>(
           local_observer, observers::ObservationId(time),
           std::string{"/element_data"},
           std::vector<std::string>{"Time", "NumberOfPoints", "UError"},
-          ReData{time.value(),
-                 db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points(),
-                 u_error});
+          reduction_data{
+              time.value(),
+              db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points(),
+              u_error});
     }
     return std::forward_as_tuple(std::move(box));
   }

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
@@ -32,21 +32,20 @@ namespace ValenciaDivClean {
 
 namespace Actions {
 
-namespace observe_detail {
-using reduction_datum = Parallel::ReductionDatum<double, funcl::Plus<>,
-                                                 funcl::Sqrt<funcl::Divides<>>,
-                                                 std::index_sequence<1>>;
-using reduction_datums =
-    tmpl::list<Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
-               Parallel::ReductionDatum<size_t, funcl::Plus<>>, reduction_datum,
-               reduction_datum, reduction_datum>;
-
-}  // namespace observe_detail
-
 /*!
  * \brief Temporary action for observing volume and reduction data
  */
 struct Observe {
+ private:
+  using l2_error_datum = Parallel::ReductionDatum<double, funcl::Plus<>,
+                                                  funcl::Sqrt<funcl::Divides<>>,
+                                                  std::index_sequence<1>>;
+  using reduction_data = Parallel::ReductionData<
+      Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
+      Parallel::ReductionDatum<size_t, funcl::Plus<>>, l2_error_datum,
+      l2_error_datum, l2_error_datum>;
+
+ public:
   struct ObserveNSlabs {
     using type = size_t;
     static constexpr OptionString help = {"Observe every Nth slab"};
@@ -57,9 +56,8 @@ struct Observe {
   };
 
   using const_global_cache_tags = tmpl::list<ObserveNSlabs, ObserveAtT0>;
-
-  using reduction_data_tags =
-      ::observers::make_reduction_data_tags_t<observe_detail::reduction_datums>;
+  using observed_reduction_data_tags =
+      observers::make_reduction_data_tags<tmpl::list<reduction_data>>;
 
   template <typename... DbTags, typename... InboxTags, typename Metavariables,
             size_t Dim, typename ActionList, typename ParallelComponent>
@@ -232,19 +230,17 @@ struct Observe {
           std::move(components), extents);
 
       // Send data to reduction observer
-      using ReData =
-          ::observers::make_reduction_data_t<observe_detail::reduction_datums>;
-
       Parallel::simple_action<observers::Actions::ContributeReductionData>(
           local_observer, observers::ObservationId(time),
           std::string{"/element_data"},
           std::vector<std::string>{
               "Time", "NumberOfPoints", "RestMassDensityError",
               "SpecificInternalEnergyError", "PressureError"},
-          ReData{time.value(),
-                 db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points(),
-                 rest_mass_density_error, specific_internal_energy_error,
-                 pressure_error});
+          reduction_data{
+              time.value(),
+              db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points(),
+              rest_mass_density_error, specific_internal_energy_error,
+              pressure_error});
     }
     return std::forward_as_tuple(std::move(box));
   }

--- a/src/IO/Observer/Helpers.hpp
+++ b/src/IO/Observer/Helpers.hpp
@@ -11,38 +11,39 @@
 namespace observers {
 namespace detail {
 template <class ObservingAction, class = cpp17::void_t<>>
-struct get_reduction_data_tags_from_observing_action {
+struct get_reduction_data_tags {
   using type = tmpl::list<>;
 };
 
 template <class ObservingAction>
-struct get_reduction_data_tags_from_observing_action<
+struct get_reduction_data_tags<
     ObservingAction,
-    cpp17::void_t<typename ObservingAction::reduction_data_tags>> {
-  using type = typename ObservingAction::reduction_data_tags;
+    cpp17::void_t<typename ObservingAction::observed_reduction_data_tags>> {
+  using type = typename ObservingAction::observed_reduction_data_tags;
+};
+
+template <class ReductionDataType>
+struct make_reduction_data_tag_impl {
+  using type = tmpl::wrap<typename ReductionDataType::datum_list,
+                          ::observers::Tags::ReductionData>;
 };
 }  // namespace detail
 
 /// Each Action that sends data to the reduction Observer must specify
-/// a type alias `reduction_data_tags` that describes the data it
-/// sends.  Given a list of such Actions, this metafunction is used to
-/// create `Metavariables::reduction_data_tags` (which is required to
+/// a type alias `observed_reduction_data_tags` that describes the data it
+/// sends.  Given a list of such Actions (or other types that expose the alias),
+/// this metafunction is used to create
+/// `Metavariables::observed_reduction_data_tags` (which is required to
 /// initialize the Observer).
 template <class ObservingActionList>
-using get_reduction_data_tags_from_observing_actions =
-    tmpl::remove_duplicates<tmpl::transform<
-        ObservingActionList,
-        detail::get_reduction_data_tags_from_observing_action<tmpl::_1>>>;
+using collect_reduction_data_tags =
+    tmpl::remove_duplicates<tmpl::flatten<tmpl::transform<
+        ObservingActionList, detail::get_reduction_data_tags<tmpl::_1>>>>;
 
-/// Given a tmpl::list of ReductionDatums, makes an
-/// observers::Tags::ReductionData.
-template <typename ReductionDatumList>
-using make_reduction_data_tags_t =
-    tmpl::wrap<ReductionDatumList, ::observers::Tags::ReductionData>;
-
-/// Given a tmpl::list of ReductionDatums, makes a
-/// Parallel::ReductionData.
-template <typename ReductionDatumList>
-using make_reduction_data_t =
-    tmpl::wrap<ReductionDatumList, ::Parallel::ReductionData>;
+/// Produces the `tmpl::list` of `observers::Tags::ReductionData` tags that
+/// corresponds to the `tmpl::list` of `Parallel::ReductionData` passed into
+/// this metafunction.
+template <typename ReductionDataList>
+using make_reduction_data_tags = tmpl::remove_duplicates<tmpl::transform<
+    ReductionDataList, detail::make_reduction_data_tag_impl<tmpl::_1>>>;
 }  // namespace observers

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -21,6 +21,10 @@ using reduction_data_to_reduction_names = typename Tag::names_tag;
 }  // namespace detail
 /*!
  * \brief Initializes the DataBox on the observer parallel component
+ *
+ * Uses:
+ * - Metavariables:
+ *   - `observed_reduction_data_tags` (see ContributeReductionData)
  */
 template <class Metavariables>
 struct Initialize {
@@ -28,9 +32,9 @@ struct Initialize {
       db::AddSimpleTags<Tags::NumberOfEvents, Tags::ReductionArrayComponentIds,
                         Tags::VolumeArrayComponentIds, Tags::TensorData,
                         Tags::ReductionObserversContributed>,
-      typename Metavariables::reduction_data_tags,
+      typename Metavariables::observed_reduction_data_tags,
       tmpl::transform<
-          typename Metavariables::reduction_data_tags,
+          typename Metavariables::observed_reduction_data_tags,
           tmpl::bind<detail::reduction_data_to_reduction_names, tmpl::_1>>>;
   using compute_tags = db::AddComputeTags<>;
 
@@ -44,7 +48,7 @@ struct Initialize {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    return helper(typename Metavariables::reduction_data_tags{});
+    return helper(typename Metavariables::observed_reduction_data_tags{});
   }
 
  private:
@@ -65,15 +69,19 @@ struct Initialize {
 /*!
  * \brief Initializes the DataBox of the observer parallel component that writes
  * to disk.
+ *
+ * Uses:
+ * - Metavariables:
+ *   - `observed_reduction_data_tags` (see ContributeReductionData)
  */
 template <class Metavariables>
 struct InitializeWriter {
   using simple_tags = tmpl::append<
       db::AddSimpleTags<Tags::TensorData, Tags::VolumeObserversContributed,
                         Tags::ReductionObserversContributed, Tags::H5FileLock>,
-      typename Metavariables::reduction_data_tags,
+      typename Metavariables::observed_reduction_data_tags,
       tmpl::transform<
-          typename Metavariables::reduction_data_tags,
+          typename Metavariables::observed_reduction_data_tags,
           tmpl::bind<detail::reduction_data_to_reduction_names, tmpl::_1>>>;
   using compute_tags = db::AddComputeTags<>;
 
@@ -87,7 +95,7 @@ struct InitializeWriter {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
-    return helper(typename Metavariables::reduction_data_tags{});
+    return helper(typename Metavariables::observed_reduction_data_tags{});
   }
 
  private:

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -56,6 +56,19 @@ struct ContributeReductionDataToWriter;
  * of names of the quantities being reduced (e.g. `{"Time", "L1ErrorDensity",
  * "L2ErrorDensity"}`), and the `Parallel::ReductionData` that holds the
  * `ReductionDatums` containing info on how to do the reduction.
+ *
+ * The observer components need to know all expected reduction data types by
+ * compile-time, so they rely on the
+ * `Metavariables::observed_reduction_data_tags` alias to collect them in one
+ * place. To this end, each Action that contributes reduction data must expose
+ * the type alias as:
+ *
+ * \snippet ObserverHelpers.hpp make_reduction_data_tags
+ *
+ * Then, in the `Metavariables` collect them from all observing Actions like
+ * this:
+ *
+ * \snippet Test_Observe.cpp collect_reduction_data_tags
  */
 struct ContributeReductionData {
   template <typename... DbTags, typename... InboxTags, typename Metavariables,

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -115,7 +115,6 @@ struct VolumeFileName {
   using type = std::string;
   static constexpr OptionString help = {
       "Name of the volume data file without extension"};
-  static type default_value() noexcept { return "./VolumeData"; }
 };
 
 /// \ingroup ObserversGroup
@@ -124,7 +123,6 @@ struct ReductionFileName {
   using type = std::string;
   static constexpr OptionString help = {
       "Name of the reduction data file without extension"};
-  static type default_value() noexcept { return "./TimeSeriesData"; }
 };
 }  // namespace OptionTags
 }  // namespace observers

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
@@ -104,6 +104,10 @@ struct ConjugateGradient {
    */
   using tags = cg_detail::InitializeElement<Metavariables>;
 
+  // Compile-time interface for observers
+  using observed_reduction_data_tags = observers::make_reduction_data_tags<
+      tmpl::list<cg_detail::observed_reduction_data>>;
+
   /*!
    * \brief Perform an iteration of the conjugate gradient linear solver
    *

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -5,6 +5,9 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
 #include "Informer/Tags.hpp"
 #include "Informer/Verbosity.hpp"
 #include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
@@ -13,7 +16,9 @@
 #include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Printf.hpp"
+#include "Parallel/Reduction.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/Functional.hpp"
 #include "Utilities/Requires.hpp"
 
 /// \cond
@@ -100,6 +105,10 @@ struct ComputeAlpha {
   }
 };
 
+using observed_reduction_data = Parallel::ReductionData<
+    Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
+    Parallel::ReductionDatum<double, funcl::AssertEqual<>>>;
+
 template <typename BroadcastTarget>
 struct UpdateResidual {
   template <
@@ -132,6 +141,23 @@ struct UpdateResidual {
           "Linear solver iteration %d done. Remaining residual: %e\n",
           get<LinearSolver::Tags::IterationId>(box).step_number + 1, residual);
     }
+
+    // Contribute data to the observer
+    const auto observation_id =
+        observers::ObservationId(get<LinearSolver::Tags::IterationId>(box));
+    auto& reduction_writer = Parallel::get_parallel_component<
+        observers::ObserverWriter<Metavariables>>(cache);
+    Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(
+        // Node 0 is always the writer, so directly call the component on that
+        // node
+        reduction_writer[0], observation_id,
+        // When multiple linear solves are performed, e.g. for the nonlinear
+        // solver, we'll need to write into separate subgroups, e.g.:
+        // `/linear_residuals/<nonlinear_iteration_id>`
+        std::string{"/linear_residuals"},
+        std::vector<std::string>{"Iteration", "Residual"},
+        observed_reduction_data{
+            get<LinearSolver::Tags::IterationId>(box).step_number, residual});
 
     // Determine whether the linear solver has converged
     // More sophisticated convergence criteria can be added in the future.

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "IO/Observer/Helpers.hpp"
 #include "NumericalAlgorithms/LinearSolver/Gmres/ElementActions.hpp"
 #include "NumericalAlgorithms/LinearSolver/Gmres/InitializeElement.hpp"
 #include "NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp"
@@ -119,6 +120,10 @@ struct Gmres {
    * first step of the algorithm.
    */
   using tags = gmres_detail::InitializeElement<Metavariables>;
+
+  // Compile-time interface for observers
+  using observed_reduction_data_tags = observers::make_reduction_data_tags<
+      tmpl::list<gmres_detail::observed_reduction_data>>;
 
   /*!
    * \brief Perform an iteration of the GMRES linear solver

--- a/src/Parallel/Reduction.hpp
+++ b/src/Parallel/Reduction.hpp
@@ -81,6 +81,8 @@ struct ReductionData<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
   static_assert(sizeof...(Ts) > 0,
                 "Must be reducing at least one piece of data.");
   static constexpr size_t pack_size() noexcept { return sizeof...(Ts); }
+  using datum_list = tmpl::list<ReductionDatum<Ts, InvokeCombines, InvokeFinals,
+                                               InvokeFinalExtraArgsIndices>...>;
 
   explicit ReductionData(
       ReductionDatum<Ts, InvokeCombines, InvokeFinals,

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -34,4 +34,5 @@ SlopeLimiterParams:
 ObserveNSlabs: 1000000
 ObserveAtT0: false
 
-VolumeFileName: "./Burgers"
+VolumeFileName: "./BurgersVolume"
+ReductionFileName: "./BurgersReductions"

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -41,8 +41,6 @@ TimeStepper:
 #   - Cfl:
 #       SafetyFactor: 0.2
 
-VolumeFileName: "./GrMhd"
-
 NumericalFluxParams:
 
 DampingParameter: 0.0
@@ -63,6 +61,9 @@ FixConservatives:
 FixToAtmosphere:
   DensityOfAtmosphere: 1.0e-12
   DensityCutoff: 1.0e-12
+
+VolumeFileName: "./GrMhdVolume"
+ReductionFileName: "./GrMhdReductions"
 
 ObserveNSlabs: 1000
 ObserveAtT0: false

--- a/tests/InputFiles/Poisson/Input1D.yaml
+++ b/tests/InputFiles/Poisson/Input1D.yaml
@@ -20,6 +20,5 @@ NumericalFluxParams:
 
 Verbosity: Verbose
 
-VolumeFileName: "./PoissonVolume1D"
-
-ReductionFileName: "./PoissonReduction1D"
+VolumeFileName: "./Poisson1DVolume"
+ReductionFileName: "./Poisson1DReductions"

--- a/tests/InputFiles/Poisson/Input2D.yaml
+++ b/tests/InputFiles/Poisson/Input2D.yaml
@@ -20,6 +20,5 @@ NumericalFluxParams:
 
 Verbosity: Verbose
 
-VolumeFileName: "./PoissonVolume2D"
-
-ReductionFileName: "./PoissonReduction2D"
+VolumeFileName: "./Poisson2DVolume"
+ReductionFileName: "./Poisson2DReductions"

--- a/tests/InputFiles/Poisson/Input3D.yaml
+++ b/tests/InputFiles/Poisson/Input3D.yaml
@@ -20,6 +20,5 @@ NumericalFluxParams:
 
 Verbosity: Verbose
 
-VolumeFileName: "./PoissonVolume3D"
-
-ReductionFileName: "./PoissonReduction3D"
+VolumeFileName: "./Poisson3DVolume"
+ReductionFileName: "./Poisson3DReductions"

--- a/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input1DPeriodic.yaml
@@ -41,7 +41,8 @@ StepChoosers:
 
 NumericalFluxParams:
 
-VolumeFileName: "./ScalarWave1DPeriodic"
+VolumeFileName: "./ScalarWave1DPeriodicVolume"
+ReductionFileName: "./ScalarWave1DPeriodicReductions"
 
 ObserveNSlabs: 10000000
 ObserveAtT0: false

--- a/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input2DPeriodic.yaml
@@ -41,7 +41,8 @@ StepChoosers:
 
 NumericalFluxParams:
 
-VolumeFileName: "./ScalarWave2DPeriodic"
+VolumeFileName: "./ScalarWave2DPeriodicVolume"
+ReductionFileName: "./ScalarWave2DPeriodicReductions"
 
 ObserveNSlabs: 10000000
 ObserveAtT0: false

--- a/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
+++ b/tests/InputFiles/ScalarWave/Input3DPeriodic.yaml
@@ -41,7 +41,8 @@ StepChoosers:
 
 NumericalFluxParams:
 
-VolumeFileName: "./ScalarWave3DPeriodic"
+VolumeFileName: "./ScalarWave3DPeriodicVolume"
+ReductionFileName: "./ScalarWave3DPeriodicReductions"
 
 ObserveNSlabs: 10
 ObserveAtT0: false

--- a/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
@@ -24,6 +24,7 @@
 #include "IO/H5/File.hpp"
 #include "IO/H5/VolumeData.hpp"
 #include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
+#include "IO/Observer/Helpers.hpp"  // IWYU pragma: keep
 #include "IO/Observer/Initialize.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/Tags.hpp"
@@ -31,10 +32,8 @@
 #include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
-#include "Parallel/Reduction.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/FileSystem.hpp"
-#include "Utilities/Functional.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
@@ -116,14 +115,10 @@ struct Metavariables {
   using analytic_solution_tag = AnalyticSolutionTag;
   using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
 
-  // This has to be kept in sync with
-  // `Elliptic/Systems/Poisson/Actions/Observe.hpp` for now
-  using reduction_data_tags = tmpl::list<observers::Tags::ReductionData<
-      Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
-      Parallel::ReductionDatum<size_t, funcl::Plus<>>,
-      Parallel::ReductionDatum<double, funcl::Plus<>,
-                               funcl::Sqrt<funcl::Divides<>>,
-                               std::index_sequence<1>>>>;
+  /// [collect_reduction_data_tags]
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::list<Poisson::Actions::Observe>>;
+  /// [collect_reduction_data_tags]
 
   enum class Phase { Initialize, Exit };
 };

--- a/tests/Unit/IO/Observers/Test_Initialize.cpp
+++ b/tests/Unit/IO/Observers/Test_Initialize.cpp
@@ -32,7 +32,7 @@ struct observer_component {
 struct Metavariables {
   using component_list = tmpl::list<observer_component<Metavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
-  using reduction_data_tags = tmpl::list<>;
+  using observed_reduction_data_tags = tmpl::list<>;
 
   enum class Phase { Initialize, Exit };
 };

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -219,11 +219,10 @@ struct MockMetavariables {
     using type = typename compute_target_points::options_type;
   };
 
-  using reduction_data_tags =
-      observers::get_reduction_data_tags_from_observing_actions<
-          tmpl::list<typename SurfaceA::post_interpolation_callback,
-                     typename SurfaceB::post_interpolation_callback,
-                     typename SurfaceC::post_interpolation_callback>>;
+  using observed_reduction_data_tags = observers::collect_reduction_data_tags<
+      tmpl::list<typename SurfaceA::post_interpolation_callback,
+                 typename SurfaceB::post_interpolation_callback,
+                 typename SurfaceC::post_interpolation_callback>>;
 
   using interpolator_source_vars =
       tmpl::list<Tags::TestSolution,

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/CMakeLists.txt
@@ -12,7 +12,7 @@ add_test_library(
   ${LIBRARY}
   "NumericalAlgorithms/LinearSolver/ConjugateGradient"
   "${LIBRARY_SOURCES}"
-  "DataStructures;LinearSolver"
+  "DataStructures;IO;LinearSolver"
   )
 
 # This code is adapted from Parallel/CMakeLists.txt
@@ -36,6 +36,7 @@ function(add_algorithm_test TEST_NAME)
     ${EXECUTABLE_NAME}
     ErrorHandling
     Informer
+    IO
     DataStructures
     LinearSolver
     ${SPECTRE_LIBRARIES}

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.input
@@ -7,3 +7,6 @@ InitialGuess: [2, 1]
 ExpectedResult: [0.0909090909090909, 0.6363636363636364]
 
 Verbosity: Verbose
+
+VolumeFileName: "Test_ConjugateGradientAlgorithm_Volume"
+ReductionFileName: "Test_ConjugateGradientAlgorithm_Reductions"

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.input
@@ -26,3 +26,6 @@ ExpectedResult:
     - [ 0.9928055333486292,  0.7235793356729758, -0.0363482510397858]
 
 Verbosity: Verbose
+
+VolumeFileName: "./Test_DistributedConjugateGradientAlgorithm_Volume"
+ReductionFileName: "./Test_DistributedConjugateGradientAlgorithm_Reductions"

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -37,7 +37,7 @@
 #include "Utilities/TMPL.hpp"
 // IWYU pragma: no_forward_declare db::DataBox
 
-namespace DistributedLinearSolverAlgorithmTest {
+namespace DistributedLinearSolverAlgorithmTestHelpers {
 
 namespace OptionTags {
 struct NumberOfElements {
@@ -92,7 +92,7 @@ struct ComputeOperatorAction {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ActionList, typename ParallelComponent>
   static auto apply(db::DataBox<DbTagsList>& box,
-                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::ConstGlobalCache<Metavariables>& cache,
                     const int array_index, const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
@@ -124,7 +124,7 @@ struct CollectAp {
             typename ActionList, typename ParallelComponent,
             Requires<sizeof...(DbTags) != 0> = nullptr>
   static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
-                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     const Parallel::ConstGlobalCache<Metavariables>& cache,
                     const int array_index, const ActionList /*meta*/,
                     const ParallelComponent* const /*component*/,
@@ -163,9 +163,9 @@ struct TestResult {
       typename ActionList, typename ParallelComponent,
       Requires<tmpl2::flat_any_v<cpp17::is_same_v<fields_tag, DbTags>...>> =
           nullptr>
-  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
-                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    Parallel::ConstGlobalCache<Metavariables>& cache,
+  static void apply(const db::DataBox<tmpl::list<DbTags...>>& box,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
                     const int array_index, const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
     const auto& expected_result =
@@ -255,6 +255,8 @@ struct ElementArray {
       case Metavariables::Phase::TestResult:
         Parallel::simple_action<TestResult>(array_proxy);
         break;
+      case Metavariables::Phase::CleanOutput:
+        break;
       default:
         ERROR(
             "The Metavariables is expected to have the following Phases: "
@@ -264,7 +266,7 @@ struct ElementArray {
 };
 
 struct System {
-  using fields_tag = ::DistributedLinearSolverAlgorithmTest::fields_tag;
+  using fields_tag = ::DistributedLinearSolverAlgorithmTestHelpers::fields_tag;
 };
 
-}  // namespace DistributedLinearSolverAlgorithmTest
+}  // namespace DistributedLinearSolverAlgorithmTestHelpers

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/CMakeLists.txt
@@ -12,7 +12,7 @@ add_test_library(
   ${LIBRARY}
   "NumericalAlgorithms/LinearSolver/Gmres"
   "${LIBRARY_SOURCES}"
-  "DataStructures;LinearSolver"
+  "DataStructures;IO;LinearSolver"
   )
 
 # This code is adapted from Parallel/CMakeLists.txt
@@ -36,6 +36,7 @@ function(add_algorithm_test TEST_NAME)
     ${EXECUTABLE_NAME}
     ErrorHandling
     Informer
+    IO
     DataStructures
     LinearSolver
     ${SPECTRE_LIBRARIES}

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -6,31 +6,47 @@
 #include <vector>
 
 #include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "IO/Observer/Helpers.hpp"            // IWYU pragma: keep
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Main.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp"
+#include "tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"  // IWYU pragma: keep
+
+namespace helpers = LinearSolverAlgorithmTestHelpers;
+namespace helpers_distributed = DistributedLinearSolverAlgorithmTestHelpers;
 
 namespace {
 
 struct Metavariables {
-  using system = DistributedLinearSolverAlgorithmTest::System;
+  using system = helpers_distributed::System;
 
   using linear_solver = LinearSolver::Gmres<Metavariables>;
 
-  using component_list = tmpl::append<
-      tmpl::list<
-          DistributedLinearSolverAlgorithmTest::ElementArray<Metavariables>>,
-      typename linear_solver::component_list>;
+  using component_list =
+      tmpl::append<tmpl::list<helpers_distributed::ElementArray<Metavariables>,
+                              observers::ObserverWriter<Metavariables>,
+                              helpers::OutputCleaner<Metavariables>>,
+                   typename linear_solver::component_list>;
   using const_global_cache_tag_list = tmpl::list<>;
+
+  using observed_reduction_data_tags =
+      observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
 
   static constexpr const char* const help{
       "Test the GMRES linear solver algorithm on multiple elements"};
   static constexpr bool ignore_unrecognized_command_line_options = false;
 
-  enum class Phase { Initialization, PerformLinearSolve, TestResult, Exit };
+  enum class Phase {
+    Initialization,
+    PerformLinearSolve,
+    TestResult,
+    CleanOutput,
+    Exit
+  };
 
   static Phase determine_next_phase(
       const Phase& current_phase,
@@ -41,6 +57,8 @@ struct Metavariables {
         return Phase::PerformLinearSolve;
       case Phase::PerformLinearSolve:
         return Phase::TestResult;
+      case Phase::TestResult:
+        return Phase::CleanOutput;
       default:
         return Phase::Exit;
     }

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.input
@@ -26,3 +26,6 @@ ExpectedResult:
     - [ 0.9928055333486292,  0.7235793356729758, -0.0363482510397858]
 
 Verbosity: Verbose
+
+VolumeFileName: "Test_DistributedGmresAlgorithm_Volume"
+ReductionFileName: "Test_DistributedGmresAlgorithm_Reductions"

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -6,30 +6,45 @@
 #include <vector>
 
 #include "ErrorHandling/FloatingPointExceptions.hpp"
+#include "IO/Observer/Helpers.hpp"            // IWYU pragma: keep
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/InitializationFunctions.hpp"
 #include "Parallel/Main.hpp"
 #include "Utilities/TMPL.hpp"
-#include "tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"
+#include "tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp"  // IWYU pragma: keep
+
+namespace helpers = LinearSolverAlgorithmTestHelpers;
 
 namespace {
 
 struct Metavariables {
-  using system = LinearSolverAlgorithmTest::System;
+  using system = helpers::System;
 
   using linear_solver = LinearSolver::Gmres<Metavariables>;
 
-  using component_list = tmpl::append<
-      tmpl::list<LinearSolverAlgorithmTest::ElementArray<Metavariables>>,
-      typename linear_solver::component_list>;
+  using component_list =
+      tmpl::append<tmpl::list<helpers::ElementArray<Metavariables>,
+                              observers::ObserverWriter<Metavariables>,
+                              helpers::OutputCleaner<Metavariables>>,
+                   typename linear_solver::component_list>;
   using const_global_cache_tag_list = tmpl::list<>;
+
+  using observed_reduction_data_tags =
+      observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
 
   static constexpr const char* const help{
       "Test the GMRES linear solver algorithm"};
   static constexpr bool ignore_unrecognized_command_line_options = false;
 
-  enum class Phase { Initialization, PerformLinearSolve, TestResult, Exit };
+  enum class Phase {
+    Initialization,
+    PerformLinearSolve,
+    TestResult,
+    CleanOutput,
+    Exit
+  };
 
   static Phase determine_next_phase(
       const Phase& current_phase,
@@ -40,6 +55,8 @@ struct Metavariables {
         return Phase::PerformLinearSolve;
       case Phase::PerformLinearSolve:
         return Phase::TestResult;
+      case Phase::TestResult:
+        return Phase::CleanOutput;
       default:
         return Phase::Exit;
     }

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.input
@@ -7,3 +7,6 @@ InitialGuess: [2, 1]
 ExpectedResult: [-1., 5.]
 
 Verbosity: Verbose
+
+VolumeFileName: "Test_GmresAlgorithm_Volume"
+ReductionFileName: "Test_GmresAlgorithm_Reductions"

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cmath>
+#include <string>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+
+namespace ResidualMonitorActionsTestHelpers {
+
+struct CheckObservationIdTag : db::SimpleTag {
+  using type = observers::ObservationId;
+  static std::string name() noexcept { return "CheckObservationIdTag"; }
+};
+
+struct CheckSubfileNameTag : db::SimpleTag {
+  using type = std::string;
+  static std::string name() noexcept { return "CheckSubfileNameTag"; }
+};
+
+struct CheckReductionNamesTag : db::SimpleTag {
+  using type = std::vector<std::string>;
+  static std::string name() noexcept { return "CheckReductionNamesTag"; }
+};
+
+struct CheckReductionDataTag : db::SimpleTag {
+  using type = std::tuple<size_t, double>;
+  static std::string name() noexcept { return "CheckReductionDataTag"; }
+};
+
+using observer_writer_tags =
+    tmpl::list<CheckObservationIdTag, CheckSubfileNameTag,
+               CheckReductionNamesTag, CheckReductionDataTag>;
+
+struct MockWriteReductionData {
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent, typename ArrayIndex,
+            typename... ReductionDatums>
+  static void apply(db::DataBox<observer_writer_tags>& box,  // NOLINT
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const gsl::not_null<CmiNodeLock*> /*node_lock*/,
+                    const observers::ObservationId& observation_id,
+                    const std::string& subfile_name,
+                    std::vector<std::string>&& reduction_names,
+                    Parallel::ReductionData<ReductionDatums...>&&
+                        in_reduction_data) noexcept {
+    db::mutate<CheckObservationIdTag, CheckSubfileNameTag,
+               CheckReductionNamesTag, CheckReductionDataTag>(
+        make_not_null(&box),
+        [ observation_id, subfile_name, reduction_names, in_reduction_data ](
+            const gsl::not_null<db::item_type<CheckObservationIdTag>*>
+                check_observation_id,
+            const gsl::not_null<db::item_type<CheckSubfileNameTag>*>
+                check_subfile_name,
+            const gsl::not_null<db::item_type<CheckReductionNamesTag>*>
+                check_reduction_names,
+            const gsl::not_null<db::item_type<CheckReductionDataTag>*>
+                check_reduction_data) noexcept {
+          *check_observation_id = observation_id;
+          *check_subfile_name = subfile_name;
+          *check_reduction_names = reduction_names;
+          *check_reduction_data = in_reduction_data.data();
+        });
+  }
+};
+
+template <typename Metavariables>
+struct MockObserverWriter {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using action_list = tmpl::list<>;
+  using component_being_mocked = observers::ObserverWriter<Metavariables>;
+  using initial_databox = db::compute_databox_type<observer_writer_tags>;
+
+  using replace_these_threaded_actions =
+      tmpl::list<observers::ThreadedActions::WriteReductionData>;
+  using with_these_threaded_actions = tmpl::list<MockWriteReductionData>;
+};
+
+}  // namespace ResidualMonitorActionsTestHelpers


### PR DESCRIPTION
## Proposed changes

With this PR the linear solver residual monitor (which is a singleton) directly contributes the residual to the reduction observer for writing out to disk. The data is written into the standard reduction file, but into a separate `"/linear_residuals.dat"` H5 group.

Closes #1198.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
