### PR TITLE
Minor block cleanup

### DIFF
--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -8,29 +8,29 @@ add_subdirectory(Creators)
 set(LIBRARY Domain)
 
 set(LIBRARY_SOURCES
-    Block.cpp
-    BlockLogicalCoordinates.cpp
-    BlockNeighbor.cpp
-    CreateInitialElement.cpp
-    Domain.cpp
-    DomainHelpers.cpp
-    Direction.cpp
-    Element.cpp
-    ElementId.cpp
-    ElementIndex.cpp
-    ElementLogicalCoordinates.cpp
-    ElementMap.cpp
-    FaceNormal.cpp
-    InitialElementIds.cpp
-    LogicalCoordinates.cpp
-    Mesh.cpp
-    MinimumGridSpacing.cpp
-    Neighbors.cpp
-    OrientationMap.cpp
-    SegmentId.cpp
-    Side.cpp
-    SizeOfElement.cpp
-    )
+  Block.cpp
+  BlockLogicalCoordinates.cpp
+  BlockNeighbor.cpp
+  CreateInitialElement.cpp
+  Direction.cpp
+  Domain.cpp
+  DomainHelpers.cpp
+  Element.cpp
+  ElementId.cpp
+  ElementIndex.cpp
+  ElementLogicalCoordinates.cpp
+  ElementMap.cpp
+  FaceNormal.cpp
+  InitialElementIds.cpp
+  LogicalCoordinates.cpp
+  Mesh.cpp
+  MinimumGridSpacing.cpp
+  Neighbors.cpp
+  OrientationMap.cpp
+  SegmentId.cpp
+  Side.cpp
+  SizeOfElement.cpp
+  )
 
 add_library(${LIBRARY} ${LIBRARY_SOURCES})
 

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -22,6 +22,7 @@
 #include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace {
 template <size_t Dim>
 void test_block() {
   PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Grid,
@@ -55,13 +56,12 @@ void test_block() {
   const Block<Dim, Frame::Grid> block_copy(identity_map.get_clone(), 7, {});
   test_move_semantics(std::move(block), block_copy);
 }
+}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Block.Identity", "[Domain][Unit]") {
+SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
   test_block<1>();
   test_block<2>();
-}
 
-SPECTRE_TEST_CASE("Unit.Domain.Block.Neighbors", "[Domain][Unit]") {
   // Create DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>>
 
   // Each BlockNeighbor is an id and an OrientationMap:


### PR DESCRIPTION
## Proposed changes

- Fix indentation in `src/Domain/CmakeLists.txt`
- Combine different test cases in `Domain/Test_Block.cpp`

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
