### PR TITLE
Rework spin weighted utilities

### DIFF
--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -137,6 +137,57 @@ struct SpinWeighted<T, Spin, true> {
 };
 // @}
 
+// @{
+/// \ingroup TypeTraitsGroup
+/// \ingroup DataStructuresGroup
+/// This is a `std::true_type` if the provided type is a `SpinWeighted` of any
+/// type and spin, otherwise is a `std::false_type`.
+template <typename T>
+struct is_any_spin_weighted : std::false_type {};
+
+template <typename T, int S>
+struct is_any_spin_weighted<SpinWeighted<T, S>> : std::true_type {};
+// @}
+
+template <typename T>
+constexpr bool is_any_spin_weighted_v = is_any_spin_weighted<T>::value;
+
+// @{
+/// \ingroup TypeTraitsGroup
+/// \ingroup DataStructuresGroup
+/// This is a `std::true_type` if the provided type `T` is a `SpinWeighted` of
+/// `InternalType` and any spin, otherwise is a `std::false_type`.
+template <typename InternalType, typename T>
+struct is_spin_weighted_of : std::false_type {};
+
+template <typename InternalType, int S>
+struct is_spin_weighted_of<InternalType, SpinWeighted<InternalType, S>>
+    : std::true_type {};
+// @}
+
+template <typename InternalType, typename T>
+constexpr bool is_spin_weighted_of_v =
+    is_spin_weighted_of<InternalType, T>::value;
+
+// @{
+/// \ingroup TypeTraitsGroup
+/// \ingroup DataStructuresGroup
+/// This is a `std::true_type` if the provided type `T1` is a `SpinWeighted` and
+/// `T2` is a `SpinWeighted`, and both have the same internal type, but any
+/// combination of spin weights.
+template <typename T1, typename T2>
+struct is_spin_weighted_of_same_type : std::false_type {};
+
+template <typename T, int Spin1, int Spin2>
+struct is_spin_weighted_of_same_type<SpinWeighted<T, Spin1>,
+                                     SpinWeighted<T, Spin2>> : std::true_type {
+};
+// @}
+
+template <typename T1, typename T2>
+constexpr bool is_spin_weighted_of_same_type_v =
+    is_spin_weighted_of_same_type<T1, T2>::value;
+
 // {@
 /// \brief Add two spin-weighted quantities if the types are compatible and
 /// spins are the same. Un-weighted quantities are assumed to be spin 0.

--- a/src/DataStructures/SpinWeighted.hpp
+++ b/src/DataStructures/SpinWeighted.hpp
@@ -3,10 +3,12 @@
 
 #pragma once
 
+#include "DataStructures/ComplexDataVector.hpp"
 #include "Utilities/ForceInline.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TypeTraits.hpp"
 
+// @{
 /*!
  * \ingroup DataStructuresGroup
  * \brief Make a spin-weighted type `T` with spin-weight `Spin`. Mathematical
@@ -18,120 +20,320 @@
  * two summands possess the same spin weight, and multiplication (or division)
  * result in a summed (or subtracted) spin weight.
  */
+template <typename T, int Spin, bool is_vector = is_derived_of_vector_impl_v<T>>
+struct SpinWeighted;
+
 template <typename T, int Spin>
