### PR TITLE
Add Magnetized FM Disk

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -456,6 +456,25 @@
   url            = "http://cdsads.u-strasbg.fr/abs/1999JCoPh.150..199Y",
 }
 
+@article{White2015omx,
+  author         = "White, Christopher J. and Stone, James M. and Gammie,
+                    Charles F.",
+  title          = "{An Extension of the Athena++ Code Framework for GRMHD
+                    Based on Advanced Riemann Solvers and Staggered-Mesh
+                    Constrained Transport}",
+  journal        = "Astrophys. J. Suppl.",
+  volume         = "225",
+  year           = "2016",
+  number         = "2",
+  pages          = "22",
+  doi            = "10.3847/0067-0049/225/2/22",
+  url            = "https://doi.org/10.3847/0067-0049/225/2/22",
+  eprint         = "1511.00943",
+  archivePrefix  = "arXiv",
+  primaryClass   = "astro-ph.HE",
+  SLACcitation   = "%%CITATION = ARXIV:1511.00943;%%"
+}
+
 
 # When editing this file, please follow the guidelines in
 # https://spectre-code.org/writing_good_dox.html#writing_dox_citations.

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY GrMhdAnalyticData)
 set(LIBRARY_SOURCES
   BondiHoyleAccretion.cpp
   CylindricalBlastWave.cpp
+  MagnetizedFmDisk.cpp
   OrszagTangVortex.cpp
   )
 
