### PR TITLE
Have GH char fields inherit from db::SimpleTag

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -72,22 +72,22 @@ struct SpacetimeDerivGaugeH : db::SimpleTag {
 /// \details For details on how these are defined and computed, see
 /// CharacteristicSpeedsCompute
 template <size_t Dim, typename Frame>
-struct UPsi {
+struct UPsi : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
   static std::string name() noexcept { return "UPsi"; }
 };
 template <size_t Dim, typename Frame>
-struct UZero {
+struct UZero : db::SimpleTag {
   using type = tnsr::iaa<DataVector, Dim, Frame>;
   static std::string name() noexcept { return "UZero"; }
 };
 template <size_t Dim, typename Frame>
-struct UPlus {
+struct UPlus : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
   static std::string name() noexcept { return "UPlus"; }
 };
 template <size_t Dim, typename Frame>
-struct UMinus {
+struct UMinus : db::SimpleTag {
   using type = tnsr::aa<DataVector, Dim, Frame>;
   static std::string name() noexcept { return "UMinus"; }
 };


### PR DESCRIPTION
## Proposed changes

The GeneralizedHarmonic characteristic field tags should inherit from `db::SimpleTag`.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
