### PR TITLE
Attempt to reduce Travis CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,10 +152,10 @@ jobs:
   - <<: *GccDebug
     stage: Build and Run Tests, ClangTidy, IWYU, and Doxygen
   - <<: *GccRelease
-  - <<: *Gcc6Debug
-  - <<: *Gcc6Release
   - <<: *ClangDebug
   - <<: *ClangRelease
+  - <<: *Gcc6Debug
+  - <<: *Gcc6Release
   # - <<: *MacOsDebug9_2
   # - <<: *MacOsRelease9_2
 
@@ -301,7 +301,7 @@ script:
         -t ${TRAVIS_REPO_SLUG}
         -f ${HOME}/docker/Dockerfile.travis
         ${HOME}/docker/
-    && rm -rf ${HOME}/ccache/*
+    && rm -rf ${HOME}/ccache/build_${CC}_${BUILD_TYPE}
     && CON=$(docker run -d ${TRAVIS_REPO_SLUG} /bin/bash)
     && docker cp ${CON}:/root/.ccache ${HOME}/ccache/build_${CC}_${BUILD_TYPE}/
     && docker cp ${CON}:/work/build_${BUILD_TYPE}_${CC}/tmp/coverage.info


### PR DESCRIPTION
Move GCC 6 builds after clang builds
Only delete specifice ccache dir

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
