### PR TITLE
Allow MAKE_GENERATOR to take a seed

### DIFF
--- a/tests/Unit/Test_TestHelpers.cpp
+++ b/tests/Unit/Test_TestHelpers.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <limits>
 #include <map>
+#include <random>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -133,4 +134,14 @@ SPECTRE_TEST_CASE("Unit.TestHelpers.Derivative", "[Unit]") {
             approx(gsl::at(dfunc(x), i)));
     }
   }
+}
+
+SPECTRE_TEST_CASE("Unit.TestHelpers.MAKE_GENERATOR", "[Unit]") {
+  MAKE_GENERATOR(gen1);
+  MAKE_GENERATOR(gen2);
+  // This will fail randomly every 2**32 runs.  That is probably OK.
+  CHECK(gen1() != gen2());
+
+  MAKE_GENERATOR(seeded_gen, 12345);
+  CHECK(seeded_gen() == 3992670690);
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
