### PR TITLE
Minor cleanups in Domain

### DIFF
--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -33,6 +33,8 @@ using EquatorialCompression = CoordinateMaps::EquatorialCompression;
 using Wedge2D = CoordinateMaps::Wedge2D;
 using Wedge3D = CoordinateMaps::Wedge3D;
 using Wedge3DPrism = CoordinateMaps::ProductOf2Maps<Wedge2D, Affine>;
+using Identity2D = CoordinateMaps::Identity<2>;
+using Translation3D = CoordinateMaps::ProductOf2Maps<Affine, Identity2D>;
 
 template <size_t Dim>
 void register_with_charm();
@@ -79,6 +81,9 @@ void register_with_charm<3>() {
                                          Wedge3D, EquatorialCompression>));
   PUPable_reg(SINGLE_ARG(
       ::CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3DPrism>));
+  PUPable_reg(
+      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3D,
+                                 EquatorialCompression, Translation3D>));
 }
 }  // namespace DomainCreators_detail
 

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -57,9 +57,9 @@ void test_brick_construction(
 
   test_initial_domain(domain, brick.initial_refinement_levels());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Brick", "[Domain][Unit]") {
+void test_brick() {
+  INFO("Brick");
   const std::vector<std::array<size_t, 3>> grid_points{{{4, 6, 3}}},
       refinement_level{{{3, 2, 4}}};
   const std::array<double, 3> lower_bound{{-1.2, 3.0, 2.5}},
@@ -197,7 +197,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Brick", "[Domain][Unit]") {
                  *serialize_and_deserialize(base_map));
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Brick.Factory", "[Domain][Unit]") {
+void test_brick_factory() {
+  INFO("Brick factory");
   const auto domain_creator =
       test_factory_creation<DomainCreator<3, Frame::Inertial>>(
           "  Brick:\n"
@@ -219,4 +220,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Brick.Factory", "[Domain][Unit]") {
            {Direction<3>::upper_zeta(), {0, {}}}}},
       std::vector<std::unordered_set<Direction<3>>>{
           {{Direction<3>::lower_eta()}, {Direction<3>::upper_eta()}}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.Brick", "[Domain][Unit]") {
+  test_brick();
+  test_brick_factory();
 }

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -187,10 +187,9 @@ void test_cylinder_construction(
 
   test_initial_domain(domain, cylinder.initial_refinement_levels());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder.Boundaries.Equiangular",
-                  "[Domain][Unit]") {
+void test_cylinder_boundaries_equiangular() {
+  INFO("Cylinder boundaries equiangular");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const double lower_bound = -2.5, upper_bound = 5.0;
   const size_t refinement_level = 2;
@@ -205,8 +204,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder.Boundaries.Equiangular",
                              {5, make_array<3>(refinement_level)}, true);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder.Factory.Equiangular",
-                  "[Domain][Unit]") {
+void test_cylinder_factory_equiangular() {
+  INFO("Cylinder factory equiangular");
   const auto cylinder =
       test_factory_creation<DomainCreator<3, Frame::Inertial>>(
           "  Cylinder:\n"
@@ -229,8 +228,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder.Factory.Equiangular",
       {5, make_array<3>(refinement_level)}, true);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder.Boundaries.Equidistant",
-                  "[Domain][Unit]") {
+void test_cylinder_boundaries_equidistant() {
+  INFO("Cylinder boundaries equidistant");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const double lower_bound = -2.5, upper_bound = 5.0;
   const size_t refinement_level = 2;
@@ -245,8 +244,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder.Boundaries.Equidistant",
                              {5, make_array<3>(refinement_level)}, false);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder.Factory.Equidistant",
-                  "[Domain][Unit]") {
+void test_cylinder_factory_equidistant() {
+  INFO("Cylinder factory equidistant");
   const auto cylinder =
       test_factory_creation<DomainCreator<3, Frame::Inertial>>(
           "  Cylinder:\n"
@@ -269,9 +268,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder.Factory.Equidistant",
       {5, make_array<3>(refinement_level)}, false);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.Creators.Cylinder.Boundaries.Equiangular.NotPeriodicInZ",
-    "[Domain][Unit]") {
+void test_cylinder_boundaries_equiangular_not_periodic_in_z() {
+  INFO("Cylinder boundaries equiangular not periodic in z");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const double lower_bound = -2.5, upper_bound = 5.0;
   const size_t refinement_level = 2;
@@ -286,9 +284,8 @@ SPECTRE_TEST_CASE(
                              {5, make_array<3>(refinement_level)}, true);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.Creators.Cylinder.Factory.Equiangular.NotPeriodicInZ",
-    "[Domain][Unit]") {
+void test_cylinder_factory_equiangular_not_periodic_in_z() {
+  INFO("Cylinder factory equiangular not periodic in z");
   const auto cylinder =
       test_factory_creation<DomainCreator<3, Frame::Inertial>>(
           "  Cylinder:\n"
@@ -312,9 +309,8 @@ SPECTRE_TEST_CASE(
       {5, make_array<3>(refinement_level)}, true);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.Creators.Cylinder.Boundaries.Equidistant.NotPeriodicInZ",
-    "[Domain][Unit]") {
+void test_cylinder_boundaries_equidistant_not_periodic_in_z() {
+  INFO("Cylinder boundaries equidistant not periodic in z");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const double lower_bound = -2.5, upper_bound = 5.0;
   const size_t refinement_level = 2;
@@ -329,9 +325,8 @@ SPECTRE_TEST_CASE(
                              {5, make_array<3>(refinement_level)}, false);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.Creators.Cylinder.Factory.Equidistant.NotPeriodicInZ",
-    "[Domain][Unit]") {
+void test_cylinder_factory_equidistant_not_periodic_in_z() {
+  INFO("Cylinder factory equidistant not periodic in z");
   const auto cylinder =
       test_factory_creation<DomainCreator<3, Frame::Inertial>>(
           "  Cylinder:\n"
@@ -353,4 +348,16 @@ SPECTRE_TEST_CASE(
           *cylinder),
       inner_radius, outer_radius, lower_bound, upper_bound, false, grid_points,
       {5, make_array<3>(refinement_level)}, false);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder", "[Domain][Unit]") {
+  test_cylinder_boundaries_equiangular();
+  test_cylinder_factory_equiangular();
+  test_cylinder_boundaries_equidistant();
+  test_cylinder_factory_equidistant();
+  test_cylinder_boundaries_equiangular_not_periodic_in_z();
+  test_cylinder_factory_equiangular_not_periodic_in_z();
+  test_cylinder_boundaries_equidistant_not_periodic_in_z();
+  test_cylinder_factory_equidistant_not_periodic_in_z();
 }

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -124,10 +124,9 @@ void test_disk_construction(
 
   test_initial_domain(domain, disk.initial_refinement_levels());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Boundaries.Equiangular",
-                  "[Domain][Unit]") {
+void test_disk_boundaries_equiangular() {
+  INFO("Disk boundaries equiangular");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points{{4, 4}};
@@ -139,8 +138,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Boundaries.Equiangular",
                          {5, make_array<2>(refinement_level)}, true);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Factory.Equiangular",
-                  "[Domain][Unit]") {
+void test_disk_factory_equiangular() {
+  INFO("Disk factory equiangular");
   const auto disk = test_factory_creation<DomainCreator<2, Frame::Inertial>>(
       "  Disk:\n"
       "    InnerRadius: 1\n"
@@ -158,8 +157,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Factory.Equiangular",
       {5, make_array<2>(refinement_level)}, true);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Boundaries.Equidistant",
-                  "[Domain][Unit]") {
+void test_disk_boundaries_equidistant() {
+  INFO("Disk boundaries equidistant");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points{{4, 4}};
@@ -171,8 +170,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Boundaries.Equidistant",
                          {5, make_array<2>(refinement_level)}, false);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Factory.Equidistant",
-                  "[Domain][Unit]") {
+void test_disk_factory_equidistant() {
+  INFO("Disk factory equidistant");
   const auto disk = test_factory_creation<DomainCreator<2, Frame::Inertial>>(
       "  Disk:\n"
       "    InnerRadius: 1\n"
@@ -188,4 +187,13 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Factory.Equidistant",
       dynamic_cast<const domain::creators::Disk<Frame::Inertial>&>(*disk),
       inner_radius, outer_radius, grid_points,
       {5, make_array<2>(refinement_level)}, false);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Factory.Equidistant",
+                  "[Domain][Unit]") {
+  test_disk_boundaries_equiangular();
+  test_disk_factory_equiangular();
+  test_disk_boundaries_equidistant();
+  test_disk_factory_equidistant();
 }

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -50,9 +50,9 @@ void test_interval_construction(
           CoordinateMaps::Affine{-1., 1., lower_bound[0], upper_bound[0]})));
   test_initial_domain(domain, interval.initial_refinement_levels());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Interval", "[Domain][Unit]") {
+void test_interval() {
+  INFO("Interval");
   const std::vector<std::array<size_t, 1>> grid_points{{{4}}},
       refinement_level{{{3}}};
   const std::array<double, 1> lower_bound{{-1.2}}, upper_bound{{0.8}};
@@ -94,7 +94,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Interval", "[Domain][Unit]") {
   CHECK(*dynamic_cast<MapType>(base_map.get()) == coord_map);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Interval.Factory", "[Domain][Unit]") {
+void test_interval_factory() {
+  INFO("Interval factory");
   const auto domain_creator =
       test_factory_creation<DomainCreator<1, Frame::Inertial>>(
           "  Interval:\n"
@@ -112,4 +113,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Interval.Factory", "[Domain][Unit]") {
                                  {{Direction<1>::lower_xi(), {0, {}}},
                                   {Direction<1>::upper_xi(), {0, {}}}}},
                              std::vector<std::unordered_set<Direction<1>>>{{}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.Interval.Factory", "[Domain][Unit]") {
+  test_interval();
+  test_interval_factory();
 }

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -54,9 +54,9 @@ void test_rectangle_construction(
                    Affine{-1., 1., lower_bound[1], upper_bound[1]}})));
   test_initial_domain(domain, rectangle.initial_refinement_levels());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Rectangle", "[Domain][Unit]") {
+void test_rectangle() {
+  INFO("Rectangle");
   const std::vector<std::array<size_t, 2>> grid_points{{{4, 6}}},
       refinement_level{{{3, 2}}};
   const std::array<double, 2> lower_bound{{-1.2, 3.0}}, upper_bound{{0.8, 5.0}};
@@ -129,7 +129,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Rectangle", "[Domain][Unit]") {
   CHECK(*dynamic_cast<MapType>(base_map.get()) == coord_map);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Rectangle.Factory", "[Domain][Unit]") {
+void test_rectangle_factory() {
+  INFO("Rectangle factory");
   const auto domain_creator =
       test_factory_creation<DomainCreator<2, Frame::Inertial>>(
           "  Rectangle:\n"
@@ -148,4 +149,10 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Rectangle.Factory", "[Domain][Unit]") {
            {Direction<2>::upper_xi(), {0, {}}}}},
       std::vector<std::unordered_set<Direction<2>>>{
           {{Direction<2>::lower_eta()}, {Direction<2>::upper_eta()}}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.Rectangle.Factory", "[Domain][Unit]") {
+  test_rectangle();
+  test_rectangle_factory();
 }

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -106,9 +106,9 @@ void test_rotated_bricks_construction(
                            expected_external_boundaries, coord_maps);
   test_initial_domain(domain, rotated_bricks.initial_refinement_levels());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedBricks", "[Domain][Unit]") {
+void test_rotated_bricks() {
+  INFO("Rotated bricks");
   const std::vector<std::array<size_t, 3>> grid_points{
       {{4, 2, 5}}, {{5, 2, 1}}, {{4, 5, 3}}, {{3, 5, 1}},
       {{2, 4, 6}}, {{6, 1, 2}}, {{3, 6, 4}}, {{1, 3, 6}}},
@@ -255,8 +255,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedBricks", "[Domain][Unit]") {
           {}, {}, {}, {}, {}, {}, {}, {}});
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedBricks.Factory",
-                  "[Domain][Unit]") {
+void test_rotated_bricks_factory() {
+  INFO("Rotated bricks factory");
   const OrientationMap<3> aligned{};
   const OrientationMap<3> rotation_F{std::array<Direction<3>, 3>{
       {Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
@@ -346,4 +346,11 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedBricks.Factory",
            Direction<3>::lower_zeta()},
           {Direction<3>::upper_xi(), Direction<3>::upper_eta(),
            Direction<3>::upper_zeta()}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedBricks.Factory",
+                  "[Domain][Unit]") {
+  test_rotated_bricks();
+  test_rotated_bricks_factory();
 }

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -58,9 +58,9 @@ void test_rotated_intervals_construction(
               CoordinateMaps::Affine{-1., 1., midpoint[0], upper_bound[0]})));
   test_initial_domain(domain, rotated_intervals.initial_refinement_levels());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedIntervals", "[Domain][Unit]") {
+void test_rotated_intervals() {
+  INFO("Rotated intervals");
   const std::vector<std::array<size_t, 1>> grid_points{{{4}}, {{2}}},
       refinement_level{{{0}}, {{0}}};
   const std::array<double, 1> lower_bound{{-1.2}}, midpoint{{-0.6}},
@@ -98,8 +98,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedIntervals", "[Domain][Unit]") {
       std::vector<std::unordered_set<Direction<1>>>{{}, {}});
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedIntervals.Factory",
-                  "[Domain][Unit]") {
+void test_rotated_intervals_factory() {
+  INFO("Rotated intervals factory");
   const OrientationMap<1> flipped{
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
   const auto domain_creator =
@@ -123,4 +123,11 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedIntervals.Factory",
           {{Direction<1>::lower_xi(), {0, flipped}},
            {Direction<1>::upper_xi(), {0, flipped}}}},
       std::vector<std::unordered_set<Direction<1>>>{{}, {}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedIntervals.Factory",
+                  "[Domain][Unit]") {
+  test_rotated_intervals();
+  test_rotated_intervals_factory();
 }

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -79,9 +79,9 @@ void test_rotated_rectangles_construction(
                            expected_external_boundaries, coord_maps);
   test_initial_domain(domain, rotated_rectangles.initial_refinement_levels());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedRectangles", "[Domain][Unit]") {
+void test_rotated_rectangles() {
+  INFO("Rotated rectangles");
   const std::vector<std::array<size_t, 2>> grid_points{
       {{4, 2}}, {{1, 2}}, {{3, 4}}, {{3, 1}}},
       refinement_level{{{0, 1}}, {{0, 1}}, {{1, 0}}, {{1, 0}}};
@@ -153,8 +153,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedRectangles", "[Domain][Unit]") {
       std::vector<std::unordered_set<Direction<2>>>{{}, {}, {}, {}});
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedRectangles.Factory",
-                  "[Domain][Unit]") {
+void test_rotated_rectangles_factory() {
+  INFO("Rotated rectangles factory");
   const OrientationMap<2> half_turn{std::array<Direction<2>, 2>{
       {Direction<2>::lower_xi(), Direction<2>::lower_eta()}}};
   const OrientationMap<2> quarter_turn_cw{std::array<Direction<2>, 2>{
@@ -192,4 +192,11 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedRectangles.Factory",
           {Direction<2>::lower_xi(), Direction<2>::upper_eta()},
           {Direction<2>::upper_xi(), Direction<2>::upper_eta()},
           {Direction<2>::lower_xi(), Direction<2>::upper_eta()}});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedRectangles.Factory",
+                  "[Domain][Unit]") {
+  test_rotated_rectangles();
+  test_rotated_rectangles_factory();
 }

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -251,9 +251,9 @@ void test_shell_construction(
 
   test_initial_domain(domain, shell.initial_refinement_levels());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Boundaries", "[Domain][Unit]") {
+void test_shell_boundaries() {
+  INFO("Shell boundaries");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
@@ -269,8 +269,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Boundaries", "[Domain][Unit]") {
   }
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Factory.Equiangular",
-                  "[Domain][Unit]") {
+void test_shell_factory_equiangular() {
+  INFO("Shell factory equiangular");
   const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
@@ -286,8 +286,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Factory.Equiangular",
       {6, make_array<3>(refinement_level)});
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Factory.Equidistant",
-                  "[Domain][Unit]") {
+void test_shell_factory_equidistant() {
+  INFO("Shell factory equidistant");
   const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
@@ -304,8 +304,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Factory.Equidistant",
       {6, make_array<3>(refinement_level)});
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Boundaries.AspectRatio",
-                  "[Domain][Unit]") {
+void test_shell_boundaries_aspect_ratio() {
+  INFO("Shell boundaries aspect ratio");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
@@ -320,8 +320,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Boundaries.AspectRatio",
                           {6, make_array<3>(refinement_level)}, aspect_ratio);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Factory.AspectRatio",
-                  "[Domain][Unit]") {
+void test_shell_factory_aspect_ratio() {
+  INFO("Shell factory aspect ratio");
   const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
@@ -340,8 +340,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Factory.AspectRatio",
       {6, make_array<3>(refinement_level)}, aspect_ratio);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Boundaries.LogarithmicMap",
-                  "[Domain][Unit]") {
+void test_shell_boundaries_logarithmic_map() {
+  INFO("Shell boundaries logarithmic map");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
@@ -357,8 +357,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Boundaries.LogarithmicMap",
       {6, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Factory.LogarithmicMap",
-                  "[Domain][Unit]") {
+void test_shell_factory_logarithmic_map() {
+  INFO("Shell factory logarithmic map");
   const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
       "  Shell:\n"
       "    InnerRadius: 1\n"
@@ -379,57 +379,56 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Factory.LogarithmicMap",
       {6, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Shell.Factory.ShellWedges",
-                  "[Domain][Unit]") {
-  {
-    const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-        "  Shell:\n"
-        "    InnerRadius: 1\n"
-        "    OuterRadius: 3\n"
-        "    InitialRefinement: 2\n"
-        "    InitialGridPoints: [2,3]\n"
-        "    UseEquiangularMap: false\n"
-        "    AspectRatio: 2.0        \n"
-        "    UseLogarithmicMap: true\n"
-        "    WhichWedges: FourOnEquator\n");
-    const double inner_radius = 1.0, outer_radius = 3.0;
-    const size_t refinement_level = 2;
-    const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
-    const double aspect_ratio = 2.0;
-    const bool use_logarithmic_map = true;
-    const ShellWedges which_wedges = ShellWedges::FourOnEquator;
-    test_shell_construction(
-        dynamic_cast<const domain::creators::Shell<Frame::Inertial>&>(*shell),
-        inner_radius, outer_radius, false, grid_points_r_angular,
-        {4, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map,
-        which_wedges);
-  }
-  {
-    const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-        "  Shell:\n"
-        "    InnerRadius: 2\n"
-        "    OuterRadius: 3\n"
-        "    InitialRefinement: 2\n"
-        "    InitialGridPoints: [2,3]\n"
-        "    UseEquiangularMap: true\n"
-        "    AspectRatio: 2.7        \n"
-        "    UseLogarithmicMap: false\n"
-        "    WhichWedges: OneAlongMinusX \n");
-    const double inner_radius = 2.0, outer_radius = 3.0;
-    const size_t refinement_level = 2;
-    const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
-    const double aspect_ratio = 2.7;
-    const bool use_logarithmic_map = false;
-    const ShellWedges which_wedges = ShellWedges::OneAlongMinusX;
-    test_shell_construction(
-        dynamic_cast<const domain::creators::Shell<Frame::Inertial>&>(*shell),
-        inner_radius, outer_radius, true, grid_points_r_angular,
-        {1, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map,
-        which_wedges);
-  }
+void test_shell_factory_wedges_four_on_equator() {
+  INFO("Shell factory wedges four on equator");
+  const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+      "  Shell:\n"
+      "    InnerRadius: 1\n"
+      "    OuterRadius: 3\n"
+      "    InitialRefinement: 2\n"
+      "    InitialGridPoints: [2,3]\n"
+      "    UseEquiangularMap: false\n"
+      "    AspectRatio: 2.0        \n"
+      "    UseLogarithmicMap: true\n"
+      "    WhichWedges: FourOnEquator\n");
+  const double inner_radius = 1.0, outer_radius = 3.0;
+  const size_t refinement_level = 2;
+  const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
+  const double aspect_ratio = 2.0;
+  const bool use_logarithmic_map = true;
+  const ShellWedges which_wedges = ShellWedges::FourOnEquator;
+  test_shell_construction(
+      dynamic_cast<const domain::creators::Shell<Frame::Inertial>&>(*shell),
+      inner_radius, outer_radius, false, grid_points_r_angular,
+      {4, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map,
+      which_wedges);
 }
 
-namespace {
+void test_shell_factory_wedges_one_along_minus_x() {
+  INFO("Shell factory wedges one along minus x");
+  const auto shell = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+      "  Shell:\n"
+      "    InnerRadius: 2\n"
+      "    OuterRadius: 3\n"
+      "    InitialRefinement: 2\n"
+      "    InitialGridPoints: [2,3]\n"
+      "    UseEquiangularMap: true\n"
+      "    AspectRatio: 2.7        \n"
+      "    UseLogarithmicMap: false\n"
+      "    WhichWedges: OneAlongMinusX \n");
+  const double inner_radius = 2.0, outer_radius = 3.0;
+  const size_t refinement_level = 2;
+  const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
+  const double aspect_ratio = 2.7;
+  const bool use_logarithmic_map = false;
+  const ShellWedges which_wedges = ShellWedges::OneAlongMinusX;
+  test_shell_construction(
+      dynamic_cast<const domain::creators::Shell<Frame::Inertial>&>(*shell),
+      inner_radius, outer_radius, true, grid_points_r_angular,
+      {1, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map,
+      which_wedges);
+}
+
 // Tests that the underlying element structure is the same regardless of
 // whether they are created through InitialRefinement or RadialBlockLayers.
 // This is done by constructing a set of expected boundary points dependent on
@@ -513,22 +512,45 @@ void test_radial_block_layers(const double inner_radius,
 }
 }  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell.RadialBlockLayers",
-                  "[Domain][Unit]") {
-  const auto log_shell =
-      test_factory_creation<DomainCreator<3, Frame::Inertial>>(
-          "  Shell:\n"
-          "    InnerRadius: 1\n"
-          "    OuterRadius: 3\n"
-          "    InitialRefinement: 2\n"
-          "    InitialGridPoints: [2,3]\n"
-          "    UseEquiangularMap: false\n"
-          "    AspectRatio: 2.0        \n"
-          "    UseLogarithmicMap: true\n"
-          "    RadialBlockLayers: 6\n");
+SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell", "[Domain][Unit]") {
+  test_shell_boundaries();
+  test_shell_factory_equiangular();
+  test_shell_factory_equidistant();
+  test_shell_boundaries_aspect_ratio();
+  test_shell_factory_aspect_ratio();
+  test_shell_boundaries_logarithmic_map();
+  test_shell_factory_logarithmic_map();
+  test_shell_factory_wedges_four_on_equator();
+  test_shell_factory_wedges_one_along_minus_x();
 
-   test_radial_block_layers(1.0, 10.0, 0, true, 8, {0, 1, 2, 3, 4, 5, 6, 7});
-   test_radial_block_layers(2.0, 9.0, 0, false, 8, {0, 1, 2, 3, 4, 5, 6, 7});
-   test_radial_block_layers(4.0, 9.0, 3, true, 1, {0, 0, 0, 0, 0, 0, 0, 0});
-   test_radial_block_layers(3.0, 6.0, 3, false, 1, {0, 0, 0, 0, 0, 0, 0, 0});
+  {
+    INFO("shell factory logarithmic block layers");
+    const auto log_shell =
+        test_factory_creation<DomainCreator<3, Frame::Inertial>>(
+            "  Shell:\n"
+            "    InnerRadius: 1\n"
+            "    OuterRadius: 3\n"
+            "    InitialRefinement: 2\n"
+            "    InitialGridPoints: [2,3]\n"
+            "    UseEquiangularMap: false\n"
+            "    AspectRatio: 2.0        \n"
+            "    UseLogarithmicMap: true\n"
+            "    RadialBlockLayers: 6\n");
+  }
+  {
+    INFO("Radial block layers 1");
+    test_radial_block_layers(1.0, 10.0, 0, true, 8, {0, 1, 2, 3, 4, 5, 6, 7});
+  }
+  {
+    INFO("Radial block layers 2");
+    test_radial_block_layers(2.0, 9.0, 0, false, 8, {0, 1, 2, 3, 4, 5, 6, 7});
+  }
+  {
+    INFO("Radial block layers 3");
+    test_radial_block_layers(4.0, 9.0, 3, true, 1, {0, 0, 0, 0, 0, 0, 0, 0});
+  }
+  {
+    INFO("Radial block layers 4");
+    test_radial_block_layers(3.0, 6.0, 3, false, 1, {0, 0, 0, 0, 0, 0, 0, 0});
+  }
 }

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -188,10 +188,9 @@ void test_sphere_construction(
                            expected_external_boundaries, coord_maps);
   test_initial_domain(domain, sphere.initial_refinement_levels());
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere.Boundaries.Equiangular",
-                  "[Domain][Unit]") {
+void test_sphere_boundaries_equiangular() {
+  INFO("Sphere boundaries equiangular");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const size_t refinement = 2;
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
@@ -205,8 +204,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere.Boundaries.Equiangular",
                            {7, make_array<3>(refinement)});
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere.Factory.Equiangular",
-                  "[Domain][Unit]") {
+void test_sphere_factory_equiangular() {
+  INFO("Sphere factory equiangular");
   const auto sphere = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
       "  Sphere:\n"
       "    InnerRadius: 1\n"
@@ -223,8 +222,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere.Factory.Equiangular",
       {7, make_array<3>(refinement_level)});
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere.Boundaries.Equidistant",
-                  "[Domain][Unit]") {
+void test_sphere_boundaries_equidistant() {
+  INFO("Sphere boundaries equidistant");
   const double inner_radius = 1.0, outer_radius = 2.0;
   const size_t refinement = 2;
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
@@ -238,8 +237,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere.Boundaries.Equidistant",
                            {7, make_array<3>(refinement)});
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere.Factory.Equidistant",
-                  "[Domain][Unit]") {
+void test_sphere_factory_equidistant() {
+  INFO("Sphere factory equidistant");
   const auto sphere = test_factory_creation<DomainCreator<3, Frame::Inertial>>(
       "  Sphere:\n"
       "    InnerRadius: 1\n"
@@ -254,4 +253,12 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere.Factory.Equidistant",
       dynamic_cast<const domain::creators::Sphere<Frame::Inertial>&>(*sphere),
       inner_radius, outer_radius, false, grid_points_r_angular,
       {7, make_array<3>(refinement_level)});
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere", "[Domain][Unit]") {
+  test_sphere_boundaries_equiangular();
+  test_sphere_factory_equiangular();
+  test_sphere_boundaries_equidistant();
+  test_sphere_factory_equidistant();
 }

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -6,7 +6,6 @@
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 
 #include <algorithm>
-#include <typeinfo>
 #include <unordered_map>
 
 #include "DataStructures/DataVector.hpp"     // IWYU pragma: keep
@@ -301,7 +300,6 @@ void test_domain_construction(
     CHECK(block.id() == i);
     CHECK(block.neighbors() == expected_block_neighbors[i]);
     CHECK(block.external_boundaries() == expected_external_boundaries[i]);
-    CHECK(typeid(*expected_maps[i]) == typeid(block.coordinate_map()));
     check_if_maps_are_equal(*expected_maps[i], block.coordinate_map());
   }
   domain::creators::register_derived_with_charm();

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -304,10 +304,8 @@ void test_wedge_map_generation_against_domain_helpers(
 #endif
 }
 
-
-SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.DefaultSixWedgeDirections.Equiangular",
-    "[Domain][Unit]") {
+void test_default_six_wedge_directions_equiangular() {
+  INFO("Default six wedge directions equiangular");
   const double inner_radius = 1.2;
   const double outer_radius = 2.7;
   const double inner_sphericity = 0.8;
@@ -318,9 +316,8 @@ SPECTRE_TEST_CASE(
       use_equiangular_map);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.DefaultSixWedgeDirections.Equidistant",
-    "[Domain][Unit]") {
+void test_default_six_wedge_directions_equidistant() {
+  INFO("Defaul six wedge directions equidistant");
   const double inner_radius = 0.8;
   const double outer_radius = 7.1;
   const double inner_sphericity = 0.2;
@@ -331,9 +328,8 @@ SPECTRE_TEST_CASE(
       use_equiangular_map);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.TranslatedSixWedgeDirections.Equiangular",
-    "[Domain][Unit]") {
+void test_translated_six_wedge_directions_equiangular() {
+  INFO("Translated six wedge directions equiangular");
   const double inner_radius = 1.2;
   const double outer_radius = 3.1;
   const double inner_sphericity = 0.3;
@@ -345,9 +341,8 @@ SPECTRE_TEST_CASE(
       use_equiangular_map, x_coord_of_shell_center);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.TranslatedSixWedgeDirections.Equidistant",
-    "[Domain][Unit]") {
+void test_translated_six_wedge_directions_equidistant() {
+  INFO("Translated six wedge directions equidistant");
   const double inner_radius = 12.2;
   const double outer_radius = 31.1;
   const double inner_sphericity = 0.9;
@@ -359,8 +354,8 @@ SPECTRE_TEST_CASE(
       use_equiangular_map, x_coord_of_shell_center);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.TenWedgeDirections.Equiangular",
-                  "[Domain][Unit]") {
+void test_ten_wedge_directions_equiangular() {
+  INFO("Ten wedge directions equiangular");
   const double inner_radius = 0.2;
   const double outer_radius = 2.2;
   const double inner_sphericity = 0.0;
@@ -372,8 +367,8 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.TenWedgeDirections.Equiangular",
       use_equiangular_map, 0.0, use_half_wedges);
 }
 
-SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.TenWedgeDirections.Equidistant",
-                  "[Domain][Unit]") {
+void test_ten_wedge_directions_equidistant() {
+  INFO("Ten wedge directions equidistant");
   const double inner_radius = 0.2;
   const double outer_radius = 29.2;
   const double inner_sphericity = 0.01;
@@ -385,9 +380,8 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.TenWedgeDirections.Equidistant",
       use_equiangular_map, 0.0, use_half_wedges);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.SixWedgeDirectionsCompressed.Equiangular",
-    "[Domain][Unit]") {
+void test_six_wedge_directions_compressed_equiangular() {
+  INFO("Six wedge directions compressed equiangular");
   const double inner_radius = 7.2;
   const double outer_radius = 12.2;
   const double inner_sphericity = 0.0;
@@ -400,9 +394,8 @@ SPECTRE_TEST_CASE(
       use_equiangular_map, 0.0, use_half_wedges, aspect_ratio);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.SixWedgeDirectionsCompressed.Equidistant",
-    "[Domain][Unit]") {
+void test_six_wedge_directions_compressed_equidistant() {
+  INFO("Six wedge directions compressed equidistant");
   const double inner_radius = 9.6;
   const double outer_radius = 29.2;
   const double inner_sphericity = 0.0;
@@ -415,10 +408,8 @@ SPECTRE_TEST_CASE(
       use_equiangular_map, 0.0, use_half_wedges, aspect_ratio);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.SixWedgeDirectionsCompressedTranslated."
-    "Equiangular",
-    "[Domain][Unit]") {
+void test_six_wedge_directions_compressed_translated_equiangular() {
+  INFO("Six wedge directions compressed translated equiangular");
   const double inner_radius = 7.2;
   const double outer_radius = 12.2;
   const double inner_sphericity = 0.0;
@@ -433,10 +424,8 @@ SPECTRE_TEST_CASE(
       aspect_ratio);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.SixWedgeDirectionsCompressedTranslated."
-    "Equidistant",
-    "[Domain][Unit]") {
+void test_six_wedge_directions_compressed_translated_equidistant() {
+  INFO("Six wedge directions compressed translated equidistant");
   const double inner_radius = 9.6;
   const double outer_radius = 29.2;
   const double inner_sphericity = 0.0;
@@ -451,10 +440,8 @@ SPECTRE_TEST_CASE(
       aspect_ratio);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.TenWedgeDirectionsCompressedTranslated."
-    "Equiangular",
-    "[Domain][Unit]") {
+void test_ten_wedge_directions_compressed_translated_equiangular() {
+  INFO("Ten wedge directions compressed translated equiangular");
   const double inner_radius = 0.2;
   const double outer_radius = 2.2;
   const double inner_sphericity = 0.0;
@@ -469,10 +456,8 @@ SPECTRE_TEST_CASE(
       aspect_ratio);
 }
 
-SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.TenWedgeDirectionsCompressedTranslated."
-    "Equidistant",
-    "[Domain][Unit]") {
+void test_ten_wedge_directions_compressed_translated_equidistant() {
+  INFO("Ten wedge directions compressed translated equidistant");
   const double inner_radius = 0.2;
   const double outer_radius = 29.2;
   const double inner_sphericity = 0.01;
@@ -485,6 +470,22 @@ SPECTRE_TEST_CASE(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
       aspect_ratio);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.WedgeMapGeneration",
+                  "[Domain][Unit]") {
+  test_default_six_wedge_directions_equiangular();
+  test_default_six_wedge_directions_equidistant();
+  test_translated_six_wedge_directions_equiangular();
+  test_translated_six_wedge_directions_equidistant();
+  test_ten_wedge_directions_equiangular();
+  test_ten_wedge_directions_equidistant();
+  test_six_wedge_directions_compressed_equiangular();
+  test_six_wedge_directions_compressed_equidistant();
+  test_six_wedge_directions_compressed_translated_equiangular();
+  test_six_wedge_directions_compressed_translated_equidistant();
+  test_ten_wedge_directions_compressed_translated_equiangular();
+  test_ten_wedge_directions_compressed_translated_equidistant();
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.AllFrustumDirections",

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -33,6 +33,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeVector.hpp"
 #include "Utilities/StdHelpers.hpp"
+#include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.SameBlock",
                   "[Domain][Unit]") {
@@ -99,97 +100,79 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                           bool use_half_wedges = false,
                           double aspect_ratio = 1.0) {
   using Wedge3DMap = CoordinateMaps::Wedge3D;
+  using Identity2D = CoordinateMaps::Identity<2>;
+  using Affine = CoordinateMaps::Affine;
+  const auto translation = CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(
+      Affine{-1.0, 1.0, -1.0 + x_coord_of_shell_center,
+             1.0 + x_coord_of_shell_center},
+      Identity2D{});
+  const auto compression = CoordinateMaps::EquatorialCompression{aspect_ratio};
+
   if (use_half_wedges) {
     using Halves = Wedge3DMap::WedgeHalves;
-    return make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-        Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
-                   inner_sphericity, outer_sphericity, use_equiangular_map,
-                   Halves::LowerOnly},
-        Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
-                   inner_sphericity, outer_sphericity, use_equiangular_map,
-                   Halves::UpperOnly},
-        Wedge3DMap{inner_radius, outer_radius,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                        Direction<3>::lower_zeta()}}},
-                   inner_sphericity, outer_sphericity, use_equiangular_map,
-                   Halves::LowerOnly},
-        Wedge3DMap{inner_radius, outer_radius,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                        Direction<3>::lower_zeta()}}},
-                   inner_sphericity, outer_sphericity, use_equiangular_map,
-                   Halves::UpperOnly},
-        Wedge3DMap{inner_radius, outer_radius,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                        Direction<3>::lower_eta()}}},
-                   inner_sphericity, outer_sphericity, use_equiangular_map,
-                   Halves::LowerOnly},
-        Wedge3DMap{inner_radius, outer_radius,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                        Direction<3>::lower_eta()}}},
-                   inner_sphericity, outer_sphericity, use_equiangular_map,
-                   Halves::UpperOnly},
-        Wedge3DMap{inner_radius, outer_radius,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                        Direction<3>::upper_eta()}}},
-                   inner_sphericity, outer_sphericity, use_equiangular_map,
-                   Halves::LowerOnly},
-        Wedge3DMap{inner_radius, outer_radius,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                        Direction<3>::upper_eta()}}},
-                   inner_sphericity, outer_sphericity, use_equiangular_map,
-                   Halves::UpperOnly},
-        Wedge3DMap{inner_radius, outer_radius,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
-                        Direction<3>::upper_eta()}}},
-                   inner_sphericity, outer_sphericity, use_equiangular_map},
-        Wedge3DMap{inner_radius, outer_radius,
-                   OrientationMap<3>{std::array<Direction<3>, 3>{
-                       {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
-                        Direction<3>::upper_eta()}}},
-                   inner_sphericity, outer_sphericity, use_equiangular_map});
-  }
-  if (x_coord_of_shell_center != 0.0) {
-    using Identity2D = CoordinateMaps::Identity<2>;
-    using Affine = CoordinateMaps::Affine;
-    const auto translation = CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(
-        Affine{-1.0, 1.0, -1.0 + x_coord_of_shell_center,
-               1.0 + x_coord_of_shell_center},
-        Identity2D{});
     return make_vector(
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
-                       inner_sphericity, outer_sphericity, use_equiangular_map},
-            translation),
+                       inner_sphericity, outer_sphericity, use_equiangular_map,
+                       Halves::LowerOnly},
+            compression, translation),
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
+                       inner_sphericity, outer_sphericity, use_equiangular_map,
+                       Halves::UpperOnly},
+            compression, translation),
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{inner_radius, outer_radius,
                        OrientationMap<3>{std::array<Direction<3>, 3>{
                            {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
                             Direction<3>::lower_zeta()}}},
-                       inner_sphericity, outer_sphericity, use_equiangular_map},
-            translation),
+                       inner_sphericity, outer_sphericity, use_equiangular_map,
+                       Halves::LowerOnly},
+            compression, translation),
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            Wedge3DMap{inner_radius, outer_radius,
+                       OrientationMap<3>{std::array<Direction<3>, 3>{
+                           {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                            Direction<3>::lower_zeta()}}},
+                       inner_sphericity, outer_sphericity, use_equiangular_map,
+                       Halves::UpperOnly},
+            compression, translation),
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
                      Direction<3>::lower_eta()}}},
