### PR TITLE
Add Krivodonova hierarchical limiter

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -281,6 +281,19 @@
   pages    = "209--220",
 }
 
+@article{Krivodonova2007,
+  title   = "Limiters for high-order discontinuous {Galerkin} methods",
+  journal = "Journal of Computational Physics",
+  volume  = "226",
+  number  = "1",
+  pages   = "879 - 896",
+  year    = "2007",
+  issn    = "0021-9991",
+  url     = "https://doi.org/10.1016/j.jcp.2007.05.011",
+  doi     = "10.1016/j.jcp.2007.05.011",
+  author  = "Krivodonova, Lilia"
+}
+
 @article{Lindblom1998dp,
   author         = "Lindblom, Lee",
   title          = "Phase transitions and the mass radius curves of
@@ -434,4 +447,3 @@
 
 # When editing this file, please follow the guidelines in
 # https://spectre-code.org/writing_good_dox.html#writing_dox_citations.
-

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Krivodonova.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Krivodonova.hpp
@@ -1,0 +1,997 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/functional/hash.hpp>  // IWYU pragma: keep
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <ostream>
+#include <pup.h>  // IWYU pragma: keep
+#include <type_traits>
+#include <unordered_map>
+#include <utility>  // for pair
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Index.hpp"
+#include "DataStructures/ModalVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Metafunctions.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/Tensor.hpp"         // IWYU pragma: keep
+#include "DataStructures/Variables.hpp"             // IWYU pragma: keep
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"    // IWYU pragma: keep
+#include "Domain/ElementId.hpp"  // IWYU pragma: keep
+#include "Domain/Mesh.hpp"
+#include "Domain/OrientationMap.hpp"  // IWYU pragma: keep
+#include "Domain/Tags.hpp"            // IWYU pragma: keep
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Options/Options.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_include <algorithm>
+// IWYU pragma: no_forward_declare Variables
+
+/// \cond
+namespace SlopeLimiters {
+template <size_t VolumeDim, typename TagsToLimit>
+class Krivodonova;
+}  // namespace SlopeLimiters
+/// \endcond
+
+namespace SlopeLimiters {
+/*!
+ * \ingroup SlopeLimitersGroup
+ * \brief An implementation of the Krivodonova slope limiter.
+ *
+ * The slope limiter is described in \cite Krivodonova2007. The Krivodonova
+ * limiter works by limiting the highest derivatives/modal coefficients using an
+ * aggressive minmod approach, decreasing in derivative/modal coefficient order
+ * until no more limiting is necessary. In 3d, the function being limited is
+ * expanded as:
+ *
+ * \f{align}{
+ * u^{l,m,n}=\sum_{i,j,k=0,0,0}^{N_i,N_j,N_k}c^{l,m,n}_{i,j,k}
+ *  P_{i}(\xi)P_{j}(\eta)P_{k}(\zeta)
+ * \f}
+ *
+ * where \f$\left\{\xi, \eta, \zeta\right\}\f$ are the logical coordinates,
+ * \f$P_{i}\f$ are the Legendre polynomials, the superscript \f$\{l,m,n\}\f$
+ * represents the element indexed by \f$l,m,n\f$, and \f$N_i,N_j\f$ and
+ * \f$N_k\f$ are the number of collocation points minus one in the
+ * \f$\xi,\eta,\f$ and \f$\zeta\f$ direction, respectively. The coefficients are
+ * limited according to:
+ *
+ * \f{align}{
+ * \tilde{c}^{l,m,n}_{i,j,k}=\mathrm{minmod}
+ *   &\left(c_{i,j,k}^{l,m,n},
+ *          \alpha_i\left(c^{l+1,m,n}_{i-1,j,k}-c^{l,m,n}_{i-1,j,k}\right),
+ *          \alpha_i\left(c^{l,m,n}_{i-1,j,k}-c^{l-1,m,n}_{i-1,j,k}\right),
+ *     \right.\notag \\
+ *   &\;\;\;\;
+ *          \alpha_j\left(c^{l,m+1,n}_{i,j-1,k}-c^{l,m,n}_{i,j-1,k}\right),
+ *          \alpha_j\left(c^{l,m,n}_{i,j-1,k}-c^{l,m-1,n}_{i,j-1,k}\right),
+ *     \notag \\
+ *   &\;\;\;\;\left.
+ *          \alpha_k\left(c^{l,m,n+1}_{i,j,k-1}-c^{l,m,n}_{i,j,k-1}\right),
+ *          \alpha_k\left(c^{l,m,n}_{i,j,k-1}-c^{l,m,n-1}_{i,j,k-1}\right)
+ *     \right),
+ * \label{eq:krivodonova 3d minmod}
+ * \f}
+ *
+ * where \f$\mathrm{minmod}\f$ is the minmod function defined as
+ *
+ * \f{align}{
+ *  \mathrm{minmod}(a,b,c,\ldots)=
+ *  \left\{
+ *  \begin{array}{ll}
+ *    \mathrm{sgn}(a)\min(\lvert a\rvert, \lvert b\rvert,
+ *    \lvert c\rvert, \ldots) & \mathrm{if} \;
+ *    \mathrm{sgn}(a)=\mathrm{sgn}(b)=\mathrm{sgn}(c)=\mathrm{sgn}(\ldots) \\
+ *    0 & \mathrm{otherwise}
+ *  \end{array}\right.
+ * \f}
+ *
+ * Krivodonova \cite Krivodonova2007 requires \f$\alpha_i\f$ to be in the range
+ *
+ * \f{align*}{
+ * \frac{1}{2(2i-1)}\le \alpha_i \le 1
+ * \f}
+ *
+ * where the lower bound comes from finite differencing the coefficients between
+ * neighbor elements when using Legendre polynomials (see \cite Krivodonova2007
+ * for details). Note that we normalize our Legendre polynomials by \f$P_i(1) =
+ * 1\f$; this is the normalization \cite Krivodonova2007 uses in 1D, (but not in
+ * 2D), which is why our bounds on \f$\alpha_i\f$ match Eq. 14 of
+ * \cite Krivodonova2007 (but not Eq. 23). We relax the lower bound:
+ *
+ * \f{align*}{
+ * 0 \le \alpha_i \le 1
+ * \f}
+ *
+ * to allow different basis functions (e.g. Chebyshev polynomials) and to allow
+ * the limiter to be more dissipative if necessary. The same \f$\alpha_i\f$s are
+ * used in all dimensions.
+ *
+ * \note The only place where the specific choice of 1d basis
+ * comes in is the lower bound for the \f$\alpha_i\f$s, and so in general the
+ * limiter can be applied to any 1d or tensor product of 1d basis functions.
+ *
+ * The limiting procedure must be applied from the highest derivatives to the
+ * lowest, i.e. the highest coefficients to the lowest. Let us consider a 3d
+ * element with \f$N+1\f$ coefficients in each dimension and denote the
+ * coefficients as \f$c_{i,j,k}\f$. Then the limiting procedure starts at
+ * \f$c_{N,N,N}\f$, followed by \f$c_{N,N,N-1}\f$, \f$c_{N,N-1,N}\f$, and
+ * \f$c_{N-1,N,N}\f$. A detailed example is given below. Limiting is stopped if
+ * all symmetric pairs of coefficients are left unchanged, i.e.
+ * \f$c_{i,j,k}=\tilde{c}_{i,j,k}\f$. By all symmetric coefficients we mean
+ * that, for example, \f$c_{N-i,N-j,N-k}\f$, \f$c_{N-j,N-i,N-k}\f$,
+ * \f$c_{N-k,N-j,N-i}\f$, \f$c_{N-j,N-k,N-i}\f$, \f$c_{N-i,N-k,N-j}\f$, and
+ * \f$c_{N-k,N-i,N-j}\f$ are not limited. As a concrete example, consider a 3d
+ * element with 3 collocation points per dimension. Each limited coefficient is
+ * defined as (though only computed if needed):
+ *
+ * \f{align*}{
+ * \tilde{c}^{l,m,n}_{2,2,2}=\mathrm{minmod}
+ *   &\left(c_{2,2,2}^{l,m,n},
+ *          \alpha_2\left(c^{l+1,m,n}_{1,2,2}-c^{l,m,n}_{1,2,2}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,2,2}-c^{l-1,m,n}_{1,2,2}\right),
+ *     \right.\\
+ *   &\;\;\;\;
+ *          \alpha_2\left(c^{l,m+1,n}_{2,1,2}-c^{l,m,n}_{2,1,2}\right),
+ *          \alpha_2\left(c^{l,m,n}_{2,1,2}-c^{l,m-1,n}_{2,1,2}\right),\\
+ *   &\;\;\;\;\left.
+ *          \alpha_2\left(c^{l,m,n+1}_{2,2,1}-c^{l,m,n}_{2,2,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{2,2,1}-c^{l,m,n-1}_{2,2,1}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{2,2,1}=\mathrm{minmod}
+ *   &\left(c_{2,2,1}^{l,m,n},
+ *          \alpha_2\left(c^{l+1,m,n}_{1,2,1}-c^{l,m,n}_{1,2,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,2,1}-c^{l-1,m,n}_{1,2,1}\right),
+ *     \right.\\
+ *   &\;\;\;\;
+ *          \alpha_2\left(c^{l,m+1,n}_{2,1,1}-c^{l,m,n}_{2,1,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{2,1,1}-c^{l,m-1,n}_{2,1,1}\right),\\
+ *   &\;\;\;\;\left.
+ *          \alpha_1\left(c^{l,m,n+1}_{2,2,0}-c^{l,m,n}_{2,2,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{2,2,0}-c^{l,m,n-1}_{2,2,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{2,1,2}=\mathrm{minmod}
+ *   &\left(c_{2,1,2}^{l,m,n},
+ *          \alpha_2\left(c^{l+1,m,n}_{1,1,2}-c^{l,m,n}_{1,1,2}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,1,2}-c^{l-1,m,n}_{1,1,2}\right),
+ *     \right.\\
+ *   &\;\;\;\;
+ *          \alpha_1\left(c^{l,m+1,n}_{2,0,2}-c^{l,m,n}_{2,0,2}\right),
+ *          \alpha_1\left(c^{l,m,n}_{2,0,2}-c^{l,m-1,n}_{2,0,2}\right),\\
+ *   &\;\;\;\;\left.
+ *          \alpha_2\left(c^{l,m,n+1}_{2,1,1}-c^{l,m,n}_{2,1,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{2,1,1}-c^{l,m,n-1}_{2,1,1}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{1,2,2}=\mathrm{minmod}
+ *   &\left(c_{1,2,2}^{l,m,n},
+ *          \alpha_1\left(c^{l+1,m,n}_{0,2,2}-c^{l,m,n}_{0,2,2}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,2,2}-c^{l-1,m,n}_{0,2,2}\right),
+ *     \right.\\
+ *   &\;\;\;\;
+ *          \alpha_2\left(c^{l,m+1,n}_{1,1,2}-c^{l,m,n}_{1,1,2}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,1,2}-c^{l,m-1,n}_{1,1,2}\right),\\
+ *   &\;\;\;\;\left.
+ *          \alpha_2\left(c^{l,m,n+1}_{1,2,1}-c^{l,m,n}_{1,2,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,2,1}-c^{l,m,n-1}_{1,2,1}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{2,2,0}=\mathrm{minmod}
+ *   &\left(c_{2,2,0}^{l,m,n},
+ *          \alpha_2\left(c^{l+1,m,n}_{1,2,0}-c^{l,m,n}_{1,2,0}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,2,0}-c^{l-1,m,n}_{1,2,0}\right),
+ *     \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_2\left(c^{l,m+1,n}_{2,1,0}-c^{l,m,n}_{2,1,0}\right),
+ *          \alpha_2\left(c^{l,m,n}_{2,1,0}-c^{l,m-1,n}_{2,1,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{2,0,2}=\mathrm{minmod}
+ *   &\left(c_{2,0,2}^{l,m,n},
+ *          \alpha_2\left(c^{l+1,m,n}_{1,0,2}-c^{l,m,n}_{1,0,2}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,0,2}-c^{l-1,m,n}_{1,0,2}\right),
+ *     \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_2\left(c^{l,m,n+1}_{2,0,1}-c^{l,m,n}_{2,0,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{2,0,1}-c^{l,m,n-1}_{2,0,1}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{0,2,2}=\mathrm{minmod}
+ *   &\left(c_{0,2,2}^{l,m,n},
+ *          \alpha_2\left(c^{l,m+1,n}_{0,1,2}-c^{l,m,n}_{0,1,2}\right),
+ *          \alpha_2\left(c^{l,m,n}_{0,1,2}-c^{l,m-1,n}_{0,1,2}\right),
+ *     \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_2\left(c^{l,m,n+1}_{0,2,1}-c^{l,m,n}_{0,2,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{0,2,1}-c^{l,m,n-1}_{0,2,1}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{2,1,1}=\mathrm{minmod}
+ *   &\left(c_{2,1,1}^{l,m,n},
+ *          \alpha_2\left(c^{l+1,m,n}_{1,1,1}-c^{l,m,n}_{1,1,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,1,1}-c^{l-1,m,n}_{1,1,1}\right),
+ *     \right.\\
+ *   &\;\;\;\;
+ *          \alpha_1\left(c^{l,m+1,n}_{2,0,1}-c^{l,m,n}_{2,0,1}\right),
+ *          \alpha_1\left(c^{l,m,n}_{2,0,1}-c^{l,m-1,n}_{2,0,1}\right),\\
+ *   &\;\;\;\;\left.
+ *          \alpha_1\left(c^{l,m,n+1}_{2,1,0}-c^{l,m,n}_{2,1,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{2,1,0}-c^{l,m,n-1}_{2,1,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{1,2,1}=\mathrm{minmod}
+ *   &\left(c_{1,2,1}^{l,m,n},
+ *          \alpha_1\left(c^{l+1,m,n}_{0,2,1}-c^{l,m,n}_{0,2,1}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,2,1}-c^{l-1,m,n}_{0,2,1}\right),
+ *     \right.\\
+ *   &\;\;\;\;
+ *          \alpha_2\left(c^{l,m+1,n}_{1,1,1}-c^{l,m,n}_{1,1,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,1,1}-c^{l,m-1,n}_{1,1,1}\right),\\
+ *   &\;\;\;\;\left.
+ *          \alpha_1\left(c^{l,m,n+1}_{1,2,0}-c^{l,m,n}_{1,2,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{1,2,0}-c^{l,m,n-1}_{1,2,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{1,1,2}=\mathrm{minmod}
+ *   &\left(c_{1,1,2}^{l,m,n},
+ *          \alpha_1\left(c^{l+1,m,n}_{0,1,2}-c^{l,m,n}_{0,1,2}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,1,2}-c^{l-1,m,n}_{0,1,2}\right),
+ *     \right.\\
+ *   &\;\;\;\;
+ *          \alpha_1\left(c^{l,m+1,n}_{1,0,2}-c^{l,m,n}_{1,0,2}\right),
+ *          \alpha_1\left(c^{l,m,n}_{1,0,2}-c^{l,m-1,n}_{1,0,2}\right),\\
+ *   &\;\;\;\;\left.
+ *          \alpha_2\left(c^{l,m,n+1}_{1,1,1}-c^{l,m,n}_{1,1,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,1,1}-c^{l,m,n-1}_{1,1,1}\right)
+ *     \right),
+ * \f}
+ * \f{align*}{
+ * \tilde{c}^{l,m,n}_{2,1,0}=\mathrm{minmod}
+ *   &\left(c_{2,1,0}^{l,m,n},
+ *          \alpha_2\left(c^{l+1,m,n}_{1,1,0}-c^{l,m,n}_{1,1,0}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,1,0}-c^{l-1,m,n}_{1,1,0}\right),
+ *     \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_1\left(c^{l,m+1,n}_{2,0,0}-c^{l,m,n}_{2,0,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{2,0,0}-c^{l,m-1,n}_{2,0,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{2,0,1}=\mathrm{minmod}
+ *   &\left(c_{2,0,1}^{l,m,n},
+ *          \alpha_2\left(c^{l+1,m,n}_{1,0,1}-c^{l,m,n}_{1,0,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,0,1}-c^{l-1,m,n}_{1,0,1}\right),
+ *     \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_1\left(c^{l,m,n+1}_{2,0,0}-c^{l,m,n}_{2,0,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{2,0,0}-c^{l,m,n-1}_{2,0,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{1,2,0}=\mathrm{minmod}
+ *   &\left(c_{1,2,0}^{l,m,n},
+ *          \alpha_1\left(c^{l+1,m,n}_{0,2,0}-c^{l,m,n}_{0,2,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,2,0}-c^{l-1,m,n}_{0,2,0}\right),
+ *     \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_2\left(c^{l,m+1,n}_{1,1,0}-c^{l,m,n}_{1,1,0}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,1,0}-c^{l,m-1,n}_{1,1,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{1,0,2}=\mathrm{minmod}
+ *   &\left(c_{1,0,2}^{l,m,n},
+ *          \alpha_1\left(c^{l+1,m,n}_{0,0,2}-c^{l,m,n}_{0,0,2}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,0,2}-c^{l-1,m,n}_{0,0,2}\right),
+ *     \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_2\left(c^{l,m,n+1}_{1,0,1}-c^{l,m,n}_{1,0,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,0,1}-c^{l,m,n-1}_{1,0,1}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{0,1,2}=\mathrm{minmod}
+ *   &\left(c_{0,1,2}^{l,m,n},
+ *          \alpha_1\left(c^{l,m+1,n}_{0,0,2}-c^{l,m,n}_{0,0,2}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,0,2}-c^{l,m-1,n}_{0,0,2}\right),
+ *   \right. \\
+ *   &\;\;\;\;\left.
+ *          \alpha_2\left(c^{l,m,n+1}_{0,1,1}-c^{l,m,n}_{0,1,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{0,1,1}-c^{l,m,n-1}_{0,1,1}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{0,2,1}=\mathrm{minmod}
+ *   &\left(c_{0,2,1}^{l,m,n},
+ *          \alpha_2\left(c^{l,m+1,n}_{0,1,1}-c^{l,m,n}_{0,1,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{0,1,1}-c^{l,m-1,n}_{0,1,1}\right),
+ *   \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_1\left(c^{l,m,n+1}_{0,2,0}-c^{l,m,n}_{0,2,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,2,0}-c^{l,m,n-1}_{0,2,0}\right)
+ *     \right),
+ * \f}
+ * \f{align*}{
+ * \tilde{c}^{l,m,n}_{2,0,0}=\mathrm{minmod}
+ *   &\left(c_{2,0,0}^{l,m,n},
+ *          \alpha_2\left(c^{l+1,m,n}_{1,0,0}-c^{l,m,n}_{1,0,0}\right),
+ *          \alpha_2\left(c^{l,m,n}_{1,0,0}-c^{l-1,m,n}_{1,0,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{0,2,0}=\mathrm{minmod}
+ *   &\left(c_{0,2,0}^{l,m,n},
+ *          \alpha_2\left(c^{l,m+1,n}_{0,1,0}-c^{l,m,n}_{0,1,0}\right),
+ *          \alpha_2\left(c^{l,m,n}_{0,1,0}-c^{l,m-1,n}_{0,1,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{0,0,2}=\mathrm{minmod}
+ *   &\left(c_{0,0,2}^{l,m,n},
+ *          \alpha_2\left(c^{l,m,n+1}_{0,0,1}-c^{l,m,n}_{0,0,1}\right),
+ *          \alpha_2\left(c^{l,m,n}_{0,0,1}-c^{l,m,n-1}_{0,0,1}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{1,1,1}=\mathrm{minmod}
+ *   &\left(c_{1,1,1}^{l,m,n},
+ *          \alpha_1\left(c^{l+1,m,n}_{0,1,1}-c^{l,m,n}_{0,1,1}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,1,1}-c^{l-1,m,n}_{0,1,1}\right),
+ *     \right.\\
+ *   &\;\;\;\;
+ *          \alpha_1\left(c^{l,m+1,n}_{1,0,1}-c^{l,m,n}_{1,0,1}\right),
+ *          \alpha_1\left(c^{l,m,n}_{1,0,1}-c^{l,m-1,n}_{1,0,1}\right),\\
+ *   &\;\;\;\;\left.
+ *          \alpha_1\left(c^{l,m,n+1}_{1,1,0}-c^{l,m,n}_{1,1,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{1,1,0}-c^{l,m,n-1}_{1,1,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{1,1,0}=\mathrm{minmod}
+ *   &\left(c_{1,1,0}^{l,m,n},
+ *          \alpha_1\left(c^{l+1,m,n}_{0,1,0}-c^{l,m,n}_{0,1,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,1,0}-c^{l-1,m,n}_{0,1,0}\right),
+ *     \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_1\left(c^{l,m+1,n}_{1,0,0}-c^{l,m,n}_{1,0,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{1,0,0}-c^{l,m-1,n}_{1,0,0}\right),
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{1,0,1}=\mathrm{minmod}
+ *   &\left(c_{1,0,1}^{l,m,n},
+ *          \alpha_1\left(c^{l+1,m,n}_{0,0,1}-c^{l,m,n}_{0,0,1}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,0,1}-c^{l-1,m,n}_{0,0,1}\right),
+ *     \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_1\left(c^{l,m,n+1}_{1,0,0}-c^{l,m,n}_{1,0,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{1,0,0}-c^{l,m,n-1}_{1,0,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{0,1,1}=\mathrm{minmod}
+ *   &\left(c_{0,1,1}^{l,m,n},
+ *          \alpha_1\left(c^{l,m+1,n}_{0,0,1}-c^{l,m,n}_{0,0,1}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,0,1}-c^{l,m-1,n}_{0,0,1}\right),
+ *   \right.\\
+ *   &\;\;\;\;\left.
+ *          \alpha_1\left(c^{l,m,n+1}_{0,1,0}-c^{l,m,n}_{0,1,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,1,0}-c^{l,m,n-1}_{0,1,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{1,0,0}=\mathrm{minmod}
+ *   &\left(c_{1,0,0}^{l,m,n},
+ *          \alpha_1\left(c^{l+1,m,n}_{0,0,0}-c^{l,m,n}_{0,0,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,0,0}-c^{l-1,m,n}_{0,0,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{0,1,0}=\mathrm{minmod}
+ *   &\left(c_{0,1,0}^{l,m,n},
+ *          \alpha_1\left(c^{l,m+1,n}_{0,0,0}-c^{l,m,n}_{0,0,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,0,0}-c^{l,m-1,n}_{0,0,0}\right)
+ *     \right),\\
+ * \tilde{c}^{l,m,n}_{0,0,1}=\mathrm{minmod}
+ *   &\left(c_{0,0,1}^{l,m,n},
+ *          \alpha_1\left(c^{l,m,n+1}_{0,0,0}-c^{l,m,n}_{0,0,0}\right),
+ *          \alpha_1\left(c^{l,m,n}_{0,0,0}-c^{l,m,n-1}_{0,0,0}\right)
+ *     \right),
+ * \f}
+ *
+ *
+ * The algorithm to perform the limiting is as follows:
+ *
+ * - limit \f$c_{2,2,2}\f$ (i.e. \f$c_{2,2,2}\leftarrow\tilde{c}_{2,2,2}\f$), if
+ *   not changed, stop
+ * - limit \f$c_{2,2,1}\f$, \f$c_{2,1,2}\f$, and \f$c_{1,2,2}\f$, if all not
+ * changed, stop
+ * - limit \f$c_{2,2,0}\f$, \f$c_{2,0,2}\f$, and \f$c_{0,2,2}\f$, if all not
+ * changed, stop
+ * - limit \f$c_{2,1,1}\f$, \f$c_{1,2,1}\f$, and \f$c_{1,1,2}\f$, if all not
+ * changed, stop
+ * - limit \f$c_{2,1,0}\f$, \f$c_{2,0,1}\f$, \f$c_{1,2,0}\f$, \f$c_{1,0,2}\f$,
+ * \f$c_{0,1,2}\f$, and \f$c_{0,2,1}\f$, if all not changed, stop
+ * - limit \f$c_{2,0,0}\f$, \f$c_{0,2,0}\f$, and \f$c_{0,0,2}\f$, if all not
+ * changed, stop
+ * - limit \f$c_{1,1,1}\f$, if not changed, stop
+ * - limit \f$c_{1,1,0}\f$, \f$c_{1,0,1}\f$, and \f$c_{0,1,1}\f$, if all not
+ * changed, stop
+ * - limit \f$c_{1,0,0}\f$, \f$c_{0,1,0}\f$, and \f$c_{0,0,1}\f$, if all not
+ * changed, stop
+ *
+ * The 1d and 2d implementations are straightforward restrictions of the
+ * described algorithm.
+ *
+ * #### Limitations:
+ *
+ * - We currently recompute the spectral coefficients for local use, after
+ *   having computed these same coefficients for sending to the neighbors. We
+ *   should be able to avoid this either by storing the coefficients in the
+ *   DataBox or by allowing the limiters' `packaged_data` function to return an
+ *   object to be passed as an additional argument to the `operator()` (still
+ *   would need to be stored in the DataBox).
+ * - We cannot handle the case where neighbors have more/fewer
+ *   coefficients. In the case that the neighbor has more coefficients we could
+ *   just ignore the higher coefficients. In the case that the neighbor has
+ *   fewer coefficients we have a few choices.
+ * - Having a different number of collocation points in different directions is
+ *   not supported. However, it is straightforward to handle this case. The
+ *   outermost loop should be in the direction with the most collocation points,
+ *   while the inner most loop should be over the direction with the fewest
+ *   collocation points. The highest to lowest coefficients can then be limited
+ *   appropriately again.
+ * - h-refinement is not supported, but there is one reasonably straightforward
+ *   implementation that may work. In this case we would ignore refinement that
+ *   is not in the direction of the neighbor, treating the element as
+ *   simply having multiple neighbors in that direction. The only change would
+ *   be accounting for different refinement in the direction of the neighor,
+ *   which should be easy to add since the differences in coefficients in
+ *   Eq.\f$\ref{eq:krivodonova 3d minmod}\f$ will just be multiplied by
+ *   non-unity factors.
+ */
+template <size_t VolumeDim, typename... Tags>
+class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
+ public:
+  /*!
+   * \brief The \f$\alpha_i\f$ values in the Krivodonova algorithm.
+   */
+  struct Alphas {
+    using type = std::array<
+        double, Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>;
+    static constexpr OptionString help = {
+        "The alpha parameters of the Krivodonova limiter"};
+    static type default_value() noexcept {
+      return make_array<
+          Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(1.0);
+    }
+  };
+  /*!
+   * \brief Turn the limiter off
+   *
+   * This option exists to temporarily disable the limiter for debugging
+   * purposes. For problems where limiting is not needed, the preferred
+   * approach is to not compile the limiter into the executable.
+   */
+  struct DisableForDebugging {
+    using type = bool;
+    static type default_value() noexcept { return false; }
+    static constexpr OptionString help = {"Disable the limiter"};
+  };
+
+  using options = tmpl::list<Alphas, DisableForDebugging>;
+  static constexpr OptionString help = {
+      "The hierarchical slope limiter of Krivodonova.\n\n"
+      "This slope limiter works by limiting the highest modal "
+      "coefficients/derivatives using an aggressive minmod approach, "
+      "decreasing in modal coefficient order until no more limiting is "
+      "necessary."};
+
+  explicit Krivodonova(
+      std::array<double,
+                 Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>
+          alphas,
+      bool disable_for_debugging = false, const OptionContext& context = {});
+
+  Krivodonova() = default;
+  Krivodonova(const Krivodonova&) = delete;
+  Krivodonova& operator=(const Krivodonova&) = delete;
+  Krivodonova(Krivodonova&&) = default;
+  Krivodonova& operator=(Krivodonova&&) = default;
+  ~Krivodonova() = default;
+
+  // NOLINTNEXTLINE(google-runtime-reference)
+  void pup(PUP::er& p) noexcept;
+
+  bool operator==(const Krivodonova& rhs) const noexcept;
+
+  struct PackagedData {
+    Variables<tmpl::list<::Tags::Modal<Tags>...>> modal_volume_data;
+    Mesh<VolumeDim> mesh;
+
+    // clang-tidy: google-runtime-references
+    void pup(PUP::er& p) noexcept {  // NOLINT
+      p | modal_volume_data;
+      p | mesh;
+    }
+  };
+
+  using package_argument_tags = tmpl::list<Tags..., ::Tags::Mesh<VolumeDim>>;
+
+  /// \brief Package data for sending to neighbor elements.
+  void package_data(gsl::not_null<PackagedData*> packaged_data,
+                    const db::item_type<Tags>&... tensors,
+                    const Mesh<VolumeDim>& mesh,
+                    const OrientationMap<VolumeDim>& orientation_map) const
+      noexcept;
+
+  using limit_tags = tmpl::list<Tags...>;
+  using limit_argument_tags =
+      tmpl::list<::Tags::Element<VolumeDim>, ::Tags::Mesh<VolumeDim>>;
+
+  bool operator()(
+      const gsl::not_null<std::add_pointer_t<db::item_type<Tags>>>... tensors,
+      const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+      const std::unordered_map<
+          std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+          boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+          neighbor_data) const noexcept;
+
+ private:
+  template <typename Tag>
+  char limit_one_tensor(
+      gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*> coeffs_self,
+      gsl::not_null<bool*> limited_any_component, const Mesh<1>& mesh,
+      const std::unordered_map<
+          std::pair<Direction<1>, ElementId<1>>, PackagedData,
+          boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data)
+      const noexcept;
+  template <typename Tag>
+  char limit_one_tensor(
+      gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*> coeffs_self,
+      gsl::not_null<bool*> limited_any_component, const Mesh<2>& mesh,
+      const std::unordered_map<
+          std::pair<Direction<2>, ElementId<2>>, PackagedData,
+          boost::hash<std::pair<Direction<2>, ElementId<2>>>>& neighbor_data)
+      const noexcept;
+  template <typename Tag>
+  char limit_one_tensor(
+      gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*> coeffs_self,
+      gsl::not_null<bool*> limited_any_component, const Mesh<3>& mesh,
+      const std::unordered_map<
+          std::pair<Direction<3>, ElementId<3>>, PackagedData,
+          boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data)
+      const noexcept;
+
+  template <typename Tag, size_t Dim>
+  char fill_variables_tag_with_spectral_coeffs(
+      gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*>
+          modal_coeffs,
+      const db::item_type<Tag>& nodal_tensor, const Mesh<Dim>& mesh) const
+      noexcept;
+
+  std::array<double,
+             Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>
+      alphas_ = make_array<
+          Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(1.0);
+  bool disable_for_debugging_{false};
+};
+
+template <size_t VolumeDim, typename... Tags>
+Krivodonova<VolumeDim, tmpl::list<Tags...>>::Krivodonova(
+    std::array<double,
+               Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>
+        alphas,
+    bool disable_for_debugging, const OptionContext& context)
+    : alphas_(alphas), disable_for_debugging_(disable_for_debugging) {
+  // See the main documentation for an explanation of why these bounds are
+  // different from those of Krivodonova 2007
+  if (alg::any_of(alphas_, [](const double t) noexcept {
+        return t > 1.0 or t <= 0.0;
+      })) {
+    PARSE_ERROR(context,
+                "The alphas in the Krivodonova limiter must be in the range "
+                "(0,1].");
+  }
+}
+
+template <size_t VolumeDim, typename... Tags>
+void Krivodonova<VolumeDim, tmpl::list<Tags...>>::package_data(
+    const gsl::not_null<PackagedData*> packaged_data,
+    const db::item_type<Tags>&... tensors, const Mesh<VolumeDim>& mesh,
+    const OrientationMap<VolumeDim>& orientation_map) const noexcept {
+  if (UNLIKELY(disable_for_debugging_)) {
+    // Do not initialize packaged_data
+    return;
+  }
+
+  packaged_data->modal_volume_data.initialize(mesh.number_of_grid_points());
+  // perform nodal coefficients to modal coefficients transformation on each
+  // tensor component
+  expand_pack(fill_variables_tag_with_spectral_coeffs<Tags>(
+      &(packaged_data->modal_volume_data), tensors, mesh)...);
+
+  packaged_data->modal_volume_data = orient_variables(
+      packaged_data->modal_volume_data, mesh.extents(), orientation_map);
+
+  packaged_data->mesh = orientation_map(mesh);
+}
+
+template <size_t VolumeDim, typename... Tags>
+bool Krivodonova<VolumeDim, tmpl::list<Tags...>>::operator()(
+    const gsl::not_null<std::add_pointer_t<db::item_type<Tags>>>... tensors,
+    const Element<VolumeDim>& element, const Mesh<VolumeDim>& mesh,
+    const std::unordered_map<
+        std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+        boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
+        neighbor_data) const noexcept {
+  if (UNLIKELY(disable_for_debugging_)) {
+    // Do not modify input tensors
+    return false;
+  }
+  if (UNLIKELY(mesh != Mesh<VolumeDim>(mesh.extents()[0], mesh.basis()[0],
+                                       mesh.quadrature()[0]))) {
+    ERROR(
+        "The Krivodonova limiter does not yet support non-uniform number of "
+        "collocation points, bases, and quadrature in each direction. The "
+        "mesh is: "
+        << mesh);
+  }
+  if (UNLIKELY(alg::any_of(element.neighbors(),
+                           [](const auto& direction_neighbors) noexcept {
+                             return direction_neighbors.second.size() != 1;
+                           }))) {
+    ERROR("The Krivodonova limiter does not yet support h-refinement");
+  }
+  alg::for_each(neighbor_data, [&mesh](const auto& id_packaged_data) noexcept {
+    if (UNLIKELY(id_packaged_data.second.mesh != mesh)) {
+      ERROR(
+          "The Krivodonova limiter does not yet support differing meshes "
+          "between neighbors. Self mesh is: "
+          << mesh << " neighbor mesh is: " << id_packaged_data.second.mesh);
+    }
+  });
+
+  // Compute local modal coefficients
+  Variables<tmpl::list<::Tags::Modal<Tags>...>> coeffs_self(
+      mesh.number_of_grid_points(), 0.0);
+  expand_pack(fill_variables_tag_with_spectral_coeffs<Tags>(&coeffs_self,
+                                                            *tensors, mesh)...);
+
+  // Perform the limiting on the modal coefficients
+  bool limited_any_component = false;
+  expand_pack(limit_one_tensor<::Tags::Modal<Tags>>(
+      make_not_null(&coeffs_self), make_not_null(&limited_any_component), mesh,
+      neighbor_data)...);
+
+  // transform back to nodal coefficients
+  const auto wrap_copy_nodal_coeffs =
+      [&mesh, &coeffs_self ](auto tag, const auto tensor) noexcept {
+    auto& coeffs_tensor = get<decltype(tag)>(coeffs_self);
+    auto tensor_it = tensor->begin();
+    for (auto coeffs_it = coeffs_tensor.begin();
+         coeffs_it != coeffs_tensor.end();
+         (void)++coeffs_it, (void)++tensor_it) {
+      to_nodal_coefficients(make_not_null(&*tensor_it), *coeffs_it, mesh);
+    }
+    return '0';
+  };
+  expand_pack(wrap_copy_nodal_coeffs(::Tags::Modal<Tags>{}, tensors)...);
+
+  return limited_any_component;
+}
+
+template <size_t VolumeDim, typename... Tags>
+template <typename Tag>
+char Krivodonova<VolumeDim, tmpl::list<Tags...>>::limit_one_tensor(
+    const gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*>
+        coeffs_self,
+    const gsl::not_null<bool*> limited_any_component, const Mesh<1>& mesh,
+    const std::unordered_map<
+        std::pair<Direction<1>, ElementId<1>>, PackagedData,
+        boost::hash<std::pair<Direction<1>, ElementId<1>>>>& neighbor_data)
+    const noexcept {
+  using tensor_type = typename Tag::type;
+  for (size_t storage_index = 0; storage_index < tensor_type::size();
+       ++storage_index) {
+    // for each coefficient...
+    for (size_t i = mesh.extents()[0] - 1; i > 0; --i) {
+      auto& self_coeffs = get<Tag>(*coeffs_self)[storage_index];
+      double min_abs_coeff = std::abs(self_coeffs[i]);
+      const double sgn_of_coeff = sgn(self_coeffs[i]);
+      bool sgns_all_equal = true;
+      for (const auto& kv : neighbor_data) {
+        const auto& neighbor_coeffs =
+            get<Tag>(kv.second.modal_volume_data)[storage_index];
+        const double tmp = kv.first.first.sign() * gsl::at(alphas_, i) *
+                           (neighbor_coeffs[i - 1] - self_coeffs[i - 1]);
+
+        min_abs_coeff = std::min(min_abs_coeff, std::abs(tmp));
+        sgns_all_equal &= sgn(tmp) == sgn_of_coeff;
+        if (not sgns_all_equal) {
+          self_coeffs[i] = 0.0;
+          break;
+        }
+      }
+      if (sgns_all_equal) {
+        const double tmp = sgn_of_coeff * min_abs_coeff;
+        if (tmp == self_coeffs[i]) {
+          break;
+        }
+        *limited_any_component |= true;
+        self_coeffs[i] = tmp;
+      }
+    }
+  }
+  return '0';
+}
+
+template <size_t VolumeDim, typename... Tags>
+template <typename Tag>
+char Krivodonova<VolumeDim, tmpl::list<Tags...>>::limit_one_tensor(
+    const gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*>
+        coeffs_self,
+    const gsl::not_null<bool*> limited_any_component, const Mesh<2>& mesh,
+    const std::unordered_map<
+        std::pair<Direction<2>, ElementId<2>>, PackagedData,
+        boost::hash<std::pair<Direction<2>, ElementId<2>>>>& neighbor_data)
+    const noexcept {
+  using tensor_type = typename Tag::type;
+  const auto minmod = [&coeffs_self, &mesh, &neighbor_data, this ](
+      const size_t local_i, const size_t local_j,
+      const size_t local_tensor_storage_index) noexcept {
+    const auto& self_coeffs =
+        get<Tag>(*coeffs_self)[local_tensor_storage_index];
+    double min_abs_coeff = std::abs(
+        self_coeffs[mesh.storage_index(Index<VolumeDim>{local_i, local_j})]);
+    const double sgn_of_coeff = sgn(
+        self_coeffs[mesh.storage_index(Index<VolumeDim>{local_i, local_j})]);
+    for (const auto& kv : neighbor_data) {
+      const Direction<2>& dir = kv.first.first;
+      const auto& neighbor_coeffs =
+          get<Tag>(kv.second.modal_volume_data)[local_tensor_storage_index];
+      const size_t index_i =
+          dir.axis() == Direction<VolumeDim>::Axis::Xi ? local_i - 1 : local_i;
+      const size_t index_j =
+          dir.axis() == Direction<VolumeDim>::Axis::Eta ? local_j - 1 : local_j;
+      // skip neighbors where we cannot compute a finite difference in that
+      // direction because we are already at the lowest coefficient.
+      if (index_i == std::numeric_limits<size_t>::max() or
+          index_j == std::numeric_limits<size_t>::max()) {
+        continue;
+      }
+      const size_t alpha_index =
+          dir.axis() == Direction<VolumeDim>::Axis::Xi ? local_i : local_j;
+      const double tmp =
+          dir.sign() * gsl::at(alphas_, alpha_index) *
+          (neighbor_coeffs[mesh.storage_index(
+               Index<VolumeDim>{index_i, index_j})] -
+           self_coeffs[mesh.storage_index(Index<VolumeDim>{index_i, index_j})]);
+
+      min_abs_coeff = std::min(min_abs_coeff, std::abs(tmp));
+      if (sgn(tmp) != sgn_of_coeff) {
+        return 0.0;
+      }
+    }
+    return sgn_of_coeff * min_abs_coeff;
+  };
+
+  for (size_t tensor_storage_index = 0;
+       tensor_storage_index < tensor_type::size(); ++tensor_storage_index) {
+    // for each coefficient...
+    for (size_t i = mesh.extents()[0] - 1; i > 0; --i) {
+      for (size_t j = i; j < mesh.extents()[1]; --j) {
+        // Check if we are done limiting, and if so we move on to the next
+        // tensor component.
+        auto& self_coeffs = get<Tag>(*coeffs_self)[tensor_storage_index];
+        // We treat the different cases separately to reduce the number of
+        // times we call minmod, not because it is required for correctness.
+        if (UNLIKELY(i == j)) {
+          const double tmp = minmod(i, j, tensor_storage_index);
+          if (tmp == self_coeffs[mesh.storage_index(Index<VolumeDim>{i, j})]) {
+            goto next_tensor_index;
+          }
+          *limited_any_component |= true;
+          self_coeffs[mesh.storage_index(Index<VolumeDim>{i, j})] = tmp;
+        } else {
+          const double tmp_ij = minmod(i, j, tensor_storage_index);
+          const double tmp_ji = minmod(j, i, tensor_storage_index);
+          if (tmp_ij ==
+                  self_coeffs[mesh.storage_index(Index<VolumeDim>{i, j})] and
+              tmp_ji ==
+                  self_coeffs[mesh.storage_index(Index<VolumeDim>{j, i})]) {
+            goto next_tensor_index;
+          }
+          *limited_any_component |= true;
+          self_coeffs[mesh.storage_index(Index<VolumeDim>{i, j})] = tmp_ij;
+          self_coeffs[mesh.storage_index(Index<VolumeDim>{j, i})] = tmp_ji;
+        }
+      }
+    }
+  next_tensor_index:
+    continue;
+  }
+  return '0';
+}
+
+template <size_t VolumeDim, typename... Tags>
+template <typename Tag>
+char Krivodonova<VolumeDim, tmpl::list<Tags...>>::limit_one_tensor(
+    const gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*>
+        coeffs_self,
+    const gsl::not_null<bool*> limited_any_component, const Mesh<3>& mesh,
+    const std::unordered_map<
+        std::pair<Direction<3>, ElementId<3>>, PackagedData,
+        boost::hash<std::pair<Direction<3>, ElementId<3>>>>& neighbor_data)
+    const noexcept {
+  using tensor_type = typename Tag::type;
+  const auto minmod = [&coeffs_self, &mesh, &neighbor_data, this ](
+      const size_t local_i, const size_t local_j, const size_t local_k,
+      const size_t local_tensor_storage_index) noexcept {
+    const auto& self_coeffs =
+        get<Tag>(*coeffs_self)[local_tensor_storage_index];
+    double min_abs_coeff = std::abs(self_coeffs[mesh.storage_index(
+        Index<VolumeDim>{local_i, local_j, local_k})]);
+    const double sgn_of_coeff = sgn(self_coeffs[mesh.storage_index(
+        Index<VolumeDim>{local_i, local_j, local_k})]);
+    for (const auto& kv : neighbor_data) {
+      const Direction<3>& dir = kv.first.first;
+      const auto& neighbor_coeffs =
+          get<Tag>(kv.second.modal_volume_data)[local_tensor_storage_index];
+      const size_t index_i =
+          dir.axis() == Direction<VolumeDim>::Axis::Xi ? local_i - 1 : local_i;
+      const size_t index_j =
+          dir.axis() == Direction<VolumeDim>::Axis::Eta ? local_j - 1 : local_j;
+      const size_t index_k = dir.axis() == Direction<VolumeDim>::Axis::Zeta
+                                 ? local_k - 1
+                                 : local_k;
+      // skip neighbors where we cannot compute a finite difference in that
+      // direction because we are already at the lowest coefficient.
+      if (index_i == std::numeric_limits<size_t>::max() or
+          index_j == std::numeric_limits<size_t>::max() or
+          index_k == std::numeric_limits<size_t>::max()) {
+        continue;
+      }
+      const size_t alpha_index =
+          dir.axis() == Direction<VolumeDim>::Axis::Xi
+              ? local_i
+              : dir.axis() == Direction<VolumeDim>::Axis::Eta ? local_j
+                                                              : local_k;
+      const double tmp = dir.sign() * gsl::at(alphas_, alpha_index) *
+                         (neighbor_coeffs[mesh.storage_index(
+                              Index<VolumeDim>{index_i, index_j, index_k})] -
+                          self_coeffs[mesh.storage_index(
+                              Index<VolumeDim>{index_i, index_j, index_k})]);
+
+      min_abs_coeff = std::min(min_abs_coeff, std::abs(tmp));
+      if (sgn(tmp) != sgn_of_coeff) {
+        return 0.0;
+      }
+    }
+    return sgn_of_coeff * min_abs_coeff;
+  };
+
+  for (size_t tensor_storage_index = 0;
+       tensor_storage_index < tensor_type::size(); ++tensor_storage_index) {
+    // for each coefficient...
+    for (size_t i = mesh.extents()[0] - 1; i > 0; --i) {
+      for (size_t j = i; j < mesh.extents()[1]; --j) {
+        for (size_t k = j; k < mesh.extents()[2]; --k) {
+          // Check if we are done limiting, and if so we move on to the next
+          // tensor component.
+          auto& self_coeffs = get<Tag>(*coeffs_self)[tensor_storage_index];
+          // We treat the different cases separately to reduce the number of
+          // times we call minmod, not because it is required for correctness.
+          //
+          // Note that the case `i == k and i != j` cannot be encountered since
+          // the loop bounds are `i >= j >= k`.
+          if (UNLIKELY(i == j and i == k)) {
+            const double tmp = minmod(i, j, k, tensor_storage_index);
+            if (tmp ==
+                self_coeffs[mesh.storage_index(Index<VolumeDim>{i, j, k})]) {
+              goto next_tensor_index;
+            }
+            *limited_any_component |= true;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{i, j, k})] = tmp;
+          } else if (i == j and i != k) {
+            const double tmp_ijk = minmod(i, j, k, tensor_storage_index);
+            const double tmp_ikj = minmod(i, k, j, tensor_storage_index);
+            const double tmp_kij = minmod(k, i, j, tensor_storage_index);
+            if (tmp_ijk == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{i, j, k})] and
+                tmp_ikj == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{i, k, j})] and
+                tmp_kij == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{k, i, j})]) {
+              goto next_tensor_index;
+            }
+            *limited_any_component |= true;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{i, j, k})] =
+                tmp_ijk;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{i, k, j})] =
+                tmp_ikj;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{k, i, j})] =
+                tmp_kij;
+          } else if (i != j and j == k) {
+            const double tmp_ijk = minmod(i, j, k, tensor_storage_index);
+            const double tmp_kij = minmod(k, i, j, tensor_storage_index);
+            const double tmp_kji = minmod(k, j, i, tensor_storage_index);
+            if (tmp_ijk == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{i, j, k})] and
+                tmp_kij == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{k, i, j})] and
+                tmp_kji == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{k, j, i})]) {
+              goto next_tensor_index;
+            }
+            *limited_any_component |= true;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{i, j, k})] =
+                tmp_ijk;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{k, i, j})] =
+                tmp_kij;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{k, j, i})] =
+                tmp_kji;
+          } else {
+            const double tmp_ijk = minmod(i, j, k, tensor_storage_index);
+            const double tmp_jik = minmod(j, i, k, tensor_storage_index);
+            const double tmp_ikj = minmod(i, k, j, tensor_storage_index);
+            const double tmp_jki = minmod(j, k, i, tensor_storage_index);
+            const double tmp_kij = minmod(k, i, j, tensor_storage_index);
+            const double tmp_kji = minmod(k, j, i, tensor_storage_index);
+            if (tmp_ijk == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{i, j, k})] and
+                tmp_jik == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{j, i, k})] and
+                tmp_ikj == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{i, k, j})] and
+                tmp_jki == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{j, k, i})] and
+                tmp_kij == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{k, i, j})] and
+                tmp_kji == self_coeffs[mesh.storage_index(
+                               Index<VolumeDim>{k, j, i})]) {
+              goto next_tensor_index;
+            }
+            *limited_any_component |= true;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{i, j, k})] =
+                tmp_ijk;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{j, i, k})] =
+                tmp_jik;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{i, k, j})] =
+                tmp_ikj;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{j, k, i})] =
+                tmp_jki;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{k, i, j})] =
+                tmp_kij;
+            self_coeffs[mesh.storage_index(Index<VolumeDim>{k, j, i})] =
+                tmp_kji;
+          }
+        }
+      }
+    }
+  next_tensor_index:
+    continue;
+  }
+  return '0';
+}
+
+template <size_t VolumeDim, typename... Tags>
+template <typename Tag, size_t Dim>
+char Krivodonova<VolumeDim, tmpl::list<Tags...>>::
+    fill_variables_tag_with_spectral_coeffs(
+        const gsl::not_null<Variables<tmpl::list<::Tags::Modal<Tags>...>>*>
+            modal_coeffs,
+        const db::item_type<Tag>& nodal_tensor, const Mesh<Dim>& mesh) const
+    noexcept {
+  auto& coeffs_tensor = get<::Tags::Modal<Tag>>(*modal_coeffs);
+  auto tensor_it = nodal_tensor.begin();
+  for (auto coeffs_it = coeffs_tensor.begin(); coeffs_it != coeffs_tensor.end();
+       (void)++coeffs_it, (void)++tensor_it) {
+    to_modal_coefficients(make_not_null(&*coeffs_it), *tensor_it, mesh);
+  }
+  return '0';
+}
+
+template <size_t VolumeDim, typename... Tags>
+void Krivodonova<VolumeDim, tmpl::list<Tags...>>::pup(PUP::er& p) noexcept {
+  p | alphas_;
+  p | disable_for_debugging_;
+}
+
+template <size_t VolumeDim, typename... Tags>
+bool Krivodonova<VolumeDim, tmpl::list<Tags...>>::operator==(
+    const Krivodonova<VolumeDim, tmpl::list<Tags...>>& rhs) const noexcept {
+  return alphas_ == rhs.alphas_ and
+         disable_for_debugging_ == rhs.disable_for_debugging_;
+}
+
+template <size_t VolumeDim, typename... Tags>
+bool operator!=(
+    const Krivodonova<VolumeDim, tmpl::list<Tags...>>& lhs,
+    const Krivodonova<VolumeDim, tmpl::list<Tags...>>& rhs) noexcept {
+  return not(lhs == rhs);
+}
+}  // namespace SlopeLimiters

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_SlopeLimiters")
 
 set(LIBRARY_SOURCES
+  Test_Krivodonova.cpp
   Test_LimiterActions.cpp
   Test_LimiterActionsWithMinmod.cpp
   Test_Minmod.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Krivodonova.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Krivodonova.cpp
@@ -1,0 +1,2905 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <boost/functional/hash/extensions.hpp>
+#include <cstddef>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/OrientationMap.hpp"
+#include "Evolution/DiscontinuousGalerkin/SlopeLimiters/Krivodonova.hpp"
+#include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace SlopeLimiters {
+
+// The overall way of testing the Krivodonova limiter is to set the modal
+// coefficients directly, then compare to the expected result from the algorithm
+// for 3 collocation points in the documentation. In the 1D case it is easy
+// enough to test with 4 collocation points, so this is done instead. In order
+// to make sure the loops over tensor components work correctly we apply the
+// limiter both to a Scalar and to a tnsr::I<Dim>.
+namespace {
+template <size_t VolumeDim, typename PackagedData>
+using NeighborData = std::unordered_map<
+    std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
+    boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>;
+
+template <size_t Identifier>
+struct ScalarTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim, size_t Identifier>
+struct VectorTag : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+
+namespace test_1d {
+void test_package_data(const size_t order) noexcept {
+  INFO("Testing package data");
+  CAPTURE(order);
+  const Mesh<1> mesh(order + 1, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto);
+  const DataVector& x = Spectral::collocation_points(mesh);
+  using Limiter = Krivodonova<1, tmpl::list<ScalarTag<0>, VectorTag<1, 0>>>;
+  Limiter krivodonova{};
+
+  Scalar<DataVector> tensor0(mesh.number_of_grid_points());
+  get(tensor0) =
+      Spectral::compute_basis_function_value<Spectral::Basis::Legendre>(order,
+                                                                        x);
+  tnsr::I<DataVector, 1> tensor1(mesh.number_of_grid_points());
+  get<0>(tensor1) =
+      Spectral::compute_basis_function_value<Spectral::Basis::Legendre>(order,
+                                                                        x) +
+      2.0 * Spectral::compute_basis_function_value<Spectral::Basis::Legendre>(
+                order - 1, x);
+  Limiter::PackagedData packaged_data{};
+
+  // test no reorienting
+  {
+    krivodonova.package_data(make_not_null(&packaged_data), tensor0, tensor1,
+                             mesh, {});
+    ModalVector expected0(mesh.number_of_grid_points(), 0.0);
+    expected0[mesh.number_of_grid_points() - 1] = 1.0;
+    CHECK(get(get<::Tags::Modal<ScalarTag<0>>>(
+              packaged_data.modal_volume_data)) == expected0);
+    ModalVector expected1(mesh.number_of_grid_points(), 0.0);
+    expected1[mesh.number_of_grid_points() - 1] = 1.0;
+    expected1[mesh.number_of_grid_points() - 2] = 2.0;
+    CHECK(get<0>(get<::Tags::Modal<VectorTag<1, 0>>>(
+              packaged_data.modal_volume_data)) == expected1);
+  }
+  // test reorienting
+  {
+    krivodonova.package_data(
+        make_not_null(&packaged_data), tensor0, tensor1, mesh,
+        {{{Direction<1>::upper_xi()}}, {{Direction<1>::lower_xi()}}});
+    ModalVector expected0(mesh.number_of_grid_points(), 0.0);
+    expected0[0] = 1.0;
+    CHECK(get(get<::Tags::Modal<ScalarTag<0>>>(
+              packaged_data.modal_volume_data)) == expected0);
+    ModalVector expected1(mesh.number_of_grid_points(), 0.0);
+    expected1[0] = 1.0;
+    expected1[1] = 2.0;
+    CHECK(get<0>(get<::Tags::Modal<VectorTag<1, 0>>>(
+              packaged_data.modal_volume_data)) == expected1);
+  }
+}
+
+void test_limiting_two_neighbors() noexcept {
+  INFO("Testing applying limiter to coefficients");
+  constexpr size_t dim = 1;
+  const size_t order = 3;
+  const Mesh<dim> mesh(order + 1, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
+  const size_t num_pts = mesh.number_of_grid_points();
+
+  using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
+  // Use non-unity (because that's the default) but close alpha values to make
+  // the math easier but still test thoroughly.
+  Limiter krivodonova{
+      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
+          0.99)};
+
+  NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
+
+  const Element<dim> element(ElementId<dim>{0}, {});
+  // We don't care about the ElementId for these tests, just the direction.
+  Limiter::PackagedData& package_data_upper = neighbor_data[std::make_pair(
+      Direction<dim>::upper_xi(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lower = neighbor_data[std::make_pair(
+      Direction<dim>::lower_xi(), ElementId<dim>{0})];
+
+  package_data_upper.modal_volume_data.initialize(num_pts);
+  package_data_upper.mesh = mesh;
+  package_data_lower.modal_volume_data.initialize(num_pts);
+  package_data_lower.mesh = mesh;
+
+  Scalar<DataVector> nodal_scalar_data_to_limit(num_pts, 0.0);
+  tnsr::I<DataVector, dim> nodal_vector_data_to_limit(num_pts, 0.0);
+  DataVector expected(num_pts);
+  const auto helper =
+      [
+        &element, &expected, &krivodonova, &mesh, &neighbor_data,
+        &package_data_lower, &package_data_upper, &nodal_scalar_data_to_limit, &
+        nodal_vector_data_to_limit
+      ](const ModalVector& upper_coeffs, const ModalVector& initial_coeffs,
+        const ModalVector& lower_coeffs,
+        const ModalVector& expected_coeffs) noexcept {
+    to_nodal_coefficients(&get(nodal_scalar_data_to_limit), initial_coeffs,
+                          mesh);
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_upper.modal_volume_data)) = upper_coeffs;
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_lower.modal_volume_data)) = lower_coeffs;
+    for (size_t i = 0; i < dim; ++i) {
+      to_nodal_coefficients(&nodal_vector_data_to_limit.get(i), initial_coeffs,
+                            mesh);
+      get<::Tags::Modal<VectorTag<dim, 0>>>(
+          package_data_upper.modal_volume_data)
+          .get(i) = upper_coeffs;
+      get<::Tags::Modal<VectorTag<dim, 0>>>(
+          package_data_lower.modal_volume_data)
+          .get(i) = lower_coeffs;
+    }
+    krivodonova(&nodal_scalar_data_to_limit, &nodal_vector_data_to_limit,
+                element, mesh, neighbor_data);
+    to_nodal_coefficients(&expected, expected_coeffs, mesh);
+    CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit), expected);
+    for (size_t i = 0; i < dim; ++i) {
+      CHECK_ITERABLE_APPROX(nodal_vector_data_to_limit.get(i), expected);
+    }
+  };
+
+  // Note: Throughout the tests 1.0e-18 is used anywhere that we need a positive
+  // but zero coefficient, because it is below machine precision for O(1)
+  // numbers.
+
+  // Limit no coefficients because the highest coefficient doesn't need
+  // limiting.
+  helper({7.0, 3.0, 4.1, 0.0}, {3.0, -2.0, 2.0, 1.0}, {1.0, -5.0, 1.0e-18, 0.0},
+         {3.0, -2.0, 2.0, 1.0});
+
+  // Limit the highest coefficient only:
+  // Limit top coeff from upper neighbor
+  helper({7.0, 3.0, 2.5, 0.0}, {3.0, -2.0, 2.0, 1.0}, {1.0, -5.0, 1.0e-18, 0.0},
+         {3.0, -2.0, 2.0, 0.5 * 0.99});
+  // Limit top coeff from lower neighbor
+  helper({7.0, 3.0, 4.1, 0.0}, {3.0, -2.0, 2.0, 1.0}, {1.0, -5.0, 1.3, 0.0},
+         {3.0, -2.0, 2.0, 0.7 * 0.99});
+  // Zero top coeff from upper neighbor
+  helper({7.0, 3.0, 1.9, 0.0}, {3.0, -2.0, 2.0, 1.0}, {1.0, -5.0, 1.0e-18, 0.0},
+         {3.0, -2.0, 2.0, 0.0});
+  // Zero top coeff from lower neighbor
+  helper({7.0, 3.0, 4.1, 0.0}, {3.0, -2.0, 2.0, 1.0}, {1.0, -5.0, 5.3, 0.0},
+         {3.0, -2.0, 2.0, 0.0});
+
+  // Limit the top 2 coeffs:
+  // Limit top upper neighbor, limit second upper neighbor
+  helper({7.0, 3.0, 2.5, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, -5.0, 1.0e-18, 0.0},
+         {3.0, 2.0, 1.0 * 0.99, 0.5 * 0.99});
+  // Limit top upper neighbor, limit second lower neighbor
+  helper({7.0, 5.0, 2.5, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 1.1, 1.0e-18, 0.0},
+         {3.0, 2.0, 0.9 * 0.99, 0.5 * 0.99});
+  // Limit top upper neighbor, zero second upper neighbor
+  helper({7.0, 1.0, 2.5, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 1.1, 1.0e-18, 0.0},
+         {3.0, 2.0, 0.0, 0.5 * 0.99});
+  // Limit top upper neighbor, zero second lower neighbor
+  helper({7.0, 5.0, 2.5, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 2.1, 1.0e-18, 0.0},
+         {3.0, 2.0, 0.0, 0.5 * 0.99});
+  // Zero top upper neighbor, limit second upper neighbor
+  helper({7.0, 3.0, 1.9, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, -5.0, 1.0e-18, 0.0},
+         {3.0, 2.0, 1.0 * 0.99, 0.0});
+  // Zero top upper neighbor, limit second lower neighbor
+  helper({7.0, 5.0, 1.9, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 1.1, 1.0e-18, 0.0},
+         {3.0, 2.0, 0.9 * 0.99, 0.0});
+  // Zero top upper neighbor, zero second upper neighbor
+  helper({7.0, 1.0, 1.9, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 1.1, 1.0e-18, 0.0},
+         {3.0, 2.0, 0.0, 0.0});
+  // Zero top upper neighbor, zero second lower neighbor
+  helper({7.0, 5.0, 1.9, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 2.1, 1.0e-18, 0.0},
+         {3.0, 2.0, 0.0, 0.0});
+
+  // Limit top lower neighbor, limit second upper neighbor
+  helper({7.0, 3.0, 4.1, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, -5.0, 1.3, 0.0},
+         {3.0, 2.0, 1.0 * 0.99, 0.7 * 0.99});
+  // Limit top lower neighbor, limit second lower neighbor
+  helper({7.0, 5.0, 4.1, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 1.1, 1.3, 0.0},
+         {3.0, 2.0, 0.9 * 0.99, 0.7 * 0.99});
+  // Limit top lower neighbor, zero second upper neighbor
+  helper({7.0, 1.0, 4.1, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 1.1, 1.3, 0.0},
+         {3.0, 2.0, 0.0, 0.7 * 0.99});
+  // Limit top lower neighbor, zero second lower neighbor
+  helper({7.0, 5.0, 4.1, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 2.1, 1.3, 0.0},
+         {3.0, 2.0, 0.0, 0.7 * 0.99});
+  // Zero top lower neighbor, limit second upper neighbor
+  helper({7.0, 3.0, 4.1, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, -5.0, 3.0, 0.0},
+         {3.0, 2.0, 1.0 * 0.99, 0.0});
+  // Zero top lower neighbor, limit second lower neighbor
+  helper({7.0, 5.0, 4.1, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 1.1, 3.0, 0.0},
+         {3.0, 2.0, 0.9 * 0.99, 0.0});
+  // Zero top lower neighbor, zero second upper neighbor
+  helper({7.0, 1.0, 4.1, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 1.1, 3.0, 0.0},
+         {3.0, 2.0, 0.0, 0.0});
+  // Zero top lower neighbor, zero second lower neighbor
+  helper({7.0, 5.0, 4.1, 0.0}, {3.0, 2.0, 2.0, 1.0}, {-2.1, 2.1, 3.0, 0.0},
+         {3.0, 2.0, 0.0, 0.0});
+}
+
+void test_limiting_different_values_different_tensors() noexcept {
+  INFO("Testing different values for each tensor component");
+  constexpr size_t dim = 1;
+  const size_t order = 3;
+  const Mesh<dim> mesh(order + 1, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
+  const size_t num_pts = mesh.number_of_grid_points();
+  using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
+  // Use non-unity (because that's the default) but close alpha values to make
+  // the math easier but still test thoroughly.
+  Limiter krivodonova{
+      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
+          0.99)};
+
+  NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
+
+  const Element<dim> element(ElementId<dim>{0}, {});
+  // We don't care about the ElementId for these tests, just the direction.
+  Limiter::PackagedData& package_data_up_xi = neighbor_data[std::make_pair(
+      Direction<dim>::upper_xi(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_xi = neighbor_data[std::make_pair(
+      Direction<dim>::lower_xi(), ElementId<dim>{0})];
+
+  package_data_up_xi.modal_volume_data.initialize(num_pts);
+  package_data_up_xi.mesh = mesh;
+  package_data_lo_xi.modal_volume_data.initialize(num_pts);
+  package_data_lo_xi.mesh = mesh;
+
+  Scalar<DataVector> nodal_scalar_data_to_limit(num_pts, 0.0);
+  tnsr::I<DataVector, dim> nodal_vector_data_to_limit(num_pts, 0.0);
+  Scalar<DataVector> nodal_scalar_expected(num_pts, 0.0);
+  tnsr::I<DataVector, dim> nodal_vector_expected(num_pts, 0.0);
+
+  // Limit top coeff from upper neighbor
+  to_nodal_coefficients(&get(nodal_scalar_data_to_limit), {3.0, -2.0, 2.0, 1.0},
+                        mesh);
+  get(get<::Tags::Modal<ScalarTag<0>>>(package_data_up_xi.modal_volume_data)) =
+      ModalVector{7.0, 3.0, 2.5, 0.0};
+  get(get<::Tags::Modal<ScalarTag<0>>>(package_data_lo_xi.modal_volume_data)) =
+      ModalVector{1.0, -5.0, 1.0e-18, 0.0};
+  to_nodal_coefficients(&get(nodal_scalar_expected),
+                        {3.0, -2.0, 2.0, 0.5 * 0.99}, mesh);
+
+  // Limit top upper neighbor, limit second lower neighbor
+  to_nodal_coefficients(&nodal_vector_data_to_limit.get(0),
+                        {3.0, 2.0, 2.0, 1.0}, mesh);
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_xi.modal_volume_data)
+      .get(0) = ModalVector{7.0, 5.0, 2.5, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_xi.modal_volume_data)
+      .get(0) = ModalVector{-2.1, 1.1, 1.0e-18, 0.0};
+  to_nodal_coefficients(&nodal_vector_expected.get(0),
+                        {3.0, 2.0, 0.9 * 0.99, 0.5 * 0.99}, mesh);
+
+  krivodonova(&nodal_scalar_data_to_limit, &nodal_vector_data_to_limit, element,
+              mesh, neighbor_data);
+  CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit),
+                        get(nodal_scalar_expected));
+  for (size_t i = 0; i < dim; ++i) {
+    CAPTURE(i);
+    CHECK_ITERABLE_APPROX(nodal_vector_data_to_limit.get(i),
+                          nodal_vector_expected.get(i));
+  }
+}
+
+void run() noexcept {
+  INFO("Testing 1d limiter");
+  for (size_t order = Spectral::minimum_number_of_points<
+           Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
+       order < Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+       ++order) {
+    test_package_data(order);
+  }
+  test_limiting_two_neighbors();
+  test_limiting_different_values_different_tensors();
+}
+}  // namespace test_1d
+
+namespace test_2d {
+void test_package_data() noexcept {
+  INFO("Testing package data");
+  constexpr size_t dim = 2;
+  const Mesh<dim> mesh({{2, 3}},
+                       {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+                       {{Spectral::Quadrature::GaussLobatto,
+                         Spectral::Quadrature::GaussLobatto}});
+  CAPTURE(mesh);
+  using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
+  Limiter krivodonova{};
+
+  const ModalVector neighbor_modes{1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+  Scalar<DataVector> tensor0(mesh.number_of_grid_points());
+  to_nodal_coefficients(&get(tensor0), neighbor_modes, mesh);
+
+  tnsr::I<DataVector, dim> tensor1(mesh.number_of_grid_points());
+  for (size_t d = 0; d < dim; ++d) {
+    to_nodal_coefficients(&tensor1.get(d), (d + 2.0) * neighbor_modes, mesh);
+  }
+  Limiter::PackagedData packaged_data{};
+
+  // test no reorienting
+  {
+    krivodonova.package_data(make_not_null(&packaged_data), tensor0, tensor1,
+                             mesh, {});
+    CHECK(get(get<::Tags::Modal<ScalarTag<0>>>(
+              packaged_data.modal_volume_data)) == neighbor_modes);
+    for (size_t d = 0; d < dim; ++d) {
+      CHECK(
+          get<::Tags::Modal<VectorTag<dim, 0>>>(packaged_data.modal_volume_data)
+              .get(d) == ModalVector((d + 2.0) * neighbor_modes));
+    }
+  }
+  // test reorienting
+  {
+    krivodonova.package_data(
+        make_not_null(&packaged_data), tensor0, tensor1, mesh,
+        OrientationMap<2>{
+            {{Direction<2>::lower_eta(), Direction<2>::upper_xi()}}});
+    const ModalVector expected_modes{2.0, 4.0, 6.0, 1.0, 3.0, 5.0};
+    CHECK(get(get<::Tags::Modal<ScalarTag<0>>>(
+              packaged_data.modal_volume_data)) == expected_modes);
+    for (size_t d = 0; d < dim; ++d) {
+      CHECK(
+          get<::Tags::Modal<VectorTag<dim, 0>>>(packaged_data.modal_volume_data)
+              .get(d) == ModalVector((d + 2.0) * expected_modes));
+    }
+  }
+}
+
+template <typename F>
+void test_limiting_2_2_coefficient(const F& helper) noexcept {
+  // Limit no coefficients because the highest coefficient doesn't need
+  // limiting.
+  helper({0.0, 1.0, 2.0, 3.0, 4.0, 7.0, 3.0, 4.1, 0.0},
+         {0.0, 1.0, 2.0, 3.0, 4.0, 7.0, 3.0, 4.1, 0.0},
+         {0.0, 1.0, 2.0, 3.0, 4.0, 3.0, -2.0, 2.0, 1.0},
+         {0.0, 1.0, 2.0, 3.0, 4.0, 1.0, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, 2.0, 3.0, 4.0, 1.0, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, 2.0, 3.0, 4.0, 3.0, -2.0, 2.0, 1.0});
+
+  // Limit (2,2) because +(1,2)
+  helper({0.0, 1.0, 3.0, 3.0, 3.0, 7.0, 3.0, 2.5, 0.0},
+         {0.0, 1.0, 3.0, 3.0, 3.0, 7.0, 3.0, 4.1, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 1.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 0.5 * 0.99});
+
+  // Limit (2,2) because +(2,1)
+  helper({0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, 3.0, 3.0, 3.0, 2.5, 3.0, 4.1, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 1.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 0.5 * 0.99});
+
+  // Limit (2,2) because -(1,2)
+  helper({0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 1.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.3, 0.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 0.7 * 0.99});
+
+  // Limit (2,2) because -(2,1)
+  helper({0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 1.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 0.7 * 0.99});
+
+  // Zero (2,2) because +(1,2)
+  helper({0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 1.9, 0.0},
+         {0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 1.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 0.0});
+
+  // Zero (2,2) because +(2,1)
+  helper({0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, 3.0, 3.0, 3.0, 1.9, 3.0, 4.1, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 1.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 0.0});
+
+  // Zero (2,2) because -(1,2)
+  helper({0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 1.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 5.3, 0.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 0.0});
+
+  // Zero (2,2) because -(2,1)
+  helper({0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, 3.0, 3.0, 3.0, 4.1, 3.0, 4.1, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 1.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -5.0, -5.0, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 1.0, -2.0, -2.0, -2.0, 2.0, -2.0, 2.0, 0.0});
+}
+
+template <typename F>
+void test_limiting_2_1_coefficient(const F& helper) noexcept {
+  // Limit (2,1) because +(2,0)
+  helper({0.0, 7.0, 3.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 3.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 0.99, 3.0, 2.0, 0.0});
+
+  // Limit (2,1) because -(2,0)
+  helper({0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, 1.1, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, 1.1, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 0.9 * 0.99, 3.0, 2.0, 0.0});
+
+  // Zero (2,1) because +(2,0)
+  helper({0.0, 7.0, 1.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 1.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, 1.1, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, 1.1, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 0.0, 3.0, 2.0, 0.0});
+
+  // Zero (2,1) because -(2,0)
+  helper({0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, 2.1, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, 2.1, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 0.0, 3.0, 2.0, 0.0});
+
+  // Limit (2,1) because +(1,1)
+  helper({0.0, 7.0, 5.0, 7.0, 0.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 0.99 * 2.0, 3.0, 2.0, 0.0});
+
+  // Limit (2,1) because -(1,1)
+  helper({0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -2.1, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 0.99 * 0.1, 3.0, 2.0, 0.0});
+
+  // Zero (2,1) because +(1,1)
+  helper({0.0, 7.0, 5.0, 7.0, -3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 0.0, 3.0, 2.0, 0.0});
+
+  // Zero (2,1) because -(1,1)
+  helper({0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, 5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 0.0, 3.0, 2.0, 0.0});
+}
+
+template <typename F>
+void test_limiting_1_2_coefficient(const F& helper) noexcept {
+  // Limit (1,2) because +(0,2)
+  helper({0.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {0.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 0.99, 0.0});
+
+  // Limit (1,2) because -(0,2)
+  helper({0.0, 7.0, 7.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 7.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, 2.1, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, 2.1, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 0.9 * 0.99, 0.0});
+
+  // Zero (1,2) because +(0,2)
+  helper({0.0, 7.0, 7.0, 7.0, 3.0, 4.1, 2.9, 4.1, 0.0},
+         {0.0, 7.0, 7.0, 7.0, 3.0, 4.1, 2.9, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 0.0, 0.0});
+
+  // Zero (1,2) because -(0,2)
+  helper({0.0, 7.0, 7.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 7.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, 8.1, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, 8.1, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 0.0, 0.0});
+
+  // Limit (2,1) because +(1,1)
+  helper({0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 5.0, 7.0, 0.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 0.99 * 2.0, 0.0});
+
+  // Limit (2,1) because -(1,1)
+  helper({0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -4.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 0.99 * 2.0, 0.0});
+
+  // Zero (2,1) because +(1,1)
+  helper({0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 5.0, 7.0, -3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 0.0, 0.0});
+
+  // Zero (2,1) because -(1,1)
+  helper({0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0},
+         {0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0, -2.1, -5.0, -2.1, -1.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 0.0, 0.0});
+}
+
+template <typename F>
+void test_limiting_2_0_coefficient(const F& helper) noexcept {
+  // Limit (2,0) because +(1,0)
+  helper({5.0, 3.1, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 0.1 * 0.99, 3.0, 0.2, 2.0, 3.0, 0.99, 0.0});
+
+  // Limit (2,0) because -(1,0)
+  helper({5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, 2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 0.9 * 0.99, 3.0, 0.2, 2.0, 3.0, 0.99, 0.0});
+
+  // Zero (2,0) because +(1,0)
+  helper({5.0, 2.9, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 0.0, 3.0, 0.2, 2.0, 3.0, 0.99, 0.0});
+
+  // Zero (2,0) because -(1,0)
+  helper({5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, 3.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 0.0, 3.0, 0.2, 2.0, 3.0, 0.99, 0.0});
+}
+
+template <typename F>
+void test_limiting_0_2_coefficient(const F& helper) noexcept {
+  // Limit (0,2) because +(0,1)
+  helper({5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 7.0, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 0.1 * 0.99, 0.99, 0.0});
+
+  // Limit (0,2) because -(0,1)
+  helper({5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, 2.2, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 0.8 * 0.99, 0.99, 0.0});
+
+  // Zero (0,2) because +(0,1)
+  helper({5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 7.0, 7.0, 2.9, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 0.0, 0.99, 0.0});
+
+  // Zero (0,2) because -(0,1)
+  helper({5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 7.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, 3.2, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 0.2, 2.0, 0.0, 0.99, 0.0});
+}
+
+template <typename F>
+void test_limiting_1_1_coefficient(const F& helper) noexcept {
+  // Limit (1,1) because +(1,0)
+  helper({5.0, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 3.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 1.0 * 0.99, 3.0, 0.3 * 0.99, 2.0 * 0.99, 0.1 * 0.99, 0.99,
+          0.0});
+
+  // Limit (1,1) because -(1,0)
+  helper({5.0, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 4.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, 2.6, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 1.0 * 0.99, 3.0, 0.4 * 0.99, 2.0 * 0.99, 0.1 * 0.99, 0.99,
+          0.0});
+
+  // Limit (1,1) because +(0,1)
+  helper({5.0, 3.3, 7.0, 3.4, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 4.2, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 0.3 * 0.99, 3.0, 0.4 * 0.99, 2.0 * 0.99, 0.1 * 0.99, 0.99,
+          0.0});
+
+  // Limit (1,1) because -(0,1)
+  helper({5.0, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 4.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, 2.5, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 1.0 * 0.99, 3.0, 0.5 * 0.99, 2.0 * 0.99, 0.1 * 0.99, 0.99,
+          0.0});
+
+  // Zero (1,1) because +(1,0)
+  helper({5.0, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 2.9, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 1.0 * 0.99, 3.0, 0.0, 2.0 * 0.99, 0.1 * 0.99, 0.99, 0.0});
+
+  // Zero (1,1) because -(1,0)
+  helper({5.0, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 4.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, 3.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 1.0 * 0.99, 3.0, 0.0, 2.0 * 0.99, 0.1 * 0.99, 0.99, 0.0});
+
+  // Zero (1,1) because +(0,1)
+  helper({5.0, 3.3, 7.0, 2.9, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 4.2, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 0.3 * 0.99, 3.0, 0.0, 2.0 * 0.99, 0.1 * 0.99, 0.99, 0.0});
+
+  // Zero (1,1) because -(0,1)
+  helper({5.0, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 4.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, 4.5, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 3.0, 1.0 * 0.99, 3.0, 0.0, 2.0 * 0.99, 0.1 * 0.99, 0.99, 0.0});
+}
+
+template <typename F>
+void test_limiting_1_0_coefficient(const F& helper) noexcept {
+  // Limit (1,0) because +(0,0)
+  helper({1.5, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 3.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 0.5 * 0.99, 1.0 * 0.99, 3.0, 0.3 * 0.99, 2.0 * 0.99, 0.1 * 0.99,
+          0.99, 0.0});
+
+  // Limit (1,0) because -(0,0)
+  helper({5.0, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 3.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {0.6, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 0.4 * 0.99, 1.0 * 0.99, 3.0, 0.3 * 0.99, 2.0 * 0.99, 0.1 * 0.99,
+          0.99, 0.0});
+
+  // Zero (1,0) because +(0,0)
+  helper({0.5, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 3.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 0.0, 1.0 * 0.99, 3.0, 0.3 * 0.99, 2.0 * 0.99, 0.1 * 0.99, 0.99,
+          0.0});
+
+  // Zero (1,0) because -(0,0)
+  helper({5.0, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 3.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {1.6, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 0.0, 1.0 * 0.99, 3.0, 0.3 * 0.99, 2.0 * 0.99, 0.1 * 0.99, 0.99,
+          0.0});
+}
+
+template <typename F>
+void test_limiting_0_1_coefficient(const F& helper) noexcept {
+  // Limit (0,1) because +(0,0)
+  helper({1.4, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.5, 3.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 0.4 * 0.99, 1.0 * 0.99, 0.5 * 0.99, 0.3 * 0.99, 2.0 * 0.99,
+          0.1 * 0.99, 0.99, 0.0});
+
+  // Limit (0,1) because -(0,0)
+  helper({0.9, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 3.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.7, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 0.0, 1.0 * 0.99, 0.3 * 0.99, 0.3 * 0.99, 2.0 * 0.99, 0.1 * 0.99,
+          0.99, 0.0});
+
+  // Zero (0,1) because +(0,0)
+  helper({1.4, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {0.5, 3.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 0.4 * 0.99, 1.0 * 0.99, 0.0, 0.3 * 0.99, 2.0 * 0.99, 0.1 * 0.99,
+          0.99, 0.0});
+
+  // Zero (0,1) because -(0,0)
+  helper({5.0, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {5.0, 3.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0},
+         {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0},
+         {0.4, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {1.7, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0},
+         {1.0, 0.6 * 0.99, 1.0 * 0.99, 0.0, 0.3 * 0.99, 2.0 * 0.99, 0.1 * 0.99,
+          0.99, 0.0});
+}
+
+void test_limiting_different_values_different_tensors() noexcept {
+  INFO("Testing different values for each tensor component");
+  constexpr size_t dim = 2;
+  const size_t order = 2;  // Use only 3 coefficients because more is tedious...
+  const Mesh<dim> mesh(order + 1, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
+  const size_t num_pts = mesh.number_of_grid_points();
+  using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
+  // Use non-unity (because that's the default) but close alpha values to make
+  // the math easier but still test thoroughly.
+  Limiter krivodonova{
+      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
+          0.99)};
+
+  NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
+
+  const Element<dim> element(ElementId<dim>{0}, {});
+  // We don't care about the ElementId for these tests, just the direction.
+  Limiter::PackagedData& package_data_up_xi = neighbor_data[std::make_pair(
+      Direction<dim>::upper_xi(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_xi = neighbor_data[std::make_pair(
+      Direction<dim>::lower_xi(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_up_eta = neighbor_data[std::make_pair(
+      Direction<dim>::upper_eta(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_eta = neighbor_data[std::make_pair(
+      Direction<dim>::lower_eta(), ElementId<dim>{0})];
+
+  package_data_up_xi.modal_volume_data.initialize(num_pts);
+  package_data_up_xi.mesh = mesh;
+  package_data_lo_xi.modal_volume_data.initialize(num_pts);
+  package_data_lo_xi.mesh = mesh;
+  package_data_up_eta.modal_volume_data.initialize(num_pts);
+  package_data_up_eta.mesh = mesh;
+  package_data_lo_eta.modal_volume_data.initialize(num_pts);
+  package_data_lo_eta.mesh = mesh;
+
+  Scalar<DataVector> nodal_scalar_data_to_limit(num_pts, 0.0);
+  tnsr::I<DataVector, dim> nodal_vector_data_to_limit(num_pts, 0.0);
+  Scalar<DataVector> nodal_scalar_expected(num_pts, 0.0);
+  tnsr::I<DataVector, dim> nodal_vector_expected(num_pts, 0.0);
+
+  // Limit (1,0) because +(0,0)
+  to_nodal_coefficients(&get(nodal_scalar_data_to_limit),
+                        {1.0, 3.0, 2.0, 3.0, 1.0, 2.0, 3.0, 2.0, 1.0}, mesh);
+  get(get<::Tags::Modal<ScalarTag<0>>>(package_data_up_xi.modal_volume_data)) =
+      ModalVector{1.5, 4.0, 7.0, 7.0, 3.0, 4.1, 4.0, 4.1, 0.0};
+  get(get<::Tags::Modal<ScalarTag<0>>>(package_data_lo_xi.modal_volume_data)) =
+      ModalVector{-5.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  get(get<::Tags::Modal<ScalarTag<0>>>(package_data_up_eta.modal_volume_data)) =
+      ModalVector{5.0, 3.3, 7.0, 3.1, 3.0, 4.1, 4.0, 4.1, 0.0};
+  get(get<::Tags::Modal<ScalarTag<0>>>(package_data_lo_eta.modal_volume_data)) =
+      ModalVector{-5.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0};
+  to_nodal_coefficients(&get(nodal_scalar_expected),
+                        {1.0, 0.5 * 0.99, 1.0 * 0.99, 3.0, 0.3 * 0.99,
+                         2.0 * 0.99, 0.1 * 0.99, 0.99, 0.0},
+                        mesh);
+
+  // Zero (1,2) because +(0,2)
+  to_nodal_coefficients(&nodal_vector_data_to_limit.get(0),
+                        {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0}, mesh);
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_xi.modal_volume_data)
+      .get(0) = ModalVector{0.0, 7.0, 7.0, 7.0, 3.0, 4.1, 2.9, 4.1, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_xi.modal_volume_data)
+      .get(0) =
+      ModalVector{0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_eta.modal_volume_data)
+      .get(0) = ModalVector{0.0, 7.0, 7.0, 7.0, 3.0, 4.1, 2.9, 4.1, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_eta.modal_volume_data)
+      .get(0) =
+      ModalVector{0.0, -2.1, -5.0, -2.1, -5.0, 5.3, -5.0, 1.0e-18, 0.0};
+  to_nodal_coefficients(&nodal_vector_expected.get(0),
+                        {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 0.0, 0.0}, mesh);
+
+  // Limit (2,1) because +(1,1)
+  to_nodal_coefficients(&nodal_vector_data_to_limit.get(1),
+                        {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 2.0, 1.0}, mesh);
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_xi.modal_volume_data)
+      .get(1) = ModalVector{0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_xi.modal_volume_data)
+      .get(1) =
+      ModalVector{0.0, -2.1, -5.0, -2.1, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_eta.modal_volume_data)
+      .get(1) = ModalVector{0.0, 7.0, 5.0, 7.0, 3.0, 4.1, 7.0, 4.1, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_eta.modal_volume_data)
+      .get(1) =
+      ModalVector{0.0, -2.1, -5.0, -2.1, -4.0, 5.3, -5.0, 1.0e-18, 0.0};
+  to_nodal_coefficients(&nodal_vector_expected.get(1),
+                        {0.0, 3.0, 2.0, 3.0, -2.0, 2.0, 3.0, 0.99 * 2.0, 0.0},
+                        mesh);
+
+  krivodonova(&nodal_scalar_data_to_limit, &nodal_vector_data_to_limit, element,
+              mesh, neighbor_data);
+  CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit),
+                        get(nodal_scalar_expected));
+  for (size_t i = 0; i < dim; ++i) {
+    CAPTURE(i);
+    CHECK_ITERABLE_APPROX(nodal_vector_data_to_limit.get(i),
+                          nodal_vector_expected.get(i));
+  }
+}
+
+void run() noexcept {
+  INFO("Testing 2d limiter");
+  test_package_data();
+
+  INFO("Testing applying limiter to coefficients");
+  constexpr size_t dim = 2;
+  const size_t order = 2;  // Use only 3 coefficients because more is tedious...
+  const Mesh<dim> mesh(order + 1, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
+  const size_t num_pts = mesh.number_of_grid_points();
+  using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>>>;
+  // Use non-unity (because that's the default) but close alpha values to make
+  // the math easier but still test thoroughly.
+  Limiter krivodonova{
+      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
+          0.99)};
+
+  NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
+
+  const Element<dim> element(ElementId<dim>{0}, {});
+  // We don't care about the ElementId for these tests, just the direction.
+  Limiter::PackagedData& package_data_up_xi = neighbor_data[std::make_pair(
+      Direction<dim>::upper_xi(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_xi = neighbor_data[std::make_pair(
+      Direction<dim>::lower_xi(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_up_eta = neighbor_data[std::make_pair(
+      Direction<dim>::upper_eta(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_eta = neighbor_data[std::make_pair(
+      Direction<dim>::lower_eta(), ElementId<dim>{0})];
+
+  package_data_up_xi.modal_volume_data.initialize(num_pts);
+  package_data_up_xi.mesh = mesh;
+  package_data_lo_xi.modal_volume_data.initialize(num_pts);
+  package_data_lo_xi.mesh = mesh;
+  package_data_up_eta.modal_volume_data.initialize(num_pts);
+  package_data_up_eta.mesh = mesh;
+  package_data_lo_eta.modal_volume_data.initialize(num_pts);
+  package_data_lo_eta.mesh = mesh;
+
+  Scalar<DataVector> nodal_scalar_data_to_limit(num_pts, 0.0);
+  DataVector expected(num_pts);
+  const auto helper =
+      [
+        &element, &expected, &krivodonova, &mesh, &neighbor_data,
+        &package_data_lo_xi, &package_data_up_xi, &package_data_lo_eta,
+        &package_data_up_eta, &nodal_scalar_data_to_limit
+      ](const ModalVector& up_xi_coeffs, const ModalVector& up_eta_coeffs,
+        const ModalVector& initial_coeffs, const ModalVector& lo_xi_coeffs,
+        const ModalVector& lo_eta_coeffs,
+        const ModalVector& expected_coeffs) noexcept {
+    to_nodal_coefficients(&get(nodal_scalar_data_to_limit), initial_coeffs,
+                          mesh);
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_up_xi.modal_volume_data)) = up_xi_coeffs;
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_lo_xi.modal_volume_data)) = lo_xi_coeffs;
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_up_eta.modal_volume_data)) = up_eta_coeffs;
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_lo_eta.modal_volume_data)) = lo_eta_coeffs;
+    krivodonova(&nodal_scalar_data_to_limit, element, mesh, neighbor_data);
+    to_nodal_coefficients(&expected, expected_coeffs, mesh);
+    CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit), expected);
+  };
+
+  // Map between 2D and 1D coefficients:
+  // [(0,0), (1,0), (2,0), (0,1), (1,1), (2,1), (0,2), (1,2), (2,2)]
+  //  (0,     1,     2,     3,     4,     5,     6,     7,     8)
+
+  test_limiting_2_2_coefficient(helper);
+  test_limiting_2_1_coefficient(helper);
+  test_limiting_1_2_coefficient(helper);
+  test_limiting_2_0_coefficient(helper);
+  test_limiting_0_2_coefficient(helper);
+  test_limiting_1_1_coefficient(helper);
+  test_limiting_1_0_coefficient(helper);
+  test_limiting_0_1_coefficient(helper);
+
+  test_limiting_different_values_different_tensors();
+}
+}  // namespace test_2d
+
+namespace test_3d {
+void test_package_data() noexcept {
+  INFO("Testing package data");
+  constexpr size_t dim = 3;
+  const Mesh<dim> mesh(
+      {{2, 3, 4}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+        Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::GaussLobatto,
+        Spectral::Quadrature::GaussLobatto}});
+  CAPTURE(mesh);
+  const auto logical_x = logical_coordinates(mesh);
+  using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
+  Limiter krivodonova{};
+
+  const ModalVector neighbor_modes{
+      0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,  9.0,  10.0, 11.0,
+      12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0};
+  Scalar<DataVector> tensor0(mesh.number_of_grid_points());
+  to_nodal_coefficients(&get(tensor0), neighbor_modes, mesh);
+
+  tnsr::I<DataVector, dim> tensor1(mesh.number_of_grid_points());
+  for (size_t d = 0; d < dim; ++d) {
+    to_nodal_coefficients(&tensor1.get(d), (d + 2.0) * neighbor_modes, mesh);
+  }
+  Limiter::PackagedData packaged_data{};
+
+  // test no reorienting
+  {
+    krivodonova.package_data(make_not_null(&packaged_data), tensor0, tensor1,
+                             mesh, {});
+    CHECK(get(get<::Tags::Modal<ScalarTag<0>>>(
+              packaged_data.modal_volume_data)) == neighbor_modes);
+    for (size_t d = 0; d < dim; ++d) {
+      CHECK(
+          get<::Tags::Modal<VectorTag<dim, 0>>>(packaged_data.modal_volume_data)
+              .get(d) == ModalVector((d + 2.0) * neighbor_modes));
+    }
+  }
+  // test reorienting
+  {
+    krivodonova.package_data(make_not_null(&packaged_data), tensor0, tensor1,
+                             mesh,
+                             OrientationMap<3>{{{Direction<3>::upper_zeta(),
+                                                 Direction<3>::upper_eta(),
+                                                 Direction<3>::upper_xi()}}});
+    const ModalVector expected_modes{
+        0.0, 6.0, 12.0, 18.0, 2.0, 8.0, 14.0, 20.0, 4.0, 10.0, 16.0, 22.0,
+        1.0, 7.0, 13.0, 19.0, 3.0, 9.0, 15.0, 21.0, 5.0, 11.0, 17.0, 23.0};
+    CHECK(get(get<::Tags::Modal<ScalarTag<0>>>(
+              packaged_data.modal_volume_data)) == expected_modes);
+    for (size_t d = 0; d < dim; ++d) {
+      CHECK(
+          get<::Tags::Modal<VectorTag<dim, 0>>>(packaged_data.modal_volume_data)
+              .get(d) == ModalVector((d + 2.0) * expected_modes));
+    }
+  }
+}
+
+template <typename F>
+void test_limiting_2_2_2_coefficient(const F& helper) noexcept {
+  // Limit no coefficients because the highest coefficient doesn't need
+  // limiting.
+  helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 4.1,
+          18.0, 19.0, 20.0, 21.0, 22.0, 4.1,  3.0,  4.1,  0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 4.1,
+          18.0, 19.0, 20.0, 21.0, 22.0, 4.1,  3.0,  4.1,  0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 4.1,
+          18.0, 19.0, 20.0, 21.0, 22.0, 4.1,  3.0,  4.1,  0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 2.0,
+          18.0, 19.0, 20.0, 21.0, 22.0, 3.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     8.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, 14.0,    15.0, 16.0,    1.0e-18,
+          18.0, 19.0, 20.0, 21.0, 22.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     8.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, 14.0,    15.0, 16.0,    1.0e-18,
+          18.0, 19.0, 20.0, 21.0, 22.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     8.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, 14.0,    15.0, 16.0,    1.0e-18,
+          18.0, 19.0, 20.0, 21.0, 22.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  8.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 2.0,
+          18.0, 19.0, 20.0, 21.0, 22.0, 3.0,  -2.0, 2.0,  1.0});
+
+  {  // Limit (2,2,2)
+    // Limit (2,2,2) because +(1,2,2)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+    // Limit (2,2,2) because +(2,1,2)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  2.5, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+    // Limit (2,2,2) because +(2,2,1)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 2.5,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+    // Limit (2,2,2) because -(1,2,2)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,  -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0, 1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.3,  0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.7 * 0.99});
+
+    // Limit (2,2,2) because -(2,1,2)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0, 15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.3,  -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.7 * 0.99});
+
+    // Limit (2,2,2) because -(2,2,1)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.3,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.7 * 0.99});
+  }
+
+  {  // Zero (2,2,2)
+    // Zero (2,2,2) because +(1,2,2)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  1.9, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.0});
+
+    // Zero (2,2,2) because +(2,1,2)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  1.9, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.0});
+
+    // Zero (2,2,2) because +(2,2,1)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 1.9,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.0});
+
+    // Zero (2,2,2) because -(1,2,2)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,  -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0, 1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 5.3,  0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.0});
+
+    // Zero (2,2,2) because -(2,1,2)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0, 15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 5.3,  -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.0});
+
+    // Zero (2,2,2) because -(1,2,2)
+    helper({0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0, 6.0,  7.0, 3.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, 3.0, 15.0, 3.0, 4.1,
+            18.0, 19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    5.3,
+            18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+           {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+            9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+            18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.0});
+  }
+}
+
+template <typename F>
+void test_limiting_2_2_1_coefficient(const F& helper) noexcept {
+  // Limit (2,2,1) because +(1,2,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0,  3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, -1.1, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5,  0.0},
+    {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+    {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+    {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+    {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+    {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+    {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 0.9 * 0.99,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,2,1) because +(1,2,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0,   3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, -16.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5,   0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 0.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Limit (2,2,1) because -(1,2,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 1.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -3.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 1.0 * 0.99,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,2,1) because -(1,2,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 1.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, 16.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 0.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Limit (2,2,1) because +(2,1,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 1.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0,  6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, -1.3, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1,  3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 0.7 * 0.99,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,2,1) because +(2,1,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 1.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0,   6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, -14.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1,   3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 0.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Limit (2,2,1) because -(2,1,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 1.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.2,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 0.2 * 0.99,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,2,1) because -(2,1,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 1.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, 12.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 0.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Limit (2,2,1) because +(2,2,0)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 1.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, -0.5,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 1.5 * 0.99,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,2,1) because +(2,2,0)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 1.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, -8.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 0.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Limit (2,2,1) because -(2,2,0)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 1.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -3.8,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 1.8 * 0.99,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,2,1) because -(2,2,0)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 1.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -0.8,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 0.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99});
+}
+
+template <typename F>
+void test_limiting_2_1_2_coefficient(const F& helper) noexcept {
+  // Limit (2,1,2) because +(1,1,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,   5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0,  2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, -1.15, 4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,         6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0,        15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 0.85 * 0.99, -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,1,2) because +(1,1,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,   5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0,  2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, -10.0, 4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 0.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Limit (2,1,2) because -(1,1,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,   5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0,  -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -3.05, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,         6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0,        15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 1.05 * 0.99, -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,1,2) because -(1,1,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, 22.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 0.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Limit (2,1,2) because +(2,0,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,   3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0,  12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, -1.15, -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,         6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0,        15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 0.85 * 0.99, -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,1,2) because +(2,0,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, -4.0, -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 0.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Limit (2,1,2) because -(2,0,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0,  12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -2.25, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,         6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0,        15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 0.25 * 0.99, -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,1,2) because -(2,0,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, 7.0,  43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 0.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Limit (2,1,2) because +(2,1,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0,   6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, -1.33, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1,   3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,         6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0,        15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 0.67 * 0.99, -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,1,2) because +(2,1,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0,  6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, -4.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1,  3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 0.0,  -2.0, 2.0,  0.5 * 0.99});
+
+  // Limit (2,1,2) because -(2,1,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -3.75,   31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,         6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0,        15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 1.75 * 0.99, -2.0, 2.0,  0.5 * 0.99});
+
+  // Zero (2,1,2) because -(2,1,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -1.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 0.0,  -2.0, 2.0,  0.5 * 0.99});
+}
+
+template <typename F>
+void test_limiting_1_2_2_coefficient(const F& helper) noexcept {
+  // Limit (1,2,2) because +(0,2,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,   3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0,  3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, -0.64, 2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,         -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0,        2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 1.36 * 0.99, 0.5 * 0.99});
+
+  // Zero (1,2,2) because +(0,2,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, -8.0, 2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 0.0,  0.5 * 0.99});
+
+  // Limit (1,2,2) because -(0,2,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,   11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0,  -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -3.13, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,         -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0,        2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 1.13 * 0.99, 0.5 * 0.99});
+
+  // Zero (1,2,2) because -(0,2,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -1.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 0.0,  0.5 * 0.99});
+
+  // Limit (1,2,2) because +(1,1,2)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,   2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0,  3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, -1.08, 4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,         -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0,        2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 0.92 * 0.99, 0.5 * 0.99});
+
+  // Skipping other (1,1,2) cases since they add limited value to the test
+
+  // Limit (1,2,2) because +(1,2,1)
+  helper({0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0, 3.0,
+          9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, 3.0, 4.1,
+          18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5, 0.0},
+         {0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+          18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0,   3.0,
+          9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, -1.03, 4.1,
+          18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1,   0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+          18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+          9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+          18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,         -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0,        2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 0.97 * 0.99, 0.5 * 0.99});
+
+  // Skipping other (1,2,1) cases since they add limited value to the test
+}
+
+template <typename F>
+void test_limiting_0_1_2_coefficient_permutations(const F& helper) noexcept {
+  // Limit (2,1,0) because -(2,0,0)
+  helper({0.0,   10.0,  2.0,  3.0,   8.0,  5.0, 60.0,  3.0, 3.0,
+          9.0,   100.0, 11.0, 120.0, 11.8, 2.0, -15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,   2.5, 0.0},
+         {0.0,   1.0,   5.0,   30.0,  40.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,   100.0, -11.0, 120.0, -13.0, 3.0, 15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,   -21.0, 3.0,   4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,   20.0, 3.0,   44.0,  4.0, 60.0,  -7.0,  3.0,
+          90.0, 100.0, 10.0, 120.0, -13.0, 3.0, -15.0, -1.03, 4.1,
+          18.0, 19.0,  3.0,  21.0,  3.0,   4.1, 3.0,   4.1,   0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,    -10.0,  2.0,  3.0,    -4.0, 5.0,     -60.0, 11.0,    -5.0,
+          9.0,    -100.0, 11.0, -120.0, 13.8, -5.0,    150.0, -8.0,    1.0e-18,
+          -180.0, 49.0,   -5.0, 210.0,  -5.0, 1.0e-18, -5.0,  1.0e-18, 0.0},
+         {0.0,    1.0,   1.5,  -30.0,  -40.0, 8.0,     6.0,  7.0,     -5.0,
+          9.0,    -10.0, 11.5, -120.0, 130.0, -5.0,    15.0, -5.0,    1.0e-18,
+          -180.0, 190.0, -5.0, 43.0,   -5.0,  1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,   1.0,    -20.0, 3.0,    -44.0, 8.0,     -60.0, 8.0,     -5.0,
+          -90.0, -100.0, 28.0,  -120.0, 14.0,  -5.0,    31.0,  -5.0,    1.0e-18,
+          18.0,  19.0,   -5.0,  21.0,   -5.0,  1.0e-18, -5.0,  1.0e-18, 0.0},
+
+         {0.0,  1.0,         2.0,         3.0,  4.0,         0.5 * 0.99,
+          6.0,  7.0,         -2.0,        9.0,  10.0,        11.0,
+          12.0, 13.0,        -0.5 * 0.99, 15.0, -1.0 * 0.99, 2.0,
+          18.0, 19.0,        -0.99,       21.0, -1.0 * 0.99, 2.0,
+          -2.0, 0.97 * 0.99, 0.5 * 0.99});
+
+  // Limit (1,2,0) because +(0,2,0)
+  helper({0.0,   10.0,  2.0,  3.0,   80.0, 5.0, 8.0,   3.0, 3.0,
+          9.0,   100.0, 11.0, 120.0, 11.8, 2.0, -15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,   2.5, 0.0},
+         {0.0,   1.0,   50.0,  30.0,  40.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,   100.0, -11.0, 120.0, -13.0, 3.0, 15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,   -21.0, 3.0,   4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,   20.0, 3.0,   44.0,  4.0, 60.0,  -7.0,  3.0,
+          90.0, 100.0, 10.0, 120.0, -13.0, 3.0, -15.0, -1.03, 4.1,
+          18.0, 19.0,  3.0,  21.0,  3.0,   4.1, 3.0,   4.1,   0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,    -10.0,  2.0,  3.0,    -4.0, 5.0,     -60.0, 11.0,    -5.0,
+          9.0,    -100.0, 11.0, -120.0, 13.8, -5.0,    150.0, -8.0,    1.0e-18,
+          -180.0, 49.0,   -5.0, 210.0,  -5.0, 1.0e-18, -5.0,  1.0e-18, 0.0},
+         {0.0,    1.0,   -8.0, -30.0,  -40.0, 8.0,     6.0,  7.0,     -5.0,
+          9.0,    -10.0, 11.5, -120.0, 130.0, -5.0,    15.0, -5.0,    1.0e-18,
+          -180.0, 190.0, -8.0, 43.0,   -5.0,  1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,   1.0,    -20.0, 3.0,    -44.0, 8.0,     -60.0, 8.0,     -5.0,
+          -90.0, -100.0, 28.0,  -120.0, 14.0,  -5.0,    31.0,  -5.0,    1.0e-18,
+          18.0,  19.0,   -5.0,  21.0,   -5.0,  1.0e-18, -5.0,  1.0e-18, 0.0},
+
+         {0.0,  1.0,         2.0,         3.0,  4.0,         5.0,
+          6.0,  2.0 * 0.99,  -2.0,        9.0,  10.0,        11.0,
+          12.0, 13.0,        -0.5 * 0.99, 15.0, -1.0 * 0.99, 2.0,
+          18.0, 19.0,        -0.99,       21.0, -1.0 * 0.99, 2.0,
+          -2.0, 0.97 * 0.99, 0.5 * 0.99});
+
+  // Limit (2,0,1) because +(2,0,0)
+  helper({0.0,   10.0,  2.0,  3.0,   80.0, 5.0, 60.0,  3.0, 3.0,
+          9.0,   100.0, 11.0, 120.0, 11.8, 2.0, -15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,   2.5, 0.0},
+         {0.0,   1.0,   50.0,  30.0,  40.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,   100.0, -11.0, 120.0, -13.0, 3.0, 15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,   -21.0, 3.0,   4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,   3.0,  3.0,   44.0,  4.0, 60.0,  -7.0,  3.0,
+          90.0, 100.0, 10.0, 120.0, -13.0, 3.0, -15.0, -1.03, 4.1,
+          18.0, 19.0,  3.0,  21.0,  3.0,   4.1, 3.0,   4.1,   0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,    -10.0,  2.0,  3.0,    -4.0, 5.0,     -60.0, 11.0,    -5.0,
+          9.0,    -100.0, 11.0, -120.0, 13.8, -5.0,    150.0, -8.0,    1.0e-18,
+          -180.0, 49.0,   -5.0, 210.0,  -5.0, 1.0e-18, -5.0,  1.0e-18, 0.0},
+         {0.0,    1.0,   -8.0, -30.0,  -40.0, 8.0,     6.0,  7.0,     -5.0,
+          9.0,    -10.0, 11.5, -120.0, 130.0, -5.0,    15.0, -5.0,    1.0e-18,
+          -180.0, 190.0, -8.0, 43.0,   -5.0,  1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,   1.0,    -20.0, 3.0,    -44.0, 8.0,     -60.0, 8.0,     -5.0,
+          -90.0, -100.0, 28.0,  -120.0, 14.0,  -5.0,    31.0,  -5.0,    1.0e-18,
+          18.0,  19.0,   -5.0,  21.0,   -5.0,  1.0e-18, -5.0,  1.0e-18, 0.0},
+
+         {0.0,  1.0,         2.0,         3.0,  4.0,         5.0,
+          6.0,  7.0,         -2.0,        9.0,  10.0,        1.0 * 0.99,
+          12.0, 13.0,        -0.5 * 0.99, 15.0, -1.0 * 0.99, 2.0,
+          18.0, 19.0,        -0.99,       21.0, -1.0 * 0.99, 2.0,
+          -2.0, 0.97 * 0.99, 0.5 * 0.99});
+
+  // Limit (1,0,2) because -(0,0,2)
+  helper({0.0,   10.0,  2.0,  3.0,   80.0, 5.0, 60.0,  3.0, 3.0,
+          9.0,   100.0, 11.0, 120.0, 11.8, 2.0, -15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,   2.5, 0.0},
+         {0.0,   1.0,   50.0,  30.0,  40.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,   100.0, -11.0, 120.0, -13.0, 3.0, 15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,   -21.0, 3.0,   4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,   20.0, 3.0,   44.0,  4.0, 60.0,  -7.0,  3.0,
+          90.0, 100.0, 10.0, 120.0, -13.0, 3.0, -15.0, -1.03, 4.1,
+          18.0, 19.0,  3.0,  21.0,  3.0,   4.1, 3.0,   4.1,   0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,  -10.0,  2.0,  3.0,    -4.0, 5.0,     -60.0, 11.0,    -5.0,
+          9.0,  -100.0, 11.0, -120.0, 13.8, -5.0,    150.0, -8.0,    1.0e-18,
+          14.0, 49.0,   -5.0, 210.0,  -5.0, 1.0e-18, -5.0,  1.0e-18, 0.0},
+         {0.0,    1.0,   -8.0, -30.0,  -40.0, 8.0,     6.0,  7.0,     -5.0,
+          9.0,    -10.0, 11.5, -120.0, 130.0, -5.0,    15.0, -5.0,    1.0e-18,
+          -180.0, 190.0, -8.0, 43.0,   -5.0,  1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,   1.0,    -20.0, 3.0,    -44.0, 8.0,     -60.0, 8.0,     -5.0,
+          -90.0, -100.0, 28.0,  -120.0, 14.0,  -5.0,    31.0,  -5.0,    1.0e-18,
+          18.0,  19.0,   -5.0,  21.0,   -5.0,  1.0e-18, -5.0,  1.0e-18, 0.0},
+
+         {0.0,  1.0,         2.0,         3.0,  4.0,         5.0,
+          6.0,  7.0,         -2.0,        9.0,  10.0,        11.0,
+          12.0, 13.0,        -0.5 * 0.99, 15.0, -1.0 * 0.99, 2.0,
+          18.0, 4.0 * 0.99,  -0.99,       21.0, -1.0 * 0.99, 2.0,
+          -2.0, 0.97 * 0.99, 0.5 * 0.99});
+
+  // Limit (0,2,1) because +(0,2,0)
+  helper({0.0,   10.0,  2.0,  3.0,   80.0, 5.0, 60.0,  3.0, 3.0,
+          9.0,   100.0, 11.0, 120.0, 11.8, 2.0, -15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,   2.5, 0.0},
+         {0.0,   1.0,   50.0,  30.0,  40.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,   100.0, -11.0, 120.0, -13.0, 3.0, 15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,   -21.0, 3.0,   4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,   20.0, 3.0,   44.0,  4.0, 8.0,   -7.0,  3.0,
+          90.0, 100.0, 10.0, 120.0, -13.0, 3.0, -15.0, -1.03, 4.1,
+          18.0, 19.0,  3.0,  21.0,  3.0,   4.1, 3.0,   4.1,   0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,    -10.0,  2.0,  3.0,    -4.0, 5.0,     -60.0, 11.0,    -5.0,
+          9.0,    -100.0, 11.0, -120.0, 13.8, -5.0,    150.0, -8.0,    1.0e-18,
+          -180.0, 49.0,   -5.0, 210.0,  -5.0, 1.0e-18, -5.0,  1.0e-18, 0.0},
+         {0.0,    1.0,   -8.0, -30.0,  -40.0, 8.0,     6.0,  7.0,     -5.0,
+          9.0,    -10.0, 11.5, -120.0, 130.0, -5.0,    15.0, -5.0,    1.0e-18,
+          -180.0, 190.0, -8.0, 43.0,   -5.0,  1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,   1.0,    -20.0, 3.0,    -44.0, 8.0,     -60.0, 8.0,     -5.0,
+          -90.0, -100.0, 28.0,  -120.0, 14.0,  -5.0,    31.0,  -5.0,    1.0e-18,
+          18.0,  19.0,   -5.0,  21.0,   -5.0,  1.0e-18, -5.0,  1.0e-18, 0.0},
+
+         {0.0,  1.0,         2.0,         3.0,        4.0,         5.0,
+          6.0,  7.0,         -2.0,        9.0,        10.0,        11.0,
+          12.0, 13.0,        -0.5 * 0.99, 2.0 * 0.99, -1.0 * 0.99, 2.0,
+          18.0, 19.0,        -0.99,       21.0,       -1.0 * 0.99, 2.0,
+          -2.0, 0.97 * 0.99, 0.5 * 0.99});
+
+  // Limit (0,1, 2) because +(0,0,2)
+  helper({0.0,   10.0,  2.0,  3.0,   80.0, 5.0, 60.0,  3.0, 3.0,
+          9.0,   100.0, 11.0, 120.0, 11.8, 2.0, -15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,   2.5, 0.0},
+         {0.0,  1.0,   50.0,  30.0,  40.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,  100.0, -11.0, 120.0, -13.0, 3.0, 15.0, 3.0, 4.1,
+          21.0, -19.0, 3.0,   -21.0, 3.0,   4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,   20.0, 3.0,   44.0,  4.0, 60.0,  -7.0,  3.0,
+          90.0, 100.0, 10.0, 120.0, -13.0, 3.0, -15.0, -1.03, 4.1,
+          18.0, 19.0,  3.0,  21.0,  3.0,   4.1, 3.0,   4.1,   0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,    -10.0,  2.0,  3.0,    -4.0, 5.0,     -60.0, 11.0,    -5.0,
+          9.0,    -100.0, 11.0, -120.0, 13.8, -5.0,    150.0, -8.0,    1.0e-18,
+          -180.0, 49.0,   -5.0, 210.0,  -5.0, 1.0e-18, -5.0,  1.0e-18, 0.0},
+         {0.0,    1.0,   -8.0, -30.0,  -40.0, 8.0,     6.0,  7.0,     -5.0,
+          9.0,    -10.0, 11.5, -120.0, 130.0, -5.0,    15.0, -5.0,    1.0e-18,
+          -180.0, 190.0, -8.0, 43.0,   -5.0,  1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,   1.0,    -20.0, 3.0,    -44.0, 8.0,     -60.0, 8.0,     -5.0,
+          -90.0, -100.0, 28.0,  -120.0, 14.0,  -5.0,    31.0,  -5.0,    1.0e-18,
+          18.0,  19.0,   -5.0,  21.0,   -5.0,  1.0e-18, -5.0,  1.0e-18, 0.0},
+
+         {0.0,  1.0,         2.0,         3.0,        4.0,         5.0,
+          6.0,  7.0,         -2.0,        9.0,        10.0,        11.0,
+          12.0, 13.0,        -0.5 * 0.99, 15.0,       -1.0 * 0.99, 2.0,
+          18.0, 19.0,        -0.99,       3.0 * 0.99, -1.0 * 0.99, 2.0,
+          -2.0, 0.97 * 0.99, 0.5 * 0.99});
+
+  // Don't limit (0,1,2) permutations to verify we stop correctly
+  helper({0.0,   10.0,  2.0,  3.0,   80.0, 5.0, 60.0,  3.0, 3.0,
+          9.0,   100.0, 11.0, 120.0, 11.8, 2.0, -15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,   2.5, 0.0},
+         {0.0,   1.0,   50.0,  30.0,  40.0,  2.0, 6.0,  7.0, 3.0,
+          9.0,   100.0, -11.0, 120.0, -13.0, 3.0, 15.0, 3.0, 4.1,
+          180.0, -19.0, 3.0,   -21.0, 3.0,   4.1, 3.0,  4.1, 0.0},
+         {0.0,  1.0,   20.0, 3.0,   44.0,  4.0, 60.0,  -7.0,  3.0,
+          90.0, 100.0, 10.0, 120.0, -13.0, 3.0, -15.0, -1.03, 4.1,
+          18.0, 19.0,  3.0,  21.0,  3.0,   4.1, 3.0,   4.1,   0.0},
+
+         {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+          9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+          18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+
+         {0.0,    -10.0,  2.0,  3.0,    -4.0, 5.0,     -60.0, 11.0,    -5.0,
+          9.0,    -100.0, 11.0, -120.0, 13.8, -5.0,    150.0, -8.0,    1.0e-18,
+          -180.0, 49.0,   -5.0, 210.0,  -5.0, 1.0e-18, -5.0,  1.0e-18, 0.0},
+         {0.0,    1.0,   -8.0, -30.0,  -40.0, 8.0,     6.0,  7.0,     -5.0,
+          9.0,    -10.0, 11.5, -120.0, 130.0, -5.0,    15.0, -5.0,    1.0e-18,
+          -180.0, 190.0, -8.0, 43.0,   -5.0,  1.0e-18, -5.0, 1.0e-18, 0.0},
+         {0.0,   1.0,    -20.0, 3.0,    -44.0, 8.0,     -60.0, 8.0,     -5.0,
+          -90.0, -100.0, 28.0,  -120.0, 14.0,  -5.0,    31.0,  -5.0,    1.0e-18,
+          18.0,  19.0,   -5.0,  21.0,   -5.0,  1.0e-18, -5.0,  1.0e-18, 0.0},
+
+         {0.0,  1.0,         2.0,         3.0,  4.0,         5.0,
+          6.0,  7.0,         -2.0,        9.0,  10.0,        11.0,
+          12.0, 13.0,        -0.5 * 0.99, 15.0, -1.0 * 0.99, 2.0,
+          18.0, 19.0,        -0.99,       21.0, -1.0 * 0.99, 2.0,
+          -2.0, 0.97 * 0.99, 0.5 * 0.99});
+}
+
+void test_limiting_different_values_different_tensors() noexcept {
+  INFO("Testing different values for each tensor component");
+  constexpr size_t dim = 3;
+  const size_t order = 2;  // Use only 3 coefficients because more is tedious...
+  const Mesh<dim> mesh(order + 1, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
+  const size_t num_pts = mesh.number_of_grid_points();
+  const auto x = logical_coordinates(mesh);
+  using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
+  // Use non-unity (because that's the default) but close alpha values to make
+  // the math easier but still test thoroughly.
+  Limiter krivodonova{
+      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
+          0.99)};
+
+  NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
+
+  const Element<dim> element(ElementId<dim>{0}, {});
+  // We don't care about the ElementId for these tests, just the direction.
+  Limiter::PackagedData& package_data_up_xi = neighbor_data[std::make_pair(
+      Direction<dim>::upper_xi(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_xi = neighbor_data[std::make_pair(
+      Direction<dim>::lower_xi(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_up_eta = neighbor_data[std::make_pair(
+      Direction<dim>::upper_eta(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_eta = neighbor_data[std::make_pair(
+      Direction<dim>::lower_eta(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_up_zeta = neighbor_data[std::make_pair(
+      Direction<dim>::upper_zeta(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_zeta = neighbor_data[std::make_pair(
+      Direction<dim>::lower_zeta(), ElementId<dim>{0})];
+
+  package_data_up_xi.modal_volume_data.initialize(num_pts);
+  package_data_up_xi.mesh = mesh;
+  package_data_lo_xi.modal_volume_data.initialize(num_pts);
+  package_data_lo_xi.mesh = mesh;
+  package_data_up_eta.modal_volume_data.initialize(num_pts);
+  package_data_up_eta.mesh = mesh;
+  package_data_lo_eta.modal_volume_data.initialize(num_pts);
+  package_data_lo_eta.mesh = mesh;
+  package_data_up_zeta.modal_volume_data.initialize(num_pts);
+  package_data_up_zeta.mesh = mesh;
+  package_data_lo_zeta.modal_volume_data.initialize(num_pts);
+  package_data_lo_zeta.mesh = mesh;
+
+  Scalar<DataVector> nodal_scalar_data_to_limit(num_pts, 0.0);
+  tnsr::I<DataVector, dim> nodal_vector_data_to_limit(num_pts, 0.0);
+  Scalar<DataVector> nodal_scalar_expected(num_pts, 0.0);
+  tnsr::I<DataVector, dim> nodal_vector_expected(num_pts, 0.0);
+
+  // Limit (2,2,1) because +(1,2,1)
+  to_nodal_coefficients(&get(nodal_scalar_data_to_limit),
+                        {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+                         9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+                         18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+                        mesh);
+  get(get<::Tags::Modal<ScalarTag<0>>>(package_data_up_xi.modal_volume_data)) =
+      ModalVector{0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,  3.0,  3.0,
+                  9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0, -1.1, 4.1,
+                  18.0, -19.0, 3.0,  21.0, 3.0,  4.1, 3.0,  2.5,  0.0};
+  get(get<::Tags::Modal<ScalarTag<0>>>(package_data_lo_xi.modal_volume_data)) =
+      ModalVector{0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+                  9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+                  18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  get(get<::Tags::Modal<ScalarTag<0>>>(package_data_up_eta.modal_volume_data)) =
+      ModalVector{0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+                  9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+                  18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0};
+  get(get<::Tags::Modal<ScalarTag<0>>>(package_data_lo_eta.modal_volume_data)) =
+      ModalVector{0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+                  9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+                  18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  get(get<::Tags::Modal<ScalarTag<0>>>(
+      package_data_up_zeta.modal_volume_data)) =
+      ModalVector{0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+                  9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+                  18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0};
+  get(get<::Tags::Modal<ScalarTag<0>>>(
+      package_data_lo_zeta.modal_volume_data)) =
+      ModalVector{0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+                  9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+                  18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  to_nodal_coefficients(
+      &get(nodal_scalar_expected),
+      {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+       9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 0.9 * 0.99,
+       18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  0.5 * 0.99},
+      mesh);
+
+  // Limit (2,1,2) because +(1,1,2)
+  to_nodal_coefficients(&nodal_vector_data_to_limit.get(0),
+                        {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+                         9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+                         18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+                        mesh);
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_xi.modal_volume_data)
+      .get(0) =
+      ModalVector{0.0,  1.0,   2.0,  3.0,  4.0,   5.0, 6.0,  3.0, 3.0,
+                  9.0,  10.0,  11.0, 12.0, 13.0,  2.0, 15.0, 3.0, 4.1,
+                  18.0, -19.0, 3.0,  21.0, -1.15, 4.1, 3.0,  2.5, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_xi.modal_volume_data)
+      .get(0) =
+      ModalVector{0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+                  9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+                  18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_eta.modal_volume_data)
+      .get(0) = ModalVector{0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+                            9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+                            18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_eta.modal_volume_data)
+      .get(0) =
+      ModalVector{0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+                  9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+                  18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_zeta.modal_volume_data)
+      .get(0) =
+      ModalVector{0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+                  9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+                  18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_zeta.modal_volume_data)
+      .get(0) =
+      ModalVector{0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+                  9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+                  18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  to_nodal_coefficients(
+      &nodal_vector_expected.get(0),
+      {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,         6.0,  7.0,  -2.0,
+       9.0,  10.0, 11.0, 12.0, 13.0, -2.0,        15.0, -2.0, 2.0,
+       18.0, 19.0, -2.0, 21.0, -2.0, 0.85 * 0.99, -2.0, 2.0,  0.5 * 0.99},
+      mesh);
+
+  // Limit (1,2,2) because +(0,2,2)
+  to_nodal_coefficients(&nodal_vector_data_to_limit.get(1),
+                        {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+                         9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+                         18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+                        mesh);
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_xi.modal_volume_data)
+      .get(1) =
+      ModalVector{0.0,  1.0,   2.0,  3.0,  4.0,  5.0, 6.0,   3.0, 3.0,
+                  9.0,  10.0,  11.0, 12.0, 13.0, 2.0, 15.0,  3.0, 4.1,
+                  18.0, -19.0, 3.0,  21.0, 3.0,  4.1, -0.64, 2.5, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_xi.modal_volume_data)
+      .get(1) =
+      ModalVector{0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  11.0,    -5.0,
+                  9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -8.0,    1.0e-18,
+                  18.0, 49.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_eta.modal_volume_data)
+      .get(1) = ModalVector{0.0,  1.0,  2.0,  3.0,   4.0,  2.0, 6.0,  7.0, 3.0,
+                            9.0,  10.0, 11.0, 12.0,  13.0, 3.0, 15.0, 3.0, 4.1,
+                            18.0, 19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,  4.1, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_eta.modal_volume_data)
+      .get(1) =
+      ModalVector{0.0,  1.0,  2.0,  3.0,  4.0,  8.0,     6.0,  7.0,     -5.0,
+                  9.0,  10.0, 11.0, 12.0, 13.0, -5.0,    15.0, -5.0,    1.0e-18,
+                  18.0, 19.0, -5.0, 43.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_zeta.modal_volume_data)
+      .get(1) =
+      ModalVector{0.0,  1.0,  2.0,   3.0,  4.0,  5.0, 6.0,   7.0, 3.0,
+                  9.0,  10.0, -11.0, 12.0, 13.0, 3.0, -15.0, 3.0, 4.1,
+                  18.0, 19.0, 3.0,   21.0, 3.0,  4.1, 3.0,   4.1, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_zeta.modal_volume_data)
+      .get(1) =
+      ModalVector{0.0,  1.0,  2.0,  3.0,  4.0,  5.0,     6.0,  7.0,     -5.0,
+                  9.0,  10.0, 28.0, 12.0, 13.0, -5.0,    31.0, -5.0,    1.0e-18,
+                  18.0, 19.0, -5.0, 21.0, -5.0, 1.0e-18, -5.0, 1.0e-18, 0.0};
+  to_nodal_coefficients(
+      &nodal_vector_expected.get(1),
+      {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,         -2.0,
+       9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0,        2.0,
+       18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 1.36 * 0.99, 0.5 * 0.99},
+      mesh);
+
+  // Limit (2,1,0) because -(2,0,0)
+  to_nodal_coefficients(&nodal_vector_data_to_limit.get(2),
+                        {0.0,  1.0,  2.0,  3.0,  4.0,  5.0,  6.0,  7.0,  -2.0,
+                         9.0,  10.0, 11.0, 12.0, 13.0, -2.0, 15.0, -2.0, 2.0,
+                         18.0, 19.0, -2.0, 21.0, -2.0, 2.0,  -2.0, 2.0,  1.0},
+                        mesh);
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_xi.modal_volume_data)
+      .get(2) =
+      ModalVector{0.0,   10.0,  2.0,  3.0,   8.0,  5.0, 60.0,  3.0, 3.0,
+                  9.0,   100.0, 11.0, 120.0, 11.8, 2.0, -15.0, 3.0, 4.1,
+                  180.0, -19.0, 3.0,  -21.0, 3.0,  4.1, 3.0,   2.5, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_xi.modal_volume_data)
+      .get(2) = ModalVector{
+      0.0,    -10.0,  2.0,  3.0,    -4.0, 5.0,     -60.0, 11.0,    -5.0,
+      9.0,    -100.0, 11.0, -120.0, 13.8, -5.0,    150.0, -8.0,    1.0e-18,
+      -180.0, 49.0,   -5.0, 210.0,  -5.0, 1.0e-18, -5.0,  1.0e-18, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_eta.modal_volume_data)
+      .get(2) =
+      ModalVector{0.0,   1.0,   5.0,   30.0,  40.0,  2.0, 6.0,  7.0, 3.0,
+                  9.0,   100.0, -11.0, 120.0, -13.0, 3.0, 15.0, 3.0, 4.1,
+                  180.0, -19.0, 3.0,   -21.0, 3.0,   4.1, 3.0,  4.1, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_eta.modal_volume_data)
+      .get(2) = ModalVector{
+      0.0,    1.0,   1.5,  -30.0,  -40.0, 8.0,     6.0,  7.0,     -5.0,
+      9.0,    -10.0, 11.5, -120.0, 130.0, -5.0,    15.0, -5.0,    1.0e-18,
+      -180.0, 190.0, -5.0, 43.0,   -5.0,  1.0e-18, -5.0, 1.0e-18, 0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_up_zeta.modal_volume_data)
+      .get(2) =
+      ModalVector{0.0,  1.0,   20.0, 3.0,   44.0,  4.0, 60.0,  -7.0,  3.0,
+                  90.0, 100.0, 10.0, 120.0, -13.0, 3.0, -15.0, -1.03, 4.1,
+                  18.0, 19.0,  3.0,  21.0,  3.0,   4.1, 3.0,   4.1,   0.0};
+  get<::Tags::Modal<VectorTag<dim, 0>>>(package_data_lo_zeta.modal_volume_data)
+      .get(2) = ModalVector{
+      0.0,   1.0,    -20.0, 3.0,    -44.0, 8.0,     -60.0, 8.0,     -5.0,
+      -90.0, -100.0, 28.0,  -120.0, 14.0,  -5.0,    31.0,  -5.0,    1.0e-18,
+      18.0,  19.0,   -5.0,  21.0,   -5.0,  1.0e-18, -5.0,  1.0e-18, 0.0};
+  to_nodal_coefficients(
+      &nodal_vector_expected.get(2),
+      {0.0,  1.0,         2.0,         3.0,  4.0,         0.5 * 0.99,
+       6.0,  7.0,         -2.0,        9.0,  10.0,        11.0,
+       12.0, 13.0,        -0.5 * 0.99, 15.0, -1.0 * 0.99, 2.0,
+       18.0, 19.0,        -0.99,       21.0, -1.0 * 0.99, 2.0,
+       -2.0, 0.97 * 0.99, 0.5 * 0.99},
+      mesh);
+
+  krivodonova(&nodal_scalar_data_to_limit, &nodal_vector_data_to_limit, element,
+              mesh, neighbor_data);
+  CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit),
+                        get(nodal_scalar_expected));
+  for (size_t i = 0; i < dim; ++i) {
+    CAPTURE(i);
+    CHECK_ITERABLE_APPROX(nodal_vector_data_to_limit.get(i),
+                          nodal_vector_expected.get(i));
+  }
+}
+
+void run() noexcept {
+  INFO("Testing 3d limiter");
+  test_package_data();
+
+  INFO("Testing applying limiter to coefficients");
+  constexpr size_t dim = 3;
+  const size_t order = 2;  // Use only 3 coefficients because more is tedious...
+  const Mesh<dim> mesh(order + 1, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto);
+  const size_t num_pts = mesh.number_of_grid_points();
+  using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
+  // Use non-unity (because that's the default) but close alpha values to make
+  // the math easier but still test thoroughly.
+  Limiter krivodonova{
+      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
+          0.99)};
+
+  NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
+
+  const Element<dim> element(ElementId<dim>{0}, {});
+  // We don't care about the ElementId for these tests, just the direction.
+  Limiter::PackagedData& package_data_up_xi = neighbor_data[std::make_pair(
+      Direction<dim>::upper_xi(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_xi = neighbor_data[std::make_pair(
+      Direction<dim>::lower_xi(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_up_eta = neighbor_data[std::make_pair(
+      Direction<dim>::upper_eta(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_eta = neighbor_data[std::make_pair(
+      Direction<dim>::lower_eta(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_up_zeta = neighbor_data[std::make_pair(
+      Direction<dim>::upper_zeta(), ElementId<dim>{0})];
+  Limiter::PackagedData& package_data_lo_zeta = neighbor_data[std::make_pair(
+      Direction<dim>::lower_zeta(), ElementId<dim>{0})];
+
+  package_data_up_xi.modal_volume_data.initialize(num_pts);
+  package_data_up_xi.mesh = mesh;
+  package_data_lo_xi.modal_volume_data.initialize(num_pts);
+  package_data_lo_xi.mesh = mesh;
+  package_data_up_eta.modal_volume_data.initialize(num_pts);
+  package_data_up_eta.mesh = mesh;
+  package_data_lo_eta.modal_volume_data.initialize(num_pts);
+  package_data_lo_eta.mesh = mesh;
+  package_data_up_zeta.modal_volume_data.initialize(num_pts);
+  package_data_up_zeta.mesh = mesh;
+  package_data_lo_zeta.modal_volume_data.initialize(num_pts);
+  package_data_lo_zeta.mesh = mesh;
+
+  Scalar<DataVector> nodal_scalar_data_to_limit(num_pts, 0.0);
+  tnsr::I<DataVector, dim> nodal_vector_data_to_limit(num_pts, 0.0);
+  DataVector expected(num_pts);
+  const auto helper =
+      [
+        &element, &expected, &krivodonova, &mesh, &neighbor_data,
+        &package_data_lo_xi, &package_data_up_xi, &package_data_lo_eta,
+        &package_data_up_eta, &package_data_lo_zeta, &package_data_up_zeta,
+        &nodal_scalar_data_to_limit, &nodal_vector_data_to_limit
+      ](const ModalVector& up_xi_coeffs, const ModalVector& up_eta_coeffs,
+        const ModalVector& up_zeta_coeffs, const ModalVector& initial_coeffs,
+        const ModalVector& lo_xi_coeffs, const ModalVector& lo_eta_coeffs,
+        const ModalVector& lo_zeta_coeffs,
+        const ModalVector& expected_coeffs) noexcept {
+    to_nodal_coefficients(&get(nodal_scalar_data_to_limit), initial_coeffs,
+                          mesh);
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_up_xi.modal_volume_data)) = up_xi_coeffs;
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_lo_xi.modal_volume_data)) = lo_xi_coeffs;
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_up_eta.modal_volume_data)) = up_eta_coeffs;
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_lo_eta.modal_volume_data)) = lo_eta_coeffs;
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_up_zeta.modal_volume_data)) = up_zeta_coeffs;
+    get(get<::Tags::Modal<ScalarTag<0>>>(
+        package_data_lo_zeta.modal_volume_data)) = lo_zeta_coeffs;
+
+    for (size_t i = 0; i < dim; ++i) {
+      to_nodal_coefficients(&nodal_vector_data_to_limit.get(i), initial_coeffs,
+                            mesh);
+      get<::Tags::Modal<VectorTag<dim, 0>>>(
+          package_data_up_xi.modal_volume_data)
+          .get(i) = up_xi_coeffs;
+      get<::Tags::Modal<VectorTag<dim, 0>>>(
+          package_data_lo_xi.modal_volume_data)
+          .get(i) = lo_xi_coeffs;
+      get<::Tags::Modal<VectorTag<dim, 0>>>(
+          package_data_up_eta.modal_volume_data)
+          .get(i) = up_eta_coeffs;
+      get<::Tags::Modal<VectorTag<dim, 0>>>(
+          package_data_lo_eta.modal_volume_data)
+          .get(i) = lo_eta_coeffs;
+      get<::Tags::Modal<VectorTag<dim, 0>>>(
+          package_data_up_zeta.modal_volume_data)
+          .get(i) = up_zeta_coeffs;
+      get<::Tags::Modal<VectorTag<dim, 0>>>(
+          package_data_lo_zeta.modal_volume_data)
+          .get(i) = lo_zeta_coeffs;
+    }
+
+    krivodonova(&nodal_scalar_data_to_limit, &nodal_vector_data_to_limit,
+                element, mesh, neighbor_data);
+    to_nodal_coefficients(&expected, expected_coeffs, mesh);
+    CHECK_ITERABLE_APPROX(get(nodal_scalar_data_to_limit), expected);
+    for (size_t i = 0; i < dim; ++i) {
+      CHECK_ITERABLE_APPROX(nodal_vector_data_to_limit.get(i), expected);
+    }
+  };
+
+  // Map between 3D and 1D coefficients:
+  // [(0,0,0), (1,0,0), (2,0,0), (0,1,0), (1,1,0), (2,1,0), (0,2,0), (1,2,0),
+  //  (0,       1,       2,       3,       4,       5,       6,       7,
+  //
+  //  (2,2,0), (0,0,1), (1,0,1), (2,0,1), (0,1,1), (1,1,1), (2,1,1), (0,2,1),
+  //   8,       9,       10,      11,      12,      13,      14,      15,
+  //
+  //  (1,2,1), (2,2,1), (0,0,2), (1,0,2), (2,0,2), (0,1,2), (1,1,2), (2,1,2),
+  //   16,      17,      18,      19,      20,      21,      22,      23,
+  //
+  //  (0,2,2), (1,2,2), (2,2,2)]
+  //   24,      25,      26)
+
+  test_limiting_2_2_2_coefficient(helper);
+  test_limiting_2_2_1_coefficient(helper);
+  test_limiting_2_1_2_coefficient(helper);
+  test_limiting_1_2_2_coefficient(helper);
+  test_limiting_0_1_2_coefficient_permutations(helper);
+
+  test_limiting_different_values_different_tensors();
+}
+}  // namespace test_3d
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.Krivodonova",
+                  "[SlopeLimiters][Unit]") {
+  test_1d::run();
+  test_2d::run();
+  test_3d::run();
+}
+}  // namespace SlopeLimiters

--- a/tools/Hooks/CheckFileSize.py
+++ b/tools/Hooks/CheckFileSize.py
@@ -8,10 +8,11 @@ import sys
 import os
 
 # The maximum file-size for a file to be committed in kB
-max_file_size = 130.0
+max_file_size = 200.0
 
 # The path to the git-binary:
 git_executable = "@GIT_EXECUTABLE@"
+
 
 def sizeof_fmt(num):
     """
@@ -19,10 +20,11 @@ def sizeof_fmt(num):
     like "3.5 MB" for its given 'num'-parameter.
     From http://stackoverflow.com/questions/1094841
     """
-    for x in ['bytes','KB','MB','GB','TB']:
+    for x in ['bytes', 'KB', 'MB', 'GB', 'TB']:
         if num < 1024.0:
             return "%3.1f %s" % (num, x)
         num /= 1024.0
+
 
 # Check all files in the staging-area:
 text = subprocess.check_output(
@@ -35,9 +37,10 @@ for file_s in file_list:
     if not os.path.isfile(file_s[3:]):
         continue
     stat = os.stat(file_s[3:])
-    if stat.st_size > (max_file_size*1024):
-        print("File '"+file_s[3:]+"' is too large to be committed. The file "
-                                  "is %s and the limit is %s" %
+    if stat.st_size > (max_file_size * 1024):
+        print("File '" + file_s[3:] +
+              "' is too large to be committed. The file "
+              "is %s and the limit is %s" %
               (sizeof_fmt(stat.st_size), sizeof_fmt(max_file_size * 1024)))
         sys.exit(1)
 


### PR DESCRIPTION
## Proposed changes

**Note:** Only the last commit is new "Add Krivodonova Limiter"

Adds the hierarchical limiter of Krivodonova.

Depends on:
- [x] #1337 
- [x] #1352 in the sense that it assumes #1352 will be merged first, but I've added a fixup commit that can be squashed in to get around this.
- [x] #1376 (loosely)
- [x] #1377 
- [x] #1380 

Commit order:
- Add ModalTag prefix tag
- Add function to get collapsed index from Index
- Factor Mesh tests
- Add function to compute collapsed index in Mesh
- Add Krivodonova limiter
- add_krivodonova_limiter fixup: Add Krivodonova limiter

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
