### PR TITLE
Utilities/Algorithm cleanup and additions

### DIFF
--- a/src/Utilities/Algorithm.hpp
+++ b/src/Utilities/Algorithm.hpp
@@ -161,6 +161,23 @@ decltype(auto) none_of(const Container& c, UnaryPredicate&& unary_predicate) {
                       std::forward<UnaryPredicate>(unary_predicate));
 }
 
+/// Convenience wrapper around std::count
+template <class Container, class T>
+decltype(auto) count(const Container& c, const T& value) {
+  using std::begin;
+  using std::end;
+  return std::count(begin(c), end(c), value);
+}
+
+/// Convenience wrapper around std::count_if
+template <class Container, class UnaryPredicate>
+decltype(auto) count_if(const Container& c, UnaryPredicate&& unary_predicate) {
+  using std::begin;
+  using std::end;
+  return std::count_if(begin(c), end(c),
+                       std::forward<UnaryPredicate>(unary_predicate));
+}
+
 /// Convenience wrapper around std::find
 template <class Container, class T>
 decltype(auto) find(const Container& c, const T& value) {

--- a/src/Utilities/Algorithm.hpp
+++ b/src/Utilities/Algorithm.hpp
@@ -262,4 +262,21 @@ decltype(auto) equal(const Container& lhs, const Container2& rhs,
   return std::equal(begin(lhs), end(lhs), begin(rhs),
                     std::forward<BinaryPredicate>(p));
 }
+
+/// Convenience wrapper around std::remove
+template <class Container, class T>
+decltype(auto) remove(Container& c, const T& value) {
+  using std::begin;
+  using std::end;
+  return std::remove(begin(c), end(c), value);
+}
+
+/// Convenience wrapper around std::remove_if
+template <class Container, class UnaryPredicate>
+decltype(auto) remove_if(Container& c, UnaryPredicate&& unary_predicate) {
+  using std::begin;
+  using std::end;
+  return std::remove_if(begin(c), end(c),
+                        std::forward<UnaryPredicate>(unary_predicate));
+}
 }  // namespace alg

--- a/src/Utilities/Algorithm.hpp
+++ b/src/Utilities/Algorithm.hpp
@@ -263,6 +263,38 @@ decltype(auto) equal(const Container& lhs, const Container2& rhs,
                     std::forward<BinaryPredicate>(p));
 }
 
+/// Convenience wrapper around std::max_element
+template <class Container>
+decltype(auto) max_element(const Container& c) {
+  using std::begin;
+  using std::end;
+  return std::max_element(begin(c), end(c));
+}
+
+/// Convenience wrapper around std::max_element
+template <class Container, class Compare>
+decltype(auto) max_element(const Container& c, Compare&& comp) {
+  using std::begin;
+  using std::end;
+  return std::max_element(begin(c), end(c), std::forward<Compare>(comp));
+}
+
+/// Convenience wrapper around std::min_element
+template <class Container>
+decltype(auto) min_element(const Container& c) {
+  using std::begin;
+  using std::end;
+  return std::min_element(begin(c), end(c));
+}
+
+/// Convenience wrapper around std::min_element
+template <class Container, class Compare>
+decltype(auto) min_element(const Container& c, Compare&& comp) {
+  using std::begin;
+  using std::end;
+  return std::min_element(begin(c), end(c), std::forward<Compare>(comp));
+}
+
 /// Convenience wrapper around std::remove
 template <class Container, class T>
 decltype(auto) remove(Container& c, const T& value) {

--- a/tests/Unit/Utilities/Test_Algorithm.cpp
+++ b/tests/Unit/Utilities/Test_Algorithm.cpp
@@ -101,6 +101,24 @@ void test_all_of_and_any_of_and_none_of() noexcept {
                            [](const int t) { return t == 1; }));
 }
 
