### PR TITLE
Fix bug when multiple files fail file checks

### DIFF
--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -177,6 +177,9 @@ run_tests() {
 standard_checks=()
 
 # Check for lines longer than 80 characters
+long_lines_exclude() {
+    grep -Ev 'https?://' | grep -v '// IWYU pragma:' | grep -v '// NOLINT'
+}
 long_lines() {
     whitelist "$1" \
               '.cmake$' \
@@ -190,15 +193,11 @@ long_lines() {
               'docs/MainSite/Main.md' \
               'docs/DevGuide/Travis.md' \
               'tools/Iwyu/boost-all.imp$' && \
-        staged_grep '^[^#].\{80,\}' "$1" | grep -Ev 'https?://' | \
-            grep -v '// IWYU pragma:' | grep -v '// NOLINT' >/dev/null
+        staged_grep '^[^#].\{80,\}' "$1" | long_lines_exclude >/dev/null
 }
 long_lines_report() {
     echo "Found lines over 80 characters:"
-    # This doesn't filter out URLs, but I can't think of a way to do
-    # that without breaking the highlighting.  They only get printed
-    # if there's another problem in the file.
-    pretty_grep '^[^#].\{80,\}' "$@"
+    pretty_grep '^[^#].\{80,\}' "$@" | long_lines_exclude
 }
 long_lines_test() {
     local ten=xxxxxxxxxx

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -24,7 +24,7 @@ die() {
 # support color
 color_option=''
 if grep --help 2>&1 | grep -q -e --color ; then
-  color_option='--color=auto'
+  color_option='--color=always'
 fi
 
 # Utility that uses grep on the staged version of the file specified by the last argument
@@ -35,12 +35,47 @@ staged_grep() {
     git show ":./${@: -1}" | grep "${@:1:$(($#-1))}"
 }
 
-# Utility function for reporters that enables lots of decorators in grep
-# Works like staged_grep
+# Utility function for reporters that enables lots of decorators in
+# grep.  Works like staged_grep, except that it can take multiple file
+# arguments like real grep.  Accepts the same arguments as grep except
+# that any option taking an argument must use the --opt=arg form
+# instead of the short form.  Additionally, the order of options is
+# restricted as compared to real grep: only filename arguments are
+# allowed to follow the pattern.
 pretty_grep() {
-    echo -n -e "\033[0;35m${@: -1}\033[0m:"
-    git show ":./${@: -1}" | \
-        GREP_COLOR='1;37;41' grep -n $color_option "${@:1:$(($#-1))}"
+    local -a non_file_args
+    local file file_prefix
+    # This loop extracts all the flags and the pattern into
+    # non_file_args, leaving the filenames in $@.
+    while [ $# -gt 0 ] ; do
+        case "$1" in
+            # "--" indicates the end of command line switches, so the
+            # following argument is the pattern and the remainder are
+            # file names.
+            --)
+                non_file_args+=("$1" "$2")
+                shift 2
+                break
+                ;;
+            -*)
+                non_file_args+=("$1")
+                shift
+                ;;
+            *)
+                # This is the pattern
+                non_file_args+=("$1")
+                shift
+                break
+                ;;
+        esac
+    done
+
+    for file in "$@" ; do
+        printf -v file_prefix "\033[0;35m%s\033[0m:" "${file}"
+        git show ":./${file}" | \
+            GREP_COLOR='1;37;41' grep -n $color_option "${non_file_args[@]}" | \
+            sed "s|^|${file_prefix}|"
+    done
 }
 
 # Utility functions for checks classifying a file based on its name


### PR DESCRIPTION
If two files fail the same check then the pretty_grep function will be
supplied multiple filenames and needs to process them all individually.

staged_grep is only ever called with one file, so changes there are
unnecessary.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
