### PR TITLE
cleanup Fishbone-Moncrief disk

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -41,7 +41,19 @@
   volume        = {193},
 }
 
-  @book{Hartle2003Gravity,
+@article{Fishbone1976apj,
+  author  = {Fishbone, L. G. and Moncrief, V.},
+  title   = {Relativistic Fluid Disks in Orbit Around {Kerr} Black Holes},
+  year    = 1976,
+  url     = {http://cdsads.u-strasbg.fr/abs/1976ApJ...207..962F},
+  doi     = {10.1086/154565},
+  journal = {The Astrophysical Journal},
+  number  = {1},
+  pages   = {962--976},
+  volume  = {207},
+}
+
+@book{Hartle2003Gravity,
   author     = {Hartle, J.B.},
   title      = {Gravity: An Introduction to {Einstein's} General Relativity},
   isbn       = {9780805386622},
@@ -84,6 +96,17 @@
   volume  = {303},
   number  = {2},
   pages   = {343--366},
+}
+
+@article{Kozlowski1978aa,
+  author  = {Kozlowski, M. and Jaroszynski, M. and Abramowicz, M. A.},
+  title   = {The analytic theory of fluid disks orbiting the {Kerr} black hole},
+  year    = {1978},
+  url     = {http://cdsads.u-strasbg.fr/abs/1978A%26A....63..209K},
+  journal = {Astronomy and Astrophysics},
+  volume  = {63},
+  number  = {1-2},
+  pages   = {209--220},
 }
 
 @book{Kopriva,

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.cpp
@@ -130,21 +130,10 @@ FishboneMoncriefDisk::IntermediateVariables<DataType, NeedSpacetime>::
     : spatial_velocity_index(in_spatial_velocity_index),
       lorentz_factor_index(in_lorentz_factor_index) {
   const double a_squared = bh_spin_a * bh_spin_a;
-
-  DataType z_squared = square(x.get(2));
-  r_squared = [&x, &z_squared, &a_squared ]() noexcept {
-    DataType temp =
-        0.5 * (square(x.get(0)) + square(x.get(1)) + z_squared - a_squared);
-    temp += sqrt(square(temp) + a_squared * z_squared);
-    return temp;
-  }
-  ();
-  z_squared /= -r_squared;
-  z_squared += 1.0;
-  sin_theta_squared = std::move(z_squared);
-  // Because of the subtraction done to compute sin^2(theta) can be negative by
-  // roundoff. This is a fix for that for now.
-  sin_theta_squared = abs(sin_theta_squared);
+  sin_theta_squared = square(get<0>(x)) + square(get<1>(x));
+  r_squared = 0.5 * (sin_theta_squared + square(get<2>(x)) - a_squared);
+  r_squared += sqrt(square(r_squared) + a_squared * square(get<2>(x)));
+  sin_theta_squared /= (r_squared + a_squared);
 
   if (NeedSpacetime) {
     kerr_schild_soln = background_spacetime.variables(

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -20,7 +20,7 @@
 
 /// \cond
 namespace PUP {
-class er; // IWYU pragma: keep
+class er;  // IWYU pragma: keep
 }  // namespace PUP
 /// \endcond
 
@@ -166,27 +166,26 @@ class FishboneMoncriefDisk {
  public:
   using equation_of_state_type = EquationsOfState::PolytropicFluid<true>;
 
-  /// The mass of the black hole.
-  struct BlackHoleMass {
+  /// The mass of the black hole, \f$M\f$.
+  struct BhMass {
     using type = double;
     static constexpr OptionString help = {"The mass of the black hole."};
     static type lower_bound() noexcept { return 0.0; }
   };
-  /// The dimensionless black hole spin magnitude.
-  struct BlackHoleSpin {
+  /// The dimensionless black hole spin, \f$\chi = a/M\f$.
+  struct BhDimlessSpin {
     using type = double;
-    static constexpr OptionString help = {
-        "The dimensionless black hole spin magnitude."};
-    static type lower_bound() noexcept { return 0.0; }
-    static type upper_bound() noexcept { return 1.0; }
+    static constexpr OptionString help = {"The dimensionless black hole spin."};
+    static type lower_bound() { return 0.0; }
+    static type upper_bound() { return 1.0; }
   };
-  /// The radial coordinate of the inner edge of the disk.
+  /// The radial coordinate of the inner edge of the disk, in units of \f$M\f$.
   struct InnerEdgeRadius {
     using type = double;
     static constexpr OptionString help = {
         "The radial coordinate of the inner edge of the disk."};
   };
-  /// The radial coordinate at which the pressure reaches its maximum.
+  /// The radial coordinate of the maximum pressure, in units of \f$M\f$.
   struct MaxPressureRadius {
     using type = double;
     static constexpr OptionString help = {
@@ -208,8 +207,8 @@ class FishboneMoncriefDisk {
   };
 
   using options =
-      tmpl::list<BlackHoleMass, BlackHoleSpin, InnerEdgeRadius,
-                 MaxPressureRadius, PolytropicConstant, PolytropicExponent>;
+      tmpl::list<BhMass, BhDimlessSpin, InnerEdgeRadius, MaxPressureRadius,
+                 PolytropicConstant, PolytropicExponent>;
   static constexpr OptionString help = {
       "Fluid disk orbiting a Kerr black hole."};
 
@@ -221,7 +220,7 @@ class FishboneMoncriefDisk {
       default;
   ~FishboneMoncriefDisk() = default;
 
-  FishboneMoncriefDisk(double black_hole_mass, double black_hole_spin,
+  FishboneMoncriefDisk(double bh_mass, double bh_dimless_spin,
                        double inner_edge_radius, double max_pressure_radius,
                        double polytropic_constant,
                        double polytropic_exponent) noexcept;
@@ -279,8 +278,8 @@ class FishboneMoncriefDisk {
             cpp17::is_same_v<Tags, hydro::Tags::SpatialVelocity<DataType, 3>> or
             cpp17::is_same_v<Tags, hydro::Tags::LorentzFactor<DataType>> or
             not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tags>)...>>
-        vars(black_hole_mass_, black_hole_spin_, max_pressure_radius_,
-             background_spacetime_, x, t,
+        vars(bh_mass_, bh_spin_a_, max_pressure_radius_, background_spacetime_,
+             x, t,
              index_helper(
                  tmpl::index_of<tmpl::list<Tags...>,
                                 hydro::Tags::SpatialVelocity<DataType, 3>>{}),
@@ -302,8 +301,8 @@ class FishboneMoncriefDisk {
         DataType,
         cpp17::is_same_v<Tag, hydro::Tags::SpatialVelocity<DataType, 3>> or
             not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tag>>
-        intermediate_vars(black_hole_mass_, black_hole_spin_,
-                          max_pressure_radius_, background_spacetime_, x, t,
+        intermediate_vars(bh_mass_, bh_spin_a_, max_pressure_radius_,
+                          background_spacetime_, x, t,
                           std::numeric_limits<size_t>::max(),
                           std::numeric_limits<size_t>::max());
     return variables(x, tmpl::list<Tag>{}, intermediate_vars, 0);
@@ -413,7 +412,7 @@ class FishboneMoncriefDisk {
   // solution's variables.
   template <typename DataType, bool NeedSpacetime>
   struct IntermediateVariables {
-    IntermediateVariables(double black_hole_mass, double black_hole_spin,
+    IntermediateVariables(double bh_mass, double bh_spin_a,
                           double max_pressure_radius,
                           const gr::Solutions::KerrSchild& background_spacetime,
                           const tnsr::I<DataType, 3>& x, double t,
@@ -433,8 +432,8 @@ class FishboneMoncriefDisk {
   friend bool operator==(const FishboneMoncriefDisk& lhs,
                          const FishboneMoncriefDisk& rhs) noexcept;
 
-  double black_hole_mass_ = std::numeric_limits<double>::signaling_NaN();
-  double black_hole_spin_ = std::numeric_limits<double>::signaling_NaN();
+  double bh_mass_ = std::numeric_limits<double>::signaling_NaN();
+  double bh_spin_a_ = std::numeric_limits<double>::signaling_NaN();
   double inner_edge_radius_ = std::numeric_limits<double>::signaling_NaN();
   double max_pressure_radius_ = std::numeric_limits<double>::signaling_NaN();
   double polytropic_constant_ = std::numeric_limits<double>::signaling_NaN();

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -286,6 +286,7 @@ class FishboneMoncriefDisk {
     IntermediateVariables<
         DataType,
         cpp17::is_same_v<Tag, hydro::Tags::SpatialVelocity<DataType, 3>> or
+            cpp17::is_same_v<Tag, hydro::Tags::LorentzFactor<DataType>> or
             not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tag>>
         intermediate_vars(bh_spin_a_, background_spacetime_, x, t,
                           std::numeric_limits<size_t>::max(),

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -32,10 +32,10 @@ namespace Solutions {
 /*!
  * \brief Fluid disk orbiting a Kerr black hole
  *
- * The Fishbone-Moncrief solution to the 3D relativistic Euler system,
- * representing the isentropic flow of a thick fluid disk orbiting a Kerr black
- * hole. In Boyer-Lindquist coordinates \f$(t, r, \theta, \phi)\f$, the flow is
- * assumed to be purely toroidal,
+ * The Fishbone-Moncrief solution to the 3D relativistic Euler system
+ * \cite fishbone1976apj, representing the isentropic flow of a thick fluid disk
+ * orbiting a Kerr black hole. In Boyer-Lindquist coordinates
+ * \f$(t, r, \theta, \phi)\f$, the flow is assumed to be purely toroidal,
  *
  * \f{align*}
  * u^\mu = (u^t, 0, 0, u^\phi),
@@ -44,10 +44,15 @@ namespace Solutions {
  * where \f$u^\mu\f$ is the 4-velocity. Then, all the fluid quantities are
  * assumed to share the same symmetries as those of the background spacetime,
  * namely they are stationary (independent of \f$t\f$), and axially symmetric
- * (independent of \f$\phi\f$). Self-gravity is neglected, so that the fluid
+ * (independent of \f$\phi\f$). Note that \f$r\f$ and \f$\theta\f$ can also be
+ * interpreted as Kerr (a.k.a. "spherical" Kerr-Schild) coordinates
+ * (see gr::KerrSchildCoords), and that the symmetries of the equilibrium ensure
+ * that \f$u^\mu\f$ as defined above is also the 4-velocity in Kerr coordinates.
+ *
+ * Self-gravity is neglected, so that the fluid
  * variables are determined as functions of the metric. Following the treatment
- * by Kozlowski et al. (1978) (but using signature +2) the solution is
- * expressed in terms of the quantities
+ * by Kozlowski et al. \cite Kozlowski1978aa (but using signature +2)
+ * the solution is expressed in terms of the quantities
  *
  * \f{align*}
  * \Omega &= \dfrac{u^\phi}{u^t},\\
@@ -119,35 +124,18 @@ namespace Solutions {
  * p = K\rho^\gamma.
  * \f}
  *
- * Once all the variables are known in Boyer-Lindquist coordinates, it is
- * straightforward to write them in Kerr-Schild coordinates. The coordinate
- * transformation
- *
- * \f{align*}
- * t_\text{KS} &= t\\
- * x &= \sqrt{r^2 + a^2}\sin\theta\cos\phi\\
- * y &= \sqrt{r^2 + a^2}\sin\theta\sin\phi\\
- * z &= r\cos\theta
- * \f}
- *
- * helps read the Jacobian matrix, which, applied to the azimuthal flow of the
- * disk, gives
+ * Once all the variables are known in Boyer-Lindquist (or Kerr) coordinates, it
+ * is straightforward to write them in Cartesian Kerr-Schild coordinates. The
+ * coordinate transformation in gr::KerrSchildCoords helps read the Jacobian
+ * matrix, which, applied to the azimuthal flow of the disk, gives
  *
  * \f{align*}
  * u_\text{KS}^\mu = u^t(1, -y\Omega, x\Omega, 0),
  * \f}
  *
  * where \f$u^t\f$ and \f$\Omega\f$ are now understood as functions of the
- * Kerr-Schild coordinates, for which the relations
- *
- * \f{align*}
- * r^2 &= \frac{1}{2}\left(x^2 + y^2 + z^2 - a^2 +
- * \sqrt{(x^2 + y^2 + z^2 - a^2)^2 + 4a^2z^2}\right)\\
- * \theta &= \cos^{-1}\left(\frac{z}{r}\right)
- * \f}
- *
- * are needed. Finally, the spatial velocity can be readily obtained from its
- * definition,
+ * Kerr-Schild coordinates. Finally, the spatial velocity can be readily
+ * obtained from its definition,
  *
  * \f{align*}
  * \alpha v^i = \frac{u^i}{u^t} + \beta^i,
@@ -156,7 +144,8 @@ namespace Solutions {
  * where \f$\alpha\f$ and \f$\beta^i\f$ are the lapse and the shift,
  * respectively.
  *
- * \note Kozlowski et al. (1978) denote \f$l_* = u_\phi u^t\f$ in order to
+ * \note Kozlowski et al. \cite Kozlowski1978aa denote
+ * \f$l_* = u_\phi u^t\f$ in order to
  * distinguish this quantity from their own definition \f$l = - u_\phi/u_t\f$.
  */
 class FishboneMoncriefDisk {

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -228,17 +228,15 @@ class FishboneMoncriefDisk {
 
   template <typename DataType>
   DataType four_velocity_t_sqrd(const DataType& r_sqrd,
-                                const DataType& sin_theta_sqrd,
-                                double angular_momentum) const noexcept;
+                                const DataType& sin_theta_sqrd) const noexcept;
 
   template <typename DataType>
   DataType angular_velocity(const DataType& r_sqrd,
-                            const DataType& sin_theta_sqrd,
-                            double angular_momentum) const noexcept;
+                            const DataType& sin_theta_sqrd) const noexcept;
 
   template <typename DataType>
-  DataType potential(const DataType& r_sqrd, const DataType& sin_theta_sqrd,
-                     double angular_momentum) const noexcept;
+  DataType potential(const DataType& r_sqrd,
+                     const DataType& sin_theta_sqrd) const noexcept;
 
   SPECTRE_ALWAYS_INLINE size_t index_helper(tmpl::no_such_type_ /*meta*/) const
       noexcept {
@@ -267,8 +265,7 @@ class FishboneMoncriefDisk {
             cpp17::is_same_v<Tags, hydro::Tags::SpatialVelocity<DataType, 3>> or
             cpp17::is_same_v<Tags, hydro::Tags::LorentzFactor<DataType>> or
             not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tags>)...>>
-        vars(bh_mass_, bh_spin_a_, max_pressure_radius_, background_spacetime_,
-             x, t,
+        vars(bh_spin_a_, background_spacetime_, x, t,
              index_helper(
                  tmpl::index_of<tmpl::list<Tags...>,
                                 hydro::Tags::SpatialVelocity<DataType, 3>>{}),
@@ -290,8 +287,7 @@ class FishboneMoncriefDisk {
         DataType,
         cpp17::is_same_v<Tag, hydro::Tags::SpatialVelocity<DataType, 3>> or
             not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tag>>
-        intermediate_vars(bh_mass_, bh_spin_a_, max_pressure_radius_,
-                          background_spacetime_, x, t,
+        intermediate_vars(bh_spin_a_, background_spacetime_, x, t,
                           std::numeric_limits<size_t>::max(),
                           std::numeric_limits<size_t>::max());
     return variables(x, tmpl::list<Tag>{}, intermediate_vars, 0);
@@ -401,8 +397,7 @@ class FishboneMoncriefDisk {
   // solution's variables.
   template <typename DataType, bool NeedSpacetime>
   struct IntermediateVariables {
-    IntermediateVariables(double bh_mass, double bh_spin_a,
-                          double max_pressure_radius,
+    IntermediateVariables(double bh_spin_a,
                           const gr::Solutions::KerrSchild& background_spacetime,
                           const tnsr::I<DataType, 3>& x, double t,
                           size_t in_spatial_velocity_index,
@@ -410,7 +405,6 @@ class FishboneMoncriefDisk {
 
     DataType r_squared{};
     DataType sin_theta_squared{};
-    double angular_momentum{};
     tuples::tagged_tuple_from_typelist<
         typename gr::Solutions::KerrSchild::tags<DataType>>
         kerr_schild_soln{};
@@ -427,6 +421,7 @@ class FishboneMoncriefDisk {
   double max_pressure_radius_ = std::numeric_limits<double>::signaling_NaN();
   double polytropic_constant_ = std::numeric_limits<double>::signaling_NaN();
   double polytropic_exponent_ = std::numeric_limits<double>::signaling_NaN();
+  double angular_momentum_ = std::numeric_limits<double>::signaling_NaN();
   EquationsOfState::PolytropicFluid<true> equation_of_state_{};
   gr::Solutions::KerrSchild background_spacetime_{};
 };

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/GrMhd.yaml
@@ -20,8 +20,8 @@ DomainCreator:
     InitialGridPoints: [5, 5, 5]
 
 AnalyticSolution:
-  BlackHoleMass: 1.0
-  BlackHoleSpin: 0.9375
+  BhMass: 1.0
+  BhDimlessSpin: 0.9375
   InnerEdgeRadius: 6.0
   MaxPressureRadius: 12.0
   PolytropicConstant: 0.001

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/TestFunctions.py
@@ -100,77 +100,80 @@ def potential(angular_momentum, r_sqrd, sin_theta_sqrd, m, a):
             u_t(angular_momentum, r_sqrd, sin_theta_sqrd, m, a)))
 
 
-def fishbone_specific_enthalpy(x, t, black_hole_mass, black_hole_spin, r_in,
-                               r_max, polytropic_constant,
+def fishbone_specific_enthalpy(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                               dimless_r_max, polytropic_constant,
                                polytropic_exponent):
-    l = angular_momentum(black_hole_mass, black_hole_spin, r_max)
-    Win = potential(l, r_in * r_in, 1.0, black_hole_mass, black_hole_spin)
-    r_sqrd = boyer_lindquist_r_sqrd(x, black_hole_spin)
+    r_in = bh_mass * dimless_r_in
+    bh_spin_a = bh_mass * bh_dimless_a
+    l = angular_momentum(bh_mass, bh_spin_a, bh_mass * dimless_r_max)
+    Win = potential(l, r_in * r_in, 1.0, bh_mass, bh_spin_a)
+    r_sqrd = boyer_lindquist_r_sqrd(x, bh_spin_a)
     sin_theta_sqrd = boyer_lindquist_sin_theta_sqrd(x[2] * x[2], r_sqrd)
     result = 1.0
     if (np.sqrt(r_sqrd * sin_theta_sqrd) >= r_in):
-        W = potential(l, r_sqrd, sin_theta_sqrd, black_hole_mass,
-                      black_hole_spin)
+        W = potential(l, r_sqrd, sin_theta_sqrd, bh_mass, bh_spin_a)
         if (W < Win):
             result = np.exp(Win - W)
 
     return result
 
 
-def fishbone_rest_mass_density(x, t, black_hole_mass, black_hole_spin, r_in,
-                               r_max, polytropic_constant,
+def fishbone_rest_mass_density(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                               dimless_r_max, polytropic_constant,
                                polytropic_exponent):
     return np.power((polytropic_exponent - 1.0) * (fishbone_specific_enthalpy(
-        x, t, black_hole_mass, black_hole_spin, r_in, r_max,
+        x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
         polytropic_constant, polytropic_exponent) - 1.0) /
                     (polytropic_exponent * polytropic_constant),
                     1.0 / (polytropic_exponent - 1.0))
 
 
-def fishbone_specific_internal_energy(x, t, black_hole_mass, black_hole_spin,
-                                      r_in, r_max, polytropic_constant,
+def fishbone_specific_internal_energy(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                                      dimless_r_max, polytropic_constant,
                                       polytropic_exponent):
     return (polytropic_constant * np.power(
-        fishbone_rest_mass_density(x, t, black_hole_mass, black_hole_spin,
-                                   r_in, r_max, polytropic_constant,
+        fishbone_rest_mass_density(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                                   dimless_r_max, polytropic_constant,
                                    polytropic_exponent),
         polytropic_exponent - 1.0) / (polytropic_exponent - 1.0))
 
 
-def fishbone_pressure(x, t, black_hole_mass, black_hole_spin, r_in, r_max,
+def fishbone_pressure(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
                       polytropic_constant, polytropic_exponent):
     return (polytropic_constant * np.power(
-        fishbone_rest_mass_density(x, t, black_hole_mass, black_hole_spin,
-                                   r_in, r_max, polytropic_constant,
+        fishbone_rest_mass_density(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                                   dimless_r_max, polytropic_constant,
                                    polytropic_exponent), polytropic_exponent))
 
 
-def fishbone_spatial_velocity(x, t, black_hole_mass, black_hole_spin, r_in,
-                              r_max, polytropic_constant, polytropic_exponent):
-    l = angular_momentum(black_hole_mass, black_hole_spin, r_max)
-    Win = potential(l, r_in * r_in, 1.0, black_hole_mass, black_hole_spin)
-    r_sqrd = boyer_lindquist_r_sqrd(x, black_hole_spin)
+def fishbone_spatial_velocity(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                              dimless_r_max, polytropic_constant,
+                              polytropic_exponent):
+    r_in = bh_mass * dimless_r_in
+    bh_spin_a = bh_mass * bh_dimless_a
+    l = angular_momentum(bh_mass, bh_spin_a, bh_mass * dimless_r_max)
+    Win = potential(l, r_in * r_in, 1.0, bh_mass, bh_spin_a)
+    r_sqrd = boyer_lindquist_r_sqrd(x, bh_spin_a)
     sin_theta_sqrd = boyer_lindquist_sin_theta_sqrd(x[2] * x[2], r_sqrd)
 
     result = np.array([0.0, 0.0, 0.0])
     if (np.sqrt(r_sqrd * sin_theta_sqrd) >= r_in):
-        W = potential(l, r_sqrd, sin_theta_sqrd, black_hole_mass,
-                      black_hole_spin)
+        W = potential(l, r_sqrd, sin_theta_sqrd, bh_mass, bh_spin_a)
         if (W < Win):
             result += ((np.array([-x[1], x[0], 0.0]) * angular_velocity(
-                l, r_sqrd, sin_theta_sqrd, black_hole_mass, black_hole_spin) +
-                        kerr_schild_shift(x, black_hole_mass, black_hole_spin))
-                       / kerr_schild_lapse(x, black_hole_mass,
-                                           black_hole_spin))
+                l, r_sqrd, sin_theta_sqrd, bh_mass, bh_spin_a) +
+                        kerr_schild_shift(x, bh_mass, bh_spin_a))
+                       / kerr_schild_lapse(x, bh_mass, bh_spin_a))
     return result
 
 
-def fishbone_lorentz_factor(x, t, black_hole_mass, black_hole_spin, r_in,
-                            r_max, polytropic_constant, polytropic_exponent):
-    spatial_metric = kerr_schild_spatial_metric(x, black_hole_mass,
-                                                black_hole_spin)
+def fishbone_lorentz_factor(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                            dimless_r_max, polytropic_constant,
+                            polytropic_exponent):
+    bh_spin_a = bh_mass * bh_dimless_a
+    spatial_metric = kerr_schild_spatial_metric(x, bh_mass, bh_spin_a)
     velocity = fishbone_spatial_velocity(
-        x, t, black_hole_mass, black_hole_spin, r_in, r_max,
+        x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
         polytropic_constant, polytropic_exponent)
     return 1.0 / np.sqrt(
         1.0 - np.einsum("i,j,ij", velocity, velocity, spatial_metric))

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
@@ -62,8 +62,8 @@ struct FishboneMoncriefDiskProxy
 void test_create_from_options() noexcept {
   const auto disk =
       test_creation<RelativisticEuler::Solutions::FishboneMoncriefDisk>(
-          "  BlackHoleMass: 1.0\n"
-          "  BlackHoleSpin: 0.23\n"
+          "  BhMass: 1.0\n"
+          "  BhDimlessSpin: 0.23\n"
           "  InnerEdgeRadius: 6.0\n"
           "  MaxPressureRadius: 12.0\n"
           "  PolytropicConstant: 0.001\n"
@@ -88,18 +88,18 @@ void test_serialize() noexcept {
 
 template <typename DataType>
 void test_variables(const DataType& used_for_size) noexcept {
-  const double black_hole_mass = 1.0;
-  const double black_hole_spin = 0.9375;
+  const double bh_mass = 1.34;
+  const double bh_dimless_spin = 0.94432;
   const double inner_edge_radius = 6.0;
   const double max_pressure_radius = 12.0;
   const double polytropic_constant = 0.001;
   const double polytropic_exponent = 4.0 / 3.0;
 
-  FishboneMoncriefDiskProxy disk(black_hole_mass, black_hole_spin,
-                                 inner_edge_radius, max_pressure_radius,
-                                 polytropic_constant, polytropic_exponent);
+  FishboneMoncriefDiskProxy disk(bh_mass, bh_dimless_spin, inner_edge_radius,
+                                 max_pressure_radius, polytropic_constant,
+                                 polytropic_exponent);
   const auto member_variables = std::make_tuple(
-      black_hole_mass, black_hole_spin, inner_edge_radius, max_pressure_radius,
+      bh_mass, bh_dimless_spin, inner_edge_radius, max_pressure_radius,
       polytropic_constant, polytropic_exponent);
 
   pypp::check_with_random_values<
@@ -125,7 +125,7 @@ void test_variables(const DataType& used_for_size) noexcept {
   // correctly forwards to the background solution. Not meant to be extensive.
   const auto coords = make_with_value<tnsr::I<DataType, 3>>(used_for_size, 1.0);
   const gr::Solutions::KerrSchild ks_soln{
-      black_hole_mass, {{0.0, 0.0, black_hole_spin}}, {{0.0, 0.0, 0.0}}};
+      bh_mass, {{0.0, 0.0, bh_dimless_spin}}, {{0.0, 0.0, 0.0}}};
   CHECK_ITERABLE_APPROX(
       get<gr::Tags::Lapse<DataType>>(ks_soln.variables(
           coords, 0.0, gr::Solutions::KerrSchild::tags<DataType>{})),
@@ -168,7 +168,7 @@ struct Disk {
       "A fluid disk orbiting a Kerr black hole."};
 };
 
-// [[OutputRegex, In string:.*At line 2 column 18:.Value -1.5 is below the lower
+// [[OutputRegex, In string:.*At line 2 column 11:.Value -1.5 is below the lower
 // bound of 0]]
 SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.FMDiskBHMassOpt",
@@ -177,8 +177,8 @@ SPECTRE_TEST_CASE(
   Options<tmpl::list<Disk>> test_options("");
   test_options.parse(
       "Disk:\n"
-      "  BlackHoleMass: -1.5\n"
-      "  BlackHoleSpin: 0.3\n"
+      "  BhMass: -1.5\n"
+      "  BhDimlessSpin: 0.3\n"
       "  InnerEdgeRadius: 4.3\n"
       "  MaxPressureRadius: 6.7\n"
       "  PolytropicConstant: 0.12\n"
@@ -195,8 +195,8 @@ SPECTRE_TEST_CASE(
   Options<tmpl::list<Disk>> test_options("");
   test_options.parse(
       "Disk:\n"
-      "  BlackHoleMass: 1.5\n"
-      "  BlackHoleSpin: -0.24\n"
+      "  BhMass: 1.5\n"
+      "  BhDimlessSpin: -0.24\n"
       "  InnerEdgeRadius: 5.76\n"
       "  MaxPressureRadius: 13.2\n"
       "  PolytropicConstant: 0.002\n"
@@ -213,8 +213,8 @@ SPECTRE_TEST_CASE(
   Options<tmpl::list<Disk>> test_options("");
   test_options.parse(
       "Disk:\n"
-      "  BlackHoleMass: 1.5\n"
-      "  BlackHoleSpin: 1.24\n"
+      "  BhMass: 1.5\n"
+      "  BhDimlessSpin: 1.24\n"
       "  InnerEdgeRadius: 5.76\n"
       "  MaxPressureRadius: 13.2\n"
       "  PolytropicConstant: 0.002\n"
@@ -231,8 +231,8 @@ SPECTRE_TEST_CASE(
   Options<tmpl::list<Disk>> test_options("");
   test_options.parse(
       "Disk:\n"
-      "  BlackHoleMass: 1.5\n"
-      "  BlackHoleSpin: 0.3\n"
+      "  BhMass: 1.5\n"
+      "  BhDimlessSpin: 0.3\n"
       "  InnerEdgeRadius: 4.3\n"
       "  MaxPressureRadius: 6.7\n"
       "  PolytropicConstant: -0.12\n"
@@ -249,8 +249,8 @@ SPECTRE_TEST_CASE(
   Options<tmpl::list<Disk>> test_options("");
   test_options.parse(
       "Disk:\n"
-      "  BlackHoleMass: 1.5\n"
-      "  BlackHoleSpin: 0.3\n"
+      "  BhMass: 1.5\n"
+      "  BhDimlessSpin: 0.3\n"
       "  InnerEdgeRadius: 4.3\n"
       "  MaxPressureRadius: 6.7\n"
       "  PolytropicConstant: 0.123\n"


### PR DESCRIPTION
## Proposed changes

- Following discussions on other PRs, dimless spin $a$ is now the member variable to pass.
- Adds BibTeX bibliography to the documentation (should fix [#1065)](https://github.com/sxs-collaboration/spectre/issues/1065)
- Fixes a small bug when trying to obtain the Lorentz factor using the `variables` function
- Improves calculation of sin theta squared (should fix [#1270)](https://github.com/sxs-collaboration/spectre/issues/1270). A similar expression is also computed in `BondiHoyleAccretion`, but the quantity there is ensured to be positive.
- The `background_spacetime` getter and having `angular_momentum` be a member variable are needed for a `MagnetizedDisk` class I wrote that simply wraps most of the functions in `FishboneMoncriefDisk` before adding the magnetic field. 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
