### PR TITLE
Move building Test_DataStructures to Travis second stage

### DIFF
--- a/cmake/SetupBuildStageTargets.cmake
+++ b/cmake/SetupBuildStageTargets.cmake
@@ -10,7 +10,6 @@ add_custom_target(test-libs-stage1)
 add_dependencies(test-libs-stage1
   Test_ApparentHorizons
   Test_ControlSystem
-  Test_DataStructures
   Test_Amr
   Test_CoordinateMaps
   Test_DomainCreators


### PR DESCRIPTION
## Proposed changes

Make Travis not fail in the first stage from a timeout

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
