### PR TITLE
Metavariables option parsing

### DIFF
--- a/src/ApparentHorizons/FastFlow.cpp
+++ b/src/ApparentHorizons/FastFlow.cpp
@@ -17,7 +17,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"  // IWYU pragma: keep
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "ErrorHandling/Error.hpp"
 #include "Options/ParseOptions.hpp"
@@ -28,6 +28,8 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 // IWYU pragma: no_forward_declare Tensor
+
+// IWYU pragma: no_include <complex>
 
 FastFlow::FastFlow(FastFlow::Flow::type flow, FastFlow::Alpha::type alpha,
                    FastFlow::Beta::type beta, FastFlow::AbsTol::type abs_tol,
@@ -336,7 +338,8 @@ bool operator==(const FastFlow& lhs, const FastFlow& rhs) noexcept {
              rhs.iter_at_min_residual_mesh_norm_;
 }
 
-FastFlow::FlowType create_from_yaml<FastFlow::FlowType>::create(
+template <>
+FastFlow::FlowType create_from_yaml<FastFlow::FlowType>::create<void>(
     const Option& options) {
   const std::string flow_type_read = options.parse_as<std::string>();
   if ("Jacobi" == flow_type_read) {

--- a/src/ApparentHorizons/FastFlow.hpp
+++ b/src/ApparentHorizons/FastFlow.hpp
@@ -209,5 +209,11 @@ SPECTRE_ALWAYS_INLINE bool operator!=(const FastFlow& lhs,
 
 template <>
 struct create_from_yaml<FastFlow::FlowType> {
-  static FastFlow::FlowType create(const Option& options);
+  template <typename Metavariables>
+  static FastFlow::FlowType create(const Option& options) {
+    return create<void>(options);
+  }
 };
+template <>
+FastFlow::FlowType create_from_yaml<FastFlow::FlowType>::create<void>(
+    const Option& options);

--- a/src/DataStructures/DenseMatrix.hpp
+++ b/src/DataStructures/DenseMatrix.hpp
@@ -53,6 +53,7 @@ class DenseMatrix : public blaze::DynamicMatrix<T, SO> {
 
 template <typename T, bool SO>
 struct create_from_yaml<DenseMatrix<T, SO>> {
+  template <typename Metavariables>
   static DenseMatrix<T, SO> create(const Option& options) {
     const auto data = options.parse_as<std::vector<std::vector<T>>>();
     const size_t num_rows = data.size();

--- a/src/DataStructures/DenseVector.hpp
+++ b/src/DataStructures/DenseVector.hpp
@@ -72,6 +72,7 @@ struct MakeWithValueImpl<DenseVector<double, TFOut>, DenseVector<TIn, TFIn>> {
 
 template <typename T, bool TF>
 struct create_from_yaml<DenseVector<T, TF>> {
+  template <typename Metavariables>
   static DenseVector<T, TF> create(const Option& options) {
     const auto data = options.parse_as<std::vector<T>>();
     DenseVector<T, TF> result(data.size());

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -1015,7 +1015,8 @@ std::ostream& operator<<(std::ostream& os,
   }
 }
 
-ShellWedges create_from_yaml<ShellWedges>::create(const Option& options) {
+template <>
+ShellWedges create_from_yaml<ShellWedges>::create<void>(const Option& options) {
   const std::string which_wedges = options.parse_as<std::string>();
   if (which_wedges == "All") {
     return ShellWedges::All;

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -379,5 +379,10 @@ std::ostream& operator<<(std::ostream& os,
 
 template <>
 struct create_from_yaml<ShellWedges> {
-  static ShellWedges create(const Option& options);
+  template <typename Metavariables>
+  static ShellWedges create(const Option& options) {
+    return create<void>(options);
+  }
 };
+template <>
+ShellWedges create_from_yaml<ShellWedges>::create<void>(const Option& options);

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
@@ -313,7 +313,9 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 #undef INSTANTIATE
 }  // namespace Minmod_detail
 
-SlopeLimiters::MinmodType create_from_yaml<SlopeLimiters::MinmodType>::create(
+template <>
+SlopeLimiters::MinmodType
+create_from_yaml<SlopeLimiters::MinmodType>::create<void>(
     const Option& options) {
   const std::string minmod_type_read = options.parse_as<std::string>();
   if (minmod_type_read == "LambdaPi1") {

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -483,5 +483,12 @@ bool operator!=(const Minmod<VolumeDim, TagList>& lhs,
 
 template <>
 struct create_from_yaml<SlopeLimiters::MinmodType> {
-  static SlopeLimiters::MinmodType create(const Option& options);
+  template <typename Metavariables>
+  static SlopeLimiters::MinmodType create(const Option& options) {
+    return create<void>(options);
+  }
 };
+template <>
+SlopeLimiters::MinmodType
+create_from_yaml<SlopeLimiters::MinmodType>::create<void>(
+    const Option& options);

--- a/src/Evolution/EventsAndTriggers/EventsAndTriggers.hpp
+++ b/src/Evolution/EventsAndTriggers/EventsAndTriggers.hpp
@@ -57,6 +57,7 @@ class EventsAndTriggers {
 template <typename EventRegistrars, typename TriggerRegistrars>
 struct create_from_yaml<EventsAndTriggers<EventRegistrars, TriggerRegistrars>> {
   using type = EventsAndTriggers<EventRegistrars, TriggerRegistrars>;
+  template <typename Metavariables>
   static type create(const Option& options) {
     return type(options.parse_as<typename type::Storage>());
   }

--- a/src/Evolution/EventsAndTriggers/LogicalTriggers.hpp
+++ b/src/Evolution/EventsAndTriggers/LogicalTriggers.hpp
@@ -162,6 +162,7 @@ PUP::able::PUP_ID Or<TriggerRegistrars>::my_PUP_ID = 0;  // NOLINT
 
 template <typename TriggerRegistrars>
 struct create_from_yaml<Triggers::Not<TriggerRegistrars>> {
+  template <typename Metavariables>
   static Triggers::Not<TriggerRegistrars> create(const Option& options) {
     return Triggers::Not<TriggerRegistrars>(
         options.parse_as<std::unique_ptr<Trigger<TriggerRegistrars>>>());
@@ -170,6 +171,7 @@ struct create_from_yaml<Triggers::Not<TriggerRegistrars>> {
 
 template <typename TriggerRegistrars>
 struct create_from_yaml<Triggers::And<TriggerRegistrars>> {
+  template <typename Metavariables>
   static Triggers::And<TriggerRegistrars> create(const Option& options) {
     return Triggers::And<TriggerRegistrars>(
         options.parse_as<
@@ -179,6 +181,7 @@ struct create_from_yaml<Triggers::And<TriggerRegistrars>> {
 
 template <typename TriggerRegistrars>
 struct create_from_yaml<Triggers::Or<TriggerRegistrars>> {
+  template <typename Metavariables>
   static Triggers::Or<TriggerRegistrars> create(const Option& options) {
     return Triggers::Or<TriggerRegistrars>(
         options.parse_as<

--- a/src/Informer/Verbosity.cpp
+++ b/src/Informer/Verbosity.cpp
@@ -10,7 +10,8 @@
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
 
-Verbosity create_from_yaml<Verbosity>::create(const Option& options) {
+template <>
+Verbosity create_from_yaml<Verbosity>::create<void>(const Option& options) {
   const std::string type_read = options.parse_as<std::string>();
   if ("Silent" == type_read) {
     return Verbosity::Silent;

--- a/src/Informer/Verbosity.hpp
+++ b/src/Informer/Verbosity.hpp
@@ -19,5 +19,10 @@ std::ostream& operator<<(std::ostream& os, const Verbosity& verbosity) noexcept;
 
 template <>
 struct create_from_yaml<Verbosity> {
-  static Verbosity create(const Option& options);
+  template <typename Metavariables>
+  static Verbosity create(const Option& options) {
+    return create<void>(options);
+  }
 };
+template <>
+Verbosity create_from_yaml<Verbosity>::create<void>(const Option& options);

--- a/src/Options/Options.hpp
+++ b/src/Options/Options.hpp
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "ErrorHandling/Error.hpp"
+#include "Utilities/NoSuchType.hpp"
 
 /// \cond
 namespace YAML {
@@ -108,7 +109,7 @@ class Option {
   void append_context(const std::string& context) noexcept;
 
   /// Convert to an object of type `T`.
-  template <typename T>
+  template <typename T, typename Metavariables = NoSuchType>
   T parse_as() const;
 
   /// \note This constructor overwrites the mark data in the supplied
@@ -141,5 +142,6 @@ class Option {
 /// Do not call create directly.  Use Option::parse_as instead.
 template <typename T>
 struct create_from_yaml {
+  template <typename Metavariables>
   static T create(const Option& options);
 };

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -219,7 +219,7 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept
 
     if (parsed_command_line_options.count("check-options") != 0) {
       // Force all the options to be created.
-      options_.template apply<option_list>([](auto... args) {
+      options_.template apply<option_list, Metavariables>([](auto... args) {
         (void)std::initializer_list<char>{((void)args, '0')...};
       });
       if (has_options) {
@@ -236,11 +236,12 @@ Main<Metavariables>::Main(CkArgMsg* msg) noexcept
   }
 
   const_global_cache_proxy_ =
-      options_.template apply<const_global_cache_tags>([](auto... args) {
-        return CProxy_ConstGlobalCache<Metavariables>::ckNew(
-            tuples::tagged_tuple_from_typelist<const_global_cache_tags>(
-                std::move(args)...));
-      });
+      options_.template apply<const_global_cache_tags, Metavariables>(
+          [](auto... args) {
+            return CProxy_ConstGlobalCache<Metavariables>::ckNew(
+                tuples::tagged_tuple_from_typelist<const_global_cache_tags>(
+                    std::move(args)...));
+          });
 
   tuples::tagged_tuple_from_typelist<parallel_component_tag_list>
       the_parallel_components;
@@ -326,7 +327,7 @@ template <typename Metavariables>
 void Main<Metavariables>::initialize() noexcept {
   tmpl::for_each<component_list>([this](auto parallel_component) noexcept {
     using ParallelComponent = tmpl::type_from<decltype(parallel_component)>;
-    options_.template apply<typename ParallelComponent::options>(
+    options_.template apply<typename ParallelComponent::options, Metavariables>(
         [this](auto... opts) {
           ParallelComponent::initialize(const_global_cache_proxy_,
                                         std::move(opts)...);

--- a/src/Time/StepChoosers/Constant.hpp
+++ b/src/Time/StepChoosers/Constant.hpp
@@ -72,6 +72,7 @@ double parse_options(const Option& options);
 
 template <typename StepChooserRegistrars>
 struct create_from_yaml<StepChoosers::Constant<StepChooserRegistrars>> {
+  template <typename Metavariables>
   static StepChoosers::Constant<StepChooserRegistrars> create(
       const Option& options) {
     return StepChoosers::Constant<StepChooserRegistrars>(

--- a/src/Time/Triggers/PastTime.hpp
+++ b/src/Time/Triggers/PastTime.hpp
@@ -74,6 +74,7 @@ PUP::able::PUP_ID PastTime<TriggerRegistrars>::my_PUP_ID = 0;  // NOLINT
 
 template <typename TriggerRegistrars>
 struct create_from_yaml<Triggers::PastTime<TriggerRegistrars>> {
+  template <typename Metavariables>
   static Triggers::PastTime<TriggerRegistrars> create(const Option& options) {
     return Triggers::PastTime<TriggerRegistrars>(options.parse_as<double>());
   }

--- a/tests/Unit/Options/Test_CustomTypeConstruction.cpp
+++ b/tests/Unit/Options/Test_CustomTypeConstruction.cpp
@@ -12,6 +12,11 @@
 
 namespace {
 /// [class_creation_example]
+template <bool Valid>
+struct Metavariables {
+  static constexpr bool valid = Valid;
+};
+
 template <typename>
 class CreateFromOptions;
 struct CFO {
@@ -30,15 +35,20 @@ class CreateFromOptions {
   static constexpr OptionString help = {"Class help text"};
 
   CreateFromOptions() = default;
-  // The OptionContext argument can be left off if unneeded.
-  CreateFromOptions(std::string str, const OptionContext& context)
-      : str_(std::move(str)) {
+  // The Metavariables arguments can be left off if unneeded, and the
+  // OptionContext as well.
+  template <typename Metavariables>
+  CreateFromOptions(std::string str, const OptionContext& context,
+                    Metavariables /*meta*/)
+      : str_(std::move(str)), valid_(Metavariables::valid) {
     if (str_[0] != 'f') {
-      PARSE_ERROR(context, "Option must start with an f");
+      PARSE_ERROR(context,
+                  "Option must start with an 'f' but is '" << str_ << "'");
     }
   }
 
-  std::string str_;
+  std::string str_{};
+  bool valid_{false};
 };
 
 const char* const input_file_text = R"(
@@ -51,7 +61,9 @@ CFO:
 SPECTRE_TEST_CASE("Unit.Options.CustomType", "[Unit][Options]") {
   Options<tmpl::list<CFO>> opts("");
   opts.parse(input_file_text);
-  CHECK(opts.get<CFO>().str_ == "foo");
+  CHECK(opts.get<CFO, Metavariables<true>>().str_ == "foo");
+  CHECK(opts.get<CFO, Metavariables<true>>().valid_);
+  CHECK_FALSE(opts.get<CFO, Metavariables<false>>().valid_);
 }
 
 // [[OutputRegex, In string:.*At line 2 column 3:.Option 'NotOption' is not a
@@ -61,16 +73,17 @@ SPECTRE_TEST_CASE("Unit.Options.CustomType.error", "[Unit][Options]") {
   Options<tmpl::list<CFO>> opts("");
   opts.parse("CFO:\n"
              "  NotOption: foo");
-  opts.get<CFO>();
+  opts.get<CFO, Metavariables<true>>();
 }
 
-// [[OutputRegex, In string:.*At line 2 column 3:.Option must start with an f]]
+// [[OutputRegex, In string:.*At line 2 column 3:.Option must start with an 'f'
+// but is]]
 SPECTRE_TEST_CASE("Unit.Options.CustomType.custom_error", "[Unit][Options]") {
   ERROR_TEST();
   Options<tmpl::list<CFO>> opts("");
   opts.parse("CFO:\n"
              "  Option: zoo");
-  opts.get<CFO>();
+  opts.get<CFO, Metavariables<true>>();
 }
 
 /// [enum_creation_example]
@@ -85,6 +98,7 @@ struct CFOAnimal {
 
 template <>
 struct create_from_yaml<CreateFromOptionsAnimal> {
+  template <typename Metavariables>
   static CreateFromOptionsAnimal create(const Option& options) {
     const std::string animal = options.parse_as<std::string>();
     if (animal == "Cat") {
@@ -103,6 +117,60 @@ SPECTRE_TEST_CASE("Unit.Options.CustomType.specialized", "[Unit][Options]") {
   Options<tmpl::list<CFOAnimal>> opts("");
   opts.parse("CFOAnimal: Cat");
   CHECK(opts.get<CFOAnimal>() == CreateFromOptionsAnimal::Cat);
+}
+
+/// [enum_void_creation_header_example]
+namespace {
+enum class CreateFromOptionsExoticAnimal { MexicanWalkingFish, Platypus };
+
+struct CFOExoticAnimal {
+  using type = CreateFromOptionsExoticAnimal;
+  static constexpr OptionString help = {"Option help text"};
+};
+}  // namespace
+
+template <>
+struct create_from_yaml<CreateFromOptionsExoticAnimal> {
+  template <typename Metavariables>
+  static CreateFromOptionsExoticAnimal create(const Option& options) {
+    return create<void>(options);
+  }
+};
+template <>
+CreateFromOptionsExoticAnimal
+create_from_yaml<CreateFromOptionsExoticAnimal>::create<void>(
+    const Option& options);
+/// [enum_void_creation_header_example]
+
+/// [enum_void_creation_cpp_example]
+template <>
+CreateFromOptionsExoticAnimal
+create_from_yaml<CreateFromOptionsExoticAnimal>::create<void>(
+    const Option& options) {
+  const std::string animal = options.parse_as<std::string>();
+  if (animal == "MexicanWalkingFish") {
+    return CreateFromOptionsExoticAnimal::MexicanWalkingFish;
+  }
+  if (animal == "Platypus") {
+    return CreateFromOptionsExoticAnimal::Platypus;
+  }
+  PARSE_ERROR(options.context(),
+              "CreateFromOptionsExoticAnimal must be 'MexicanWalkingFish' or "
+              "'Platypus'");
+}
+/// [enum_void_creation_cpp_example]
+
+SPECTRE_TEST_CASE("Unit.Options.CustomType.specialized_void",
+                  "[Unit][Options]") {
+  const auto helper = [](const std::string& name,
+                         const CreateFromOptionsExoticAnimal expected) {
+    Options<tmpl::list<CFOExoticAnimal>> opts("");
+    opts.parse("CFOExoticAnimal: " + name);
+    CHECK(opts.get<CFOExoticAnimal>() == expected);
+  };
+  helper("Platypus", CreateFromOptionsExoticAnimal::Platypus);
+  helper("MexicanWalkingFish",
+         CreateFromOptionsExoticAnimal::MexicanWalkingFish);
 }
 
 // [[OutputRegex, In string:.*While parsing option CFOAnimal:.*At line 1

--- a/tests/Unit/Options/Test_Factory.cpp
+++ b/tests/Unit/Options/Test_Factory.cpp
@@ -85,30 +85,31 @@ struct Map {
   using type = std::map<std::string, std::unique_ptr<OptionTest>>;
   static constexpr OptionString help = {"halp"};
 };
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Options.Factory", "[Unit][Options]") {
+void test_factory() {
   Options<tmpl::list<OptionType>> opts("");
   opts.parse("OptionType: Test2");
   CHECK(opts.get<OptionType>()->name() == "Test2");
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Factory.with_colon", "[Unit][Options]") {
+void test_factory_with_colon() {
   Options<tmpl::list<OptionType>> opts("");
-  opts.parse("OptionType:\n"
-             "  Test2:");
+  opts.parse(
+      "OptionType:\n"
+      "  Test2:");
   CHECK(opts.get<OptionType>()->name() == "Test2");
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Factory.with_arg", "[Unit][Options]") {
+void test_factory_with_arg() {
   Options<tmpl::list<OptionType>> opts("");
-  opts.parse("OptionType:\n"
-             "  TestWithArg:\n"
-             "    Arg: stuff");
+  opts.parse(
+      "OptionType:\n"
+      "  TestWithArg:\n"
+      "    Arg: stuff");
   CHECK(opts.get<OptionType>()->name() == "TestWithArg(stuff)");
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Factory.object_vector", "[Unit][Options]") {
+void test_factory_object_vector() {
   Options<tmpl::list<Vector>> opts("");
   opts.parse("Vector: [Test1, Test2, Test1]");
   const auto& arg = opts.get<Vector>();
@@ -118,17 +119,38 @@ SPECTRE_TEST_CASE("Unit.Options.Factory.object_vector", "[Unit][Options]") {
   CHECK(arg[2]->name() == "Test1");
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Factory.object_map", "[Unit][Options]") {
+void test_factory_object_map() {
   Options<tmpl::list<Map>> opts("");
-  opts.parse("Map:\n"
-             "  A: Test1\n"
-             "  B: Test2\n"
-             "  C: Test1\n");
+  opts.parse(
+      "Map:\n"
+      "  A: Test1\n"
+      "  B: Test2\n"
+      "  C: Test1\n");
   const auto& arg = opts.get<Map>();
   CHECK(arg.size() == 3);
   CHECK(arg.at("A")->name() == "Test1");
   CHECK(arg.at("B")->name() == "Test2");
   CHECK(arg.at("C")->name() == "Test1");
+}
+
+void test_factory_format() {
+  Options<tmpl::list<OptionType>> opts("");
+  INFO(opts.help());
+  // The compiler puts "(anonymous namespace)::" before the type, but
+  // I don't want to rely on that, so just check that the type is at
+  // the end of the line, which should ensure it is not in a template
+  // parameter or something.
+  CHECK(opts.help().find("OptionTest\n") != std::string::npos);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Options.Factory", "[Unit][Options]") {
+  test_factory();
+  test_factory_with_arg();
+  test_factory_with_colon();
+  test_factory_object_vector();
+  test_factory_object_map();
+  test_factory_format();
 }
 
 // [[OutputRegex, In string:.*At line 1 column 1:.Expected a class to
@@ -176,14 +198,4 @@ SPECTRE_TEST_CASE("Unit.Options.Factory.missing_arg", "[Unit][Options]") {
   opts.parse("OptionType:\n"
              "  TestWithArg:");
   CHECK(opts.get<OptionType>()->name() == "TestWithArg(stuff)");
-}
-
-SPECTRE_TEST_CASE("Unit.Options.Factory.Format", "[Unit][Options]") {
-  Options<tmpl::list<OptionType>> opts("");
-  INFO(opts.help());
-  // The compiler puts "(anonymous namespace)::" before the type, but
-  // I don't want to rely on that, so just check that the type is at
-  // the end of the line, which should ensure it is not in a template
-  // parameter or something.
-  CHECK(opts.help().find("OptionTest\n") != std::string::npos);
 }

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -437,6 +437,7 @@ struct hash<Wrapped<T>> {
 
 template <typename T>
 struct create_from_yaml<Wrapped<T>> {
+  template <typename Metavariables>
   static Wrapped<T> create(const Option& options) {
     return Wrapped<T>{options.parse_as<T>()};
   }

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -19,7 +19,8 @@
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/TMPL.hpp"
 
-SPECTRE_TEST_CASE("Unit.Options.Empty.success", "[Unit][Options]") {
+namespace {
+void test_options_empty_success() {
   Options<tmpl::list<>> opts("");
   opts.parse("");
   // Catch requires us to have at least one CHECK in each test
@@ -51,7 +52,6 @@ SPECTRE_TEST_CASE("Unit.Options.syntax_error", "[Unit][Options]") {
              "  IsPeriodicIn: [false]");
 }
 
-namespace {
 struct Simple {
   using type = int;
   static constexpr OptionString help = {"halp"};
@@ -61,9 +61,8 @@ struct NamedSimple {
   static std::string name() noexcept { return "SomeName"; }
   static constexpr OptionString help = {"halp"};
 };
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Options.Simple.success", "[Unit][Options]") {
+void test_options_simple_success() {
   {
     Options<tmpl::list<Simple>> opts("");
     opts.parse("Simple: -4");
@@ -148,7 +147,6 @@ SPECTRE_TEST_CASE("Unit.Options.NamedSimple.invalid", "[Unit][Options]") {
   opts.get<NamedSimple>();
 }
 
-namespace {
 /// [options_example_scalar_struct]
 struct Bounded {
   using type = int;
@@ -160,17 +158,16 @@ struct Bounded {
   static type upper_bound() noexcept { return 10; }
 };
 /// [options_example_scalar_struct]
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Options.Defaulted.specified", "[Unit][Options]") {
-/// [options_example_scalar_parse]
+void test_options_default_specified() {
+  /// [options_example_scalar_parse]
   Options<tmpl::list<Bounded>> opts("Overall help text");
   opts.parse("Bounded: 8");
   CHECK(opts.get<Bounded>() == 8);
 /// [options_example_scalar_parse]
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Defaulted.defaulted", "[Unit][Options]") {
+void test_options_default_defaulted() {
   Options<tmpl::list<Bounded>> opts("");
   opts.parse("");
   CHECK(opts.get<Bounded>() == 3);
@@ -185,13 +182,13 @@ SPECTRE_TEST_CASE("Unit.Options.Bounded.below", "[Unit][Options]") {
   opts.get<Bounded>();
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Bounded.lower_bound", "[Unit][Options]") {
+void test_options_bounded_lower_bound() {
   Options<tmpl::list<Bounded>> opts("");
   opts.parse("Bounded: 2");
   CHECK(opts.get<Bounded>() == 2);
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Bounded.upper_bound", "[Unit][Options]") {
+void test_options_bounded_upper_bound() {
   Options<tmpl::list<Bounded>> opts("");
   opts.parse("Bounded: 10");
   CHECK(opts.get<Bounded>() == 10);
@@ -206,7 +203,6 @@ SPECTRE_TEST_CASE("Unit.Options.Bounded.above", "[Unit][Options]") {
   opts.get<Bounded>();
 }
 
-namespace {
 struct BadDefault {
   using type = int;
   static constexpr OptionString help = {"halp"};
@@ -220,7 +216,6 @@ struct NamedBadDefault {
   static type default_value() noexcept { return 3; }
   static type lower_bound() noexcept { return 4; }
 };
-}  // namespace
 
 // [[OutputRegex, Checking DEFAULT value for BadDefault:.Value 3 is below the
 // lower bound of 4]]
@@ -240,7 +235,6 @@ SPECTRE_TEST_CASE("Unit.Options.NamedBadDefault", "[Unit][Options]") {
   opts.get<NamedBadDefault>();
 }
 
-namespace {
 /// [options_example_vector_struct]
 struct VectorOption {
   using type = std::vector<int>;
@@ -253,7 +247,6 @@ struct VectorOption {
   static size_t upper_bound_on_size() { return 5; }
 };
 /// [options_example_vector_struct]
-}  // namespace
 
 // [[OutputRegex, In string:.*While parsing option Vector:.At line 1 column
 // 9:.Value must have at least 2 entries, but 1 were given.]]
@@ -264,13 +257,13 @@ SPECTRE_TEST_CASE("Unit.Options.Vector.too_short", "[Unit][Options]") {
   opts.get<VectorOption>();
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Vector.lower_bound", "[Unit][Options]") {
+void test_options_vector_lower_bound() {
   Options<tmpl::list<VectorOption>> opts("");
   opts.parse("Vector: [2,3]");
   CHECK(opts.get<VectorOption>() == (std::vector<int>{2, 3}));
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Vector.upper_bound", "[Unit][Options]") {
+void test_options_vector_upper_bound() {
   Options<tmpl::list<VectorOption>> opts("");
   opts.parse("Vector: [2, 3, 3, 3, 5]");
   CHECK(opts.get<VectorOption>() == (std::vector<int>{2, 3, 3, 3, 5}));
@@ -294,12 +287,10 @@ SPECTRE_TEST_CASE("Unit.Options.Vector.empty_too_short", "[Unit][Options]") {
   opts.get<VectorOption>();
 }
 
-namespace {
 struct Array {
   using type = std::array<int, 3>;
   static constexpr OptionString help = {"halp"};
 };
-}  // namespace
 
 // [[OutputRegex, In string:.*While parsing option Array:.At line 1 column
 // 8:.Failed to convert value to type \[int x3\]:]]
@@ -310,7 +301,7 @@ SPECTRE_TEST_CASE("Unit.Options.Array.too_short", "[Unit][Options]") {
   opts.get<Array>();
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Array.success", "[Unit][Options]") {
+void test_options_array_success() {
   Options<tmpl::list<Array>> opts("");
   opts.parse("Array: [1,2,3]");
   CHECK(opts.get<Array>() == (std::array<int, 3>{{1, 2, 3}}));
@@ -348,14 +339,12 @@ SPECTRE_TEST_CASE("Unit.Options.Array.missing", "[Unit][Options]") {
   opts.get<Array>();
 }
 
-namespace {
 struct ZeroArray {
   using type = std::array<int, 0>;
   static constexpr OptionString help = {"halp"};
 };
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Options.ZeroArray.missing", "[Unit][Options]") {
+void test_options_zero_array_missing() {
   Options<tmpl::list<ZeroArray>> opts("");
   opts.parse("ZeroArray:");
   opts.get<ZeroArray>();
@@ -364,14 +353,12 @@ SPECTRE_TEST_CASE("Unit.Options.ZeroArray.missing", "[Unit][Options]") {
   CHECK(true);
 }
 
-namespace {
 struct Map {
   using type = std::map<std::string, int>;
   static constexpr OptionString help = {"halp"};
 };
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Options.Map.success", "[Unit][Options]") {
+void test_options_map_success() {
   Options<tmpl::list<Map>> opts("");
   opts.parse("Map:\n"
              "  A: 3\n"
@@ -382,7 +369,7 @@ SPECTRE_TEST_CASE("Unit.Options.Map.success", "[Unit][Options]") {
   CHECK(opts.get<Map>() == expected);
 }
 
-SPECTRE_TEST_CASE("Unit.Options.Map.empty", "[Unit][Options]") {
+void test_options_map_empty() {
   Options<tmpl::list<Map>> opts("");
   opts.parse("Map:");
   CHECK(opts.get<Map>().empty());
@@ -407,14 +394,12 @@ SPECTRE_TEST_CASE("Unit.Options.Map.invalid_entry", "[Unit][Options]") {
   opts.get<Map>();
 }
 
-namespace {
 struct UnorderedMap {
   using type = std::unordered_map<std::string, int>;
   static constexpr OptionString help = {"halp"};
 };
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Options.UnorderedMap.success", "[Unit][Options]") {
+void test_options_unordered_map_success() {
   Options<tmpl::list<UnorderedMap>> opts("");
   opts.parse("UnorderedMap:\n"
              "  A: 3\n"
@@ -425,7 +410,6 @@ SPECTRE_TEST_CASE("Unit.Options.UnorderedMap.success", "[Unit][Options]") {
   CHECK(opts.get<UnorderedMap>() == expected);
 }
 
-namespace {
 template <typename T>
 struct Wrapped {
   T data;
@@ -483,9 +467,8 @@ struct WrapUnorderedMap {
   using type = std::unordered_map<Wrapped<int>, Wrapped<std::string>>;
   static constexpr OptionString help = {"halp"};
 };
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Options.ComplexContainers", "[Unit][Options]") {
+void test_options_complex_containers() {
   Options<tmpl::list<WrapMap, WrapVector, WrapList, WrapArray, WrapPair,
                      WrapUnorderedMap>> opts("");
   opts.parse("WrapMap: {1: A, 2: B}\n"
@@ -508,7 +491,6 @@ SPECTRE_TEST_CASE("Unit.Options.ComplexContainers", "[Unit][Options]") {
 }
 
 #ifdef SPECTRE_DEBUG
-namespace {
 struct Duplicate {
   using type = int;
   static constexpr OptionString help = {"halp"};
@@ -518,7 +500,6 @@ struct NamedDuplicate {
   static std::string name() noexcept { return "Duplicate"; }
   static constexpr OptionString help = {"halp"};
 };
-}  // namespace
 #endif  // SPECTRE_DEBUG
 
 // [[OutputRegex, Duplicate option name: Duplicate]]
@@ -531,7 +512,6 @@ struct NamedDuplicate {
 }
 
 #ifdef SPECTRE_DEBUG
-namespace {
 struct TooooooooooooooooooooLong {
   using type = int;
   static constexpr OptionString help = {"halp"};
@@ -561,7 +541,6 @@ struct NamedTooLongHelp {
   static constexpr OptionString help = {
     "halp halp halp halp halp halp halp halp halp halp halp halp"};
 };
-}  // namespace
 #endif  // SPECTRE_DEBUG
 
 // [[OutputRegex, The option name TooooooooooooooooooooLong is too long for
@@ -621,7 +600,6 @@ struct NamedTooLongHelp {
 #endif
 }
 
-namespace {
 struct Apply1 {
   using type = int;
   static constexpr OptionString help = {"halp"};
@@ -634,9 +612,8 @@ struct Apply3 {
   using type = std::vector<int>;
   static constexpr OptionString help = {"halp"};
 };
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Options.Apply", "[Unit][Options]") {
+void test_options_apply() {
   Options<tmpl::list<Apply1, Apply2, Apply3>> opts("");
   opts.parse("Apply1: 2\n"
              "Apply2: str\n"
@@ -653,12 +630,10 @@ SPECTRE_TEST_CASE("Unit.Options.Apply", "[Unit][Options]") {
   CHECK(arg2 == 2);
 }
 
-SPECTRE_TEST_CASE("Unit.Options.OptionContext.default_stream",
-                  "[Unit][Options]") {
+void test_options_option_context_default_stream() {
   CHECK(get_output(OptionContext{}).empty());
 }
 
-namespace {
 // Use formatted inner types to make sure nested formatting works
 template <typename T>
 using In = std::array<T, 0>;
@@ -697,9 +672,8 @@ struct FormatUnorderedMap {
   static constexpr OptionString help = {"halp"};
   static constexpr const char* const expected = "{[int x0]: [double x0]}";
 };
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Options.Format", "[Unit][Options]") {
+void test_options_format() {
   const auto check = [](auto opt) noexcept {
     using Opt = decltype(opt);
     Options<tmpl::list<Opt>> opts("");
@@ -730,4 +704,25 @@ SPECTRE_TEST_CASE("Unit.Options.bad_colon", "[Unit][Options]") {
   ERROR_TEST();
   Options<tmpl::list<>> opts("");
   opts.parse("\n\n:");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Options", "[Unit][Options]") {
+  test_options_empty_success();
+  test_options_simple_success();
+  test_options_default_specified();
+  test_options_default_defaulted();
+  test_options_bounded_lower_bound();
+  test_options_bounded_upper_bound();
+  test_options_vector_lower_bound();
+  test_options_vector_upper_bound();
+  test_options_array_success();
+  test_options_zero_array_missing();
+  test_options_map_success();
+  test_options_map_empty();
+  test_options_unordered_map_success();
+  test_options_complex_containers();
+  test_options_apply();
+  test_options_option_context_default_stream();
+  test_options_format();
 }

--- a/tests/Unit/TestCreation.hpp
+++ b/tests/Unit/TestCreation.hpp
@@ -8,6 +8,7 @@
 
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
+#include "Utilities/NoSuchType.hpp"
 
 namespace TestCreation_detail {
 template <typename T>
@@ -20,18 +21,19 @@ struct Opt {
 /// \ingroup TestingFrameworkGroup
 /// Construct an object from a given string.  Each line in the string
 /// must be indented.
-template <typename T>
+template <typename T, typename Metavariables = NoSuchType>
 T test_creation(const std::string& construction_string) noexcept {
   Options<tmpl::list<TestCreation_detail::Opt<T>>> options("");
   options.parse("Opt:\n" + construction_string);
-  return options.template get<TestCreation_detail::Opt<T>>();
+  return options.template get<TestCreation_detail::Opt<T>, Metavariables>();
 }
 
 /// \ingroup TestingFrameworkGroup
 /// Construct a factory object from a given string.  Each line in the
 /// string must be indented.
-template <typename BaseClass>
+template <typename BaseClass, typename Metavariables = NoSuchType>
 std::unique_ptr<BaseClass> test_factory_creation(
     const std::string& construction_string) noexcept {
-  return test_creation<std::unique_ptr<BaseClass>>(construction_string);
+  return test_creation<std::unique_ptr<BaseClass>, Metavariables>(
+      construction_string);
 }


### PR DESCRIPTION
## Proposed changes

- Clean up some of the option parsing tests
- Add support for passing `Metavariables` through the option parser so that classes can (optionally) use it during construction. This is useful for boundary conditions to be able to check that the variable names in the input file are valid for the system, and possibly for observers in the future.

Commit order:
1. Factor options tests
2. Factor factory tests
3. Add support passing metavariables through options
4. Pass Metavariables to option parsing in Main.hpp

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
