### PR TITLE
HDF5 cleanups

### DIFF
--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -4,19 +4,20 @@
 set(LIBRARY IO)
 
 set(LIBRARY_SOURCES
-    Connectivity.cpp
-    H5/Dat.cpp
-    H5/File.cpp
-    H5/Header.cpp
-    H5/Helpers.cpp
-    H5/OpenGroup.cpp
-    H5/StellarCollapseEos.cpp
-    H5/Version.cpp
-    H5/VolumeData.cpp
-    Observer/ArrayComponentId.cpp
-    Observer/ObservationId.cpp
-    Observer/TypeOfObservation.cpp
-)
+  Connectivity.cpp
+  H5/AccessType.cpp
+  H5/Dat.cpp
+  H5/File.cpp
+  H5/Header.cpp
+  H5/Helpers.cpp
+  H5/OpenGroup.cpp
+  H5/StellarCollapseEos.cpp
+  H5/Version.cpp
+  H5/VolumeData.cpp
+  Observer/ArrayComponentId.cpp
+  Observer/ObservationId.cpp
+  Observer/TypeOfObservation.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 

--- a/src/IO/H5/AccessType.cpp
+++ b/src/IO/H5/AccessType.cpp
@@ -1,0 +1,21 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/H5/AccessType.hpp"
+
+#include <ostream>
+
+#include "ErrorHandling/Error.hpp"
+
+namespace h5 {
+std::ostream& operator<<(std::ostream& os, const AccessType t) noexcept {
+  switch (t) {
+    case AccessType::ReadOnly:
+      return os << "ReadOnly";
+    case AccessType::ReadWrite:
+      return os << "ReadWrite";
+    default:
+      ERROR("Unknown h5::AccessType. Known values are ReadWrite and ReadOnly.");
+  }
+}
+}  // namespace h5

