### PR TITLE
Convert Burgers observation Action to an Event

### DIFF
--- a/src/Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp
+++ b/src/Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp
@@ -34,7 +34,7 @@ struct RunEventsAndTriggers {
                     const ArrayIndex& array_index,
                     const ActionList /*meta*/,
                     const ParallelComponent* const component) noexcept {
-    Parallel::get<Tags::EventsAndTriggersTagBase>(cache).run_events(
+    Parallel::get<OptionTags::EventsAndTriggersTagBase>(cache).run_events(
         box, cache, array_index, component);
 
     return std::forward_as_tuple(std::move(box));

--- a/src/Evolution/EventsAndTriggers/EventsAndTriggers.hpp
+++ b/src/Evolution/EventsAndTriggers/EventsAndTriggers.hpp
@@ -4,13 +4,22 @@
 #pragma once
 
 #include <memory>
-#include <pup.h>
+#include <pup.h>  // IWYU pragma: keep
 #include <unordered_map>
+#include <vector>
 
-#include "DataStructures/DataBox/DataBox.hpp"
-#include "Evolution/EventsAndTriggers/Event.hpp"
-#include "Evolution/EventsAndTriggers/Trigger.hpp"
-#include "Parallel/ConstGlobalCache.hpp"
+#include "Evolution/EventsAndTriggers/Event.hpp"  // IWYU pragma: keep // for option parsing
+#include "Evolution/EventsAndTriggers/Trigger.hpp"  // IWYU pragma: keep // for option parsing
+#include "Options/Options.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables> class ConstGlobalCache;
+}  // namespace Parallel
+namespace db {
+template <typename TagsList> class DataBox;
+}  // namespace db
+/// \endcond
 
 /// \ingroup EventsAndTriggersGroup
 /// Class that checks triggers and runs events
@@ -63,16 +72,8 @@ struct create_from_yaml<EventsAndTriggers<EventRegistrars, TriggerRegistrars>> {
   }
 };
 
-namespace Tags {
+namespace OptionTags {
 /// \cond
 struct EventsAndTriggersTagBase {};
 /// \endcond
-
-/// \ingroup OptionTagsGroup
-/// \ingroup EventsAndTriggersGroup
-/// Contains the events and triggers
-template <typename EventRegistrars, typename TriggerRegistrars>
-struct EventsAndTriggers : EventsAndTriggersTagBase {
-  using type = ::EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
-};
-}  // namespace Tags
+}  // namespace OptionTags

--- a/src/Evolution/Systems/Burgers/Observe.hpp
+++ b/src/Evolution/Systems/Burgers/Observe.hpp
@@ -4,141 +4,178 @@
 #pragma once
 
 #include <cstddef>
+#include <pup.h>
 #include <string>
-#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
-#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/EventsAndTriggers/Event.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
-#include "IO/Observer/Actions.hpp"
 #include "IO/Observer/ArrayComponentId.hpp"
-#include "IO/Observer/Helpers.hpp"
+#include "IO/Observer/Helpers.hpp"  // IWYU pragma: keep
 #include "IO/Observer/ObservationId.hpp"
-#include "IO/Observer/ObserverComponent.hpp"
-#include "IO/Observer/ReductionActions.hpp"
-#include "IO/Observer/VolumeActions.hpp"
+#include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
+#include "IO/Observer/ReductionActions.hpp"  // IWYU pragma: keep
+#include "IO/Observer/Tags.hpp"
+#include "IO/Observer/VolumeActions.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/CharmPupable.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Invoke.hpp"
+#include "Parallel/Reduction.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
-#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
 #include "Utilities/Functional.hpp"
 #include "Utilities/MakeString.hpp"
 #include "Utilities/Numeric.hpp"