+void test_count_related() noexcept {
+  std::vector<int> a{1, 2, 3, 4, 3, 5};
+  CHECK(alg::count(a, 0) == 0);
+  CHECK(alg::count(a, -1) == 0);
+  CHECK(alg::count(a, -2) == 0);
+  for (int i = 1; i < 5; ++i) {
+    CHECK(alg::count(a, i) == (i == 3 ? 2 : 1));
+  }
+
+  CHECK(alg::count_if(a, [](const int t) { return t == 0; }) == 0);
+  CHECK(alg::count_if(a, [](const int t) { return t == -1; }) == 0);
+  CHECK(alg::count_if(a, [](const int t) { return t == -2; }) == 0);
+  CHECK(alg::count_if(a, [](const int t) { return t % 2 == 0; }) == 2);
+  CHECK(alg::count_if(a, [](const int t) { return t % 3 == 0; }) == 2);
+  CHECK(alg::count_if(a, [](const int t) { return t % 5 == 0; }) == 1);
+  CHECK(alg::count_if(a, [](const int t) { return t % 7 == 0; }) == 0);
+}
+
 void test_equal() noexcept {
   // Test alg::equal
   CHECK(alg::equal(std::vector<int>{1, -7, 8, 9},
@@ -149,6 +167,7 @@ void test_for_each() noexcept {
 SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
   test_constexpr_swap_iter_swap_reverse_etc();
   test_all_of_and_any_of_and_none_of();
+  test_count_related();
   test_equal();
   test_find_related();
   test_for_each();

--- a/tests/Unit/Utilities/Test_Algorithm.cpp
+++ b/tests/Unit/Utilities/Test_Algorithm.cpp
@@ -136,6 +136,16 @@ void test_equal() noexcept {
       [](const int lhs, const int rhs) noexcept { return lhs == -rhs; }));
 }
 
+void test_min_max_element() noexcept {
+  std::vector<int> t{3, 5, 8, -1};
+  CHECK(*alg::min_element(t) == -1);
+  CHECK(*alg::max_element(t) == 8);
+  CHECK(*alg::min_element(t, [](const int a, const int b) { return a > b; }) ==
+        8);
+  CHECK(*alg::max_element(t, [](const int a, const int b) { return a > b; }) ==
+        -1);
+}
+
 void test_find_related() noexcept {
   const std::vector<int> a{1, 2, 3, 4};
   CHECK(alg::find(a, 3) == a.begin() + 2);
@@ -185,5 +195,6 @@ SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
   test_equal();
   test_find_related();
   test_for_each();
+  test_min_max_element();
   test_remove();
 }

--- a/tests/Unit/Utilities/Test_Algorithm.cpp
+++ b/tests/Unit/Utilities/Test_Algorithm.cpp
@@ -58,9 +58,8 @@ constexpr bool check_next_permutation() noexcept {
   cpp17::array<size_t, size> expected{{1, 2, 4, 6, 5, 3}};
   return a == expected;
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
+void test_constexpr_swap_iter_swap_reverse_etc() noexcept {
   // Check the functions at runtime
   CHECK(check_swap());
   CHECK(check_iter_swap());
@@ -76,7 +75,9 @@ SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
                 "Failed test Unit.Utilities.Algorithm");
   static_assert(check_next_permutation(),
                 "Failed test Unit.Utilities.Algorithm");
+}
 
+void test_all_of_and_any_of_and_none_of() noexcept {
   // Test wrappers around STL algorithms
   CHECK(alg::all_of(std::vector<int>{1, 1, 1, 1},
                     [](const int t) { return t == 1; }));
@@ -98,6 +99,24 @@ SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
                            [](const int t) { return t == 1; }));
   CHECK_FALSE(alg::none_of(std::vector<int>{4, 2, -1, 1},
                            [](const int t) { return t == 1; }));
+}
+
+void test_equal() noexcept {
+  // Test alg::equal
+  CHECK(alg::equal(std::vector<int>{1, -7, 8, 9},
+                   std::array<int, 4>{{1, -7, 8, 9}}));
+  CHECK_FALSE(alg::equal(std::vector<int>{1, 7, 8, 9},
+                         std::array<int, 4>{{1, -7, 8, 9}}));
+
+  CHECK(alg::equal(
+      std::vector<int>{1, -7, 8, 9}, std::array<int, 4>{{-1, 7, -8, -9}},
+      [](const int lhs, const int rhs) noexcept { return lhs == -rhs; }));
+  CHECK_FALSE(alg::equal(
+      std::vector<int>{1, -7, 8, 9}, std::array<int, 4>{{-1, -7, -8, -9}},
+      [](const int lhs, const int rhs) noexcept { return lhs == -rhs; }));
+}
+
+void test_find_related() noexcept {
   const std::vector<int> a{1, 2, 3, 4};
   CHECK(alg::find(a, 3) == a.begin() + 2);
   CHECK(alg::find(a, 5) == a.end());
@@ -113,7 +132,9 @@ SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
   CHECK(alg::find_if_not(a, [](const int t) { return t < 8; }) == a.end());
   CHECK(alg::found_if_not(a, [](const int t) { return t < 3; }));
   CHECK_FALSE(alg::found_if_not(a, [](const int t) { return t < 8; }));
+}
 