--- a/src/IO/H5/AccessType.hpp
+++ b/src/IO/H5/AccessType.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <iosfwd>
+
 /*!
  * \ingroup HDF5Group
  * \brief Contains functions and classes for manipulating HDF5 files
@@ -24,4 +26,6 @@ enum class AccessType {
   /// Allow only read access to the file
   ReadOnly
 };
+
+std::ostream& operator<<(std::ostream& os, AccessType t) noexcept;
 }  // namespace h5

--- a/src/IO/H5/Dat.cpp
+++ b/src/IO/H5/Dat.cpp
@@ -20,6 +20,8 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"
 
+// IWYU pragma: no_include "DataStructures/Index.hpp"
+
 namespace {
 /*!
  * Given a vector of contiguous data and an array giving the dimensions of the
@@ -107,6 +109,7 @@ void Dat::append_impl(const hsize_t number_of_rows,
     }
     CHECK_H5(H5Sclose(dataspace_id), "Failed to close dataspace");
     if (read_size != size_) {
+      using ::operator<<;
       ERROR("Mismatch in the size of the read dataset. Read "
             << read_size << " but have stored " << size_
             << ". This means that another thread or process is writing data at "
@@ -205,6 +208,7 @@ Matrix Dat::get_data() const {
   CHECK_H5(H5Sclose(dataspace_id), "Failed to close dataspace");
 
   if (size != size_) {
+    using ::operator<<;
     ERROR("Mismatch in the size of the read dataset. Read "
           << size << " but have stored " << size_
           << ". This means that another thread or process is writing data at "
@@ -242,6 +246,7 @@ Matrix Dat::get_data_subset(const std::vector<size_t>& these_columns,
     ERROR("Incorrect dimension in get_data()");  // LCOV_EXCL_LINE
   }
   if (size != size_) {
+    using ::operator<<;
     CHECK_H5(H5Sclose(dataspace_id), "Failed to close dataspace");
     ERROR("Mismatch in the size of the read dataset. Read "
           << size << " but have stored " << size_

--- a/src/IO/H5/File.cpp
+++ b/src/IO/H5/File.cpp
@@ -46,7 +46,11 @@ H5File<Access_t>::H5File(std::string file_name, bool append_to_file)
                            h5p_default())
                  : H5Fcreate(file_name_.c_str(), h5f_acc_trunc(), h5p_default(),
                              h5p_default());
-  CHECK_H5(file_id_, "Failed to open file '" << file_name_ << "'");
+  CHECK_H5(file_id_, "Failed to open file '"
+                         << file_name_ << "'. The file exists status is: "
+                         << std::boolalpha << file_exists
+                         << ". Writing from directory: " << file_system::cwd()
+                         << ". Trying to open in mode: " << Access_t);
   if (not file_exists) {
     insert_header();
   }

--- a/src/IO/H5/Helpers.cpp
+++ b/src/IO/H5/Helpers.cpp
@@ -468,6 +468,7 @@ T read_data(const hid_t group_id, const std::string& dataset_name) noexcept {
   const size_t total_number_of_components = std::accumulate(
       size.begin(), size.end(), static_cast<size_t>(1), std::multiplies<>());
   if (UNLIKELY(total_number_of_components == 0)) {
+    using ::operator<<;
     ERROR("At least one element in 'size' is 0. Expected data along "
           << Rank << " dimensions. size = " << size);
   }

--- a/tests/Unit/IO/Test_H5.cpp
+++ b/tests/Unit/IO/Test_H5.cpp
@@ -38,6 +38,13 @@
 // IWYU pragma: no_include <boost/multi_array/extent_gen.hpp>
 // IWYU pragma: no_include <boost/multi_array/subarray.hpp>
 
+namespace {
+void test_access_type() noexcept {
+  CHECK(get_output(h5::AccessType::ReadOnly) == "ReadOnly");
+  CHECK(get_output(h5::AccessType::ReadWrite) == "ReadWrite");
+}
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
   const std::string h5_file_name("Unit.IO.H5.File.h5");
   if (file_system::check_if_file_exists(h5_file_name)) {
@@ -65,6 +72,8 @@ SPECTRE_TEST_CASE("Unit.IO.H5.File", "[Unit][IO][H5]") {
   if (file_system::check_if_file_exists(h5_file_name)) {
     file_system::rm(h5_file_name, true);
   }
+
+  test_access_type();
 }
 
 SPECTRE_TEST_CASE("Unit.IO.H5.FileMove", "[Unit][IO][H5]") {

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ObserveTimeSeriesOnSurface.cpp
@@ -244,6 +244,12 @@ struct MockMetavariables {
 
 SPECTRE_TEST_CASE(
     "Unit.NumericalAlgorithms.Interpolator.ObserveSurfaceIntegrals", "[Unit]") {
+  const std::string h5_file_prefix = "Test_ObserveSurfaceIntegrals";
+  const auto h5_file_name = h5_file_prefix + ".h5";
+  if (file_system::check_if_file_exists(h5_file_name)) {
+    file_system::rm(h5_file_name, true);
+  }
+
   using metavars = MockMetavariables;
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
   using TupleOfMockDistributedObjects =
@@ -289,7 +295,6 @@ SPECTRE_TEST_CASE(
                                                         2.0, {{0.0, 0.0, 0.0}});
   intrp::OptionHolders::KerrHorizon kerr_horizon_opts_C(10, {{0.0, 0.0, 0.0}},
                                                         1.5, {{0.0, 0.0, 0.0}});
-  std::string h5_file_prefix = "Test_ObserveSurfaceIntegrals";
   tuples::TaggedTuple<observers::OptionTags::ReductionFileName,
                       metavars::SurfaceA, metavars::SurfaceB,
                       metavars::SurfaceC>
@@ -430,7 +435,6 @@ SPECTRE_TEST_CASE(
                                                    "SurfaceIntegralNegate"};
 
   // Check that the H5 file was written correctly.
-  const auto h5_file_name = h5_file_prefix + ".h5";
   const auto file = h5::H5File<h5::AccessType::ReadOnly>(h5_file_name);
   auto check_file_contents = [&file](
       const std::vector<double>& expected_integral,


### PR DESCRIPTION
## Proposed changes

- Minor cleanups to testing of HDF5 infrastructure
- Add stream operator for `h5::AccessType` so we can print out its state in error messages.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
