### PR TITLE
Update Isentropic Vortex Interface

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -386,6 +386,19 @@
   SLACcitation   = "%%CITATION = ARXIV:1510.01190;%%"
 }
 
+@article{Yee1999,
+  author         = "Yee, H. C. and Sandham, N. D. and Djomehri, M. J.",
+  title          = "Low-Dissipative High-Order Shock-Capturing Methods Using
+                    Characteristic-Based Filters",
+  journal        = "J. Comput. Phys.",
+  volume         = "150",
+  year           = "1999",
+  pages          = "199--238",
+  doi            = "10.1006/jcph.1998.6177",
+  url            = "http://cdsads.u-strasbg.fr/abs/1999JCoPh.150..199Y",
+}
+
+
 # When editing this file, please follow the guidelines in
 # https://spectre-code.org/writing_good_dox.html#writing_dox_citations.
 

--- a/src/Evolution/Systems/NewtonianEuler/Fluxes.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Fluxes.hpp
@@ -5,7 +5,9 @@
 
 #include <cstddef>
 
-#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"    // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 
 // IWYU pragma: no_forward_declare Tensor
@@ -17,21 +19,6 @@ class not_null;
 }  // namespace gsl
 
 class DataVector;
-
-namespace Tags {
-template <typename>
-struct Fluxes;
-}  // namespace Tags
-
-namespace NewtonianEuler {
-struct MassDensity;
-template <size_t Dim>
-struct MomentumDensity;
-struct EnergyDensity;
-template <size_t Dim>
-struct Velocity;
-struct Pressure;
-}  // namespace NewtonianEuler
 /// \endcond
 
 namespace NewtonianEuler {
@@ -61,11 +48,17 @@ namespace NewtonianEuler {
 template <size_t Dim>
 struct ComputeFluxes {
   using return_tags =
-      tmpl::list<Tags::Fluxes<MassDensity>, Tags::Fluxes<MomentumDensity<Dim>>,
-                 Tags::Fluxes<EnergyDensity>>;
+      tmpl::list<::Tags::Flux<Tags::MassDensity<DataVector>, tmpl::size_t<Dim>,
+                              Frame::Inertial>,
+                 ::Tags::Flux<Tags::MomentumDensity<DataVector, Dim>,
+                              tmpl::size_t<Dim>, Frame::Inertial>,
+                 ::Tags::Flux<Tags::EnergyDensity<DataVector>,
+                              tmpl::size_t<Dim>, Frame::Inertial>>;
 
   using argument_tags =
-      tmpl::list<MomentumDensity<Dim>, EnergyDensity, Velocity<Dim>, Pressure>;
+      tmpl::list<Tags::MomentumDensity<DataVector, Dim>,
+                 Tags::EnergyDensity<DataVector>,
+                 Tags::Velocity<DataVector, Dim>, Tags::Pressure<DataVector>>;
 
   static void apply(
       gsl::not_null<tnsr::I<DataVector, Dim>*> mass_density_flux,

--- a/src/Evolution/Systems/NewtonianEuler/Tags.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Tags.hpp
@@ -8,8 +8,10 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp"
 
 namespace NewtonianEuler {
+/// %Tags for the conservative formulation of the Newtonian Euler system
 namespace Tags {
 
 /// The mass density of the fluid.
@@ -20,10 +22,12 @@ struct MassDensity : db::SimpleTag {
 };
 
 /// The momentum density of the fluid.
-template <typename DataType, size_t Dim, typename VolumeFrame = Frame::Inertial>
+template <typename DataType, size_t Dim, typename Fr>
 struct MomentumDensity : db::SimpleTag {
-  using type = tnsr::I<DataType, Dim, VolumeFrame>;
-  static std::string name() noexcept { return "MomentumDensity"; }
+  using type = tnsr::I<DataType, Dim, Fr>;
+  static std::string name() noexcept {
+    return Frame::prefix<Fr>() + "MomentumDensity";
+  }
 };
 
 /// The energy density of the fluid.
@@ -34,10 +38,12 @@ struct EnergyDensity : db::SimpleTag {
 };
 
 /// The macroscopic or flow velocity of the fluid.
-template <typename DataType, size_t Dim, typename VolumeFrame = Frame::Inertial>
+template <typename DataType, size_t Dim, typename Fr>
 struct Velocity : db::SimpleTag {
-  using type = tnsr::I<DataType, Dim, VolumeFrame>;
-  static std::string name() noexcept { return "Velocity"; }
+  using type = tnsr::I<DataType, Dim, Fr>;
+  static std::string name() noexcept {
+    return Frame::prefix<Fr>() + "Velocity";
+  }
 };
 
 /// The specific internal energy of the fluid.

--- a/src/Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/TagsDeclarations.hpp
@@ -1,0 +1,27 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+
+/// \cond
+namespace NewtonianEuler {
+namespace Tags {
+template <typename DataType>
+struct MassDensity;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct MomentumDensity;
+template <typename DataType>
+struct EnergyDensity;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct Velocity;
+template <typename DataType>
+struct SpecificInternalEnergy;
+template <typename DataType>
+struct Pressure;
+}  // namespace Tags
+}  // namespace NewtonianEuler
+/// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
@@ -32,10 +32,6 @@ IsentropicVortex::IsentropicVortex(
       mean_velocity_(std::move(mean_velocity)),  // NOLINT
       perturbation_amplitude_(perturbation_amplitude),
       strength_(strength) {
-  ASSERT(adiabatic_index_ > 1.0 and adiabatic_index_ < 2.0,
-         "The adiabatic index must be in the range (1, 2). The value given "
-         "was "
-             << adiabatic_index_ << ".");
   ASSERT(strength_ >= 0.0,
          "The strength must be non-negative. The value given "
          "was "

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
@@ -12,7 +12,6 @@
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Assert.hpp"
-#include "Evolution/Systems/NewtonianEuler/ConservativeFromPrimitive.hpp"
 #include "Parallel/PupStlCpp11.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -104,28 +103,6 @@ IsentropicVortex::primitive_variables(const tnsr::I<DataType, 3>& x,
   return result;
 }
 
-template <typename DataType>
-tuples::tagged_tuple_from_typelist<IsentropicVortex::conservative_t<DataType>>
-IsentropicVortex::conservative_variables(const tnsr::I<DataType, 3>& x,
-                                         const double t) const noexcept {
-  const auto primitives = primitive_variables(x, t);
-
-  auto result = make_with_value<tuples::tagged_tuple_from_typelist<
-      IsentropicVortex::conservative_t<DataType>>>(x, 0.0);
-
-  get<Tags::MassDensity<DataType>>(result) =
-      get<Tags::MassDensity<DataType>>(primitives);
-
-  conservative_from_primitive(
-      make_not_null(&get<Tags::MomentumDensity<DataType, 3>>(result)),
-      make_not_null(&get<Tags::EnergyDensity<DataType>>(result)),
-      get<Tags::MassDensity<DataType>>(primitives),
-      get<Tags::Velocity<DataType, 3>>(primitives),
-      get<Tags::SpecificInternalEnergy<DataType>>(primitives));
-
-  return result;
-}
-
 }  // namespace Solutions
 }  // namespace NewtonianEuler
 
@@ -138,11 +115,6 @@ IsentropicVortex::conservative_variables(const tnsr::I<DataType, 3>& x,
   template tuples::tagged_tuple_from_typelist<                               \
       NewtonianEuler::Solutions::IsentropicVortex::primitive_t<DTYPE(data)>> \
   NewtonianEuler::Solutions::IsentropicVortex::primitive_variables(          \
-      const tnsr::I<DTYPE(data), 3>& x, const double t) const noexcept;      \
-  template tuples::tagged_tuple_from_typelist<                               \
-      NewtonianEuler::Solutions::IsentropicVortex::conservative_t<DTYPE(     \
-          data)>>                                                            \
-  NewtonianEuler::Solutions::IsentropicVortex::conservative_variables(       \
       const tnsr::I<DTYPE(data), 3>& x, const double t) const noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
@@ -57,11 +57,15 @@ IsentropicVortex<Dim>::IntermediateVariables<DataType>::IntermediateVariables(
     const tnsr::I<DataType, Dim, Frame::Inertial>& x, const double t,
     const std::array<double, Dim>& center,
     const std::array<double, Dim>& mean_velocity,
-    const double strength) noexcept {
+    const double perturbation_amplitude, const double strength) noexcept {
   x_tilde = get<0>(x) - center[0] - t * mean_velocity[0];
   y_tilde = get<1>(x) - center[1] - t * mean_velocity[1];
   profile = 0.5 * strength *
             exp(0.5 - 0.5 * (square(x_tilde) + square(y_tilde))) / M_PI;
+  if (Dim == 3) {
+    // Can be any smooth function of z. For testing purpose, we choose sin(z).
+    perturbation = perturbation_amplitude * sin(get<Dim - 1>(x));
+  }
 }
 
 template <size_t Dim>
@@ -89,7 +93,9 @@ IsentropicVortex<Dim>::variables(
   }
   get<0>(velocity) -= vars.y_tilde * vars.profile;
   get<1>(velocity) += vars.x_tilde * vars.profile;
-
+  if (Dim == 3) {
+    get<Dim - 1>(velocity) += vars.perturbation;
+  }
   return velocity;
 }
 

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.cpp
@@ -3,118 +3,167 @@
 
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp"
 
-#include <algorithm>
 #include <cmath>
 #include <cstddef>
-#include <ostream>
+#include <pup.h>  // IWYU pragma: keep
 
 #include "DataStructures/DataVector.hpp"                   // IWYU pragma: keep
-#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Assert.hpp"
-#include "Parallel/PupStlCpp11.hpp"
+#include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"  // IWYU pragma: keep
+#include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"  // IWYU pragma: keep
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_include <complex>
 
 /// \cond
 namespace NewtonianEuler {
 namespace Solutions {
 
-IsentropicVortex::IsentropicVortex(
-    const double adiabatic_index, IsentropicVortex::Center::type center,
-    IsentropicVortex::MeanVelocity::type mean_velocity,
+template <size_t Dim>
+IsentropicVortex<Dim>::IsentropicVortex(
+    const double adiabatic_index, const std::array<double, Dim>& center,
+    const std::array<double, Dim>& mean_velocity,
     const double perturbation_amplitude, const double strength)
     : adiabatic_index_(adiabatic_index),
-      // clang-tidy: do not std::move trivial types.
-      center_(std::move(center)),  // NOLINT
-      // clang-tidy: do not std::move trivial types.
-      mean_velocity_(std::move(mean_velocity)),  // NOLINT
+      center_(center),
+      mean_velocity_(mean_velocity),
       perturbation_amplitude_(perturbation_amplitude),
-      strength_(strength) {
+      strength_(strength),
+      // Polytropic constant is set equal to 1.0
+      equation_of_state_(1.0, adiabatic_index) {
   ASSERT(strength_ >= 0.0,
          "The strength must be non-negative. The value given "
          "was "
              << strength_ << ".");
 }
 
-void IsentropicVortex::pup(PUP::er& p) noexcept {
+template <size_t Dim>
+void IsentropicVortex<Dim>::pup(PUP::er& p) noexcept {
   p | adiabatic_index_;
   p | center_;
   p | mean_velocity_;
   p | perturbation_amplitude_;
   p | strength_;
+  p | equation_of_state_;
 }
 
+template <size_t Dim>
 template <typename DataType>
-Scalar<DataType> IsentropicVortex::perturbation(const DataType& coord_z) const
-    noexcept {
-  return Scalar<DataType>{perturbation_amplitude_ * sin(coord_z)};
+IsentropicVortex<Dim>::IntermediateVariables<DataType>::IntermediateVariables(
+    const tnsr::I<DataType, Dim, Frame::Inertial>& x, const double t,
+    const std::array<double, Dim>& center,
+    const std::array<double, Dim>& mean_velocity,
+    const double strength) noexcept {
+  x_tilde = get<0>(x) - center[0] - t * mean_velocity[0];
+  y_tilde = get<1>(x) - center[1] - t * mean_velocity[1];
+  profile = 0.5 * strength *
+            exp(0.5 - 0.5 * (square(x_tilde) + square(y_tilde))) / M_PI;
 }
 
+template <size_t Dim>
 template <typename DataType>
-tuples::tagged_tuple_from_typelist<IsentropicVortex::primitive_t<DataType>>
-IsentropicVortex::primitive_variables(const tnsr::I<DataType, 3>& x,
-                                      const double t) const noexcept {
-  const auto adiabatic_index_minus_one = adiabatic_index_ - 1.0;
+tuples::TaggedTuple<Tags::MassDensity<DataType>>
+IsentropicVortex<Dim>::variables(
+    tmpl::list<Tags::MassDensity<DataType>> /*meta*/,
+    const IntermediateVariables<DataType>& vars) const noexcept {
+  const double adiabatic_index_minus_one = adiabatic_index_ - 1.0;
+  return Scalar<DataType>(pow(1.0 - 0.5 * adiabatic_index_minus_one *
+                                        square(vars.profile) / adiabatic_index_,
+                              1.0 / adiabatic_index_minus_one));
+}
 
-  const auto x_tilde = [&x, &t, this ]() noexcept {
-    auto l_x_tilde = make_with_value<tnsr::I<DataType, 2>>(x, 0.0);
-    // Note: x_tilde has only 2 components as it is used to
-    // compute a distance on a plane perpendicular to the z-axis.
-    for (size_t i = 0; i < 2; ++i) {
-      l_x_tilde.get(i) =
-          x.get(i) - gsl::at(center_, i) - t * gsl::at(mean_velocity_, i);
-    }
-    return l_x_tilde;
-  }
-  ();
-
-  auto result = make_with_value<tuples::tagged_tuple_from_typelist<
-      IsentropicVortex::primitive_t<DataType>>>(x, 0.0);
-
-  const DataType temp = 0.5 * strength_ *
-                        exp(0.5 - 0.5 * get(dot_product(x_tilde, x_tilde))) /
-                        M_PI;
-
-  get<Tags::MassDensity<DataType>>(result) = Scalar<DataType>(pow(
-      1.0 - 0.5 * adiabatic_index_minus_one * temp * temp / adiabatic_index_,
-      1.0 / adiabatic_index_minus_one));
-
-  auto velocity = make_with_value<tnsr::I<DataType, 3>>(x, 0.0);
-  for (size_t i = 0; i < 3; ++i) {
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::Velocity<DataType, Dim, Frame::Inertial>>
+IsentropicVortex<Dim>::variables(
+    tmpl::list<Tags::Velocity<DataType, Dim, Frame::Inertial>> /*meta*/,
+    const IntermediateVariables<DataType>& vars) const noexcept {
+  auto velocity = make_with_value<tnsr::I<DataType, Dim, Frame::Inertial>>(
+      vars.y_tilde, 0.0);
+  for (size_t i = 0; i < Dim; ++i) {
     velocity.get(i) = gsl::at(mean_velocity_, i);
   }
-  velocity.get(0) -= x_tilde.get(1) * temp;
-  velocity.get(1) += x_tilde.get(0) * temp;
-  velocity.get(2) += get(perturbation(x.get(2)));
+  get<0>(velocity) -= vars.y_tilde * vars.profile;
+  get<1>(velocity) += vars.x_tilde * vars.profile;
 
-  get<Tags::Velocity<DataType, 3>>(result) = std::move(velocity);
-
-  get<Tags::SpecificInternalEnergy<DataType>>(result) =
-      Scalar<DataType>(pow(get(get<Tags::MassDensity<DataType>>(result)),
-                           adiabatic_index_minus_one) /
-                       adiabatic_index_minus_one);
-
-  return result;
+  return velocity;
 }
+
+template <size_t Dim>
+template <typename DataType>
+tuples::TaggedTuple<Tags::SpecificInternalEnergy<DataType>>
+IsentropicVortex<Dim>::variables(
+    tmpl::list<Tags::SpecificInternalEnergy<DataType>> /*meta*/,
+    const IntermediateVariables<DataType>& vars) const noexcept {
+  return equation_of_state_.specific_internal_energy_from_density(
+      get<Tags::MassDensity<DataType>>(
+          variables(tmpl::list<Tags::MassDensity<DataType>>{}, vars)));
+}
+
+template <size_t Dim>
+bool operator==(const IsentropicVortex<Dim>& lhs,
+                const IsentropicVortex<Dim>& rhs) noexcept {
+  // No comparison for equation_of_state_. Comparing adiabatic_index_ should
+  // suffice.
+  return lhs.adiabatic_index_ == rhs.adiabatic_index_ and
+         lhs.center_ == rhs.center_ and
+         lhs.mean_velocity_ == rhs.mean_velocity_ and
+         lhs.perturbation_amplitude_ == rhs.perturbation_amplitude_ and
+         lhs.strength_ == rhs.strength_;
+}
+
+template <size_t Dim>
+bool operator!=(const IsentropicVortex<Dim>& lhs,
+                const IsentropicVortex<Dim>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define TAG(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE_CLASS(_, data)                                            \
+  template class IsentropicVortex<DIM(data)>;                                 \
+  template struct IsentropicVortex<DIM(data)>::IntermediateVariables<double>; \
+  template struct IsentropicVortex<DIM(                                       \
+      data)>::IntermediateVariables<DataVector>;                              \
+  template bool operator==(const IsentropicVortex<DIM(data)>&,                \
+                           const IsentropicVortex<DIM(data)>&) noexcept;      \
+  template bool operator!=(const IsentropicVortex<DIM(data)>&,                \
+                           const IsentropicVortex<DIM(data)>&) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_CLASS, (2, 3))
+
+#define INSTANTIATE_SCALARS(_, data)                     \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data)>> \
+      IsentropicVortex<DIM(data)>::variables(            \
+          tmpl::list<TAG(data) < DTYPE(data)>>,          \
+          const IntermediateVariables<DTYPE(data)>&) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALARS, (2, 3), (double, DataVector),
+                        (Tags::MassDensity, Tags::SpecificInternalEnergy))
+
+#define INSTANTIATE_VELOCITY(_, data)                                       \
+  template tuples::TaggedTuple<TAG(data) < DTYPE(data), DIM(data),          \
+                               Frame::Inertial>>                            \
+      IsentropicVortex<DIM(data)>::variables(                               \
+          tmpl::list<TAG(data) < DTYPE(data), DIM(data), Frame::Inertial>>, \
+          const IntermediateVariables<DTYPE(data)>&) const noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_VELOCITY, (2, 3), (double, DataVector),
+                        (Tags::Velocity))
+
+#undef DIM
+#undef DTYPE
+#undef TAG
+#undef INSTANTIATE_CLASS
+#undef INSTANTIATE_SCALARS
+#undef INSTANTIATE_VELOCITY
 
 }  // namespace Solutions
 }  // namespace NewtonianEuler
-
-#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
-
-#define INSTANTIATE(_, data)                                                 \
-  template Scalar<DTYPE(data)>                                               \
-  NewtonianEuler::Solutions::IsentropicVortex::perturbation(                 \
-      const DTYPE(data) & coord_z) const noexcept;                           \
-  template tuples::tagged_tuple_from_typelist<                               \
-      NewtonianEuler::Solutions::IsentropicVortex::primitive_t<DTYPE(data)>> \
-  NewtonianEuler::Solutions::IsentropicVortex::primitive_variables(          \
-      const tnsr::I<DTYPE(data), 3>& x, const double t) const noexcept;
-
-GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
-
-#undef DTYPE
-#undef INSTANTIATE
 /// \endcond

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp
@@ -22,7 +22,7 @@ namespace Solutions {
  *
  * The analytic solution to the 2-D Newtonian Euler system
  * representing the slow advection of an incompressible, isentropic
- * vortex \ref vortex_ref "[1]". The initial condition is the superposition of a
+ * vortex \cite Yee1999. The initial condition is the superposition of a
  * mean uniform flow with a gaussian-profile vortex. When embedded in
  * 3-D space, the isentropic vortex is still a solution to the corresponding 3-D
  * system if the velocity along the third axis is a constant. In Cartesian
@@ -71,10 +71,6 @@ namespace Solutions {
  * where \f$\epsilon\f$ is the amplitude of the perturbation. The resulting
  * source for the Newtonian Euler system will then be proportional to
  * \f$\epsilon \cos{z}\f$.
- *
- * \anchor vortex_ref [1] H.C Yee, N.D Sandham, M.J Djomehri, Low-dissipative
- * high-order shock-capturing methods using characteristic-based filters, J.
- * Comput. Phys. [150 (1999) 199](http://dx.doi.org/10.1006/jcph.1998.6177)
  */
 class IsentropicVortex {
  public:

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp
@@ -138,21 +138,11 @@ class IsentropicVortex {
                  Tags::SpecificInternalEnergy<DataType>>;
 
   template <typename DataType>
-  using conservative_t = tmpl::list<Tags::MassDensity<DataType>,
-                                    Tags::MomentumDensity<DataType, 3>,
-                                    Tags::EnergyDensity<DataType>>;
-
-  template <typename DataType>
   Scalar<DataType> perturbation(const DataType& coord_z) const noexcept;
 
   template <typename DataType>
   tuples::tagged_tuple_from_typelist<primitive_t<DataType>> primitive_variables(
       const tnsr::I<DataType, 3>& x, double t) const noexcept;
-
-  template <typename DataType>
-  tuples::tagged_tuple_from_typelist<conservative_t<DataType>>
-  conservative_variables(const tnsr::I<DataType, 3>& x, double t) const
-      noexcept;
 
   // clang-tidy: no runtime references
   void pup(PUP::er& /*p*/) noexcept;  //  NOLINT

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp
@@ -78,9 +78,6 @@ class IsentropicVortex {
   struct AdiabaticIndex {
     using type = double;
     static constexpr OptionString help = {"The adiabatic index of the fluid."};
-    // Note: bounds only valid for an ideal gas.
-    static type lower_bound() noexcept { return 1.0; }
-    static type upper_bound() noexcept { return 2.0; }
   };
 
   /// The position of the center of the vortex at \f$t = 0\f$

--- a/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp
@@ -153,7 +153,7 @@ class IsentropicVortex {
                   "The generic template will recurse infinitely if only one "
                   "tag is being retrieved.");
     IntermediateVariables<DataType> vars(x, t, center_, mean_velocity_,
-                                         strength_);
+                                         perturbation_amplitude_, strength_);
     return {tuples::get<Tags>(variables(tmpl::list<Tags>{}, vars))...};
   }
 
@@ -191,10 +191,13 @@ class IsentropicVortex {
     IntermediateVariables(const tnsr::I<DataType, Dim, Frame::Inertial>& x,
                           double t, const std::array<double, Dim>& center,
                           const std::array<double, Dim>& mean_velocity,
+                          double perturbation_amplitude,
                           double strength) noexcept;
     DataType x_tilde{};
     DataType y_tilde{};
     DataType profile{};
+    // (3D only) Extra term in the velocity along z that generates sources.
+    DataType perturbation{};
   };
 
   template <size_t SpatialDim>

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_ConservativeFromPrimitive.cpp
   Test_Fluxes.cpp
   Test_PrimitiveFromConservative.cpp
+  Test_Tags.cpp
   )
 
 add_subdirectory(Sources)

--- a/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/NewtonianEuler/Test_Tags.cpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/Tensor/IndexType.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/NewtonianEuler/Tags.hpp"
+
+class DataVector;
+
+namespace {
+template <size_t Dim>
+void test_tags() noexcept {
+  CHECK(NewtonianEuler::Tags::MassDensity<DataVector>::name() == "MassDensity");
+  CHECK(NewtonianEuler::Tags::MomentumDensity<DataVector, Dim,
+                                              Frame::Inertial>::name() ==
+        "MomentumDensity");
+  CHECK(NewtonianEuler::Tags::MomentumDensity<DataVector, Dim,
+                                              Frame::Grid>::name() ==
+        "Grid_MomentumDensity");
+  CHECK(NewtonianEuler::Tags::EnergyDensity<DataVector>::name() ==
+        "EnergyDensity");
+  CHECK(NewtonianEuler::Tags::Velocity<DataVector, Dim,
+                                       Frame::Inertial>::name() == "Velocity");
+  CHECK(
+      NewtonianEuler::Tags::Velocity<DataVector, Dim, Frame::Logical>::name() ==
+      "Logical_Velocity");
+  CHECK(NewtonianEuler::Tags::SpecificInternalEnergy<DataVector>::name() ==
+        "SpecificInternalEnergy");
+  CHECK(NewtonianEuler::Tags::Pressure<DataVector>::name() == "Pressure");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.NewtonianEuler.Tags",
+                  "[Unit][Evolution]") {
+  test_tags<1>();
+  test_tags<2>();
+  test_tags<3>();
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/TestFunctions.py
@@ -24,6 +24,8 @@ def velocity(x, t, adiabatic_index, center, mean_velocity,
     velocity = np.copy(mean_velocity)
     velocity[0] -= x_tilde[1] * temp
     velocity[1] += x_tilde[0] * temp
+    if (velocity.size == 3):
+        velocity[2] += perturbation_amplitude * np.sin(x[2])
     return velocity
 
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/TestFunctions.py
@@ -5,6 +5,8 @@ import numpy as np
 
 
 # Functions for testing IsentropicVortex.cpp
+
+
 def mass_density(x, t, adiabatic_index, center, mean_velocity,
                  perturbation_amplitude, strength):
     x_tilde = x - center - t * np.array(mean_velocity)
@@ -31,26 +33,6 @@ def specific_internal_energy(x, t, adiabatic_index, center, mean_velocity,
     return (np.power(mass_density(x, t, adiabatic_index, center, mean_velocity,
                                   perturbation_amplitude, strength),
                      adiabatic_index - 1.0) / (adiabatic_index - 1.0))
-
-
-def momentum_density(x, t, adiabatic_index, center, mean_velocity,
-                     perturbation_amplitude, strength):
-    return (mass_density(x, t, adiabatic_index, center, mean_velocity,
-                         perturbation_amplitude, strength) *
-            velocity(x, t, adiabatic_index, center, mean_velocity,
-                     perturbation_amplitude, strength))
-
-
-def energy_density(x, t, adiabatic_index, center, mean_velocity,
-                   perturbation_amplitude, strength):
-    veloc = velocity(x, t, adiabatic_index, center, mean_velocity,
-                     perturbation_amplitude, strength)
-    return (mass_density(x, t, adiabatic_index, center,
-                         mean_velocity, perturbation_amplitude, strength)
-            * (0.5 * np.dot(veloc, veloc) +
-               specific_internal_energy(x, t, adiabatic_index, center,
-                                        mean_velocity, perturbation_amplitude,
-                                        strength)))
 
 
 # End functions for testing IsentropicVortex.cpp

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/TestFunctions.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/TestFunctions.py
@@ -24,7 +24,6 @@ def velocity(x, t, adiabatic_index, center, mean_velocity,
     velocity = np.copy(mean_velocity)
     velocity[0] -= x_tilde[1] * temp
     velocity[1] += x_tilde[0] * temp
-    velocity[2] += perturbation_amplitude * np.sin(x[2])
     return velocity
 
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
@@ -71,20 +71,6 @@ void test_variables(const DataType& used_for_size) noexcept {
       {{{-1.0, 1.0}}}, std::make_tuple(adiabatic_index, center, mean_velocity,
                                        perturbation_amplitude, strength),
       used_for_size);
-
-  pypp::check_with_random_values<
-      1, tmpl::list<NewtonianEuler::Tags::MassDensity<DataType>,
-                    NewtonianEuler::Tags::MomentumDensity<DataType, 3>,
-                    NewtonianEuler::Tags::EnergyDensity<DataType>>>(
-      &NewtonianEuler::Solutions::IsentropicVortex::conservative_variables<
-          DataType>,
-      NewtonianEuler::Solutions::IsentropicVortex(
-          adiabatic_index, center, mean_velocity, perturbation_amplitude,
-          strength),
-      "TestFunctions", {"mass_density", "momentum_density", "energy_density"},
-      {{{-1.0, 1.0}}}, std::make_tuple(adiabatic_index, center, mean_velocity,
-                                       perturbation_amplitude, strength),
-      used_for_size);
 }
 
 }  // namespace

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
@@ -3,74 +3,83 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <algorithm>
 #include <array>
+#include <cstddef>
 #include <limits>
 #include <string>
 #include <tuple>
 
+#include "DataStructures/DataBox/Prefixes.hpp"  // IWYU pragma: keep
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Evolution/Systems/NewtonianEuler/Tags.hpp"  // IWYU pragma: keep
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/NewtonianEuler/IsentropicVortex.hpp"
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
 #include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+// IWYU pragma: no_include <pup.h>
+
 namespace {
 
-void test_create_from_options() noexcept {
-  const auto created_solution =
-      test_creation<NewtonianEuler::Solutions::IsentropicVortex>(
+template <size_t Dim>
+struct IsentropicVortexProxy
+    : NewtonianEuler::Solutions::IsentropicVortex<Dim> {
+  using NewtonianEuler::Solutions::IsentropicVortex<Dim>::IsentropicVortex;
+
+  template <typename DataType>
+  using variables_tags =
+      tmpl::list<NewtonianEuler::Tags::MassDensity<DataType>,
+                 NewtonianEuler::Tags::Velocity<DataType, Dim, Frame::Inertial>,
+                 NewtonianEuler::Tags::SpecificInternalEnergy<DataType>>;
+
+  template <typename DataType>
+  tuples::tagged_tuple_from_typelist<variables_tags<DataType>>
+  primitive_variables(const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+                      double t) const noexcept {
+    return this->variables(x, t, variables_tags<DataType>{});
+  }
+};
+
+template <size_t Dim, typename DataType>
+void test_solution(const DataType& used_for_size,
+                   const std::array<double, Dim>& center,
+                   const std::string& center_option,
+                   const std::array<double, Dim>& mean_velocity,
+                   const std::string& mean_velocity_option) noexcept {
+  IsentropicVortexProxy<Dim> vortex(1.43, center, mean_velocity, 0.5, 3.76);
+  pypp::check_with_random_values<
+      1,
+      typename IsentropicVortexProxy<Dim>::template variables_tags<DataType>>(
+      &IsentropicVortexProxy<Dim>::template primitive_variables<DataType>,
+      vortex, "TestFunctions",
+      {"mass_density", "velocity", "specific_internal_energy"}, {{{-15., 15.}}},
+      std::make_tuple(1.43, center, mean_velocity, 0.5, 3.76), used_for_size);
+
+  const auto vortex_from_options =
+      test_creation<NewtonianEuler::Solutions::IsentropicVortex<Dim>>(
           "  AdiabaticIndex: 1.43\n"
-          "  Center: [2.3, -1.3, -0.6]\n"
-          "  MeanVelocity: [-0.3, 0.1, 0.7]\n"
+          "  Center: " +
+          center_option +
+          "\n"
+          "  MeanVelocity: " +
+          mean_velocity_option +
+          "\n"
           "  PerturbAmplitude: 0.5\n"
           "  Strength: 3.76");
-  CHECK(created_solution ==
-        NewtonianEuler::Solutions::IsentropicVortex(
-            1.43, {{2.3, -1.3, -0.6}}, {{-0.3, 0.1, 0.7}}, 0.5, 3.76));
-}
+  CHECK(vortex_from_options == vortex);
 
-void test_move() noexcept {
-  NewtonianEuler::Solutions::IsentropicVortex vortex(
-      1.32, {{3.2, -4.1, 9.0}}, {{0.43, 0.31, -0.68}}, 0.23, 1.65);
-  NewtonianEuler::Solutions::IsentropicVortex vortex_copy(
-      1.32, {{3.2, -4.1, 9.0}}, {{0.43, 0.31, -0.68}}, 0.23, 1.65);
-  test_move_semantics(std::move(vortex), vortex_copy);  //  NOLINT
-}
+  IsentropicVortexProxy<Dim> vortex_to_move(1.43, center, mean_velocity, 0.5,
+                                            3.76);
+  test_move_semantics(std::move(vortex_to_move), vortex);  //  NOLINT
 
-void test_serialize() noexcept {
-  NewtonianEuler::Solutions::IsentropicVortex vortex(
-      1.5, {{3.2, 0.1, -1.3}}, {{0.2, -0.25, 0.41}}, 0.13, 1.65);
   test_serialization(vortex);
-}
-
-template <typename DataType>
-void test_variables(const DataType& used_for_size) noexcept {
-  const double adiabatic_index = 1.56;
-  const std::array<double, 3> center = {{0.15, -0.02, 1.9}};
-  const std::array<double, 3> mean_velocity = {{1.2, 0.43, 0.5}};
-  const double perturbation_amplitude = 0.47;
-  const double strength = 2.0;
-
-  pypp::check_with_random_values<
-      1, tmpl::list<NewtonianEuler::Tags::MassDensity<DataType>,
-                    NewtonianEuler::Tags::Velocity<DataType, 3>,
-                    NewtonianEuler::Tags::SpecificInternalEnergy<DataType>>>(
-      &NewtonianEuler::Solutions::IsentropicVortex::primitive_variables<
-          DataType>,
-      NewtonianEuler::Solutions::IsentropicVortex(
-          adiabatic_index, center, mean_velocity, perturbation_amplitude,
-          strength),
-      "TestFunctions", {"mass_density", "velocity", "specific_internal_energy"},
-      {{{-1.0, 1.0}}}, std::make_tuple(adiabatic_index, center, mean_velocity,
-                                       perturbation_amplitude, strength),
-      used_for_size);
 }
 
 }  // namespace
@@ -80,44 +89,84 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.Vortex",
   pypp::SetupLocalPythonEnvironment local_python_env{
       "PointwiseFunctions/AnalyticSolutions/NewtonianEuler"};
 
-  test_create_from_options();
-  test_serialize();
-  test_move();
+  const std::array<double, 2> center_2d = {{0.12, -0.04}};
+  const std::array<double, 2> mean_velocity_2d = {{0.54, -0.02}};
+  test_solution<2>(std::numeric_limits<double>::signaling_NaN(), center_2d,
+                   "[0.12, -0.04]", mean_velocity_2d, "[0.54, -0.02]");
+  test_solution<2>(DataVector(5), center_2d, "[0.12, -0.04]", mean_velocity_2d,
+                   "[0.54, -0.02]");
 
-  test_variables(std::numeric_limits<double>::signaling_NaN());
-  test_variables(DataVector(5));
+  const std::array<double, 3> center_3d = {{-0.53, -0.1, 1.4}};
+  const std::array<double, 3> mean_velocity_3d = {{-0.04, 0.14, 0.3}};
+  test_solution<3>(std::numeric_limits<double>::signaling_NaN(), center_3d,
+                   "[-0.53, -0.1, 1.4]", mean_velocity_3d,
+                   "[-0.04, 0.14, 0.3]");
+  test_solution<3>(DataVector(5), center_3d, "[-0.53, -0.1, 1.4]",
+                   mean_velocity_3d, "[-0.04, 0.14, 0.3]");
 }
-
-struct Vortex {
-  using type = NewtonianEuler::Solutions::IsentropicVortex;
-  static constexpr OptionString help = {"A Newtonian isentropic vortex."};
-};
 
 // [[OutputRegex, The strength must be non-negative.]]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrength",
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrength2d",
     "[Unit][PointwiseFunctions]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
-  NewtonianEuler::Solutions::IsentropicVortex test_vortex(
-      1.3, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}}, -0.15, -1.7);
+  NewtonianEuler::Solutions::IsentropicVortex<2> test_vortex(
+      1.3, {{3.21, -1.4}}, {{0.12, -0.53}}, -0.15, -1.7);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
 
+    // clang-format off
+// [[OutputRegex, The strength must be non-negative.]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrength3d",
+    "[Unit][PointwiseFunctions]") {
+  // clang-format on
+  ASSERTION_TEST();
+#ifdef SPECTRE_DEBUG
+  NewtonianEuler::Solutions::IsentropicVortex<3> test_vortex(
+      1.65, {{-0.12, 1.542, 3.12}}, {{-0.04, -0.32, 0.003}}, 4.2, -0.5);
+  ERROR("Failed to trigger ASSERT in an assertion test");
+#endif
+}
+
+template <size_t Dim>
+struct Vortex {
+  using type = NewtonianEuler::Solutions::IsentropicVortex<Dim>;
+  static constexpr OptionString help = {"A Newtonian isentropic vortex."};
+};
+
 // [[OutputRegex, In string:.*At line 6 column 13:.Value -0.2 is below the lower
 // bound of 0]]
 SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrengthOpt",
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrengthOpt2d",
     "[PointwiseFunctions][Unit]") {
   ERROR_TEST();
-  Options<tmpl::list<Vortex>> test_options("");
+  Options<tmpl::list<Vortex<2>>> test_options("");
   test_options.parse(
       "Vortex:\n"
       "  AdiabaticIndex: 1.4\n"
-      "  Center: [-3.9, 1.1, 4.5]\n"
-      "  MeanVelocity: [0.1, 0.0, 0.65]\n"
+      "  Center: [-3.9, 1.1]\n"
+      "  MeanVelocity: [0.1, -0.032]\n"
       "  PerturbAmplitude: 0.13\n"
       "  Strength: -0.2");
-  test_options.get<Vortex>();
+  test_options.get<Vortex<2>>();
+}
+
+// [[OutputRegex, In string:.*At line 6 column 13:.Value -0.3 is below the lower
+// bound of 0]]
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrengthOpt3d",
+    "[PointwiseFunctions][Unit]") {
+  ERROR_TEST();
+  Options<tmpl::list<Vortex<3>>> test_options("");
+  test_options.parse(
+      "Vortex:\n"
+      "  AdiabaticIndex: 1.12\n"
+      "  Center: [0.3, -0.12, 4.2]\n"
+      "  MeanVelocity: [-0.03, -0.1, 0.09]\n"
+      "  PerturbAmplitude: 0.42\n"
+      "  Strength: -0.3");
+  test_options.get<Vortex<3>>();
 }

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/NewtonianEuler/Test_IsentropicVortex.cpp
@@ -93,20 +93,6 @@ struct Vortex {
   static constexpr OptionString help = {"A Newtonian isentropic vortex."};
 };
 
-// [[OutputRegex, The adiabatic index must be in the range \(1, 2\)]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexAdIndex",
-    "[Unit][PointwiseFunctions]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  NewtonianEuler::Solutions::IsentropicVortex test_vortex(
-      0.9, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}}, 0.21, 2.5);
-  NewtonianEuler::Solutions::IsentropicVortex another_test_vortex(
-      2.2, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}}, 0.21, 2.5);
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
 // [[OutputRegex, The strength must be non-negative.]]
 [[noreturn]] SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexStrength",
@@ -117,40 +103,6 @@ struct Vortex {
       1.3, {{1.0, 1.0, 1.0}}, {{0.0, 0.0, 0.0}}, -0.15, -1.7);
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
-}
-
-// [[OutputRegex, In string:.*At line 2 column 19:.Value 0.4 is below the lower
-// bound of 1.]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexAdIndexOptLo",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  Options<tmpl::list<Vortex>> test_options("");
-  test_options.parse(
-      "Vortex:\n"
-      "  AdiabaticIndex: 0.4\n"
-      "  Center: [2.3, -1.3, -0.6]\n"
-      "  MeanVelocity: [-0.3, 0.1, 0.7]\n"
-      "  PerturbAmplitude: -0.2\n"
-      "  Strength: 3.76");
-  test_options.get<Vortex>();
-}
-
-// [[OutputRegex, In string:.*At line 2 column 19:.Value 2.7 is above the upper
-// bound of 2.]]
-SPECTRE_TEST_CASE(
-    "Unit.PointwiseFunctions.AnalyticSolutions.NewtEuler.VortexAdIndexOptUp",
-    "[PointwiseFunctions][Unit]") {
-  ERROR_TEST();
-  Options<tmpl::list<Vortex>> test_options("");
-  test_options.parse(
-      "Vortex:\n"
-      "  AdiabaticIndex: 2.7\n"
-      "  Center: [1.4, -0.1, 2.3]\n"
-      "  MeanVelocity: [0.56, 0.2, -0.16]\n"
-      "  PerturbAmplitude: 0.41\n"
-      "  Strength: 1.53");
-  test_options.get<Vortex>();
 }
 
 // [[OutputRegex, In string:.*At line 6 column 13:.Value -0.2 is below the lower


### PR DESCRIPTION
## Proposed changes

Required update so we can use it as initial data for evolving Newtonian Euler. I'm not 100% sure about the instantiations in the .cpp so any feedback would be appreciated. So far I am getting a clang-tidy error on Travis that might be related.

Should fix [#1313](https://github.com/sxs-collaboration/spectre/issues/1313) and [#1314](https://github.com/sxs-collaboration/spectre/issues/1314)

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