@@ -16,4 +17,5 @@ target_link_libraries(
   INTERFACE DataStructures
   INTERFACE ErrorHandling
   INTERFACE Hydro
+  INTERFACE RelativisticEulerSolutions
   )

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.cpp
@@ -1,0 +1,274 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <ostream>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+namespace grmhd {
+namespace AnalyticData {
+
+MagnetizedFmDisk::MagnetizedFmDisk(
+    const double bh_mass, const double bh_dimless_spin,
+    const double inner_edge_radius, const double max_pressure_radius,
+    const double polytropic_constant, const double polytropic_exponent,
+    const double threshold_density, const double inverse_plasma_beta,
+    const size_t normalization_grid_res) noexcept
+    : RelativisticEuler::Solutions::FishboneMoncriefDisk(
+          bh_mass, bh_dimless_spin, inner_edge_radius, max_pressure_radius,
+          polytropic_constant, polytropic_exponent),
+      threshold_density_(threshold_density),
+      inverse_plasma_beta_(inverse_plasma_beta),
+      normalization_grid_res_(normalization_grid_res),
+      kerr_schild_coords_{bh_mass, bh_dimless_spin} {
+  ASSERT(threshold_density_ > 0.0 and threshold_density_ < 1.0,
+         "The threshold density must be in the range (0, 1). The value given "
+         "was "
+             << threshold_density_ << ".");
+  ASSERT(inverse_plasma_beta_ >= 0.0,
+         "The inverse plasma beta must be non-negative. The value given "
+         "was "
+             << inverse_plasma_beta_ << ".");
+  ASSERT(normalization_grid_res_ >= 4,
+         "The grid resolution used in the magnetic field normalization must be "
+         "at least 4 points. The value given was "
+             << normalization_grid_res_);
+
+  // The normalization of the magnetic field is determined by the condition
+  //
+  // plasma beta = pgas_max / pmag_max
+  //
+  // where pgas_max and pmag_max are the maximum values of the gas and magnetic
+  // pressure over the domain, respectively. pgas_max is obtained by
+  // evaluating the pressure of the Fishbone-Moncrief solution at the
+  // corresponding radius. In order to compare with other groups, pmag_max is
+  // obtained by precomputing the unnormalized magnetic field and then
+  // finding the maximum of the comoving field squared on a given grid.
+  // Following the CodeComparisonProject files, we choose to find the maximum
+  // on a spherical grid as described below.
+
+  // Set up a Kerr ("spherical Kerr-Schild") grid of constant phi = 0,
+  // whose parameterization in Cartesian Kerr-Schild coordinates is
+  // x(r, theta) = r sin_theta,
+  // y(r, theta) = a sin_theta,
+  // z(r, theta) = r cos_theta.
+  const double r_init = inner_edge_radius_ * bh_mass_;
+  const double r_fin = max_pressure_radius_ * bh_mass_;
+  const double dr = (r_fin - r_init) / normalization_grid_res_;
+  const double dtheta = M_PI / normalization_grid_res_;
+  const double cartesian_n_pts = square(normalization_grid_res_);
+  Index<2> extents(normalization_grid_res_, normalization_grid_res_);
+  auto grid =
+      make_with_value<tnsr::I<DataVector, 3>>(DataVector(cartesian_n_pts), 0.0);
+  for (size_t i = 0; i < normalization_grid_res_; ++i) {
+    double r_i = r_init + static_cast<double>(i) * dr;
+    for (size_t j = 0; j < normalization_grid_res_; ++j) {
+      double sin_theta_j = sin(static_cast<double>(j) * dtheta);
+      auto index = collapsed_index(Index<2>{i, j}, extents);
+      get<0>(grid)[index] = r_i * sin_theta_j;
+      get<1>(grid)[index] = bh_spin_a_ * sin_theta_j;
+      get<2>(grid)[index] = r_i * cos(static_cast<double>(j) * dtheta);
+    }
+  }
+
+  const auto b_field = unnormalized_magnetic_field(grid);
+  const auto spatial_metric = get<
+      gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>(variables(
+      grid,
+      tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>>{}));
+
+  const tnsr::I<double, 3, Frame::Inertial> x_max{
+      {{max_pressure_radius_, bh_spin_a_, 0.0}}};
+
+  const double b_squared_max = max(
+      get(dot_product(b_field, b_field, spatial_metric)) /
+          square(get(get<hydro::Tags::LorentzFactor<DataVector>>(variables(
+              grid, tmpl::list<hydro::Tags::LorentzFactor<DataVector>>{})))) +
+      square(get(dot_product(
+          b_field,
+          get<hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>>(
+              variables(grid, tmpl::list<hydro::Tags::SpatialVelocity<
+                                  DataVector, 3, Frame::Inertial>>{})),
+          spatial_metric))));
+  ASSERT(b_squared_max > 0.0, "Max b squared is zero.");
+  b_field_normalization_ =
+      sqrt(2.0 *
+           get(get<hydro::Tags::Pressure<double>>(
+               variables(x_max, tmpl::list<hydro::Tags::Pressure<double>>{}))) *
+           inverse_plasma_beta_ / b_squared_max);
+}
+
+void MagnetizedFmDisk::pup(PUP::er& p) noexcept {
+  RelativisticEuler::Solutions::FishboneMoncriefDisk::pup(p);
+  p | threshold_density_;
+  p | inverse_plasma_beta_;
+  p | b_field_normalization_;
+  p | normalization_grid_res_;
+  p | kerr_schild_coords_;
+}
+
+template <typename DataType>
+tnsr::I<DataType, 3, Frame::Inertial>
+MagnetizedFmDisk::unnormalized_magnetic_field(
+    const tnsr::I<DataType, 3, Frame::Inertial>& x) const noexcept {
+  auto magnetic_field =
+      make_with_value<tnsr::I<DataType, 3, Frame::NoFrame>>(x, 0.0);
+
+  // The maximum pressure (and hence the maximum rest mass density) is located
+  // on the ring x^2 + y^2 = r_max^2 + a^2, z = 0.
+  // Note that `x` may or may not include points on this ring.
+  const tnsr::I<double, 3, Frame::Inertial> x_max{
+      {{max_pressure_radius_, bh_spin_a_, 0.0}}};
+  const double threshold_rest_mass_density =
+      threshold_density_ *
+      get(get<hydro::Tags::RestMassDensity<double>>(variables(
+          x_max, tmpl::list<hydro::Tags::RestMassDensity<double>>{})));
+
+  const double inner_edge_potential =
+      fm_disk::potential(square(inner_edge_radius_), 1.0);
+
+  // A_phi \propto rho - rho_threshold. Normalization comes later.
+  const auto mag_potential =
+      [ this, &threshold_rest_mass_density, &inner_edge_potential ](
+          const double& r, const double& sin_theta_squared) noexcept {
+    // enthalpy = exp(Win - W(r,theta)), as in the Fishbone-Moncrief disk
+    return get(equation_of_state_.rest_mass_density_from_enthalpy(
+               Scalar<double>{
+                   exp(inner_edge_potential -
+                       fm_disk::potential(square(r), sin_theta_squared))})) -
+           threshold_rest_mass_density;
+  };
+
+  // The magnetic field is present only within the disk, where the
+  // rest mass density is greater than the threshold rest mass density.
+  const DataType rest_mass_density =
+      get(get<hydro::Tags::RestMassDensity<DataType>>(
+          variables(x, tmpl::list<hydro::Tags::RestMassDensity<DataType>>{})));
+  for (size_t s = 0; s < get_size(get<0>(x)); ++s) {
+    if (get_element(rest_mass_density, s) > threshold_rest_mass_density) {
+      // The magnetic field is defined in terms of the Faraday tensor in Kerr
+      // (r, theta, phi) coordinates. We need to get B^r, B^theta, B^phi first,
+      // then we transform to Cartesian coordinates.
+      const double z_squared = square(get_element(get<2>(x), s));
+      const double a_squared = bh_spin_a_ * bh_spin_a_;
+
+      double sin_theta_squared =
+          square(get_element(get<0>(x), s)) + square(get_element(get<1>(x), s));
+      double r_squared = 0.5 * (sin_theta_squared + z_squared - a_squared);
+      r_squared += sqrt(square(r_squared) + a_squared * z_squared);
+      sin_theta_squared /= (r_squared + a_squared);
+
+      // B^i is proportional to derivatives of the magnetic potential. One has
+      //
+      // B^r = sqrt(gamma) * \partial_\theta A_\phi
+      // B^\theta = -sqrt(gamma) * \partial_r A_\phi
+      //
+      // where sqrt(gamma) = sqrt( sigma (sigma + 2Mr) ) * sin\theta.
+      const double radius = sqrt(r_squared);
+      const double sin_theta = sqrt(sin_theta_squared);
+      double prefactor = r_squared + square(bh_spin_a_) * z_squared / r_squared;
+      prefactor *= (prefactor + 2.0 * bh_mass_ * radius);
+
+      // As done by SpEC and other groups, we approximate the derivatives
+      // with a 2nd-order centered finite difference expression.
+      // For simplicity, we set \delta r = \delta\theta = small number.
+      const double small = 0.0001 * bh_mass_;
+      prefactor = 2.0 * small * sqrt(prefactor) * sin_theta;
+      prefactor = 1.0 / prefactor;
+
+      // Since the metric, and thus the field, depend on theta through
+      // sin^2(theta) only, we use chain rule in B^\theta and write
+      //
+      // d/d\theta = 2 * sin\theta * cos\theta * d/d(sin^2(theta)),
+      //
+      // where cos\theta = z/r.
+      get_element(get<0>(magnetic_field), s) =
+          2.0 * prefactor * sin_theta * get_element(get<2>(x), s) *
+          (mag_potential(radius, sin_theta_squared + small) -
+           mag_potential(radius, sin_theta_squared - small)) /
+          radius;
+      get_element(get<1>(magnetic_field), s) =
+          prefactor * (mag_potential(radius - small, sin_theta_squared) -
+                       mag_potential(radius + small, sin_theta_squared));
+      // phi component of the field vanishes identically.
+    }
+  }
+  return kerr_schild_coords_.cartesian_from_spherical_ks(
+      std::move(magnetic_field), x);
+}
+
+template <typename DataType, bool NeedSpacetime>
+tuples::TaggedTuple<hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>
+MagnetizedFmDisk::variables(
+    const tnsr::I<DataType, 3>& x,
+    tmpl::list<
+        hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>> /*meta*/,
+    const IntermediateVariables<DataType, NeedSpacetime>& /*vars*/,
+    const size_t /*index*/) const noexcept {
+  auto result = unnormalized_magnetic_field(x);
+  for (size_t i = 0; i < 3; ++i) {
+    result.get(i) *= b_field_normalization_;
+  }
+  return result;
+}
+
+bool operator==(const MagnetizedFmDisk& lhs,
+                const MagnetizedFmDisk& rhs) noexcept {
+  using fm_disk = MagnetizedFmDisk::fm_disk;
+  return *static_cast<const fm_disk*>(&lhs) ==
+             *static_cast<const fm_disk*>(&rhs) and
+         lhs.threshold_density_ == rhs.threshold_density_ and
+         lhs.inverse_plasma_beta_ == rhs.inverse_plasma_beta_ and
+         lhs.b_field_normalization_ == rhs.b_field_normalization_ and
+         lhs.normalization_grid_res_ == rhs.normalization_grid_res_;
+}
+
+bool operator!=(const MagnetizedFmDisk& lhs,
+                const MagnetizedFmDisk& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define NEED_SPACETIME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                            \
+  template tuples::TaggedTuple<                                         \
+      hydro::Tags::MagneticField<DTYPE(data), 3, Frame::Inertial>>      \
+  MagnetizedFmDisk::variables(                                          \
+      const tnsr::I<DTYPE(data), 3>& x,                                 \
+      tmpl::list<hydro::Tags::MagneticField<DTYPE(data), 3,             \
+                                            Frame::Inertial>> /*meta*/, \
+      const FishboneMoncriefDisk::IntermediateVariables<                \
+          DTYPE(data), NEED_SPACETIME(data)>& vars,                     \
+      const size_t) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (true, false))
+
+#undef DTYPE
+#undef NEED_SPACETIME
+#undef INSTANTIATE
+}  // namespace AnalyticData
+}  // namespace grmhd
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp
@@ -1,0 +1,204 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/Options.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp"
+#include "PointwiseFunctions/GeneralRelativity/KerrSchildCoords.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+
+// IWYU pragma:  no_include <pup.h>
+
+/// \cond
+namespace PUP {
+class er;  // IWYU pragma: keep
+}  // namespace PUP
+/// \endcond
+
+namespace grmhd {
+namespace AnalyticData {
+
+/*!
+ * \brief Magnetized fluid disk orbiting a Kerr black hole.
+ *
+ * In the context of simulating accretion disks, this class implements a widely
+ * used (e.g. \cite Gammie2003, \cite Porth2016rfi, \cite White2015omx)
+ * initial setup for the GRMHD variables, consisting of a Fishbone-Moncrief disk
+ * \cite Fishbone1976apj (see also
+ * RelativisticEuler::Solutions::FishboneMoncriefDisk),
+ * threaded by a weak poloidal magnetic field. The magnetic field is constructed
+ * from an axially symmetric toroidal magnetic potential which, in Kerr
+ * ("spherical Kerr-Schild") coordinates, has the form
+ *
+ * \f{align*}
+ * A_\phi(r,\theta) \propto \text{max}(\rho(r,\theta) - \rho_\text{thresh}, 0),
+ * \f}
+ *
+ * where \f$\rho_\text{thresh}\f$ is a user-specified threshold density that
+ * confines the magnetic flux to exist inside of the fluid disk only. A commonly
+ * used value for this parameter is
+ * \f$\rho_\text{thresh} = 0.2\rho_\text{max}\f$, where \f$\rho_\text{max}\f$
+ * is the maximum value of
+ * the rest mass density in the disk. Using this potential, the Eulerian
+ * magnetic field takes the form
+ *
+ * \f{align*}
+ * B^r = \frac{F_{\theta\phi}}{\sqrt{\gamma}},\quad
+ * B^\theta = \frac{F_{\phi r}}{\sqrt{\gamma}},\quad B^\phi = 0,
+ * \f}
+ *
+ * where \f$F_{ij} = \partial_i A_j - \partial_j A_i\f$ are the spatial
+ * components of the Faraday tensor, and \f$\gamma\f$ is the determinant of the
+ * spatial metric. The magnetic field is then normalized so that the
+ * plasma-\f$\beta\f$ parameter, \f$\beta = 2p/b^2\f$, equals some value
+ * specified by the user. Here, \f$p\f$ is the fluid pressure, and
+ *
+ * \f{align*}
+ * b^2 = b^\mu b_\mu = \frac{B_iB^i}{W^2} + (B^iv_i)^2
+ * \f}
+ *
+ * is the norm of the magnetic field in the fluid frame, with \f$v_i\f$ being
+ * the spatial velocity, and \f$W\f$ the Lorentz factor.
+ */
+class MagnetizedFmDisk
+    : public RelativisticEuler::Solutions::FishboneMoncriefDisk {
+ private:
+  using fm_disk = RelativisticEuler::Solutions::FishboneMoncriefDisk;
+
+ public:
+  /// The rest mass density (in units of the maximum rest mass density in the
+  /// disk) below which the matter in the disk is initially unmagetized.
+  struct ThresholdDensity {
+    using type = double;
+    static constexpr OptionString help = {
+        "Frac. rest mass density below which B-field vanishes."};
+    static type lower_bound() { return 0.0; }
+    static type upper_bound() { return 1.0; }
+  };
+  /// The maximum-magnetic-pressure-to-maximum-fluid-pressure ratio.
+  struct InversePlasmaBeta {
+    using type = double;
+    static constexpr OptionString help = {
+        "Ratio of max magnetic pressure to max fluid pressure."};
+    static type lower_bound() { return 0.0; }
+  };
+  /// Grid resolution used in magnetic field normalization.
+  struct BFieldNormGridRes {
+    using type = size_t;
+    static constexpr OptionString help = {
+        "Grid Resolution for b-field normalization."};
+    static type default_value() { return 255; }
+    static type lower_bound() { return 4; }
+  };
+
+  using options = tmpl::push_back<fm_disk::options, ThresholdDensity,
+                                  InversePlasmaBeta, BFieldNormGridRes>;
+
+  static constexpr OptionString help = {"Magnetized Fishbone-Moncrief disk."};
+
+  MagnetizedFmDisk() = default;
+  MagnetizedFmDisk(const MagnetizedFmDisk& /*rhs*/) = delete;
+  MagnetizedFmDisk& operator=(const MagnetizedFmDisk& /*rhs*/) = delete;
+  MagnetizedFmDisk(MagnetizedFmDisk&& /*rhs*/) noexcept = default;
+  MagnetizedFmDisk& operator=(MagnetizedFmDisk&& /*rhs*/) noexcept = default;
+  ~MagnetizedFmDisk() = default;
+
+  MagnetizedFmDisk(double bh_mass, double bh_dimless_spin,
+                   double inner_edge_radius, double max_pressure_radius,
+                   double polytropic_constant, double polytropic_exponent,
+                   double threshold_density, double inverse_plasma_beta,
+                   size_t normalization_grid_res =
+                       BFieldNormGridRes::default_value()) noexcept;
+
+  // Overload the variables function from the base class.
+  using fm_disk::variables;
+
+  // @{
+  /// The grmhd variables in Cartesian Kerr-Schild coordinates at `(x, t)`
+  ///
+  /// \note The functions are optimized for retrieving the hydro variables
+  /// before the metric variables.
+  template <typename DataType, typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(const tnsr::I<DataType, 3>& x,
+                                         tmpl::list<Tags...> /*meta*/) const
+      noexcept {
+    // Can't store IntermediateVariables as member variable because we
+    // need to be threadsafe.
+    constexpr double dummy_time = 0.0;
+    IntermediateVariables<
+        DataType,
+        tmpl2::flat_any_v<(
+            cpp17::is_same_v<Tags, hydro::Tags::SpatialVelocity<DataType, 3>> or
+            cpp17::is_same_v<Tags, hydro::Tags::LorentzFactor<DataType>> or
+            not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tags>)...>>
+        vars(bh_spin_a_, background_spacetime_, x, dummy_time,
+             index_helper(
+                 tmpl::index_of<tmpl::list<Tags...>,
+                                hydro::Tags::SpatialVelocity<DataType, 3>>{}),
+             index_helper(
+                 tmpl::index_of<tmpl::list<Tags...>,
+                                hydro::Tags::LorentzFactor<DataType>>{}));
+    return {std::move(get<Tags>(
+        variables(x, tmpl::list<Tags>{}, vars,
+                  tmpl::index_of<tmpl::list<Tags...>, Tags>::value)))...};
+  }
+
+  template <typename DataType, typename Tag>
+  tuples::TaggedTuple<Tag> variables(const tnsr::I<DataType, 3>& x,
+                                     tmpl::list<Tag> /*meta*/) const noexcept {
+    // Can't store IntermediateVariables as member variable because we need to
+    // be threadsafe.
+    constexpr double dummy_time = 0.0;
+    IntermediateVariables<
+        DataType,
+        cpp17::is_same_v<Tag, hydro::Tags::SpatialVelocity<DataType, 3>> or
+            cpp17::is_same_v<Tag, hydro::Tags::LorentzFactor<DataType>> or
+            not tmpl::list_contains_v<hydro::grmhd_tags<DataType>, Tag>>
+        intermediate_vars(bh_spin_a_, background_spacetime_, x, dummy_time,
+                          std::numeric_limits<size_t>::max(),
+                          std::numeric_limits<size_t>::max());
+    return variables(x, tmpl::list<Tag>{}, intermediate_vars, 0);
+  }
+  // @}
+
+  // clang-tidy: no runtime references
+  void pup(PUP::er& /*p*/) noexcept;  //  NOLINT
+
+ private:
+  template <typename DataType, bool NeedSpacetime>
+  auto variables(
+      const tnsr::I<DataType, 3>& x,
+      tmpl::list<
+          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>> /*meta*/,
+      const IntermediateVariables<DataType, NeedSpacetime>& vars,
+      size_t index) const noexcept
+      -> tuples::TaggedTuple<
+          hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>>;
+
+  template <typename DataType>
+  tnsr::I<DataType, 3, Frame::Inertial> unnormalized_magnetic_field(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x) const noexcept;
+
+  friend bool operator==(const MagnetizedFmDisk& lhs,
+                         const MagnetizedFmDisk& rhs) noexcept;
+
+  double threshold_density_ = std::numeric_limits<double>::signaling_NaN();
+  double inverse_plasma_beta_ = std::numeric_limits<double>::signaling_NaN();
+  double b_field_normalization_ = std::numeric_limits<double>::signaling_NaN();
+  size_t normalization_grid_res_ = 255;
+  gr::KerrSchildCoords kerr_schild_coords_{};
+};
+
+bool operator!=(const MagnetizedFmDisk& lhs,
+                const MagnetizedFmDisk& rhs) noexcept;
+
+}  // namespace AnalyticData
+}  // namespace grmhd

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.hpp
@@ -149,6 +149,7 @@ namespace Solutions {
  * distinguish this quantity from their own definition \f$l = - u_\phi/u_t\f$.
  */
 class FishboneMoncriefDisk {
+ protected:
   template <typename DataType, bool NeedSpacetime>
   struct IntermediateVariables;
 
@@ -303,7 +304,7 @@ class FishboneMoncriefDisk {
     return equation_of_state_;
   }
 
- private:
+ protected:
   template <typename DataType, bool NeedSpacetime>
   auto variables(const tnsr::I<DataType, 3>& x,
                  tmpl::list<hydro::Tags::RestMassDensity<DataType>> /*meta*/,

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_GrMhdAnalyticData")
 set(LIBRARY_SOURCES
   Test_BondiHoyleAccretion.cpp
   Test_CylindricalBlastWave.cpp
+  Test_MagnetizedFmDisk.cpp
   Test_OrszagTangVortex.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.py
@@ -1,0 +1,140 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+import PointwiseFunctions.AnalyticSolutions.\
+    RelativisticEuler.FishboneMoncriefDisk as fm_disk
+import PointwiseFunctions.GeneralRelativity.KerrSchildCoords as ks_coords
+
+
+
+def rest_mass_density(x, bh_mass, bh_dimless_spin, dimless_r_in, dimless_r_max,
+                      polytropic_constant, polytropic_exponent,
+                      threshold_density, plasma_beta):
+    dummy_time = 0.0
+    return fm_disk.rest_mass_density(x, dummy_time, bh_mass, bh_dimless_spin,
+                                     dimless_r_in, dimless_r_max,
+                                     polytropic_constant, polytropic_exponent)
+
+
+def spatial_velocity(x, bh_mass, bh_dimless_spin, dimless_r_in, dimless_r_max,
+                     polytropic_constant, polytropic_exponent,
+                     threshold_density, plasma_beta):
+    dummy_time = 0.0
+    return fm_disk.spatial_velocity(x, dummy_time, bh_mass, bh_dimless_spin,
+                                    dimless_r_in, dimless_r_max,
+                                    polytropic_constant, polytropic_exponent)
+
+
+def specific_internal_energy(x, bh_mass, bh_dimless_spin, dimless_r_in,
+                             dimless_r_max, polytropic_constant,
+                             polytropic_exponent, threshold_density,
+                             plasma_beta):
+    dummy_time = 0.0
+    return fm_disk.specific_internal_energy(x, dummy_time, bh_mass,
+                                            bh_dimless_spin, dimless_r_in,
+                                            dimless_r_max, polytropic_constant,
+                                            polytropic_exponent)
+
+
+def pressure(x, bh_mass, bh_dimless_spin, dimless_r_in, dimless_r_max,
+             polytropic_constant, polytropic_exponent, threshold_density,
+             plasma_beta):
+    dummy_time = 0.0
+    return fm_disk.pressure(x, dummy_time, bh_mass, bh_dimless_spin,
+                            dimless_r_in, dimless_r_max, polytropic_constant,
+                            polytropic_exponent)
+
+
+def magnetic_potential(r, sin_theta_sqrd, m, a, rin, rmax, polytropic_constant,
+                       polytropic_exponent, threshold_rest_mass_density):
+    l = fm_disk.angular_momentum(m, a, rmax)
+    Win = fm_disk.potential(l, rin**2, 1.0, m, a)
+    h = np.exp(Win - fm_disk.potential(l, r**2, sin_theta_sqrd, m, a))
+    return pow((h - 1.0) * (polytropic_exponent - 1.0) /
+               (polytropic_constant * polytropic_exponent),
+               1.0 / (polytropic_exponent - 1.0)) - threshold_rest_mass_density
+
+
+def magnetic_field(x, bh_mass, bh_dimless_spin, dimless_r_in, dimless_r_max,
+                   polytropic_constant, polytropic_exponent, threshold_density,
+                   plasma_beta):
+    dummy_time = 0.0
+    result = np.zeros(3)
+    spin_a = bh_mass * bh_dimless_spin
+    r_in = bh_mass * dimless_r_in
+    r_max = bh_mass * dimless_r_max
+    rho = fm_disk.rest_mass_density(x, dummy_time, bh_mass, bh_dimless_spin,
+                                    dimless_r_in, dimless_r_max,
+                                    polytropic_constant, polytropic_exponent)
+    x_max = np.array([r_max, spin_a, 0.0])
+    threshold_rho = (threshold_density *
+                     (fm_disk.rest_mass_density(x_max, dummy_time, bh_mass,
+                                                bh_dimless_spin, dimless_r_in,
+                                                dimless_r_max,
+                                                polytropic_constant,
+                                                polytropic_exponent)))
+    if (rho > threshold_rho):
+        small = 0.0001 * bh_mass
+        a_squared = spin_a**2
+        sin_theta_squared = x[0]**2 + x[1]**2
+        r_squared = 0.5 * (sin_theta_squared + x[2]**2 - a_squared)
+        r_squared += np.sqrt(r_squared**2 + a_squared * x[2]**2)
+        sin_theta_squared /= (r_squared + a_squared)
+
+        r = np.sqrt(r_squared)
+        sin_theta = np.sqrt(sin_theta_squared)
+        sigma = r_squared + a_squared * x[2]**2 / r_squared
+        prefactor = np.sqrt(sigma * (sigma + 2.0 * bh_mass * r)) * sin_theta
+        prefactor = 1.0 / (2.0 * small * prefactor)
+        result[0] = ((magnetic_potential(r, sin_theta_squared + small, bh_mass,
+                                         spin_a, r_in, r_max,
+                                         polytropic_constant,
+                                         polytropic_exponent, threshold_rho) -
+                      magnetic_potential(r, sin_theta_squared - small, bh_mass,
+                                         spin_a, r_in, r_max,
+                                         polytropic_constant,
+                                         polytropic_exponent, threshold_rho)) *
+                     2.0 * prefactor * sin_theta * x[2]) / r
+        result[1] = (magnetic_potential(r - small, sin_theta_squared, bh_mass,
+                                        spin_a, r_in, r_max,
+                                        polytropic_constant,
+                                        polytropic_exponent, threshold_rho) -
+                     magnetic_potential(r + small, sin_theta_squared, bh_mass,
+                                        spin_a, r_in, r_max,
+                                        polytropic_constant,
+                                        polytropic_exponent,
+                                        threshold_rho)) * prefactor
+
+    # This normalization is specific for the default normalization resolution
+    # grid and for the specific member variables of the disk in test_variables
+    normalization = 1.7162625566578704
+    return (normalization *
+            ks_coords.cartesian_from_spherical_ks(result, x, bh_mass,
+                                                  bh_dimless_spin))
+
+
+def divergence_cleaning_field(x, bh_mass, bh_dimless_spin, dimless_r_in,
+                              dimless_r_max, polytropic_constant,
+                              polytropic_exponent, threshold_density,
+                              plasma_beta):
+    return 0.0
+
+
+def lorentz_factor(x, bh_mass, bh_dimless_spin, dimless_r_in, dimless_r_max,
+                   polytropic_constant, polytropic_exponent, threshold_density,
+                   plasma_beta):
+    dummy_time = 0.0
+    return fm_disk.lorentz_factor(x, dummy_time, bh_mass, bh_dimless_spin,
+                                  dimless_r_in, dimless_r_max,
+                                  polytropic_constant, polytropic_exponent)
+
+
+def specific_enthalpy(x, bh_mass, bh_dimless_spin, dimless_r_in, dimless_r_max,
+                      polytropic_constant, polytropic_exponent,
+                      threshold_density, plasma_beta):
+    dummy_time = 0.0
+    return fm_disk.specific_enthalpy(x, dummy_time, bh_mass, bh_dimless_spin,
+                                     dimless_r_in, dimless_r_max,
+                                     polytropic_constant, polytropic_exponent)

--- a/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/GrMhd/Test_MagnetizedFmDisk.cpp
@@ -1,0 +1,344 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <tuple>
+
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataVector.hpp"        // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "ErrorHandling/Error.hpp"
+#include "Options/Options.hpp"
+#include "Options/ParseOptions.hpp"
+#include "PointwiseFunctions/AnalyticData/GrMhd/MagnetizedFmDisk.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+namespace {
+struct MagnetizedFmDiskProxy : grmhd::AnalyticData::MagnetizedFmDisk {
+  using grmhd::AnalyticData::MagnetizedFmDisk::MagnetizedFmDisk;
+
+  template <typename DataType>
+  using hydro_variables_tags =
+      tmpl::list<hydro::Tags::RestMassDensity<DataType>,
+                 hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>,
+                 hydro::Tags::SpecificInternalEnergy<DataType>,
+                 hydro::Tags::Pressure<DataType>,
+                 hydro::Tags::LorentzFactor<DataType>,
+                 hydro::Tags::SpecificEnthalpy<DataType>>;
+
+  template <typename DataType>
+  using grmhd_variables_tags =
+      tmpl::push_back<hydro_variables_tags<DataType>,
+                      hydro::Tags::MagneticField<DataType, 3, Frame::Inertial>,
+                      hydro::Tags::DivergenceCleaningField<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<hydro_variables_tags<DataType>>
+  hydro_variables(const tnsr::I<DataType, 3>& x) const noexcept {
+    return variables(x, hydro_variables_tags<DataType>{});
+  }
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<grmhd_variables_tags<DataType>>
+  grmhd_variables(const tnsr::I<DataType, 3>& x) const noexcept {
+    return variables(x, grmhd_variables_tags<DataType>{});
+  }
+};
+
+void test_create_from_options() noexcept {
+  const auto disk = test_creation<grmhd::AnalyticData::MagnetizedFmDisk>(
+      "  BhMass: 1.3\n"
+      "  BhDimlessSpin: 0.345\n"
+      "  InnerEdgeRadius: 6.123\n"
+      "  MaxPressureRadius: 14.2\n"
+      "  PolytropicConstant: 0.065\n"
+      "  PolytropicExponent: 1.654\n"
+      "  ThresholdDensity: 0.42\n"
+      "  InversePlasmaBeta: 85.0\n"
+      "  BFieldNormGridRes: 6");
+  CHECK(disk == grmhd::AnalyticData::MagnetizedFmDisk(
+                    1.3, 0.345, 6.123, 14.2, 0.065, 1.654, 0.42, 85.0, 6));
+}
+
+void test_move() noexcept {
+  grmhd::AnalyticData::MagnetizedFmDisk disk(3.51, 0.87, 7.43, 15.3, 42.67,
+                                             1.87, 0.13, 0.015, 4);
+  grmhd::AnalyticData::MagnetizedFmDisk disk_copy(3.51, 0.87, 7.43, 15.3, 42.67,
+                                                  1.87, 0.13, 0.015, 4);
+  test_move_semantics(std::move(disk), disk_copy);  //  NOLINT
+}
+
+void test_serialize() noexcept {
+  grmhd::AnalyticData::MagnetizedFmDisk disk(3.51, 0.87, 7.43, 15.3, 42.67,
+                                             1.87, 0.13, 0.015, 4);
+  test_serialization(disk);
+}
+
+template <typename DataType>
+void test_variables(const DataType& used_for_size) {
+  const double bh_mass = 1.12;
+  const double bh_dimless_spin = 0.97;
+  const double inner_edge_radius = 6.2;
+  const double max_pressure_radius = 11.6;
+  const double polytropic_constant = 0.034;
+  const double polytropic_exponent = 1.65;
+  const double threshold_density = 0.14;
+  const double inverse_plasma_beta = 0.023;
+
+  MagnetizedFmDiskProxy disk(bh_mass, bh_dimless_spin, inner_edge_radius,
+                             max_pressure_radius, polytropic_constant,
+                             polytropic_exponent, threshold_density,
+                             inverse_plasma_beta);
+  const auto member_variables = std::make_tuple(
+      bh_mass, bh_dimless_spin, inner_edge_radius, max_pressure_radius,
+      polytropic_constant, polytropic_exponent, threshold_density,
+      inverse_plasma_beta);
+
+  pypp::check_with_random_values<
+      1, MagnetizedFmDiskProxy::grmhd_variables_tags<DataType>>(
+      &MagnetizedFmDiskProxy::grmhd_variables<DataType>, disk,
+      "PointwiseFunctions.AnalyticData.GrMhd.MagnetizedFmDisk",
+      {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
+       "pressure", "lorentz_factor", "specific_enthalpy", "magnetic_field",
+       "divergence_cleaning_field"},
+      {{{-20., 20.}}}, member_variables, used_for_size, 1.0e-8);
+
+  // Test a few of the GR components to make sure that the implementation
+  // correctly forwards to the background solution of the base class.
+  const auto coords = make_with_value<tnsr::I<DataType, 3>>(used_for_size, 1.0);
+  const gr::Solutions::KerrSchild ks_soln{
+      bh_mass, {{0.0, 0.0, bh_dimless_spin}}, {{0.0, 0.0, 0.0}}};
+  CHECK_ITERABLE_APPROX(
+      get<gr::Tags::Lapse<DataType>>(ks_soln.variables(
+          coords, 0.0, gr::Solutions::KerrSchild::tags<DataType>{})),
+      get<gr::Tags::Lapse<DataType>>(
+          disk.variables(coords, tmpl::list<gr::Tags::Lapse<DataType>>{})));
+  CHECK_ITERABLE_APPROX(
+      get<gr::Tags::SqrtDetSpatialMetric<DataType>>(ks_soln.variables(
+          coords, 0.0, gr::Solutions::KerrSchild::tags<DataType>{})),
+      get<gr::Tags::SqrtDetSpatialMetric<DataType>>(disk.variables(
+          coords, tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>>{})));
+  const auto expected_spatial_metric =
+      get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>(
+          ks_soln.variables(coords, 0.0,
+                            gr::Solutions::KerrSchild::tags<DataType>{}));
+  const auto spatial_metric =
+      get<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>(disk.variables(
+          coords,
+          tmpl::list<gr::Tags::SpatialMetric<3, Frame::Inertial, DataType>>{}));
+  CHECK_ITERABLE_APPROX(expected_spatial_metric, spatial_metric);
+
+  // Check that when InversePlasmaBeta = 0, magnetic field vanishes and
+  // we recover FishboneMoncriefDisk
+  MagnetizedFmDiskProxy another_disk(
+      bh_mass, bh_dimless_spin, inner_edge_radius, max_pressure_radius,
+      polytropic_constant, polytropic_exponent, threshold_density, 0.0, 4);
+
+  pypp::check_with_random_values<
+      1, MagnetizedFmDiskProxy::hydro_variables_tags<DataType>>(
+      &MagnetizedFmDiskProxy::hydro_variables<DataType>, another_disk,
+      "PointwiseFunctions.AnalyticData.GrMhd.MagnetizedFmDisk",
+      {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
+       "pressure", "lorentz_factor", "specific_enthalpy"},
+      {{{-20., 20.}}}, member_variables, used_for_size, 1.0e-8);
+  const auto magnetic_field =
+      get<hydro::Tags::SpatialVelocity<DataType, 3, Frame::Inertial>>(
+          another_disk.variables(
+              coords,
+              tmpl::list<hydro::Tags::SpatialVelocity<DataType, 3,
+                                                      Frame::Inertial>>{}));
+  const auto expected_magnetic_field =
+      make_with_value<tnsr::I<DataType, 3>>(used_for_size, 0.0);
+  CHECK_ITERABLE_APPROX(magnetic_field, expected_magnetic_field);
+  CHECK_ITERABLE_APPROX(
+      get<hydro::Tags::DivergenceCleaningField<DataType>>(
+          another_disk.variables(
+              coords,
+              tmpl::list<hydro::Tags::DivergenceCleaningField<DataType>>{})),
+      make_with_value<Scalar<DataType>>(used_for_size, 0.0));
+}
+}  // namespace
+
+// [[TimeOut, 8]]
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDisk",
+                  "[Unit][PointwiseFunctions]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{""};
+
+  test_create_from_options();
+  test_serialize();
+  test_move();
+
+  test_variables(std::numeric_limits<double>::signaling_NaN());
+  test_variables(DataVector(5));
+}
+
+// [[OutputRegex, The threshold density must be in the range \(0, 1\)]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskThreshLower",
+    "[Unit][PointwiseFunctions]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182, 11.123,
+                                             1.44, -0.2, 0.023, 4);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+    // clang-format off
+// [[OutputRegex, The threshold density must be in the range \(0, 1\)]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskThreshUpper",
+    "[Unit][PointwiseFunctions]") {
+  // clang-format on
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182, 11.123,
+                                             1.44, 1.45, 0.023, 4);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// [[OutputRegex, The inverse plasma beta must be non-negative.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskInvBeta",
+    "[Unit][PointwiseFunctions]") {
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182, 11.123,
+                                             1.44, 0.2, -0.153, 4);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+    // clang-format off
+// [[OutputRegex, The grid resolution used in the magnetic field
+// normalization must be at least 4 points.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskGridRes",
+    "[Unit][PointwiseFunctions]") {
+  // clang-format on
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182, 11.123,
+                                             1.44, 0.2, 0.153, 2);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+// Some random member variables might give rise to vanishing magnetic fields.
+// clang-format off
+// [[OutputRegex, Max b squared is zero.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskGridUnphysical",
+    "[Unit][PointwiseFunctions]") {
+  // clang-format on
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  grmhd::AnalyticData::MagnetizedFmDisk disk(0.7, 0.61, 5.4, 9.182, 11.123,
+                                             1.44, 0.2, 0.023, 5);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+struct MagFmDisk {
+  using type = grmhd::AnalyticData::MagnetizedFmDisk;
+  static constexpr OptionString help = {
+      "A magnetized fluid disk orbiting a Kerr black hole."};
+};
+
+// [[OutputRegex, In string:.*At line 8 column 21:.Value -0.01 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskThreshLowerOpt",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<MagFmDisk>> test_options("");
+  test_options.parse(
+      "MagFmDisk:\n"
+      "  BhMass: 13.45\n"
+      "  BhDimlessSpin: 0.45\n"
+      "  InnerEdgeRadius: 6.1\n"
+      "  MaxPressureRadius: 7.6\n"
+      "  PolytropicConstant: 2.42\n"
+      "  PolytropicExponent: 1.33\n"
+      "  ThresholdDensity: -0.01\n"
+      "  InversePlasmaBeta: 0.016\n"
+      "  BFieldNormGridRes: 4");
+  test_options.get<MagFmDisk>();
+}
+
+// [[OutputRegex, In string:.*At line 8 column 21:.Value 4.1 is above the
+// upper bound of 1]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskThreshUpperOpt",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<MagFmDisk>> test_options("");
+  test_options.parse(
+      "MagFmDisk:\n"
+      "  BhMass: 1.5\n"
+      "  BhDimlessSpin: 0.94\n"
+      "  InnerEdgeRadius: 6.4\n"
+      "  MaxPressureRadius: 8.2\n"
+      "  PolytropicConstant: 41.1\n"
+      "  PolytropicExponent: 1.8\n"
+      "  ThresholdDensity: 4.1\n"
+      "  InversePlasmaBeta: 0.03\n"
+      "  BFieldNormGridRes: 4");
+  test_options.get<MagFmDisk>();
+}
+
+// [[OutputRegex, In string:.*At line 9 column 22:.Value -0.03 is below the
+// lower bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskInvBetaOpt",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<MagFmDisk>> test_options("");
+  test_options.parse(
+      "MagFmDisk:\n"
+      "  BhMass: 1.4\n"
+      "  BhDimlessSpin: 0.91\n"
+      "  InnerEdgeRadius: 6.5\n"
+      "  MaxPressureRadius: 7.8\n"
+      "  PolytropicConstant: 13.5\n"
+      "  PolytropicExponent: 1.54\n"
+      "  ThresholdDensity: 0.22\n"
+      "  InversePlasmaBeta: -0.03\n"
+      "  BFieldNormGridRes: 4");
+  test_options.get<MagFmDisk>();
+}
+
+// [[OutputRegex, In string:.*At line 10 column 22:.Value 2 is below the
+// lower bound of 4]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.GrMhd.MagFmDiskGridResOpt",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<MagFmDisk>> test_options("");
+  test_options.parse(
+      "MagFmDisk:\n"
+      "  BhMass: 1.4\n"
+      "  BhDimlessSpin: 0.91\n"
+      "  InnerEdgeRadius: 6.5\n"
+      "  MaxPressureRadius: 7.8\n"
+      "  PolytropicConstant: 13.5\n"
+      "  PolytropicExponent: 1.54\n"
+      "  ThresholdDensity: 0.22\n"
+      "  InversePlasmaBeta: 0.03\n"
+      "  BFieldNormGridRes: 2");
+  test_options.get<MagFmDisk>();
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/FishboneMoncriefDisk.py
@@ -4,7 +4,6 @@
 import numpy as np
 
 