+#include "Utilities/Registration.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
+/// \cond
+// IWYU pragma: no_forward_declare Tensor
+namespace Tags {
+struct Time;
+}  // namespace Tags
+/// \endcond
+
 namespace Burgers {
-namespace Actions {
+namespace Events {
+template <typename EventRegistrars>
+class Observe;
+
+namespace Registrars {
+using Observe = Registration::Registrar<Events::Observe>;
+}  // namespace Registrars
 
 /*!
- * \brief Temporary action for observing volume and reduction data
+ * \brief Observe the Burgers system
  *
- * A few notes:
- * - Writes the solution and error in \f$U\f$ to disk.
- * - The RMS error of \f$U\f$ is written to disk.
+ * Writes volume quantities:
+ * - `InertialCoordinates`
+ * - `U`
+ * - `ErrorU` = \f$U - \text{analytic solution}\f$
+ *
+ * Writes reduction quantities:
+ * - `Time`
+ * - `NumberOfPoints` = total number of points in the domain
+ * - `ErrorU` = \f$\operatorname{RMS}(U - \text{analytic solution})\f$
+ *   over all points
+ *
+ * \warning Currently, only one observation event can be triggered at
+ * a given time.  Causing multiple events to run at once will produce
+ * unpredictable results.
  */
-struct Observe {
+template <typename EventRegistrars = tmpl::list<Registrars::Observe>>
+class Observe : public Event<EventRegistrars> {
  private:
-  using l2_error_datum = Parallel::ReductionDatum<double, funcl::Plus<>,
-                                                  funcl::Sqrt<funcl::Divides<>>,
-                                                  std::index_sequence<1>>;
-  using reduction_data = Parallel::ReductionData<
+  using L2ErrorDatum =
+      Parallel::ReductionDatum<double, funcl::Plus<>,
+                               funcl::Sqrt<funcl::Divides<>>,
+                               std::index_sequence<1>>;
+  using ReductionData = Parallel::ReductionData<
       Parallel::ReductionDatum<double, funcl::AssertEqual<>>,
-      Parallel::ReductionDatum<size_t, funcl::Plus<>>, l2_error_datum>;
+      Parallel::ReductionDatum<size_t, funcl::Plus<>>, L2ErrorDatum>;
 
  public:
-  struct ObserveNSlabs {
-    using type = size_t;
-    static constexpr OptionString help = {"Observe every Nth slab"};
-  };
-  struct ObserveAtT0 {
-    using type = bool;
-    static constexpr OptionString help = {"If true observe at t=0"};
-  };
+  /// \cond
+  explicit Observe(CkMigrateMessage* /*unused*/) noexcept {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Observe);  // NOLINT
+  /// \endcond
 
-  using const_global_cache_tags = tmpl::list<ObserveNSlabs, ObserveAtT0>;
+  using options = tmpl::list<>;
+  static constexpr OptionString help =
+      "Observes the Burgers field U and its error.\n"
+      "\n"
+      "Writes volume quantities:\n"
+      " * InertialCoordinates\n"
+      " * U\n"
+      " * ErrorU = U - analytic solution\n"
+      "\n"
+      "Writes reduction quantities:\n"
+      " * Time\n"
+      " * NumberOfPoints = total number of points in the domain\n"
+      " * ErrorU = RMS(U - analytic solution) over all points";
+
+  Observe() = default;
+
   using observed_reduction_data_tags =
-      observers::make_reduction_data_tags<tmpl::list<reduction_data>>;
+      observers::make_reduction_data_tags<tmpl::list<ReductionData>>;
 
-  template <typename... DbTags, typename... InboxTags, typename Metavariables,
-            size_t Dim, typename ActionList, typename ParallelComponent>
-  static auto apply(db::DataBox<tmpl::list<DbTags...>>& box,
-                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    Parallel::ConstGlobalCache<Metavariables>& cache,
-                    const ElementIndex<Dim>& array_index,
-                    const ActionList /*meta*/,
-                    const ParallelComponent* const /*meta*/) noexcept {
-    const auto& time_id = db::get<::Tags::TimeId>(box);
-    if (time_id.substep() != 0 or (time_id.slab_number() == 0 and
-                                   not Parallel::get<ObserveAtT0>(cache))) {
-      return std::forward_as_tuple(std::move(box));
-    }
+  using argument_tags =
+      tmpl::list<::Tags::Time, ::Tags::Mesh<1>,
+                 ::Tags::Coordinates<1, Frame::Inertial>, Tags::U>;
 
-    const auto& time = time_id.time();
-
-    const std::string element_name = MakeString{} << ElementId<Dim>(array_index)
+  template <typename Metavariables, typename ParallelComponent>
+  void operator()(
+      const Time& time, const Mesh<1>& mesh,
+      const tnsr::I<DataVector, 1, Frame::Inertial>& inertial_coordinates,
+      const Scalar<DataVector>& u,
+      Parallel::ConstGlobalCache<Metavariables>& cache,
+      const ElementIndex<1>& array_index,
+      const ParallelComponent* const /*meta*/) const noexcept {
+    const std::string element_name = MakeString{} << ElementId<1>(array_index)
                                                   << '/';
-    if (time_id.slab_number() >= 0 and time_id.time().is_at_slab_start() and
-        static_cast<size_t>(time_id.slab_number()) %
-                Parallel::get<ObserveNSlabs>(cache) ==
-            0) {
-      const auto& extents = db::get<::Tags::Mesh<Dim>>(box).extents();
-      // Retrieve the tensors and compute the solution error.
-      const auto& u = db::get<Burgers::Tags::U>(box);
-      const auto& inertial_coordinates =
-          db::get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+    // Compute the error in the solution, and generate tensor component list.
+    using Vars = typename Metavariables::system::variables_tag::type;
+    using solution_tag = OptionTags::AnalyticSolutionBase;
+    const auto exact_solution = Parallel::get<solution_tag>(cache).variables(
+        inertial_coordinates, time.value(), typename Vars::tags_list{});
 
-      // Compute the error in the solution, and generate tensor component list.
-      using Vars = typename Metavariables::system::variables_tag::type;
-      using solution_tag = OptionTags::AnalyticSolutionBase;
-      const auto exact_solution = Parallel::get<solution_tag>(cache).variables(
-          inertial_coordinates, time.value(), typename Vars::tags_list{});
+    // Remove tensor types, only storing individual components.
+    std::vector<TensorComponent> components;
+    // U, ErrorU, x
+    components.reserve(3);
 
-      // Remove tensor types, only storing individual components.
-      std::vector<TensorComponent> components;
-      // U, UError, x
-      components.reserve(3);
+    components.emplace_back(element_name + Tags::U::name(), get(u));
+    using PlusSquare = funcl::Plus<funcl::Identity, funcl::Square<>>;
+    DataVector error = get(u) - get(tuples::get<Tags::U>(exact_solution));
+    const double u_error = alg::accumulate(error, 0.0, PlusSquare{});
+    components.emplace_back(element_name + "Error" + Tags::U::name(),
+                            std::move(error));
+    components.emplace_back(
+        element_name + ::Tags::Coordinates<1, Frame::Inertial>::name() + "_x",
+        get<0>(inertial_coordinates));
 
-      components.emplace_back(element_name + Burgers::Tags::U::name(), u.get());
-      using PlusSquare = funcl::Plus<funcl::Identity, funcl::Square<>>;
-      DataVector error =
-          tuples::get<Burgers::Tags::U>(exact_solution).get() - u.get();
-      const double u_error = alg::accumulate(error, 0.0, PlusSquare{});
-      components.emplace_back(element_name + "Error" + Burgers::Tags::U::name(),
-                              error);
-      components.emplace_back(
-          element_name + ::Tags::Coordinates<1, Frame::Inertial>::name() + "_x",
-          get<0>(inertial_coordinates));
+    // Send data to volume observer
+    auto& local_observer =
+        *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
+             cache)
+             .ckLocalBranch();
+    Parallel::simple_action<observers::Actions::ContributeVolumeData>(
+        local_observer,
+        observers::ObservationId(
+            time, typename Metavariables::element_observation_type{}),
+        std::string{"/element_data"},
+        observers::ArrayComponentId(
+            std::add_pointer_t<ParallelComponent>{nullptr},
+            Parallel::ArrayIndex<ElementIndex<1>>(array_index)),
+        std::move(components), mesh.extents());
 
-      // Send data to volume observer
-      auto& local_observer =
-          *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
-               cache)
-               .ckLocalBranch();
-      Parallel::simple_action<observers::Actions::ContributeVolumeData>(
-          local_observer,
-          observers::ObservationId(
-              time, typename Metavariables::element_observation_type{}),
-          std::string{"/element_data"},
-          observers::ArrayComponentId(
-              std::add_pointer_t<ParallelComponent>{nullptr},
-              Parallel::ArrayIndex<ElementIndex<Dim>>(array_index)),
-          std::move(components), extents);
-
-      // Send data to reduction observer
-      Parallel::simple_action<observers::Actions::ContributeReductionData>(
-          local_observer,
-          observers::ObservationId(
-              time, typename Metavariables::element_observation_type{}),
-          std::string{"/element_data"},
-          std::vector<std::string>{"Time", "NumberOfPoints", "UError"},
-          reduction_data{
-              time.value(),
-              db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points(),
-              u_error});
-    }
-    return std::forward_as_tuple(std::move(box));
+    // Send data to reduction observer
+    Parallel::simple_action<observers::Actions::ContributeReductionData>(
+        local_observer,
+        observers::ObservationId(
+            time, typename Metavariables::element_observation_type{}),
+        std::string{"/element_data"},
+        std::vector<std::string>{"Time", "NumberOfPoints", "ErrorU"},
+        ReductionData{time.value(), mesh.number_of_grid_points(), u_error});
   }
 };
-}  // namespace Actions
+
+/// \cond
+template <typename EventRegistrars>
+PUP::able::PUP_ID Observe<EventRegistrars>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+}  // namespace Events
 }  // namespace Burgers

