### PR TITLE
Add Tags for Spin-weighted spherical harmonic utilities

### DIFF
--- a/docs/GroupDefs.hpp
+++ b/docs/GroupDefs.hpp
@@ -1141,6 +1141,12 @@ then typically look as follows:
  */
 
 /*!
+ * \defgroup SwshGroup Spin-weighted spherical harmonics
+ * Utilities, tags, and metafunctions for using and manipulating spin-weighted
+ * spherical harmonics
+ */
+
+/*!
  * \defgroup TensorGroup Tensor
  * Tensor use documentation.
  */

--- a/src/DataStructures/DataBox/DataBoxTag.hpp
+++ b/src/DataStructures/DataBox/DataBoxTag.hpp
@@ -655,4 +655,14 @@ template <typename Tag, typename TagList = NoSuchType>
 using split_tag = tmpl::conditional_t<
     tmpl::size<typename Subitems<TagList, Tag>::type>::value == 0,
     tmpl::list<Tag>, typename Subitems<TagList, Tag>::type>;
+
+/// \ingroup DataBoxTagsGroup
+/// \brief `true_type` if the prefix tag wraps the specified tag, `false_type`
+/// otherwise. Can be used with `tmpl::filter` to extract a subset of a
+/// `tmpl::list` of prefix tags which wrap a specified tag.
+///
+/// \snippet Test_DataBoxTag.cpp prefix_tag_wraps_specified_tag
+template <typename PrefixTag, typename Tag>
+struct prefix_tag_wraps_specified_tag
+    : std::is_same<Tag, typename PrefixTag::tag> {};
 }  // namespace db

--- a/src/DataStructures/Tensor/Tensor.hpp
+++ b/src/DataStructures/Tensor/Tensor.hpp
@@ -83,16 +83,18 @@ class Tensor<X, Symm, IndexList<Indices...>> {
                 "file an issue on GitHub or discuss with a core developer of "
                 "SpECTRE.");
   static_assert(
-      cpp17::is_same_v<X, double> or cpp17::is_same_v<X, DataVector> or
-          cpp17::is_same_v<X, ModalVector> or
-          cpp17::is_same_v<X, std::complex<double>> or
+      cpp17::is_same_v<X, std::complex<double>> or
+          cpp17::is_same_v<X, double> or
           cpp17::is_same_v<X, ComplexDataVector> or
           cpp17::is_same_v<X, ComplexModalVector> or
-          is_spin_weighted_of_v<ComplexDataVector, X>,
-      "Only a Tensor<double>, Tensor<DataVector>, Tensor<ModalVector>, "
-      "Tensor<std::complex<double>>, Tensor<ComplexDataVector>, "
-      "Tensor<ComplexModalVector>, or "
-      "Tensor<SpinWeighted<ComplexDataVector, N>> is currently "
+          cpp17::is_same_v<X, DataVector> or cpp17::is_same_v<X, ModalVector> or
+          is_spin_weighted_of_v<ComplexDataVector, X> or
+          is_spin_weighted_of_v<ComplexModalVector, X>,
+      "Only a Tensor<std::complex<double>>, Tensor<double>, "
+      "Tensor<ComplexDataVector>, Tensor<ComplexModalVector>, "
+      "Tensor<DataVector>, Tensor<ModalVector>, "
+      "Tensor<SpinWeighted<ComplexDataVector, N>>, "
+      "or Tensor<SpinWeighted<ComplexModalVector, N>> is currently "
       "allowed. While other types are technically possible it is not "
       "clear that Tensor is the correct container for them. Please "
       "seek advice on the topic by discussing with the SpECTRE developers.");

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
     Projection.cpp
     Spectral.cpp
     SwshCollocation.cpp
+    SwshTags.cpp
     )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/NumericalAlgorithms/Spectral/SwshTags.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTags.cpp
