### PR TITLE
Add coefficient transforms

### DIFF
--- a/src/DataStructures/VariablesHelpers.hpp
+++ b/src/DataStructures/VariablesHelpers.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
 #include "DataStructures/SliceIterator.hpp"
 #include "ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
@@ -188,6 +189,7 @@ void orient_each_component(
     const gsl::not_null<Variables<TagsList>*> oriented_variables,
     const Variables<TagsList>& variables,
     const std::vector<size_t>& oriented_offset) noexcept {
+  using VectorType = typename Variables<TagsList>::vector_type;
   tmpl::for_each<TagsList>(
       [&oriented_variables, &variables, &oriented_offset](auto tag) {
         using Tag = tmpl::type_from<decltype(tag)>;
@@ -195,9 +197,9 @@ void orient_each_component(
         const auto& tensor = get<Tag>(variables);
         for (decltype(auto) oriented_and_tensor_components :
              boost::combine(oriented_tensor, tensor)) {
-          DataVector& oriented_tensor_component =
+          VectorType& oriented_tensor_component =
               boost::get<0>(oriented_and_tensor_components);
-          const DataVector& tensor_component =
+          const VectorType& tensor_component =
               boost::get<1>(oriented_and_tensor_components);
           for (size_t s = 0; s < tensor_component.size(); ++s) {
             oriented_tensor_component[oriented_offset[s]] = tensor_component[s];

--- a/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -4,11 +4,12 @@
 set(LIBRARY LinearOperators)
 
 set(LIBRARY_SOURCES
-    ApplyMatrices.cpp
-    DefiniteIntegral.cpp
-    Linearize.cpp
-    MeanValue.cpp
-    )
+  ApplyMatrices.cpp
+  CoefficientTransforms.cpp
+  DefiniteIntegral.cpp
+  Linearize.cpp
+  MeanValue.cpp
+  )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 

--- a/src/NumericalAlgorithms/LinearOperators/CoefficientTransforms.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/CoefficientTransforms.cpp
@@ -1,0 +1,130 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "DataStructures/StripeIterator.hpp"
+#include "Domain/Mesh.hpp"
+#include "ErrorHandling/Assert.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+void transform_impl_helper(double* const output_coeffs,
+                           const double* const input_coeffs,
+                           const Mesh<Dim>& mesh, const bool nodal_to_modal,
+                           const size_t dim) noexcept {
+  for (StripeIterator stripe_it(mesh.extents(), dim); stripe_it; ++stripe_it) {
+    const Matrix& transformation_matrix =
+        nodal_to_modal
+            ? Spectral::grid_points_to_spectral_matrix(mesh.slice_through(dim))
+            : Spectral::spectral_to_grid_points_matrix(mesh.slice_through(dim));
+    dgemv_('N', mesh.extents()[dim], mesh.extents()[dim], 1.0,
+           transformation_matrix.data(), mesh.extents()[dim],
+           input_coeffs + stripe_it.offset(), stripe_it.stride(),  // NOLINT
+           0.0, output_coeffs + stripe_it.offset(),                // NOLINT
+           stripe_it.stride());
+  }
+}
+
+void transform_impl(double* const modal_coefficients,
+                    const double* const nodal_coefficients, const Mesh<1>& mesh,
+                    const bool nodal_to_modal) noexcept {
+  transform_impl_helper(modal_coefficients, nodal_coefficients, mesh,
+                        nodal_to_modal, 0);
+}
+
+void transform_impl(double* const modal_coefficients,
+                    const double* const nodal_coefficients, const Mesh<2>& mesh,
+                    const bool nodal_to_modal) noexcept {
+  DataVector temp(mesh.number_of_grid_points());
+  transform_impl_helper(temp.data(), nodal_coefficients, mesh, nodal_to_modal,
+                        0);
+  transform_impl_helper(modal_coefficients, temp.data(), mesh, nodal_to_modal,
+                        1);
+}
+
+void transform_impl(double* const modal_coefficients,
+                    const double* const nodal_coefficients, const Mesh<3>& mesh,
+                    const bool nodal_to_modal) noexcept {
+  DataVector temp(mesh.number_of_grid_points());
+  transform_impl_helper(modal_coefficients, nodal_coefficients, mesh,
+                        nodal_to_modal, 0);
+  transform_impl_helper(temp.data(), modal_coefficients, mesh, nodal_to_modal,
+                        1);
+  transform_impl_helper(modal_coefficients, temp.data(), mesh, nodal_to_modal,
+                        2);
+}
+}  // namespace
+
+template <size_t Dim>
+void to_modal_coefficients(const gsl::not_null<ModalVector*> modal_coefficients,
+                           const DataVector& nodal_coefficients,
+                           const Mesh<Dim>& mesh) noexcept {
+  if (modal_coefficients->size() != nodal_coefficients.size()) {
+    ASSERT(modal_coefficients->is_owning(),
+           "Cannot resize a non-owning ModalVector");
+    *modal_coefficients = ModalVector(nodal_coefficients.size());
+  }
+  transform_impl(modal_coefficients->data(), nodal_coefficients.data(), mesh,
+                 true);
+}
+
+template <size_t Dim>
+ModalVector to_modal_coefficients(const DataVector& nodal_coefficients,
+                                  const Mesh<Dim>& mesh) noexcept {
+  ModalVector modal_coefficients(nodal_coefficients.size());
+  transform_impl(modal_coefficients.data(), nodal_coefficients.data(), mesh,
+                 true);
+  return modal_coefficients;
+}
+
+template <size_t Dim>
+void to_nodal_coefficients(const gsl::not_null<DataVector*> nodal_coefficients,
+                           const ModalVector& modal_coefficients,
+                           const Mesh<Dim>& mesh) noexcept {
+  if (nodal_coefficients->size() != modal_coefficients.size()) {
+    ASSERT(nodal_coefficients->is_owning(),
+           "Cannot resize a non-owning DataVector");
+    *nodal_coefficients = DataVector(modal_coefficients.size());
+  }
+  transform_impl(nodal_coefficients->data(), modal_coefficients.data(), mesh,
+                 false);
+}
+
+template <size_t Dim>
+DataVector to_nodal_coefficients(const ModalVector& modal_coefficients,
+                                 const Mesh<Dim>& mesh) noexcept {
+  DataVector nodal_coefficients(modal_coefficients.size());
+  transform_impl(nodal_coefficients.data(), modal_coefficients.data(), mesh,
+                 false);
+  return nodal_coefficients;
+}
+
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(r, data)                                 \
+  template void to_modal_coefficients<GET_DIM(data)>(        \
+      const gsl::not_null<ModalVector*> modal_coefficients,  \
+      const DataVector& nodal_coefficients,                  \
+      const Mesh<GET_DIM(data)>& mesh) noexcept;             \
+  template ModalVector to_modal_coefficients<GET_DIM(data)>( \
+      const DataVector& nodal_coefficients,                  \
+      const Mesh<GET_DIM(data)>& mesh) noexcept;             \
+  template void to_nodal_coefficients<GET_DIM(data)>(        \
+      const gsl::not_null<DataVector*> nodal_coefficients,   \
+      const ModalVector& modal_coefficients,                 \
+      const Mesh<GET_DIM(data)>& mesh) noexcept;             \
+  template DataVector to_nodal_coefficients<GET_DIM(data)>(  \
+      const ModalVector& modal_coefficients,                 \
+      const Mesh<GET_DIM(data)>& mesh) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+#undef GET_DIM
+#undef INSTANTIATE

--- a/src/NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp
@@ -1,0 +1,52 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+class ModalVector;
+
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+// @{
+/*!
+ * \ingroup SpectralGroup
+ * \brief Compute the modal coefficients from the nodal coefficients
+ *
+ * \see Spectral::grid_points_to_spectral_matrix
+ */
+template <size_t Dim>
+void to_modal_coefficients(gsl::not_null<ModalVector*> modal_coefficients,
+                           const DataVector& nodal_coefficients,
+                           const Mesh<Dim>& mesh) noexcept;
+
+template <size_t Dim>
+ModalVector to_modal_coefficients(const DataVector& nodal_coefficients,
+                                  const Mesh<Dim>& mesh) noexcept;
+// @}
+
+// @{
+/*!
+ * \ingroup SpectralGroup
+ * \brief Compute the nodal coefficients from the modal coefficients
+ *
+ * \see Spectral::spectral_to_grid_points_matrix
+ */
+template <size_t Dim>
+void to_nodal_coefficients(gsl::not_null<DataVector*> nodal_coefficients,
+                           const ModalVector& modal_coefficients,
+                           const Mesh<Dim>& mesh) noexcept;
+
+template <size_t Dim>
+DataVector to_nodal_coefficients(const ModalVector& modal_coefficients,
+                                 const Mesh<Dim>& mesh) noexcept;
+// @}

--- a/src/NumericalAlgorithms/Spectral/Legendre.cpp
+++ b/src/NumericalAlgorithms/Spectral/Legendre.cpp
@@ -13,26 +13,26 @@
 #include "ErrorHandling/Assert.hpp"
 #include "NumericalAlgorithms/RootFinding/NewtonRaphson.hpp"
 #include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/MakeWithValue.hpp"
 
 namespace Spectral {
 
 // Algorithms to compute Legendre basis functions
 // These functions specialize the templates declared in `Spectral.hpp`.
 
-/// \cond
-template <>
-DataVector compute_basis_function_values<Basis::Legendre>(
-    const size_t k, const DataVector& x) noexcept {
+namespace {
+template <typename T>
+T compute_basis_function_value_impl(const size_t k, const T& x) noexcept {
   // Algorithm 20 in Kopriva, p. 60
   switch (k) {
     case 0:
-      return DataVector(x.size(), 1.);
+      return make_with_value<T>(x, 1.);
     case 1:
       return x;
     default:
-      DataVector L_k_minus_2(x.size(), 1.);
-      DataVector L_k_minus_1 = x;
-      DataVector L_k(x.size());
+      T L_k_minus_2 = make_with_value<T>(x, 1.);
+      T L_k_minus_1 = x;
+      T L_k = make_with_value<T>(x, 0.);
       for (size_t j = 2; j <= k; j++) {
         L_k = ((2. * j - 1.) * x * L_k_minus_1 - (j - 1.) * L_k_minus_2) / j;
         L_k_minus_2 = L_k_minus_1;
@@ -40,6 +40,20 @@ DataVector compute_basis_function_values<Basis::Legendre>(
       }
       return L_k;
   }
+}
+}  // namespace
+
+/// \cond
+template <>
+DataVector compute_basis_function_value<Basis::Legendre>(
+    const size_t k, const DataVector& x) noexcept {
+  return compute_basis_function_value_impl(k, x);
+}
+
+template <>
+double compute_basis_function_value<Basis::Legendre>(const size_t k,
+                                                     const double& x) noexcept {
+  return compute_basis_function_value_impl(k, x);
 }
 
 template <>

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -155,7 +155,7 @@ struct SpectralToGridPointsMatrixGenerator {
     Matrix vandermonde_matrix(num_points, num_points);
     for (size_t j = 0; j < num_points; j++) {
       const auto& basis_function_values =
-          compute_basis_function_values<BasisType>(j, collocation_pts);
+          compute_basis_function_value<BasisType>(j, collocation_pts);
       for (size_t i = 0; i < num_points; i++) {
         vandermonde_matrix(i, j) = basis_function_values[i];
       }

--- a/src/NumericalAlgorithms/Spectral/Spectral.hpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.hpp
@@ -99,9 +99,8 @@ constexpr size_t maximum_number_of_points = 12;
  * \brief Compute the function values of the basis function \f$\Phi_k(x)\f$
  * (zero-indexed).
  */
-template <Basis BasisType>
-DataVector compute_basis_function_values(size_t k,
-                                         const DataVector& x) noexcept;
+template <Basis BasisType, typename T>
+T compute_basis_function_value(size_t k, const T& x) noexcept;
 
 /*!
  * \brief Compute the inverse of the weight function \f$w(x)\f$ w.r.t. which

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_LinearOperators")
 
 set(LIBRARY_SOURCES
   Test_ApplyMatrices.cpp
+  Test_CoefficientTransforms.cpp
   Test_DefiniteIntegral.cpp
   Test_Divergence.cpp
   Test_Linearize.cpp

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_CoefficientTransforms.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_CoefficientTransforms.cpp
@@ -1,0 +1,145 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/IndexIterator.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
+
+// These tests generate a function `u_nodal_expected` from a linear
+// superposition of the basis functions, which are then transformed to spectral
+// space (`u_modal`). The coefficients are compared to their expected values,
+// which is 1 if the coefficient is specified in `coeffs_to_include` and 0
+// otherwise. Finally, the modal coefficients are transformed back to the nodal
+// coefficients and compared to `u_nodal_expected`.
+namespace {
+template <Spectral::Basis Basis, Spectral::Quadrature Quadrature, size_t Dim>
+void check_transforms(
+    const Mesh<Dim>& mesh,
+    const std::vector<std::array<size_t, Dim>>& coeffs_to_include) noexcept {
+  CAPTURE(Basis);
+  CAPTURE(Quadrature);
+  CAPTURE(mesh);
+  CAPTURE(coeffs_to_include);
+
+  // Construct a functions:
+  //
+  // 1D: u(\xi) = sum_i c_i phi_i(\xi)
+  // 2D: u(\xi,\eta) = sum_{i,j} c_{i,j} phi_i(\xi) phi_j(\eta)
+  // 3D: u(\xi,\eta,\zeta) = sum_{i,j,k} c_{i,j,k} phi_i(\xi)
+  //                                     phi_j(\eta) phi_k(\zeta)
+  //
+  // where the coefficients c_{i,j,k} are 1 if listed in `coeffs_to_include` and
+  // 0 otherwise.
+  const auto logical_coords = logical_coordinates(mesh);
+  DataVector u_nodal_expected(mesh.number_of_grid_points(), 0.0);
+  for (const auto& coeff : coeffs_to_include) {
+    DataVector basis_function = Spectral::compute_basis_function_value<Basis>(
+        coeff[0], get<0>(logical_coords));
+    for (size_t dim = 1; dim < Dim; ++dim) {
+      basis_function *= Spectral::compute_basis_function_value<Basis>(
+          gsl::at(coeff, dim), logical_coords.get(dim));
+    }
+    u_nodal_expected += basis_function;
+  }
+
+  // Transform to modal coefficients and check their values
+  const ModalVector u_modal = to_modal_coefficients(u_nodal_expected, mesh);
+  for (IndexIterator<Dim> index_it(mesh.extents()); index_it; ++index_it) {
+    CAPTURE(*index_it);
+    if (alg::found(coeffs_to_include, index_it->indices())) {
+      CHECK(u_modal[index_it.collapsed_index()] == approx(1.0));
+    } else {
+      CHECK(u_modal[index_it.collapsed_index()] == approx(0.0));
+    }
+  }
+
+  // Back to nodal coefficients, which should match what we set up initially
+  const DataVector u_nodal = to_nodal_coefficients(u_modal, mesh);
+  CHECK_ITERABLE_APPROX(u_nodal_expected, u_nodal);
+}
+
+template <Spectral::Basis Basis, Spectral::Quadrature Quadrature>
+void test_1d() noexcept {
+  // Start at 1st order so we are independent of the minimum number of
+  // coefficients.
+  for (size_t order = 1; order < Spectral::maximum_number_of_points<Basis>;
+       ++order) {
+    CAPTURE(order);
+    const Mesh<1> mesh(order + 1, Basis, Quadrature);
+    check_transforms<Basis, Quadrature>(mesh, {{{{order}}}});
+    check_transforms<Basis, Quadrature>(mesh, {{{{order}}, {{order / 2}}}});
+    if (order > 4) {
+      check_transforms<Basis, Quadrature>(mesh, {{{{order}}, {{order / 3}}}});
+    }
+  }
+}
+
+template <Spectral::Basis Basis, Spectral::Quadrature Quadrature>
+void test_2d() noexcept {
+  // Start at one higher order so we can drop one order in the y-direction.
+  for (size_t order = Spectral::minimum_number_of_points<Basis, Quadrature> + 1;
+       order < Spectral::maximum_number_of_points<Basis>; ++order) {
+    CAPTURE(order);
+    const Mesh<2> mesh({{order + 1, order}}, Basis, Quadrature);
+    check_transforms<Basis, Quadrature>(mesh, {{{{order, order - 1}}}});
+    check_transforms<Basis, Quadrature>(
+        mesh, {{{{order, order - 1}}, {{order / 2, order / 2}}}});
+    check_transforms<Basis, Quadrature>(
+        Mesh<2>{{{order + 1, order + 1}}, Basis, Quadrature},
+        {{{{order - 1, order}}, {{order / 2, order / 2}}}});
+    check_transforms<Basis, Quadrature>(
+        Mesh<2>{{{order + 1, order + 1}}, Basis, Quadrature},
+        {{{{order, order}}, {{order / 2, order / 2}}}});
+    check_transforms<Basis, Quadrature>(
+        mesh, {{{{order, order - 1}}, {{order / 3, order / 3}}}});
+  }
+}
+
+template <Spectral::Basis Basis, Spectral::Quadrature Quadrature>
+void test_3d() noexcept {
+  // Start at two orders higher so we can drop one order in the y-direction and
+  // two in z-direction.
+  for (size_t order = Spectral::minimum_number_of_points<Basis, Quadrature> + 2;
+       order < Spectral::maximum_number_of_points<Basis>; ++order) {
+    CAPTURE(order);
+    const Mesh<3> mesh({{order + 1, order, order - 1}}, Basis, Quadrature);
+    check_transforms<Basis, Quadrature>(mesh,
+                                        {{{{order, order - 1, order - 2}}}});
+    check_transforms<Basis, Quadrature>(
+        mesh, {{{{order, order - 1, order - 2}},
+                {{order / 2, order / 2, order / 2}}}});
+    check_transforms<Basis, Quadrature>(
+        Mesh<3>{{{order + 1, order + 1, order + 1}}, Basis, Quadrature},
+        {{{{order, order, order}}}});
+    check_transforms<Basis, Quadrature>(
+        mesh, {{{{order, order - 1, order - 2}},
+                {{order / 3, order / 3, order / 3}}}});
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.CoefficientTransforms",
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+  test_1d<Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>();
+  test_1d<Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>();
+  test_2d<Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>();
+  test_2d<Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>();
+  test_3d<Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>();
+  test_3d<Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>();
+  // We can't test Chebyshev because our Chebyshev matrices implementation is
+  // incomplete. What appears to be missing is an entry for Chebyshev in the
+  // `get_spectral_quantity_for_mesh` function.
+}


### PR DESCRIPTION
## Proposed changes

Adds methods to transform from the nodal to modal coefficients and back again. This is needed for limiters that are applied to the spectral coefficients.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
