### PR TITLE
Add build python bindings for Wheeler Environments files

### DIFF
--- a/support/Environments/wheeler_clang.sh
+++ b/support/Environments/wheeler_clang.sh
@@ -63,5 +63,6 @@ spectre_run_cmake() {
           -D CMAKE_CXX_COMPILER=clang++ \
           -D CMAKE_Fortran_COMPILER=gfortran \
           -D MEMORY_ALLOCATOR=SYSTEM \
+          -D BUILD_PYTHON_BINDINGS=on \
           $SPECTRE_HOME
 }

--- a/support/Environments/wheeler_gcc.sh
+++ b/support/Environments/wheeler_gcc.sh
@@ -61,5 +61,6 @@ spectre_run_cmake() {
           -D CMAKE_BUILD_TYPE=Release \
           -D CMAKE_Fortran_COMPILER=gfortran \
           -D MEMORY_ALLOCATOR=SYSTEM \
+          -D BUILD_PYTHON_BINDINGS=on \
           $SPECTRE_HOME
 }


### PR DESCRIPTION
## Proposed changes

<!--
This PR adds to the Wheeler Environments files so that the python libraries are built whenever the code is compiled.
-->

### Types of changes:

- [ ] Bugfix
- [ x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
