### PR TITLE
Add nonconservative initialization for scalar wave

### DIFF
--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -12,8 +12,8 @@
 #include "ErrorHandling/FloatingPointExceptions.hpp"
 #include "Evolution/Actions/ComputeTimeDerivative.hpp"  // IWYU pragma: keep
 #include "Evolution/DiscontinuousGalerkin/DgElementArray.hpp"  // IWYU pragma: keep
-#include "Evolution/DiscontinuousGalerkin/InitializeElement.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/ScalarWave/Equations.hpp"  // IWYU pragma: keep // for UpwindFlux
+#include "Evolution/Systems/ScalarWave/Initialize.hpp"  // IWYU pragma: keep
 #include "Evolution/Systems/ScalarWave/Observe.hpp"    // IWYU pragma: keep
 #include "Evolution/Systems/ScalarWave/System.hpp"
 #include "IO/Observer/Actions.hpp"            // IWYU pragma: keep
@@ -110,7 +110,7 @@ struct EvolutionMetavars {
       observers::Observer<EvolutionMetavars>,
       observers::ObserverWriter<EvolutionMetavars>,
       DgElementArray<
-          EvolutionMetavars, dg::Actions::InitializeElement<Dim>,
+          EvolutionMetavars, ScalarWave::Actions::Initialize<Dim>,
           tmpl::flatten<tmpl::list<
               SelfStart::self_start_procedure<compute_rhs, update_variables>,
               Actions::Label<EvolvePhaseStart>, Actions::AdvanceTime,

--- a/src/Evolution/Initialization/NonConservativeInterface.hpp
+++ b/src/Evolution/Initialization/NonConservativeInterface.hpp
@@ -1,0 +1,97 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Initialization {
+
+/// \brief Initialize items related to the interfaces between Elements and on
+/// external boundaries, for non-conservative systems
+///
+/// DataBox changes:
+/// - Adds:
+///   * `face_tags<Tags::InternalDirections<Dim>>`
+///   * `face_tags<Tags::BoundaryDirectionsInterior<Dim>>`
+///   * `face_tags<Tags::BoundaryDirectionsExterior<Dim>>`
+///
+/// - For face_tags:
+///   * `Tags::InterfaceComputeItem<Directions, Tags::Direction<Dim>>`
+///   * `Tags::InterfaceComputeItem<Directions, Tags::InterfaceMesh<Dim>>`
+///   * `Tags::Slice<Directions, typename System::variables_tag>`
+///   * `Tags::InterfaceComputeItem<Directions,
+///                                Tags::UnnormalizedFaceNormal<Dim>>`
+///   * Tags::InterfaceComputeItem<Directions,
+///                                typename System::template magnitude_tag<
+///                                    Tags::UnnormalizedFaceNormal<Dim>>>
+///   * `Tags::InterfaceComputeItem<
+///         Directions, Tags::Normalized<Tags::UnnormalizedFaceNormal<Dim>>>`
+/// - Removes: nothing
+/// - Modifies: nothing
+template <typename System>
+struct NonConservativeInterface {
+  static constexpr size_t dim = System::volume_dim;
+  using simple_tags =
+      db::AddSimpleTags<Tags::Interface<Tags::BoundaryDirectionsExterior<dim>,
+                                        typename System::variables_tag>>;
+
+  template <typename Directions>
+  using face_tags = tmpl::list<
+      Directions, Tags::InterfaceComputeItem<Directions, Tags::Direction<dim>>,
+      Tags::InterfaceComputeItem<Directions, Tags::InterfaceMesh<dim>>,
+      Tags::Slice<Directions, typename System::variables_tag>,
+      Tags::InterfaceComputeItem<Directions, Tags::UnnormalizedFaceNormal<dim>>,
+      Tags::InterfaceComputeItem<Directions,
+                                 typename System::template magnitude_tag<
+                                     Tags::UnnormalizedFaceNormal<dim>>>,
+      Tags::InterfaceComputeItem<
+          Directions, Tags::Normalized<Tags::UnnormalizedFaceNormal<dim>>>>;
+
+  using ext_tags = tmpl::list<
+      Tags::BoundaryDirectionsExterior<dim>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::Direction<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::InterfaceMesh<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::BoundaryCoordinates<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 Tags::UnnormalizedFaceNormal<dim>>,
+      Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<dim>,
+                                 typename System::template magnitude_tag<
+                                     Tags::UnnormalizedFaceNormal<dim>>>,
+      Tags::InterfaceComputeItem<
+          Tags::BoundaryDirectionsExterior<dim>,
+          Tags::Normalized<Tags::UnnormalizedFaceNormal<dim>>>>;
+
+  using compute_tags =
+      tmpl::append<face_tags<Tags::InternalDirections<dim>>,
+                   face_tags<Tags::BoundaryDirectionsInterior<dim>>, ext_tags>;
+
+  template <typename TagsList>
+  static auto initialize(db::DataBox<TagsList>&& box) noexcept {
+    const auto& mesh = db::get<Tags::Mesh<dim>>(box);
+    std::unordered_map<Direction<dim>,
+                       db::item_type<typename System::variables_tag>>
+        external_boundary_vars{};
+
+    for (const auto& direction :
+         db::get<Tags::Element<dim>>(box).external_boundaries()) {
+      external_boundary_vars[direction] =
+          db::item_type<typename System::variables_tag>{
+              mesh.slice_away(direction.dimension()).number_of_grid_points()};
+    }
+
+    return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+        std::move(box), std::move(external_boundary_vars));
+  }
+};
+
+}  // namespace Initialization

