### PR TITLE
Fix the check for including TmplDebugging

### DIFF
--- a/tests/Unit/DataStructures/VectorImplTestHelper.hpp
+++ b/tests/Unit/DataStructures/VectorImplTestHelper.hpp
@@ -21,7 +21,6 @@
 #include "Utilities/Math.hpp"  // IWYU pragma: keep
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TmplDebugging.hpp"
 #include "Utilities/Tuple.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/TestHelpers.hpp"

--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -17,6 +17,9 @@ pretty_grep() {
     GREP_COLOR='1;37;41' grep --with-filename -n $color_option "$@"
 }
 
+##### CI checks #####
+ci_checks=()
+
 # Check for iostream header
 iostream() {
     is_c++ "$1" && grep -q '#include <iostream>' "$1"
@@ -29,6 +32,7 @@ iostream_test() {
     test_check pass foo.cpp '#include <vector>'$'\n'
     test_check fail foo.cpp '#include <iostream>'$'\n'
 }
+ci_checks+=(iostream)
 
 # Check for TmplDebugging header
 tmpl_debugging() {
@@ -42,14 +46,15 @@ tmpl_debugging_test() {
     test_check pass foo.cpp '#include <vector>'$'\n'
     test_check fail foo.cpp '#include "Utilities/TmplDebugging.hpp"'$'\n'
 }
+ci_checks+=(tmpl_debugging)
 
 if [ "$1" = --test ] ; then
-    run_tests iostream tmpl_debugging
+    run_tests "${ci_checks[@]}"
     exit 0
 fi
 
 # Exclude files that are generated, out of our control, etc.
-if ! find \
+if ! find . \
      -type f \
      ! -path "./.git/*" \
      ! -path "./docs/*" \
@@ -62,7 +67,7 @@ if ! find \
      ! -path "./external/*" \
      ! -name deploy_key.enc \
      -print0 \
-        | run_checks "${standard_checks[@]}" iostream
+        | run_checks "${standard_checks[@]}" "${ci_checks[@]}"
 then
     echo "This script can be run locally from any source dir using:"
     echo "SPECTRE_ROOT/tools/CheckFiles.sh"

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -145,6 +145,7 @@ standard_checks=()
 long_lines() {
     whitelist "$1" \
               '.cmake$' \
+              '.h5$' \
               '.html$' \
               '.min.js$' \
               '.travis.yml$' \


### PR DESCRIPTION
## Proposed changes

- Fix the check for including the template debugging header
- Remove such an include

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [x] Build system
- [x] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