--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -68,7 +68,7 @@ struct ContributeReductionDataToWriter;
  * Then, in the `Metavariables` collect them from all observing Actions like
  * this:
  *
- * \snippet Test_Observe.cpp collect_reduction_data_tags
+ * \snippet tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp collect_reduction_data_tags
  */
 struct ContributeReductionData {
   template <typename... DbTags, typename... InboxTags, typename Metavariables,

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -52,15 +52,6 @@ struct Time : db::ComputeTag {
   using argument_tags = tmpl::list<TimeId>;
 };
 
-/// \ingroup DataBoxTagsGroup
-/// \ingroup TimeGroup
-/// \brief Tag for compute item for current time as a double
-struct TimeValue : db::ComputeTag {
-  static std::string name() noexcept { return "TimeValue"; }
-  static auto function(const ::Time& t) noexcept { return t.value(); }
-  using argument_tags = tmpl::list<Time>;
-};
-
 /// \ingroup DataBoxTags
 /// \ingroup TimeGroup
 /// \brief Prefix for TimeStepper history

--- a/src/Time/Tags.hpp
+++ b/src/Time/Tags.hpp
@@ -13,6 +13,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "Evolution/EventsAndTriggers/EventsAndTriggers.hpp"
 #include "Options/Options.hpp"
 #include "Time/BoundaryHistory.hpp"
 #include "Time/History.hpp"
@@ -21,11 +22,6 @@
 #include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
 #include "Utilities/TMPL.hpp"
-
-/// \cond
-// NOLINTNEXTLINE(misc-forward-declaration-namespace)
-class TimeStepper;
-/// \endcond
 
 namespace Tags {
 
@@ -163,5 +159,17 @@ struct InitialSlabSize {
   using type = double;
   static constexpr OptionString help = "The initial slab size";
   static type lower_bound() noexcept { return 0.; }
+};
+
+
+/// \ingroup OptionTagsGroup
+/// \ingroup EventsAndTriggersGroup
+/// \ingroup TimeGroup
+/// Contains the events and triggers
+template <typename EventRegistrars, typename TriggerRegistrars>
+struct EventsAndTriggers : EventsAndTriggersTagBase {
+  using type = ::EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
+  static constexpr OptionString help =
+      "Events and triggers to run at slab boundaries";
 };
 }  // namespace OptionTags

--- a/src/Time/Triggers/PastTime.hpp
+++ b/src/Time/Triggers/PastTime.hpp
@@ -10,14 +10,15 @@
 #include "Options/Options.hpp"
 #include "Parallel/CharmPupable.hpp"
 #include "Time/EvolutionOrdering.hpp"
+#include "Time/Time.hpp"
 #include "Time/TimeId.hpp"
 #include "Utilities/Registration.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 namespace Tags {
+struct Time;
 struct TimeId;
-struct TimeValue;
 }  // namespace Tags
 /// \endcond
 