-struct SpinWeighted {
-  T data;
+struct SpinWeighted<T, Spin, false> {
   using value_type = T;
   constexpr static int spin = Spin;
+
+  SpinWeighted() = default;
+  SpinWeighted(const SpinWeighted&) noexcept = default;
+  SpinWeighted(SpinWeighted&&) noexcept = default;
+  SpinWeighted& operator=(const SpinWeighted&) noexcept = default;
+  SpinWeighted& operator=(SpinWeighted&&) noexcept = default;
+  ~SpinWeighted() noexcept = default;
+
+  // clang-tidy asks that these be marked explicit, but we actually do not want
+  // them explicit for use in the math operations below.
+  template <typename Rhs>
+  SpinWeighted(const SpinWeighted<Rhs, Spin>& rhs) noexcept  // NOLINT
+      : data_{rhs.data()} {}
+
+  template <typename Rhs>
+  SpinWeighted(SpinWeighted<Rhs, Spin>&& rhs) noexcept  // NOLINT
+      : data_{std::move(rhs.data())} {}
+
+  SpinWeighted(const T& rhs) noexcept : data_{rhs} {}        // NOLINT
+  SpinWeighted(T&& rhs) noexcept : data_{std::move(rhs)} {}  // NOLINT
+
+  template <typename Rhs>
+  SpinWeighted& operator=(const SpinWeighted<Rhs, Spin>& rhs) noexcept {
+    data_ = rhs.data();
+    return *this;
+  }
+
+  template <typename Rhs>
+  SpinWeighted& operator=(SpinWeighted<Rhs, Spin>&& rhs) noexcept {
+    data_ = std::move(rhs.data());
+    return *this;
+  }
+
+  SpinWeighted& operator=(const T& rhs) noexcept {
+    data_ = rhs;
+    return *this;
+  }
+  SpinWeighted& operator=(T&& rhs) noexcept {
+    data_ = std::move(rhs);
+    return *this;
+  }
+
+  T& data() noexcept { return data_; }
+  const T& data() const noexcept { return data_; }
+
+ private:
+  T data_;
 };
+
+template <typename T, int Spin>
+struct SpinWeighted<T, Spin, true> {
+  using value_type = T;
+  constexpr static int spin = Spin;
+
+  void set_data_ref(gsl::not_null<T*> rhs) noexcept { data_.set_data_ref(rhs); }
+
+  template <typename ValueType>
+  void set_data_ref(ValueType* const start, const size_t set_size) noexcept {
+    data_.set_data_ref(start, set_size);
+  }
+
+  SpinWeighted() = default;
+  SpinWeighted(const SpinWeighted&) noexcept = default;
+  SpinWeighted(SpinWeighted&&) noexcept = default;
+  SpinWeighted& operator=(const SpinWeighted&) noexcept = default;
+  SpinWeighted& operator=(SpinWeighted&&) noexcept = default;
+  ~SpinWeighted() noexcept = default;
+
+  // clang-tidy asks that these be marked explicit, but we actually do not want
+  // them explicit for use in the math operations below.
+  template <typename Rhs>
+  SpinWeighted(const SpinWeighted<Rhs, Spin>& rhs) noexcept  // NOLINT
+      : data_{rhs.data()} {}
+
+  template <typename Rhs>
+  SpinWeighted(SpinWeighted<Rhs, Spin>&& rhs) noexcept  // NOLINT
+      : data_{std::move(rhs.data())} {}
+
+  SpinWeighted(const T& rhs) noexcept : data_{rhs} {}        // NOLINT
+  SpinWeighted(T&& rhs) noexcept : data_{std::move(rhs)} {}  // NOLINT
+
+  template <typename Rhs>
+  SpinWeighted& operator=(const SpinWeighted<Rhs, Spin>& rhs) noexcept {
+    data_ = rhs.data();
+    return *this;
+  }
+
+  template <typename Rhs>
+  SpinWeighted& operator=(SpinWeighted<Rhs, Spin>&& rhs) noexcept {
+    data_ = std::move(rhs.data());
+    return *this;
+  }
+
+  SpinWeighted& operator=(const T& rhs) noexcept {
+    data_ = rhs;
+    return *this;
+  }
+  SpinWeighted& operator=(T&& rhs) noexcept {
+    data_ = std::move(rhs);
+    return *this;
+  }
+
+  T& data() noexcept { return data_; }
+  const T& data() const noexcept { return data_; }
+
+ private:
+  T data_;
+};
+// @}
 
 // {@
 /// \brief Add two spin-weighted quantities if the types are compatible and
 /// spins are the same. Un-weighted quantities are assumed to be spin 0.
+// These overloads are designed to allow SpinWeighted to wrap Blaze expression
+// templates to ensure efficient math operations, necessitating the
+// `decltype(declval<T>() ...` syntax
 template <typename T1, typename T2, int Spin>
 SPECTRE_ALWAYS_INLINE
     SpinWeighted<decltype(std::declval<T1>() + std::declval<T2>()), Spin>
     operator+(const SpinWeighted<T1, Spin>& lhs,
               const SpinWeighted<T2, Spin>& rhs) noexcept {
-  return {lhs.data + rhs.data};
+  return {lhs.data() + rhs.data()};
 }
 template <typename T>
-SPECTRE_ALWAYS_INLINE SpinWeighted<T, 0> operator+(
-    const SpinWeighted<T, 0>& lhs, const T& rhs) noexcept {
-  return {lhs.data + rhs};
+SPECTRE_ALWAYS_INLINE
+    SpinWeighted<decltype(std::declval<T>() + std::declval<T>()), 0>
+    operator+(const SpinWeighted<T, 0>& lhs, const T& rhs) noexcept {
+  return {lhs.data() + rhs};
 }
 template <typename T>
-SPECTRE_ALWAYS_INLINE SpinWeighted<T, 0> operator+(
-    const T& lhs, const SpinWeighted<T, 0>& rhs) noexcept {
-  return {lhs + rhs.data};
+SPECTRE_ALWAYS_INLINE SpinWeighted<
+    decltype(std::declval<T>() + std::declval<get_vector_element_type_t<T>>()),
+    0>
+operator+(const SpinWeighted<T, 0>& lhs,
+          const get_vector_element_type_t<T>& rhs) noexcept {
+  return {lhs.data() + rhs};
+}
+template <typename T>
+SPECTRE_ALWAYS_INLINE
+    SpinWeighted<decltype(std::declval<T>() + std::declval<T>()), 0>
+    operator+(const T& lhs, const SpinWeighted<T, 0>& rhs) noexcept {
+  return {lhs + rhs.data()};
+}
+template <typename T>
+SPECTRE_ALWAYS_INLINE SpinWeighted<
+    decltype(std::declval<get_vector_element_type_t<T>>() + std::declval<T>()),
+    0>
+operator+(const get_vector_element_type_t<T>& lhs,
+          const SpinWeighted<T, 0>& rhs) noexcept {
+  return {lhs + rhs.data()};
 }
 // @}
 
 // @{
 /// \brief Subtract two spin-weighted quantities if the types are compatible and
 /// spins are the same. Un-weighted quantities are assumed to be spin 0.
+// These overloads are designed to allow SpinWeighted to wrap Blaze expression
+// templates to ensure efficient math operations, necessitating the
+// `decltype(declval<T>() ...` syntax
 template <typename T1, typename T2, int Spin>
 SPECTRE_ALWAYS_INLINE
     SpinWeighted<decltype(std::declval<T1>() - std::declval<T2>()), Spin>
     operator-(const SpinWeighted<T1, Spin>& lhs,
               const SpinWeighted<T2, Spin>& rhs) noexcept {
-  return {lhs.data - rhs.data};
+  return {lhs.data() - rhs.data()};
 }
 template <typename T>
-SPECTRE_ALWAYS_INLINE SpinWeighted<T, 0> operator-(
-    const SpinWeighted<T, 0>& lhs, const T& rhs) noexcept {
-  return {lhs.data - rhs};
+SPECTRE_ALWAYS_INLINE
+    SpinWeighted<decltype(std::declval<T>() - std::declval<T>()), 0>
+    operator-(const SpinWeighted<T, 0>& lhs, const T& rhs) noexcept {
+  return {lhs.data() - rhs};
 }
 template <typename T>
-SPECTRE_ALWAYS_INLINE SpinWeighted<T, 0> operator-(
-    const T& lhs, const SpinWeighted<T, 0>& rhs) noexcept {
-  return {lhs - rhs.data};
+SPECTRE_ALWAYS_INLINE SpinWeighted<
+    decltype(std::declval<T>() - std::declval<get_vector_element_type_t<T>>()),
+    0>
+operator-(const SpinWeighted<T, 0>& lhs,
+          const get_vector_element_type_t<T>& rhs) noexcept {
+  return {lhs.data() - rhs};
+}
+template <typename T>
+SPECTRE_ALWAYS_INLINE
+    SpinWeighted<decltype(std::declval<T>() - std::declval<T>()), 0>
+    operator-(const T& lhs, const SpinWeighted<T, 0>& rhs) noexcept {
+  return {lhs - rhs.data()};
+}
+template <typename T>
+SPECTRE_ALWAYS_INLINE SpinWeighted<
+    decltype(std::declval<get_vector_element_type_t<T>>() - std::declval<T>()),
+    0>
+operator-(const get_vector_element_type_t<T>& lhs,
+          const SpinWeighted<T, 0>& rhs) noexcept {
+  return {lhs - rhs.data()};
 }
 // @}
 
 // @{
 /// \brief Multiply two spin-weighted quantities if the types are compatible and
 /// add the spins. Un-weighted quantities are assumed to be spin 0.
+// These overloads are designed to allow SpinWeighted to wrap Blaze expression
+// templates to ensure efficient math operations, necessitating the
+// `decltype(declval<T>() ...` syntax
 template <typename T1, typename T2, int Spin1, int Spin2>
 SPECTRE_ALWAYS_INLINE SpinWeighted<
     decltype(std::declval<T1>() * std::declval<T2>()), Spin1 + Spin2>
 operator*(const SpinWeighted<T1, Spin1>& lhs,
           const SpinWeighted<T2, Spin2>& rhs) noexcept {
-  return {lhs.data * rhs.data};
+  return {lhs.data() * rhs.data()};
 }
 template <typename T, int Spin>
-SPECTRE_ALWAYS_INLINE SpinWeighted<T, Spin> operator*(
-    const SpinWeighted<T, Spin>& lhs, const T& rhs) noexcept {
-  return {lhs.data * rhs};
+SPECTRE_ALWAYS_INLINE
+    SpinWeighted<decltype(std::declval<T>() * std::declval<T>()), Spin>
+    operator*(const SpinWeighted<T, Spin>& lhs, const T& rhs) noexcept {
+  return {lhs.data() * rhs};
 }
 template <typename T, int Spin>
-SPECTRE_ALWAYS_INLINE SpinWeighted<T, Spin> operator*(
-    const T& lhs, const SpinWeighted<T, Spin>& rhs) noexcept {
-  return {lhs * rhs.data};
+SPECTRE_ALWAYS_INLINE SpinWeighted<
+    decltype(std::declval<T>() * std::declval<get_vector_element_type_t<T>>()),
+    Spin>
+operator*(const SpinWeighted<T, Spin>& lhs,
+          const get_vector_element_type_t<T>& rhs) noexcept {
+  return {lhs.data() * rhs};
+}
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE
+    SpinWeighted<decltype(std::declval<T>() * std::declval<T>()), Spin>
+    operator*(const T& lhs, const SpinWeighted<T, Spin>& rhs) noexcept {
+  return {lhs * rhs.data()};
+}
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE SpinWeighted<
+    decltype(std::declval<get_vector_element_type_t<T>>() * std::declval<T>()),
+    Spin>
+operator*(const get_vector_element_type_t<T>& lhs,
+          const SpinWeighted<T, Spin>& rhs) noexcept {
+  return {lhs * rhs.data()};
 }
 // @}
 
 // @{
 /// \brief Divide two spin-weighted quantities if the types are compatible and
 /// subtract the spins. Un-weighted quantities are assumed to be spin 0.
+// These overloads are designed to allow SpinWeighted to wrap Blaze expression
+// templates to ensure efficient math operations, necessitating the
+// `decltype(declval<T>() ...` syntax
 template <typename T1, typename T2, int Spin1, int Spin2>
 SPECTRE_ALWAYS_INLINE SpinWeighted<
     decltype(std::declval<T1>() / std::declval<T2>()), Spin1 - Spin2>
 operator/(const SpinWeighted<T1, Spin1>& lhs,
           const SpinWeighted<T2, Spin2>& rhs) noexcept {
-  return {lhs.data / rhs.data};
+  return {lhs.data() / rhs.data()};
 }
 template <typename T, int Spin>
-SPECTRE_ALWAYS_INLINE SpinWeighted<T, Spin> operator/(
-    const SpinWeighted<T, Spin>& lhs, const T& rhs) noexcept {
-  return {lhs.data / rhs};
+SPECTRE_ALWAYS_INLINE
+    SpinWeighted<decltype(std::declval<T>() / std::declval<T>()), Spin>
+    operator/(const SpinWeighted<T, Spin>& lhs, const T& rhs) noexcept {
+  return {lhs.data() / rhs};
 }
 template <typename T, int Spin>
-SPECTRE_ALWAYS_INLINE SpinWeighted<T, -Spin> operator/(
-    const T& lhs, const SpinWeighted<T, Spin>& rhs) noexcept {
-  return {lhs / rhs.data};
+SPECTRE_ALWAYS_INLINE SpinWeighted<
+    decltype(std::declval<T>() / std::declval<get_vector_element_type_t<T>>()),
+    Spin>
+operator/(const SpinWeighted<T, Spin>& lhs,
+          const get_vector_element_type_t<T>& rhs) noexcept {
+  return {lhs.data() / rhs};
+}
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE
+    SpinWeighted<decltype(std::declval<T>() / std::declval<T>()), -Spin>
+    operator/(const T& lhs, const SpinWeighted<T, Spin>& rhs) noexcept {
+  return {lhs / rhs.data()};
+}
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE SpinWeighted<
+    decltype(std::declval<get_vector_element_type_t<T>>() / std::declval<T>()),
+    -Spin>
+operator/(const get_vector_element_type_t<T>& lhs,
+          const SpinWeighted<T, Spin>& rhs) noexcept {
+  return {lhs / rhs.data()};
 }
 // @}
 
+template <typename T, int Spin>
+SPECTRE_ALWAYS_INLINE SpinWeighted<decltype(conj(std::declval<T>())), -Spin>
+conj(const SpinWeighted<T, Spin> value) noexcept {
+  return {conj(value.data())};
+}
+
 // @{
 /// \brief Test equivalence of spin-weighted quantities if the types are
-/// compatible and spins are the same. Un-weighted quantities are assumed to be
-/// spin 0.
+/// compatible and spins are the same. Un-weighted quantities are assumed to
+/// be spin 0.
 template <typename T1, typename T2, int Spin>
 SPECTRE_ALWAYS_INLINE bool operator==(
     const SpinWeighted<T1, Spin>& lhs,
     const SpinWeighted<T2, Spin>& rhs) noexcept {
-  return lhs.data == rhs.data;
+  return lhs.data() == rhs.data();
 }
 template <typename T>
 SPECTRE_ALWAYS_INLINE bool operator==(const SpinWeighted<T, 0>& lhs,
                                       const T& rhs) noexcept {
-  return lhs.data == rhs;
+  return lhs.data() == rhs;
 }
 template <typename T>
 SPECTRE_ALWAYS_INLINE bool operator==(const T& lhs,
                                       const SpinWeighted<T, 0>& rhs) noexcept {
-  return lhs == rhs.data;
+  return lhs == rhs.data();
 }
 // @}
 
@@ -156,3 +358,28 @@ SPECTRE_ALWAYS_INLINE bool operator!=(const T& lhs,
   return not(lhs == rhs);
 }
 // @}
+
+namespace MakeWithValueImpls {
+template <int Spin1, int Spin2, typename SpinWeightedType1,
+          typename SpinWeightedType2>
+struct MakeWithValueImpl<SpinWeighted<SpinWeightedType1, Spin1>,
+                         SpinWeighted<SpinWeightedType2, Spin2>> {
+  template <typename ValueType>
+  static SPECTRE_ALWAYS_INLINE SpinWeighted<SpinWeightedType1, Spin1> apply(
+      const SpinWeighted<SpinWeightedType2, Spin2>& input,
+      const ValueType value) noexcept {
+    return SpinWeighted<SpinWeightedType1, Spin1>{
+        make_with_value<SpinWeightedType1>(input.data(), value)};
+  }
+};
+
+template <int Spin, typename SpinWeightedType, typename MakeWithType>
+struct MakeWithValueImpl<SpinWeighted<SpinWeightedType, Spin>, MakeWithType> {
+  template <typename ValueType>
+  static SPECTRE_ALWAYS_INLINE SpinWeighted<SpinWeightedType, Spin> apply(
+      const MakeWithType& input, const ValueType value) noexcept {
+    return SpinWeighted<SpinWeightedType, Spin>{
+        make_with_value<SpinWeightedType>(input, value)};
+  }
+};
+}  // namespace MakeWithValueImpls

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/ComplexModalVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/Expressions/Contract.hpp"
 #include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
@@ -86,13 +87,15 @@ class Tensor<X, Symm, IndexList<Indices...>> {
           cpp17::is_same_v<X, ModalVector> or
           cpp17::is_same_v<X, std::complex<double>> or
           cpp17::is_same_v<X, ComplexDataVector> or
-          cpp17::is_same_v<X, ComplexModalVector>,
+          cpp17::is_same_v<X, ComplexModalVector> or
+          is_spin_weighted_of_v<ComplexDataVector, X>,
       "Only a Tensor<double>, Tensor<DataVector>, Tensor<ModalVector>, "
-      "Tensor<std::complex<double>>, Tensor<ComplexDataVector>, or "
-      "Tensor<ComplexModalVector> is currently allowed. While other types are "
-      "technically possible it is not clear that Tensor is the correct "
-      "container for them. Please seek advice on the topic by discussing with "
-      "the SpECTRE developers.");
+      "Tensor<std::complex<double>>, Tensor<ComplexDataVector>, "
+      "Tensor<ComplexModalVector>, or "
+      "Tensor<SpinWeighted<ComplexDataVector, N>> is currently "
+      "allowed. While other types are technically possible it is not "
+      "clear that Tensor is the correct container for them. Please "
+      "seek advice on the topic by discussing with the SpECTRE developers.");
   /// The Tensor_detail::Structure for the particular tensor index structure
   ///
   /// Each tensor index structure, e.g. \f$T_{ab}\f$, \f$T_a{}^b\f$ or

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -107,9 +107,12 @@ class Variables<tmpl::list<Tags...>> {
                 "for type inference");
 
   static_assert(
-      tmpl2::flat_all_v<
-          cpp17::is_same_v<typename Tags::type::type,
-                           typename tmpl::front<tags_list>::type::type>...>,
+      (tmpl2::flat_all_v<
+           cpp17::is_same_v<typename Tags::type::type,
+                            typename tmpl::front<tags_list>::type::type>...> or
+       tmpl2::flat_all_v<is_spin_weighted_of_same_type_v<
+           typename tmpl::front<tags_list>::type::type,
+           typename Tags::type::type>...>),
       "All tensors stored in a single Variables must "
       "have the same internal storage type.");
 
@@ -120,7 +123,10 @@ class Variables<tmpl::list<Tags...>> {
       "a vector with a member `value_type` (e.g. Tensors of doubles are "
       "disallowed, use instead a Tensor of DataVectors).");
 
-  using vector_type = typename tmpl::front<tags_list>::type::type;
+  using vector_type = tmpl::conditional_t<
+      is_any_spin_weighted_v<typename tmpl::front<tags_list>::type::value_type>,
+      typename tmpl::front<tags_list>::type::type::value_type,
+      typename tmpl::front<tags_list>::type::type>;
   using value_type = typename vector_type::value_type;
   using allocator_type = std::allocator<value_type>;
   using pointer_type =

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -549,16 +549,23 @@ std::ostream& operator<<(std::ostream& os,
  *
  * \param VECTOR_TYPE The vector type (e.g. `DataVector`)
  */
-#define MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(VECTOR_TYPE)  \
-  namespace MakeWithValueImpls {                          \
-  template <>                                             \
-  struct MakeWithValueImpl<VECTOR_TYPE, VECTOR_TYPE> {    \
-    static SPECTRE_ALWAYS_INLINE VECTOR_TYPE              \
-    apply(const VECTOR_TYPE& input,                       \
-          const VECTOR_TYPE::value_type value) noexcept { \
-      return VECTOR_TYPE(input.size(), value);            \
-    }                                                     \
-  };                                                      \
+#define MAKE_WITH_VALUE_IMPL_DEFINITION_FOR(VECTOR_TYPE)                      \
+  namespace MakeWithValueImpls {                                              \
+  template <>                                                                 \
+  struct MakeWithValueImpl<VECTOR_TYPE, VECTOR_TYPE> {                        \
+    static SPECTRE_ALWAYS_INLINE VECTOR_TYPE                                  \
+    apply(const VECTOR_TYPE& input,                                           \
+          const VECTOR_TYPE::value_type value) noexcept {                     \
+      return VECTOR_TYPE(input.size(), value);                                \
+    }                                                                         \
+  };                                                                          \
+  template <>                                                                 \
+  struct MakeWithValueImpl<VECTOR_TYPE, size_t> {                             \
+    static SPECTRE_ALWAYS_INLINE VECTOR_TYPE                                  \
+    apply(const size_t& size, const VECTOR_TYPE::value_type value) noexcept { \
+      return VECTOR_TYPE(size, value);                                        \
+    }                                                                         \
+  };                                                                          \
   }  // namespace MakeWithValueImpls
 
 // {@

--- a/src/DataStructures/VectorImpl.hpp
+++ b/src/DataStructures/VectorImpl.hpp
@@ -611,3 +611,23 @@ struct get_vector_element_type<std::array<T, S>, false> {
 
 template <typename T>
 using get_vector_element_type_t = typename get_vector_element_type<T>::type;
+
+namespace detail {
+template <typename... VectorImplTemplateArgs>
+std::true_type is_derived_of_vector_impl_impl(
+    const VectorImpl<VectorImplTemplateArgs...>*);
+
+std::false_type is_derived_of_vector_impl_impl(...);
+}  // namespace detail
+
+/// \ingroup TypeTraitsGroup
+/// This is `std::true_type` if the provided type possesses an implicit
+/// conversion to any `VectorImpl`, which is the primary feature of SpECTRE
+/// vectors generally. Otherwise, it is `std::false_type`.
+template <typename T>
+using is_derived_of_vector_impl =
+    decltype(detail::is_derived_of_vector_impl_impl(std::declval<T*>()));
+
+template <typename T>
+constexpr bool is_derived_of_vector_impl_v =
+    is_derived_of_vector_impl<T>::value;

--- a/src/Utilities/MakeWithValue.hpp
+++ b/src/Utilities/MakeWithValue.hpp
@@ -64,12 +64,12 @@ struct MakeWithValueImpl<std::complex<double>, T> {
 };
 
 /// \brief Makes a `std::array`; each element of the `std::array`
-/// must be `make_with_value`-creatable from a `T`.
-template <size_t Size, typename T>
-struct MakeWithValueImpl<std::array<T, Size>, T> {
+/// must be `make_with_value`-creatable from a `InputType`.
+template <size_t Size, typename T, typename InputType>
+struct MakeWithValueImpl<std::array<T, Size>, InputType> {
   template <typename ValueType>
   static SPECTRE_ALWAYS_INLINE std::array<T, Size> apply(
-      const T& input, const ValueType value) noexcept {
+      const InputType& input, const ValueType value) noexcept {
     return make_array<Size>(make_with_value<T>(input, value));
   }
 };

--- a/src/Utilities/TypeTraits.hpp
+++ b/src/Utilities/TypeTraits.hpp
@@ -1412,7 +1412,15 @@ struct is_complex_of_fundamental<
 /// \endcond
 // @}
 template <typename T>
-const bool is_complex_of_fundamental_v = is_complex_of_fundamental<T>::value;
+constexpr bool is_complex_of_fundamental_v =
+    is_complex_of_fundamental<T>::value;
+
+/// \ingroup TypeTraitsGroup
+/// \brief Evaluates to `true` if type `T` is a `std::complex` of a fundamental
+/// type or if `T` is a fundamental type.
+template <typename T>
+constexpr bool is_complex_or_fundamental_v =
+    is_complex_of_fundamental_v<T> or cpp17::is_fundamental_v<T>;
 
 namespace tt_detail {
 template <typename T>

--- a/tests/Unit/DataStructures/Test_SpinWeighted.cpp
+++ b/tests/Unit/DataStructures/Test_SpinWeighted.cpp
@@ -20,6 +20,42 @@
 // IWYU pragma: no_forward_declare DataVector
 // IWYU pragma: no_forward_declare SpinWeighted
 
+// tests for is_any_spin_weighted
+static_assert(is_any_spin_weighted_v<SpinWeighted<int, 3>>,
+              "failed testing is_any_spin_weighted");
+static_assert(is_any_spin_weighted_v<SpinWeighted<DataVector, 0>>,
+              "failed testing is_any_spin_weighted");
+static_assert(not is_any_spin_weighted_v<ComplexDataVector>,
+              "failed testing is_any_spin_weighted");
+
+// tests for is_spin_weighted_of
+static_assert(is_spin_weighted_of_v<DataVector, SpinWeighted<DataVector, 1>>,
+              "failed testing is_spin_weighted_of");
+static_assert(is_spin_weighted_of_v<ComplexDataVector,
+                                    SpinWeighted<ComplexDataVector, -1>>,
+              "failed testing is_spin_weighted_of");
+static_assert(
+    not is_spin_weighted_of_v<ComplexDataVector, SpinWeighted<DataVector, -2>>,
+    "failed testing is_spin_weighted_of");
+static_assert(not is_spin_weighted_of_v<ComplexDataVector, ComplexDataVector>,
+              "failed testing is_spin_weighted_of");
+
+// tests for is_spin_weighted_of_same_type
+static_assert(is_spin_weighted_of_same_type_v<SpinWeighted<DataVector, -2>,
+                                              SpinWeighted<DataVector, 1>>,
+              "failed testing is_spin_weighted_of_same_type");
+static_assert(
+    is_spin_weighted_of_same_type_v<SpinWeighted<ComplexDataVector, 0>,
+                                    SpinWeighted<ComplexDataVector, -1>>,
+    "failed testing is_spin_weighted_of_same_type");
+static_assert(not is_spin_weighted_of_same_type_v<ComplexDataVector,
+                                                  SpinWeighted<DataVector, -2>>,
+              "failed testing is_spin_weighted_of_same_type");
+static_assert(
+    not is_spin_weighted_of_same_type_v<SpinWeighted<ComplexDataVector, 1>,
+                                        SpinWeighted<DataVector, 1>>,
+    "failed testing is_spin_weighted_of_same_type");
+
 namespace {
 template <typename SpinWeightedType, typename CompatibleType>
 void test_spinweights() {

--- a/tests/Unit/DataStructures/Test_VectorImpl.cpp
+++ b/tests/Unit/DataStructures/Test_VectorImpl.cpp
@@ -3,7 +3,9 @@
 
 #include <array>
 #include <complex>
+#include <vector>
 
+#include "DataStructures/ComplexDataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
 #include "DataStructures/VectorImpl.hpp"  // IWYU pragma: keep
 #include "Utilities/TypeTraits.hpp"
@@ -23,3 +25,12 @@ static_assert(cpp17::is_same_v<get_vector_element_type_t<std::complex<double>*>,
 static_assert(cpp17::is_same_v<get_vector_element_type_t<DataVector&>, double>,
               "Failed testing type trait get_vector_element_type");
 /// [get_vector_element_type_example]
+
+static_assert(is_derived_of_vector_impl_v<DataVector>,
+              "Failed testing type trait is_derived_of_vector_impl");
+static_assert(is_derived_of_vector_impl_v<ComplexDataVector>,
+              "Failed testing type trait is_derived_of_vector_impl");
+static_assert(not is_derived_of_vector_impl_v<std::complex<double>>,
+              "Failed testing type trait is_derived_of_vector_impl");
+static_assert(not is_derived_of_vector_impl_v<std::vector<int>>,
+              "Failed testing type trait is_derived_of_vector_impl");

--- a/tests/Unit/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/DataStructures/VectorImplTestHelper.hpp
@@ -492,28 +492,6 @@ auto wrap_tuple(std::tuple<Operands...>& operand_values,
   return std::make_tuple(wrap(Wraps{}, get<Is>(operand_values))...);
 }
 
-// Helper function for obtaining an appropriate vector to pass to
-// make_with_values as the used_for_size.
-// clang-tidy sometimes believes this to be a declaration rather than a
-// definition, so warns about the `const` not doing anything.
-template <typename T>
-auto get_used_for_size(const size_t size, T /*meta*/,  // NOLINT
-                       cpp17::bool_constant<false> /*meta*/) noexcept {
-  return T(size);
-}
-
-template <typename T, size_t S>
-auto get_used_for_size(size_t size, std::array<T, S> /*meta*/,
-                       cpp17::bool_constant<false> /*meta*/) noexcept {
-  return T{size};
-}
-
-template <typename T>
-auto get_used_for_size(size_t /*size*/, T /*meta*/,
-                       cpp17::bool_constant<true> /*meta*/) noexcept {
-  return T{};
-}
-
 // given the set of types of operands to test (`Operands`), and a set of
 // reference wrappers (`Wraps`), make each operand with random values according
 // to the bound from `Bounds`. Then, call
@@ -535,10 +513,7 @@ void test_function_on_vector_operands(
       UniformCustomDistribution<
           tt::get_fundamental_type_t<get_vector_element_type_t<Operands>>>{
           std::get<Is>(bounds)},
-      get_used_for_size(size, Operands{},
-                        cpp17::bool_constant<(
-                            cpp17::is_fundamental_v<Operands> or
-                            tt::is_complex_of_fundamental_v<Operands>)>{}))...);
+      size)...);
   // wrap the tuple of random values according to the passed in `Wraps`
   auto wrapped_operands = wrap_tuple<Wraps...>(
       operand_values, std::make_index_sequence<sizeof...(Bounds)>{});

--- a/tests/Unit/Utilities/Test_TypeTraits.cpp
+++ b/tests/Unit/Utilities/Test_TypeTraits.cpp
@@ -725,6 +725,17 @@ static_assert(not tt::is_complex_of_fundamental_v<DataVector>,
               "Failed testing is_complex_of_fundamental");
 /// [is_complex_of_fundamental]
 
+static_assert(tt::is_complex_or_fundamental_v<std::complex<double>>,
+              "Failed testing is_complex_of_fundamental");
+static_assert(tt::is_complex_or_fundamental_v<std::complex<int>>,
+              "Failed testing is_complex_of_fundamental");
+static_assert(tt::is_complex_or_fundamental_v<double>,
+              "Failed testing is_complex_of_fundamental");
+static_assert(not tt::is_complex_or_fundamental_v<std::complex<DataVector>>,
+              "Failed testing is_complex_of_fundamental");
+static_assert(not tt::is_complex_or_fundamental_v<DataVector>,
+              "Failed testing is_complex_of_fundamental");
+
 namespace {
 // The name syntax is ReturnType_NumberOfArgs_Counter
 // clang-tidy: no non-const references (we need them for testing)

--- a/tests/Utilities/MakeWithRandomValues.hpp
+++ b/tests/Utilities/MakeWithRandomValues.hpp
@@ -62,7 +62,8 @@ struct FillWithRandomValuesImpl<SpinWeighted<T, Spin>> {
       const gsl::not_null<SpinWeighted<T, Spin>*> data,
       const gsl::not_null<UniformRandomBitGenerator*> generator,
       const gsl::not_null<RandomNumberDistribution*> distribution) noexcept {
-    FillWithRandomValuesImpl<T>::apply(&(data->data), generator, distribution);
+    FillWithRandomValuesImpl<T>::apply(&(data->data()), generator,
+                                       distribution);
   }
 };
 
@@ -161,7 +162,9 @@ ReturnType make_with_random_values(
     const gsl::not_null<RandomNumberDistribution*> distribution,
     const T& used_for_size) noexcept {
   auto result = make_with_value<ReturnType>(
-      used_for_size, std::numeric_limits<double>::signaling_NaN());
+      used_for_size,
+      std::numeric_limits<
+          tt::get_fundamental_type_t<ReturnType>>::signaling_NaN());
   fill_with_random_values(make_not_null(&result), generator, distribution);
   return result;
 }


### PR DESCRIPTION
## Proposed changes

This PR provides some adjustments that I have found necessary to use the `SpinWeighted` wrapper in an elegant way for CCE equations. In the process, there are a number of type traits that I have also found useful, provided in separate commits.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