-                inner_sphericity, outer_sphericity, use_equiangular_map},
-            translation),
+                inner_sphericity, outer_sphericity, use_equiangular_map,
+                Halves::LowerOnly},
+            compression, translation),
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            Wedge3DMap{
+                inner_radius, outer_radius,
+                OrientationMap<3>{std::array<Direction<3>, 3>{
+                    {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                     Direction<3>::lower_eta()}}},
+                inner_sphericity, outer_sphericity, use_equiangular_map,
+                Halves::UpperOnly},
+            compression, translation),
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius,
                 OrientationMap<3>{std::array<Direction<3>, 3>{
                     {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
                      Direction<3>::upper_eta()}}},
-                inner_sphericity, outer_sphericity, use_equiangular_map},
-            translation),
+                inner_sphericity, outer_sphericity, use_equiangular_map,
+                Halves::LowerOnly},
+            compression, translation),
+        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            Wedge3DMap{
+                inner_radius, outer_radius,
+                OrientationMap<3>{std::array<Direction<3>, 3>{
+                    {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                     Direction<3>::upper_eta()}}},
+                inner_sphericity, outer_sphericity, use_equiangular_map,
+                Halves::UpperOnly},
+            compression, translation),
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius,
@@ -197,7 +180,7 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                     {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
                      Direction<3>::upper_eta()}}},
                 inner_sphericity, outer_sphericity, use_equiangular_map},