@@ -50,11 +51,11 @@ class PastTime : public Trigger<TriggerRegistrars> {
   explicit PastTime(const double trigger_time) noexcept
       : trigger_time_(trigger_time) {}
 
-  using argument_tags = tmpl::list<Tags::TimeValue, Tags::TimeId>;
+  using argument_tags = tmpl::list<Tags::Time, Tags::TimeId>;
 
-  bool operator()(const double time, const TimeId& time_id) const noexcept {
+  bool operator()(const Time& time, const TimeId& time_id) const noexcept {
     return evolution_greater<double>{time_id.time_runs_forward()}(
-        time, trigger_time_);
+        time.value(), trigger_time_);
   }
 
   // clang-tidy: google-runtime-references

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -30,9 +30,7 @@ NumericalFluxParams:
 SlopeLimiterParams:
   Type: LambdaPi1
 
-# Avoid observations during input-file testing:
-ObserveNSlabs: 1000000
-ObserveAtT0: false
+EventsAndTriggers:
 
 VolumeFileName: "./BurgersVolume"
 ReductionFileName: "./BurgersReductions"

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -964,7 +964,7 @@ class MockRuntimeSystem {
     return tuples::get<MockDistributedObjectsTag<Component>>(local_algorithms_);
   }
 
-  const GlobalCache& cache() noexcept { return cache_; }
+  GlobalCache& cache() noexcept { return cache_; }
 
  private:
   GlobalCache cache_;

--- a/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
+++ b/tests/Unit/Evolution/EventsAndTriggers/Test_EventsAndTriggers.cpp
@@ -6,11 +6,10 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <algorithm>
 #include <memory>
-#include <pup.h>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Evolution/EventsAndTriggers/Actions/RunEventsAndTriggers.hpp"  // IWYU pragma: keep
@@ -20,6 +19,7 @@
 #include "Evolution/EventsAndTriggers/LogicalTriggers.hpp"  // IWYU pragma: keep
 #include "Evolution/EventsAndTriggers/Trigger.hpp"
 #include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "Time/Tags.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -27,11 +27,15 @@
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+// IWYU pragma: no_include <pup.h>
+
+// IWYU pragma: no_include "Parallel/PupStlCpp11.hpp"
+
 // IWYU pragma: no_forward_declare db::DataBox
 
 namespace {
 using events_and_triggers_tag =
-    Tags::EventsAndTriggers<tmpl::list<>, tmpl::list<>>;
+    OptionTags::EventsAndTriggers<tmpl::list<>, tmpl::list<>>;
 
 struct Metavariables;
 struct component {

--- a/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/Burgers/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_Burgers")
 set(LIBRARY_SOURCES
   Test_Equations.cpp
   Test_Fluxes.cpp
+  Test_Observe.cpp
   )
 
 add_test_library(

--- a/tests/Unit/Evolution/Systems/Burgers/Test_Observe.cpp
+++ b/tests/Unit/Evolution/Systems/Burgers/Test_Observe.cpp
@@ -1,0 +1,280 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TensorData.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/ElementIndex.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/EventsAndTriggers/Event.hpp"
+#include "Evolution/Systems/Burgers/Observe.hpp"
+#include "Evolution/Systems/Burgers/System.hpp"
+#include "Evolution/Systems/Burgers/Tags.hpp"
+#include "IO/Observer/ArrayComponentId.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ObserverComponent.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Parallel/ArrayIndex.hpp"
+#include "Parallel/PupStlCpp11.hpp"
+#include "Parallel/Reduction.hpp"
+#include "Parallel/RegisterDerivedClassesWithCharm.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Burgers/Linear.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"  // IWYU pragma: keep
+#include "Time/Slab.hpp"
+#include "Time/Tags.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeId.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Numeric.hpp"
+#include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
+#include "tests/Unit/TestCreation.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+// IWYU pragma: no_include <memory>
+// IWYU pragma: no_include <pup.h>
+
+namespace Parallel {
+template <typename Metavariables>
+class ConstGlobalCache;
+}  // namespace Parallel
+// IWYU pragma: no_forward_declare db::DataBox
+namespace observers {
+namespace Actions {
+struct ContributeReductionData;
+struct ContributeVolumeData;
+}  // namespace Actions
+}  // namespace observers
+
+namespace {
+
+struct MockContributeVolumeData {
+  struct Results {
+    observers::ObservationId observation_id{};
+    std::string subfile_name{};
+    observers::ArrayComponentId array_component_id{};
+    std::vector<TensorComponent> in_received_tensor_data{};
+    Index<1> received_extents{};
+  };
+  static Results results;
+
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, size_t Dim>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const observers::ObservationId& observation_id,
+                    const std::string& subfile_name,
+                    const observers::ArrayComponentId& array_component_id,
+                    std::vector<TensorComponent>&& in_received_tensor_data,
+                    const Index<Dim>& received_extents) noexcept {
+    results.observation_id = observation_id;
+    results.subfile_name = subfile_name;
+    results.array_component_id = array_component_id;
+    results.in_received_tensor_data = in_received_tensor_data;
+    results.received_extents = received_extents;
+  }
+};
+
+MockContributeVolumeData::Results MockContributeVolumeData::results{};
+
+struct MockContributeReductionData {
+  struct Results {
+    observers::ObservationId observation_id;
+    std::string subfile_name;
+    std::vector<std::string> reduction_names;
+    double time;
+    size_t number_of_grid_points;
+    double u_error;
+  };
+  static Results results;
+
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, typename... Ts>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const observers::ObservationId& observation_id,
+                    const std::string& subfile_name,
+                    const std::vector<std::string>& reduction_names,
+                    Parallel::ReductionData<Ts...>&& reduction_data) noexcept {
+    results.observation_id = observation_id;
+    results.subfile_name = subfile_name;
+    results.reduction_names = reduction_names;
+    CHECK(reduction_data.pack_size() == 3);
+    results.time = std::get<0>(reduction_data.data());
+    results.number_of_grid_points = std::get<1>(reduction_data.data());
+    results.u_error = std::get<2>(reduction_data.data());
+  }
+};
+
+MockContributeReductionData::Results MockContributeReductionData::results{};
+
+struct Metavariables;
+
+struct ElementComponent {
+  using component_being_mocked = void;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementIndex<1>;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<db::AddSimpleTags<>>;
+  using action_list = tmpl::list<>;
+};
+
+struct MockObserverComponent {
+  using component_being_mocked = observers::Observer<Metavariables>;
+  using replace_these_simple_actions =
+      tmpl::list<observers::Actions::ContributeVolumeData,
+                 observers::Actions::ContributeReductionData>;
+  using with_these_simple_actions =
+      tmpl::list<MockContributeVolumeData, MockContributeReductionData>;
+
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using const_global_cache_tag_list = tmpl::list<>;
+  using initial_databox = db::compute_databox_type<db::AddSimpleTags<>>;
+  using action_list = tmpl::list<>;
+};
+
+struct Metavariables {
+  using system = Burgers::System;
+  using component_list = tmpl::list<ElementComponent, MockObserverComponent>;
+  using const_global_cache_tag_list =
+      tmpl::list<OptionTags::AnalyticSolution<Burgers::Solutions::Linear>>;
+
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+};
+
+template <typename ObserveEvent>
+void test_observe(const std::unique_ptr<ObserveEvent> observe) noexcept {
+  Burgers::Solutions::Linear analytic_solution(0.0);
+  const ElementComponent::array_index array_index(ElementId<1>(2));
+  const std::string element_name =
+      get_output(static_cast<ElementId<1>>(array_index));
+  const Mesh<1> mesh(5, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const double observation_time = 2.0;
+
+  // Fill the variables with some data.  It doesn't matter much what,
+  // but integers are nice in that we don't have to worry about
+  // roundoff error.
+  const tnsr::I<DataVector, 1> coords{{{{4., 3., 2., 1., 0.}}}};
+  const Scalar<DataVector> u{{{{1., 2., 3., 4., 5.}}}};
+  const Scalar<DataVector> u_analytic =
+      tuples::get<Burgers::Tags::U>(analytic_solution.variables(
+          coords, observation_time, tmpl::list<Burgers::Tags::U>{}));
+  const Scalar<DataVector> u_error{get(u) - get(u_analytic)};
+
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<Metavariables>;
+
+  MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
+  tuples::get<typename MockRuntimeSystem::template MockDistributedObjectsTag<
+      ElementComponent>>(dist_objects)
+      .emplace(array_index,
+               ActionTesting::MockDistributedObject<ElementComponent>{});
+  tuples::get<typename MockRuntimeSystem::template MockDistributedObjectsTag<
+      MockObserverComponent>>(dist_objects)
+      .emplace(0,
+               ActionTesting::MockDistributedObject<MockObserverComponent>{});
+  MockRuntimeSystem runner({std::move(analytic_solution)},
+                           std::move(dist_objects));
+
+  const auto box =
+      db::create<db::AddSimpleTags<Tags::TimeId, Tags::Mesh<1>,
+                                   Tags::Coordinates<1, Frame::Inertial>,
+                                   Burgers::Tags::U>,
+                 db::AddComputeTags<Tags::Time>>(
+          TimeId(true, 0, Slab(0., observation_time).end()), mesh, coords, u);
+
+  observe->run(box, runner.cache(), array_index,
+               std::add_pointer_t<ElementComponent>{});
+
+  // Process the volume and reduction data
+  runner.invoke_queued_simple_action<MockObserverComponent>(0);
+  runner.invoke_queued_simple_action<MockObserverComponent>(0);
+  CHECK(runner.is_simple_action_queue_empty<MockObserverComponent>(0));
+
+  const auto& volume_results = MockContributeVolumeData::results;
+  CHECK(volume_results.observation_id.value() == observation_time);
+  CHECK(volume_results.subfile_name == "/element_data");
+  CHECK(volume_results.array_component_id ==
+        observers::ArrayComponentId(
+            std::add_pointer_t<ElementComponent>{},
+            Parallel::ArrayIndex<ElementIndex<1>>(array_index)));
+  CHECK(volume_results.in_received_tensor_data.size() == 3);
+  // gcc 6.4.0 gets confused if we try to capture tensor_data by
+  // reference and fails to compile because it wants it to be
+  // non-const, so we capture a pointer instead.
+  const auto check_component =
+      [&element_name, tensor_data = &volume_results.in_received_tensor_data](
+          const std::string& component, const DataVector& expected) noexcept {
+    CAPTURE(*tensor_data);
+    CAPTURE(component);
+    const auto it =
+        alg::find_if(*tensor_data, [name = element_name + "/" + component](
+                                       const TensorComponent& tc) noexcept {
+          return tc.name == name;
+        });
+    CHECK(it != tensor_data->end());
+    if (it != tensor_data->end()) {
+      CHECK(it->data == expected);
+    }
+  };
+  check_component("InertialCoordinates_x", get<0>(coords));
+  check_component("U", get(u));
+  check_component("ErrorU", get(u_error));
+  CHECK(volume_results.received_extents == mesh.extents());
+
+  const auto& reduction_results = MockContributeReductionData::results;
+  CHECK(reduction_results.observation_id.value() == observation_time);
+  CHECK(reduction_results.subfile_name == "/element_data");
+  CHECK(reduction_results.reduction_names ==
+        std::vector<std::string>{"Time", "NumberOfPoints", "ErrorU"});
+  CHECK(reduction_results.time == observation_time);
+  CHECK(reduction_results.number_of_grid_points ==
+        mesh.number_of_grid_points());
+  // The rest of the RMS calculation is done later by the writer.
+  CHECK(reduction_results.u_error ==
+        alg::accumulate(square(get(u_error)), 0.0));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Burgers.Observe", "[Unit][Burgers]") {
+  test_observe(std::make_unique<Burgers::Events::Observe<>>());
+
+  INFO("create/serialize");
+  using EventType = Event<tmpl::list<Burgers::Events::Registrars::Observe>>;
+  Parallel::register_derived_classes_with_charm<EventType>();
+  const auto factory_event = test_factory_creation<EventType>("  Observe");
+  auto serialized_event = serialize_and_deserialize(factory_event);
+  test_observe(std::move(serialized_event));
+}

--- a/tests/Unit/Time/Test_PastTime.cpp
+++ b/tests/Unit/Time/Test_PastTime.cpp
@@ -34,10 +34,9 @@ SPECTRE_TEST_CASE("Unit.Time.Triggers.PastTime", "[Unit][Time]") {
   const auto check = [&sent_trigger](const Time& time,
                                      const bool time_runs_forward,
                                      const bool expected) noexcept {
-    const auto box =
-        db::create<db::AddSimpleTags<Tags::TimeId>,
-                   db::AddComputeTags<Tags::Time, Tags::TimeValue>>(
-            TimeId(time_runs_forward, 0, time));
+    const auto box = db::create<db::AddSimpleTags<Tags::TimeId>,
+                                db::AddComputeTags<Tags::Time>>(
+        TimeId(time_runs_forward, 0, time));
     CHECK(sent_trigger->is_triggered(box) == expected);
   };
   check(slab.start(), true, false);

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -178,7 +178,10 @@ standard_checks=()
 
 # Check for lines longer than 80 characters
 long_lines_exclude() {
-    grep -Ev 'https?://' | grep -v '// IWYU pragma:' | grep -v '// NOLINT'
+    grep -Ev 'https?://' | \
+        grep -v '// IWYU pragma:' | \
+        grep -v '// NOLINT' | \
+        grep -v '\\snippet'
 }
 long_lines() {
     whitelist "$1" \


### PR DESCRIPTION
I intend to try to generalize this to cover all the systems in a future PR, which is why this does not touch the other observation Actions.

This uses the registration recommendations from #1328, but as that is a guideline change there is no actual code dependence between the two PRs.

Intended changes from the Action version:
* The label for the RMS error was changed from "UError" to "ErrorU" to match the volume version.
* The sign of the volume error was changed to the (I believe) more conventional value obtained by "measured - correct".

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
