### PR TITLE
The clang-format hook now tells you which directory to be in.

### DIFF
--- a/tools/Hooks/ClangFormat.py
+++ b/tools/Hooks/ClangFormat.py
@@ -74,9 +74,10 @@ if output not in ['\n', '', 'no modified files to format\n',
     print("\nWARNING:\n"
           "ClangFormat found differences. The diff output has been written to"
           "\n'%s'\n"
-          "You can apply the patch as is using:\n"
-          "git apply %s\n"
-          "then staging the modified files and amending your original "
+          "You can apply the patch as-is using the following two commands:\n"
+          "  cd @CMAKE_SOURCE_DIR@\n"
+          "  git apply %s\n"
+          "and then staging the modified files and amending your original "
           "commit.\n" %
           (output_file_name, output_file_name))
     sys.exit(1)


### PR DESCRIPTION
Previously the clang-format hook instructions don't tell you to be in
SpECTRE_HOME when running the `git apply` command (as you need to be).
Now it does.

Fixes #238

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [x] Bugfix

### Component:

- [x] Documentation
- [x] Build system

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
