### PR TITLE
Add GCC8 target to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,7 +198,7 @@ before_install:
   - export DEP_CACHE=$HOME/mac_cache
   - export CHARM_PATCH=v6.8.patch
   - export CHARM_CC=${CC}
-  - export FC=gfortran
+  - export FC=gfortran-8
   - if [[ ${COMPILER} =~ (gcc|clang)-([0-9\.]+) ]]; then
       CC=${BASH_REMATCH[1]}-${BASH_REMATCH[2]};
       if [[ ${BASH_REMATCH[1]} = gcc ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,19 +98,19 @@ jobs:
     name: test check files
 
   # Run full builds after static analysis
-  - &GccDebug
+  - &Gcc7Debug
     os: linux
     compiler: gcc
     dist: trusty
-    env: BUILD_TYPE=Debug COVERAGE=OFF
-    name: gcc debug
+    env: BUILD_TYPE=Debug COVERAGE=OFF COMPILER=gcc-7
+    name: gcc-7 debug
     stage: Build Libraries
-  - &GccRelease
+  - &Gcc7Release
     os: linux
     compiler: gcc
     dist: trusty
-    env: BUILD_TYPE=Release
-    name: gcc release
+    env: BUILD_TYPE=Release COMPILER=gcc-7
+    name: gcc-7 release
   - &Gcc6Debug
     os: linux
     compiler: gcc-6
@@ -123,6 +123,18 @@ jobs:
     dist: trusty
     env: BUILD_TYPE=Release COMPILER=gcc-6
     name: gcc-6 release
+  - &Gcc8Debug
+    os: linux
+    compiler: gcc-8
+    dist: trusty
+    env: BUILD_TYPE=Debug COMPILER=gcc-8
+    name: gcc-8 debug
+  - &Gcc8Release
+    os: linux
+    compiler: gcc-8
+    dist: trusty
+    env: BUILD_TYPE=Release COMPILER=gcc-8
+    name: gcc-8 release
   - &ClangDebug
     os: linux
     compiler: clang
@@ -149,13 +161,15 @@ jobs:
   #   name: osx xcode 9.2 release
 
   # Build and run tests, clang tidy, IWYU, and docs.
-  - <<: *GccDebug
+  - <<: *Gcc7Debug
     stage: Build and Run Tests, ClangTidy, IWYU, and Doxygen
-  - <<: *GccRelease
+  - <<: *Gcc7Release
   - <<: *ClangDebug
   - <<: *ClangRelease
   - <<: *Gcc6Debug
   - <<: *Gcc6Release
+  - <<: *Gcc8Debug
+  - <<: *Gcc8Release
   # - <<: *MacOsDebug9_2
   # - <<: *MacOsRelease9_2
 

--- a/cmake/SetupBuildStageTargets.cmake
+++ b/cmake/SetupBuildStageTargets.cmake
@@ -10,10 +10,6 @@ add_custom_target(test-libs-stage1)
 add_dependencies(test-libs-stage1
   Test_ApparentHorizons
   Test_ControlSystem
-  Test_DataBox
-  Test_EagerMath
-  Test_Expressions
-  Test_Tensor
   Test_DataStructures
   Test_Amr
   Test_CoordinateMaps

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -19,23 +19,26 @@ ARG PARALLEL_MAKE_ARG=-j2
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install required packages for SpECTRE
-RUN apt-get update -y && \
-    apt-get install -y gcc-6 g++-6 gfortran-6 \
-                       gcc-7 g++-7 gfortran-7 \
-                       gcc-8 g++-8 gfortran-8 \
-                       gdb git cmake \
-                       libopenblas-dev liblapack-dev libhdf5-dev hdf5-tools \
-                       libgsl0-dev \
-                       clang-5.0 clang-format-5.0 clang-tidy-5.0 \
-                       libclang-5.0-dev wget libncurses-dev \
-                       lcov cppcheck \
-                       libboost-all-dev \
-                       libssl-dev
+RUN apt-get update -y \
+    && apt-get install -y gcc-6 g++-6 gfortran-6 \
+                          gcc-7 g++-7 gfortran-7 \
+                          gcc-8 g++-8 gfortran-8 \
+                          gdb git cmake \
+                          libopenblas-dev liblapack-dev \
+                          libhdf5-dev hdf5-tools \
+                          libgsl0-dev \
+                          clang-5.0 clang-format-5.0 clang-tidy-5.0 \
+                          libclang-5.0-dev wget libncurses-dev \
+                          lcov cppcheck \
+                          libboost-all-dev \
+                          libssl-dev
 
 # Update is needed to get libc++ correctly
 # Install jemalloc
-RUN apt-get update -y && apt-get install -y libc++-dev libc++1 libc++abi-dev \
-    && apt-get update -y && apt-get install -y libjemalloc1 libjemalloc-dev
+RUN apt-get update -y \
+    && apt-get install -y libc++-dev libc++1 libc++abi-dev \
+    && apt-get update -y \
+    && apt-get install -y libjemalloc1 libjemalloc-dev
 
 # Install ccache to cache compilations for reduced compile time, and Doxygen
 RUN apt-get install -y ccache doxygen
@@ -47,18 +50,21 @@ RUN apt-get install -y python-pip \
     && pip install coverxygen beautifulsoup4 pybtex
 
 # Add ruby gems and install coveralls using gem
-RUN apt-get update -y && apt-get install -y rubygems && \
-    gem install coveralls-lcov
+RUN apt-get update -y \
+    && apt-get install -y rubygems \
+    && gem install coveralls-lcov
 
 # Enable bash-completion by installing it and then adding it to the .bashrc file
-RUN apt-get update -y && apt-get install -y bash-completion && \
-    printf "if [ -f /etc/bash_completion ] && ! shopt -oq posix; then\n\
+RUN apt-get update -y \
+    && apt-get install -y bash-completion \
+    && printf "if [ -f /etc/bash_completion ] && ! shopt -oq posix; then\n\
     . /etc/bash_completion\nfi\n\n" >> /root/.bashrc
 
 # Install LMod which is needed by Spack and set it to load at login
-RUN apt-get update -y && apt-get install -y curl lmod && \
-    printf '. /etc/profile.d/lmod.sh\n' >> /root/.bashrc && \
-    . /etc/profile.d/lmod.sh
+RUN apt-get update -y \
+    && apt-get install -y curl lmod \
+    && printf '. /etc/profile.d/lmod.sh\n' >> /root/.bashrc \
+    && . /etc/profile.d/lmod.sh
 
 # Install Spack to get remaining dependencies
 WORKDIR /work
@@ -80,23 +86,23 @@ RUN printf "\n  openssl:\n    paths:\n      openssl@1.0.2g: /usr\n\
 # The sed commands are necessary because spack fails to find the
 # fortran compilers for an unknown reason. We compile the libraries with GCC6
 # so that we do not need separate versions for GCC6 and GCC7.
-RUN echo "export PATH=\$PATH:/work/spack/bin" >> /root/.bashrc && \
-    echo '. /work/spack/share/spack/setup-env.sh' >> /root/.bashrc && \
-    export PATH=$PATH:/work/spack/bin && \
-    spack compiler find && \
-    sed -i 's@fc: null@fc: /usr/bin/gfortran@' \
-    /root/.spack/linux/compilers.yaml && \
-    sed -i 's@f77: null@f77: /usr/bin/gfortran@' \
+RUN echo "export PATH=\$PATH:/work/spack/bin" >> /root/.bashrc\
+    && echo '. /work/spack/share/spack/setup-env.sh' >> /root/.bashrc \
+    && export PATH=$PATH:/work/spack/bin \
+    && spack compiler find \
+    && sed -i 's@fc: null@fc: /usr/bin/gfortran@' \
+    /root/.spack/linux/compilers.yaml \
+    && sed -i 's@f77: null@f77: /usr/bin/gfortran@' \
     /root/.spack/linux/compilers.yaml
-RUN /work/spack/bin/spack install cmake && \
-    /work/spack/bin/spack install --no-checksum catch@2.1.0 && \
-    /work/spack/bin/spack install brigand@master && \
-    /work/spack/bin/spack install blaze && \
-    /work/spack/bin/spack install gsl%gcc@6.5.0 && \
-    /work/spack/bin/spack install libsharp -openmp -mpi && \
-    /work/spack/bin/spack install libxsmm%gcc@6.5.0 && \
-    /work/spack/bin/spack install yaml-cpp@develop%gcc@6.5.0 && \
-    /work/spack/bin/spack install benchmark%gcc@6.5.0
+RUN /work/spack/bin/spack install cmake \
+    && /work/spack/bin/spack install --no-checksum catch@2.1.0 \
+    && /work/spack/bin/spack install brigand@master \
+    && /work/spack/bin/spack install blaze \
+    && /work/spack/bin/spack install gsl%gcc@6.5.0 \
+    && /work/spack/bin/spack install libsharp -openmp -mpi \
+    && /work/spack/bin/spack install libxsmm%gcc@6.5.0 \
+    && /work/spack/bin/spack install yaml-cpp@develop%gcc@6.5.0 \
+    && /work/spack/bin/spack install benchmark%gcc@6.5.0
 
 # Install include-what-you-use
 # We patch it to allow cyclic includes in boost
@@ -125,38 +131,38 @@ RUN ln -s $(which clang++-5.0) /usr/local/bin/clang++ \
     && ln -s $(which clang-5.0) /usr/local/bin/clang \
     && ln -s $(which clang-format-5.0) /usr/local/bin/clang-format \
     && ln -s $(which clang-tidy-5.0) /usr/local/bin/clang-tidy
-RUN git clone https://charm.cs.illinois.edu/gerrit/charm && \
-    cd /work/charm && \
-    git checkout ${CHARM_GIT_TAG}  && \
-    ./build charm++ multicore-linux64 gcc ${PARALLEL_MAKE_ARG} -g -O0  && \
-    ./build charm++ multicore-linux64 clang ${PARALLEL_MAKE_ARG} -g -O0
-RUN wget https://raw.githubusercontent.com/sxs-collaboration/spectre/develop/support/Charm/v6.8.patch &&\
-    cd /work/charm &&\
-    git apply /work/v6.8.patch
+RUN git clone https://charm.cs.illinois.edu/gerrit/charm \
+    && cd /work/charm \
+    && git checkout ${CHARM_GIT_TAG} \
+    && ./build charm++ multicore-linux64 gcc ${PARALLEL_MAKE_ARG} -g -O0  \
+    && ./build charm++ multicore-linux64 clang ${PARALLEL_MAKE_ARG} -g -O0 \
+    && wget https://raw.githubusercontent.com/sxs-collaboration/spectre/develop/support/Charm/v6.8.patch \
+    && git apply /work/charm/v6.8.patch \
+    && rm /work/charm/v6.8.patch
 
 WORKDIR /work
 
 # Load Spack dependencies at container load
-RUN echo 'spack load catch' >> /root/.bashrc && \
-    echo 'spack load brigand' >> /root/.bashrc && \
-    echo 'spack load blaze' >> /root/.bashrc && \
-    echo 'spack load gsl' >> /root/.bashrc && \
-    echo 'spack load libsharp' >> /root/.bashrc && \
-    echo 'spack load libxsmm' >> /root/.bashrc && \
-    echo 'spack load yaml-cpp' >> /root/.bashrc && \
-    echo 'spack load benchmark' >> /root/.bashrc
+RUN echo 'spack load catch' >> /root/.bashrc \
+    && echo 'spack load brigand' >> /root/.bashrc \
+    && echo 'spack load blaze' >> /root/.bashrc \
+    && echo 'spack load gsl' >> /root/.bashrc \
+    && echo 'spack load libsharp' >> /root/.bashrc \
+    && echo 'spack load libxsmm' >> /root/.bashrc \
+    && echo 'spack load yaml-cpp' >> /root/.bashrc \
+    && echo 'spack load benchmark' >> /root/.bashrc
 
 # - Set the environment variable SPECTRE_CONTAINER so we can check if we are
 #   inside a container (0 is true in bash)
 # - The singularity containers work better if the locale is set properly
 ENV SPECTRE_CONTAINER 0
-RUN apt-get update && apt-get install -y \
-    locales language-pack-fi language-pack-en && \
-    export LANGUAGE=en_US.UTF-8 && \
-    export LANG=en_US.UTF-8 && \
-    export LC_ALL=en_US.UTF-8 && \
-    locale-gen en_US.UTF-8 && \
-    dpkg-reconfigure locales
+RUN apt-get update \
+    && apt-get install -y locales language-pack-fi language-pack-en \
+    && export LANGUAGE=en_US.UTF-8 \
+    && export LANG=en_US.UTF-8 \
+    && export LC_ALL=en_US.UTF-8 \
+    && locale-gen en_US.UTF-8 \
+    && dpkg-reconfigure locales
 
 # Install bibtex for Doxygen bibliography management
 # We first install the TeXLive infrastructure according to the configuration in
@@ -177,8 +183,8 @@ WORKDIR /work
 # Work around posix rename bug:
 #   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=891541
 RUN ln -s /usr/lib/x86_64-linux-gnu/lua/5.1/posix_c.so \
-    /usr/lib/x86_64-linux-gnu/lua/5.1/posix.so && \
-    ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so \
-    /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so && \
-    ln -s /usr/lib/x86_64-linux-gnu/lua/5.3/posix_c.so \
+    /usr/lib/x86_64-linux-gnu/lua/5.1/posix.so \
+    && ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so \
+    /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so \
+    && ln -s /usr/lib/x86_64-linux-gnu/lua/5.3/posix_c.so \
     /usr/lib/x86_64-linux-gnu/lua/5.3/posix.so

--- a/containers/Dockerfile.buildenv
+++ b/containers/Dockerfile.buildenv
@@ -13,13 +13,17 @@
 # someone who does. Since changes to this image effect our testing
 # infrastructure it is important all changes be carefully reviewed.
 
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 ARG PARALLEL_MAKE_ARG=-j2
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install required packages for SpECTRE
 RUN apt-get update -y && \
-    apt-get install -y gcc g++ gfortran gcc-6 g++-6 gfortran-6 gdb git cmake \
+    apt-get install -y gcc-6 g++-6 gfortran-6 \
+                       gcc-7 g++-7 gfortran-7 \
+                       gcc-8 g++-8 gfortran-8 \
+                       gdb git cmake \
                        libopenblas-dev liblapack-dev libhdf5-dev hdf5-tools \
                        libgsl0-dev \
                        clang-5.0 clang-format-5.0 clang-tidy-5.0 \
@@ -88,12 +92,11 @@ RUN /work/spack/bin/spack install cmake && \
     /work/spack/bin/spack install --no-checksum catch@2.1.0 && \
     /work/spack/bin/spack install brigand@master && \
     /work/spack/bin/spack install blaze && \
-    /work/spack/bin/spack install gsl%gcc@6.4.0 && \
+    /work/spack/bin/spack install gsl%gcc@6.5.0 && \
     /work/spack/bin/spack install libsharp -openmp -mpi && \
-    /work/spack/bin/spack install libxsmm%gcc@6.4.0
-# On 09/03/2017 CMake 3.9.0 failed to build with spack
-RUN /work/spack/bin/spack install yaml-cpp@develop%gcc@6.4.0
-RUN /work/spack/bin/spack install benchmark%gcc@6.4.0
+    /work/spack/bin/spack install libxsmm%gcc@6.5.0 && \
+    /work/spack/bin/spack install yaml-cpp@develop%gcc@6.5.0 && \
+    /work/spack/bin/spack install benchmark%gcc@6.5.0
 
 # Install include-what-you-use
 # We patch it to allow cyclic includes in boost
@@ -102,11 +105,11 @@ RUN wget https://github.com/include-what-you-use/include-what-you-use/archive/cl
     && rm clang_5.0.tar.gz \
     && mkdir /work/include-what-you-use-clang_5.0/build \
     && cd /work/include-what-you-use-clang_5.0/ \
-    && sed -i 's^\\\"third_party/^<boost/^' iwyu_include_picker.cc
-WORKDIR /work/include-what-you-use-clang_5.0/build
-RUN cmake -D CMAKE_CXX_COMPILER=clang++-5.0 \
-    -D CMAKE_C_COMPILER=clang-5.0 \
-    -D IWYU_LLVM_ROOT_PATH=/usr/lib/llvm-5.0 .. \
+    && sed -i 's^\\\"third_party/^<boost/^' iwyu_include_picker.cc \
+    && cd /work/include-what-you-use-clang_5.0/build \
+    && cmake -D CMAKE_CXX_COMPILER=clang++-5.0 \
+        -D CMAKE_C_COMPILER=clang-5.0 \
+        -D IWYU_LLVM_ROOT_PATH=/usr/lib/llvm-5.0 .. \
     && make -j2 \
     && make install \
     && cd /work \
@@ -170,3 +173,12 @@ RUN wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz \
             >> /root/.bashrc \
     && /work/texlive/bin/x86_64-linux/tlmgr install bibtex
 WORKDIR /work
+
+# Work around posix rename bug:
+#   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=891541
+RUN ln -s /usr/lib/x86_64-linux-gnu/lua/5.1/posix_c.so \
+    /usr/lib/x86_64-linux-gnu/lua/5.1/posix.so && \
+    ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so \
+    /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so && \
+    ln -s /usr/lib/x86_64-linux-gnu/lua/5.3/posix_c.so \
+    /usr/lib/x86_64-linux-gnu/lua/5.3/posix.so

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -67,23 +67,24 @@ void test_element_impl(
           composed_map.inverse(inertial_point_double).get());
   }
 
-  CHECK(element_map.inv_jacobian(logical_point_dv) ==
-        composed_map.inv_jacobian(logical_point_dv));
-  CHECK(element_map.inv_jacobian(logical_point_double) ==
-        composed_map.inv_jacobian(logical_point_double));
-  CHECK(element_map_deserialized.inv_jacobian(logical_point_dv) ==
-        composed_map.inv_jacobian(logical_point_dv));
-  CHECK(element_map_deserialized.inv_jacobian(logical_point_double) ==
-        composed_map.inv_jacobian(logical_point_double));
+  CHECK_ITERABLE_APPROX(element_map.inv_jacobian(logical_point_dv),
+                        composed_map.inv_jacobian(logical_point_dv));
+  CHECK_ITERABLE_APPROX(element_map.inv_jacobian(logical_point_double),
+                        composed_map.inv_jacobian(logical_point_double));
+  CHECK_ITERABLE_APPROX(element_map_deserialized.inv_jacobian(logical_point_dv),
+                        composed_map.inv_jacobian(logical_point_dv));
+  CHECK_ITERABLE_APPROX(
+      element_map_deserialized.inv_jacobian(logical_point_double),
+      composed_map.inv_jacobian(logical_point_double));
 
-  CHECK(element_map.inv_jacobian(logical_point_dv) ==
-        composed_map.inv_jacobian(logical_point_dv));
-  CHECK(element_map.jacobian(logical_point_double) ==
-        composed_map.jacobian(logical_point_double));
-  CHECK(element_map_deserialized.inv_jacobian(logical_point_dv) ==
-        composed_map.inv_jacobian(logical_point_dv));
-  CHECK(element_map_deserialized.jacobian(logical_point_double) ==
-        composed_map.jacobian(logical_point_double));
+  CHECK_ITERABLE_APPROX(element_map.inv_jacobian(logical_point_dv),
+                        composed_map.inv_jacobian(logical_point_dv));
+  CHECK_ITERABLE_APPROX(element_map.jacobian(logical_point_double),
+                        composed_map.jacobian(logical_point_double));
+  CHECK_ITERABLE_APPROX(element_map_deserialized.inv_jacobian(logical_point_dv),
+                        composed_map.inv_jacobian(logical_point_dv));
+  CHECK_ITERABLE_APPROX(element_map_deserialized.jacobian(logical_point_double),
+                        composed_map.jacobian(logical_point_double));
 
   CHECK(element_map.block_map() ==
         *(make_coordinate_map_base<Frame::Logical, Frame::Inertial>(


### PR DESCRIPTION
## Proposed changes

- Update docker image to Ubuntu 18.04 (long-term support release)
- Add GCC8 to docker image
- Add GCC8 target to travis

### Types of changes:

- [x] New feature

### Component:

- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