-            translation),
+            compression, translation),
         make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
             Wedge3DMap{
                 inner_radius, outer_radius,
@@ -205,84 +188,49 @@ test_wedge_map_generation(double inner_radius, double outer_radius,
                     {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
                      Direction<3>::upper_eta()}}},
                 inner_sphericity, outer_sphericity, use_equiangular_map},
-            translation));
+            compression, translation));
   }
-  if (aspect_ratio != 1.0) {
-    const auto compression =
-        CoordinateMaps::EquatorialCompression{aspect_ratio};
-    return make_vector(
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
-                       inner_sphericity, outer_sphericity, use_equiangular_map},
-            compression),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            Wedge3DMap{inner_radius, outer_radius,
-                       OrientationMap<3>{std::array<Direction<3>, 3>{
-                           {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                            Direction<3>::lower_zeta()}}},
-                       inner_sphericity, outer_sphericity, use_equiangular_map},
-            compression),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            Wedge3DMap{
-                inner_radius, outer_radius,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                     Direction<3>::lower_eta()}}},
-                inner_sphericity, outer_sphericity, use_equiangular_map},
-            compression),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            Wedge3DMap{
-                inner_radius, outer_radius,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                     Direction<3>::upper_eta()}}},
-                inner_sphericity, outer_sphericity, use_equiangular_map},
-            compression),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            Wedge3DMap{
-                inner_radius, outer_radius,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
-                     Direction<3>::upper_eta()}}},
-                inner_sphericity, outer_sphericity, use_equiangular_map},
-            compression),
-        make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-            Wedge3DMap{
-                inner_radius, outer_radius,
-                OrientationMap<3>{std::array<Direction<3>, 3>{
-                    {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
-                     Direction<3>::upper_eta()}}},
-                inner_sphericity, outer_sphericity, use_equiangular_map},
-            compression));
-  }
-  return make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-      Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
-                 inner_sphericity, outer_sphericity, use_equiangular_map},
-      Wedge3DMap{inner_radius, outer_radius,
-                 OrientationMap<3>{std::array<Direction<3>, 3>{
-                     {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
-                      Direction<3>::lower_zeta()}}},
-                 inner_sphericity, outer_sphericity, use_equiangular_map},
-      Wedge3DMap{inner_radius, outer_radius,
-                 OrientationMap<3>{std::array<Direction<3>, 3>{
-                     {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
-                      Direction<3>::lower_eta()}}},
-                 inner_sphericity, outer_sphericity, use_equiangular_map},
-      Wedge3DMap{inner_radius, outer_radius,
-                 OrientationMap<3>{std::array<Direction<3>, 3>{
-                     {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
-                      Direction<3>::upper_eta()}}},
-                 inner_sphericity, outer_sphericity, use_equiangular_map},
-      Wedge3DMap{inner_radius, outer_radius,
-                 OrientationMap<3>{std::array<Direction<3>, 3>{
-                     {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
-                      Direction<3>::upper_eta()}}},
-                 inner_sphericity, outer_sphericity, use_equiangular_map},
-      Wedge3DMap{inner_radius, outer_radius,
-                 OrientationMap<3>{std::array<Direction<3>, 3>{
-                     {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
-                      Direction<3>::upper_eta()}}},
-                 inner_sphericity, outer_sphericity, use_equiangular_map});
+
+  return make_vector(
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge3DMap{inner_radius, outer_radius, OrientationMap<3>{},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
+          compression, translation),
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                          Direction<3>::lower_zeta()}}},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
+          compression, translation),
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_xi(), Direction<3>::upper_zeta(),
+                          Direction<3>::lower_eta()}}},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
+          compression, translation),
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_xi(), Direction<3>::lower_zeta(),
+                          Direction<3>::upper_eta()}}},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
+          compression, translation),
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::upper_zeta(), Direction<3>::upper_xi(),
+                          Direction<3>::upper_eta()}}},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
+          compression, translation),
+      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Wedge3DMap{inner_radius, outer_radius,
+                     OrientationMap<3>{std::array<Direction<3>, 3>{
+                         {Direction<3>::lower_zeta(), Direction<3>::lower_xi(),
+                          Direction<3>::upper_eta()}}},
+                     inner_sphericity, outer_sphericity, use_equiangular_map},
+          compression, translation));
 }
 
 void test_wedge_map_generation_against_domain_helpers(
@@ -300,7 +248,7 @@ void test_wedge_map_generation_against_domain_helpers(
       aspect_ratio);
   CHECK(maps.size() == expected_coord_maps.size());
   for (size_t i = 0; i < expected_coord_maps.size(); i++) {
-    CHECK(*expected_coord_maps[i] == *maps[i]);
+    check_if_maps_are_equal(*expected_coord_maps[i],*maps[i]);
   }
 }
 
