### PR TITLE
Add is_identity to CoordinateMaps

### DIFF
--- a/src/Domain/CoordinateMaps/Affine.cpp
+++ b/src/Domain/CoordinateMaps/Affine.cpp
@@ -21,7 +21,8 @@ Affine::Affine(const double A, const double B, const double a, const double b)
       length_of_domain_(B - A),
       length_of_range_(b - a),
       jacobian_(length_of_range_ / length_of_domain_),
-      inverse_jacobian_(length_of_domain_ / length_of_range_) {}
+      inverse_jacobian_(length_of_domain_ / length_of_range_),
+      is_identity_(A == a and B == b) {}
 
 template <typename T>
 std::array<tt::remove_cvref_wrap_t<T>, 1> Affine::operator()(
@@ -61,6 +62,7 @@ void Affine::pup(PUP::er& p) {
   p | length_of_range_;
   p | jacobian_;
   p | inverse_jacobian_;
+  p | is_identity_;
 }
 
 bool operator==(const CoordinateMaps::Affine& lhs,
@@ -69,7 +71,8 @@ bool operator==(const CoordinateMaps::Affine& lhs,
          lhs.b_ == rhs.b_ and lhs.length_of_domain_ == rhs.length_of_domain_ and
          lhs.length_of_range_ == rhs.length_of_range_ and
          lhs.jacobian_ == rhs.jacobian_ and
-         lhs.inverse_jacobian_ == rhs.inverse_jacobian_;
+         lhs.inverse_jacobian_ == rhs.inverse_jacobian_ and
+         lhs.is_identity_ == rhs.is_identity_;
 }
 
 // Explicit instantiations

--- a/src/Domain/CoordinateMaps/Affine.hpp
+++ b/src/Domain/CoordinateMaps/Affine.hpp
@@ -62,6 +62,8 @@ class Affine {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p);  // NOLINT
 
+  bool is_identity() const noexcept { return is_identity_; }
+
  private:
   friend bool operator==(const Affine& lhs, const Affine& rhs) noexcept;
 
@@ -73,6 +75,7 @@ class Affine {
   double length_of_range_{2.0};   // b-a
   double jacobian_{length_of_range_ / length_of_domain_};
   double inverse_jacobian_{length_of_domain_ / length_of_range_};
+  bool is_identity_{false};
 };
 
 inline bool operator!=(const CoordinateMaps::Affine& lhs,

--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -99,7 +99,9 @@ BulgedCube::BulgedCube(const double radius, const double sphericity,
                        const bool use_equiangular_map) noexcept
     : radius_(radius),
       sphericity_(sphericity),
-      use_equiangular_map_(use_equiangular_map) {
+      use_equiangular_map_(use_equiangular_map),
+      is_identity_(radius_ == sqrt(3.0) and sphericity_ == 0.0 and
+                   not use_equiangular_map_) {
   ASSERT(radius > 0.0, "The radius of the cube must be greater than zero");
   ASSERT(sphericity >= 0.0 and sphericity < 1.0,
          "The sphericity must be strictly less than one.");
@@ -261,11 +263,13 @@ void BulgedCube::pup(PUP::er& p) noexcept {
   p | radius_;
   p | sphericity_;
   p | use_equiangular_map_;
+  p | is_identity_;
 }
 
 bool operator==(const BulgedCube& lhs, const BulgedCube& rhs) noexcept {
   return lhs.radius_ == rhs.radius_ and lhs.sphericity_ == rhs.sphericity_ and
-         lhs.use_equiangular_map_ == rhs.use_equiangular_map_;
+         lhs.use_equiangular_map_ == rhs.use_equiangular_map_ and
+         lhs.is_identity_ == rhs.is_identity_;
 }
 
 bool operator!=(const BulgedCube& lhs, const BulgedCube& rhs) noexcept {

--- a/src/Domain/CoordinateMaps/BulgedCube.hpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.hpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <boost/optional.hpp>
 #include <cstddef>
+#include <limits>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -513,14 +514,18 @@ class BulgedCube {
   // clang-tidy: google runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  bool is_identity() const noexcept { return is_identity_; }
+
  private:
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 3> xi_derivative(
       const std::array<T, 3>& source_coords) const noexcept;
   friend bool operator==(const BulgedCube& lhs, const BulgedCube& rhs) noexcept;
-  double radius_;
-  double sphericity_;
-  bool use_equiangular_map_;
+
+  double radius_{std::numeric_limits<double>::signaling_NaN()};
+  double sphericity_{std::numeric_limits<double>::signaling_NaN()};
+  bool use_equiangular_map_ = false;
+  bool is_identity_ = false;
 };
 
 bool operator!=(const BulgedCube& lhs, const BulgedCube& rhs) noexcept;

--- a/src/Domain/CoordinateMaps/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/CubicScale.hpp
@@ -78,6 +78,8 @@ class CubicScale {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  bool is_identity() const noexcept { return false; }
+
  private:
   friend bool operator==(const CubicScale& lhs, const CubicScale& rhs) noexcept;
 

--- a/src/Domain/CoordinateMaps/DiscreteRotation.cpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.cpp
@@ -16,7 +16,8 @@ namespace CoordinateMaps {
 template <size_t VolumeDim>
 DiscreteRotation<VolumeDim>::DiscreteRotation(
     OrientationMap<VolumeDim> orientation) noexcept
-    : orientation_(std::move(orientation)) {}
+    : orientation_(std::move(orientation)),
+      is_identity_(orientation_ == OrientationMap<VolumeDim>{}) {}
 
 template <size_t VolumeDim>
 template <typename T>
@@ -69,6 +70,7 @@ DiscreteRotation<VolumeDim>::inv_jacobian(
 template <size_t VolumeDim>
 void DiscreteRotation<VolumeDim>::pup(PUP::er& p) noexcept {
   p | orientation_;
+  p | is_identity_;
 }
 
 template class DiscreteRotation<1>;

--- a/src/Domain/CoordinateMaps/DiscreteRotation.hpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.hpp
@@ -58,13 +58,17 @@ class DiscreteRotation {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  bool is_identity() const noexcept { return is_identity_; }
+
  private:
   friend bool operator==(const DiscreteRotation& lhs,
                          const DiscreteRotation& rhs) noexcept {
-    return lhs.orientation_ == rhs.orientation_;
+    return lhs.orientation_ == rhs.orientation_ and
+           lhs.is_identity_ == rhs.is_identity_;
   }
 
   OrientationMap<VolumeDim> orientation_{};
+  bool is_identity_ = false;
 };
 
 template <size_t VolumeDim>

--- a/src/Domain/CoordinateMaps/EquatorialCompression.cpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.cpp
@@ -20,7 +20,9 @@
 namespace CoordinateMaps {
 
 EquatorialCompression::EquatorialCompression(const double aspect_ratio) noexcept
-    : aspect_ratio_(aspect_ratio), inverse_aspect_ratio_(1.0 / aspect_ratio) {
+    : aspect_ratio_(aspect_ratio),
+      inverse_aspect_ratio_(1.0 / aspect_ratio),
+      is_identity_(aspect_ratio_ == 1.0) {
   ASSERT(aspect_ratio > 0.0, "The aspect_ratio must be greater than zero.");
 }
 
@@ -146,12 +148,14 @@ EquatorialCompression::inv_jacobian(const std::array<T, 3>& source_coords) const
 void EquatorialCompression::pup(PUP::er& p) noexcept {
   p | aspect_ratio_;
   p | inverse_aspect_ratio_;
+  p | is_identity_;
 }
 
 bool operator==(const EquatorialCompression& lhs,
                 const EquatorialCompression& rhs) noexcept {
   return lhs.aspect_ratio_ == rhs.aspect_ratio_ and
-         lhs.inverse_aspect_ratio_ == rhs.inverse_aspect_ratio_;
+         lhs.inverse_aspect_ratio_ == rhs.inverse_aspect_ratio_ and
+         lhs.is_identity_ == rhs.is_identity_;
 }
 
 bool operator!=(const EquatorialCompression& lhs,

--- a/src/Domain/CoordinateMaps/EquatorialCompression.hpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.hpp
@@ -79,6 +79,8 @@ class EquatorialCompression {
   // clang-tidy: google runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  bool is_identity() const noexcept { return is_identity_; }
+
  private:
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 3> angular_distortion(
@@ -92,6 +94,7 @@ class EquatorialCompression {
 
   double aspect_ratio_{std::numeric_limits<double>::signaling_NaN()};
   double inverse_aspect_ratio_{std::numeric_limits<double>::signaling_NaN()};
+  bool is_identity_{false};
 };
 bool operator!=(const EquatorialCompression& lhs,
                 const EquatorialCompression& rhs) noexcept;

--- a/src/Domain/CoordinateMaps/Equiangular.hpp
+++ b/src/Domain/CoordinateMaps/Equiangular.hpp
@@ -78,6 +78,8 @@ class Equiangular {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  bool is_identity() const noexcept { return false; }
+
  private:
   friend bool operator==(const Equiangular& lhs,
                          const Equiangular& rhs) noexcept;

--- a/src/Domain/CoordinateMaps/Frustum.cpp
+++ b/src/Domain/CoordinateMaps/Frustum.cpp
@@ -27,7 +27,15 @@ Frustum::Frustum(const std::array<std::array<double, 2>, 4>& face_vertices,
                  const bool with_equiangular_map) noexcept
     // clang-tidy: trivially copyable
     : orientation_of_frustum_(std::move(orientation_of_frustum)),  // NOLINT
-      with_equiangular_map_(with_equiangular_map) {
+      with_equiangular_map_(with_equiangular_map),
+      is_identity_(face_vertices ==
+                       std::array<std::array<double, 2>, 4>{{{{-1.0, -1.0}},
+                                                             {{1.0, 1.0}},
+                                                             {{-1.0, -1.0}},
+                                                             {{1.0, 1.0}}}} and
+                   lower_bound == -1.0 and upper_bound == 1.0 and
+                   orientation_of_frustum_ == OrientationMap<3>{} and
+                   not with_equiangular_map) {
   const double& lower_x_lower_base = face_vertices[0][0];
   const double& lower_y_lower_base = face_vertices[0][1];
   const double& upper_x_lower_base = face_vertices[1][0];
@@ -206,6 +214,7 @@ void Frustum::pup(PUP::er& p) noexcept {
   p | midpoint_z_;
   p | half_length_z_;
   p | with_equiangular_map_;
+  p | is_identity_;
 }
 
 bool operator==(const Frustum& lhs, const Frustum& rhs) noexcept {
@@ -220,7 +229,8 @@ bool operator==(const Frustum& lhs, const Frustum& rhs) noexcept {
          lhs.dif_half_length_y_ == lhs.dif_half_length_y_ and
          lhs.midpoint_z_ == rhs.midpoint_z_ and
          lhs.half_length_z_ == rhs.half_length_z_ and
-         lhs.with_equiangular_map_ == rhs.with_equiangular_map_;
+         lhs.with_equiangular_map_ == rhs.with_equiangular_map_ and
+         lhs.is_identity_ == rhs.is_identity_;
 }
 
 bool operator!=(const Frustum& lhs, const Frustum& rhs) noexcept {

--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -70,6 +70,8 @@ class Frustum {
   // clang-tidy: google runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  bool is_identity() const noexcept { return is_identity_; }
+
  private:
   friend bool operator==(const Frustum& lhs, const Frustum& rhs) noexcept;
 
@@ -85,6 +87,7 @@ class Frustum {
   double midpoint_z_{std::numeric_limits<double>::signaling_NaN()};
   double half_length_z_{std::numeric_limits<double>::signaling_NaN()};
   bool with_equiangular_map_{false};
+  bool is_identity_{false};
 };
 
 bool operator!=(const Frustum& lhs, const Frustum& rhs) noexcept;

--- a/src/Domain/CoordinateMaps/Identity.hpp
+++ b/src/Domain/CoordinateMaps/Identity.hpp
@@ -50,6 +50,8 @@ class Identity {
 
   // clang-tidy: google-runtime-references
   void pup(PUP::er& /*p*/) {}  // NOLINT
+
+  bool is_identity() const noexcept { return true; }
 };
 
 template <size_t Dim>

--- a/src/Domain/CoordinateMaps/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.hpp
@@ -131,19 +131,25 @@ class ProductOf2Maps {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p);  // NOLINT
 
+  bool is_identity() const noexcept { return is_identity_; }
+
  private:
   friend bool operator==(const ProductOf2Maps& lhs,
                          const ProductOf2Maps& rhs) noexcept {
-    return lhs.map1_ == rhs.map1_ and lhs.map2_ == rhs.map2_;
+    return lhs.map1_ == rhs.map1_ and lhs.map2_ == rhs.map2_ and
+           lhs.is_identity_ == rhs.is_identity_;
   }
 
   Map1 map1_;
   Map2 map2_;
+  bool is_identity_ = false;
 };
 
 template <typename Map1, typename Map2>
 ProductOf2Maps<Map1, Map2>::ProductOf2Maps(Map1 map1, Map2 map2) noexcept
-    : map1_(std::move(map1)), map2_(std::move(map2)) {}
+    : map1_(std::move(map1)),
+      map2_(std::move(map2)),
+      is_identity_(map1_.is_identity() and map2_.is_identity()) {}
 
 template <typename Map1, typename Map2>
 template <typename T>
@@ -202,6 +208,7 @@ template <typename Map1, typename Map2>
 void ProductOf2Maps<Map1, Map2>::pup(PUP::er& p) {
   p | map1_;
   p | map2_;
+  p | is_identity_;
 }
 
 template <typename Map1, typename Map2>
@@ -242,22 +249,29 @@ class ProductOf3Maps {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  bool is_identity() const noexcept { return is_identity_; }
+
  private:
   friend bool operator==(const ProductOf3Maps& lhs,
                          const ProductOf3Maps& rhs) noexcept {
     return lhs.map1_ == rhs.map1_ and lhs.map2_ == rhs.map2_ and
-           lhs.map3_ == rhs.map3_;
+           lhs.map3_ == rhs.map3_ and lhs.is_identity_ == rhs.is_identity_;
   }
 
   Map1 map1_;
   Map2 map2_;
   Map3 map3_;
+  bool is_identity_ = false;
 };
 
 template <typename Map1, typename Map2, typename Map3>
 ProductOf3Maps<Map1, Map2, Map3>::ProductOf3Maps(Map1 map1, Map2 map2,
                                                  Map3 map3) noexcept
-    : map1_(std::move(map1)), map2_(std::move(map2)), map3_(std::move(map3)) {}
+    : map1_(std::move(map1)),
+      map2_(std::move(map2)),
+      map3_(std::move(map3)),
+      is_identity_(map1_.is_identity() and map2_.is_identity() and
+                   map3_.is_identity()) {}
 
 template <typename Map1, typename Map2, typename Map3>
 template <typename T>
@@ -332,6 +346,7 @@ void ProductOf3Maps<Map1, Map2, Map3>::pup(PUP::er& p) noexcept {
   p | map1_;
   p | map2_;
   p | map3_;
+  p | is_identity_;
 }
 
 template <typename Map1, typename Map2, typename Map3>

--- a/src/Domain/CoordinateMaps/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/Rotation.cpp
@@ -14,7 +14,8 @@ namespace CoordinateMaps {
 
 Rotation<2>::Rotation(const double rotation_angle)
     : rotation_angle_(rotation_angle),
-      rotation_matrix_(std::numeric_limits<double>::signaling_NaN()) {
+      rotation_matrix_(std::numeric_limits<double>::signaling_NaN()),
+      is_identity_(rotation_angle_ == 0.0) {
   const double cos_alpha = cos(rotation_angle_);
   const double sin_alpha = sin(rotation_angle_);
   get<0, 0>(rotation_matrix_) = cos_alpha;
@@ -70,10 +71,12 @@ Rotation<2>::inv_jacobian(const std::array<T, 2>& source_coords) const
 void Rotation<2>::pup(PUP::er& p) {
   p | rotation_angle_;
   p | rotation_matrix_;
+  p | is_identity_;
 }
 
 bool operator==(const Rotation<2>& lhs, const Rotation<2>& rhs) noexcept {
-  return lhs.rotation_angle_ == rhs.rotation_angle_;
+  return lhs.rotation_angle_ == rhs.rotation_angle_ and
+         lhs.is_identity_ == rhs.is_identity_;
 }
 
 bool operator!=(const Rotation<2>& lhs, const Rotation<2>& rhs) noexcept {
@@ -86,7 +89,10 @@ Rotation<3>::Rotation(const double rotation_about_z,
     : rotation_about_z_(rotation_about_z),
       rotation_about_rotated_y_(rotation_about_rotated_y),
       rotation_about_rotated_z_(rotation_about_rotated_z),
-      rotation_matrix_(std::numeric_limits<double>::signaling_NaN()) {
+      rotation_matrix_(std::numeric_limits<double>::signaling_NaN()),
+      is_identity_(rotation_about_z_ == 0.0 and
+                   rotation_about_rotated_y_ == 0.0 and
+                   rotation_about_rotated_z_ == 0.0) {
   const double cos_alpha = cos(rotation_about_z_);
   const double sin_alpha = sin(rotation_about_z_);
   const double cos_beta = cos(rotation_about_rotated_y_);
@@ -178,12 +184,14 @@ void Rotation<3>::pup(PUP::er& p) {  // NOLINT
   p | rotation_about_rotated_y_;
   p | rotation_about_rotated_z_;
   p | rotation_matrix_;
+  p | is_identity_;
 }
 
 bool operator==(const Rotation<3>& lhs, const Rotation<3>& rhs) noexcept {
   return lhs.rotation_about_z_ == rhs.rotation_about_z_ and
          lhs.rotation_about_rotated_y_ == rhs.rotation_about_rotated_y_ and
-         lhs.rotation_about_rotated_z_ == rhs.rotation_about_rotated_z_;
+         lhs.rotation_about_rotated_z_ == rhs.rotation_about_rotated_z_ and
+         lhs.is_identity_ == rhs.is_identity_;
 }
 
 bool operator!=(const Rotation<3>& lhs, const Rotation<3>& rhs) noexcept {

--- a/src/Domain/CoordinateMaps/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/Rotation.hpp
@@ -73,6 +73,8 @@ class Rotation<2> {
 
   void pup(PUP::er& p);  // NOLINT
 
+  bool is_identity() const noexcept { return is_identity_; }
+
  private:
   friend bool operator==(const Rotation<2>& lhs,
                          const Rotation<2>& rhs) noexcept;
@@ -80,6 +82,7 @@ class Rotation<2> {
   double rotation_angle_{std::numeric_limits<double>::signaling_NaN()};
   tnsr::ij<double, 2, Frame::Grid> rotation_matrix_{
       std::numeric_limits<double>::signaling_NaN()};
+  bool is_identity_{false};
 };
 
 bool operator!=(const Rotation<2>& lhs, const Rotation<2>& rhs) noexcept;
@@ -144,6 +147,8 @@ class Rotation<3> {
 
   void pup(PUP::er& p);  // NOLINT
 
+  bool is_identity() const noexcept { return is_identity_; }
+
  private:
   friend bool operator==(const Rotation<3>& lhs,
                          const Rotation<3>& rhs) noexcept;
@@ -155,6 +160,7 @@ class Rotation<3> {
       std::numeric_limits<double>::signaling_NaN()};
   tnsr::ij<double, 3, Frame::Grid> rotation_matrix_{
       std::numeric_limits<double>::signaling_NaN()};
+  bool is_identity_{false};
 };
 
 bool operator!=(const Rotation<3>& lhs, const Rotation<3>& rhs) noexcept;

--- a/src/Domain/CoordinateMaps/SpecialMobius.cpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.cpp
@@ -20,7 +20,8 @@
 
 namespace CoordinateMaps {
 
-SpecialMobius::SpecialMobius(const double mu) noexcept : mu_(mu) {
+SpecialMobius::SpecialMobius(const double mu) noexcept
+    : mu_(mu), is_identity_(mu_ == 0.0) {
   // Note: Empirically we have found that the map is accurate
   // to 12 decimal places for mu = 0.96.
   ASSERT(abs(mu) < 0.96, "The magnitude of mu must be less than 0.96.");
@@ -106,10 +107,13 @@ SpecialMobius::inv_jacobian(const std::array<T, 3>& source_coords) const
   return mobius_distortion_jacobian((*this)(source_coords), -mu_);
 }
 
-void SpecialMobius::pup(PUP::er& p) noexcept { p | mu_; }
+void SpecialMobius::pup(PUP::er& p) noexcept {
+  p | mu_;
+  p | is_identity_;
+}
 
 bool operator==(const SpecialMobius& lhs, const SpecialMobius& rhs) noexcept {
-  return lhs.mu_ == rhs.mu_;
+  return lhs.mu_ == rhs.mu_ and lhs.is_identity_ == rhs.is_identity_;
 }
 
 bool operator!=(const SpecialMobius& lhs, const SpecialMobius& rhs) noexcept {

--- a/src/Domain/CoordinateMaps/SpecialMobius.hpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.hpp
@@ -110,6 +110,8 @@ class SpecialMobius {
   // clang-tidy: google runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  bool is_identity() const noexcept { return is_identity_; }
+
  private:
   template <typename T>
   std::array<tt::remove_cvref_wrap_t<T>, 3> mobius_distortion(
@@ -122,6 +124,7 @@ class SpecialMobius {
                          const SpecialMobius& rhs) noexcept;
 
   double mu_{std::numeric_limits<double>::signaling_NaN()};
+  bool is_identity_{false};
 };
 bool operator!=(const SpecialMobius& lhs, const SpecialMobius& rhs) noexcept;
 }  // namespace CoordinateMaps

--- a/src/Domain/CoordinateMaps/Translation.hpp
+++ b/src/Domain/CoordinateMaps/Translation.hpp
@@ -59,6 +59,8 @@ class Translation {
   // clang-tidy: google-runtime-references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  bool is_identity() const noexcept { return false; }
+
  private:
   friend bool operator==(const Translation& lhs,
                          const Translation& rhs) noexcept;

--- a/src/Domain/CoordinateMaps/Wedge2D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.hpp
@@ -149,6 +149,9 @@ class Wedge2D {
 
   // clang-tidy: google runtime references
   void pup(PUP::er& p);  // NOLINT
+
+  bool is_identity() const noexcept { return false; }
+
  private:
   friend bool operator==(const Wedge2D& lhs, const Wedge2D& rhs) noexcept;
 

--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -294,6 +294,8 @@ class Wedge3D {
   // clang-tidy: google runtime references
   void pup(PUP::er& p) noexcept;  // NOLINT
 
+  bool is_identity() const noexcept { return false; }
+
  private:
   // factors out calculation of z needed for mapping and jacobian
   template <typename T>

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -17,6 +17,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/OrientationMap.hpp"
@@ -60,6 +61,18 @@ void check_if_maps_are_equal(
     CHECK_ITERABLE_APPROX(map_one.inv_jacobian(source_point),
                           map_two.inv_jacobian(source_point));
   }
+}
+
+/// \ingroup TestingFrameworkGroup
+/// \brief Given a coordinate map, check that this map is equal to the identity
+/// by evaluating the map at a random set of points.
+template <typename Map>
+void check_if_map_is_identity(const Map& map) {
+  using IdentityMap = CoordinateMaps::Identity<Map::dim>;
+  check_if_maps_are_equal(
+      make_coordinate_map<Frame::Inertial, Frame::Grid>(IdentityMap{}),
+      make_coordinate_map<Frame::Inertial, Frame::Grid>(map));
+  CHECK(map.is_identity());
 }
 
 /*!

--- a/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
@@ -5,6 +5,8 @@
 
 #include <array>
 #include <boost/optional.hpp>
+#include <memory>
+#include <pup.h>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
@@ -53,4 +55,6 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Affine", "[Domain][Unit]") {
   test_serialization(affine_map);
 
   test_coordinate_map_argument_types(affine_map, point_xi);
+
+  check_if_map_is_identity(CoordinateMaps::Affine{-1.0, 1.0, -1.0, 1.0});
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
@@ -126,4 +126,6 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube", "[Domain][Unit]") {
   test_bulged_cube(true);   // Equiangular
   test_bulged_cube(false);  // Equidistant
   test_bulged_cube_fail();
+
+  check_if_map_is_identity(CoordinateMaps::BulgedCube{sqrt(3.0), 0, false});
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
@@ -17,37 +17,6 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Identity",
-                  "[Domain][Unit]") {
-  const CoordinateMaps::BulgedCube map(sqrt(3.0), 0, false);
-  const std::array<double, 3> lower_corner{{-1.0, -1.0, -1.0}};
-  const std::array<double, 3> upper_corner{{1.0, 1.0, 1.0}};
-  const std::array<double, 3> test_point1{{-1.0, 0.25, 0.0}};
-  const std::array<double, 3> test_point2{{1.0, 1.0, -0.5}};
-  const std::array<double, 3> test_point3{{0.7, -0.2, 0.4}};
-
-  CHECK_ITERABLE_APPROX(map(lower_corner), lower_corner);
-  CHECK_ITERABLE_APPROX(map(upper_corner), upper_corner);
-  CHECK_ITERABLE_APPROX(map(test_point1), test_point1);
-  CHECK_ITERABLE_APPROX(map(test_point2), test_point2);
-  CHECK_ITERABLE_APPROX(map(test_point3), test_point3);
-
-  test_jacobian(map, test_point1);
-  test_jacobian(map, test_point2);
-  test_jacobian(map, test_point3);
-
-  test_inv_jacobian(map, test_point1);
-  test_inv_jacobian(map, test_point2);
-  test_inv_jacobian(map, test_point3);
-
-  test_coordinate_map_implementation<CoordinateMaps::BulgedCube>(map);
-
-  CHECK(serialize_and_deserialize(map) == map);
-  CHECK_FALSE(serialize_and_deserialize(map) != map);
-
-  test_coordinate_map_argument_types(map, test_point1);
-}
-
 void test_bulged_cube_fail() {
   const CoordinateMaps::BulgedCube map(2.0 * sqrt(3.0), 0.5, false);
 
@@ -126,17 +95,35 @@ void test_bulged_cube(bool with_equiangular_map) {
   test_inverse_map(map, test_point4);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Bulged.Equiangular",
-                  "[Domain][Unit]") {
-  test_bulged_cube(true);
-}
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube", "[Domain][Unit]") {
+  const CoordinateMaps::BulgedCube map(sqrt(3.0), 0, false);
+  const std::array<double, 3> lower_corner{{-1.0, -1.0, -1.0}};
+  const std::array<double, 3> upper_corner{{1.0, 1.0, 1.0}};
+  const std::array<double, 3> test_point1{{-1.0, 0.25, 0.0}};
+  const std::array<double, 3> test_point2{{1.0, 1.0, -0.5}};
+  const std::array<double, 3> test_point3{{0.7, -0.2, 0.4}};
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Bulged.Equidistant",
-                  "[Domain][Unit]") {
-  test_bulged_cube(false);
-}
+  CHECK_ITERABLE_APPROX(map(lower_corner), lower_corner);
+  CHECK_ITERABLE_APPROX(map(upper_corner), upper_corner);
+  CHECK_ITERABLE_APPROX(map(test_point1), test_point1);
+  CHECK_ITERABLE_APPROX(map(test_point2), test_point2);
+  CHECK_ITERABLE_APPROX(map(test_point3), test_point3);
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube.Bulged.Fail",
-                  "[Domain][Unit]") {
+  test_jacobian(map, test_point1);
+  test_jacobian(map, test_point2);
+  test_jacobian(map, test_point3);
+
+  test_inv_jacobian(map, test_point1);
+  test_inv_jacobian(map, test_point2);
+  test_inv_jacobian(map, test_point3);
+
+  test_coordinate_map_implementation<CoordinateMaps::BulgedCube>(map);
+
+  CHECK(serialize_and_deserialize(map) == map);
+  CHECK_FALSE(serialize_and_deserialize(map) != map);
+
+  test_coordinate_map_argument_types(map, test_point1);
+  test_bulged_cube(true);   // Equiangular
+  test_bulged_cube(false);  // Equidistant
   test_bulged_cube_fail();
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
@@ -53,16 +53,16 @@ void cubic_scale_non_invertible(const double a0, const double b0,
   // this call should fail.
   scale_map.inverse(mapped_point, t, f_of_t_list);
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.CubicScale",
-                  "[Domain][Unit]") {
+void test_map() {
   static constexpr size_t deriv_order = 2;
 
-  const auto run_tests = [](
-      const std::array<DataVector, deriv_order + 1>& init_func_a,
-      const std::array<DataVector, deriv_order + 1>& init_func_b,
-      const double outer_b, const double x0, const double final_time) {
+  const auto run_tests = [](const std::array<DataVector, deriv_order + 1>&
+                                init_func_a,
+                            const std::array<DataVector, deriv_order + 1>&
+                                init_func_b,
+                            const double outer_b, const double x0,
+                            const double final_time) {
     double t = -0.5;
     const double dt = 0.6;
 
@@ -157,7 +157,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.CubicScale",
       CHECK(approx(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
                        .get(0, 1, 0)) == time_space);
       CHECK(approx(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
-                   .get(0, 0, 1)) == time_space);
+                       .get(0, 0, 1)) == time_space);
       CHECK(approx(scale_map_deserialized.hessian(point_xi, t, f_of_t_list)
                        .get(0, 1, 1)) == space_space);
 
@@ -186,9 +186,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.CubicScale",
   run_tests(init_func_a2, init_func_b2, 6.0, 5.0, 0.0);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.CoordMapsTimeDependent.CubicScale.TestBoundaries",
-    "[Domain][Unit]") {
+void test_boundaries() {
   static constexpr size_t deriv_order = 2;
 
   const auto run_tests = [](const double x0) {
@@ -233,6 +231,13 @@ SPECTRE_TEST_CASE(
   // test inverse at inner and outer boundary values
   run_tests(0.0);
   run_tests(20.0);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.CubicScale",
+                  "[Domain][Unit]") {
+  test_map();
+  test_boundaries();
 }
 
 // [[OutputRegex, The map is invertible only if 0 < expansion_b <

--- a/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
@@ -238,6 +238,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.CubicScale",
                   "[Domain][Unit]") {
   test_map();
   test_boundaries();
+  CHECK(not CoordMapsTimeDependent::CubicScale{}.is_identity());
 }
 
 // [[OutputRegex, The map is invertible only if 0 < expansion_b <

--- a/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
@@ -96,6 +96,30 @@ void test_with_orientation() {
     test_suite_for_map_on_unit_cube(coord_map);
   }
 }
+
+void test_is_identity() {
+  check_if_map_is_identity(
+      CoordinateMaps::DiscreteRotation<1>{OrientationMap<1>{}});
+  CHECK(not CoordinateMaps::DiscreteRotation<1>{
+      OrientationMap<1>{
+          std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}}}
+                .is_identity());
+
+  check_if_map_is_identity(
+      CoordinateMaps::DiscreteRotation<2>{OrientationMap<2>{}});
+  CHECK(not CoordinateMaps::DiscreteRotation<2>{
+      OrientationMap<2>{std::array<Direction<2>, 2>{
+          {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}}
+                .is_identity());
+
+  check_if_map_is_identity(
+      CoordinateMaps::DiscreteRotation<3>{OrientationMap<3>{}});
+  CHECK(not CoordinateMaps::DiscreteRotation<3>{
+      OrientationMap<3>{std::array<Direction<3>, 3>{
+          {Direction<3>::lower_eta(), Direction<3>::lower_zeta(),
+           Direction<3>::upper_xi()}}}}
+                .is_identity());
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation",
@@ -104,4 +128,5 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation",
   test_2d();
   test_3d();
   test_with_orientation();
+  test_is_identity();
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
@@ -19,8 +19,8 @@
 #include "Domain/OrientationMap.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation.Specific1D",
-                  "[Domain][Unit]") {
+namespace {
+void test_1d() {
   const CoordinateMaps::DiscreteRotation<1> identity_map1d{};
   const CoordinateMaps::DiscreteRotation<1> rotation_nx{OrientationMap<1>{
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}}};
@@ -39,8 +39,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation.Specific1D",
   CHECK(rotation_nx(point_px) == point_nx);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation.Specific2D",
-                  "[Domain][Unit]") {
+void test_2d() {
   const CoordinateMaps::DiscreteRotation<2> identity_map2d{};
   const CoordinateMaps::DiscreteRotation<2> rotation_ny_px{
       OrientationMap<2>{std::array<Direction<2>, 2>{
@@ -60,8 +59,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation.Specific2D",
   CHECK(rotation_ny_px(point_px_py) == point_ny_px);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation.Specific3D",
-                  "[Domain][Unit]") {
+void test_3d() {
   const CoordinateMaps::DiscreteRotation<3> identity_map3d{};
   const CoordinateMaps::DiscreteRotation<3> rotation_ny_nz_px{
       OrientationMap<3>{std::array<Direction<3>, 3>{
@@ -88,8 +86,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation.Specific3D",
   CHECK(rotation_ny_nz_px(point_px_py_pz) == point_ny_nz_px);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation",
-                  "[Domain][Unit]") {
+void test_with_orientation() {
   for (OrientationMapIterator<2> map_i{}; map_i; ++map_i) {
     const CoordinateMaps::DiscreteRotation<2> coord_map{map_i()};
     test_suite_for_map_on_unit_cube(coord_map);
@@ -98,4 +95,13 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation",
     const CoordinateMaps::DiscreteRotation<3> coord_map{map_i()};
     test_suite_for_map_on_unit_cube(coord_map);
   }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation",
+                  "[Domain][Unit]") {
+  test_1d();
+  test_2d();
+  test_3d();
+  test_with_orientation();
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
@@ -5,8 +5,11 @@
 
 #include <array>
 #include <cmath>
+#include <memory>
+#include <pup.h>
 #include <random>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/EquatorialCompression.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -71,12 +74,18 @@ void test_radius() {
   CHECK(aspect_ratio * sqrt(pow<2>(x) + pow<2>(y)) / z ==
         approx(sqrt(pow<2>(result_x) + pow<2>(result_y)) / result_z));
 }
+
+void test_is_identity() {
+  check_if_map_is_identity(CoordinateMaps::EquatorialCompression{1.0});
+  CHECK(not CoordinateMaps::EquatorialCompression{0.9}.is_identity());
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.EquatorialCompression",
                   "[Domain][Unit]") {
   test_suite();
   test_radius();
+  test_is_identity();
 }
 // [[OutputRegex, The aspect_ratio must be greater than zero.]]
 [[noreturn]] SPECTRE_TEST_CASE(

--- a/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
@@ -14,9 +14,8 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.EquatorialCompression",
-                  "[Domain][Unit]") {
-  // Set up random number generator
+namespace {
+void test_suite() {  // Set up random number generator
   MAKE_GENERATOR(gen);
   std::uniform_real_distribution<> aspect_ratio_dis(0.1, 10);
 
@@ -27,8 +26,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.EquatorialCompression",
   test_suite_for_map_on_unit_cube(angular_compression_map);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.EquatorialCompression.Radius",
-                  "[Domain][Unit]") {
+void test_radius() {
   // Set up random number generator
   MAKE_GENERATOR(gen);
   std::uniform_real_distribution<> real_dis(-10, 10);
@@ -73,7 +71,13 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.EquatorialCompression.Radius",
   CHECK(aspect_ratio * sqrt(pow<2>(x) + pow<2>(y)) / z ==
         approx(sqrt(pow<2>(result_x) + pow<2>(result_y)) / result_z));
 }
+}  // namespace
 
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.EquatorialCompression",
+                  "[Domain][Unit]") {
+  test_suite();
+  test_radius();
+}
 // [[OutputRegex, The aspect_ratio must be greater than zero.]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.Domain.CoordinateMaps.EquatorialCompression.Assert2",

--- a/tests/Unit/Domain/CoordinateMaps/Test_Equiangular.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Equiangular.cpp
@@ -72,4 +72,5 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Equiangular", "[Domain][Unit]") {
   test_coordinate_map_argument_types(equiangular_map, point_xi);
   test_coordinate_map_argument_types(equiangular_map, point_r1);
   test_coordinate_map_argument_types(equiangular_map, point_r2);
+  CHECK(not CoordinateMaps::Equiangular{}.is_identity());
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -75,24 +75,7 @@ void test_frustum_fail() noexcept {
   }
 }
 
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Fail", "[Domain][Unit]") {
-  test_frustum_fail();
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Equidistant",
-                  "[Domain][Unit]") {
-  test_suite_for_frustum(false);
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Equiangular",
-                  "[Domain][Unit]") {
-  test_suite_for_frustum(true);
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Alignment",
-                  "[Domain][Unit]") {
+void test_alignment() {
   // This test tests that the logical axes point along the expected directions
   // in physical space
 
@@ -179,6 +162,14 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum.Alignment",
   CHECK(map_lower_xi(along_zeta)[0] == approx(-5.0));
   CHECK_ITERABLE_APPROX(map_lower_xi(lowest_corner),
                         lowest_physical_corner_in_map_lower_xi);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
+  test_frustum_fail();
+  test_suite_for_frustum(false);  // Equidistant
+  test_suite_for_frustum(true);   // Equiangular
+  test_alignment();
 }
 
 // [[OutputRegex, The lower bound for a coordinate must be numerically less

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -5,8 +5,11 @@
 
 #include <array>
 #include <boost/optional.hpp>
+#include <memory>
+#include <pup.h>
 #include <random>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Frustum.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "ErrorHandling/Error.hpp"
@@ -163,6 +166,18 @@ void test_alignment() {
   CHECK_ITERABLE_APPROX(map_lower_xi(lowest_corner),
                         lowest_physical_corner_in_map_lower_xi);
 }
+
+void test_is_identity() {
+  check_if_map_is_identity(CoordinateMaps::Frustum{
+      std::array<std::array<double, 2>, 4>{
+          {{{-1.0, -1.0}}, {{1.0, 1.0}}, {{-1.0, -1.0}}, {{1.0, 1.0}}}},
+      -1.0, 1.0, OrientationMap<3>{}, false});
+  CHECK(not CoordinateMaps::Frustum{
+      std::array<std::array<double, 2>, 4>{
+          {{{-1.0, -1.0}}, {{2.0, 1.0}}, {{-1.0, -3.0}}, {{1.0, 1.0}}}},
+      -1.0, 1.0, OrientationMap<3>{}, false}
+                .is_identity());
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
@@ -170,6 +185,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
   test_suite_for_frustum(false);  // Equidistant
   test_suite_for_frustum(true);   // Equiangular
   test_alignment();
+  test_is_identity();
 }
 
 // [[OutputRegex, The lower bound for a coordinate must be numerically less

--- a/tests/Unit/Domain/CoordinateMaps/Test_Identity.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Identity.cpp
@@ -31,9 +31,12 @@ void test_identity() {
   test_serialization(identity_map);
 
   test_coordinate_map_argument_types(identity_map, xi);
+
+  check_if_map_is_identity(CoordinateMaps::Identity<Dim>{});
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Identity", "[Domain][Unit]") {
   test_identity<1>();
   test_identity<2>();
+  test_identity<3>();
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
@@ -54,10 +54,7 @@ void test_product_two_maps_fail() {
     CHECK_ITERABLE_APPROX(map(map.inverse(mapped_point2).get()), mapped_point2);
   }
 }
-}  // namespace
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf2Maps",
-                  "[Domain][Unit]") {
+void test_product_of_2_maps() {
   using affine_map = CoordinateMaps::Affine;
   using affine_map_2d = CoordinateMaps::ProductOf2Maps<affine_map, affine_map>;
 
@@ -173,8 +170,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf2Maps",
   test_product_two_maps_fail();
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf3Maps",
-                  "[Domain][Unit]") {
+void test_product_of_3_maps() {
   using affine_map = CoordinateMaps::Affine;
   using affine_map_3d =
       CoordinateMaps::ProductOf3Maps<affine_map, affine_map, affine_map>;
@@ -342,4 +338,10 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductOf3Maps",
   test_serialization(affine_map_xyz);
 
   test_coordinate_map_argument_types(affine_map_xyz, point_xi);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductMaps", "[Domain][Unit]") {
+  test_product_of_2_maps();
+  test_product_of_3_maps();
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
@@ -6,6 +6,8 @@
 #include <array>
 #include <boost/optional.hpp>
 #include <cstddef>
+#include <memory>
+#include <pup.h>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -168,6 +170,16 @@ void test_product_of_2_maps() {
 
   test_coordinate_map_argument_types(affine_map_xy, point_xi);
   test_product_two_maps_fail();
+  check_if_map_is_identity(
+      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                     CoordinateMaps::Affine>{
+          CoordinateMaps::Affine{-1.0, 1.0, -1.0, 1.0},
+          CoordinateMaps::Affine{-1.0, 1.0, -1.0, 1.0}});
+  CHECK(not CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
+                                           CoordinateMaps::Affine>{
+      CoordinateMaps::Affine{-1.0, 2.0, -1.0, 1.0},
+      CoordinateMaps::Affine{-1.0, 1.0, -3.0, 1.0}}
+                .is_identity());
 }
 
 void test_product_of_3_maps() {
@@ -338,6 +350,13 @@ void test_product_of_3_maps() {
   test_serialization(affine_map_xyz);
 
   test_coordinate_map_argument_types(affine_map_xyz, point_xi);
+  check_if_map_is_identity(
+      CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
+                                     CoordinateMaps::Affine,
+                                     CoordinateMaps::Affine>{
+          CoordinateMaps::Affine{-1.0, 1.0, -1.0, 1.0},
+          CoordinateMaps::Affine{-1.0, 1.0, -1.0, 1.0},
+          CoordinateMaps::Affine{-1.0, 1.0, -1.0, 1.0}});
 }
 }  // namespace
 

--- a/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
@@ -7,6 +7,8 @@
 #include <boost/optional.hpp>
 #include <cmath>
 #include <cstddef>
+#include <memory>
+#include <pup.h>
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Rotation.hpp"
@@ -61,6 +63,7 @@ void test_rotation_3(const CoordinateMaps::Rotation<3>& three_dim_rotation_map,
 
   test_coordinate_map_argument_types(three_dim_rotation_map, xi);
 }
+
 void test_rotation_2() {
   CoordinateMaps::Rotation<2> half_pi_rotation_map(M_PI_2);
 
@@ -108,6 +111,8 @@ void test_rotation_2() {
   test_serialization(half_pi_rotation_map);
 
   test_coordinate_map_argument_types(half_pi_rotation_map, xi1);
+  check_if_map_is_identity(CoordinateMaps::Rotation<2>{0.0});
+  CHECK(not CoordinateMaps::Rotation<2>(M_PI_2).is_identity());
 }
 
 void test_rotation_3() {
@@ -140,6 +145,8 @@ void test_rotation_3() {
                   std::array<double, 3>{{0.0, 0.0, -1.0}},
                   std::array<double, 3>{{0.0, 1.0, 0.0}},
                   std::array<double, 3>{{1.0, 0.0, 0.0}});
+  check_if_map_is_identity(CoordinateMaps::Rotation<3>{0.0, 0.0, 0.0});
+  CHECK(not CoordinateMaps::Rotation<3>{0.0, 0.0, M_PI_2}.is_identity());
 }
 }  // namespace
 

--- a/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
@@ -14,9 +14,8 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius.Suite",
-                  "[Domain][Unit]") {
-  // Set up random number generator
+namespace {
+void test_suite() {  // Set up random number generator
   MAKE_GENERATOR(gen);
   // Note: Empirically we have found that the map is accurate
   // to 12 decimal places for mu = 0.96.
@@ -30,8 +29,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius.Suite",
   test_suite_for_map_on_sphere(special_mobius_map);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius.Map",
-                  "[Domain][Unit]") {
+void test_map() {
   // Set up random number generator
   MAKE_GENERATOR(gen);
   std::uniform_real_distribution<> radius_dis(0, 1);
@@ -85,8 +83,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius.Map",
   CHECK_FALSE(static_cast<bool>(special_mobius_map.inverse(bad_point)));
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius.LargeMu",
-                  "[Domain][Unit]") {
+void test_large_mu() {
   const double mu = 0.95;
   CAPTURE_PRECISE(mu);
   // A point on the unit sphere with x=0, y!=z:
@@ -108,6 +105,14 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius.LargeMu",
   CHECK(abs(expected_input_point[0] - 0.0) < 1.e-13);
   CHECK(abs(expected_input_point[1] - 0.6) < 1.e-13);
   CHECK(abs(expected_input_point[2] - 0.8) < 1.e-13);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius",
+                  "[Domain][Unit]") {
+  test_suite();
+  test_map();
+  test_large_mu();
 }
 
 // [[OutputRegex, The magnitude of mu must be less than 0.96.]]

--- a/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
@@ -6,8 +6,11 @@
 #include <array>
 #include <boost/optional/optional.hpp>
 #include <cmath>
+#include <memory>
+#include <pup.h>
 #include <random>
 
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/SpecialMobius.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
@@ -106,6 +109,11 @@ void test_large_mu() {
   CHECK(abs(expected_input_point[1] - 0.6) < 1.e-13);
   CHECK(abs(expected_input_point[2] - 0.8) < 1.e-13);
 }
+
+void test_is_identity() {
+  check_if_map_is_identity(CoordinateMaps::SpecialMobius{0.0});
+  CHECK(not CoordinateMaps::SpecialMobius{0.1}.is_identity());
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius",
@@ -113,6 +121,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius",
   test_suite();
   test_map();
   test_large_mu();
+  test_is_identity();
 }
 
 // [[OutputRegex, The magnitude of mu must be less than 0.96.]]

--- a/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
@@ -81,4 +81,5 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.Translation",
   CHECK_FALSE(trans_map != trans_map_deserialized);
 
   test_coordinate_map_argument_types(trans_map, point_xi, t, f_of_t_list);
+  CHECK(not CoordMapsTimeDependent::Translation{}.is_identity());
 }

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -179,6 +179,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Map", "[Domain][Unit]") {
   test_wedge2d_all_orientations(false);  // Equidistant
   test_wedge2d_all_orientations(true);   // Equiangular
   test_equality();
+  CHECK(not CoordinateMaps::Wedge2D{}.is_identity());
 }
 
 // [[OutputRegex, The radius of the inner surface must be greater than zero.]]

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -146,24 +146,8 @@ void test_wedge2d_fail() noexcept {
                           test_mapped_point4);
   }
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Fail", "[Domain][Unit]") {
-  test_wedge2d_fail();
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equidistant",
-                  "[Domain][Unit]") {
-  test_wedge2d_all_orientations(false);
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equiangular",
-                  "[Domain][Unit]") {
-  test_wedge2d_all_orientations(true);
-}
-
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equality",
-                  "[Domain][Unit]") {
+void test_equality() {
   const auto wedge2d =
       CoordinateMaps::Wedge2D(0.2, 4.0, 0.0, 1.0, OrientationMap<2>{}, true);
   const auto wedge2d_inner_radius_changed =
@@ -187,6 +171,14 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Equality",
   CHECK_FALSE(wedge2d == wedge2d_outer_circularity_changed);
   CHECK_FALSE(wedge2d == wedge2d_orientation_map_changed);
   CHECK_FALSE(wedge2d == wedge2d_use_equiangular_map_changed);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Map", "[Domain][Unit]") {
+  test_wedge2d_fail();
+  test_wedge2d_all_orientations(false);  // Equidistant
+  test_wedge2d_all_orientations(true);   // Equiangular
+  test_equality();
 }
 
 // [[OutputRegex, The radius of the inner surface must be greater than zero.]]

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -305,6 +305,7 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map", "[Domain][Unit]") {
   test_wedge3d_all_directions();
   test_wedge3d_alignment();
   test_wedge3d_random_radii();
+  CHECK(not CoordinateMaps::Wedge3D{}.is_identity());
 }
 
 // [[OutputRegex, The radius of the inner surface must be greater than zero.]]

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -300,11 +300,8 @@ void test_wedge3d_fail() noexcept {
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Fail", "[Domain][Unit]") {
-  test_wedge3d_fail();
-}
-
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map", "[Domain][Unit]") {
+  test_wedge3d_fail();
   test_wedge3d_all_directions();
   test_wedge3d_alignment();
   test_wedge3d_random_radii();


### PR DESCRIPTION
## Proposed changes

Adds `is_identity` to CoordinateMaps for the future functionality of skipping maps in compositions
when that map is the identity.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
