### PR TITLE
Minor cleanup of CMake

### DIFF
--- a/external/SPHEREPACK/CMakeLists.txt
+++ b/external/SPHEREPACK/CMakeLists.txt
@@ -34,4 +34,4 @@ file(GLOB FILES_WITH_WARNINGS
     )
 set_source_files_properties(${FILES_WITH_WARNINGS} PROPERTIES COMPILE_FLAGS -w)
 
-add_library(${LIBRARY} ${LIBRARY_SOURCES})
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Domain/CMakeLists.txt
+++ b/src/Domain/CMakeLists.txt
@@ -32,7 +32,7 @@ set(LIBRARY_SOURCES
     SizeOfElement.cpp
     )
 
-add_library(${LIBRARY} ${LIBRARY_SOURCES})
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/Elliptic/Systems/Poisson/CMakeLists.txt
+++ b/src/Elliptic/Systems/Poisson/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LIBRARY_SOURCES
   Equations.cpp
   )
 
-add_library(${LIBRARY} ${LIBRARY_SOURCES})
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -14,6 +14,11 @@ set(LIBRARY_SOURCES
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
+add_dependencies(
+  ${LIBRARY}
+  module_ConstGlobalCache
+  )
+
 target_link_libraries(
   ${LIBRARY}
   INTERFACE Domain

--- a/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/CMakeLists.txt
@@ -9,7 +9,7 @@ set(LIBRARY_SOURCES
   OrszagTangVortex.cpp
   )
 
-add_library(${LIBRARY} ${LIBRARY_SOURCES})
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/PointwiseFunctions/AnalyticSolutions/GrMhd/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GrMhd/CMakeLists.txt
@@ -10,7 +10,7 @@ set(LIBRARY_SOURCES
     SmoothFlow.cpp
     )
 
-add_library(${LIBRARY} ${LIBRARY_SOURCES})
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LIBRARY_SOURCES
   FishboneMoncriefDisk.cpp
   )
 
-add_library(${LIBRARY} ${LIBRARY_SOURCES})
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/src/PythonBindings/CMakeLists.txt
+++ b/src/PythonBindings/CMakeLists.txt
@@ -10,7 +10,7 @@ set(LIBRARY_SOURCES
   CharmCompatibility.cpp
   )
 
-add_library(${LIBRARY} ${LIBRARY_SOURCES})
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})
 
 target_link_libraries(
   ${LIBRARY}

--- a/tests/Utilities/CMakeLists.txt
+++ b/tests/Utilities/CMakeLists.txt
@@ -7,4 +7,4 @@ set(LIBRARY_SOURCES
   RandomUnitNormal.cpp
   )
 
-add_library(${LIBRARY} ${LIBRARY_SOURCES})
+add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})


### PR DESCRIPTION
## Proposed changes

- Add a missing dependency
- Use spectre_add_library instead of add_library


### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