@@ -1,0 +1,48 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+
+namespace Spectral {
+namespace Swsh {
+namespace Tags {
+namespace detail {
+template <>
+std::string compose_spin_weighted_derivative_name<Eth>(
+    const std::string& suffix) noexcept {
+  return "Eth(" + suffix + ")";
+}
+template <>
+std::string compose_spin_weighted_derivative_name<EthEth>(
+    const std::string& suffix) noexcept {
+  return "EthEth(" + suffix + ")";
+}
+template <>
+std::string compose_spin_weighted_derivative_name<EthEthbar>(
+    const std::string& suffix) noexcept {
+  return "EthEthbar(" + suffix + ")";
+}
+template <>
+std::string compose_spin_weighted_derivative_name<Ethbar>(
+    const std::string& suffix) noexcept {
+  return "Ethbar(" + suffix + ")";
+}
+template <>
+std::string compose_spin_weighted_derivative_name<EthbarEth>(
+    const std::string& suffix) noexcept {
+  return "EthbarEth(" + suffix + ")";
+}
+template <>
+std::string compose_spin_weighted_derivative_name<EthbarEthbar>(
+    const std::string& suffix) noexcept {
+  return "EthbarEthbar(" + suffix + ")";
+}
+template <>
+std::string compose_spin_weighted_derivative_name<NoDerivative>(
+    const std::string& suffix) noexcept {
+  return "NoDerivative(" + suffix + ")";
+}
+}  // namespace detail
+}  // namespace Tags
+}  // namespace Swsh
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshTags.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTags.hpp
@@ -1,0 +1,200 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+
+#include "DataStructures/ComplexDataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/ComplexModalVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/SpinWeighted.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+// IWYU pragma: no_forward_declare SpinWeighted
+
+namespace Spectral {
+namespace Swsh {
+namespace Tags {
+
+/// \ingroup SwshGroup
+/// \brief Struct for labeling the \f$\eth\f$ spin-weighted derivative in tags
+struct Eth {};
+/// \ingroup SwshGroup
+/// \brief Struct for labeling the \f$\bar{\eth}\f$ spin-weighted derivative in
+/// tags
+struct Ethbar {};
+/// \ingroup SwshGroup
+/// \brief Struct for labeling the \f$\eth^2\f$ spin-weighted derivative in tags
+struct EthEth {};
+/// \ingroup SwshGroup
+/// \brief Struct for labeling the \f$\bar{\eth} \eth\f$ spin-weighted
+/// derivative in tags
+struct EthbarEth {};
+/// \ingroup SwshGroup
+/// \brief Struct for labeling the \f$\eth \bar{\eth}\f$ spin-weighted
+/// derivative in tags
+struct EthEthbar {};
+/// \ingroup SwshGroup
+/// \brief Struct for labeling the \f$\bar{\eth}^2\f$ spin-weighted derivative
+/// in tags
+struct EthbarEthbar {};
+/// \brief Struct which acts as a placeholder for a spin-weighted derivative
+/// label in the spin-weighted derivative utilities, but represents a 'no-op':
+/// no derivative is taken.
+struct NoDerivative {};
+
+namespace detail {
+
+// utility function for determining the change of spin after a spin-weighted
+// derivative has been applied.
+template <typename DerivativeKind>
+constexpr int derivative_spin_weight_adjustment = 0;
+
+template <>
+constexpr int derivative_spin_weight_adjustment<Eth> = 1;
+template <>
+constexpr int derivative_spin_weight_adjustment<Ethbar> = -1;
+template <>
+constexpr int derivative_spin_weight_adjustment<EthEth> = 2;
+template <>
+constexpr int derivative_spin_weight_adjustment<EthbarEthbar> = -2;
+
+// The below tags are used to find the new type represented by the spin-weighted
+// derivative of a spin-weighted quantity. The derivatives alter the spin
+// weights, and so the utility `adjust_spin_weight_t<Tag, DerivativeKind>` is a
+// metafunction that determines the correct spin-weighted type for the
+// spin-weighted derivative `DerivativeKind` of `Tag`.
+//
+// if there is no `Tag::type::spin`, but the internal type is a compatible
+// complex vector type, the spin associated with `Tag` is assumed to be 0.
+template <typename DataType, typename DerivativeKind>
+struct adjust_spin_weight {
+  using type =
+      Scalar<SpinWeighted<DataType,
+                          derivative_spin_weight_adjustment<DerivativeKind>>>;
+};
+
+// case for if there is a `Tag::type::spin`
+template <typename DataType, int Spin, typename DerivativeKind>
+struct adjust_spin_weight<SpinWeighted<DataType, Spin>, DerivativeKind> {
+  using type = Scalar<SpinWeighted<
+      DataType, Spin + derivative_spin_weight_adjustment<DerivativeKind>>>;
+};
+
+template <typename Tag, typename DerivativeKind>
+using adjust_spin_weight_t =
+    typename adjust_spin_weight<typename Tag::type::type, DerivativeKind>::type;
+
+// Helper function for creating an appropriate prefix tag name from one of the
+// spin-weighted derivative types and an existing tag name
+template <typename DerivativeKind>
+std::string compose_spin_weighted_derivative_name(
+    const std::string& suffix) noexcept;
+
+}  // namespace detail
+
+/// \ingroup SwshGroup
+/// \brief Prefix tag representing the spin-weighted derivative of a
+/// spin-weighted scalar.
+///
+/// Template Parameters:
+/// - `Tag`: The tag to prefix
+/// - `DerivativeKind`: The type of spin-weighted derivative. This may be any of
+///   the labeling structs: `Eth`, `Ethbar`, `EthEth`, `EthbarEth`, `EthEthbar`,
+///   `EthbarEthbar`, or `NoDerivative`.
+///
+/// Type Aliases and static values:
+/// - `type`: Always a `SpinWeighted<Scalar<ComplexDataVector>, Spin>`, where
+///   `Spin` is the spin weight after the derivative `DerivativeKind` has been
+///   applied.
+/// - `tag`: An alias to the wrapped tag `Tag`. Provided for applicability to
+///   general `db::PrefixTag` functionality.
+/// - `derived_from`: Another alias to the wrapped tag `Tag`. Provided so that
+///   utilities that use this prefix for taking derivatives can have a more
+///   expressive code style.
+/// - `derivative_kind`: Type alias to `DerivativeKind`, represents the kind of
+///   spin-weighted derivative applied to `Tag`
+/// - `spin`: The spin weight of the scalar after the derivative has been
+///   applied.
+template <typename Tag, typename DerivativeKind>
+struct Derivative : db::PrefixTag, db::SimpleTag {
+  using type = detail::adjust_spin_weight_t<Tag, DerivativeKind>;
+  using tag = Tag;
+  // derived_from is provided as a second alias so that utilities that assume a
+  // derivative prefix tag fail earlier during compilation
+  using derived_from = Tag;
+  using derivative_kind = DerivativeKind;
+  const static int spin = type::type::spin;
+  static std::string name() noexcept {
+    return detail::compose_spin_weighted_derivative_name<DerivativeKind>(
+        Tag::name());
+  }
+};
+
+/// \ingroup SwshGroup
+/// \brief Prefix tag representing the spin-weighted spherical harmonic
+/// transform of a spin-weighted scalar.
+///
+/// Template Parameters:
+/// - `Tag`: The tag to prefix.
+///
+/// Type aliases and static values:
+/// - `type`: Always a `SpinWeighted<Scalar<ComplexModalVector>, Spin>`, where
+///   `Spin` is the same spin weight of the pre-transformed `Tag`, and 0 if
+///   provided a `Tag` with a `Type` that is not `SpinWeighted`
+/// - `tag`: An alias to the wrapped tag `Tag`. Provided for applicability to
+///   general `db::PrefixTag` functionality
+/// - `transform_of`: Another alias to the wrapped tag `Tag`. Provided so that
+///   utilities that use this prefix for taking transforms can have a more
+///   expressive code style.
+template <typename Tag>
+struct SwshTransform : db::PrefixTag, db::SimpleTag {
+  using type = Scalar<SpinWeighted<
+      ComplexModalVector,
+      detail::adjust_spin_weight_t<Tag, NoDerivative>::type::spin>>;
+  using tag = Tag;
+  // transform_of is provided as a second alias so that utilities that assume a
+  // derivative prefix tag fail earlier during compilation
+  using transform_of = Tag;
+  const static int spin = type::type::spin;
+  static std::string name() noexcept {
+    return "SwshTransform(" + Tag::name() + ")";
+  }
+};
+}  // namespace Tags
+
+namespace detail {
+// implementation for get_tags_with_spin
+template <typename Tag, typename S>
+struct has_spin : cpp17::bool_constant<Tag::type::type::spin == S::value> {};
+
+template <typename PrefixTag, typename S>
+struct wrapped_has_spin : has_spin<typename PrefixTag::tag, S> {};
+
+}  // namespace detail
+
+/// \ingroup SwshGroup
+/// \brief Extract from `TagList` the subset of those tags that have a static
+/// int member `spin` equal to the template parameter `Spin`.
+///
+/// \snippet Test_SwshTags.cpp get_tags_with_spin
+template <int Spin, typename TagList>
+using get_tags_with_spin = tmpl::remove_duplicates<tmpl::filter<
+    TagList, detail::has_spin<tmpl::_1, std::integral_constant<int, Spin>>>>;
+
+/// \ingroup SwshGroup
+/// \brief Extract from `TagList` the subset of  those tags that wrap a tag
+/// that has a static int member `spin` equal to the template parameter `Spin`.
+///
+/// \snippet Test_SwshTags.cpp get_prefix_tags_that_wrap_tags_with_spin
+template <int Spin, typename TagList>
+using get_prefix_tags_that_wrap_tags_with_spin =
+    tmpl::filter<TagList, tmpl::bind<detail::wrapped_has_spin, tmpl::_1,
+                                     std::integral_constant<int, Spin>>>;
+
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxTag.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxTag.cpp
@@ -167,3 +167,23 @@ static_assert(
         db::split_tag<Prefix<Tags::Variables<tmpl::list<Var, Prefix<Var>>>>>,
         tmpl::list<Var, Prefix<Var>>>,
     "Failed testing split_tag");
+
+/// [prefix_tag_wraps_specified_tag]
+static_assert(db::prefix_tag_wraps_specified_tag<Prefix<Var>, Var>::value,
+              "failed testing prefix_tag_wraps_specified_tag");
+
+static_assert(not db::prefix_tag_wraps_specified_tag<Prefix<Var2>, Var>::value,
+              "failed testing prefix_tag_wraps_specified_tag");
+
+static_assert(db::prefix_tag_wraps_specified_tag<PrefixWithArgs<Var, int, int>,
+                                                 Var>::value,
+              "failed testing prefix_tag_wraps_specified_tag");
+
+static_assert(
+    cpp17::is_same_v<tmpl::filter<tmpl::list<Prefix<Var>, Prefix<Var2>,
+                                             PrefixWithArgs<Var, int, int>>,
+                                  db::prefix_tag_wraps_specified_tag<
+                                      tmpl::_1, tmpl::pin<Var>>>,
+                     tmpl::list<Prefix<Var>, PrefixWithArgs<Var, int, int>>>,
+    "failed testing prefix_tag_wraps_specified_tag");
+/// [prefix_tag_wraps_specified_tag]

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_Projection.cpp
   Test_Spectral.cpp
   Test_SwshCollocation.cpp
+  Test_SwshTags.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTags.cpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"       // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+// IWYU pragma: no_forward_declare SpinWeighted
+// IWYU pragma: no_forward_declare Tensor
+
+/// \cond
+class ComplexDataVector;
+class ComplexModalVector;
+/// \endcond
+
+namespace Spectral {
+namespace Swsh {
+namespace Tags {
+namespace {
+
+struct UnweightedTestTag : db::SimpleTag {
+  static std::string name() noexcept { return "UnweightedTestTag"; }
+  using type = Scalar<ComplexDataVector>;
+};
+
+struct SpinMinus1TestTag : db::SimpleTag {
+  static std::string name() noexcept { return "SpinMinus1TestTag"; }
+  using type = Scalar<SpinWeighted<ComplexDataVector, -1>>;
+};
+
+struct AnotherSpinMinus1TestTag : db::SimpleTag {
+  static std::string name() noexcept { return "AnotherSpinMinus1TestTag"; }
+  using type = Scalar<SpinWeighted<ComplexDataVector, -1>>;
+};
+
+struct Spin2TestTag : db::SimpleTag {
+  static std::string name() noexcept { return "Spin2TestTag"; }
+  using type = Scalar<SpinWeighted<ComplexDataVector, 2>>;
+};
+
+static_assert(Derivative<Spin2TestTag, Ethbar>::spin == 1,
+              "failed testing DerivativeTag with DerivativeType Ethbar");
+
+static_assert(
+    cpp17::is_same_v<Derivative<SpinMinus1TestTag, Ethbar>::derived_from,
+                     SpinMinus1TestTag>,
+    "failed testing DerivativeTag with DerivativeType Ethbar");
+
+static_assert(cpp17::is_same_v<SwshTransform<Spin2TestTag>::type,
+                               Scalar<SpinWeighted<ComplexModalVector, 2>>>,
+              "failed testing SwshTransform");
+
+static_assert(
+    cpp17::is_same_v<
+        SwshTransform<Derivative<Spin2TestTag, EthEthbar>>::transform_of,
+        Derivative<Spin2TestTag, EthEthbar>>,
+    "failed testing SwshTransform");
+
+/// [get_tags_with_spin]
+using TestVarTagList = tmpl::list<SpinMinus1TestTag, SpinMinus1TestTag,
+                                  AnotherSpinMinus1TestTag, Spin2TestTag>;
+
+static_assert(
+    cpp17::is_same_v<get_tags_with_spin<-1, TestVarTagList>,
+                     tmpl::list<SpinMinus1TestTag, AnotherSpinMinus1TestTag>>,
+    "failed testing get_tags_with_spin");
+
+using TestDerivativeTagList =
+    tmpl::list<Derivative<SpinMinus1TestTag, Eth>,
+               Derivative<SpinMinus1TestTag, EthEthbar>,
+               Derivative<AnotherSpinMinus1TestTag, EthEth>,
+               Derivative<Spin2TestTag, Ethbar>>;
+
+static_assert(
+    cpp17::is_same_v<get_tags_with_spin<1, TestDerivativeTagList>,
+                     tmpl::list<Derivative<AnotherSpinMinus1TestTag, EthEth>,
+                                Derivative<Spin2TestTag, Ethbar>>>,
+    "failed testing get_tags_with_spin");
+/// [get_tags_with_spin]
+
+/// [get_prefix_tags_that_wrap_tags_with_spin]
+using WrappedTagList = tmpl::list<Derivative<SpinMinus1TestTag, Eth>,
+                                  Derivative<SpinMinus1TestTag, EthEthbar>,
+                                  Derivative<AnotherSpinMinus1TestTag, EthEth>,
+                                  Derivative<Spin2TestTag, Ethbar>>;
+static_assert(cpp17::is_same_v<
+                  get_prefix_tags_that_wrap_tags_with_spin<-1, WrappedTagList>,
+                  tmpl::list<Derivative<SpinMinus1TestTag, Eth>,
+                             Derivative<SpinMinus1TestTag, EthEthbar>,
+                             Derivative<AnotherSpinMinus1TestTag, EthEth>>>,
+              "failed testing get_wrapped_tags_with_spin_from_prefix_tag_list");
+/// [get_prefix_tags_that_wrap_tags_with_spin]
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Tags",
+                  "[Unit][NumericalAlgorithms]") {
+  CHECK(Derivative<SpinMinus1TestTag, Eth>::name() == "Eth(SpinMinus1TestTag)");
+  CHECK(Derivative<SpinMinus1TestTag, EthEth>::name() ==
+        "EthEth(SpinMinus1TestTag)");
+  CHECK(Derivative<SpinMinus1TestTag, EthEthbar>::name() ==
+        "EthEthbar(SpinMinus1TestTag)");
+  CHECK(Derivative<SpinMinus1TestTag, Ethbar>::name() ==
+        "Ethbar(SpinMinus1TestTag)");
+  CHECK(Derivative<SpinMinus1TestTag, EthbarEth>::name() ==
+        "EthbarEth(SpinMinus1TestTag)");
+  CHECK(Derivative<SpinMinus1TestTag, EthbarEthbar>::name() ==
+        "EthbarEthbar(SpinMinus1TestTag)");
+  CHECK(Derivative<SpinMinus1TestTag, NoDerivative>::name() ==
+        "NoDerivative(SpinMinus1TestTag)");
+  CHECK(SwshTransform<Spin2TestTag>::name() == "SwshTransform(Spin2TestTag)");
+}
+}  // namespace
+}  // namespace Tags
+}  // namespace Swsh
+}  // namespace Spectral


### PR DESCRIPTION
## Proposed changes

Add Tags for spin-weighted libraries, including derivative prefix tags, coefficient prefix tags, and various utilities for dealing with those prefix tags.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
