### PR TITLE
Add convergence criteria to linear solver

### DIFF
--- a/src/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -4,8 +4,9 @@
 set(LIBRARY LinearSolver)
 
 set(LIBRARY_SOURCES
-    IterationId.cpp
-    )
+  Convergence.cpp
+  IterationId.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
@@ -48,8 +48,7 @@ namespace LinearSolver {
  * new \f$r^2\f$.
  * 4. `UpdateResidual` (on `ResidualMonitor`): Store the new \f$r^2\f$ and
  * broadcast the ratio of the new and old \f$r^2\f$, as well as a termination
- * flag if the residual vanishes to a precision determined by
- * `equal_within_roundoff`.
+ * flag if the `LinearSolver::Tags::ConvergenceCriteria` are met.
  * 5. `UpdateOperand` (on elements): Update \f$p\f$.
  *
  * \see Gmres for a linear solver that can invert nonsymmetric operators
@@ -81,15 +80,12 @@ struct ConjugateGradient {
    * `db::add_tag_prefix<LinearSolver::Tags::OperatorAppliedTo, operand_tag>`
    * - `residual_tag` =
    * `db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>`
-   * - `residual_magnitude_tag` =
-   * `db::add_tag_prefix<LinearSolver::Tags::Magnitude, residual_tag>`
    *
    * DataBox changes:
    * - Adds:
    *   * `LinearSolver::Tags::IterationId`
    *   * `Tags::Next<LinearSolver::Tags::IterationId>`
    *   * `residual_tag`
-   *   * `residual_magnitude_tag`
    *   * `LinearSolver::Tags::HasConverged`
    * - Removes: nothing
    * - Modifies:
@@ -121,8 +117,6 @@ struct ConjugateGradient {
    * `db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>`
    * - `residual_tag` =
    * `db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>`
-   * - `residual_magnitude_tag` =
-   * `db::add_tag_prefix<LinearSolver::Tags::Magnitude, residual_tag>`
    *
    * DataBox changes:
    * - Adds: nothing
@@ -133,7 +127,6 @@ struct ConjugateGradient {
    *   * `fields_tag`
    *   * `operand_tag`
    *   * `residual_tag`
-   *   * `residual_magnitude_tag`
    *   * `LinearSolver::Tags::HasConverged`
    */
   using perform_step = cg_detail::PerformStep;

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ConjugateGradient.hpp
@@ -102,7 +102,7 @@ struct ConjugateGradient {
 
   // Compile-time interface for observers
   using observed_reduction_data_tags = observers::make_reduction_data_tags<
-      tmpl::list<cg_detail::observed_reduction_data>>;
+      tmpl::list<observe_detail::reduction_data>>;
 
   /*!
    * \brief Perform an iteration of the conjugate gradient linear solver

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/InitializeElement.hpp
@@ -39,15 +39,12 @@ struct InitializeElement {
       db::add_tag_prefix<LinearSolver::Tags::Operand, fields_tag>;
   using residual_tag =
       db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>;
-  using residual_magnitude_tag =
-      db::add_tag_prefix<LinearSolver::Tags::Magnitude, residual_tag>;
 
  public:
   using simple_tags =
       db::AddSimpleTags<LinearSolver::Tags::IterationId,
                         ::Tags::Next<LinearSolver::Tags::IterationId>,
-                        residual_tag, residual_magnitude_tag,
-                        LinearSolver::Tags::HasConverged>;
+                        residual_tag, LinearSolver::Tags::HasConverged>;
   using compute_tags = db::AddComputeTags<>;
 
   template <typename TagsList, typename ArrayIndex, typename ParallelComponent>
@@ -81,7 +78,7 @@ struct InitializeElement {
 
     return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
         std::move(box), iteration_id, next_iteration_id, std::move(r),
-        std::numeric_limits<double>::signaling_NaN(), false);
+        db::item_type<LinearSolver::Tags::HasConverged>{});
   }
 };
 

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -5,18 +5,15 @@
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
-#include "IO/Observer/ObservationId.hpp"
-#include "IO/Observer/ObserverComponent.hpp"
-#include "IO/Observer/ReductionActions.hpp"
 #include "Informer/Tags.hpp"
 #include "Informer/Verbosity.hpp"
 #include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Observe.hpp"
 #include "NumericalAlgorithms/LinearSolver/Tags.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Parallel/Printf.hpp"
-#include "Parallel/Reduction.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/Requires.hpp"
@@ -77,6 +74,8 @@ struct InitializeResidual {
         },
         get<residual_magnitude_tag>(box));
 
+    LinearSolver::observe_detail::contribute_to_reduction_observer(box, cache);
+
     // Determine whether the linear solver has converged. This invokes the
     // compute item.
     const auto& has_converged = db::get<LinearSolver::Tags::HasConverged>(box);
@@ -117,10 +116,6 @@ struct ComputeAlpha {
   }
 };
 
-using observed_reduction_data = Parallel::ReductionData<
-    Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
-    Parallel::ReductionDatum<double, funcl::AssertEqual<>>>;
-
 template <typename BroadcastTarget>
 struct UpdateResidual {
   template <typename... DbTags, typename... InboxTags, typename Metavariables,
@@ -159,23 +154,7 @@ struct UpdateResidual {
     // logging and checking convergence before broadcasting back to the
     // elements.
 
-    // Contribute data to the observer
-    const auto observation_id =
-        observers::ObservationId(get<LinearSolver::Tags::IterationId>(box));
-    auto& reduction_writer = Parallel::get_parallel_component<
-        observers::ObserverWriter<Metavariables>>(cache);
-    Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(
-        // Node 0 is always the writer, so directly call the component on that
-        // node
-        reduction_writer[0], observation_id,
-        // When multiple linear solves are performed, e.g. for the nonlinear
-        // solver, we'll need to write into separate subgroups, e.g.:
-        // `/linear_residuals/<nonlinear_iteration_id>`
-        std::string{"/linear_residuals"},
-        std::vector<std::string>{"Iteration", "Residual"},
-        observed_reduction_data{
-            get<LinearSolver::Tags::IterationId>(box).step_number,
-            get<residual_magnitude_tag>(box)});
+    LinearSolver::observe_detail::contribute_to_reduction_observer(box, cache);
 
     // Determine whether the linear solver has converged. This invokes the
     // compute item.

--- a/src/NumericalAlgorithms/LinearSolver/Convergence.cpp
+++ b/src/NumericalAlgorithms/LinearSolver/Convergence.cpp
@@ -1,0 +1,149 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/LinearSolver/Convergence.hpp"
+
+#include <boost/optional.hpp>
+#include <ostream>
+#include <pup.h>  // IWYU pragma: keep
+
+#include "ErrorHandling/Assert.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+
+namespace LinearSolver {
+
+ConvergenceCriteria::ConvergenceCriteria(
+    const double max_iterations_in, const double absolute_residual_in,
+    const double relative_residual_in) noexcept
+    : max_iterations(max_iterations_in),
+      absolute_residual(absolute_residual_in),
+      relative_residual(relative_residual_in) {}
+
+void ConvergenceCriteria::pup(PUP::er& p) noexcept {
+  p | max_iterations;
+  p | absolute_residual;
+  p | relative_residual;
+}
+
+bool operator==(const ConvergenceCriteria& lhs,
+                const ConvergenceCriteria& rhs) noexcept {
+  return lhs.max_iterations == rhs.max_iterations and
+         lhs.absolute_residual == rhs.absolute_residual and
+         lhs.relative_residual == rhs.relative_residual;
+}
+
+bool operator!=(const ConvergenceCriteria& lhs,
+                const ConvergenceCriteria& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const ConvergenceReason& convergence_reason) noexcept {
+  switch (convergence_reason) {
+    case ConvergenceReason::MaxIterations:
+      return os << "MaxIterations";
+    case ConvergenceReason::AbsoluteResidual:
+      return os << "AbsoluteResidual";
+    case ConvergenceReason::RelativeResidual:
+      return os << "RelativeResidual";
+    default:
+      ERROR("Unknown convergence reason");
+  }
+}
+
+boost::optional<ConvergenceReason> convergence_criteria_match(
+    const ConvergenceCriteria& convergence_criteria,
+    const IterationId& iteration_id, const double residual_magnitude,
+    const double initial_residual_magnitude) noexcept {
+  if (residual_magnitude <= convergence_criteria.absolute_residual) {
+    return ConvergenceReason::AbsoluteResidual;
+  }
+  if (residual_magnitude / initial_residual_magnitude <=
+      convergence_criteria.relative_residual) {
+    return ConvergenceReason::RelativeResidual;
+  }
+  if (iteration_id.step_number >= convergence_criteria.max_iterations) {
+    return ConvergenceReason::MaxIterations;
+  }
+  return boost::none;
+}
+
+HasConverged::HasConverged(const ConvergenceCriteria& convergence_criteria,
+                           const IterationId& iteration_id,
+                           const double residual_magnitude,
+                           const double initial_residual_magnitude) noexcept
+    : reason_(convergence_criteria_match(convergence_criteria, iteration_id,
+                                         residual_magnitude,
+                                         initial_residual_magnitude)),
+      convergence_criteria_(convergence_criteria),
+      iteration_id_(iteration_id),
+      residual_magnitude_(residual_magnitude),
+      initial_residual_magnitude_(initial_residual_magnitude) {}
+
+ConvergenceReason HasConverged::reason() const noexcept {
+  ASSERT(reason_,
+         "Tried to retrieve the convergence reason, but has not yet converged. "
+         "Check if the instance of HasConverged evaluates to `true` first.");
+  return *reason_;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const HasConverged& has_converged) noexcept {
+  if (has_converged) {
+    switch (has_converged.reason()) {
+      case ConvergenceReason::MaxIterations:
+        return os << "The linear solver has reached its maximum number of "
+                     "iterations ("
+                  << has_converged.convergence_criteria_.max_iterations
+                  << ").\n";
+      case ConvergenceReason::AbsoluteResidual:
+        return os << "The linear solver has converged in "
+                  << has_converged.iteration_id_.step_number
+                  << " iterations: AbsoluteResidual - The residual magnitude "
+                     "has decreased to "
+                  << has_converged.convergence_criteria_.absolute_residual
+                  << " or below (" << has_converged.residual_magnitude_
+                  << ").\n";
+      case ConvergenceReason::RelativeResidual:
+        return os << "The linear solver has converged in "
+                  << has_converged.iteration_id_.step_number
+                  << " iterations: RelativeResidual - The residual magnitude "
+                     "has decreased to a fraction of "
+                  << has_converged.convergence_criteria_.relative_residual
+                  << " of its initial value or below ("
+                  << has_converged.residual_magnitude_ /
+                         has_converged.initial_residual_magnitude_
+                  << ").\n";
+      default:
+        ERROR("Unknown convergence reason");
+    };
+  } else {
+    return os << "The linear solver has not yet converged.\n";
+  }
+}
+
+void HasConverged::pup(PUP::er& p) noexcept {
+  p | convergence_criteria_;
+  p | iteration_id_;
+  p | residual_magnitude_;
+  p | initial_residual_magnitude_;
+  if (p.isUnpacking()) {
+    reason_ = convergence_criteria_match(convergence_criteria_, iteration_id_,
+                                         residual_magnitude_,
+                                         initial_residual_magnitude_);
+  }
+}
+
+bool operator==(const HasConverged& lhs, const HasConverged& rhs) noexcept {
+  return lhs.convergence_criteria_ == rhs.convergence_criteria_ and
+         lhs.iteration_id_ == rhs.iteration_id_ and
+         lhs.residual_magnitude_ == rhs.residual_magnitude_ and
+         lhs.initial_residual_magnitude_ == rhs.initial_residual_magnitude_;
+}
+
+bool operator!=(const HasConverged& lhs, const HasConverged& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+}  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/Convergence.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Convergence.hpp
@@ -1,0 +1,188 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/none.hpp>
+#include <boost/optional.hpp>
+#include <cstddef>
+#include <iosfwd>
+
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace LinearSolver {
+
+/*!
+ * \ingroup LinearSolverGroup
+ * \brief Criteria that determine the linear solve has converged
+ *
+ * \details Most criteria are based on the residual magnitude
+ * \f$|r_k|=|b-Ax_k|\f$, where \f$x_k\f$ denotes the numerical solution after
+ * completion of iteration \f$k\f$ (see the \ref LinearSolverGroup
+ * documentation, `LinearSolver::Tags::Residual` and
+ * `LinearSolver::Tags::Magnitude`).
+ *
+ * The following criteria are implemented, ordered from highest to lowest
+ * priority:
+ *
+ * - AbsoluteResidual: Matches if the residual has reached this magnitude.
+ * - RelativeResidual: Matches if the residual has decreased by this factor,
+ * relative to the start of the first linear solver iteration.
+ * - MaxIterations: Matches if the number of iterations exceeds this limit.
+ *
+ * \note The smallest possible residual magnitude the linear solver can reach is
+ * the product between the machine epsilon and the condition number of the
+ * linear operator that is being inverted. Smaller residuals are numerical
+ * artifacts. Requiring an absolute or relative residual below this limit will
+ * likely lead to termination by `MaxIterations`.
+ *
+ * \note Remember that when the linear operator \f$A\f$ corresponds to a PDE
+ * discretization, decreasing the linear solver residual below the
+ * discretization error will not improve the numerical solution any further.
+ * I.e. the error \f$e_k=x_k-x_\mathrm{analytic}\f$ to an analytic solution
+ * will be dominated by the linear solver residual at first, but even if the
+ * discretization \f$Ax_k=b\f$ was exactly solved after some iteration \f$k\f$,
+ * the discretization residual
+ * \f$Ae_k=b-Ax_\mathrm{analytic}=r_\mathrm{discretization}\f$ would still
+ * remain. Therefore, ideally choose the absolute or relative residual criteria
+ * based on an estimate of the discretization residual.
+ */
+struct ConvergenceCriteria {
+  static constexpr OptionString help =
+      "The linear solver terminates when any of these criteria is matched.";
+
+  struct MaxIterations {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "The number of iterations exceeds this limit."};
+    static type lower_bound() noexcept { return 0; }
+  };
+
+  struct AbsoluteResidual {
+    using type = double;
+    static constexpr OptionString help = {
+        "The residual has reached this magnitude."};
+    static type lower_bound() noexcept { return 0.; }
+  };
+
+  struct RelativeResidual {
+    using type = double;
+    static constexpr OptionString help = {
+        "The residual has decreased by this factor."};
+    static type lower_bound() noexcept { return 0.; }
+    static type upper_bound() noexcept { return 1.; }
+  };
+
+  using options = tmpl::list<MaxIterations, AbsoluteResidual, RelativeResidual>;
+
+  ConvergenceCriteria() = default;
+  ConvergenceCriteria(double max_iterations_in, double absolute_residual_in,
+                      double relative_residual_in) noexcept;
+
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  double max_iterations{};
+  double absolute_residual{};
+  double relative_residual{};
+};
+
+bool operator==(const ConvergenceCriteria& lhs,
+                const ConvergenceCriteria& rhs) noexcept;
+bool operator!=(const ConvergenceCriteria& lhs,
+                const ConvergenceCriteria& rhs) noexcept;
+
+/*!
+ * \brief The reason the linear solver has converged.
+ *
+ * \see LinearSolver::ConvergenceCriteria
+ */
+enum class ConvergenceReason {
+  MaxIterations,
+  AbsoluteResidual,
+  RelativeResidual
+};
+
+std::ostream& operator<<(std::ostream& os,
+                         const ConvergenceReason& convergence_reason) noexcept;
+
+/*!
+ * \brief Determine whether the \p convergence_criteria are met.
+ *
+ * \note This function assumes the \p iteration_id is that of the next, but
+ * not yet performed step. For instance, a `MaxIteration` criterion of 1 will
+ * match if the \p iteration_id is 1 or higher, since the first iteration
+ * (with id 0) has been completed. At this point, also the \p residual_magnitude
+ * reflects the state of the algorithm after completion of the first iteration.
+ * The `initial_residual_magnitude` always refers to the state before the first
+ * iteration has begun.
+ *
+ * \returns a `LinearSolver::ConvergenceReason` if the criteria are met, or
+ * `boost::none` otherwise.
+ */
+boost::optional<ConvergenceReason> convergence_criteria_match(
+    const ConvergenceCriteria& convergence_criteria,
+    const IterationId& iteration_id, double residual_magnitude,
+    double initial_residual_magnitude) noexcept;
+
+/*!
+ * \brief Signals convergence of the linear solver.
+ *
+ * \details Evaluates to `true` if the linear solver has converged and no
+ * further iterations should be performed. In this case, the `reason()` member
+ * function provides more information. If `false`, calling `reason()` is an
+ * error.
+ *
+ * The stream operator provides a human-readable description of the convergence
+ * status.
+ *
+ * This type default-constructs to a state that signals the linear solver has
+ * not yet converged.
+ */
+struct HasConverged {
+ public:
+  HasConverged() = default;
+  /*!
+   * \brief Determine whether the \p convergence_criteria are met by means of
+   * `LinearSolver::convergence_criteria_match`.
+   */
+  HasConverged(const ConvergenceCriteria& convergence_criteria,
+               const IterationId& iteration_id, double residual_magnitude,
+               double initial_residual_magnitude) noexcept;
+
+  explicit operator bool() const noexcept { return static_cast<bool>(reason_); }
+
+  /*!
+   * \brief The reason the linear solver has converged.
+   *
+   * \warning Calling this function is an error if the linear solver has not yet
+   * converged.
+   */
+  ConvergenceReason reason() const noexcept;
+
+  void pup(PUP::er& p) noexcept;  // NOLINT
+
+  friend bool operator==(const HasConverged& lhs,
+                         const HasConverged& rhs) noexcept;
+  friend bool operator!=(const HasConverged& lhs,
+                         const HasConverged& rhs) noexcept;
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const HasConverged& has_converged) noexcept;
+
+ private:
+  boost::optional<ConvergenceReason> reason_{boost::none};
+  ConvergenceCriteria convergence_criteria_{};
+  IterationId iteration_id_{};
+  double residual_magnitude_{};
+  double initial_residual_magnitude_{};
+};
+
+}  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -53,9 +53,8 @@ namespace LinearSolver {
  * vector is constructed. Then compute its magnitude and reduce.
  * 4. `StoreFinalOrthogonalization` (on `ResidualMonitor`): Perform a QR
  * decomposition of the Hessenberg matrix to produce a residual vector.
- * Broadcast to `UpdateFieldAndTerminate` if the residual vanishes to a
- * precision determined by `equal_within_roundoff`, else broadcast to
- * `NormalizeOperand`.
+ * Broadcast to `NormalizeOperandAndUpdateField` along with a termination
+ * flag if the `LinearSolver::Tags::ConvergenceCriteria` are met.
  * 5. `NormalizeOperandAndUpdateField` (on elements): Set the operand \f$q\f$ as
  * the new orthogonal vector and normalize. Use the residual vector and the set
  * of orthogonal vectors to determine the solution \f$x\f$.
@@ -95,9 +94,6 @@ struct Gmres {
    * LinearSolver::Tags::IterationId>`
    * - `basis_history_tag` =
    * `LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>`
-   * - `residual_magnitude_tag` =
-   * `db::add_tag_prefix<LinearSolver::Tags::Magnitude,
-   * db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>`
    *
    * DataBox changes:
    * - Adds:
@@ -106,7 +102,6 @@ struct Gmres {
    *   * `initial_fields_tag`
    *   * `orthogonalization_iteration_id_tag`
    *   * `basis_history_tag`
-   *   * `residual_magnitude_tag`
    *   * `LinearSolver::Tags::HasConverged`
    * - Removes: nothing
    * - Modifies:
@@ -141,9 +136,6 @@ struct Gmres {
    * LinearSolver::Tags::IterationId>`
    * - `basis_history_tag` =
    * `LinearSolver::Tags::KrylovSubspaceBasis<fields_tag>`
-   * - `residual_magnitude_tag` =
-   * `db::add_tag_prefix<LinearSolver::Tags::Magnitude,
-   * db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>`
    *
    * DataBox changes:
    * - Adds: nothing
@@ -155,7 +147,6 @@ struct Gmres {
    *   * `operand_tag`
    *   * `orthogonalization_iteration_id_tag`
    *   * `basis_history_tag`
-   *   * `residual_magnitude_tag`
    *   * `LinearSolver::Tags::HasConverged`
    */
   using perform_step = gmres_detail::PerformStep;

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/Gmres.hpp
@@ -118,7 +118,7 @@ struct Gmres {
 
   // Compile-time interface for observers
   using observed_reduction_data_tags = observers::make_reduction_data_tags<
-      tmpl::list<gmres_detail::observed_reduction_data>>;
+      tmpl::list<observe_detail::reduction_data>>;
 
   /*!
    * \brief Perform an iteration of the GMRES linear solver

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -41,15 +41,10 @@ namespace gmres_detail {
 
 template <typename BroadcastTarget>
 struct InitializeResidualMagnitude {
-  template <
-      typename... DbTags, typename... InboxTags, typename Metavariables,
-      typename ArrayIndex, typename ActionList, typename ParallelComponent,
-      Requires<tmpl2::flat_any_v<cpp17::is_same_v<
-          db::add_tag_prefix<
-              LinearSolver::Tags::Magnitude,
-              db::add_tag_prefix<LinearSolver::Tags::Residual,
-                                 typename Metavariables::system::fields_tag>>,
-          DbTags>...>> = nullptr>
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent,
+            Requires<sizeof...(DbTags) != 0> = nullptr>
   static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
                     tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
@@ -61,51 +56,32 @@ struct InitializeResidualMagnitude {
     using residual_magnitude_tag = db::add_tag_prefix<
         LinearSolver::Tags::Magnitude,
         db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>;
+    using initial_residual_magnitude_tag =
+        db::add_tag_prefix<LinearSolver::Tags::Initial, residual_magnitude_tag>;
 
-    db::mutate<residual_magnitude_tag>(
+    db::mutate<residual_magnitude_tag, initial_residual_magnitude_tag>(
         make_not_null(&box), [residual_magnitude](
                                  const gsl::not_null<double*>
-                                     stored_residual_magnitude) noexcept {
-          *stored_residual_magnitude = residual_magnitude;
+                                     local_residual_magnitude,
+                                 const gsl::not_null<double*>
+                                     initial_residual_magnitude) noexcept {
+          *local_residual_magnitude = *initial_residual_magnitude =
+              residual_magnitude;
         });
 
-    // When more sophisticated convergence criteria are implemented we may also
-    // want to check for convergence here.
+    // Determine whether the linear solver has already converged. This invokes
+    // the compute item.
+    const auto& has_converged = db::get<LinearSolver::Tags::HasConverged>(box);
+
+    if (UNLIKELY(has_converged and
+                 static_cast<int>(get<::Tags::Verbosity>(box)) >=
+                     static_cast<int>(::Verbosity::Quiet))) {
+      Parallel::printf("%s", has_converged);
+    }
 
     Parallel::simple_action<NormalizeInitialOperand>(
         Parallel::get_parallel_component<BroadcastTarget>(cache),
-        residual_magnitude);
-  }
-};
-
-struct InitializeSourceMagnitude {
-  template <
-      typename... DbTags, typename... InboxTags, typename Metavariables,
-      typename ArrayIndex, typename ActionList, typename ParallelComponent,
-      Requires<tmpl2::flat_any_v<cpp17::is_same_v<
-          db::add_tag_prefix<
-              LinearSolver::Tags::Magnitude,
-              db::add_tag_prefix<::Tags::Source,
-                                 typename Metavariables::system::fields_tag>>,
-          DbTags>...>> = nullptr>
-  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
-                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-                    const ArrayIndex& /*array_index*/,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/,
-                    const double source_magnitude) noexcept {
-    using fields_tag = typename Metavariables::system::fields_tag;
-    using source_magnitude_tag =
-        db::add_tag_prefix<LinearSolver::Tags::Magnitude,
-                           db::add_tag_prefix<::Tags::Source, fields_tag>>;
-
-    db::mutate<source_magnitude_tag>(
-        make_not_null(&box), [source_magnitude](
-                                 const gsl::not_null<double*>
-                                     stored_source_magnitude) noexcept {
-          *stored_source_magnitude = source_magnitude;
-        });
+        residual_magnitude, has_converged);
   }
 };
 
@@ -114,10 +90,7 @@ struct StoreOrthogonalization {
   template <typename... DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent,
-            Requires<tmpl2::flat_any_v<cpp17::is_same_v<
-                db::add_tag_prefix<LinearSolver::Tags::OrthogonalizationHistory,
-                                   typename Metavariables::system::fields_tag>,
-                DbTags>...>> = nullptr>
+            Requires<sizeof...(DbTags) != 0> = nullptr>
   static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
                     tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
@@ -163,10 +136,7 @@ struct StoreFinalOrthogonalization {
   template <typename... DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
             typename ParallelComponent,
-            Requires<tmpl2::flat_any_v<cpp17::is_same_v<
-                db::add_tag_prefix<LinearSolver::Tags::OrthogonalizationHistory,
-                                   typename Metavariables::system::fields_tag>,
-                DbTags>...>> = nullptr>
+            Requires<sizeof...(DbTags) != 0> = nullptr>
   static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
                     tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
@@ -178,9 +148,8 @@ struct StoreFinalOrthogonalization {
     using residual_magnitude_tag = db::add_tag_prefix<
         LinearSolver::Tags::Magnitude,
         db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>;
-    using source_magnitude_tag =
-        db::add_tag_prefix<LinearSolver::Tags::Magnitude,
-                           db::add_tag_prefix<::Tags::Source, fields_tag>>;
+    using initial_residual_magnitude_tag =
+        db::add_tag_prefix<LinearSolver::Tags::Initial, residual_magnitude_tag>;
     using orthogonalization_iteration_id_tag =
         db::add_tag_prefix<LinearSolver::Tags::Orthogonalization,
                            LinearSolver::Tags::IterationId>;
@@ -213,19 +182,44 @@ struct StoreFinalOrthogonalization {
     blaze::qr(orthogonalization_history, qr_Q, qr_R);
     // Compute the residual vector from the QR decomposition
     DenseVector<double> beta(num_rows, 0.);
-    beta[0] = get<residual_magnitude_tag>(box);
+    beta[0] = get<initial_residual_magnitude_tag>(box);
     const DenseVector<double> minres =
         blaze::inv(qr_R) * blaze::trans(qr_Q) * beta;
-    const double absolute_residual =
+    const double residual_magnitude =
         blaze::length(beta - orthogonalization_history * minres);
 
-    if (UNLIKELY(static_cast<int>(get<::Tags::Verbosity>(box)) >=
-                 static_cast<int>(::Verbosity::Verbose))) {
-      Parallel::printf(
-          "Linear solver iteration %d done. Remaining absolute residual: %e\n",
-          get<LinearSolver::Tags::IterationId>(box).step_number + 1,
-          absolute_residual);
-    }
+    // Store residual magnitude and prepare for the next iteration
+    db::mutate<residual_magnitude_tag, LinearSolver::Tags::IterationId,
+               orthogonalization_iteration_id_tag,
+               orthogonalization_history_tag>(
+        make_not_null(&box),
+        [residual_magnitude](
+            const gsl::not_null<double*> local_residual_magnitude,
+            const gsl::not_null<IterationId*> iteration_id,
+            const gsl::not_null<IterationId*> orthogonalization_iteration_id,
+            const gsl::not_null<db::item_type<orthogonalization_history_tag>*>
+                local_orthogonalization_history) noexcept {
+          *local_residual_magnitude = residual_magnitude;
+          // Prepare for the next iteration
+          iteration_id->step_number++;
+          orthogonalization_iteration_id->step_number = 0;
+          local_orthogonalization_history->resize(
+              iteration_id->step_number + 2, iteration_id->step_number + 1);
+          // Make sure the new entries are zero
+          for (size_t i = 0; i < local_orthogonalization_history->rows(); i++) {
+            (*local_orthogonalization_history)(
+                i, local_orthogonalization_history->columns() - 1) = 0.;
+          }
+          for (size_t j = 0; j < local_orthogonalization_history->columns();
+               j++) {
+            (*local_orthogonalization_history)(
+                local_orthogonalization_history->rows() - 1, j) = 0.;
+          }
+        });
+
+    // At this point, the iteration is complete. We proceed with observing,
+    // logging and checking convergence before broadcasting back to the
+    // elements.
 
     // Contribute data to the observer
     const auto observation_id =
@@ -243,43 +237,29 @@ struct StoreFinalOrthogonalization {
         std::vector<std::string>{"Iteration", "Residual"},
         observed_reduction_data{
             get<LinearSolver::Tags::IterationId>(box).step_number,
-            absolute_residual});
+            residual_magnitude});
 
-    // Determine whether the linear solver has converged
-    // More sophisticated convergence criteria can be added in the future.
-    const double relative_residual =
-        absolute_residual / get<source_magnitude_tag>(box);
-    const bool has_converged = equal_within_roundoff(relative_residual, 0.);
+    // Determine whether the linear solver has converged. This invokes the
+    // compute item.
+    const auto& has_converged = db::get<LinearSolver::Tags::HasConverged>(box);
 
-    // Prepare for the next iteration
-    db::mutate<LinearSolver::Tags::IterationId,
-               orthogonalization_iteration_id_tag,
-               orthogonalization_history_tag>(
-        make_not_null(&box),
-        [](const gsl::not_null<IterationId*> iteration_id,
-           const gsl::not_null<IterationId*> orthogonalization_iteration_id,
-           // `local_` prefix to silence gcc shadowing complaints
-           const gsl::not_null<db::item_type<orthogonalization_history_tag>*>
-               local_orthogonalization_history) noexcept {
-          iteration_id->step_number++;
-          orthogonalization_iteration_id->step_number = 0;
-          local_orthogonalization_history->resize(
-              iteration_id->step_number + 2, iteration_id->step_number + 1);
-          // Make sure the new entries are zero
-          for (size_t i = 0; i < local_orthogonalization_history->rows(); i++) {
-            (*local_orthogonalization_history)(
-                i, local_orthogonalization_history->columns() - 1) = 0.;
-          }
-          for (size_t j = 0; j < local_orthogonalization_history->columns();
-               j++) {
-            (*local_orthogonalization_history)(
-                local_orthogonalization_history->rows() - 1, j) = 0.;
-          }
-        });
+    // Do some logging
+    if (UNLIKELY(static_cast<int>(get<::Tags::Verbosity>(box)) >=
+                 static_cast<int>(::Verbosity::Verbose))) {
+      Parallel::printf(
+          "Linear solver iteration %d done. Remaining residual: %e\n",
+          get<LinearSolver::Tags::IterationId>(box).step_number,
+          residual_magnitude);
+    }
+    if (UNLIKELY(has_converged and
+                 static_cast<int>(get<::Tags::Verbosity>(box)) >=
+                     static_cast<int>(::Verbosity::Quiet))) {
+      Parallel::printf("%s", has_converged);
+    }
 
     Parallel::simple_action<NormalizeOperandAndUpdateField>(
         Parallel::get_parallel_component<BroadcastTarget>(cache),
-        sqrt(orthogonalization), minres, absolute_residual, has_converged);
+        sqrt(orthogonalization), minres, has_converged);
   }
 };
 

--- a/src/NumericalAlgorithms/LinearSolver/Observe.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Observe.hpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "IO/Observer/ReductionActions.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "NumericalAlgorithms/LinearSolver/Tags.hpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
+
+namespace LinearSolver {
+namespace observe_detail {
+
+using reduction_data = Parallel::ReductionData<
+    // Iteration
+    Parallel::ReductionDatum<size_t, funcl::AssertEqual<>>,
+    // Residual
+    Parallel::ReductionDatum<double, funcl::AssertEqual<>>>;
+
+/*!
+ * \brief Contributes data from the residual monitor to the reduction observer
+ *
+ * With:
+ * - `residual_magnitude_tag` = `db::add_tag_prefix<
+ * LinearSolver::Tags::Magnitude, db::add_tag_prefix<
+ * LinearSolver::Tags::Residual, fields_tag>>`
+ *
+ * Uses:
+ * - System:
+ *   - `fields_tag`
+ * - DataBox:
+ *   - `LinearSolver::Tags::IterationId`
+ *   - `residual_magnitude_tag`
+ */
+template <typename DbTagsList, typename Metavariables>
+void contribute_to_reduction_observer(
+    db::DataBox<DbTagsList>& box,
+    Parallel::ConstGlobalCache<Metavariables>& cache) noexcept {
+  using fields_tag = typename Metavariables::system::fields_tag;
+  using residual_magnitude_tag = db::add_tag_prefix<
+      LinearSolver::Tags::Magnitude,
+      db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>;
+
+  const auto observation_id =
+      observers::ObservationId(get<LinearSolver::Tags::IterationId>(box));
+  auto& reduction_writer = Parallel::get_parallel_component<
+      observers::ObserverWriter<Metavariables>>(cache);
+  Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(
+      // Node 0 is always the writer, so directly call the component on that
+      // node
+      reduction_writer[0], observation_id,
+      // When multiple linear solves are performed, e.g. for the nonlinear
+      // solver, we'll need to write into separate subgroups, e.g.:
+      // `/linear_residuals/<nonlinear_iteration_id>`
+      std::string{"/linear_residuals"},
+      std::vector<std::string>{"Iteration", "Residual"},
+      reduction_data{get<LinearSolver::Tags::IterationId>(box).step_number,
+                     get<residual_magnitude_tag>(box)});
+}
+
+}  // namespace observe_detail
+}  // namespace LinearSolver

--- a/src/NumericalAlgorithms/LinearSolver/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Tags.hpp
@@ -15,6 +15,8 @@
 #include "DataStructures/DenseMatrix.hpp"
 #include "NumericalAlgorithms/LinearSolver/Convergence.hpp"
 #include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/TypeTraits.hpp"
 
 /*!
  * \ingroup LinearSolverGroup
@@ -117,6 +119,21 @@ struct Magnitude : db::PrefixTag, db::SimpleTag {
   }
   using type = double;
   using tag = Tag;
+};
+
+/*!
+ * \brief Compute the `LinearSolver::Magnitude` of a tag from its
+ * `LinearSolver::MagnitudeSquare`.
+ */
+template <typename MagnitudeSquareTag,
+          Requires<tt::is_a_v<MagnitudeSquare, MagnitudeSquareTag>> = nullptr>
+struct MagnitudeCompute
+    : db::add_tag_prefix<Magnitude, db::remove_tag_prefix<MagnitudeSquareTag>>,
+      db::ComputeTag {
+  static constexpr double function(const double& magnitude_square) noexcept {
+    return sqrt(magnitude_square);
+  }
+  using argument_tags = tmpl::list<MagnitudeSquareTag>;
 };
 
 /*!

--- a/tests/InputFiles/Poisson/Input1D.yaml
+++ b/tests/InputFiles/Poisson/Input1D.yaml
@@ -22,3 +22,8 @@ Verbosity: Verbose
 
 VolumeFileName: "./Poisson1DVolume"
 ReductionFileName: "./Poisson1DReductions"
+
+ConvergenceCriteria:
+  MaxIterations: 1
+  AbsoluteResidual: 0
+  RelativeResidual: 0

--- a/tests/InputFiles/Poisson/Input2D.yaml
+++ b/tests/InputFiles/Poisson/Input2D.yaml
@@ -22,3 +22,8 @@ Verbosity: Verbose
 
 VolumeFileName: "./Poisson2DVolume"
 ReductionFileName: "./Poisson2DReductions"
+
+ConvergenceCriteria:
+  MaxIterations: 1
+  AbsoluteResidual: 0
+  RelativeResidual: 0

--- a/tests/InputFiles/Poisson/Input3D.yaml
+++ b/tests/InputFiles/Poisson/Input3D.yaml
@@ -22,3 +22,8 @@ Verbosity: Verbose
 
 VolumeFileName: "./Poisson3DVolume"
 ReductionFileName: "./Poisson3DReductions"
+
+ConvergenceCriteria:
+  MaxIterations: 1
+  AbsoluteResidual: 0
+  RelativeResidual: 0

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_LinearSolver")
 
 set(LIBRARY_SOURCES
+  Test_Convergence.cpp
   Test_InnerProduct.cpp
   Test_IterationId.cpp
   Test_Tags.cpp

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.input
@@ -10,3 +10,8 @@ Verbosity: Verbose
 
 VolumeFileName: "Test_ConjugateGradientAlgorithm_Volume"
 ReductionFileName: "Test_ConjugateGradientAlgorithm_Reductions"
+
+ConvergenceCriteria:
+  MaxIterations: 2
+  AbsoluteResidual: 1e-14
+  RelativeResidual: 0

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.input
@@ -29,3 +29,8 @@ Verbosity: Verbose
 
 VolumeFileName: "./Test_DistributedConjugateGradientAlgorithm_Volume"
 ReductionFileName: "./Test_DistributedConjugateGradientAlgorithm_Reductions"
+
+ConvergenceCriteria:
+  MaxIterations: 6
+  AbsoluteResidual: 1e-14
+  RelativeResidual: 0

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/DistributedLinearSolverAlgorithmTestHelpers.hpp
@@ -168,6 +168,10 @@ struct TestResult {
                     const Parallel::ConstGlobalCache<Metavariables>& cache,
                     const int array_index, const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
+    const auto& has_converged = get<LinearSolver::Tags::HasConverged>(box);
+    SPECTRE_PARALLEL_REQUIRE(has_converged);
+    SPECTRE_PARALLEL_REQUIRE(has_converged.reason() ==
+                             LinearSolver::ConvergenceReason::AbsoluteResidual);
     const auto& expected_result =
         gsl::at(get<ExpectedResult>(cache), array_index);
     const auto& result = get<ScalarFieldTag>(box).get();

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.input
@@ -29,3 +29,8 @@ Verbosity: Verbose
 
 VolumeFileName: "Test_DistributedGmresAlgorithm_Volume"
 ReductionFileName: "Test_DistributedGmresAlgorithm_Reductions"
+
+ConvergenceCriteria:
+  MaxIterations: 6
+  AbsoluteResidual: 1e-14
+  RelativeResidual: 0

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.input
@@ -10,3 +10,8 @@ Verbosity: Verbose
 
 VolumeFileName: "Test_GmresAlgorithm_Volume"
 ReductionFileName: "Test_GmresAlgorithm_Reductions"
+
+ConvergenceCriteria:
+  MaxIterations: 2
+  AbsoluteResidual: 1e-14
+  RelativeResidual: 0

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+// IWYU pragma: no_include <boost/variant/get.hpp>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
@@ -18,6 +19,7 @@
 #include "DataStructures/DenseVector.hpp"
 #include "IO/Observer/ObservationId.hpp"
 #include "Informer/Verbosity.hpp"
+#include "NumericalAlgorithms/LinearSolver/Convergence.hpp"
 #include "NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp"
 #include "NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
@@ -54,9 +56,6 @@ struct VectorTag : db::SimpleTag {
 using residual_magnitude_tag = db::add_tag_prefix<
     LinearSolver::Tags::Magnitude,
     db::add_tag_prefix<LinearSolver::Tags::Residual, VectorTag>>;
-using source_magnitude_tag =
-    db::add_tag_prefix<LinearSolver::Tags::Magnitude,
-                       db::add_tag_prefix<::Tags::Source, VectorTag>>;
 using orthogonalization_iteration_id_tag =
     db::add_tag_prefix<LinearSolver::Tags::Orthogonalization,
                        LinearSolver::Tags::IterationId>;
@@ -73,10 +72,9 @@ struct CheckVectorTag : db::SimpleTag {
   static std::string name() noexcept { return "CheckVectorTag"; }
 };
 
-struct CheckConvergedTag : db::SimpleTag {
-  using type = bool;
-  static std::string name() noexcept { return "CheckConvergedTag"; }
-};
+using CheckConvergedTag = LinearSolver::Tags::HasConverged;
+
+using check_tags = tmpl::list<CheckValueTag, CheckVectorTag, CheckConvergedTag>;
 
 template <typename Metavariables>
 using residual_monitor_tags =
@@ -103,18 +101,23 @@ struct MockResidualMonitor {
 struct MockNormalizeInitialOperand {
   template <typename... InboxTags, typename Metavariables, typename ActionList,
             typename ParallelComponent, typename ArrayIndex>
-  static void apply(
-      db::DataBox<tmpl::list<CheckValueTag, CheckVectorTag, CheckConvergedTag>>&
-          box,  // NOLINT
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/,
-      const double residual_squared) noexcept {
-    db::mutate<CheckValueTag>(
-        make_not_null(&box), [residual_squared](const gsl::not_null<double*>
-                                                    value_box) noexcept {
-          *value_box = residual_squared;
+  static void apply(db::DataBox<check_tags>& box,  // NOLINT
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const double residual_magnitude,
+                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                        has_converged) noexcept {
+    db::mutate<CheckValueTag, CheckConvergedTag>(
+        make_not_null(&box),
+        [ residual_magnitude, &has_converged ](
+            const gsl::not_null<double*> check_value,
+            const gsl::not_null<db::item_type<CheckConvergedTag>*>
+                check_converged) noexcept {
+          *check_value = residual_magnitude;
+          *check_converged = has_converged;
         });
   }
 };
@@ -122,18 +125,17 @@ struct MockNormalizeInitialOperand {
 struct MockOrthogonalizeOperand {
   template <typename... InboxTags, typename Metavariables, typename ActionList,
             typename ParallelComponent, typename ArrayIndex>
-  static void apply(
-      db::DataBox<tmpl::list<CheckValueTag, CheckVectorTag, CheckConvergedTag>>&
-          box,  // NOLINT
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/,
-      const double orthogonalization) noexcept {
+  static void apply(db::DataBox<check_tags>& box,  // NOLINT
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const double orthogonalization) noexcept {
     db::mutate<CheckValueTag>(
         make_not_null(&box), [orthogonalization](const gsl::not_null<double*>
-                                                     value_box) noexcept {
-          *value_box = orthogonalization;
+                                                     check_value) noexcept {
+          *check_value = orthogonalization;
         });
   }
 };
@@ -141,24 +143,26 @@ struct MockOrthogonalizeOperand {
 struct MockNormalizeOperandAndUpdateField {
   template <typename... InboxTags, typename Metavariables, typename ActionList,
             typename ParallelComponent, typename ArrayIndex>
-  static void apply(
-      db::DataBox<tmpl::list<CheckValueTag, CheckVectorTag, CheckConvergedTag>>&
-          box,  // NOLINT
-      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/, const double normalization,
-      const DenseVector<double>& minres, const double residual_magnitude,
-      const bool has_converged) noexcept {
+  static void apply(db::DataBox<check_tags>& box,  // NOLINT
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const double normalization,
+                    const DenseVector<double>& minres,
+                    const db::item_type<LinearSolver::Tags::HasConverged>&
+                        has_converged) noexcept {
     db::mutate<CheckValueTag, CheckVectorTag, CheckConvergedTag>(
         make_not_null(&box),
-        [ normalization, minres, residual_magnitude, has_converged ](
-            const gsl::not_null<double*> value_box,
-            const gsl::not_null<DenseVector<double>*> vector_box,
-            const gsl::not_null<bool*> converged_box) noexcept {
-          *value_box = normalization + residual_magnitude;
-          *vector_box = minres;
-          *converged_box = has_converged;
+        [ normalization, &minres, &has_converged ](
+            const gsl::not_null<double*> check_value,
+            const gsl::not_null<DenseVector<double>*> check_vector,
+            const gsl::not_null<db::item_type<CheckConvergedTag>*>
+                check_converged) noexcept {
+          *check_value = normalization;
+          *check_vector = minres;
+          *check_converged = has_converged;
         });
   }
 };
@@ -172,8 +176,7 @@ struct MockElementArray {
   using array_index = int;
   using const_global_cache_tag_list = tmpl::list<>;
   using action_list = tmpl::list<>;
-  using initial_databox = db::compute_databox_type<
-      tmpl::list<CheckValueTag, CheckVectorTag, CheckConvergedTag>>;
+  using initial_databox = db::compute_databox_type<check_tags>;
 
   using replace_these_simple_actions =
       tmpl::list<LinearSolver::gmres_detail::NormalizeInitialOperand,
@@ -210,8 +213,13 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
   tuples::get<MockSingletonObjectsTag>(dist_objects)
       .emplace(
           singleton_id,
-          db::create<residual_monitor_tags<Metavariables>>(
-              Verbosity::Verbose, std::numeric_limits<double>::signaling_NaN(),
+          db::create<
+              typename LinearSolver::gmres_detail::InitializeResidualMonitor<
+                  Metavariables>::simple_tags,
+              typename LinearSolver::gmres_detail::InitializeResidualMonitor<
+                  Metavariables>::compute_tags>(
+              Verbosity::Verbose, LinearSolver::ConvergenceCriteria{2, 0., 0.5},
+              std::numeric_limits<double>::signaling_NaN(),
               std::numeric_limits<double>::signaling_NaN(),
               LinearSolver::IterationId{0}, LinearSolver::IterationId{0},
               DenseMatrix<double>{2, 1, 0.}));
@@ -223,10 +231,9 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
   const int element_id{0};
   tuples::get<MockDistributedObjectsTag>(dist_objects)
       .emplace(element_id,
-               db::create<db::AddSimpleTags<CheckValueTag, CheckVectorTag,
-                                            CheckConvergedTag>>(
+               db::create<check_tags>(
                    std::numeric_limits<double>::signaling_NaN(),
-                   DenseVector<double>{}, false));
+                   DenseVector<double>{}, db::item_type<CheckConvergedTag>{}));
 
   // Setup mock observer writer
   using MockObserverObjectsTag = MockRuntimeSystem::MockDistributedObjectsTag<
@@ -251,8 +258,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
   const auto get_mock_element_box = [&runner, &element_id]() -> decltype(auto) {
     return runner.algorithms<MockElementArray<Metavariables>>()
         .at(element_id)
-        .get_databox<db::compute_databox_type<db::AddSimpleTags<
-            CheckValueTag, CheckVectorTag, CheckConvergedTag>>>();
+        .get_databox<db::compute_databox_type<check_tags>>();
   };
   const auto get_mock_observer_writer_box =
       [&runner, &singleton_id]() -> decltype(auto) {
@@ -271,16 +277,30 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
     const auto& box = get_box();
     CHECK(db::get<residual_magnitude_tag>(box) == 2.);
     CHECK(db::get<LinearSolver::Tags::IterationId>(box).step_number == 0);
+    CHECK_FALSE(db::get<LinearSolver::Tags::HasConverged>(box));
     const auto& mock_element_box = get_mock_element_box();
     CHECK(db::get<CheckValueTag>(mock_element_box) == 2.);
+    CHECK(db::get<CheckConvergedTag>(mock_element_box) ==
+          db::get<LinearSolver::Tags::HasConverged>(box));
   }
 
-  SECTION("InitializeSourceMagnitude") {
-    runner.simple_action<MockResidualMonitor<Metavariables>,
-                         LinearSolver::gmres_detail::InitializeSourceMagnitude>(
-        singleton_id, 2.);
+  SECTION("InitializeResidualMagnitudeAndConverge") {
+    runner
+        .simple_action<MockResidualMonitor<Metavariables>,
+                       LinearSolver::gmres_detail::InitializeResidualMagnitude<
+                           MockElementArray<Metavariables>>>(singleton_id, 0.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
     const auto& box = get_box();
-    CHECK(db::get<source_magnitude_tag>(box) == 2.);
+    CHECK(db::get<residual_magnitude_tag>(box) == 0.);
+    CHECK(db::get<LinearSolver::Tags::IterationId>(box).step_number == 0);
+    CHECK(db::get<LinearSolver::Tags::HasConverged>(box));
+    CHECK(db::get<LinearSolver::Tags::HasConverged>(box).reason() ==
+          LinearSolver::ConvergenceReason::AbsoluteResidual);
+    const auto& mock_element_box = get_mock_element_box();
+    CHECK(db::get<CheckValueTag>(mock_element_box) == 0.);
+    CHECK(db::get<CheckConvergedTag>(mock_element_box) ==
+          db::get<LinearSolver::Tags::HasConverged>(box));
   }
 
   SECTION("StoreOrthogonalization") {
@@ -306,9 +326,6 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
     runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
         element_id);
     runner.simple_action<MockResidualMonitor<Metavariables>,
-                         LinearSolver::gmres_detail::InitializeSourceMagnitude>(
-        singleton_id, 2.);
-    runner.simple_action<MockResidualMonitor<Metavariables>,
                          LinearSolver::gmres_detail::StoreOrthogonalization<
                              MockElementArray<Metavariables>>>(singleton_id,
                                                                3.);
@@ -316,7 +333,6 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
         element_id);
     const auto& intermediate_box = get_box();
     CHECK(db::get<residual_magnitude_tag>(intermediate_box) == 2.);
-    CHECK(db::get<source_magnitude_tag>(intermediate_box) == 2.);
     CHECK(db::get<orthogonalization_history_tag>(intermediate_box) ==
           DenseMatrix<double>({{3.}, {0.}}));
     CHECK(db::get<LinearSolver::Tags::IterationId>(intermediate_box)
@@ -332,7 +348,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
     runner.invoke_queued_threaded_action<MockObserverWriter<Metavariables>>(
         singleton_id);
     const auto& box = get_box();
-    // residual should be nonzero, so don't terminate
+    // Iteration ids should be prepared for next iteration
     CHECK(db::get<LinearSolver::Tags::IterationId>(box).step_number == 1);
     CHECK(db::get<orthogonalization_iteration_id_tag>(box).step_number == 0);
     // H = [[3.], [2.]] and added a zero row and column
@@ -346,9 +362,11 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
                           DenseVector<double>({0.4615384615384615}));
     // r = beta - H * minres = [0.6153846153846154, -0.923076923076923]
     // |r| = 1.1094003924504583
-    CHECK(db::get<CheckValueTag>(mock_element_box) ==
-          approx(2. + 1.1094003924504583));
-    CHECK(db::get<CheckConvergedTag>(mock_element_box) == false);
+    CHECK(get<residual_magnitude_tag>(box) == approx(1.1094003924504583));
+    CHECK_FALSE(db::get<LinearSolver::Tags::HasConverged>(box));
+    CHECK(db::get<CheckConvergedTag>(mock_element_box) ==
+          db::get<LinearSolver::Tags::HasConverged>(box));
+    CHECK(db::get<CheckValueTag>(mock_element_box) == approx(2.));
     const auto& mock_observer_writer_box = get_mock_observer_writer_box();
     CHECK(db::get<CheckObservationIdTag>(mock_observer_writer_box) ==
           observers::ObservationId{LinearSolver::IterationId{0}});
@@ -362,16 +380,13 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
           approx(1.1094003924504583));
   }
 
-  SECTION("Converge") {
+  SECTION("ConvergeByAbsoluteResidual") {
     runner
         .simple_action<MockResidualMonitor<Metavariables>,
                        LinearSolver::gmres_detail::InitializeResidualMagnitude<
                            MockElementArray<Metavariables>>>(singleton_id, 2.);
     runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
         element_id);
-    runner.simple_action<MockResidualMonitor<Metavariables>,
-                         LinearSolver::gmres_detail::InitializeSourceMagnitude>(
-        singleton_id, 2.);
     runner.simple_action<MockResidualMonitor<Metavariables>,
                          LinearSolver::gmres_detail::StoreOrthogonalization<
                              MockElementArray<Metavariables>>>(singleton_id,
@@ -390,14 +405,20 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
     // H = [[1.], [0.]] and added a zero row and column
     CHECK(db::get<orthogonalization_history_tag>(box) ==
           DenseMatrix<double>({{1., 0.}, {0., 0.}, {0., 0.}}));
-    // residual should be zero, so converge
     const auto& mock_element_box = get_mock_element_box();
     // beta = [2., 0.]
-    // inv(qr_R(H)) * trans(qr_Q(H)) * beta = {2.}
+    // minres = inv(qr_R(H)) * trans(qr_Q(H)) * beta = [2.]
     CHECK(db::get<CheckVectorTag>(mock_element_box).size() == 1);
     CHECK_ITERABLE_APPROX(db::get<CheckVectorTag>(mock_element_box),
                           DenseVector<double>({2.}));
-    CHECK(db::get<CheckConvergedTag>(mock_element_box) == true);
+    // r = beta - H * minres = [0., 0.]
+    // |r| = 0.
+    CHECK(get<residual_magnitude_tag>(box) == approx(0.));
+    CHECK(db::get<LinearSolver::Tags::HasConverged>(box));
+    CHECK(db::get<LinearSolver::Tags::HasConverged>(box).reason() ==
+          LinearSolver::ConvergenceReason::AbsoluteResidual);
+    CHECK(db::get<CheckConvergedTag>(mock_element_box) ==
+          db::get<LinearSolver::Tags::HasConverged>(box));
     const auto& mock_observer_writer_box = get_mock_observer_writer_box();
     CHECK(db::get<CheckObservationIdTag>(mock_observer_writer_box) ==
           observers::ObservationId{LinearSolver::IterationId{0}});
@@ -409,5 +430,105 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
           0);
     CHECK(get<1>(db::get<CheckReductionDataTag>(mock_observer_writer_box)) ==
           approx(0.));
+  }
+
+  SECTION("ConvergeByMaxIterations") {
+    runner
+        .simple_action<MockResidualMonitor<Metavariables>,
+                       LinearSolver::gmres_detail::InitializeResidualMagnitude<
+                           MockElementArray<Metavariables>>>(singleton_id, 1.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    // Perform 2 mock iterations
+    runner.simple_action<MockResidualMonitor<Metavariables>,
+                         LinearSolver::gmres_detail::StoreOrthogonalization<
+                             MockElementArray<Metavariables>>>(singleton_id,
+                                                               1.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    runner
+        .simple_action<MockResidualMonitor<Metavariables>,
+                       LinearSolver::gmres_detail::StoreFinalOrthogonalization<
+                           MockElementArray<Metavariables>>>(singleton_id, 4.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    runner.simple_action<MockResidualMonitor<Metavariables>,
+                         LinearSolver::gmres_detail::StoreOrthogonalization<
+                             MockElementArray<Metavariables>>>(singleton_id,
+                                                               3.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    runner.simple_action<MockResidualMonitor<Metavariables>,
+                         LinearSolver::gmres_detail::StoreOrthogonalization<
+                             MockElementArray<Metavariables>>>(singleton_id,
+                                                               4.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    runner
+        .simple_action<MockResidualMonitor<Metavariables>,
+                       LinearSolver::gmres_detail::StoreFinalOrthogonalization<
+                           MockElementArray<Metavariables>>>(singleton_id, 25.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    const auto& box = get_box();
+    CHECK(db::get<orthogonalization_history_tag>(box) ==
+          DenseMatrix<double>(
+              {{1., 3., 0.}, {2., 4., 0.}, {0., 5., 0.}, {0., 0., 0.}}));
+    const auto& mock_element_box = get_mock_element_box();
+    // beta = [1., 0., 0.]
+    // minres = inv(qr_R(H)) * trans(qr_Q(H)) * beta = [0.13178295, 0.03100775]
+    CHECK(db::get<CheckVectorTag>(mock_element_box).size() == 2);
+    CHECK_ITERABLE_APPROX(
+        db::get<CheckVectorTag>(mock_element_box),
+        DenseVector<double>({0.1317829457364342, 0.0310077519379845}));
+    // r = beta - H * minres = [0.77519, -0.38759, -0.15503]
+    // |r| = 0.8804509063256237
+    CHECK(get<residual_magnitude_tag>(box) == approx(0.8804509063256237));
+    const auto& has_converged = get<LinearSolver::Tags::HasConverged>(box);
+    CHECK(db::get<LinearSolver::Tags::HasConverged>(box));
+    CHECK(db::get<LinearSolver::Tags::HasConverged>(box).reason() ==
+          LinearSolver::ConvergenceReason::MaxIterations);
+    CHECK(db::get<CheckConvergedTag>(mock_element_box) ==
+          db::get<LinearSolver::Tags::HasConverged>(box));
+  }
+
+  SECTION("ConvergeByRelativeResidual") {
+    runner
+        .simple_action<MockResidualMonitor<Metavariables>,
+                       LinearSolver::gmres_detail::InitializeResidualMagnitude<
+                           MockElementArray<Metavariables>>>(singleton_id, 2.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    runner.simple_action<MockResidualMonitor<Metavariables>,
+                         LinearSolver::gmres_detail::StoreOrthogonalization<
+                             MockElementArray<Metavariables>>>(singleton_id,
+                                                               3.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    runner
+        .simple_action<MockResidualMonitor<Metavariables>,
+                       LinearSolver::gmres_detail::StoreFinalOrthogonalization<
+                           MockElementArray<Metavariables>>>(singleton_id, 1.);
+    runner.invoke_queued_simple_action<MockElementArray<Metavariables>>(
+        element_id);
+    const auto& box = get_box();
+    // H = [[3.], [1.]] and added a zero row and column
+    CHECK(db::get<orthogonalization_history_tag>(box) ==
+          DenseMatrix<double>({{3., 0.}, {1., 0.}, {0., 0.}}));
+    const auto& mock_element_box = get_mock_element_box();
+    // beta = [2., 0.]
+    // minres = inv(qr_R(H)) * trans(qr_Q(H)) * beta = [0.6]
+    CHECK(db::get<CheckVectorTag>(mock_element_box).size() == 1);
+    CHECK_ITERABLE_APPROX(db::get<CheckVectorTag>(mock_element_box),
+                          DenseVector<double>({0.6}));
+    // r = beta - H * minres = [0.2, -0.6]
+    // |r| = 0.6324555320336759
+    CHECK(get<residual_magnitude_tag>(box) == approx(0.6324555320336759));
+    // |r| / |r_initial| = 0.31622776601683794
+    CHECK(db::get<LinearSolver::Tags::HasConverged>(box));
+    CHECK(db::get<LinearSolver::Tags::HasConverged>(box).reason() ==
+          LinearSolver::ConvergenceReason::RelativeResidual);
+    CHECK(db::get<CheckConvergedTag>(mock_element_box) ==
+          db::get<LinearSolver::Tags::HasConverged>(box));
   }
 }

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/LinearSolverAlgorithmTestHelpers.hpp
@@ -84,6 +84,10 @@ struct TestResult {
                     const Parallel::ConstGlobalCache<Metavariables>& cache,
                     const int /*array_index*/, const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/) noexcept {
+    const auto& has_converged = get<LinearSolver::Tags::HasConverged>(box);
+    SPECTRE_PARALLEL_REQUIRE(has_converged);
+    SPECTRE_PARALLEL_REQUIRE(has_converged.reason() ==
+                             LinearSolver::ConvergenceReason::AbsoluteResidual);
     const auto& result = get<VectorTag>(box);
     const auto& expected_result = get<ExpectedResult>(cache);
     for (size_t i = 0; i < expected_result.size(); i++) {

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Convergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Convergence.cpp
@@ -1,0 +1,126 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <boost/none.hpp>
+#include <boost/none_t.hpp>
+#include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
+#include <string>
+
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/LinearSolver/Convergence.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Convergence",
+                  "[Unit][NumericalAlgorithms][LinearSolver]") {
+  const LinearSolver::ConvergenceCriteria criteria{2, 0., 0.5};
+
+  {
+    INFO("ConvergenceCriteria");
+    CHECK(criteria == LinearSolver::ConvergenceCriteria{2, 0., 0.5});
+    CHECK(criteria != LinearSolver::ConvergenceCriteria{3, 0., 0.5});
+    CHECK(criteria != LinearSolver::ConvergenceCriteria{2, 1., 0.5});
+    CHECK(criteria != LinearSolver::ConvergenceCriteria{2, 0., 0.6});
+    test_serialization(criteria);
+    test_copy_semantics(criteria);
+    const auto created_criteria =
+        test_creation<LinearSolver::ConvergenceCriteria>(
+            "  MaxIterations: 2\n"
+            "  AbsoluteResidual: 0.\n"
+            "  RelativeResidual: 0.5\n");
+    CHECK(created_criteria == criteria);
+  }
+
+  {
+    INFO("Convergence logic");
+    CHECK(LinearSolver::convergence_criteria_match(
+              criteria, LinearSolver::IterationId{1}, 1., 1.) == boost::none);
+    CHECK(LinearSolver::convergence_criteria_match(
+              criteria, LinearSolver::IterationId{2}, 1., 1.) ==
+          LinearSolver::ConvergenceReason::MaxIterations);
+    CHECK(LinearSolver::convergence_criteria_match(
+              criteria, LinearSolver::IterationId{1}, 0., 1.) ==
+          LinearSolver::ConvergenceReason::AbsoluteResidual);
+    CHECK(LinearSolver::convergence_criteria_match(
+              criteria, LinearSolver::IterationId{1}, 1., 2.) ==
+          LinearSolver::ConvergenceReason::RelativeResidual);
+  }
+
+  {
+    INFO("HasNotConverged");
+    const LinearSolver::HasConverged has_not_converged_by_default{};
+    CHECK_FALSE(has_not_converged_by_default);
+    test_serialization(has_not_converged_by_default);
+    test_copy_semantics(has_not_converged_by_default);
+    const LinearSolver::HasConverged has_not_converged{
+        criteria, LinearSolver::IterationId{1}, 1., 1.};
+    CHECK_FALSE(has_not_converged);
+    CHECK(get_output(has_not_converged) ==
+          "The linear solver has not yet converged.\n");
+    test_serialization(has_not_converged);
+    test_copy_semantics(has_not_converged);
+  }
+
+  {
+    INFO("HasConverged - MaxIterations")
+    const LinearSolver::HasConverged has_converged{
+        criteria, LinearSolver::IterationId{2}, 1., 1.};
+    CHECK(has_converged);
+    CHECK(has_converged.reason() ==
+          LinearSolver::ConvergenceReason::MaxIterations);
+    CHECK(get_output(has_converged) ==
+          "The linear solver has reached its maximum number of iterations "
+          "(2).\n");
+    test_serialization(has_converged);
+    test_copy_semantics(has_converged);
+  }
+
+  {
+    INFO("HasConverged - AbsoluteResidual")
+    const LinearSolver::HasConverged has_converged{
+        criteria, LinearSolver::IterationId{1}, 0., 1.};
+    CHECK(has_converged);
+    CHECK(has_converged.reason() ==
+          LinearSolver::ConvergenceReason::AbsoluteResidual);
+    CHECK(get_output(has_converged) ==
+          "The linear solver has converged in 1 iterations: AbsoluteResidual - "
+          "The residual magnitude has decreased to 0 or below (0).\n");
+    test_serialization(has_converged);
+    test_copy_semantics(has_converged);
+  }
+
+  {
+    INFO("HasConverged - RelativeResidual")
+    const LinearSolver::HasConverged has_converged{
+        criteria, LinearSolver::IterationId{1}, 1., 2.};
+    CHECK(has_converged);
+    CHECK(has_converged.reason() ==
+          LinearSolver::ConvergenceReason::RelativeResidual);
+    CHECK(get_output(has_converged) ==
+          "The linear solver has converged in 1 iterations: RelativeResidual - "
+          "The residual magnitude has decreased to a fraction of 0.5 of its "
+          "initial value or below (0.5).\n");
+    test_serialization(has_converged);
+    test_copy_semantics(has_converged);
+  }
+}
+
+// [[OutputRegex, Tried to retrieve the convergence reason, but has not yet
+// converged.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.Numerical.LinearSolver.Convergence.HasConvergedReasonAssert",
+    "[Unit][NumericalAlgorithms][LinearSolver]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  const LinearSolver::HasConverged has_not_converged{
+      LinearSolver::ConvergenceCriteria{2, 0., 0.5},
+      LinearSolver::IterationId{1}, 1., 1.};
+  has_not_converged.reason();
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Tags.cpp
@@ -17,6 +17,8 @@ struct Tag : db::SimpleTag {
   static std::string name() noexcept { return "Tag"; }
   using type = int;
 };
+using magnitude_square_tag = LinearSolver::Tags::MagnitudeSquare<Tag>;
+using magnitude_tag = LinearSolver::Tags::Magnitude<Tag>;
 using residual_magnitude_tag =
     LinearSolver::Tags::Magnitude<LinearSolver::Tags::Residual<Tag>>;
 using initial_residual_magnitude_tag =
@@ -75,5 +77,16 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Tags",
     CHECK(db::get<LinearSolver::Tags::HasConverged>(box));
     CHECK(db::get<LinearSolver::Tags::HasConverged>(box).reason() ==
           LinearSolver::ConvergenceReason::AbsoluteResidual);
+  }
+
+  {
+    INFO("MagnitudeCompute");
+    CHECK(LinearSolver::Tags::MagnitudeCompute<magnitude_square_tag>::name() ==
+          "LinearMagnitude(Tag)");
+    const auto box =
+        db::create<db::AddSimpleTags<magnitude_square_tag>,
+                   db::AddComputeTags<LinearSolver::Tags::MagnitudeCompute<
+                       magnitude_square_tag>>>(4.);
+    CHECK(db::get<magnitude_tag>(box) == approx(2.));
   }
 }


### PR DESCRIPTION
## Proposed changes

Convergence criteria for the linear solver implemented so far:
- Max. number of iterations
- Absolute residual
- Residual relative to the initial residual

Also adds a compute item for `LinearSolver::Tags::HasConverged` that uses the convergence criteria.

Please see the commit messages for more details.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
