### PR TITLE
Add return-by-ref versions for derivs of lapse

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -309,7 +309,7 @@ Scalar<DataType> time_deriv_of_lapse(
  *  =& \psi^{ja} N t^b \Phi_{iab} - 2 t^j \partial_i N \\
  *  =& N (\psi^{ja} + t^j t^a) t^b \Phi_{iab}.
  * \f}
- * where we used the equation from \ref spatial_deriv_of_lapse for
+ * where we used the equation from spatial_deriv_of_lapse() for
  * \f$\partial_i N\f$.
  */
 template <size_t SpatialDim, typename Frame, typename DataType>

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -203,6 +203,7 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_det_spatial_metric(
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
 // @}
 
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes spatial derivatives of lapse (N) from the generalized
@@ -228,11 +229,20 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_det_spatial_metric(
  * \f]
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
-tnsr::i<DataType, SpatialDim, Frame> spatial_deriv_of_lapse(
+void spatial_deriv_of_lapse(
+    gsl::not_null<tnsr::i<DataType, SpatialDim, Frame>*> deriv_lapse,
     const Scalar<DataType>& lapse,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
 
+template <size_t SpatialDim, typename Frame, typename DataType>
+tnsr::i<DataType, SpatialDim, Frame> spatial_deriv_of_lapse(
+    const Scalar<DataType>& lapse,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+// @}
+
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes time derivative of lapse (N) from the generalized
@@ -263,12 +273,21 @@ tnsr::i<DataType, SpatialDim, Frame> spatial_deriv_of_lapse(
  * \f]
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
+void time_deriv_of_lapse(
+    gsl::not_null<Scalar<DataType>*> dt_lapse, const Scalar<DataType>& lapse,
+    const tnsr::I<DataType, SpatialDim, Frame>& shift,
+    const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
+    const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
+    const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 Scalar<DataType> time_deriv_of_lapse(
     const Scalar<DataType>& lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::A<DataType, SpatialDim, Frame>& spacetime_unit_normal,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi,
     const tnsr::aa<DataType, SpatialDim, Frame>& pi) noexcept;
+// @}
 
 // @{
 /*!


### PR DESCRIPTION
## Proposed changes

This PR adds return-by-reference counterparts to existing return-by-value functions that compute temporal and spatial derivatives of lapse.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