@@ -356,55 +304,6 @@ void test_wedge_map_generation_against_domain_helpers(
 #endif
 }
 
-// [[OutputRegex, Only one of: using a non-zero translation, using half wedges,
-// or using a non-unity aspect_ratio, can be done at a time.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert3", "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const double inner_radius = 0.5;
-  const double outer_radius = 2.0;
-  const double inner_sphericity = 0.2;
-  const double outer_sphericity = 0.2;
-  const bool use_equiangular_map = true;
-  const double x_coord_of_shell_center = 0.1;
-  const bool use_half_wedges = true;
-  const double aspect_ratio = 1.0;
-  const bool use_logarithmic_map = false;
-  const ShellWedges which_wedges = ShellWedges::All;
-  const size_t number_of_layers = 3;
-  static_cast<void>(wedge_coordinate_maps<Frame::Inertial>(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, use_logarithmic_map, which_wedges, number_of_layers));
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
-// [[OutputRegex, Only one of: using a non-zero translation, using half wedges,
-// or using a non-unity aspect_ratio, can be done at a time.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.WedgeCoordinateMaps.Assert4", "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  const double inner_radius = 0.5;
-  const double outer_radius = 2.0;
-  const double inner_sphericity = 0.2;
-  const double outer_sphericity = 0.2;
-  const bool use_equiangular_map = true;
-  const double x_coord_of_shell_center = 0.0;
-  const bool use_half_wedges = true;
-  const double aspect_ratio = 0.3;
-  const bool use_logarithmic_map = false;
-  const ShellWedges which_wedges = ShellWedges::All;
-  const size_t number_of_layers = 3;
-  static_cast<void>(wedge_coordinate_maps<Frame::Inertial>(
-      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
-      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
-      aspect_ratio, use_logarithmic_map, which_wedges, number_of_layers));
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
 
 SPECTRE_TEST_CASE(
     "Unit.Domain.DomainHelpers.DefaultSixWedgeDirections.Equiangular",
@@ -514,6 +413,78 @@ SPECTRE_TEST_CASE(
   test_wedge_map_generation_against_domain_helpers(
       inner_radius, outer_radius, inner_sphericity, outer_sphericity,
       use_equiangular_map, 0.0, use_half_wedges, aspect_ratio);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.SixWedgeDirectionsCompressedTranslated."
+    "Equiangular",
+    "[Domain][Unit]") {
+  const double inner_radius = 7.2;
+  const double outer_radius = 12.2;
+  const double inner_sphericity = 0.0;
+  const double outer_sphericity = 1.0;
+  const bool use_equiangular_map = true;
+  const bool use_half_wedges = false;
+  const double aspect_ratio = 6.0;
+  const double x_coord_of_shell_center = 2.7;
+  test_wedge_map_generation_against_domain_helpers(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
+      aspect_ratio);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.SixWedgeDirectionsCompressedTranslated."
+    "Equidistant",
+    "[Domain][Unit]") {
+  const double inner_radius = 9.6;
+  const double outer_radius = 29.2;
+  const double inner_sphericity = 0.0;
+  const double outer_sphericity = 1.0;
+  const bool use_equiangular_map = false;
+  const bool use_half_wedges = false;
+  const double aspect_ratio = 0.6;
+  const double x_coord_of_shell_center = 2.7;
+  test_wedge_map_generation_against_domain_helpers(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
+      aspect_ratio);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.TenWedgeDirectionsCompressedTranslated."
+    "Equiangular",
+    "[Domain][Unit]") {
+  const double inner_radius = 0.2;
+  const double outer_radius = 2.2;
+  const double inner_sphericity = 0.0;
+  const double outer_sphericity = 1.0;
+  const bool use_equiangular_map = true;
+  const bool use_half_wedges = true;
+  const double aspect_ratio = 0.6;
+  const double x_coord_of_shell_center = 2.7;
+  test_wedge_map_generation_against_domain_helpers(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
+      aspect_ratio);
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.DomainHelpers.TenWedgeDirectionsCompressedTranslated."
+    "Equidistant",
+    "[Domain][Unit]") {
+  const double inner_radius = 0.2;
+  const double outer_radius = 29.2;
+  const double inner_sphericity = 0.01;
+  const double outer_sphericity = 0.99;
+  const bool use_equiangular_map = false;
+  const bool use_half_wedges = true;
+  const double aspect_ratio = 0.6;
+  const double x_coord_of_shell_center = 2.7;
+  test_wedge_map_generation_against_domain_helpers(
+      inner_radius, outer_radius, inner_sphericity, outer_sphericity,
+      use_equiangular_map, x_coord_of_shell_center, use_half_wedges,
+      aspect_ratio);
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.AllFrustumDirections",


### PR DESCRIPTION
## Proposed changes

The first commit makes use of #1279 to generalize the maps created using `wedge_coordinate_maps`
The second commit reduces the number of `SPECTRE_TEST_CASES` in the Creators directory
Addresses #1151 and #877 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
