### PR TITLE
Update tolerances for randomized tests for GH system

### DIFF
--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -29,7 +29,6 @@
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 #include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
@@ -90,7 +89,6 @@ void test_characteristic_speeds_analytic(
     const std::array<double, 3>& upper_bound) noexcept {
   // Set up grid
   const size_t spatial_dim = 3;
-  const size_t data_size = pow<spatial_dim>(grid_size_each_dimension);
   Mesh<spatial_dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                          Spectral::Quadrature::GaussLobatto};
 
@@ -191,12 +189,14 @@ void test_characteristic_fields() noexcept {
   pypp::check_with_random_values<1>(
       compute_field_with_tag<GeneralizedHarmonic::Tags::UZero<Dim, Frame>, Dim,
                              Frame>,
-      "TestFunctions", "char_field_uzero", {{{-100., 100.}}}, used_for_size);
+      "TestFunctions", "char_field_uzero", {{{-100., 100.}}}, used_for_size,
+      1.e-10);
   // UPlus
   pypp::check_with_random_values<1>(
       compute_field_with_tag<GeneralizedHarmonic::Tags::UPlus<Dim, Frame>, Dim,
                              Frame>,
-      "TestFunctions", "char_field_uplus", {{{-100., 100.}}}, used_for_size);
+      "TestFunctions", "char_field_uplus", {{{-100., 100.}}}, used_for_size,
+      1.e-11);
   // UMinus
   pypp::check_with_random_values<1>(
       compute_field_with_tag<GeneralizedHarmonic::Tags::UMinus<Dim, Frame>, Dim,
@@ -212,7 +212,6 @@ void test_characteristic_fields_analytic(
     const std::array<double, 3>& upper_bound) noexcept {
   // Set up grid
   const size_t spatial_dim = 3;
-  const size_t data_size = pow<spatial_dim>(grid_size_each_dimension);
   Mesh<spatial_dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                          Spectral::Quadrature::GaussLobatto};
 
@@ -380,7 +379,6 @@ void test_evolved_from_characteristic_fields_analytic(
     const std::array<double, 3>& upper_bound) noexcept {
   // Set up grid
   const size_t spatial_dim = 3;
-  const size_t data_size = pow<spatial_dim>(grid_size_each_dimension);
   Mesh<spatial_dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                          Spectral::Quadrature::GaussLobatto};
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -66,7 +66,8 @@ void test_gauge_constraint_random(const DataType& used_for_size) noexcept {
           const tnsr::aa<DataType, SpatialDim, Frame>&,
           const tnsr::iaa<DataType, SpatialDim, Frame>&)>(
           &GeneralizedHarmonic::gauge_constraint<SpatialDim, Frame, DataType>),
-      "TestFunctions", "gauge_constraint", {{{-10.0, 10.0}}}, used_for_size);
+      "TestFunctions", "gauge_constraint", {{{-10.0, 10.0}}}, used_for_size,
+      1.0e-11);
 }
 
 // Test the return-by-reference gauge constraint by comparing to Kerr-Schild


### PR DESCRIPTION
## Proposed changes

- Fix for #1308. This PR updates tolerances for `check_with_random_values` tests of GH characteristic fields to achieve a reliable success rate (no failure in 1000 repetitions).
- Also fixes a similar issue in #1315


### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
