### PR TITLE
Fix memory issue 1018 in DomainHelpers

### DIFF
--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -874,6 +874,14 @@ maps_for_rectilinear_domains(
   std::vector<std::unique_ptr<
       CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
       maps{};
+  // block_orientation_index is the index into orientation_of_all_blocks,
+  // and is equal to IndexIterator.collapsed_index()
+  // except in the case where block_indices_to_exclude.size() != 0. That is,
+  // orientation_of_all_blocks does not get incremented if a block is excluded.
+  // (ii.collapsed_index() is incremented in both case, and if used as the
+  // index into orientation_of_all_blocks would lead to
+  // out-of-bounds indexing into the orientations_of_all_blocks array.
+  size_t block_orientation_index = 0;
   for (IndexIterator<VolumeDim> ii(domain_extents); ii; ++ii) {
     if (std::find(block_indices_to_exclude.begin(),
                   block_indices_to_exclude.end(),
@@ -897,7 +905,8 @@ maps_for_rectilinear_domains(
         }
         if (not orientations_of_all_blocks.empty()) {
           maps.push_back(product_of_1d_maps<TargetFrame>(
-              affine_maps, orientations_of_all_blocks[ii.collapsed_index()]));
+              affine_maps,
+              orientations_of_all_blocks[block_orientation_index]));
         } else {
           maps.push_back(product_of_1d_maps<TargetFrame>(affine_maps));
         }
@@ -911,11 +920,12 @@ maps_for_rectilinear_domains(
         if (not orientations_of_all_blocks.empty()) {
           maps.push_back(product_of_1d_maps<TargetFrame>(
               equiangular_maps,
-              orientations_of_all_blocks[ii.collapsed_index()]));
+              orientations_of_all_blocks[block_orientation_index]));
         } else {
           maps.push_back(product_of_1d_maps<TargetFrame>(equiangular_maps));
         }
       }
+      block_orientation_index++;
     }
   }
   return maps;


### PR DESCRIPTION
## Proposed changes
Closes #1018 
Running with ASAN finds a heap overflow in DomainHelpers. This is caused by an indexing error in `maps_for_rectilinear_domain`. An ASSERT is added such that if an invalid OrientationMap is encountered, the ASSERT is triggered. A test is also added such that the test fails as expected when the mistake is present. Running with ASAN on with this fix results in no heap overflow in DomainHelpers.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
