### PR TITLE
Modify registration recommendations

### DIFF
--- a/src/Time/StepChoosers/Cfl.hpp
+++ b/src/Time/StepChoosers/Cfl.hpp
@@ -23,9 +23,21 @@ class ConstGlobalCache;
 /// \endcond
 
 namespace StepChoosers {
+template <size_t Dim, typename Frame, typename StepChooserRegistrars>
+class Cfl;
+
+namespace Registrars {
+template <size_t Dim, typename Frame>
+struct Cfl {
+  template <typename StepChooserRegistrars>
+  using f = StepChoosers::Cfl<Dim, Frame, StepChooserRegistrars>;
+};
+}  // namespace Registrars
 
 /// Suggests a step size based on the CFL stability criterion.
-template <size_t Dim, typename Frame, typename StepChooserRegistrars>
+template <size_t Dim, typename Frame,
+          typename StepChooserRegistrars =
+              tmpl::list<Registrars::Cfl<Dim, Frame>>>
 class Cfl : public StepChooser<StepChooserRegistrars> {
  public:
   /// \cond
@@ -74,14 +86,6 @@ class Cfl : public StepChooser<StepChooserRegistrars> {
  private:
   double safety_factor_ = std::numeric_limits<double>::signaling_NaN();
 };
-
-namespace Registrars {
-template <size_t Dim, typename Frame>
-struct Cfl {
-  template <typename StepChooserRegistrars>
-  using f = StepChoosers::Cfl<Dim, Frame, StepChooserRegistrars>;
-};
-}  // namespace Registrars
 
 /// \cond
 template <size_t Dim, typename Frame, typename StepChooserRegistrars>

--- a/src/Time/StepChoosers/Constant.hpp
+++ b/src/Time/StepChoosers/Constant.hpp
@@ -21,9 +21,15 @@ class ConstGlobalCache;
 /// \endcond
 
 namespace StepChoosers {
+template <typename StepChooserRegistrars>
+class Constant;
+
+namespace Registrars {
+using Constant = Registration::Registrar<StepChoosers::Constant>;
+}  // namespace Registrars
 
 /// Suggests a constant step size.
-template <typename StepChooserRegistrars = tmpl::list<>>
+template <typename StepChooserRegistrars = tmpl::list<Registrars::Constant>>
 class Constant : public StepChooser<StepChooserRegistrars> {
  public:
   /// \cond
@@ -53,10 +59,6 @@ class Constant : public StepChooser<StepChooserRegistrars> {
  private:
   double value_ = std::numeric_limits<double>::signaling_NaN();
 };
-
-namespace Registrars {
-using Constant = Registration::Registrar<StepChoosers::Constant>;
-}  // namespace Registrars
 
 /// \cond
 template <typename StepChooserRegistrars>

--- a/src/Time/StepChoosers/Increase.hpp
+++ b/src/Time/StepChoosers/Increase.hpp
@@ -25,9 +25,15 @@ struct TimeStep;
 /// \endcond
 
 namespace StepChoosers {
+template <typename StepChooserRegistrars>
+class Increase;
+
+namespace Registrars {
+using Increase = Registration::Registrar<StepChoosers::Increase>;
+}  // namespace Registrars
 
 /// Suggests increasing the step size by a constant ratio.
-template <typename StepChooserRegistrars = tmpl::list<>>
+template <typename StepChooserRegistrars = tmpl::list<Registrars::Increase>>
 class Increase : public StepChooser<StepChooserRegistrars> {
  public:
   /// \cond
@@ -63,10 +69,6 @@ class Increase : public StepChooser<StepChooserRegistrars> {
  private:
   double factor_ = std::numeric_limits<double>::signaling_NaN();
 };
-
-namespace Registrars {
-using Increase = Registration::Registrar<StepChoosers::Increase>;
-}  // namespace Registrars
 
 /// \cond
 template <typename StepChooserRegistrars>

--- a/src/Time/Triggers/EveryNSlabs.hpp
+++ b/src/Time/Triggers/EveryNSlabs.hpp
@@ -20,10 +20,17 @@ struct TimeId;
 /// \endcond
 
 namespace Triggers {
+template <typename TriggerRegistrars>
+class EveryNSlabs;
+
+namespace Registrars {
+using EveryNSlabs = Registration::Registrar<Triggers::EveryNSlabs>;
+}  // namespace Registrars
+
 /// \ingroup EventsAndTriggersGroup
 /// \ingroup TimeGroup
 /// Trigger every N time slabs after a given offset.
-template <typename TriggerRegistrars = tmpl::list<>>
+template <typename TriggerRegistrars = tmpl::list<Registrars::EveryNSlabs>>
 class EveryNSlabs : public Trigger<TriggerRegistrars> {
  public:
   /// \cond
@@ -68,10 +75,6 @@ class EveryNSlabs : public Trigger<TriggerRegistrars> {
   uint64_t interval_{0};
   uint64_t offset_{0};
 };
-
-namespace Registrars {
-using EveryNSlabs = Registration::Registrar<Triggers::EveryNSlabs>;
-}  // namespace Registrars
 
 /// \cond
 template <typename TriggerRegistrars>

--- a/src/Time/Triggers/PastTime.hpp
+++ b/src/Time/Triggers/PastTime.hpp
@@ -12,12 +12,19 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Triggers {
+template <typename TriggerRegistrars>
+class PastTime;
+
+namespace Registrars {
+using PastTime = Registration::Registrar<Triggers::PastTime>;
+}  // namespace Registrars
+
 /// \ingroup EventsAndTriggersGroup
 /// \ingroup TimeGroup
 /// Trigger when the simulation is past a certain time (after that
 /// time if time is running forward, before that time if time is
 /// running backward).
-template <typename TriggerRegistrars = tmpl::list<>>
+template <typename TriggerRegistrars = tmpl::list<Registrars::PastTime>>
 class PastTime : public Trigger<TriggerRegistrars> {
  public:
   /// \cond
@@ -52,10 +59,6 @@ class PastTime : public Trigger<TriggerRegistrars> {
  private:
   double trigger_time_{std::numeric_limits<double>::signaling_NaN()};
 };
-
-namespace Registrars {
-using PastTime = Registration::Registrar<Triggers::PastTime>;
-}  // namespace Registrars
 
 /// \cond
 template <typename TriggerRegistrars>

--- a/src/Time/Triggers/SpecifiedSlabs.hpp
+++ b/src/Time/Triggers/SpecifiedSlabs.hpp
@@ -22,10 +22,17 @@ struct TimeId;
 /// \endcond
 
 namespace Triggers {
+template <typename TriggerRegistrars>
+class SpecifiedSlabs;
+
+namespace Registrars {
+using SpecifiedSlabs = Registration::Registrar<Triggers::SpecifiedSlabs>;
+}  // namespace Registrars
+
 /// \ingroup EventsAndTriggersGroup
 /// \ingroup TimeGroup
 /// Trigger at specified numbers of slabs after the simulation start.
-template <typename TriggerRegistrars = tmpl::list<>>
+template <typename TriggerRegistrars = tmpl::list<Registrars::SpecifiedSlabs>>
 class SpecifiedSlabs : public Trigger<TriggerRegistrars> {
  public:
   /// \cond
@@ -63,10 +70,6 @@ class SpecifiedSlabs : public Trigger<TriggerRegistrars> {
  private:
   std::unordered_set<uint64_t> slabs_;
 };
-
-namespace Registrars {
-using SpecifiedSlabs = Registration::Registrar<Triggers::SpecifiedSlabs>;
-}  // namespace Registrars
 
 /// \cond
 template <typename TriggerRegistrars>

--- a/src/Utilities/FakeVirtual.hpp
+++ b/src/Utilities/FakeVirtual.hpp
@@ -87,7 +87,7 @@ template <typename Result, typename Classes, typename Base, typename Callable,
 }
 /// \endcond
 
-/// \ingroup Utilities
+/// \ingroup UtilitiesGroup
 /// \brief Call a functor with the derived type of a base class pointer.
 ///
 /// \details Calls functor with obj cast to type `T*` where T is the

--- a/src/Utilities/Registration.hpp
+++ b/src/Utilities/Registration.hpp
@@ -22,6 +22,13 @@
 /// A concrete base class type with a specific set of derived classes
 /// is constructed like
 /// \snippet Test_Registration.cpp registrar_use
+///
+/// It is frequently useful to default the registrar list in a derived
+/// class to the registrar for that class.  This ensures that any
+/// methods in the base class using the registrar list (such as those
+/// using `DEFINE_FAKE_VIRTUAL()` or `call_with_dynamic_type()`) work
+/// as expected on an explicitly constructed derived class with the
+/// list omitted.
 namespace Registration {
 /// A template for defining a registrar.
 ///

--- a/tests/Unit/Time/StepChoosers/Test_Constant.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Constant.cpp
@@ -22,18 +22,19 @@ struct Metavariables {
   using const_global_cache_tag_list = tmpl::list<>;
 };
 
-using registrars = tmpl::list<StepChoosers::Registrars::Constant>;
-using Constant = StepChoosers::Constant<registrars>;
+using StepChooserType =
+    StepChooser<tmpl::list<StepChoosers::Registrars::Constant>>;
+using Constant = StepChoosers::Constant<>;
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant", "[Unit][Time]") {
-  Parallel::register_derived_classes_with_charm<StepChooser<registrars>>();
+  Parallel::register_derived_classes_with_charm<StepChooserType>();
 
   const Parallel::ConstGlobalCache<Metavariables> cache{{}};
   const auto box = db::create<db::AddSimpleTags<>>();
 
   const Constant constant{5.4};
-  const std::unique_ptr<StepChooser<registrars>> constant_base =
+  const std::unique_ptr<StepChooserType> constant_base =
       std::make_unique<Constant>(constant);
 
   CHECK(constant(cache) == 5.4);
@@ -42,12 +43,12 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant", "[Unit][Time]") {
   CHECK(serialize_and_deserialize(constant_base)->desired_step(box, cache) ==
         5.4);
 
-  test_factory_creation<StepChooser<registrars>>("  Constant: 5.4");
+  test_factory_creation<StepChooserType>("  Constant: 5.4");
 }
 
 // [[OutputRegex, Requested step magnitude should be positive]]
 SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Constant.bad_create",
                   "[Unit][Time]") {
   ERROR_TEST();
-  test_factory_creation<StepChooser<registrars>>("  Constant: -5.4");
+  test_factory_creation<StepChooserType>("  Constant: -5.4");
 }

--- a/tests/Unit/Time/StepChoosers/Test_Increase.cpp
+++ b/tests/Unit/Time/StepChoosers/Test_Increase.cpp
@@ -28,10 +28,11 @@ struct Metavariables {
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Increase", "[Unit][Time]") {
-  using registrars = tmpl::list<StepChoosers::Registrars::Increase>;
-  using Increase = StepChoosers::Increase<registrars>;
+  using StepChooserType =
+      StepChooser<tmpl::list<StepChoosers::Registrars::Increase>>;
+  using Increase = StepChoosers::Increase<>;
 
-  Parallel::register_derived_classes_with_charm<StepChooser<registrars>>();
+  Parallel::register_derived_classes_with_charm<StepChooserType>();
 
   const Parallel::ConstGlobalCache<Metavariables> cache{{}};
   for (const auto& sign : {1, -1}) {
@@ -39,7 +40,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Increase", "[Unit][Time]") {
     const auto box = db::create<db::AddSimpleTags<Tags::TimeStep>>(step);
 
     const Increase increase{5.};
-    const std::unique_ptr<StepChooser<registrars>> increase_base =
+    const std::unique_ptr<StepChooserType> increase_base =
         std::make_unique<Increase>(increase);
 
     CHECK(increase(step, cache) == 1.25);
@@ -49,7 +50,7 @@ SPECTRE_TEST_CASE("Unit.Time.StepChoosers.Increase", "[Unit][Time]") {
           1.25);
   }
 
-  test_factory_creation<StepChooser<registrars>>(
+  test_factory_creation<StepChooserType>(
       "  Increase:\n"
       "    Factor: 5.0");
 }

--- a/tests/Unit/Utilities/Test_Registration.cpp
+++ b/tests/Unit/Utilities/Test_Registration.cpp
@@ -26,7 +26,14 @@ class Base {
   virtual int func() const noexcept = 0;
 };
 
-template <typename Registrars = tmpl::list<>>
+template <typename Registrars>
+class Derived1;
+
+namespace Registrars {
+using Derived1 = Registration::Registrar<::Derived1>;
+}  // namespace Registrars
+
+template <typename Registrars = tmpl::list<Registrars::Derived1>>
 class Derived1 : public Base<Registrars> {
  public:
   static constexpr OptionString help = "help";
@@ -35,33 +42,28 @@ class Derived1 : public Base<Registrars> {
 };
 /// [registrar_structure]
 
+/// [registrar]
+template <typename SomeArg, typename Registrars>
+class Derived2;
+
 namespace Registrars {
-using Derived1 = Registration::Registrar<::Derived1>;
+template <typename SomeArg>
+using Derived2 = Registration::Registrar<::Derived2, SomeArg>;
 }  // namespace Registrars
 
-/// [registrar]
-template <typename SomeArg, typename Registrars = tmpl::list<>>
+template <typename SomeArg,
+          typename Registrars = tmpl::list<Registrars::Derived2<SomeArg>>>
 class Derived2 : public Base<Registrars> {
  public:
   static constexpr OptionString help = "help";
   using options = tmpl::list<>;
   int func() const noexcept override { return 2; }
 };
-
-namespace Registrars {
-template <typename SomeArg>
-using Derived2 = Registration::Registrar<::Derived2, SomeArg>;
-}  // namespace Registrars
 /// [registrar]
 
 /// [custom_registrar]
-template <int N, typename Registrars = tmpl::list<>>
-class Derived3 : public Base<Registrars> {
- public:
-  static constexpr OptionString help = "help";
-  using options = tmpl::list<>;
-  int func() const noexcept override { return N; }
-};
+template <int N, typename Registrars>
+class Derived3;
 
 namespace Registrars {
 template <int N>
@@ -70,6 +72,14 @@ struct Derived3 {
   using f = ::Derived3<N, RegistrarList>;
 };
 }  // namespace Registrars
+
+template <int N, typename Registrars = tmpl::list<Registrars::Derived3<N>>>
+class Derived3 : public Base<Registrars> {
+ public:
+  static constexpr OptionString help = "help";
+  using options = tmpl::list<>;
+  int func() const noexcept override { return N; }
+};
 /// [custom_registrar]
 }  // namespace
 


### PR DESCRIPTION
This change makes derived classes using FakeVirtual stuff usable as
concrete classes without specifying the registrars parameter.  All
current uses of the registration framework fall into this category.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
