### PR TITLE
Put all coordinate maps in a domain namespace

### DIFF
--- a/src/Domain/Block.cpp
+++ b/src/Domain/Block.cpp
@@ -16,8 +16,8 @@ struct Logical;
 
 template <size_t VolumeDim, typename TargetFrame>
 Block<VolumeDim, TargetFrame>::Block(
-    std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>&&
-        map,
+    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame,
+                                              VolumeDim>>&& map,
     const size_t id,
     DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors) noexcept
     : map_(std::move(map)), id_(id), neighbors_(std::move(neighbors)) {

--- a/src/Domain/Block.hpp
+++ b/src/Domain/Block.hpp
@@ -45,8 +45,8 @@ class Block {
   /// \param id a unique ID.
   /// \param neighbors info about the Blocks that share a codimension 1
   /// boundary with this Block.
-  Block(std::unique_ptr<
-            CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>&& map,
+  Block(std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame,
+                                                  VolumeDim>>&& map,
         size_t id,
         DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors) noexcept;
 
@@ -57,7 +57,7 @@ class Block {
   Block& operator=(const Block&) = delete;
   Block& operator=(Block&&) = default;
 
-  const CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>&
+  const domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>&
   coordinate_map() const noexcept {
     return *map_;
   }
@@ -83,7 +83,8 @@ class Block {
   void pup(PUP::er& p) noexcept;  // NOLINT
 
  private:
-  std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>
+  std::unique_ptr<
+      domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>
       map_;
   size_t id_{0};
   DirectionMap<VolumeDim, BlockNeighbor<VolumeDim>> neighbors_;

--- a/src/Domain/CoordinateMaps/Affine.cpp
+++ b/src/Domain/CoordinateMaps/Affine.cpp
@@ -11,6 +11,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace domain {
 namespace CoordinateMaps {
 
 Affine::Affine(const double A, const double B, const double a, const double b)
@@ -96,3 +97,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Affine.hpp
+++ b/src/Domain/CoordinateMaps/Affine.hpp
@@ -17,6 +17,7 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
+namespace domain {
 namespace CoordinateMaps {
 
 /*!
@@ -84,3 +85,4 @@ inline bool operator!=(const CoordinateMaps::Affine& lhs,
 }
 
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -94,6 +94,7 @@ boost::optional<double> scaling_factor(RootFunction&& rootfunction) noexcept {
 }
 }  // namespace
 
+namespace domain {
 namespace CoordinateMaps {
 BulgedCube::BulgedCube(const double radius, const double sphericity,
                        const bool use_equiangular_map) noexcept
@@ -298,3 +299,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/BulgedCube.hpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.hpp
@@ -17,6 +17,7 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
+namespace domain {
 namespace CoordinateMaps {
 
 /*!
@@ -530,3 +531,4 @@ class BulgedCube {
 
 bool operator!=(const BulgedCube& lhs, const BulgedCube& rhs) noexcept;
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/CoordinateMap.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMap.hpp
@@ -35,6 +35,7 @@ class DataVector;
 class FunctionOfTime;
 /// \endcond
 
+namespace domain {
 /// Contains all coordinate maps.
 namespace CoordinateMaps {
 template <typename FirstMap, typename... Maps>
@@ -671,3 +672,4 @@ PUP::able::PUP_ID
     CoordinateMap<SourceFrame, TargetFrame, Maps...>::my_PUP_ID =  // NOLINT
     0;
 /// \endcond
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/CubicScale.cpp
+++ b/src/Domain/CoordinateMaps/CubicScale.cpp
@@ -20,6 +20,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace domain {
 namespace CoordMapsTimeDependent {
 
 CubicScale::CubicScale(const double outer_boundary) noexcept
@@ -246,3 +247,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordMapsTimeDependent
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/CubicScale.hpp
+++ b/src/Domain/CoordinateMaps/CubicScale.hpp
@@ -19,6 +19,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
+namespace domain {
 namespace CoordMapsTimeDependent {
 /*!
  * \ingroup CoordMapsTimeDependentGroup
@@ -94,3 +95,4 @@ inline bool operator!=(const CoordMapsTimeDependent::CubicScale& lhs,
 }
 
 }  // namespace CoordMapsTimeDependent
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/DiscreteRotation.cpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.cpp
@@ -11,6 +11,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace domain {
 namespace CoordinateMaps {
 
 template <size_t VolumeDim>
@@ -104,3 +105,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/DiscreteRotation.hpp
+++ b/src/Domain/CoordinateMaps/DiscreteRotation.hpp
@@ -17,6 +17,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
+namespace domain {
 namespace CoordinateMaps {
 
 /*!
@@ -79,3 +80,4 @@ inline bool operator!=(
 }
 
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/EquatorialCompression.cpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.cpp
@@ -17,6 +17,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace domain {
 namespace CoordinateMaps {
 
 EquatorialCompression::EquatorialCompression(const double aspect_ratio) noexcept
@@ -185,3 +186,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/EquatorialCompression.hpp
+++ b/src/Domain/CoordinateMaps/EquatorialCompression.hpp
@@ -15,6 +15,7 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
+namespace domain {
 namespace CoordinateMaps {
 
 /*!
@@ -99,3 +100,4 @@ class EquatorialCompression {
 bool operator!=(const EquatorialCompression& lhs,
                 const EquatorialCompression& rhs) noexcept;
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Equiangular.cpp
+++ b/src/Domain/CoordinateMaps/Equiangular.cpp
@@ -13,6 +13,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace domain {
 namespace CoordinateMaps {
 
 Equiangular::Equiangular(const double A, const double B, const double a,
@@ -125,3 +126,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Equiangular.hpp
+++ b/src/Domain/CoordinateMaps/Equiangular.hpp
@@ -18,6 +18,7 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
+namespace domain {
 namespace CoordinateMaps {
 
 /*!
@@ -106,3 +107,4 @@ inline bool operator!=(const CoordinateMaps::Equiangular& lhs,
 }
 
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Frustum.cpp
+++ b/src/Domain/CoordinateMaps/Frustum.cpp
@@ -20,6 +20,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace domain {
 namespace CoordinateMaps {
 Frustum::Frustum(const std::array<std::array<double, 2>, 4>& face_vertices,
                  const double lower_bound, const double upper_bound,
@@ -258,3 +259,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Frustum.hpp
+++ b/src/Domain/CoordinateMaps/Frustum.hpp
@@ -18,6 +18,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
+namespace domain {
 namespace CoordinateMaps {
 
 /// \ingroup CoordinateMapsGroup
@@ -92,3 +93,4 @@ class Frustum {
 
 bool operator!=(const Frustum& lhs, const Frustum& rhs) noexcept;
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Identity.cpp
+++ b/src/Domain/CoordinateMaps/Identity.cpp
@@ -8,6 +8,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeArray.hpp"
 
+namespace domain {
 namespace CoordinateMaps {
 
 template <size_t Dim>
@@ -72,3 +73,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3),
 /// \endcond
 
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Identity.hpp
+++ b/src/Domain/CoordinateMaps/Identity.hpp
@@ -17,6 +17,7 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
+namespace domain {
 namespace CoordinateMaps {
 
 /// \ingroup CoordinateMapsGroup
@@ -68,3 +69,4 @@ inline constexpr bool operator!=(
   return not(lhs == rhs);
 }
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.hpp
@@ -25,6 +25,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
+namespace domain {
 namespace CoordinateMaps {
 
 namespace product_detail {
@@ -355,3 +356,4 @@ bool operator!=(const ProductOf3Maps<Map1, Map2, Map3>& lhs,
   return not(lhs == rhs);
 }
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Rotation.cpp
+++ b/src/Domain/CoordinateMaps/Rotation.cpp
@@ -10,6 +10,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace domain {
 namespace CoordinateMaps {
 
 Rotation<2>::Rotation(const double rotation_angle)
@@ -225,3 +226,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (2, 3),
 /// \endcond
 
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Rotation.hpp
+++ b/src/Domain/CoordinateMaps/Rotation.hpp
@@ -18,6 +18,7 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
+namespace domain {
 namespace CoordinateMaps {
 
 /// \cond HIDDEN_SYMBOLS
@@ -166,3 +167,4 @@ class Rotation<3> {
 bool operator!=(const Rotation<3>& lhs, const Rotation<3>& rhs) noexcept;
 
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/SpecialMobius.cpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.cpp
@@ -18,6 +18,7 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
+namespace domain {
 namespace CoordinateMaps {
 
 SpecialMobius::SpecialMobius(const double mu) noexcept
@@ -142,3 +143,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/SpecialMobius.hpp
+++ b/src/Domain/CoordinateMaps/SpecialMobius.hpp
@@ -15,6 +15,7 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
+namespace domain {
 namespace CoordinateMaps {
 
 /*!
@@ -128,3 +129,4 @@ class SpecialMobius {
 };
 bool operator!=(const SpecialMobius& lhs, const SpecialMobius& rhs) noexcept;
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Translation.cpp
+++ b/src/Domain/CoordinateMaps/Translation.cpp
@@ -13,6 +13,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace domain {
 namespace CoordMapsTimeDependent {
 
 template <typename T>
@@ -89,3 +90,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordMapsTimeDependent
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Translation.hpp
+++ b/src/Domain/CoordinateMaps/Translation.hpp
@@ -19,6 +19,7 @@ class er;
 }  // namespace PUP
 /// \endcond
 
+namespace domain {
 namespace CoordMapsTimeDependent {
 /*!
  * \ingroup CoordMapsTimeDependentGroup
@@ -75,3 +76,4 @@ inline bool operator!=(
 }
 
 }  // namespace CoordMapsTimeDependent
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Wedge2D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.cpp
@@ -15,6 +15,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace domain {
 namespace CoordinateMaps {
 
 Wedge2D::Wedge2D(double radius_inner, double radius_outer,
@@ -225,3 +226,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Wedge2D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge2D.hpp
@@ -19,6 +19,7 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
+namespace domain {
 namespace CoordinateMaps {
 
 /*!
@@ -168,3 +169,4 @@ class Wedge2D {
 };
 bool operator!=(const Wedge2D& lhs, const Wedge2D& rhs) noexcept;
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Wedge3D.cpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.cpp
@@ -18,6 +18,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
+namespace domain {
 namespace CoordinateMaps {
 
 Wedge3D::Wedge3D(const double radius_inner, const double radius_outer,
@@ -404,3 +405,4 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
 #undef INSTANTIATE
 /// \endcond
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/CoordinateMaps/Wedge3D.hpp
+++ b/src/Domain/CoordinateMaps/Wedge3D.hpp
@@ -16,6 +16,7 @@ namespace PUP {
 class er;
 }  // namespace PUP
 
+namespace domain {
 namespace CoordinateMaps {
 
 /*!
@@ -319,3 +320,4 @@ class Wedge3D {
 };
 bool operator!=(const Wedge3D& lhs, const Wedge3D& rhs) noexcept;
 }  // namespace CoordinateMaps
+}  // namespace domain

--- a/src/Domain/Creators/DomainCreator.hpp
+++ b/src/Domain/Creators/DomainCreator.hpp
@@ -16,8 +16,10 @@
 /// \cond
 template <size_t, typename>
 class Block;
+namespace domain {
 template <typename, typename, size_t>
 class CoordinateMapBase;
+}  // namespace domain
 template <size_t, typename>
 class Domain;
 /// \endcond

--- a/src/Domain/Creators/RegisterDerivedWithCharm.cpp
+++ b/src/Domain/Creators/RegisterDerivedWithCharm.cpp
@@ -42,48 +42,47 @@ void register_with_charm();
 template <>
 void register_with_charm<1>() {
   PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine>));
+      SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial, Affine>));
   PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
-                                 CoordinateMaps::DiscreteRotation<1>, Affine>));
+      SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
+                               CoordinateMaps::DiscreteRotation<1>, Affine>));
 }
 
 template <>
 void register_with_charm<2>() {
   PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D>));
-  PUPable_reg(SINGLE_ARG(
-      ::CoordinateMap<Frame::Logical, Frame::Inertial,
-                      CoordinateMaps::DiscreteRotation<2>, Affine2D>));
-  PUPable_reg(SINGLE_ARG(
-      ::CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular2D>));
-  PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         CoordinateMaps::Identity<2>>));
+      SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial, Affine2D>));
   PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Wedge2D>));
+      SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
+                               CoordinateMaps::DiscreteRotation<2>, Affine2D>));
+  PUPable_reg(SINGLE_ARG(
+      CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular2D>));
+  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
+                                       CoordinateMaps::Identity<2>>));
+  PUPable_reg(
+      SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial, Wedge2D>));
 }
 template <>
 void register_with_charm<3>() {
   PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Affine3D>));
-  PUPable_reg(SINGLE_ARG(
-      ::CoordinateMap<Frame::Logical, Frame::Inertial,
-                      CoordinateMaps::DiscreteRotation<3>, Affine3D>));
-  PUPable_reg(SINGLE_ARG(
-      ::CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular3D>));
-  PUPable_reg(SINGLE_ARG(
-      ::CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular3DPrism>));
-  PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         CoordinateMaps::Frustum>));
+      SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial, Affine3D>));
   PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3D>));
-  PUPable_reg(SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial,
-                                         Wedge3D, EquatorialCompression>));
+      SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial,
+                               CoordinateMaps::DiscreteRotation<3>, Affine3D>));
   PUPable_reg(SINGLE_ARG(
-      ::CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3DPrism>));
+      CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular3D>));
+  PUPable_reg(SINGLE_ARG(
+      CoordinateMap<Frame::Logical, Frame::Inertial, Equiangular3DPrism>));
+  PUPable_reg(SINGLE_ARG(
+      CoordinateMap<Frame::Logical, Frame::Inertial, CoordinateMaps::Frustum>));
   PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3D,
-                                 EquatorialCompression, Translation3D>));
+      SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3D>));
+  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3D,
+                                       EquatorialCompression>));
+  PUPable_reg(
+      SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3DPrism>));
+  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial, Wedge3D,
+                                       EquatorialCompression, Translation3D>));
 }
 }  // namespace DomainCreators_detail
 

--- a/src/Domain/Domain.cpp
+++ b/src/Domain/Domain.cpp
@@ -28,7 +28,7 @@ Domain<VolumeDim, TargetFrame>::Domain(
 template <size_t VolumeDim, typename TargetFrame>
 Domain<VolumeDim, TargetFrame>::Domain(
     std::vector<std::unique_ptr<
-        CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
+        domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
         maps,
     const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
         corners_of_all_blocks,

--- a/src/Domain/Domain.hpp
+++ b/src/Domain/Domain.hpp
@@ -23,8 +23,10 @@ namespace PUP {
 class er;
 }  // namespace PUP
 /// \cond
+namespace domain {
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
+}  // namespace domain
 /// \endcond
 
 /*!
@@ -55,7 +57,7 @@ class Domain {
    * `identifications.size()` is even.
    */
   Domain(std::vector<std::unique_ptr<
-             CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
+             domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
              maps,
          const std::vector<std::array<size_t, two_to_the(VolumeDim)>>&
              corners_of_all_blocks,

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -495,7 +495,8 @@ size_t which_wedge_index(const ShellWedges& which_wedges) {
 }  // namespace
 
 template <typename TargetFrame>
-std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+std::vector<
+    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
 wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const double inner_sphericity,
                       const double outer_sphericity,
@@ -513,7 +514,7 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
 
   const auto wedge_orientations = orientations_for_wrappings();
 
-  using Wedge3DMap = CoordinateMaps::Wedge3D;
+  using Wedge3DMap = domain::CoordinateMaps::Wedge3D;
   using Halves = Wedge3DMap::WedgeHalves;
   std::vector<Wedge3DMap> wedges{};
 
@@ -545,16 +546,17 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
   }
 
   // Set up translation map:
-  using Identity2D = CoordinateMaps::Identity<2>;
-  using Affine = CoordinateMaps::Affine;
-  const auto translation = CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(
-      Affine{-1.0, 1.0, -1.0 + x_coord_of_shell_center,
-             1.0 + x_coord_of_shell_center},
-      Identity2D{});
+  using Identity2D = domain::CoordinateMaps::Identity<2>;
+  using Affine = domain::CoordinateMaps::Affine;
+  const auto translation =
+      domain::CoordinateMaps::ProductOf2Maps<Affine, Identity2D>(
+          Affine{-1.0, 1.0, -1.0 + x_coord_of_shell_center,
+                 1.0 + x_coord_of_shell_center},
+          Identity2D{});
 
   // Set up compression map:
   const auto compression =
-      CoordinateMaps::EquatorialCompression{aspect_ratio};
+      domain::CoordinateMaps::EquatorialCompression{aspect_ratio};
 
   if (use_half_wedges) {
     std::vector<Wedge3DMap> wedges_and_half_wedges{};
@@ -571,18 +573,19 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
     wedges_and_half_wedges.push_back(wedges[4]);
     wedges_and_half_wedges.push_back(wedges[5]);
 
-    // clang-tidy: trivially copyable
-    return make_vector_coordinate_map_base<Frame::Logical, TargetFrame, 3>(
-        std::move(wedges_and_half_wedges), std::move(compression), std::move(translation));  // NOLINT
+    return domain::make_vector_coordinate_map_base<Frame::Logical, TargetFrame,
+                                                   3>(
+        std::move(wedges_and_half_wedges), compression, translation);
   }
 
-    // clang-tidy: trivially copyable
-    return make_vector_coordinate_map_base<Frame::Logical, TargetFrame, 3>(
-        std::move(wedges), std::move(compression), std::move(translation));  // NOLINT
+  return domain::make_vector_coordinate_map_base<Frame::Logical, TargetFrame,
+                                                 3>(std::move(wedges),
+                                                    compression, translation);
 }
 
 template <typename TargetFrame>
-std::vector<std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
+std::vector<
+    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>
 frustum_coordinate_maps(const double length_inner_cube,
                         const double length_outer_cube,
                         const bool use_equiangular_map) noexcept {
@@ -590,7 +593,7 @@ frustum_coordinate_maps(const double length_inner_cube,
   const double lower = 0.5 * length_inner_cube;
   const double top = 0.5 * length_outer_cube;
 
-  using FrustumMap = CoordinateMaps::Frustum;
+  using FrustumMap = domain::CoordinateMaps::Frustum;
   // Binary compact object Domains use 10 Frustums, 4 around each Shell in the
   //+z,-z,+y,-y directions, and 1 Frustum capping each end in +x, -x.
   std::vector<FrustumMap> frustums{};
@@ -630,7 +633,8 @@ frustum_coordinate_maps(const double length_inner_cube,
       use_equiangular_map});
 
   // clang-tidy: trivially copyable
-  return make_vector_coordinate_map_base<Frame::Logical, TargetFrame, 3>(
+  return domain::make_vector_coordinate_map_base<Frame::Logical, TargetFrame,
+                                                 3>(
       std::move(frustums));  // NOLINT
 }
 
@@ -808,46 +812,48 @@ corners_for_rectilinear_domains(
 }
 
 template <typename TargetFrame, typename Map>
-std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 1>>
+std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 1>>
 product_of_1d_maps(std::array<Map, 1>& maps,
                    const OrientationMap<1>& rotation = {}) noexcept {
   if (rotation == OrientationMap<1>{}) {
-    return make_coordinate_map_base<Frame::Logical, TargetFrame>(maps[0]);
+    return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        maps[0]);
   }
-  return make_coordinate_map_base<Frame::Logical, TargetFrame>(
-      CoordinateMaps::DiscreteRotation<1>{rotation}, maps[0]);
+  return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+      domain::CoordinateMaps::DiscreteRotation<1>{rotation}, maps[0]);
 }
 
 template <typename TargetFrame, typename Map>
-std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 2>>
+std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 2>>
 product_of_1d_maps(std::array<Map, 2>& maps,
                    const OrientationMap<2>& rotation = {}) noexcept {
   if (rotation == OrientationMap<2>{}) {
-    return make_coordinate_map_base<Frame::Logical, TargetFrame>(
-        CoordinateMaps::ProductOf2Maps<Map, Map>(maps[0], maps[1]));
+    return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        domain::CoordinateMaps::ProductOf2Maps<Map, Map>(maps[0], maps[1]));
   }
-  return make_coordinate_map_base<Frame::Logical, TargetFrame>(
-      CoordinateMaps::DiscreteRotation<2>{rotation},
-      CoordinateMaps::ProductOf2Maps<Map, Map>(maps[0], maps[1]));
+  return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+      domain::CoordinateMaps::DiscreteRotation<2>{rotation},
+      domain::CoordinateMaps::ProductOf2Maps<Map, Map>(maps[0], maps[1]));
 }
 
 template <typename TargetFrame, typename Map>
-std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>
+std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>
 product_of_1d_maps(std::array<Map, 3>& maps,
                    const OrientationMap<3>& rotation = {}) noexcept {
   if (rotation == OrientationMap<3>{}) {
-    return make_coordinate_map_base<Frame::Logical, TargetFrame>(
-        CoordinateMaps::ProductOf3Maps<Map, Map, Map>(maps[0], maps[1],
-                                                      maps[2]));
+    return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+        domain::CoordinateMaps::ProductOf3Maps<Map, Map, Map>(maps[0], maps[1],
+                                                              maps[2]));
   }
-  return make_coordinate_map_base<Frame::Logical, TargetFrame>(
-      CoordinateMaps::DiscreteRotation<3>{rotation},
-      CoordinateMaps::ProductOf3Maps<Map, Map, Map>(maps[0], maps[1], maps[2]));
+  return domain::make_coordinate_map_base<Frame::Logical, TargetFrame>(
+      domain::CoordinateMaps::DiscreteRotation<3>{rotation},
+      domain::CoordinateMaps::ProductOf3Maps<Map, Map, Map>(maps[0], maps[1],
+                                                            maps[2]));
 }
 
 template <typename TargetFrame, size_t VolumeDim>
-std::vector<
-    std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
+std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
 maps_for_rectilinear_domains(
     const Index<VolumeDim>& domain_extents,
     const std::array<std::vector<double>, VolumeDim>& block_demarcations,
@@ -859,7 +865,7 @@ maps_for_rectilinear_domains(
            "If there are N blocks, there must be N+1 demarcations.");
   }
   std::vector<std::unique_ptr<
-      CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
+      domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>
       maps{};
   // block_orientation_index is the index into orientation_of_all_blocks,
   // and is equal to IndexIterator.collapsed_index()
@@ -884,7 +890,7 @@ maps_for_rectilinear_domains(
                "The block demarcations must be strictly increasing.");
       }
       if (not use_equiangular_map) {
-        using Affine = CoordinateMaps::Affine;
+        using Affine = domain::CoordinateMaps::Affine;
         std::array<Affine, VolumeDim> affine_maps{};
         for (size_t d = 0; d < VolumeDim; d++) {
           gsl::at(affine_maps, d) = Affine{-1.0, 1.0, gsl::at(lower_bounds, d),
@@ -898,7 +904,7 @@ maps_for_rectilinear_domains(
           maps.push_back(product_of_1d_maps<TargetFrame>(affine_maps));
         }
       } else {
-        using Equiangular = CoordinateMaps::Equiangular;
+        using Equiangular = domain::CoordinateMaps::Equiangular;
         std::array<Equiangular, VolumeDim> equiangular_maps{};
         for (size_t d = 0; d < VolumeDim; d++) {
           gsl::at(equiangular_maps, d) = Equiangular{
@@ -1074,8 +1080,8 @@ template std::array<size_t, 4> discrete_rotation(
 template std::array<size_t, 8> discrete_rotation(
     const OrientationMap<3>& orientation,
     const std::array<size_t, 8>& corners_of_aligned) noexcept;
-template std::vector<
-    std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+template std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
 wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const double inner_sphericity,
                       const double outer_sphericity,
@@ -1086,7 +1092,7 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const ShellWedges which_wedges,
                       const size_t number_of_layers) noexcept;
 template std::vector<
-    std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
+    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
 wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const double inner_sphericity,
                       const double outer_sphericity,
@@ -1096,13 +1102,13 @@ wedge_coordinate_maps(const double inner_radius, const double outer_radius,
                       const bool use_logarithmic_map,
                       const ShellWedges which_wedges,
                       const size_t number_of_layers) noexcept;
-template std::vector<
-    std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
+template std::vector<std::unique_ptr<
+    domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, 3>>>
 frustum_coordinate_maps(const double length_inner_cube,
                         const double length_outer_cube,
                         const bool use_equiangular_map) noexcept;
 template std::vector<
-    std::unique_ptr<CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
+    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, Frame::Grid, 3>>>
 frustum_coordinate_maps(const double length_inner_cube,
                         const double length_outer_cube,
                         const bool use_equiangular_map) noexcept;
@@ -1113,7 +1119,7 @@ frustum_coordinate_maps(const double length_inner_cube,
 
 #define INSTANTIATE(_, data)                                                \
   template std::vector<std::unique_ptr<                                     \
-      CoordinateMapBase<Frame::Logical, FRAME(data), DIM(data)>>>           \
+      domain::CoordinateMapBase<Frame::Logical, FRAME(data), DIM(data)>>>   \
   maps_for_rectilinear_domains(                                             \
       const Index<DIM(data)>& domain_extents,                               \
       const std::array<std::vector<double>, DIM(data)>& block_demarcations, \

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -24,8 +24,10 @@
 /// \cond
 template <size_t VolumeDim>
 class BlockNeighbor;
+namespace domain {
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
+}  // namespace domain
 template <size_t VolumeDim, typename T>
 class DirectionMap;
 template <size_t VolumeDim, typename TargetFrame>
@@ -124,8 +126,8 @@ auto wedge_coordinate_maps(double inner_radius, double outer_radius,
                            bool use_logarithmic_map = false,
                            ShellWedges which_wedges = ShellWedges::All,
                            size_t number_of_layers = 1) noexcept
-    -> std::vector<
-        std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
+    -> std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
 
 /// \ingroup ComputationalDomainGroup
 /// These are the ten Frustums used in the DomainCreators for binary compact
@@ -135,8 +137,8 @@ auto wedge_coordinate_maps(double inner_radius, double outer_radius,
 template <typename TargetFrame>
 auto frustum_coordinate_maps(double length_inner_cube, double length_outer_cube,
                              bool use_equiangular_map) noexcept
-    -> std::vector<
-        std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
+    -> std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Logical, TargetFrame, 3>>>;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief The corners for a domain with radial layers.
@@ -201,7 +203,7 @@ auto maps_for_rectilinear_domains(
         {},
     bool use_equiangular_map = false) noexcept
     -> std::vector<std::unique_ptr<
-        CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>;
+        domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>>>;
 
 /// \ingroup ComputationalDomainGroup
 /// \brief Create a rectilinear Domain of multicubes.

--- a/src/Domain/ElementMap.cpp
+++ b/src/Domain/ElementMap.cpp
@@ -12,7 +12,7 @@
 template <size_t Dim, typename TargetFrame>
 ElementMap<Dim, TargetFrame>::ElementMap(
     ElementId<Dim> element_id,
-    std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, Dim>>
+    std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, Dim>>
         block_map) noexcept
     : block_map_(std::move(block_map)),
       element_id_(std::move(element_id)),

--- a/src/Domain/ElementMap.hpp
+++ b/src/Domain/ElementMap.hpp
@@ -17,8 +17,10 @@ namespace PUP {
 class er;
 }  // namespace PUP
 /// \cond
+namespace domain {
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
+}  // namespace domain
 /// \endcond
 
 /*!
@@ -43,13 +45,13 @@ class ElementMap {
   ElementMap() = default;
   /// \endcond
 
-  ElementMap(
-      ElementId<Dim> element_id,
-      std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, Dim>>
-          block_map) noexcept;
+  ElementMap(ElementId<Dim> element_id,
+             std::unique_ptr<
+                 domain::CoordinateMapBase<Frame::Logical, TargetFrame, Dim>>
+                 block_map) noexcept;
 
-  const CoordinateMapBase<Frame::Logical, TargetFrame, Dim>& block_map() const
-      noexcept {
+  const domain::CoordinateMapBase<Frame::Logical, TargetFrame, Dim>& block_map()
+      const noexcept {
     return *block_map_;
   }
 
@@ -115,7 +117,7 @@ class ElementMap {
     }
   }
 
-  std::unique_ptr<CoordinateMapBase<Frame::Logical, TargetFrame, Dim>>
+  std::unique_ptr<domain::CoordinateMapBase<Frame::Logical, TargetFrame, Dim>>
       block_map_{nullptr};
   ElementId<Dim> element_id_{};
   // map_slope_[i] = 0.5 * (segment_ids[i].endpoint(Side::Upper) -

--- a/src/Domain/FaceNormal.cpp
+++ b/src/Domain/FaceNormal.cpp
@@ -48,7 +48,8 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
 template <size_t VolumeDim, typename TargetFrame>
 tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
     const Mesh<VolumeDim - 1>& interface_mesh,
-    const CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>& map,
+    const domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>&
+        map,
     const Direction<VolumeDim>& direction) noexcept {
   return unnormalized_face_normal_impl<TargetFrame>(interface_mesh, map,
                                                     direction);
@@ -65,8 +66,8 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
   template tnsr::i<DataVector, GET_DIM(data), GET_FRAME(data)>                \
   unnormalized_face_normal(                                                   \
       const Mesh<GET_DIM(data) - 1>&,                                         \
-      const CoordinateMapBase<Frame::Logical, GET_FRAME(data),                \
-                              GET_DIM(data)>&,                                \
+      const domain::CoordinateMapBase<Frame::Logical, GET_FRAME(data),        \
+                                      GET_DIM(data)>&,                        \
       const Direction<GET_DIM(data)>&) noexcept;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3),

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -16,8 +16,10 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
+namespace domain {
 template <typename, typename, size_t>
 class CoordinateMapBase;
+}  // namespace domain
 class DataVector;
 template <size_t>
 class Direction;
@@ -51,7 +53,8 @@ tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
 template <size_t VolumeDim, typename TargetFrame>
 tnsr::i<DataVector, VolumeDim, TargetFrame> unnormalized_face_normal(
     const Mesh<VolumeDim - 1>& interface_mesh,
-    const CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>& map,
+    const domain::CoordinateMapBase<Frame::Logical, TargetFrame, VolumeDim>&
+        map,
     const Direction<VolumeDim>& direction) noexcept;
 // @}
 

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -8,7 +8,9 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <functional>
 #include <string>
+#include <unordered_map>
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"

--- a/tests/Unit/DataStructures/Test_OrientVariables.cpp
+++ b/tests/Unit/DataStructures/Test_OrientVariables.cpp
@@ -31,9 +31,9 @@
 
 namespace {
 
-using Affine = CoordinateMaps::Affine;
-using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+using Affine = domain::CoordinateMaps::Affine;
+using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
 struct ScalarTensor {
   using type = Scalar<DataVector>;
@@ -101,10 +101,11 @@ void test_2d_with_orientation(
                             Spectral::Quadrature::GaussLobatto);
   const auto affine =
       Affine2D{Affine(-1.0, 1.0, 2.3, 4.5), Affine(-1.0, 1.0, 0.8, 3.1)};
-  const auto map = make_coordinate_map<Frame::Logical, Frame::Inertial>(affine);
+  const auto map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(affine);
   const auto map_oriented =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::DiscreteRotation<2>{orientation_map}, affine);
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::DiscreteRotation<2>{orientation_map}, affine);
 
   Variables<tmpl::list<ScalarTensor, Coords<2>>> vars(extents.product());
   // Fill ScalarTensor with x-coordinate values
@@ -178,10 +179,11 @@ void test_3d_with_orientation(
   const auto affine =
       Affine3D{Affine(-1.0, 1.0, 2.3, 4.5), Affine(-1.0, 1.0, 0.8, 3.1),
                Affine(-1.0, 1.0, -4.8, -3.9)};
-  const auto map = make_coordinate_map<Frame::Logical, Frame::Inertial>(affine);
+  const auto map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(affine);
   const auto map_oriented =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::DiscreteRotation<3>{orientation_map}, affine);
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::DiscreteRotation<3>{orientation_map}, affine);
 
   Variables<tmpl::list<ScalarTensor, Coords<3>>> vars(extents.product());
   // Fill ScalarTensor with x-coordinate values
@@ -245,7 +247,8 @@ void test_1d_slice_with_orientation(
       Mesh<1>(slice_extents.indices(), Spectral::Basis::Legendre,
               Spectral::Quadrature::GaussLobatto);
   const auto affine = Affine(-1.0, 1.0, 2.3, 4.5);
-  const auto map = make_coordinate_map<Frame::Logical, Frame::Inertial>(affine);
+  const auto map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(affine);
 
   for (const size_t sliced_dim : {0_st, 1_st}) {
     CAPTURE(sliced_dim);
@@ -258,8 +261,9 @@ void test_1d_slice_with_orientation(
             0, orientation_map(Direction<2>(remaining_dim, Side::Upper))
                    .side())}}));
     const auto map_oriented =
-        make_coordinate_map<Frame::Logical, Frame::Inertial>(
-            CoordinateMaps::DiscreteRotation<1>{slice_orientation_map}, affine);
+        domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+            domain::CoordinateMaps::DiscreteRotation<1>{slice_orientation_map},
+            affine);
 
     Variables<tmpl::list<ScalarTensor, Coords<1>>> vars(
         slice_extents.product());
@@ -308,7 +312,8 @@ void test_2d_slice_with_orientation(
               Spectral::Quadrature::GaussLobatto);
   const auto affine =
       Affine2D{Affine(-1.0, 1.0, 2.3, 4.5), Affine(-1.0, 1.0, 0.8, 3.1)};
-  const auto map = make_coordinate_map<Frame::Logical, Frame::Inertial>(affine);
+  const auto map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(affine);
 
   for (const size_t sliced_dim : {0_st, 1_st, 2_st}) {
     CAPTURE(sliced_dim);
@@ -342,8 +347,9 @@ void test_2d_slice_with_orientation(
     ();
 
     const auto map_oriented =
-        make_coordinate_map<Frame::Logical, Frame::Inertial>(
-            CoordinateMaps::DiscreteRotation<2>{slice_orientation_map}, affine);
+        domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+            domain::CoordinateMaps::DiscreteRotation<2>{slice_orientation_map},
+            affine);
 
     Variables<tmpl::list<ScalarTensor, Coords<2>>> vars(
         slice_extents.product());

--- a/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -32,9 +32,10 @@
  * downcast fails.
  */
 template <typename Map>
-bool are_maps_equal(const Map& map,
-                    const CoordinateMapBase<Frame::Logical, Frame::Inertial,
-                                            Map::dim>& map_base) {
+bool are_maps_equal(
+    const Map& map,
+    const domain::CoordinateMapBase<Frame::Logical, Frame::Inertial, Map::dim>&
+        map_base) {
   const auto* map_derived = dynamic_cast<const Map*>(&map_base);
   return map_derived == nullptr ? false : (*map_derived == map);
 }
@@ -44,8 +45,10 @@ bool are_maps_equal(const Map& map,
 /// are equal by evaluating them at a random set of points.
 template <typename SourceFrame, typename TargetFrame, size_t VolumeDim>
 void check_if_maps_are_equal(
-    const CoordinateMapBase<SourceFrame, TargetFrame, VolumeDim>& map_one,
-    const CoordinateMapBase<SourceFrame, TargetFrame, VolumeDim>& map_two) {
+    const domain::CoordinateMapBase<SourceFrame, TargetFrame, VolumeDim>&
+        map_one,
+    const domain::CoordinateMapBase<SourceFrame, TargetFrame, VolumeDim>&
+        map_two) {
   MAKE_GENERATOR(gen);
   std::uniform_real_distribution<> real_dis(-1, 1);
 
@@ -68,10 +71,10 @@ void check_if_maps_are_equal(
 /// by evaluating the map at a random set of points.
 template <typename Map>
 void check_if_map_is_identity(const Map& map) {
-  using IdentityMap = CoordinateMaps::Identity<Map::dim>;
+  using IdentityMap = domain::CoordinateMaps::Identity<Map::dim>;
   check_if_maps_are_equal(
-      make_coordinate_map<Frame::Inertial, Frame::Grid>(IdentityMap{}),
-      make_coordinate_map<Frame::Inertial, Frame::Grid>(map));
+      domain::make_coordinate_map<Frame::Inertial, Frame::Grid>(IdentityMap{}),
+      domain::make_coordinate_map<Frame::Inertial, Frame::Grid>(map));
   CHECK(map.is_identity());
 }
 
@@ -136,7 +139,8 @@ void test_inv_jacobian(const Map& map,
  */
 template <typename Map, typename... Args>
 void test_coordinate_map_implementation(const Map& map) {
-  const auto coord_map = make_coordinate_map<Frame::Logical, Frame::Grid>(map);
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Grid>(map);
   MAKE_GENERATOR(gen);
   std::uniform_real_distribution<> real_dis(-1, 1);
 
@@ -275,8 +279,8 @@ void test_coordinate_map_argument_types(
 
   jac_overloader(
       make_array_data_vector, add_reference_wrapper, map, test_point,
-      CoordinateMap_detail::is_jacobian_time_dependent_t<decltype(map),
-                                                         double>{},
+      domain::CoordinateMap_detail::is_jacobian_time_dependent_t<decltype(map),
+                                                                 double>{},
       args...);
 }
 
@@ -333,8 +337,8 @@ void test_suite_for_map_on_unit_cube(const Map& map) {
   test_helper(map);
   const auto map2 = serialize_and_deserialize(map);
   check_if_maps_are_equal(
-      make_coordinate_map<Frame::Logical, Frame::Grid>(map),
-      make_coordinate_map<Frame::Logical, Frame::Grid>(map2));
+      domain::make_coordinate_map<Frame::Logical, Frame::Grid>(map),
+      domain::make_coordinate_map<Frame::Logical, Frame::Grid>(map2));
   test_helper(map2);
 }
 
@@ -414,8 +418,8 @@ void test_suite_for_map_on_sphere(const Map& map,
   test_helper(map);
   const auto map2 = serialize_and_deserialize(map);
   check_if_maps_are_equal(
-      make_coordinate_map<Frame::Logical, Frame::Grid>(map),
-      make_coordinate_map<Frame::Logical, Frame::Grid>(map2));
+      domain::make_coordinate_map<Frame::Logical, Frame::Grid>(map),
+      domain::make_coordinate_map<Frame::Logical, Frame::Grid>(map2));
   test_helper(map2);
 }
 

--- a/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
@@ -13,6 +13,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Affine", "[Domain][Unit]") {
   const double xA = -1.0;
   const double xB = 1.0;
@@ -58,3 +59,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Affine", "[Domain][Unit]") {
 
   check_if_map_is_identity(CoordinateMaps::Affine{-1.0, 1.0, -1.0, 1.0});
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_BulgedCube.cpp
@@ -17,6 +17,8 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
+namespace {
 void test_bulged_cube_fail() {
   INFO("Bulged cube fail");
   const CoordinateMaps::BulgedCube map(2.0 * sqrt(3.0), 0.5, false);
@@ -37,11 +39,11 @@ void test_bulged_cube_fail() {
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point1)));
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point2)));
   CHECK_FALSE(static_cast<bool>(map.inverse(test_mapped_point3)));
-  if(map.inverse(test_mapped_point4)) {
+  if (map.inverse(test_mapped_point4)) {
     CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point4).get()),
                           test_mapped_point4);
   }
-  if(map.inverse(test_mapped_point5)) {
+  if (map.inverse(test_mapped_point5)) {
     CHECK_ITERABLE_APPROX(map(map.inverse(test_mapped_point5).get()),
                           test_mapped_point5);
   }
@@ -96,6 +98,7 @@ void test_bulged_cube(bool with_equiangular_map) {
   test_inverse_map(map, test_point3);
   test_inverse_map(map, test_point4);
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube", "[Domain][Unit]") {
   const CoordinateMaps::BulgedCube map(sqrt(3.0), 0, false);
@@ -131,3 +134,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.BulgedCube", "[Domain][Unit]") {
 
   check_if_map_is_identity(CoordinateMaps::BulgedCube{sqrt(3.0), 0, false});
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CoordinateMap.cpp
@@ -34,6 +34,7 @@
 
 // IWYU pragma: no_forward_declare Tensor
 
+namespace domain {
 namespace {
 template <typename Map1, typename Map2, typename DataType, size_t Dim>
 auto compose_jacobians(const Map1& map1, const Map2& map2,
@@ -898,3 +899,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMap", "[Domain][Unit]") {
   test_make_vector_coordinate_map_base();
   test_coordinate_maps_are_identity();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CubicScale.cpp
@@ -20,6 +20,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 // We will call with this function with arguments that are designed
 // to fail in a certain way.
@@ -279,3 +280,4 @@ SPECTRE_TEST_CASE(
   ERROR_TEST();
   cubic_scale_non_invertible(0.96, 1.0, 0.0);
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_DiscreteRotation.cpp
@@ -19,6 +19,7 @@
 #include "Domain/OrientationMap.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 
+namespace domain {
 namespace {
 void test_1d() {
   INFO("1d");
@@ -135,3 +136,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.DiscreteRotation",
   test_with_orientation();
   test_is_identity();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_EquatorialCompression.cpp
@@ -17,6 +17,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 void test_suite() {  // Set up random number generator
   INFO("Suite");
@@ -101,3 +102,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.EquatorialCompression",
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_Equiangular.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Equiangular.cpp
@@ -13,6 +13,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Equiangular", "[Domain][Unit]") {
   const double xA = -1.0;
   const double xB = 2.0;
@@ -74,3 +75,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Equiangular", "[Domain][Unit]") {
   test_coordinate_map_argument_types(equiangular_map, point_r2);
   CHECK(not CoordinateMaps::Equiangular{}.is_identity());
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Frustum.cpp
@@ -17,6 +17,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 void test_suite_for_frustum(const bool with_equiangular_map) {
   INFO("Suite for frustum");
@@ -286,3 +287,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Frustum", "[Domain][Unit]") {
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_Identity.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Identity.cpp
@@ -11,6 +11,8 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
+namespace {
 template <size_t Dim>
 void test_identity() {
   CoordinateMaps::Identity<Dim> identity_map;
@@ -34,9 +36,11 @@ void test_identity() {
 
   check_if_map_is_identity(CoordinateMaps::Identity<Dim>{});
 }
+}  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Identity", "[Domain][Unit]") {
   test_identity<1>();
   test_identity<2>();
   test_identity<3>();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_ProductMaps.cpp
@@ -21,6 +21,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 void test_product_two_maps_fail() {
   INFO("Product two maps fail");
@@ -367,3 +368,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.ProductMaps", "[Domain][Unit]") {
   test_product_of_2_maps();
   test_product_of_3_maps();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
@@ -18,7 +18,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
-// IWYU pragma: no_forward_declare CoordinateMaps::Rotation
+// IWYU pragma: no_forward_declare domain::CoordinateMaps::Rotation
 
 namespace domain {
 namespace {

--- a/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Rotation.cpp
@@ -20,6 +20,7 @@
 
 // IWYU pragma: no_forward_declare CoordinateMaps::Rotation
 
+namespace domain {
 namespace {
 template <typename T>
 void test_rotation_3(const CoordinateMaps::Rotation<3>& three_dim_rotation_map,
@@ -156,3 +157,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Rotation", "[Domain][Unit]") {
   test_rotation_2();
   test_rotation_3();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_SpecialMobius.cpp
@@ -17,6 +17,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 void test_suite() {  // Set up random number generator
   INFO("Suite");
@@ -149,3 +150,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.SpecialMobius",
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Translation.cpp
@@ -20,6 +20,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.Translation",
                   "[Domain][Unit]") {
   // define vars for FunctionOfTime::PiecewisePolynomial f(t) = t**2.
@@ -83,3 +84,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordMapsTimeDependent.Translation",
   test_coordinate_map_argument_types(trans_map, point_xi, t, f_of_t_list);
   CHECK(not CoordMapsTimeDependent::Translation{}.is_identity());
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge2D.cpp
@@ -18,6 +18,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 void test_wedge2d_all_orientations(const bool with_equiangular_map) {
   INFO("Wedge2d all orientations");
@@ -246,3 +247,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge2D.Map", "[Domain][Unit]") {
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+}  // namespace domain

--- a/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Wedge3D.cpp
@@ -16,6 +16,7 @@
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 void test_wedge3d_all_directions() {
   INFO("Wedge3d all directions");
@@ -386,3 +387,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Wedge3D.Map", "[Domain][Unit]") {
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
+++ b/tests/Unit/Domain/Creators/Test_AlignedLattice.cpp
@@ -18,10 +18,11 @@ namespace Frame {
 struct Inertial;
 }  // namespace Frame
 
+namespace domain {
 namespace {
 template <size_t VolumeDim>
 void test_aligned_blocks(
-    const domain::creators::AlignedLattice<VolumeDim, Frame::Inertial>&
+    const creators::AlignedLattice<VolumeDim, Frame::Inertial>&
         aligned_blocks) noexcept {
   const auto domain = aligned_blocks.create_domain();
   test_initial_domain(domain, aligned_blocks.initial_refinement_levels());
@@ -37,7 +38,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
           "    InitialGridPoints: [3]\n"
           "    InitialRefinement: [2]\n");
   const auto* aligned_blocks_creator_1d =
-      dynamic_cast<const domain::creators::AlignedLattice<1, Frame::Inertial>*>(
+      dynamic_cast<const creators::AlignedLattice<1, Frame::Inertial>*>(
           domain_creator_1d.get());
   test_aligned_blocks(*aligned_blocks_creator_1d);
 
@@ -49,7 +50,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
           "    InitialGridPoints: [3, 4]\n"
           "    InitialRefinement: [2, 1]\n");
   const auto* aligned_blocks_creator_2d =
-      dynamic_cast<const domain::creators::AlignedLattice<2, Frame::Inertial>*>(
+      dynamic_cast<const creators::AlignedLattice<2, Frame::Inertial>*>(
           domain_creator_2d.get());
   test_aligned_blocks(*aligned_blocks_creator_2d);
 
@@ -61,7 +62,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.AlignedLattice", "[Domain][Unit]") {
           "    InitialGridPoints: [3, 4, 5]\n"
           "    InitialRefinement: [2, 1, 0]\n");
   const auto* aligned_blocks_creator_3d =
-      dynamic_cast<const domain::creators::AlignedLattice<3, Frame::Inertial>*>(
+      dynamic_cast<const creators::AlignedLattice<3, Frame::Inertial>*>(
           domain_creator_3d.get());
   test_aligned_blocks(*aligned_blocks_creator_3d);
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Brick.cpp
+++ b/tests/Unit/Domain/Creators/Test_Brick.cpp
@@ -30,11 +30,12 @@
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 using Affine = CoordinateMaps::Affine;
 using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 void test_brick_construction(
-    const domain::creators::Brick<Frame::Inertial>& brick,
+    const creators::Brick<Frame::Inertial>& brick,
     const std::array<double, 3>& lower_bound,
     const std::array<double, 3>& upper_bound,
     const std::vector<std::array<size_t, 3>>& expected_extents,
@@ -67,7 +68,7 @@ void test_brick() {
   // Default OrientationMap is aligned.
   const OrientationMap<3> aligned_orientation{};
 
-  const domain::creators::Brick<Frame::Inertial> brick{
+  const creators::Brick<Frame::Inertial> brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, false, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(brick, lower_bound, upper_bound, grid_points,
@@ -81,7 +82,7 @@ void test_brick() {
                                {Direction<3>::lower_zeta()},
                                {Direction<3>::upper_zeta()}}});
 
-  const domain::creators::Brick<Frame::Inertial> periodic_x_brick{
+  const creators::Brick<Frame::Inertial> periodic_x_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, false, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -95,7 +96,7 @@ void test_brick() {
            {Direction<3>::lower_zeta()},
            {Direction<3>::upper_zeta()}}});
 
-  const domain::creators::Brick<Frame::Inertial> periodic_y_brick{
+  const creators::Brick<Frame::Inertial> periodic_y_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, true, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -109,7 +110,7 @@ void test_brick() {
            {Direction<3>::lower_zeta()},
            {Direction<3>::upper_zeta()}}});
 
-  const domain::creators::Brick<Frame::Inertial> periodic_z_brick{
+  const creators::Brick<Frame::Inertial> periodic_z_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, false, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -123,7 +124,7 @@ void test_brick() {
            {Direction<3>::lower_eta()},
            {Direction<3>::upper_eta()}}});
 
-  const domain::creators::Brick<Frame::Inertial> periodic_xy_brick{
+  const creators::Brick<Frame::Inertial> periodic_xy_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, true, false}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -137,7 +138,7 @@ void test_brick() {
       std::vector<std::unordered_set<Direction<3>>>{
           {{Direction<3>::lower_zeta()}, {Direction<3>::upper_zeta()}}});
 
-  const domain::creators::Brick<Frame::Inertial> periodic_yz_brick{
+  const creators::Brick<Frame::Inertial> periodic_yz_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{false, true, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -153,7 +154,7 @@ void test_brick() {
           {Direction<3>::upper_xi()},
       }});
 
-  const domain::creators::Brick<Frame::Inertial> periodic_xz_brick{
+  const creators::Brick<Frame::Inertial> periodic_xz_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, false, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -167,7 +168,7 @@ void test_brick() {
       std::vector<std::unordered_set<Direction<3>>>{
           {{Direction<3>::lower_eta()}, {Direction<3>::upper_eta()}}});
 
-  const domain::creators::Brick<Frame::Inertial> periodic_xyz_brick{
+  const creators::Brick<Frame::Inertial> periodic_xyz_brick{
       lower_bound, upper_bound, std::array<bool, 3>{{true, true, true}},
       refinement_level[0], grid_points[0]};
   test_brick_construction(
@@ -183,7 +184,7 @@ void test_brick() {
       std::vector<std::unordered_set<Direction<3>>>{{}});
 
   // Test serialization of the map
-  domain::creators::register_derived_with_charm();
+  creators::register_derived_with_charm();
 
   const auto base_map =
       make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
@@ -208,7 +209,7 @@ void test_brick_factory() {
           "    InitialGridPoints: [3,4,3]\n"
           "    InitialRefinement: [2,3,2]\n");
   const auto* brick_creator =
-      dynamic_cast<const domain::creators::Brick<Frame::Inertial>*>(
+      dynamic_cast<const creators::Brick<Frame::Inertial>*>(
           domain_creator.get());
   test_brick_construction(
       *brick_creator, {{0., 0., 0.}}, {{1., 2., 3.}}, {{{3, 4, 3}}},
@@ -227,3 +228,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Brick", "[Domain][Unit]") {
   test_brick();
   test_brick_factory();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Cylinder.cpp
+++ b/tests/Unit/Domain/Creators/Test_Cylinder.cpp
@@ -29,9 +29,10 @@
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 
+namespace domain {
 namespace {
 void test_cylinder_construction(
-    const domain::creators::Cylinder<Frame::Inertial>& cylinder,
+    const creators::Cylinder<Frame::Inertial>& cylinder,
     const double inner_radius, const double outer_radius,
     const double lower_bound, const double upper_bound,
     const bool is_periodic_in_z,
@@ -195,7 +196,7 @@ void test_cylinder_boundaries_equiangular() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{4, 4, 3}};
 
-  const domain::creators::Cylinder<Frame::Inertial> cylinder{
+  const creators::Cylinder<Frame::Inertial> cylinder{
       inner_radius, outer_radius,     lower_bound, upper_bound,
       true,         refinement_level, grid_points, true};
   test_physical_separation(cylinder.create_domain().blocks());
@@ -222,8 +223,7 @@ void test_cylinder_factory_equiangular() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{2, 3, 4}};
   test_cylinder_construction(
-      dynamic_cast<const domain::creators::Cylinder<Frame::Inertial>&>(
-          *cylinder),
+      dynamic_cast<const creators::Cylinder<Frame::Inertial>&>(*cylinder),
       inner_radius, outer_radius, lower_bound, upper_bound, true, grid_points,
       {5, make_array<3>(refinement_level)}, true);
 }
@@ -235,7 +235,7 @@ void test_cylinder_boundaries_equidistant() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{4, 4, 3}};
 
-  const domain::creators::Cylinder<Frame::Inertial> cylinder{
+  const creators::Cylinder<Frame::Inertial> cylinder{
       inner_radius, outer_radius,     lower_bound, upper_bound,
       true,         refinement_level, grid_points, false};
   test_physical_separation(cylinder.create_domain().blocks());
@@ -262,8 +262,7 @@ void test_cylinder_factory_equidistant() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{2, 3, 4}};
   test_cylinder_construction(
-      dynamic_cast<const domain::creators::Cylinder<Frame::Inertial>&>(
-          *cylinder),
+      dynamic_cast<const creators::Cylinder<Frame::Inertial>&>(*cylinder),
       inner_radius, outer_radius, lower_bound, upper_bound, true, grid_points,
       {5, make_array<3>(refinement_level)}, false);
 }
@@ -275,7 +274,7 @@ void test_cylinder_boundaries_equiangular_not_periodic_in_z() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{4, 4, 3}};
 
-  const domain::creators::Cylinder<Frame::Inertial> cylinder{
+  const creators::Cylinder<Frame::Inertial> cylinder{
       inner_radius, outer_radius,     lower_bound, upper_bound,
       false,        refinement_level, grid_points, true};
   test_physical_separation(cylinder.create_domain().blocks());
@@ -303,8 +302,7 @@ void test_cylinder_factory_equiangular_not_periodic_in_z() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{2, 3, 4}};
   test_cylinder_construction(
-      dynamic_cast<const domain::creators::Cylinder<Frame::Inertial>&>(
-          *cylinder),
+      dynamic_cast<const creators::Cylinder<Frame::Inertial>&>(*cylinder),
       inner_radius, outer_radius, lower_bound, upper_bound, false, grid_points,
       {5, make_array<3>(refinement_level)}, true);
 }
@@ -316,7 +314,7 @@ void test_cylinder_boundaries_equidistant_not_periodic_in_z() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{4, 4, 3}};
 
-  const domain::creators::Cylinder<Frame::Inertial> cylinder{
+  const creators::Cylinder<Frame::Inertial> cylinder{
       inner_radius, outer_radius,     lower_bound, upper_bound,
       false,        refinement_level, grid_points, false};
   test_physical_separation(cylinder.create_domain().blocks());
@@ -344,8 +342,7 @@ void test_cylinder_factory_equidistant_not_periodic_in_z() {
   const size_t refinement_level = 2;
   const std::array<size_t, 3> grid_points{{2, 3, 4}};
   test_cylinder_construction(
-      dynamic_cast<const domain::creators::Cylinder<Frame::Inertial>&>(
-          *cylinder),
+      dynamic_cast<const creators::Cylinder<Frame::Inertial>&>(*cylinder),
       inner_radius, outer_radius, lower_bound, upper_bound, false, grid_points,
       {5, make_array<3>(refinement_level)}, false);
 }
@@ -361,3 +358,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Cylinder", "[Domain][Unit]") {
   test_cylinder_boundaries_equidistant_not_periodic_in_z();
   test_cylinder_factory_equidistant_not_periodic_in_z();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Disk.cpp
+++ b/tests/Unit/Domain/Creators/Test_Disk.cpp
@@ -29,10 +29,11 @@
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 
+namespace domain {
 namespace {
 void test_disk_construction(
-    const domain::creators::Disk<Frame::Inertial>& disk,
-    const double inner_radius, const double outer_radius,
+    const creators::Disk<Frame::Inertial>& disk, const double inner_radius,
+    const double outer_radius,
     const std::array<size_t, 2>& expected_wedge_extents,
     const std::vector<std::array<size_t, 2>>& expected_refinement_level,
     const bool use_equiangular_map) {
@@ -131,7 +132,7 @@ void test_disk_boundaries_equiangular() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points{{4, 4}};
 
-  const domain::creators::Disk<Frame::Inertial> disk{
+  const creators::Disk<Frame::Inertial> disk{
       inner_radius, outer_radius, refinement_level, grid_points, true};
   test_physical_separation(disk.create_domain().blocks());
   test_disk_construction(disk, inner_radius, outer_radius, grid_points,
@@ -152,9 +153,8 @@ void test_disk_factory_equiangular() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points{{2, 3}};
   test_disk_construction(
-      dynamic_cast<const domain::creators::Disk<Frame::Inertial>&>(*disk),
-      inner_radius, outer_radius, grid_points,
-      {5, make_array<2>(refinement_level)}, true);
+      dynamic_cast<const creators::Disk<Frame::Inertial>&>(*disk), inner_radius,
+      outer_radius, grid_points, {5, make_array<2>(refinement_level)}, true);
 }
 
 void test_disk_boundaries_equidistant() {
@@ -163,7 +163,7 @@ void test_disk_boundaries_equidistant() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points{{4, 4}};
 
-  const domain::creators::Disk<Frame::Inertial> disk{
+  const creators::Disk<Frame::Inertial> disk{
       inner_radius, outer_radius, refinement_level, grid_points, false};
   test_physical_separation(disk.create_domain().blocks());
   test_disk_construction(disk, inner_radius, outer_radius, grid_points,
@@ -184,9 +184,8 @@ void test_disk_factory_equidistant() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points{{2, 3}};
   test_disk_construction(
-      dynamic_cast<const domain::creators::Disk<Frame::Inertial>&>(*disk),
-      inner_radius, outer_radius, grid_points,
-      {5, make_array<2>(refinement_level)}, false);
+      dynamic_cast<const creators::Disk<Frame::Inertial>&>(*disk), inner_radius,
+      outer_radius, grid_points, {5, make_array<2>(refinement_level)}, false);
 }
 }  // namespace
 
@@ -197,3 +196,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Disk.Factory.Equidistant",
   test_disk_boundaries_equidistant();
   test_disk_factory_equidistant();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Interval.cpp
+++ b/tests/Unit/Domain/Creators/Test_Interval.cpp
@@ -28,9 +28,10 @@
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 void test_interval_construction(
-    const domain::creators::Interval<Frame::Inertial>& interval,
+    const creators::Interval<Frame::Inertial>& interval,
     const std::array<double, 1>& lower_bound,
     const std::array<double, 1>& upper_bound,
     const std::vector<std::array<size_t, 1>>& expected_extents,
@@ -59,7 +60,7 @@ void test_interval() {
   // default Orientation is aligned
   const OrientationMap<1> aligned_orientation{};
 
-  const domain::creators::Interval<Frame::Inertial> interval{
+  const creators::Interval<Frame::Inertial> interval{
       lower_bound, upper_bound, std::array<bool, 1>{{false}},
       refinement_level[0], grid_points[0]};
   test_interval_construction(
@@ -68,7 +69,7 @@ void test_interval() {
       std::vector<std::unordered_set<Direction<1>>>{
           {{Direction<1>::lower_xi()}, {Direction<1>::upper_xi()}}});
 
-  const domain::creators::Interval<Frame::Inertial> periodic_interval{
+  const creators::Interval<Frame::Inertial> periodic_interval{
       lower_bound, upper_bound, std::array<bool, 1>{{true}},
       refinement_level[0], grid_points[0]};
   test_interval_construction(
@@ -80,7 +81,7 @@ void test_interval() {
       std::vector<std::unordered_set<Direction<1>>>{{}});
 
   // Test serialization of the map
-  domain::creators::register_derived_with_charm();
+  creators::register_derived_with_charm();
 
   const auto base_map =
       make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
@@ -105,7 +106,7 @@ void test_interval_factory() {
           "    InitialGridPoints: [3]\n"
           "    InitialRefinement: [2]\n");
   const auto* interval_creator =
-      dynamic_cast<const domain::creators::Interval<Frame::Inertial>*>(
+      dynamic_cast<const creators::Interval<Frame::Inertial>*>(
           domain_creator.get());
   test_interval_construction(*interval_creator, {{0.}}, {{1.}}, {{{3}}},
                              {{{2}}},
@@ -120,3 +121,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Interval.Factory", "[Domain][Unit]") {
   test_interval();
   test_interval_factory();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -29,11 +29,12 @@
 #include "tests/Unit/TestCreation.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 using Affine = CoordinateMaps::Affine;
 using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
 void test_rectangle_construction(
-    const domain::creators::Rectangle<Frame::Inertial>& rectangle,
+    const creators::Rectangle<Frame::Inertial>& rectangle,
     const std::array<double, 2>& lower_bound,
     const std::array<double, 2>& upper_bound,
     const std::vector<std::array<size_t, 2>>& expected_extents,
@@ -63,7 +64,7 @@ void test_rectangle() {
   // default OrientationMap is aligned
   const OrientationMap<2> aligned_orientation{};
 
-  const domain::creators::Rectangle<Frame::Inertial> rectangle{
+  const creators::Rectangle<Frame::Inertial> rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{false, false}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -75,7 +76,7 @@ void test_rectangle() {
            {Direction<2>::lower_eta()},
            {Direction<2>::upper_eta()}}});
 
-  const domain::creators::Rectangle<Frame::Inertial> periodic_x_rectangle{
+  const creators::Rectangle<Frame::Inertial> periodic_x_rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{true, false}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -87,7 +88,7 @@ void test_rectangle() {
       std::vector<std::unordered_set<Direction<2>>>{
           {{Direction<2>::lower_eta()}, {Direction<2>::upper_eta()}}});
 
-  const domain::creators::Rectangle<Frame::Inertial> periodic_y_rectangle{
+  const creators::Rectangle<Frame::Inertial> periodic_y_rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{false, true}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -99,7 +100,7 @@ void test_rectangle() {
       std::vector<std::unordered_set<Direction<2>>>{
           {{Direction<2>::lower_xi()}, {Direction<2>::upper_xi()}}});
 
-  const domain::creators::Rectangle<Frame::Inertial> periodic_xy_rectangle{
+  const creators::Rectangle<Frame::Inertial> periodic_xy_rectangle{
       lower_bound, upper_bound, std::array<bool, 2>{{true, true}},
       refinement_level[0], grid_points[0]};
   test_rectangle_construction(
@@ -113,7 +114,7 @@ void test_rectangle() {
       std::vector<std::unordered_set<Direction<2>>>{{}});
 
   // Test serialization of the map
-  domain::creators::register_derived_with_charm();
+  creators::register_derived_with_charm();
 
   const auto base_map =
       make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
@@ -140,7 +141,7 @@ void test_rectangle_factory() {
           "    InitialGridPoints: [3,4]\n"
           "    InitialRefinement: [2,3]\n");
   const auto* rectangle_creator =
-      dynamic_cast<const domain::creators::Rectangle<Frame::Inertial>*>(
+      dynamic_cast<const creators::Rectangle<Frame::Inertial>*>(
           domain_creator.get());
   test_rectangle_construction(
       *rectangle_creator, {{0., 0.}}, {{1., 2.}}, {{{3, 4}}}, {{{2, 3}}},
@@ -156,3 +157,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Rectangle.Factory", "[Domain][Unit]") {
   test_rectangle();
   test_rectangle_factory();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedBricks.cpp
@@ -25,9 +25,10 @@
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 
+namespace domain {
 namespace {
 void test_rotated_bricks_construction(
-    const domain::creators::RotatedBricks<Frame::Inertial>& rotated_bricks,
+    const creators::RotatedBricks<Frame::Inertial>& rotated_bricks,
     const std::array<double, 3>& lower_bound,
     const std::array<double, 3>& midpoint,
     const std::array<double, 3>& upper_bound,
@@ -132,7 +133,7 @@ void test_rotated_bricks() {
   const OrientationMap<3> rotation_F_then_U{std::array<Direction<3>, 3>{
       {Direction<3>::lower_zeta(), Direction<3>::upper_xi(),
        Direction<3>::lower_eta()}}};
-  const domain::creators::RotatedBricks<Frame::Inertial> rotated_bricks{
+  const creators::RotatedBricks<Frame::Inertial> rotated_bricks{
       lower_bound,
       midpoint,
       upper_bound,
@@ -189,16 +190,16 @@ void test_rotated_bricks() {
            Direction<3>::upper_zeta()}});
   test_physical_separation(rotated_bricks.create_domain().blocks());
 
-  const domain::creators::RotatedBricks<Frame::Inertial>
-      rotated_periodic_bricks{lower_bound,
-                              midpoint,
-                              upper_bound,
-                              {{true, true, true}},
-                              {{refinement_level[0][0], refinement_level[0][1],
-                                refinement_level[0][2]}},
-                              {{{{grid_points[0][0], grid_points[1][2]}},
-                                {{grid_points[0][1], grid_points[2][2]}},
-                                {{grid_points[0][2], grid_points[4][2]}}}}};
+  const creators::RotatedBricks<Frame::Inertial> rotated_periodic_bricks{
+      lower_bound,
+      midpoint,
+      upper_bound,
+      {{true, true, true}},
+      {{refinement_level[0][0], refinement_level[0][1],
+        refinement_level[0][2]}},
+      {{{{grid_points[0][0], grid_points[1][2]}},
+        {{grid_points[0][1], grid_points[2][2]}},
+        {{grid_points[0][2], grid_points[4][2]}}}}};
   test_rotated_bricks_construction(
       rotated_periodic_bricks, lower_bound, midpoint, upper_bound, grid_points,
       refinement_level,
@@ -283,7 +284,7 @@ void test_rotated_bricks_factory() {
           "    InitialGridPoints: [[3,2],[1,4],[5,6]]\n"
           "    InitialRefinement: [2,1,0]\n");
   const auto* rotated_bricks_creator =
-      dynamic_cast<const domain::creators::RotatedBricks<Frame::Inertial>*>(
+      dynamic_cast<const creators::RotatedBricks<Frame::Inertial>*>(
           domain_creator.get());
   test_rotated_bricks_construction(
       *rotated_bricks_creator, {{0.1, -0.4, -0.2}}, {{2.6, 3.2, 1.7}},
@@ -354,3 +355,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedBricks.Factory",
   test_rotated_bricks();
   test_rotated_bricks_factory();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedIntervals.cpp
@@ -26,10 +26,10 @@
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 
+namespace domain {
 namespace {
 void test_rotated_intervals_construction(
-    const domain::creators::RotatedIntervals<Frame::Inertial>&
-        rotated_intervals,
+    const creators::RotatedIntervals<Frame::Inertial>& rotated_intervals,
     const std::array<double, 1>& lower_bound,
     const std::array<double, 1>& midpoint,
     const std::array<double, 1>& upper_bound,
@@ -68,7 +68,7 @@ void test_rotated_intervals() {
   const OrientationMap<1> flipped{
       std::array<Direction<1>, 1>{{Direction<1>::lower_xi()}}};
 
-  const domain::creators::RotatedIntervals<Frame::Inertial> rotated_intervals{
+  const creators::RotatedIntervals<Frame::Inertial> rotated_intervals{
       lower_bound,         midpoint,
       upper_bound,         std::array<bool, 1>{{false}},
       refinement_level[0], {{{{grid_points[0][0], grid_points[1][0]}}}}};
@@ -82,11 +82,10 @@ void test_rotated_intervals() {
           {Direction<1>::lower_xi()}, {Direction<1>::lower_xi()}});
   test_physical_separation(rotated_intervals.create_domain().blocks());
 
-  const domain::creators::RotatedIntervals<Frame::Inertial>
-      periodic_rotated_intervals{
-          lower_bound,         midpoint,
-          upper_bound,         std::array<bool, 1>{{true}},
-          refinement_level[0], {{{{grid_points[0][0], grid_points[1][0]}}}}};
+  const creators::RotatedIntervals<Frame::Inertial> periodic_rotated_intervals{
+      lower_bound,         midpoint,
+      upper_bound,         std::array<bool, 1>{{true}},
+      refinement_level[0], {{{{grid_points[0][0], grid_points[1][0]}}}}};
   test_rotated_intervals_construction(
       periodic_rotated_intervals, lower_bound, midpoint, upper_bound,
       grid_points, refinement_level,
@@ -112,7 +111,7 @@ void test_rotated_intervals_factory() {
           "    InitialGridPoints: [[3,2]]\n"
           "    InitialRefinement: [2]\n");
   const auto* rotated_intervals_creator =
-      dynamic_cast<const domain::creators::RotatedIntervals<Frame::Inertial>*>(
+      dynamic_cast<const creators::RotatedIntervals<Frame::Inertial>*>(
           domain_creator.get());
   test_rotated_intervals_construction(
       *rotated_intervals_creator, {{0.0}}, {{0.5}}, {{1.0}}, {{{3}}, {{2}}},
@@ -131,3 +130,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedIntervals.Factory",
   test_rotated_intervals();
   test_rotated_intervals_factory();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
+++ b/tests/Unit/Domain/Creators/Test_RotatedRectangles.cpp
@@ -25,10 +25,10 @@
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 
+namespace domain {
 namespace {
 void test_rotated_rectangles_construction(
-    const domain::creators::RotatedRectangles<Frame::Inertial>&
-        rotated_rectangles,
+    const creators::RotatedRectangles<Frame::Inertial>& rotated_rectangles,
     const std::array<double, 2>& lower_bound,
     const std::array<double, 2>& midpoint,
     const std::array<double, 2>& upper_bound,
@@ -94,7 +94,7 @@ void test_rotated_rectangles() {
   const OrientationMap<2> quarter_turn_ccw{std::array<Direction<2>, 2>{
       {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}};
 
-  const domain::creators::RotatedRectangles<Frame::Inertial> rotated_rectangles{
+  const creators::RotatedRectangles<Frame::Inertial> rotated_rectangles{
       lower_bound,
       midpoint,
       upper_bound,
@@ -121,7 +121,7 @@ void test_rotated_rectangles() {
           {Direction<2>::lower_xi(), Direction<2>::upper_eta()}});
   test_physical_separation(rotated_rectangles.create_domain().blocks());
 
-  const domain::creators::RotatedRectangles<Frame::Inertial>
+  const creators::RotatedRectangles<Frame::Inertial>
       rotated_periodic_rectangles{
           lower_bound,
           midpoint,
@@ -172,7 +172,7 @@ void test_rotated_rectangles_factory() {
           "    InitialGridPoints: [[3,2],[1,4]]\n"
           "    InitialRefinement: [2,1]\n");
   const auto* rotated_rectangles_creator =
-      dynamic_cast<const domain::creators::RotatedRectangles<Frame::Inertial>*>(
+      dynamic_cast<const creators::RotatedRectangles<Frame::Inertial>*>(
           domain_creator.get());
   test_rotated_rectangles_construction(
       *rotated_rectangles_creator, {{0.1, -0.4}}, {{2.6, 3.2}}, {{5.1, 6.2}},
@@ -200,3 +200,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.RotatedRectangles.Factory",
   test_rotated_rectangles();
   test_rotated_rectangles_factory();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Shell.cpp
+++ b/tests/Unit/Domain/Creators/Test_Shell.cpp
@@ -41,12 +41,14 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
+
 // IWYU pragma: no_forward_declare BlockNeighbor
+
+namespace domain {
 namespace {
 void test_shell_construction(
-    const domain::creators::Shell<Frame::Inertial>& shell,
-    const double inner_radius, const double outer_radius,
-    const bool use_equiangular_map,
+    const creators::Shell<Frame::Inertial>& shell, const double inner_radius,
+    const double outer_radius, const bool use_equiangular_map,
     const std::array<size_t, 2>& expected_shell_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level,
     const double aspect_ratio = 1.0, const bool use_logarithmic_map = false,
@@ -259,7 +261,7 @@ void test_shell_boundaries() {
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
 
   for (const auto& use_equiangular_map : {true, false}) {
-    const domain::creators::Shell<Frame::Inertial> shell{
+    const creators::Shell<Frame::Inertial> shell{
         inner_radius, outer_radius, refinement_level, grid_points_r_angular,
         use_equiangular_map};
     test_physical_separation(shell.create_domain().blocks());
@@ -281,7 +283,7 @@ void test_shell_factory_equiangular() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
   test_shell_construction(
-      dynamic_cast<const domain::creators::Shell<Frame::Inertial>&>(*shell),
+      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
       inner_radius, outer_radius, true, grid_points_r_angular,
       {6, make_array<3>(refinement_level)});
 }
@@ -299,7 +301,7 @@ void test_shell_factory_equidistant() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
   test_shell_construction(
-      dynamic_cast<const domain::creators::Shell<Frame::Inertial>&>(*shell),
+      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
       inner_radius, outer_radius, false, grid_points_r_angular,
       {6, make_array<3>(refinement_level)});
 }
@@ -311,7 +313,7 @@ void test_shell_boundaries_aspect_ratio() {
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
   const double aspect_ratio = 1.3;
 
-  const domain::creators::Shell<Frame::Inertial> shell{
+  const creators::Shell<Frame::Inertial> shell{
       inner_radius,          outer_radius, refinement_level,
       grid_points_r_angular, false,        aspect_ratio};
   test_physical_separation(shell.create_domain().blocks());
@@ -335,7 +337,7 @@ void test_shell_factory_aspect_ratio() {
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
   const double aspect_ratio = 2.0;
   test_shell_construction(
-      dynamic_cast<const domain::creators::Shell<Frame::Inertial>&>(*shell),
+      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
       inner_radius, outer_radius, false, grid_points_r_angular,
       {6, make_array<3>(refinement_level)}, aspect_ratio);
 }
@@ -348,7 +350,7 @@ void test_shell_boundaries_logarithmic_map() {
   const double aspect_ratio = 1.0;
   const bool use_logarithmic_map = true;
 
-  const domain::creators::Shell<Frame::Inertial> shell{
+  const creators::Shell<Frame::Inertial> shell{
       inner_radius, outer_radius, refinement_level,   grid_points_r_angular,
       false,        aspect_ratio, use_logarithmic_map};
   test_physical_separation(shell.create_domain().blocks());
@@ -374,7 +376,7 @@ void test_shell_factory_logarithmic_map() {
   const double aspect_ratio = 2.0;
   const bool use_logarithmic_map = true;
   test_shell_construction(
-      dynamic_cast<const domain::creators::Shell<Frame::Inertial>&>(*shell),
+      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
       inner_radius, outer_radius, false, grid_points_r_angular,
       {6, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map);
 }
@@ -398,7 +400,7 @@ void test_shell_factory_wedges_four_on_equator() {
   const bool use_logarithmic_map = true;
   const ShellWedges which_wedges = ShellWedges::FourOnEquator;
   test_shell_construction(
-      dynamic_cast<const domain::creators::Shell<Frame::Inertial>&>(*shell),
+      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
       inner_radius, outer_radius, false, grid_points_r_angular,
       {4, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map,
       which_wedges);
@@ -423,7 +425,7 @@ void test_shell_factory_wedges_one_along_minus_x() {
   const bool use_logarithmic_map = false;
   const ShellWedges which_wedges = ShellWedges::OneAlongMinusX;
   test_shell_construction(
-      dynamic_cast<const domain::creators::Shell<Frame::Inertial>&>(*shell),
+      dynamic_cast<const creators::Shell<Frame::Inertial>&>(*shell),
       inner_radius, outer_radius, true, grid_points_r_angular,
       {1, make_array<3>(refinement_level)}, aspect_ratio, use_logarithmic_map,
       which_wedges);
@@ -476,7 +478,7 @@ void test_radial_block_layers(const double inner_radius,
   const auto zero = make_with_value<DataVector>(x_in_block_interior, 0.0);
   tnsr::I<DataVector, 3, Frame::Inertial> interior_inertial_coords{
       {{-x_in_block_interior, zero, zero}}};
-  const domain::creators::Shell<Frame::Inertial> shell{
+  const creators::Shell<Frame::Inertial> shell{
       inner_radius,          outer_radius,        refinement_level,
       grid_points_r_angular, use_equiangular_map, aspect_ratio,
       use_logarithmic_map,   which_wedges,        radial_block_layers};
@@ -554,3 +556,4 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainCreators.Shell", "[Domain][Unit]") {
     test_radial_block_layers(3.0, 6.0, 3, false, 1, {0, 0, 0, 0, 0, 0, 0, 0});
   }
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -29,11 +29,11 @@
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestCreation.hpp"
 
+namespace domain {
 namespace {
 void test_sphere_construction(
-    const domain::creators::Sphere<Frame::Inertial>& sphere,
-    const double inner_radius, const double outer_radius,
-    const bool use_equiangular_map,
+    const creators::Sphere<Frame::Inertial>& sphere, const double inner_radius,
+    const double outer_radius, const bool use_equiangular_map,
     const std::array<size_t, 2>& expected_sphere_extents,
     const std::vector<std::array<size_t, 3>>& expected_refinement_level) {
   const auto domain = sphere.create_domain();
@@ -195,7 +195,7 @@ void test_sphere_boundaries_equiangular() {
   const size_t refinement = 2;
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
 
-  const domain::creators::Sphere<Frame::Inertial> sphere{
+  const creators::Sphere<Frame::Inertial> sphere{
       inner_radius, outer_radius, refinement, grid_points_r_angular, true};
   test_physical_separation(sphere.create_domain().blocks());
 
@@ -217,7 +217,7 @@ void test_sphere_factory_equiangular() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
   test_sphere_construction(
-      dynamic_cast<const domain::creators::Sphere<Frame::Inertial>&>(*sphere),
+      dynamic_cast<const creators::Sphere<Frame::Inertial>&>(*sphere),
       inner_radius, outer_radius, true, grid_points_r_angular,
       {7, make_array<3>(refinement_level)});
 }
@@ -228,7 +228,7 @@ void test_sphere_boundaries_equidistant() {
   const size_t refinement = 2;
   const std::array<size_t, 2> grid_points_r_angular{{4, 4}};
 
-  const domain::creators::Sphere<Frame::Inertial> sphere{
+  const creators::Sphere<Frame::Inertial> sphere{
       inner_radius, outer_radius, refinement, grid_points_r_angular, false};
   test_physical_separation(sphere.create_domain().blocks());
 
@@ -250,7 +250,7 @@ void test_sphere_factory_equidistant() {
   const size_t refinement_level = 2;
   const std::array<size_t, 2> grid_points_r_angular{{2, 3}};
   test_sphere_construction(
-      dynamic_cast<const domain::creators::Sphere<Frame::Inertial>&>(*sphere),
+      dynamic_cast<const creators::Sphere<Frame::Inertial>&>(*sphere),
       inner_radius, outer_radius, false, grid_points_r_angular,
       {7, make_array<3>(refinement_level)});
 }
@@ -262,3 +262,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere", "[Domain][Unit]") {
   test_sphere_boundaries_equidistant();
   test_sphere_factory_equidistant();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/DomainTestHelpers.cpp
@@ -34,6 +34,7 @@
 template <size_t VolumeDim>
 class Element;
 
+namespace domain {
 namespace {
 template <size_t VolumeDim>
 boost::rational<size_t> fraction_of_block_face_area(
@@ -280,6 +281,7 @@ double physical_separation(
   return max_separation;
 }
 }  // namespace
+}  // namespace domain
 
 template <size_t VolumeDim, typename Fr>
 void test_domain_construction(
@@ -288,8 +290,8 @@ void test_domain_construction(
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
-    const std::vector<
-        std::unique_ptr<CoordinateMapBase<Frame::Logical, Fr, VolumeDim>>>&
+    const std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Logical, Fr, VolumeDim>>>&
         expected_maps) noexcept {
   const auto& blocks = domain.blocks();
   CHECK(blocks.size() == expected_external_boundaries.size());
@@ -314,8 +316,8 @@ void test_physical_separation(
   double tolerance = 1e-10;
   for (size_t i = 0; i < blocks.size() - 1; i++) {
     for (size_t j = i + 1; j < blocks.size(); j++) {
-      if (blocks_are_neighbors(blocks[i], blocks[j])) {
-        CHECK(physical_separation(blocks[i], blocks[j]) < tolerance);
+      if (domain::blocks_are_neighbors(blocks[i], blocks[j])) {
+        CHECK(domain::physical_separation(blocks[i], blocks[j]) < tolerance);
       }
     }
   }
@@ -345,8 +347,8 @@ void test_initial_domain(const Domain<VolumeDim, Frame>& domain,
         element_id,
         create_initial_element(element_id, blocks[element_id.block_id()]));
   }
-  test_domain_connectivity(domain, elements);
-  test_refinement_levels_of_neighbors<0>(elements);
+  domain::test_domain_connectivity(domain, elements);
+  domain::test_refinement_levels_of_neighbors<0>(elements);
 }
 
 template <size_t SpatialDim, typename Fr>
@@ -378,7 +380,7 @@ tnsr::i<DataVector, SpatialDim, Fr> euclidean_basis_vector(
       const std::vector<std::unordered_set<Direction<DIM(data)>>>&             \
           expected_external_boundaries,                                        \
       const std::vector<std::unique_ptr<                                       \
-          CoordinateMapBase<Frame::Logical, FRAME(data), DIM(data)>>>&         \
+          domain::CoordinateMapBase<Frame::Logical, FRAME(data), DIM(data)>>>& \
           expected_maps) noexcept;                                             \
   template void test_initial_domain(                                           \
       const Domain<DIM(data), FRAME(data)>& domain,                            \

--- a/tests/Unit/Domain/DomainTestHelpers.hpp
+++ b/tests/Unit/Domain/DomainTestHelpers.hpp
@@ -17,8 +17,10 @@ template <size_t VolumeDim, typename TargetFrame>
 class Block;
 template <size_t VolumeDim>
 class BlockNeighbor;
+namespace domain {
 template <typename SourceFrame, typename TargetFrame, size_t Dim>
 class CoordinateMapBase;
+}  // namespace domain
 class DataVector;
 template <size_t VolumeDim>
 class Direction;
@@ -38,8 +40,8 @@ void test_domain_construction(
         expected_block_neighbors,
     const std::vector<std::unordered_set<Direction<VolumeDim>>>&
         expected_external_boundaries,
-    const std::vector<
-        std::unique_ptr<CoordinateMapBase<Frame::Logical, Fr, VolumeDim>>>&
+    const std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Logical, Fr, VolumeDim>>>&
         expected_maps) noexcept;
 
 // Test that two neighboring Blocks abut each other.

--- a/tests/Unit/Domain/Test_Block.cpp
+++ b/tests/Unit/Domain/Test_Block.cpp
@@ -22,6 +22,7 @@
 #include "Utilities/GetOutput.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 template <size_t Dim>
 void test_block() {
@@ -104,3 +105,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Block", "[Domain][Unit]") {
   CHECK(block != neighborless_block);
   CHECK(neighborless_block == neighborless_block);
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Test_CoordinatesTag.cpp
+++ b/tests/Unit/Domain/Test_CoordinatesTag.cpp
@@ -22,6 +22,7 @@ struct Inertial;
 struct Logical;
 }  // namespace Frame
 
+namespace domain {
 namespace {
 template <size_t Dim, typename T>
 void test_coordinates_compute_item(const Mesh<Dim>& mesh, T map) noexcept {
@@ -67,3 +68,4 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinatesTag", "[Unit][Domain]") {
       Affine3d{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
                Affine{-1.0, 1.0, 2.3, 2.8}});
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -41,10 +41,11 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
       {{Direction<2>::lower_eta(), Direction<2>::upper_xi()}},
       {{Direction<2>::upper_xi(), Direction<2>::upper_eta()}});
   Block<2, Frame::Inertial> test_block(
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::Identity<2>{}),
-      0, {{Direction<2>::upper_xi(), BlockNeighbor<2>{1, aligned}},
-          {Direction<2>::upper_eta(), BlockNeighbor<2>{2, unaligned}}});
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<2>{}),
+      0,
+      {{Direction<2>::upper_xi(), BlockNeighbor<2>{1, aligned}},
+       {Direction<2>::upper_eta(), BlockNeighbor<2>{2, unaligned}}});
 
   // interior element
   test_create_initial_element(

--- a/tests/Unit/Domain/Test_Domain.cpp
+++ b/tests/Unit/Domain/Test_Domain.cpp
@@ -31,6 +31,7 @@
 #include "tests/Unit/Domain/DomainTestHelpers.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 void test_1d_domains() {
   {
@@ -282,3 +283,4 @@ SPECTRE_TEST_CASE("Unit.Domain.Domain.Rectilinear3D", "[Domain][Unit]") {
   ERROR("Failed to trigger ASSERT in an assertion test");
 #endif
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -35,6 +35,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "tests/Unit/Domain/CoordinateMaps/TestMapHelpers.hpp"
 
+namespace domain {
 SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.Periodic.SameBlock",
                   "[Domain][Unit]") {
   const std::vector<std::array<size_t, 8>> corners_of_all_blocks{
@@ -1501,3 +1502,4 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.WhichWedges", "[Domain][Unit]") {
   CHECK(get_output(ShellWedges::FourOnEquator) == "FourOnEquator");
   CHECK(get_output(ShellWedges::OneAlongMinusX) == "OneAlongMinusX");
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Test_ElementMap.cpp
+++ b/tests/Unit/Domain/Test_ElementMap.cpp
@@ -26,6 +26,7 @@
 #include "Domain/Tags.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace domain {
 namespace {
 using DV = DataVector;
 
@@ -35,8 +36,7 @@ void test_element_impl(
     const T& first_map, const U& second_map,
     const tnsr::I<double, Dim, Frame::Logical>& logical_point_double,
     const tnsr::I<DV, Dim, Frame::Logical>& logical_point_dv) {
-  PUPable_reg(
-      SINGLE_ARG(::CoordinateMap<Frame::Logical, Frame::Inertial, T, U>));
+  PUPable_reg(SINGLE_ARG(CoordinateMap<Frame::Logical, Frame::Inertial, T, U>));
   const auto composed_map =
       make_coordinate_map<Frame::Logical, Frame::Inertial>(
           affine_map, first_map, second_map);
@@ -195,3 +195,4 @@ SPECTRE_TEST_CASE("Unit.Domain.ElementMap", "[Unit][Domain]") {
   test_element_map<2>();
   test_element_map<3>();
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -37,7 +37,7 @@
 #include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
-// IWYU pragma: no_forward_declare CoordinateMaps::Rotation
+// IWYU pragma: no_forward_declare domain::CoordinateMaps::Rotation
 // IWYU pragma: no_forward_declare Tensor
 
 namespace domain {

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -40,6 +40,7 @@
 // IWYU pragma: no_forward_declare CoordinateMaps::Rotation
 // IWYU pragma: no_forward_declare Tensor
 
+namespace domain {
 namespace {
 template <typename Map>
 void check(const Map& map,
@@ -234,3 +235,4 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ComputeItem", "[Unit][Domain]") {
                                         Tags::UnnormalizedFaceNormal<2>>>(
             box_with_non_affine_map))));
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -383,8 +383,8 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.Slice", "[Unit][Domain]") {
 
   ElementMap<2, Frame::Inertial> element_map(
       ElementId<2>(0),
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::Rotation<2>(atan2(4., 3.))));
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::Rotation<2>(atan2(4., 3.))));
 
   const std::unordered_map<Direction<dim>, Mesh<dim - 1>>
       expected_interface_mesh{

--- a/tests/Unit/Domain/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_LogicalCoordinates.cpp
@@ -19,6 +19,7 @@
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
+namespace domain {
 SPECTRE_TEST_CASE("Unit.Domain.LogicalCoordinates", "[Domain][Unit]") {
   using Affine2d = CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
                                                   CoordinateMaps::Affine>;
@@ -327,3 +328,4 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceLogicalCoordinates", "[Domain][Unit]") {
   CHECK(x_3d_ub_zeta[2][12] == 74.0);
   CHECK(x_3d_ub_zeta[2][14] == 74.0);
 }
+}  // namespace domain

--- a/tests/Unit/Domain/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/Domain/Test_LogicalCoordinates.cpp
@@ -16,7 +16,7 @@
 #include "Domain/Direction.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
-#include "Domain/Tags.hpp"
+#include "Domain/Tags.hpp"  // IWYU pragma: keep
 #include "NumericalAlgorithms/Spectral/Spectral.hpp"
 
 namespace domain {

--- a/tests/Unit/Domain/Test_SizeOfElement.cpp
+++ b/tests/Unit/Domain/Test_SizeOfElement.cpp
@@ -28,11 +28,11 @@
 
 namespace {
 tnsr::I<DataVector, 2> make_inertial_coords_2d(const Mesh<2>& mesh) noexcept {
-  using Affine = CoordinateMaps::Affine;
-  using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-  const auto map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+  const auto map = domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine2D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2)},
-      CoordinateMaps::DiscreteRotation<2>(
+      domain::CoordinateMaps::DiscreteRotation<2>(
           OrientationMap<2>{std::array<Direction<2>, 2>{
               {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}}));
   return map(logical_coordinates(mesh));
@@ -44,8 +44,9 @@ SPECTRE_TEST_CASE("Unit.Domain.SizeOfElement", "[Domain][Unit]") {
     const auto mesh = Mesh<1>(4, Spectral::Basis::Legendre,
                               Spectral::Quadrature::GaussLobatto);
     const auto coords = [&mesh]() {
-      const auto map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
+      const auto map =
+          domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+              domain::CoordinateMaps::Affine(-1.0, 1.0, 0.3, 1.2));
       return map(logical_coordinates(mesh));
     }();
     const auto size = size_of_element(mesh, coords);
@@ -66,12 +67,15 @@ SPECTRE_TEST_CASE("Unit.Domain.SizeOfElement", "[Domain][Unit]") {
     const auto mesh = Mesh<3>({{4, 5, 6}}, Spectral::Basis::Legendre,
                               Spectral::Quadrature::GaussLobatto);
     const auto coords = [&mesh]() {
-      using Affine = CoordinateMaps::Affine;
-      using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
-      const auto map = make_coordinate_map<Frame::Logical, Frame::Inertial>(
-          Affine3D{Affine(-1.0, 1.0, 0.3, 0.4), Affine(-1.0, 1.0, -0.5, 1.2),
-                   Affine(-1.0, 1.0, 12.0, 12.5)},
-          CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
+      using Affine = domain::CoordinateMaps::Affine;
+      using Affine3D =
+          domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+      const auto map =
+          domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+              Affine3D{Affine(-1.0, 1.0, 0.3, 0.4),
+                       Affine(-1.0, 1.0, -0.5, 1.2),
+                       Affine(-1.0, 1.0, 12.0, 12.5)},
+              domain::CoordinateMaps::Rotation<3>(0.7, 2.3, -0.4));
       return map(logical_coordinates(mesh));
     }();
     const auto size = size_of_element(mesh, coords);

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -51,6 +51,8 @@
 // IWYU pragma: no_forward_declare Variables
 // IWYU pragma: no_forward_declare dg::Actions::ReceiveDataForFluxes
 
+// IWYU pragma: no_include <boost/variant/get.hpp>
+
 // Note: Most of this test is adapted from:
 // `NumericalAlgorithms/DiscontinuousGalerkin/Actions/
 // Test_ImposeBoundaryConditions.cpp`

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -249,13 +249,13 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Actions.BoundaryConditions",
   const ElementId<2> west_id(0);
   const ElementId<2> south_id(1, {{{0, 0}, {1, 1}}});
 
-  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
-  const CoordinateMaps::Affine eta_map{-1., 1., 7., 3.};
+  using Affine = domain::CoordinateMaps::Affine;
+  const Affine xi_map{-1., 1., 3., 7.};
+  const Affine eta_map{-1., 1., 7., 3.};
 
   const auto coord_map =
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine>(xi_map,
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
                                                                  eta_map));
 
   const auto external_directions = {Direction<2>::lower_eta(),

--- a/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Test_Equations.cpp
@@ -337,36 +337,32 @@ using compute_tags = db::AddComputeTags<
 
 SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson.FirstOrder",
                   "[Unit][Elliptic]") {
+  using Affine = domain::CoordinateMaps::Affine;
   Mesh<1> mesh_1d{5, Spectral::Basis::Legendre,
                   Spectral::Quadrature::GaussLobatto};
   ElementMap<1, Frame::Inertial> element_map_1d{
       ElementId<1>{0, make_array<1>(SegmentId{0, 0})},
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::Affine{-1., 1., 0., M_PI})};
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          Affine{-1., 1., 0., M_PI})};
   auto domain_box_1d = db::create<simple_tags<1>, compute_tags<1>>(
       mesh_1d, std::move(element_map_1d));
   Mesh<2> mesh_2d{5, Spectral::Basis::Legendre,
                   Spectral::Quadrature::GaussLobatto};
   ElementMap<2, Frame::Inertial> element_map_2d{
       ElementId<2>{0, make_array<2>(SegmentId{0, 0})},
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine>(
-              CoordinateMaps::Affine{-1., 1., 0., M_PI},
-              CoordinateMaps::Affine{-1., 1., 0., M_PI}))};
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(
+              Affine{-1., 1., 0., M_PI}, Affine{-1., 1., 0., M_PI}))};
   auto domain_box_2d = db::create<simple_tags<2>, compute_tags<2>>(
       mesh_2d, std::move(element_map_2d));
   Mesh<3> mesh_3d{5, Spectral::Basis::Legendre,
                   Spectral::Quadrature::GaussLobatto};
   ElementMap<3, Frame::Inertial> element_map_3d{
       ElementId<3>{0, make_array<3>(SegmentId{0, 0})},
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine>(
-              CoordinateMaps::Affine{-1., 1., 0., M_PI},
-              CoordinateMaps::Affine{-1., 1., 0., M_PI},
-              CoordinateMaps::Affine{-1., 1., 0., M_PI}))};
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>(
+              Affine{-1., 1., 0., M_PI}, Affine{-1., 1., 0., M_PI},
+              Affine{-1., 1., 0., M_PI}))};
   auto domain_box_3d = db::create<simple_tags<3>, compute_tags<3>>(
       mesh_3d, std::move(element_map_3d));
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_LimiterActions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_LimiterActions.cpp
@@ -155,13 +155,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.LimiterActions.Generic",
   // actions are only sensitive to the ElementMap, which does differ),
   // we need to make the xi and eta maps line up along the block
   // interface.
-  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
-  const CoordinateMaps::Affine eta_map{-1., 1., 7., 3.};
+  using Affine = domain::CoordinateMaps::Affine;
+  const Affine xi_map{-1., 1., 3., 7.};
+  const Affine eta_map{-1., 1., 7., 3.};
 
   const auto coordmap =
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine>(xi_map,
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
                                                                  eta_map));
 
   const struct {
@@ -315,13 +315,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.LimiterActions.NoNeighbors",
 
   auto input_var = Scalar<DataVector>(mesh.number_of_grid_points(), 1234.);
 
-  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
-  const CoordinateMaps::Affine eta_map{-1., 1., 7., 3.};
+  using Affine = domain::CoordinateMaps::Affine;
+  const Affine xi_map{-1., 1., 3., 7.};
+  const Affine eta_map{-1., 1., 7., 3.};
   auto map = ElementMap<2, Frame::Inertial>(
-      self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                   CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                                  CoordinateMaps::Affine>(
-                       xi_map, eta_map)));
+      self_id,
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
+                                                                 eta_map)));
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using MockDistributedObjectsTag =

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_LimiterActionsWithMinmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_LimiterActionsWithMinmod.cpp
@@ -99,13 +99,14 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.SlopeLimiters.LimiterActions.Minmod",
   const ElementId<2> self_id(1, {{{2, 0}, {1, 0}}});
   const Element<2> element(self_id, {});
 
-  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
-  const CoordinateMaps::Affine eta_map{-1., 1., 7., 3.};
+  using Affine = domain::CoordinateMaps::Affine;
+  const Affine xi_map{-1., 1., 3., 7.};
+  const Affine eta_map{-1., 1., 7., 3.};
   auto map = ElementMap<2, Frame::Inertial>(
-      self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                   CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                                  CoordinateMaps::Affine>(
-                       xi_map, eta_map)));
+      self_id,
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
+                                                                 eta_map)));
 
   auto logical_coords = logical_coordinates(mesh);
   auto inertial_coords = map(logical_coords);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -363,8 +363,9 @@ void test_mortar_orientation() noexcept {
   // This is the domain from the OrientationMap and corner numbering
   // tutorial.
   Domain<3, Frame::Inertial> domain(
-      make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::Identity<3>{}, CoordinateMaps::Identity<3>{}),
+      domain::make_vector_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<3>{},
+          domain::CoordinateMaps::Identity<3>{}),
       {{{0, 1, 3, 4, 6, 7, 9, 10}}, {{1, 4, 7, 10, 2, 5, 8, 11}}});
   const auto neighbor_direction = Direction<3>::upper_xi();
   const auto mortar_id = std::make_pair(neighbor_direction, ElementId<3>(1));

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InitializeElement.cpp
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-// IWYU pragma: no_include <pup.h>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -53,6 +52,9 @@
 #include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "tests/Unit/ActionTesting.hpp"
+
+// IWYU pragma: no_include <boost/variant/get.hpp>
+// IWYU pragma: no_include <pup.h>
 
 // IWYU pragma: no_forward_declare ElementIndex
 class TimeStepper;

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -92,10 +92,11 @@ void test_characteristic_speeds_analytic(
   Mesh<spatial_dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                          Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1., 1., lower_bound[0], upper_bound[0]},
           Affine{-1., 1., lower_bound[1], upper_bound[1]},
           Affine{-1., 1., lower_bound[2], upper_bound[2]},
@@ -215,10 +216,11 @@ void test_characteristic_fields_analytic(
   Mesh<spatial_dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                          Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1., 1., lower_bound[0], upper_bound[0]},
           Affine{-1., 1., lower_bound[1], upper_bound[1]},
           Affine{-1., 1., lower_bound[2], upper_bound[2]},
@@ -382,10 +384,11 @@ void test_evolved_from_characteristic_fields_analytic(
   Mesh<spatial_dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                          Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1., 1., lower_bound[0], upper_bound[0]},
           Affine{-1., 1., lower_bound[1], upper_bound[1]},
           Affine{-1., 1., lower_bound[2], upper_bound[2]},

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -81,10 +81,11 @@ void test_gauge_constraint_analytic(
   Mesh<3> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1.0, 1.0, lower_bound[0], upper_bound[0]},
           Affine{-1.0, 1.0, lower_bound[1], upper_bound[1]},
           Affine{-1.0, 1.0, lower_bound[2], upper_bound[2]},
@@ -191,10 +192,11 @@ void test_two_index_constraint_analytic(
   Mesh<3> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1.0, 1.0, lower_bound[0], upper_bound[0]},
           Affine{-1.0, 1.0, lower_bound[1], upper_bound[1]},
           Affine{-1.0, 1.0, lower_bound[2], upper_bound[2]},
@@ -319,10 +321,11 @@ void test_four_index_constraint_analytic(
   Mesh<3> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1.0, 1.0, lower_bound[0], upper_bound[0]},
           Affine{-1.0, 1.0, lower_bound[1], upper_bound[1]},
           Affine{-1.0, 1.0, lower_bound[2], upper_bound[2]},
@@ -418,10 +421,11 @@ void test_f_constraint_analytic(const Solution& solution,
   Mesh<3> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1.0, 1.0, lower_bound[0], upper_bound[0]},
           Affine{-1.0, 1.0, lower_bound[1], upper_bound[1]},
           Affine{-1.0, 1.0, lower_bound[2], upper_bound[2]},
@@ -556,10 +560,11 @@ void test_constraint_energy_analytic(const Solution& solution,
   Mesh<3> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1.0, 1.0, lower_bound[0], upper_bound[0]},
           Affine{-1.0, 1.0, lower_bound[1], upper_bound[1]},
           Affine{-1.0, 1.0, lower_bound[2], upper_bound[2]},

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -136,14 +136,15 @@ auto run_action(
   const Mesh<2> mesh{3, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
 
-  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
-  const CoordinateMaps::Affine eta_map{-1., 1., -2., 4.};
+  using Affine = domain::CoordinateMaps::Affine;
+  const Affine xi_map{-1., 1., 3., 7.};
+  const Affine eta_map{-1., 1., -2., 4.};
 
   auto element_map = ElementMap<2, Frame::Inertial>(
-      element.id(), make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                        CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                                       CoordinateMaps::Affine>(
-                            xi_map, eta_map)));
+      element.id(),
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
+                                                                 eta_map)));
 
   n_dot_f_tag::type n_dot_f_storage{};
   for (const auto& direction_neighbors : element.neighbors()) {

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -43,6 +43,8 @@
 // IWYU pragma: no_forward_declare Tensor
 // IWYU pragma: no_forward_declare Variables
 
+// IWYU pragma: no_include <boost/variant/get.hpp>
+
 namespace {
 struct Var : db::SimpleTag {
   static std::string name() noexcept { return "Var"; }

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -237,13 +237,13 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.Actions.FluxCommunication",
   // actions are only sensitive to the ElementMap, which does differ),
   // we need to make the xi and eta maps line up along the block
   // interface.
-  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
-  const CoordinateMaps::Affine eta_map{-1., 1., 7., 3.};
+  using Affine = domain::CoordinateMaps::Affine;
+  const Affine xi_map{-1., 1., 3., 7.};
+  const Affine eta_map{-1., 1., 7., 3.};
 
   const auto coordmap =
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine>(xi_map,
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
                                                                  eta_map));
 
   const auto neighbor_directions = {Direction<2>::lower_xi(),
@@ -539,11 +539,12 @@ SPECTRE_TEST_CASE(
 
   const Element<2> element(self_id, {});
 
+  using Affine = domain::CoordinateMaps::Affine;
   auto map = ElementMap<2, Frame::Inertial>(
-      self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                   CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                                  CoordinateMaps::Affine>(
-                       {-1., 1., 3., 7.}, {-1., 1., -2., 4.})));
+      self_id,
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(
+              {-1., 1., 3., 7.}, {-1., 1., -2., 4.})));
 
   using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavariables>;
   using MockDistributedObjectsTag =
@@ -604,8 +605,9 @@ SPECTRE_TEST_CASE(
                         Direction<3>::lower_eta()}}}}}});
 
   ElementMap<3, Frame::Inertial> map(
-      self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                   CoordinateMaps::Identity<3>{}));
+      self_id,
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<3>{}));
 
   const Mesh<3> mesh({{2, 3, 4}}, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto);
@@ -752,10 +754,11 @@ SPECTRE_TEST_CASE(
                                         Direction<2>::lower_eta()}}}}}});
 
     ElementMap<2, Frame::Inertial> map(
-        self_id, make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                                    CoordinateMaps::Affine>(
-                         {-1., 1., -1., 1.}, {-1., 1., -1., 1.})));
+        self_id,
+        domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+            domain::CoordinateMaps::ProductOf2Maps<
+                domain::CoordinateMaps::Affine, domain::CoordinateMaps::Affine>(
+                {-1., 1., -1., 1.}, {-1., 1., -1., 1.})));
 
     const Mesh<2> mesh(2, Spectral::Basis::Legendre,
                        Spectral::Quadrature::GaussLobatto);

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-// IWYU pragma: no_include <boost/functional/hash/extensions.hpp>
 #include <cstddef>
 #include <functional>
 #include <initializer_list>  // IWYU pragma: keep
@@ -23,6 +22,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Domain/DirectionMap.hpp"
 // IWYU pragma: no_include "DataStructures/VariablesHelpers.hpp"  // for Variables
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
@@ -47,6 +47,9 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
 #include "tests/Unit/ActionTesting.hpp"
+
+// IWYU pragma: no_include <boost/functional/hash/extensions.hpp>
+// IWYU pragma: no_include <boost/variant/get.hpp>
 
 // IWYU pragma: no_forward_declare Tensor
 // IWYU pragma: no_forward_declare Variables

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -221,8 +221,9 @@ void insert_neighbor(const gsl::not_null<LocalAlg*> local_alg,
                      Spectral::Quadrature::GaussLobatto};
 
   ElementMap<2, Frame::Inertial> map(
-      element.id(), make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                        CoordinateMaps::Identity<2>{}));
+      element.id(),
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<2>{}));
 
   db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>> fluxes;
   fluxes[send_direction].initialize(2, n_dot_f);
@@ -329,9 +330,9 @@ void run_lts_case(const int self_step_end, const std::vector<int>& left_steps,
                       Spectral::Quadrature::GaussLobatto},
               Element<2>{},
               ElementMap<2, Frame::Inertial>{
-                  self_id,
-                  make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-                      CoordinateMaps::Identity<2>{})},
+                  self_id, domain::make_coordinate_map_base<Frame::Logical,
+                                                            Frame::Inertial>(
+                               domain::CoordinateMaps::Identity<2>{})},
               db::item_type<normal_dot_fluxes_tag<2, flux_comm_types<2>>>{},
               db::item_type<other_data_tag<2>>{},
               db::item_type<mortar_meshes_tag<2>>{},

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -284,13 +284,13 @@ void run_test() {
   const ElementId<2> east_id(1, {{{2, 1}, {1, 0}}});
   const ElementId<2> south_id(1, {{{2, 0}, {1, 1}}});
 
-  const CoordinateMaps::Affine xi_map{-1., 1., 3., 7.};
-  const CoordinateMaps::Affine eta_map{-1., 1., 7., 3.};
+  using Affine = domain::CoordinateMaps::Affine;
+  const Affine xi_map{-1., 1., 3., 7.};
+  const Affine eta_map{-1., 1., 7., 3.};
 
   const auto coordmap =
-      make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Affine>(xi_map,
+      domain::make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
+          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
                                                                  eta_map));
 
   const auto external_directions = {Direction<2>::lower_eta(),

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_LiftFlux.cpp
@@ -36,11 +36,13 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.LiftFlux",
   const Mesh<2> mesh{
       {{3, 5}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
 
-  const CoordinateMaps::Affine xi_map(-1., 1., -5., 7.);
-  const CoordinateMaps::Affine eta_map(-1., 1., 2., 5.);
-  const auto coordinate_map = make_coordinate_map<Frame::Logical, Frame::Grid>(
-      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                     CoordinateMaps::Affine>(xi_map, eta_map));
+  using Affine = domain::CoordinateMaps::Affine;
+  const Affine xi_map(-1., 1., -5., 7.);
+  const Affine eta_map(-1., 1., 2., 5.);
+  const auto coordinate_map =
+      domain::make_coordinate_map<Frame::Logical, Frame::Grid>(
+          domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>(xi_map,
+                                                                 eta_map));
   const double element_length = (eta_map(std::array<double, 1>{{1.}}) -
                                  eta_map(std::array<double, 1>{{-1.}}))[0];
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -38,9 +38,9 @@
 
 namespace {
 
-using Affine = CoordinateMaps::Affine;
-using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+using Affine = domain::CoordinateMaps::Affine;
+using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
 const double inertial_coord_min = -0.3;
 const double inertial_coord_max = 0.7;
@@ -50,20 +50,20 @@ auto make_affine_map() noexcept;
 
 template <>
 auto make_affine_map<1>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max});
 }
 
 template <>
 auto make_affine_map<2>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine2D{Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max},
                Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max}});
 }
 
 template <>
 auto make_affine_map<3>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine3D{Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max},
                Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max},
                Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max}});

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_RegularGridInterpolant.cpp
@@ -37,9 +37,9 @@
 
 namespace {
 
-using Affine = CoordinateMaps::Affine;
-using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+using Affine = domain::CoordinateMaps::Affine;
+using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
 constexpr double inertial_coord_min = -0.3;
 constexpr double inertial_coord_max = 0.7;
@@ -49,20 +49,20 @@ auto make_affine_map() noexcept;
 
 template <>
 auto make_affine_map<1>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max});
 }
 
 template <>
 auto make_affine_map<2>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine2D{Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max},
                Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max}});
 }
 
 template <>
 auto make_affine_map<3>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine3D{Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max},
                Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max},
                Affine{-1.0, 1.0, inertial_coord_min, inertial_coord_max}});

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -36,31 +36,30 @@
 // IWYU pragma: no_forward_declare Tags::div
 
 namespace {
-using Affine = CoordinateMaps::Affine;
-using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-using Affine3D =
-    CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+using Affine = domain::CoordinateMaps::Affine;
+using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
 template <size_t VolumeDim>
 auto make_affine_map() noexcept;
 
 template <>
 auto make_affine_map<1>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine{-1.0, 1.0, -0.3, 0.7});
 }
 
 template <>
 auto make_affine_map<2>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine2D{
-      Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55}});
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine2D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55}});
 }
 
 template <>
 auto make_affine_map<3>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
-      Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
-      Affine{-1.0, 1.0, 2.3, 2.8}});
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
+      Affine3D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
+               Affine{-1.0, 1.0, 2.3, 2.8}});
 }
 
 template <size_t Dim, typename Frame>

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -65,10 +65,11 @@ void verify_time_independent_einstein_solution(
   Mesh<3> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1., 1., lower_bound[0], upper_bound[0]},
           Affine{-1., 1., lower_bound[1], upper_bound[1]},
           Affine{-1., 1., lower_bound[2], upper_bound[2]},

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -37,6 +37,10 @@
 // IWYU pragma: no_forward_declare Tensor
 
 namespace {
+using Affine = domain::CoordinateMaps::Affine;
+using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+
 template <size_t Dim, typename DataType>
 void test_compute_phi(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
@@ -180,10 +184,8 @@ void test_lapse_deriv_functions_analytic(
   Mesh<spatial_dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                          Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1., 1., lower_bound[0], upper_bound[0]},
           Affine{-1., 1., lower_bound[1], upper_bound[1]},
           Affine{-1., 1., lower_bound[2], upper_bound[2]},
@@ -303,10 +305,8 @@ void test_shift_deriv_functions_analytic(
   Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
 
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1., 1., lower_bound[0], upper_bound[0]},
           Affine{-1., 1., lower_bound[1], upper_bound[1]},
           Affine{-1., 1., lower_bound[2], upper_bound[2]},
@@ -420,10 +420,8 @@ void test_gij_deriv_functions_analytic(
   const size_t SpatialDim = 3;
   Mesh<SpatialDim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
-  using Affine = CoordinateMaps::Affine;
-  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
   const auto coord_map =
-      make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
+      domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(Affine3D{
           Affine{-1., 1., lower_bound[0], upper_bound[0]},
           Affine{-1., 1., lower_bound[1], upper_bound[1]},
           Affine{-1., 1., lower_bound[2], upper_bound[2]},

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -35,28 +35,28 @@ template <size_t VolumeDim>
 class MathFunction;
 
 namespace {
-using Affine = CoordinateMaps::Affine;
-using Affine2D = CoordinateMaps::ProductOf2Maps<Affine, Affine>;
-using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+using Affine = domain::CoordinateMaps::Affine;
+using Affine2D = domain::CoordinateMaps::ProductOf2Maps<Affine, Affine>;
+using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 
 template <size_t VolumeDim>
 auto make_affine_map() noexcept;
 
 template <>
 auto make_affine_map<1>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine{-1.0, 1.0, -0.3, 0.7});
 }
 
 template <>
 auto make_affine_map<2>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine2D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55}});
 }
 
 template <>
 auto make_affine_map<3>() noexcept {
-  return make_coordinate_map<Frame::Logical, Frame::Inertial>(
+  return domain::make_coordinate_map<Frame::Logical, Frame::Inertial>(
       Affine3D{Affine{-1.0, 1.0, -0.3, 0.7}, Affine{-1.0, 1.0, 0.3, 0.55},
                Affine{-1.0, 1.0, 2.3, 2.8}});
 }

--- a/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
+++ b/tests/Unit/PointwiseFunctions/MathFunctions/Test_TensorProduct.cpp
@@ -30,6 +30,8 @@
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
+// IWYU pragma: no_forward_declare Tags::deriv
+
 class DataVector;
 template <size_t VolumeDim>
 class MathFunction;


### PR DESCRIPTION
## Proposed changes

- makes all the coordinate map code be inside the `domain` namespace.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