--- a/src/Evolution/Systems/ScalarWave/Initialize.hpp
+++ b/src/Evolution/Systems/ScalarWave/Initialize.hpp
@@ -1,0 +1,150 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <tuple>
+#include <utility>  // IWYU pragma: keep
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Initialization/DiscontinuousGalerkin.hpp"
+#include "Evolution/Initialization/Domain.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
+#include "Evolution/Initialization/Limiter.hpp"
+#include "Evolution/Initialization/NonConservativeInterface.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.tpp"
+#include "Parallel/ConstGlobalCache.hpp"
+#include "PointwiseFunctions/AnalyticData/Tags.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ScalarWave {
+namespace Actions {
+namespace detail {
+template <class T, class = cpp17::void_t<>>
+struct has_analytic_solution_alias : std::false_type {};
+template <class T>
+struct has_analytic_solution_alias<
+    T, cpp17::void_t<typename T::analytic_solution_tag>> : std::true_type {};
+}  // namespace detail
+
+// Note:  I've left the Dim and System template parameters until it is clear
+// whether or not what remains is specific to this system, and what might be
+// applicable to more than one system
+template <size_t Dim>
+struct Initialize {
+  template <typename Metavariables>
+  struct VariablesTags {
+    using system = typename Metavariables::system;
+    using variables_tag = typename system::variables_tag;
+    using simple_tags = db::AddSimpleTags<variables_tag>;
+    using compute_tags = db::AddComputeTags<>;
+
+    template <typename TagsList>
+    static auto initialize(
+        db::DataBox<TagsList>&& box,
+        const Parallel::ConstGlobalCache<Metavariables>& cache,
+        const double initial_time) noexcept {
+      using Vars = typename variables_tag::type;
+
+      const size_t num_grid_points =
+          db::get<::Tags::Mesh<Dim>>(box).number_of_grid_points();
+
+      const auto& inertial_coords =
+          db::get<::Tags::Coordinates<Dim, Frame::Inertial>>(box);
+
+      // Set initial data from analytic solution
+      Vars vars{num_grid_points};
+      make_overloader(
+          [ initial_time, &
+            inertial_coords ](std::true_type /*is_analytic_solution*/,
+                              const gsl::not_null<Vars*> local_vars,
+                              const auto& local_cache) noexcept {
+            using solution_tag = OptionTags::AnalyticSolutionBase;
+            local_vars->assign_subset(
+                Parallel::get<solution_tag>(local_cache)
+                    .variables(inertial_coords, initial_time,
+                               typename Vars::tags_list{}));
+          },
+          [&inertial_coords](std::false_type /*is_analytic_solution*/,
+                             const gsl::not_null<Vars*> local_vars,
+                             const auto& local_cache) noexcept {
+            using analytic_data_tag = OptionTags::AnalyticDataBase;
+            local_vars->assign_subset(
+                Parallel::get<analytic_data_tag>(local_cache)
+                    .variables(inertial_coords, typename Vars::tags_list{}));
+          })(detail::has_analytic_solution_alias<Metavariables>{},
+             make_not_null(&vars), cache);
+
+      return db::create_from<db::RemoveTags<>, simple_tags, compute_tags>(
+          std::move(box), std::move(vars));
+    }
+  };
+
+  template <class Metavariables>
+  using return_tag_list =
+      tmpl::append<typename Initialization::Domain<Dim>::simple_tags,
+                   typename VariablesTags<Metavariables>::simple_tags,
+                   typename Initialization::NonConservativeInterface<
+                       typename Metavariables::system>::simple_tags,
+                   typename Initialization::Evolution<
+                       typename Metavariables::system>::simple_tags,
+                   typename Initialization::DiscontinuousGalerkin<
+                       Metavariables>::simple_tags,
+                   typename Initialization::MinMod<Dim>::simple_tags,
+                   typename Initialization::Domain<Dim>::compute_tags,
+                   typename VariablesTags<Metavariables>::compute_tags,
+                   typename Initialization::NonConservativeInterface<
+                       typename Metavariables::system>::compute_tags,
+                   typename Initialization::Evolution<
+                       typename Metavariables::system>::compute_tags,
+                   typename Initialization::DiscontinuousGalerkin<
+                       Metavariables>::compute_tags,
+                   typename Initialization::MinMod<Dim>::compute_tags>;
+
+  template <typename... InboxTags, typename Metavariables, typename ActionList,
+            typename ParallelComponent>
+  static auto apply(const db::DataBox<tmpl::list<>>& /*box*/,
+                    const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    const Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ElementIndex<Dim>& array_index,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    std::vector<std::array<size_t, Dim>> initial_extents,
+                    Domain<Dim, Frame::Inertial> domain,
+                    const double initial_time, const double initial_dt,
+                    const double initial_slab_size) noexcept {
+    using system = typename Metavariables::system;
+    auto domain_box = Initialization::Domain<Dim>::initialize(
+        db::DataBox<tmpl::list<>>{}, array_index, initial_extents, domain);
+    auto variables_box = VariablesTags<Metavariables>::initialize(
+        std::move(domain_box), cache, initial_time);
+    auto domain_interface_box =
+        Initialization::NonConservativeInterface<system>::initialize(
+            std::move(variables_box));
+    auto evolution_box = Initialization::Evolution<system>::initialize(
+        std::move(domain_interface_box), cache, initial_time, initial_dt,
+        initial_slab_size);
+    auto dg_box =
+        Initialization::DiscontinuousGalerkin<Metavariables>::initialize(
+            std::move(evolution_box), initial_extents);
+    auto limiter_box =
+        Initialization::MinMod<Dim>::initialize(std::move(dg_box));
+    return std::make_tuple(std::move(limiter_box));
+  }
+};
+}  // namespace Actions
+}  // namespace ScalarWave


### PR DESCRIPTION
## Proposed changes

Update ScalarWave to no longer use dg::Actions::initialize_element. Instead, initialization is analogous to what's done for GRMHD.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->