### PR TITLE
Add to Numpy from Matrix Function

### DIFF
--- a/src/DataStructures/Python/Bindings.cpp
+++ b/src/DataStructures/Python/Bindings.cpp
@@ -3,6 +3,25 @@
 
 #include <boost/python.hpp>
 
+// These macros are required so that the NumPy API will work when used in
+// multiple cpp files.  See
+// https://docs.scipy.org/doc/numpy/reference/c-api.array.html#importing-the-api
+#define PY_ARRAY_UNIQUE_SYMBOL SPECTRE_DATASTRUCTURES_PYTHON_BINDINGS
+// Code is clean against Numpy 1.7, see
+// https://docs.scipy.org/doc/numpy-1.15.1/reference/c-api.deprecations.html
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+
+// We do not use the antipattern:
+// #define NO_IMPORT_ARRAY
+// #include "DataStructures/Python/Numpy.hpp"
+// because
+// 1. This means we are controlling code in the header file with a
+//    local macro, which can be very confusing and should generally be avoided.
+// 2. When C++ modules land this type of pattern will no longer really be
+//    possible since it goes against exactly what modules is trying to do: make
+//    things modular.
+
 namespace py_bindings {
 void bind_datavector();
 void bind_matrix();
@@ -10,6 +29,7 @@ void bind_matrix();
 
 BOOST_PYTHON_MODULE(_DataStructures) {
   Py_Initialize();
+  import_array();
   py_bindings::bind_datavector();
   py_bindings::bind_matrix();
 }

--- a/src/DataStructures/Python/CMakeLists.txt
+++ b/src/DataStructures/Python/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_python_add_module(
   Bindings.cpp
   DataVector.cpp
   Matrix.cpp
+  ToNumpy.cpp
   )
 
 target_link_libraries(

--- a/src/DataStructures/Python/Matrix.cpp
+++ b/src/DataStructures/Python/Matrix.cpp
@@ -1,30 +1,36 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
+#include "DataStructures/Python/Matrix.hpp"
+
+#include <array>
 #include <boost/python.hpp>
 #include <boost/python/reference_existing_object.hpp>
 #include <boost/python/return_value_policy.hpp>
 #include <boost/python/tuple.hpp>
+#include <cstddef>
 #include <sstream>
 #include <string>
 #include <utility>
 
 #include "DataStructures/Matrix.hpp"
+#include "DataStructures/Python/ToNumpy.hpp"
 #include "PythonBindings/BoundChecks.hpp"
 #include "Utilities/MakeString.hpp"
 
 namespace bp = boost::python;
 
 namespace py_bindings {
+
 void bind_matrix() {
   // Wrapper for basic Matrix operations
   bp::class_<Matrix>("Matrix", bp::init<size_t, size_t>())
       .add_property("shape",
-           +[](const Matrix& self) {
-             bp::tuple a =
-                 bp::make_tuple<size_t, size_t>(self.rows(), self.columns());
-             return a;
-           })
+                    +[](const Matrix& self) {
+                      bp::tuple a = bp::make_tuple<size_t, size_t>(
+                          self.rows(), self.columns());
+                      return a;
+                    })
       // __getitem__ and __setitem__ are the subscript operators (M[*,*]).
       .def("__getitem__",
            +[](const Matrix& self, bp::tuple x) -> double {
@@ -36,10 +42,14 @@ void bind_matrix() {
       .def(
           "__str__",
           +[](const Matrix& self) { return std::string(MakeString{} << self); })
-      .def("__setitem__", +[](Matrix& self, bp::tuple x, const double val) {
-        matrix_bounds_check(self, bp::extract<size_t>(x[0]),
-                            bp::extract<size_t>(x[1]));
-        self(bp::extract<size_t>(x[0]), bp::extract<size_t>(x[1])) = val;
-      });
+      .def("__setitem__",
+           +[](Matrix& self, bp::tuple x, const double val) {
+             matrix_bounds_check(self, bp::extract<size_t>(x[0]),
+                                 bp::extract<size_t>(x[1]));
+             self(bp::extract<size_t>(x[0]), bp::extract<size_t>(x[1])) = val;
+           })
+      .def("to_numpy", +[](const Matrix& self) { return to_numpy(self); },
+           "Convert Matrix to a Numpy Array. Always creates a copy");
 }
+
 }  // namespace py_bindings

--- a/src/DataStructures/Python/Matrix.hpp
+++ b/src/DataStructures/Python/Matrix.hpp
@@ -1,0 +1,8 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+namespace py_bindings {
+void bind_matrix();
+}  // namespace py_bindings

--- a/src/DataStructures/Python/Numpy.hpp
+++ b/src/DataStructures/Python/Numpy.hpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+// These macros are required so that the NumPy API will work when used in
+// multiple cpp files.  See
+// https://docs.scipy.org/doc/numpy/reference/c-api.array.html#importing-the-api
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL SPECTRE_DATASTRUCTURES_PYTHON_BINDINGS
+// Code is clean against Numpy 1.7.  See
+// https://docs.scipy.org/doc/numpy-1.15.1/reference/c-api.deprecations.html
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>

--- a/src/DataStructures/Python/ToNumpy.cpp
+++ b/src/DataStructures/Python/ToNumpy.cpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "DataStructures/Python/ToNumpy.hpp"
+
+#include <array>
+#include <cstdlib>
+// IWYU pragma: no_include <numpy/ndarrayobject.h>
+// IWYU pragma: no_include <numpy/ndarraytypes.h>
+
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Python/Numpy.hpp"  // IWYU pragma: keep
+
+namespace py_bindings {
+
+// We use `malloc` instead of `new` because we tell NumPy it needs to free the
+// memory and NumPy uses `free`, not `delete`.
+PyObject* to_numpy(const Matrix& matrix) {
+  auto* c_style_data = static_cast<double*>(
+      malloc(sizeof(double) * (matrix.rows()) * matrix.columns()));
+  for (size_t i = 0; i < matrix.rows(); ++i) {
+    for (size_t j = 0; j < matrix.columns(); ++j) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+      c_style_data[j + i * matrix.columns()] = matrix(i, j);
+    }
+  }
+  std::array<long, 2> dims{
+      {static_cast<long>(matrix.rows()), static_cast<long>(matrix.columns())}};
+  // clang-tidy: C-style cast done implictly with Python
+  // NOLINTNEXTLINE
+  PyObject* npy_array = PyArray_SimpleNewFromData(2, dims.data(), NPY_DOUBLE,
+                                                  c_style_data);  // NOLINT
+
+  // The `reinterpret_cast` is intentional because we know the pointer actually
+  // points to an object of type `PyArrayObject` and we need to access it in
+  // that manner.
+
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto* npy_array_obj = reinterpret_cast<PyArrayObject*>(npy_array);
+  PyArray_ENABLEFLAGS(npy_array_obj, NPY_ARRAY_OWNDATA);
+  return npy_array;
+}
+}  // namespace py_bindings

--- a/src/DataStructures/Python/ToNumpy.hpp
+++ b/src/DataStructures/Python/ToNumpy.hpp
@@ -1,0 +1,15 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <Python.h>
+
+/// \cond
+class Matrix;
+/// \endcond
+
+namespace py_bindings {
+/// Convert Matrix to a Numpy Array. Always creates a copy.
+PyObject* to_numpy(const Matrix& matrix);
+}  // namespace py_bindings

--- a/tests/Unit/DataStructures/Test_Matrix.py
+++ b/tests/Unit/DataStructures/Test_Matrix.py
@@ -4,12 +4,13 @@
 from spectre.DataStructures import Matrix
 import unittest
 import math
+import numpy as np
+
 
 class TestMatrix(unittest.TestCase):
     def test_shape(self):
         M = Matrix(3, 5)
         self.assertEqual(M.shape, (3, 5))
-
 
     def test_getitem(self):
         M = Matrix(3, 4)
@@ -21,23 +22,35 @@ class TestMatrix(unittest.TestCase):
         self.assertEqual(M[2, 1], 1)
 
     def test_string(self):
-        M = Matrix(2,2)
-        M[0,0] = 1
-        M[0,1] = 2
-        M[1,0] = 3
-        M[1,1] = 4
+        M = Matrix(2, 2)
+        M[0, 0] = 1
+        M[0, 1] = 2
+        M[1, 0] = 3
+        M[1, 1] = 4
         self.assertEqual(str(M),
-            '(            1            2 )\n(            3            4 )\n')
-
+        '(            1            2 )\n(            3            4 )\n')
 
     def test_bounds_check(self):
         a = Matrix(2, 2)
-        self.assertRaises(RuntimeError, lambda: a[5,2])
+        self.assertRaises(RuntimeError, lambda: a[5, 2])
 
         def assignment_test():
-            a[5,2] = 8
+            a[5, 2] = 8
 
         self.assertRaises(RuntimeError, assignment_test)
+
+    def test_to_numpy(self):
+        M = Matrix(2, 2)
+        M[0, 0] = 1.0
+        M[1, 0] = 2.7
+        M[0, 1] = 5.42
+        M[1, 1] = -2.3
+        A = M.to_numpy()
+        self.assertTrue(isinstance(A, np.ndarray))
+        self.assertEquals(A[0, 0], 1.0)
+        self.assertEquals(A[1, 0], 2.7)
+        self.assertEquals(A[0, 1], 5.42)
+        self.assertEquals(A[1, 1], -2.3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Proposed changes

This PR introduces a function that allows a Matrix to be converted to a Numpy Array, and to be used in Python via Boost.  It will allow much easier access and manipulation of Data stored in Dat files, and will make Python examples about h5 features easier to follow in the future.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--

-->