+void test_for_each() noexcept {
   int count = 0;
   alg::for_each(std::vector<size_t>{1, 7, 234, 987, 32},
                 [&count](const size_t value) {
@@ -122,17 +143,14 @@ SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
                   }
                 });
   CHECK(count == 2);
+}
+}  // namespace
 
-  // Test alg::equal
-  CHECK(alg::equal(std::vector<int>{1, -7, 8, 9},
-                   std::array<int, 4>{{1, -7, 8, 9}}));
-  CHECK_FALSE(alg::equal(std::vector<int>{1, 7, 8, 9},
-                         std::array<int, 4>{{1, -7, 8, 9}}));
+SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
+  test_constexpr_swap_iter_swap_reverse_etc();
+  test_all_of_and_any_of_and_none_of();
+  test_equal();
+  test_find_related();
+  test_for_each();
 
-  CHECK(alg::equal(
-      std::vector<int>{1, -7, 8, 9}, std::array<int, 4>{{-1, 7, -8, -9}},
-      [](const int lhs, const int rhs) noexcept { return lhs == -rhs; }));
-  CHECK_FALSE(alg::equal(
-      std::vector<int>{1, -7, 8, 9}, std::array<int, 4>{{-1, -7, -8, -9}},
-      [](const int lhs, const int rhs) noexcept { return lhs == -rhs; }));
 }

--- a/tests/Unit/Utilities/Test_Algorithm.cpp
+++ b/tests/Unit/Utilities/Test_Algorithm.cpp
@@ -3,7 +3,9 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
+#include <cctype>
 #include <iterator>
+#include <string>
 #include <vector>
 
 #include "Utilities/Algorithm.hpp"
@@ -162,6 +164,18 @@ void test_for_each() noexcept {
                 });
   CHECK(count == 2);
 }
+
+void test_remove() noexcept {
+  std::string str1 = "Test with some   spaces";
+  str1.erase(alg::remove(str1, ' '), str1.end());
+  CHECK(str1 == "Testwithsomespaces");
+
+  std::string str2 = "Text\n with\tsome \t  whitespaces\n\n";
+  str2.erase(
+      alg::remove_if(str2, [](unsigned char x) { return std::isspace(x); }),
+      str2.end());
+  CHECK(str2 == "Textwithsomewhitespaces");
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
@@ -171,5 +185,5 @@ SPECTRE_TEST_CASE("Unit.Utilities.Algorithm", "[Unit][Utilities]") {
   test_equal();
   test_find_related();
   test_for_each();
-
+  test_remove();
 }


### PR DESCRIPTION
## Proposed changes

- Factor the tests in `Utilities/Test_Algorithm.cpp` so we have only one test case
- Add wrappers around `std::count`, `std::count_if`
- Add wrappers around `std::remove`, `std::remove_if`
- Add wrappers around `std::min_element`, `std::max_element`

These will be used in follow-up PRs and will be generally useful to have in the code.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
