### PR TITLE
Make temporal_id = Tags::TimeId for Interpolation

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp
@@ -43,7 +43,7 @@ struct AddTemporalIdsToInterpolationTarget {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/,
-                    std::vector<typename Metavariables::temporal_id>&&
+                    std::vector<typename Metavariables::temporal_id::type>&&
                         temporal_ids) noexcept {
     const bool begin_interpolation =
         db::get<Tags::TemporalIds<Metavariables>>(box).empty();

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
@@ -95,7 +95,7 @@ struct ObserveTimeSeriesOnSurface {
   static void apply(
       const db::DataBox<DbTags>& box,
       Parallel::ConstGlobalCache<Metavariables>& cache,
-      const typename Metavariables::temporal_id& temporal_id) noexcept {
+      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
     auto& proxy = Parallel::get_parallel_component<
         observers::ObserverWriter<Metavariables>>(cache);
 

--- a/src/NumericalAlgorithms/Interpolation/CleanUpInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/CleanUpInterpolator.hpp
@@ -67,7 +67,7 @@ struct CleanUpInterpolator {
       const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/,
-      const typename Metavariables::temporal_id& temporal_id) noexcept {
+      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
     // Signal that this InterpolationTarget is done at this time.
     db::mutate<Tags::InterpolatedVarsHolders<Metavariables>>(
         make_not_null(&box),

--- a/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatedVars.hpp
@@ -73,10 +73,10 @@ template <typename Metavariables,
           typename InterpolationTargetTag, typename TagList>
 struct Holder {
   std::unordered_map<
-      typename Metavariables::temporal_id,
+      typename Metavariables::temporal_id::type,
       Info<Metavariables::domain_dim, TagList>>
       infos;
-  std::unordered_set<typename Metavariables::temporal_id>
+  std::unordered_set<typename Metavariables::temporal_id::type>
       temporal_ids_when_data_has_been_interpolated;
 };
 

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -64,7 +64,7 @@ namespace intrp {
 ///```
 ///       static void apply(const DataBox<DbTags>&,
 ///                         const intrp::ConstGlobalCache<Metavariables>&,
-///                         const Metavariables::temporal_id&) noexcept;
+///                         const Metavariables::temporal_id::type&) noexcept;
 ///```
 ///                                  that will be called when interpolation
 ///                                  is complete. `DbTags` includes everything

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp
@@ -156,7 +156,7 @@ struct KerrHorizon {
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/,
-      const typename Metavariables::temporal_id& temporal_id) noexcept {
+      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
     // In the future, when we add support for multiple Frames,
     // the code that transforms coordinates from the Strahlkorper Frame
     // to `Metavariables::domain_frame` will go here.  That transformation

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp
@@ -123,7 +123,7 @@ struct LineSegment {
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/,
-      const typename Metavariables::temporal_id& temporal_id) noexcept {
+      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
     const auto& options = Parallel::get<InterpolationTargetTag>(cache);
 
     // Fill points on a line segment

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp
@@ -190,7 +190,7 @@ struct WedgeSectionTorus {
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/,
-      const typename Metavariables::temporal_id& temporal_id) noexcept {
+      const typename Metavariables::temporal_id::type& temporal_id) noexcept {
     const auto& options = Parallel::get<InterpolationTargetTag>(cache);
 
     // Compute locations of constant r/theta/phi surfaces

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceivePoints.hpp
@@ -71,7 +71,7 @@ struct ReceivePoints {
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/,
-      const typename Metavariables::temporal_id& temporal_id,
+      const typename Metavariables::temporal_id::type& temporal_id,
       std::vector<IdPair<domain::BlockId, tnsr::I<double, VolumeDim,
                                                   typename ::Frame::Logical>>>&&
           block_logical_coords) noexcept {

--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp
@@ -50,7 +50,7 @@ struct InterpolatorReceiveVolumeData {
       Parallel::ConstGlobalCache<Metavariables>& cache,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/,
-      const typename Metavariables::temporal_id& temporal_id,
+      const typename Metavariables::temporal_id::type& temporal_id,
       const ElementId<VolumeDim>& element_id, const ::Mesh<VolumeDim>& mesh,
       Variables<typename Metavariables::interpolator_source_vars>&&
           vars) noexcept {

--- a/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/SendPointsToInterpolator.hpp
@@ -41,7 +41,7 @@ template <typename InterpolationTargetTag, typename DbTags,
 void send_points_to_interpolator(
     db::DataBox<DbTags>& box, Parallel::ConstGlobalCache<Metavariables>& cache,
     const tnsr::I<DataVector, VolumeDim, Frame>& target_points,
-    const typename Metavariables::temporal_id& temporal_id) noexcept {
+    const typename Metavariables::temporal_id::type& temporal_id) noexcept {
   const auto& domain = db::get<::Tags::Domain<VolumeDim, Frame>>(box);
   auto coords = block_logical_coordinates(domain, target_points);
 

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -36,7 +36,7 @@ struct IndicesOfFilledInterpPoints : db::SimpleTag {
 /// `temporal_id`s on which to interpolate.
 template <typename Metavariables>
 struct TemporalIds : db::SimpleTag {
-  using type = std::deque<typename Metavariables::temporal_id>;
+  using type = std::deque<typename Metavariables::temporal_id::type>;
   static std::string name() noexcept { return "TemporalIds"; }
 };
 
@@ -48,7 +48,7 @@ struct VolumeVarsInfo : db::SimpleTag {
     Variables<typename Metavariables::interpolator_source_vars> vars;
   };
   using type = std::unordered_map<
-      typename Metavariables::temporal_id,
+      typename Metavariables::temporal_id::type,
       std::unordered_map<
           ElementId<Metavariables::domain_dim>, Info>>;
   static std::string name() noexcept { return "VolumeVarsInfo"; }

--- a/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
+++ b/src/NumericalAlgorithms/Interpolation/TryToInterpolate.hpp
@@ -36,7 +36,7 @@ template <typename InterpolationTargetTag, typename Metavariables,
           typename DbTags>
 void interpolate_data(
     const gsl::not_null<db::DataBox<DbTags>*> box,
-    const typename Metavariables::temporal_id& temporal_id) noexcept {
+    const typename Metavariables::temporal_id::type& temporal_id) noexcept {
   db::mutate_apply<tmpl::list<Tags::InterpolatedVarsHolders<Metavariables>>,
                    tmpl::list<Tags::VolumeVarsInfo<Metavariables>>>(
       [&temporal_id](
@@ -127,7 +127,7 @@ template <typename InterpolationTargetTag, typename Metavariables,
 void try_to_interpolate(
     const gsl::not_null<db::DataBox<DbTags>*> box,
     const gsl::not_null<Parallel::ConstGlobalCache<Metavariables>*> cache,
-    const typename Metavariables::temporal_id& temporal_id) noexcept {
+    const typename Metavariables::temporal_id::type& temporal_id) noexcept {
   const auto& holders =
       db::get<Tags::InterpolatedVarsHolders<Metavariables>>(*box);
   const auto& vars_infos =

--- a/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp
@@ -26,6 +26,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -93,7 +94,7 @@ struct MockReceivePoints {
       Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/,
-      const typename Metavariables::temporal_id& temporal_id,
+      const typename Metavariables::temporal_id::type& temporal_id,
       std::vector<IdPair<domain::BlockId,
                          tnsr::I<double, VolumeDim, typename Frame::Logical>>>&&
           block_coord_holders) noexcept {
@@ -194,7 +195,7 @@ void test_interpolation_target(
               typename mock_interpolator<metavars>::initial_databox>();
 
   Slab slab(0.0, 1.0);
-  Time temporal_id(slab, 0);
+  TimeId temporal_id(true, 0, Time(slab, 0));
 
   runner.template simple_action<
       mock_interpolation_target<metavars,
@@ -241,7 +242,7 @@ void test_interpolation_target(
   }
 
   // Call again at a different temporal_id
-  Time new_temporal_id(slab, 1);
+  TimeId new_temporal_id(true, 0, Time(slab, 1));
   runner.template simple_action<
       mock_interpolation_target<metavars,
                                 typename metavars::InterpolationTargetA>,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_CleanUpInterpolator.cpp
@@ -16,7 +16,9 @@
 #include "NumericalAlgorithms/Interpolation/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
 #include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/Rational.hpp"
 #include "Utilities/TMPL.hpp"
@@ -58,7 +60,7 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
-  using temporal_id = Time;
+  using temporal_id = ::Tags::TimeId;
   static constexpr size_t domain_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags =
@@ -80,12 +82,12 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.CleanUp", "[Unit]") {
           mock_interpolator<metavars>>;
 
   Slab slab(0.0, 1.0);
-  Time temporal_id(slab, Rational(12, 13));
+  TimeId temporal_id(true, 0, Time(slab, Rational(12, 13)));
 
   // Make a VolumeVarsInfo that contains a single temporal_id but
   // no data (since we don't need data for this test).
   std::unordered_map<
-      typename metavars::temporal_id,
+      typename metavars::temporal_id::type,
       std::unordered_map<ElementId<3>,
                          intrp::Tags::VolumeVarsInfo<metavars>::Info>>
       volume_vars_info{{temporal_id, {}}};

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolationTarget.cpp
@@ -19,7 +19,7 @@
 #include "NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp"
 #include "NumericalAlgorithms/Interpolation/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Time.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
@@ -51,7 +51,7 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
-  using temporal_id = Time;
+  using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;
   static constexpr size_t domain_dim = 3;
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InitializeInterpolator.cpp
@@ -13,10 +13,12 @@
 #include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp"
 #include "NumericalAlgorithms/Interpolation/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Time.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
+
+// IWYU pragma: no_include <boost/variant/get.hpp>
 
 /// \cond
 class DataVector;
@@ -41,7 +43,7 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
-  using temporal_id = Time;
+  using temporal_id = ::Tags::TimeId;
   static constexpr size_t domain_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetKerrHorizon.cpp
@@ -15,7 +15,7 @@
 #include "Domain/Domain.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolationTargetKerrHorizon.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Time.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Spherepack.hpp"
@@ -32,7 +32,7 @@ struct MockMetavariables {
         ::intrp::Actions::KerrHorizon<InterpolationTargetA, ::Frame::Inertial>;
     using type = compute_target_points::options_type;
   };
-  using temporal_id = Time;
+  using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;
   static constexpr size_t domain_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetLineSegment.cpp
@@ -14,7 +14,7 @@
 #include "Domain/Domain.hpp"
 #include "NumericalAlgorithms/Interpolation/InterpolationTargetLineSegment.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Time.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
@@ -28,7 +28,7 @@ struct MockMetavariables {
         ::intrp::Actions::LineSegment<InterpolationTargetA, 3>;
     using type = compute_target_points::options_type;
   };
-  using temporal_id = Time;
+  using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;
   static constexpr size_t domain_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolationTargetWedgeSectionTorus.cpp
@@ -16,7 +16,7 @@
 #include "NumericalAlgorithms/Interpolation/InterpolationTargetWedgeSectionTorus.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Time.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 #include "tests/Unit/NumericalAlgorithms/Interpolation/InterpolationTargetTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
@@ -30,7 +30,7 @@ struct MockMetavariables {
         ::intrp::Actions::WedgeSectionTorus<InterpolationTargetA>;
     using type = compute_target_points::options_type;
   };
-  using temporal_id = Time;
+  using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;
   static constexpr size_t domain_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceivePoints.cpp
@@ -27,12 +27,16 @@
 #include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
 #include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
 #include "Utilities/Rational.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
+
+// IWYU pragma: no_include <boost/variant/get.hpp>
 
 /// \cond
 namespace intrp {
@@ -139,7 +143,7 @@ struct MockMetavariables {
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-  using temporal_id = Time;
+  using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;
   static constexpr size_t domain_dim = 3;
   using component_list = tmpl::list<
@@ -194,7 +198,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceivePoints",
   }
   ();
   Slab slab(0.0, 1.0);
-  Time temporal_id(slab, Rational(11, 15));
+  TimeId temporal_id(true, 0, Time(slab, Rational(11, 15)));
 
   runner.simple_action<
       mock_interpolator<metavars>,

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorReceiveVolumeData.cpp
@@ -39,7 +39,9 @@
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
 #include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
@@ -143,7 +145,7 @@ struct MockInterpolationTargetReceiveVars {
     // This is not the usual usage of Tags::TemporalIds; this is done just
     // for the test.
     Slab slab(0.0, 1.0);
-    Time temporal_id(slab, Rational(111, 135));
+    TimeId temporal_id(true, 0, Time(slab, Rational(111, 135)));
     db::mutate<intrp::Tags::TemporalIds<Metavariables>>(
         make_not_null(&box), [&temporal_id](
                                  const gsl::not_null<db::item_type<
@@ -194,7 +196,7 @@ struct MockMetavariables {
   };
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolationTargetA>;
-  using temporal_id = Time;
+  using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;
   static constexpr size_t domain_dim = 3;
   using component_list = tmpl::list<
@@ -228,7 +230,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
       domain::creators::Shell<Frame::Inertial>(0.9, 4.9, 1, {{7, 7}}, false);
   const auto domain = domain_creator.create_domain();
   Slab slab(0.0, 1.0);
-  Time temporal_id(slab, Rational(11, 15));
+  TimeId temporal_id(true, 0, Time(slab, Rational(11, 15)));
   auto vars_holders = [&domain, &temporal_id]() {
     const size_t n_pts = 15;
     tnsr::I<DataVector, 3, Frame::Inertial> points(n_pts);
@@ -332,7 +334,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.ReceiveVolumeData",
   // by looking for a funny temporal_id that it inserts for the specific
   // purpose of this test.
   CHECK(db::get<intrp::Tags::TemporalIds<metavars>>(box_target).front() ==
-        Time(Slab(0.0, 1.0), Rational(111, 135)));
+        TimeId(true, 0, Time(Slab(0.0, 1.0), Rational(111, 135))));
 
   // No more queued simple actions.
   CHECK(runner.is_simple_action_queue_empty<

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_InterpolatorRegisterElement.cpp
@@ -12,10 +12,12 @@
 #include "NumericalAlgorithms/Interpolation/InterpolatedVars.hpp" // IWYU pragma: keep
 #include "NumericalAlgorithms/Interpolation/InterpolatorRegisterElement.hpp" // IWYU pragma: keep
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
-#include "Time/Time.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
+
+// IWYU pragma: no_include <boost/variant/get.hpp>
 
 /// \cond
 class DataVector;
@@ -45,7 +47,7 @@ struct MockMetavariables {
     using vars_to_interpolate_to_target =
         tmpl::list<gr::Tags::Lapse<DataVector>>;
   };
-  using temporal_id = Time;
+  using temporal_id = ::Tags::TimeId;
   static constexpr size_t domain_dim = 3;
   using interpolator_source_vars = tmpl::list<gr::Tags::Lapse<DataVector>>;
   using interpolation_target_tags = tmpl::list<InterpolatorTargetA>;

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstddef>
 #include <pup.h>
+#include <random>
 #include <string>
 #include <utility>
 #include <vector>
@@ -50,6 +51,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -227,7 +229,7 @@ struct MockMetavariables {
       tmpl::list<Tags::TestSolution,
                  gr::Tags::SpatialMetric<3, Frame::Inertial>>;
   using interpolation_target_tags = tmpl::list<SurfaceA, SurfaceB, SurfaceC>;
-  using temporal_id = TimeId;
+  using temporal_id = ::Tags::TimeId;
   using domain_frame = Frame::Inertial;
   static constexpr size_t domain_dim = 3;
   using component_list =


### PR DESCRIPTION
Previously, in all the Interpolation infrastructure and tests,
Metavariables::temporal_id was either TimeId or Time, depending
on the test (this was inconsistent between different tests).

But EvolveValenciaDivClean defines Metavariables::temporal_id
to be Tags::TimeId, which is neither a Time nor a TimeId, but is instead
a Tag whose type is a TimeId.

This change makes Interpolation consistent with EvolveValenciaDivClean,
by defining Metavariables::temporal_id to be Tags::TimeId everywhere.
This change also allows Interpolation to be used in the
EvolveValenciaDivClean executable (which will be done in a future commit)
because now both can use the same Metavariables::temporal_id.

This changes only NumericalAlgorithms/Interpolation and its tests:

 - Metavariables::temporal_id is now always ::Tags::TimeId
 - All function arguments formerly of type Metavariables::temporal_id
   are now of type Metavariables::temporal_id::type.
 - All internal maps with keys formerly of type Metavariables::temporal_id
   are now of type Metavariables::temporal_id::type.
 - In all cases where `Time`s were explicitly used as function
   arguments, indices of maps, or to compare temporal_id values, these
   have been replaced by `TimeId`s.  This occurred only in the tests;
   the main Interpolation code never explicitly used Time or TimeId,
   only Metavariables::temporal_id.

The changes touch many files, but are trivial.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