-# Functions for testing FishboneMoncriefDisk.cpp
 def delta(r_sqrd, m, a):
     return r_sqrd - 2.0 * m * np.sqrt(r_sqrd) + a**2
 
@@ -100,9 +99,8 @@ def potential(angular_momentum, r_sqrd, sin_theta_sqrd, m, a):
             u_t(angular_momentum, r_sqrd, sin_theta_sqrd, m, a)))
 
 
-def fishbone_specific_enthalpy(x, t, bh_mass, bh_dimless_a, dimless_r_in,
-                               dimless_r_max, polytropic_constant,
-                               polytropic_exponent):
+def specific_enthalpy(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
+                      polytropic_constant, polytropic_exponent):
     r_in = bh_mass * dimless_r_in
     bh_spin_a = bh_mass * bh_dimless_a
     l = angular_momentum(bh_mass, bh_spin_a, bh_mass * dimless_r_max)
@@ -118,37 +116,35 @@ def fishbone_specific_enthalpy(x, t, bh_mass, bh_dimless_a, dimless_r_in,
     return result
 
 
-def fishbone_rest_mass_density(x, t, bh_mass, bh_dimless_a, dimless_r_in,
-                               dimless_r_max, polytropic_constant,
-                               polytropic_exponent):
-    return np.power((polytropic_exponent - 1.0) * (fishbone_specific_enthalpy(
+def rest_mass_density(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
+                      polytropic_constant, polytropic_exponent):
+    return np.power((polytropic_exponent - 1.0) * (specific_enthalpy(
         x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
         polytropic_constant, polytropic_exponent) - 1.0) /
                     (polytropic_exponent * polytropic_constant),
                     1.0 / (polytropic_exponent - 1.0))
 
 
-def fishbone_specific_internal_energy(x, t, bh_mass, bh_dimless_a, dimless_r_in,
-                                      dimless_r_max, polytropic_constant,
-                                      polytropic_exponent):
+def specific_internal_energy(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                             dimless_r_max, polytropic_constant,
+                             polytropic_exponent):
     return (polytropic_constant * np.power(
-        fishbone_rest_mass_density(x, t, bh_mass, bh_dimless_a, dimless_r_in,
-                                   dimless_r_max, polytropic_constant,
-                                   polytropic_exponent),
+        rest_mass_density(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                          dimless_r_max, polytropic_constant,
+                          polytropic_exponent),
         polytropic_exponent - 1.0) / (polytropic_exponent - 1.0))
 
 
-def fishbone_pressure(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
-                      polytropic_constant, polytropic_exponent):
+def pressure(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
+             polytropic_constant, polytropic_exponent):
     return (polytropic_constant * np.power(
-        fishbone_rest_mass_density(x, t, bh_mass, bh_dimless_a, dimless_r_in,
-                                   dimless_r_max, polytropic_constant,
-                                   polytropic_exponent), polytropic_exponent))
+        rest_mass_density(x, t, bh_mass, bh_dimless_a, dimless_r_in,
+                          dimless_r_max, polytropic_constant,
+                          polytropic_exponent), polytropic_exponent))
 
 
-def fishbone_spatial_velocity(x, t, bh_mass, bh_dimless_a, dimless_r_in,
-                              dimless_r_max, polytropic_constant,
-                              polytropic_exponent):
+def spatial_velocity(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
+                     polytropic_constant, polytropic_exponent):
     r_in = bh_mass * dimless_r_in
     bh_spin_a = bh_mass * bh_dimless_a
     l = angular_momentum(bh_mass, bh_spin_a, bh_mass * dimless_r_max)
@@ -167,22 +163,15 @@ def fishbone_spatial_velocity(x, t, bh_mass, bh_dimless_a, dimless_r_in,
     return result
 
 
-def fishbone_lorentz_factor(x, t, bh_mass, bh_dimless_a, dimless_r_in,
-                            dimless_r_max, polytropic_constant,
-                            polytropic_exponent):
+def lorentz_factor(x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
+                   polytropic_constant, polytropic_exponent):
     bh_spin_a = bh_mass * bh_dimless_a
     spatial_metric = kerr_schild_spatial_metric(x, bh_mass, bh_spin_a)
-    velocity = fishbone_spatial_velocity(
+    velocity = spatial_velocity(
         x, t, bh_mass, bh_dimless_a, dimless_r_in, dimless_r_max,
         polytropic_constant, polytropic_exponent)
     return 1.0 / np.sqrt(
         1.0 - np.einsum("i,j,ij", velocity, velocity, spatial_metric))
-
-
-# End functions for testing FishboneMoncriefDisk.cpp
-
-# Functions for testing the zero magnetic field components of
-# relativistic Euler solutions
 
 
 def magnetic_field(*args):
@@ -191,7 +180,3 @@ def magnetic_field(*args):
 
 def divergence_cleaning_field(*args):
     return 0.0
-
-
-# End functions for testing the zero magnetic field components of
-# relativistic Euler solutions

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_FishboneMoncriefDisk.cpp
@@ -105,20 +105,18 @@ void test_variables(const DataType& used_for_size) noexcept {
   pypp::check_with_random_values<
       1, FishboneMoncriefDiskProxy::hydro_variables_tags<DataType>>(
       &FishboneMoncriefDiskProxy::hydro_variables<DataType>, disk,
-      "TestFunctions",
-      {"fishbone_rest_mass_density", "fishbone_spatial_velocity",
-       "fishbone_specific_internal_energy", "fishbone_pressure",
-       "fishbone_lorentz_factor", "fishbone_specific_enthalpy"},
+      "FishboneMoncriefDisk",
+      {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
+       "pressure", "lorentz_factor", "specific_enthalpy"},
       {{{-15., 15.}}}, member_variables, used_for_size);
 
   pypp::check_with_random_values<
       1, FishboneMoncriefDiskProxy::grmhd_variables_tags<DataType>>(
       &FishboneMoncriefDiskProxy::grmhd_variables<DataType>, disk,
-      "TestFunctions",
-      {"fishbone_rest_mass_density", "fishbone_spatial_velocity",
-       "fishbone_specific_internal_energy", "fishbone_pressure",
-       "fishbone_lorentz_factor", "fishbone_specific_enthalpy",
-       "magnetic_field", "divergence_cleaning_field"},
+      "FishboneMoncriefDisk",
+      {"rest_mass_density", "spatial_velocity", "specific_internal_energy",
+       "pressure", "lorentz_factor", "specific_enthalpy", "magnetic_field",
+       "divergence_cleaning_field"},
       {{{-15., 15.}}}, member_variables, used_for_size);
 
   // Test a few of the GR components to make sure that the implementation

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/__init__.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/__init__.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/__init__.py
@@ -1,0 +1,2 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.


### PR DESCRIPTION
## Proposed changes

Add magnetized Fishbone-Moncrief disk as initial data for GRMHD.

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
