### PR TITLE
 Group linear solver input file options

### DIFF
--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitorActions.hpp
@@ -80,8 +80,10 @@ struct InitializeResidual {
     // compute item.
     const auto& has_converged = db::get<LinearSolver::Tags::HasConverged>(box);
 
+    const auto& options =
+        get<LinearSolver::OptionTags::ResidualMonitorOptions>(cache);
     if (UNLIKELY(has_converged and
-                 static_cast<int>(get<::Tags::Verbosity>(box)) >=
+                 static_cast<int>(get<::OptionTags::Verbosity>(options)) >=
                      static_cast<int>(::Verbosity::Quiet))) {
       Parallel::printf("%s", has_converged);
     }
@@ -161,7 +163,9 @@ struct UpdateResidual {
     const auto& has_converged = get<LinearSolver::Tags::HasConverged>(box);
 
     // Do some logging
-    if (UNLIKELY(static_cast<int>(get<::Tags::Verbosity>(box)) >=
+    const auto& options =
+        get<LinearSolver::OptionTags::ResidualMonitorOptions>(cache);
+    if (UNLIKELY(static_cast<int>(get<::OptionTags::Verbosity>(options)) >=
                  static_cast<int>(::Verbosity::Verbose))) {
       Parallel::printf(
           "Linear solver iteration %d done. Remaining residual: %e\n",
@@ -169,7 +173,7 @@ struct UpdateResidual {
           get<residual_magnitude_tag>(box));
     }
     if (UNLIKELY(has_converged and
-                 static_cast<int>(get<::Tags::Verbosity>(box)) >=
+                 static_cast<int>(get<::OptionTags::Verbosity>(options)) >=
                      static_cast<int>(::Verbosity::Quiet))) {
       Parallel::printf("%s", has_converged);
     }

--- a/src/NumericalAlgorithms/LinearSolver/Convergence.cpp
+++ b/src/NumericalAlgorithms/LinearSolver/Convergence.cpp
@@ -4,6 +4,7 @@
 #include "NumericalAlgorithms/LinearSolver/Convergence.hpp"
 
 #include <boost/optional.hpp>
+#include <iomanip>
 #include <ostream>
 #include <pup.h>  // IWYU pragma: keep
 
@@ -14,7 +15,7 @@
 namespace LinearSolver {
 
 ConvergenceCriteria::ConvergenceCriteria(
-    const double max_iterations_in, const double absolute_residual_in,
+    const size_t max_iterations_in, const double absolute_residual_in,
     const double relative_residual_in) noexcept
     : max_iterations(max_iterations_in),
       absolute_residual(absolute_residual_in),
@@ -102,6 +103,7 @@ std::ostream& operator<<(std::ostream& os,
                   << has_converged.iteration_id_.step_number
                   << " iterations: AbsoluteResidual - The residual magnitude "
                      "has decreased to "
+                  << std::setprecision(6)
                   << has_converged.convergence_criteria_.absolute_residual
                   << " or below (" << has_converged.residual_magnitude_
                   << ").\n";
@@ -110,6 +112,7 @@ std::ostream& operator<<(std::ostream& os,
                   << has_converged.iteration_id_.step_number
                   << " iterations: RelativeResidual - The residual magnitude "
                      "has decreased to a fraction of "
+                  << std::setprecision(6)
                   << has_converged.convergence_criteria_.relative_residual
                   << " of its initial value or below ("
                   << has_converged.residual_magnitude_ /

--- a/src/NumericalAlgorithms/LinearSolver/Convergence.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Convergence.hpp
@@ -84,12 +84,12 @@ struct ConvergenceCriteria {
   using options = tmpl::list<MaxIterations, AbsoluteResidual, RelativeResidual>;
 
   ConvergenceCriteria() = default;
-  ConvergenceCriteria(double max_iterations_in, double absolute_residual_in,
+  ConvergenceCriteria(size_t max_iterations_in, double absolute_residual_in,
                       double relative_residual_in) noexcept;
 
   void pup(PUP::er& p) noexcept;  // NOLINT
 
-  double max_iterations{};
+  size_t max_iterations{};
   double absolute_residual{};
   double relative_residual{};
 };

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -35,16 +35,10 @@ namespace gmres_detail {
 
 template <typename Metavariables>
 struct ResidualMonitor {
-  struct Verbosity {
-    using type = ::Verbosity;
-    static constexpr OptionString help = {"Verbosity"};
-    static type default_value() { return ::Verbosity::Quiet; }
-  };
-
   using chare_type = Parallel::Algorithms::Singleton;
-  using const_global_cache_tag_list = tmpl::list<>;
-  using options =
-      tmpl::list<Verbosity, LinearSolver::Tags::ConvergenceCriteria>;
+  using const_global_cache_tag_list =
+      tmpl::list<LinearSolver::OptionTags::ResidualMonitorOptions>;
+  using options = tmpl::list<>;
   using metavariables = Metavariables;
   using action_list = tmpl::list<>;
   using initial_databox = db::compute_databox_type<tmpl::append<
@@ -52,15 +46,10 @@ struct ResidualMonitor {
       typename InitializeResidualMonitor<Metavariables>::compute_tags>>;
 
   static void initialize(
-      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache,
-      ::Verbosity verbosity,
-      LinearSolver::ConvergenceCriteria convergence_criteria) noexcept {
+      Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
     Parallel::simple_action<InitializeResidualMonitor<Metavariables>>(
         Parallel::get_parallel_component<ResidualMonitor>(
-            *(global_cache.ckLocalBranch())),
-        // clang-tidy: std::move of trivially-copyable type
-        std::move(verbosity),              // NOLINT
-        std::move(convergence_criteria));  // NOLINT
+            *(global_cache.ckLocalBranch())));
   }
 
   static void execute_next_phase(
@@ -87,26 +76,26 @@ struct InitializeResidualMonitor {
 
  public:
   using simple_tags = db::AddSimpleTags<
-      ::Tags::Verbosity, LinearSolver::Tags::ConvergenceCriteria,
-      residual_magnitude_tag, initial_residual_magnitude_tag,
-      LinearSolver::Tags::IterationId, orthogonalization_iteration_id_tag,
-      orthogonalization_history_tag>;
+      // Need the `ConvergenceCriteria` in the DataBox to make them available to
+      // `HasConvergedCompute`
+      LinearSolver::Tags::ConvergenceCriteria, residual_magnitude_tag,
+      initial_residual_magnitude_tag, LinearSolver::Tags::IterationId,
+      orthogonalization_iteration_id_tag, orthogonalization_history_tag>;
   using compute_tags =
       db::AddComputeTags<LinearSolver::Tags::HasConvergedCompute<fields_tag>>;
 
   template <typename... InboxTags, typename ArrayIndex, typename ActionList,
             typename ParallelComponent>
-  static auto apply(
-      const db::DataBox<tmpl::list<>>& /*box*/,
-      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
-      const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
-      const ParallelComponent* const /*meta*/, ::Verbosity verbosity,
-      LinearSolver::ConvergenceCriteria convergence_criteria) noexcept {
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/) noexcept {
+    const auto& options =
+        get<LinearSolver::OptionTags::ResidualMonitorOptions>(cache);
     auto box = db::create<simple_tags, compute_tags>(
-        // clang-tidy: std::move of trivially-copyable type
-        std::move(verbosity),             // NOLINT
-        std::move(convergence_criteria),  // NOLINT
+        get<LinearSolver::Tags::ConvergenceCriteria>(options),
         std::numeric_limits<double>::signaling_NaN(),
         std::numeric_limits<double>::signaling_NaN(), IterationId{0},
         IterationId{0}, DenseMatrix<double>{2, 1, 0.});

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitorActions.hpp
@@ -73,8 +73,10 @@ struct InitializeResidualMagnitude {
     // the compute item.
     const auto& has_converged = db::get<LinearSolver::Tags::HasConverged>(box);
 
+    const auto& options =
+        get<LinearSolver::OptionTags::ResidualMonitorOptions>(cache);
     if (UNLIKELY(has_converged and
-                 static_cast<int>(get<::Tags::Verbosity>(box)) >=
+                 static_cast<int>(get<::OptionTags::Verbosity>(options)) >=
                      static_cast<int>(::Verbosity::Quiet))) {
       Parallel::printf("%s", has_converged);
     }
@@ -224,7 +226,9 @@ struct StoreFinalOrthogonalization {
     const auto& has_converged = db::get<LinearSolver::Tags::HasConverged>(box);
 
     // Do some logging
-    if (UNLIKELY(static_cast<int>(get<::Tags::Verbosity>(box)) >=
+    const auto& options =
+        get<LinearSolver::OptionTags::ResidualMonitorOptions>(cache);
+    if (UNLIKELY(static_cast<int>(get<::OptionTags::Verbosity>(options)) >=
                  static_cast<int>(::Verbosity::Verbose))) {
       Parallel::printf(
           "Linear solver iteration %d done. Remaining residual: %e\n",
@@ -232,7 +236,7 @@ struct StoreFinalOrthogonalization {
           residual_magnitude);
     }
     if (UNLIKELY(has_converged and
-                 static_cast<int>(get<::Tags::Verbosity>(box)) >=
+                 static_cast<int>(get<::OptionTags::Verbosity>(options)) >=
                      static_cast<int>(::Verbosity::Quiet))) {
       Parallel::printf("%s", has_converged);
     }

--- a/src/NumericalAlgorithms/LinearSolver/Tags.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Tags.hpp
@@ -13,9 +13,12 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DenseMatrix.hpp"
+#include "Informer/Tags.hpp"
 #include "NumericalAlgorithms/LinearSolver/Convergence.hpp"
 #include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
+#include "Options/Options.hpp"
 #include "Utilities/Requires.hpp"
+#include "Utilities/TaggedTuple.hpp"
 #include "Utilities/TypeTraits.hpp"
 
 /*!
@@ -236,4 +239,22 @@ struct HasConvergedCompute : LinearSolver::Tags::HasConverged, db::ComputeTag {
 };
 
 }  // namespace Tags
+
+namespace OptionTags {
+
+struct ResidualMonitorOptions
+    : tuples::TaggedTuple<::OptionTags::Verbosity,
+                          LinearSolver::Tags::ConvergenceCriteria> {
+  // TypedTag and OptionTag interface
+  static std::string name() noexcept { return "LinearSolver"; }
+  using type = ResidualMonitorOptions;
+  // OptionCreatable interface
+  static constexpr OptionString help =
+      "Options to control the linear solver algorithm.";
+  using options = TaggedTuple::tags;
+  using TaggedTuple::TaggedTuple;
+};
+
+}  // namespace OptionTags
+
 }  // namespace LinearSolver

--- a/src/Utilities/TaggedTuple.hpp
+++ b/src/Utilities/TaggedTuple.hpp
@@ -349,6 +349,8 @@ class TaggedTuple : private tuples_detail::TaggedTupleLeaf<Tags>... {  // NOLINT
  public:
   static constexpr size_t size() noexcept { return sizeof...(Tags); }
 
+  using tags = tmpl::list<Tags...>;
+
   // clang-tidy: runtime-references
   void pup(PUP::er& p) {  // NOLINT
     static_cast<void>(std::initializer_list<char>{

--- a/tests/InputFiles/Poisson/Input1D.yaml
+++ b/tests/InputFiles/Poisson/Input1D.yaml
@@ -21,12 +21,12 @@ DomainCreator:
 NumericalFluxParams:
     PenaltyParameter: 5.729577951308232 # p^2 / h
 
-Verbosity: Verbose
-
 VolumeFileName: "./Poisson1DVolume"
 ReductionFileName: "./Poisson1DReductions"
 
-ConvergenceCriteria:
-  MaxIterations: 1
-  AbsoluteResidual: 0
-  RelativeResidual: 0
+LinearSolver:
+  Verbosity: Verbose
+  ConvergenceCriteria:
+    MaxIterations: 1
+    AbsoluteResidual: 0
+    RelativeResidual: 0

--- a/tests/InputFiles/Poisson/Input2D.yaml
+++ b/tests/InputFiles/Poisson/Input2D.yaml
@@ -21,12 +21,12 @@ DomainCreator:
 NumericalFluxParams:
     PenaltyParameter: 5.729577951308232 # p^2 / h
 
-Verbosity: Verbose
-
 VolumeFileName: "./Poisson2DVolume"
 ReductionFileName: "./Poisson2DReductions"
 
-ConvergenceCriteria:
-  MaxIterations: 1
-  AbsoluteResidual: 0
-  RelativeResidual: 0
+LinearSolver:
+  Verbosity: Verbose
+  ConvergenceCriteria:
+    MaxIterations: 1
+    AbsoluteResidual: 0
+    RelativeResidual: 0

--- a/tests/InputFiles/Poisson/Input3D.yaml
+++ b/tests/InputFiles/Poisson/Input3D.yaml
@@ -21,12 +21,12 @@ DomainCreator:
 NumericalFluxParams:
     PenaltyParameter: 2.5464790894703255 # p^2 / h
 
-Verbosity: Verbose
-
 VolumeFileName: "./Poisson3DVolume"
 ReductionFileName: "./Poisson3DReductions"
 
-ConvergenceCriteria:
-  MaxIterations: 1
-  AbsoluteResidual: 0
-  RelativeResidual: 0
+LinearSolver:
+  Verbosity: Verbose
+  ConvergenceCriteria:
+    MaxIterations: 1
+    AbsoluteResidual: 0
+    RelativeResidual: 0

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.input
@@ -6,12 +6,12 @@ Source: [1, 2]
 InitialGuess: [2, 1]
 ExpectedResult: [0.0909090909090909, 0.6363636363636364]
 
-Verbosity: Verbose
-
 VolumeFileName: "Test_ConjugateGradientAlgorithm_Volume"
 ReductionFileName: "Test_ConjugateGradientAlgorithm_Reductions"
 
-ConvergenceCriteria:
-  MaxIterations: 2
-  AbsoluteResidual: 1e-14
-  RelativeResidual: 0
+LinearSolver:
+  Verbosity: Verbose
+  ConvergenceCriteria:
+    MaxIterations: 2
+    AbsoluteResidual: 1e-14
+    RelativeResidual: 0

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.input
@@ -25,12 +25,12 @@ ExpectedResult:
     - [-0.0363482510397858,  0.7235793356729757,  0.9928055333486293]
     - [ 0.9928055333486292,  0.7235793356729758, -0.0363482510397858]
 
-Verbosity: Verbose
-
 VolumeFileName: "./Test_DistributedConjugateGradientAlgorithm_Volume"
 ReductionFileName: "./Test_DistributedConjugateGradientAlgorithm_Reductions"
 
-ConvergenceCriteria:
-  MaxIterations: 6
-  AbsoluteResidual: 1e-14
-  RelativeResidual: 0
+LinearSolver:
+  Verbosity: Verbose
+  ConvergenceCriteria:
+    MaxIterations: 6
+    AbsoluteResidual: 1e-14
+    RelativeResidual: 0

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.input
@@ -25,12 +25,12 @@ ExpectedResult:
     - [-0.0363482510397858,  0.7235793356729757,  0.9928055333486293]
     - [ 0.9928055333486292,  0.7235793356729758, -0.0363482510397858]
 
-Verbosity: Verbose
-
 VolumeFileName: "Test_DistributedGmresAlgorithm_Volume"
 ReductionFileName: "Test_DistributedGmresAlgorithm_Reductions"
 
-ConvergenceCriteria:
-  MaxIterations: 6
-  AbsoluteResidual: 1e-14
-  RelativeResidual: 0
+LinearSolver:
+  Verbosity: Verbose
+  ConvergenceCriteria:
+    MaxIterations: 6
+    AbsoluteResidual: 1e-14
+    RelativeResidual: 0

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.input
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.input
@@ -6,12 +6,12 @@ Source: [1, 2]
 InitialGuess: [2, 1]
 ExpectedResult: [-1., 5.]
 
-Verbosity: Verbose
-
 VolumeFileName: "Test_GmresAlgorithm_Volume"
 ReductionFileName: "Test_GmresAlgorithm_Reductions"
 
-ConvergenceCriteria:
-  MaxIterations: 2
-  AbsoluteResidual: 1e-14
-  RelativeResidual: 0
+LinearSolver:
+  Verbosity: Verbose
+  ConvergenceCriteria:
+    MaxIterations: 2
+    AbsoluteResidual: 1e-14
+    RelativeResidual: 0

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -92,7 +92,8 @@ struct MockResidualMonitor {
   // testing framework
   using chare_type = ActionTesting::MockArrayChare;
   using array_index = int;
-  using const_global_cache_tag_list = tmpl::list<>;
+  using const_global_cache_tag_list =
+      tmpl::list<LinearSolver::OptionTags::ResidualMonitorOptions>;
   using action_list = tmpl::list<>;
   using initial_databox =
       db::compute_databox_type<residual_monitor_tags<Metavariables>>;
@@ -207,6 +208,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
   MockRuntimeSystem::TupleOfMockDistributedObjects dist_objects{};
 
   // Setup mock residual monitor
+  const LinearSolver::OptionTags::ResidualMonitorOptions options{
+      Verbosity::Verbose, LinearSolver::ConvergenceCriteria{2, 0., 0.5}};
   using MockSingletonObjectsTag = MockRuntimeSystem::MockDistributedObjectsTag<
       MockResidualMonitor<Metavariables>>;
   const int singleton_id{0};
@@ -218,7 +221,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
                   Metavariables>::simple_tags,
               typename LinearSolver::gmres_detail::InitializeResidualMonitor<
                   Metavariables>::compute_tags>(
-              Verbosity::Verbose, LinearSolver::ConvergenceCriteria{2, 0., 0.5},
+              get<LinearSolver::Tags::ConvergenceCriteria>(options),
               std::numeric_limits<double>::signaling_NaN(),
               std::numeric_limits<double>::signaling_NaN(),
               LinearSolver::IterationId{0}, LinearSolver::IterationId{0},
@@ -246,7 +249,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
                    std::tuple<size_t, double>{
                        0, std::numeric_limits<double>::signaling_NaN()}));
 
-  MockRuntimeSystem runner{{}, std::move(dist_objects)};
+  MockRuntimeSystem runner{{options}, std::move(dist_objects)};
 
   // DataBox shortcuts
   const auto get_box = [&runner, &singleton_id]() -> decltype(auto) {

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Tags.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Test_Tags.cpp
@@ -89,4 +89,10 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Tags",
                        magnitude_square_tag>>>(4.);
     CHECK(db::get<magnitude_tag>(box) == approx(2.));
   }
+
+  {
+    INFO("ResidualMonitorOptions");
+    CHECK(LinearSolver::OptionTags::ResidualMonitorOptions::name() ==
+          "LinearSolver");
+  }
 }


### PR DESCRIPTION
## Proposed changes

This adds an option tag for the linear solver options and uses it
for the conjugate gradient and GMRES residual monitors. It allows
the options to appear in a "LinearSolver" group in the input file.
The options are stored in the global cache, but the convergence criteria
must also be present in the DataBox to be used by compute items.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
