### PR TITLE
Add M1 sources within merged framework

### DIFF
--- a/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY M1Grey)
 
 set(LIBRARY_SOURCES
   M1Closure.cpp
+  Sources.cpp
   )
 
 add_spectre_library(${LIBRARY} ${LIBRARY_SOURCES})

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.cpp
@@ -1,0 +1,90 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "PointwiseFunctions/GeneralRelativity/IndexManipulation.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp" // IWYU pragma: keep
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+struct AlphaTildeP {
+  using type = tnsr::II<DataVector, 3, Frame::Inertial>;
+};
+}  //  namespace
+
+namespace RadiationTransport {
+namespace M1Grey {
+
+namespace detail {
+void compute_sources_impl(
+    const gsl::not_null<Scalar<DataVector>*> source_tilde_e,
+    const gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+        source_tilde_s,
+    const Scalar<DataVector>& tilde_e,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& tilde_p,
+    const Scalar<DataVector>& lapse,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
+    const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
+    const tnsr::ijj<DataVector, 3, Frame::Inertial>& d_spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>&
+        extrinsic_curvature) noexcept {
+  Variables<tmpl::list<Tags::TildeSVector<Frame::Inertial>, AlphaTildeP>>
+      temp_tensors(get(tilde_e).size());
+
+  constexpr size_t spatial_dim = 3;
+
+  auto& tilde_s_M = get<Tags::TildeSVector<Frame::Inertial>>(temp_tensors);
+  raise_or_lower_index(make_not_null(&tilde_s_M), tilde_s, inv_spatial_metric);
+  auto& alpha_tilde_p = get<AlphaTildeP>(temp_tensors);
+  for (size_t i = 0; i < spatial_dim; ++i) {
+    for (size_t j = 0; j < spatial_dim; ++j) {
+      alpha_tilde_p.get(i, j) = tilde_p.get(i, j) * get(lapse);
+    }
+  }
+
+  // unroll contributions from m=0 and n=0 to avoid initializing
+  // source terms to zero
+  get(*source_tilde_e) =
+      get<0, 0>(extrinsic_curvature) * get<0, 0>(alpha_tilde_p) -
+      get<0>(tilde_s_M) * get<0>(d_lapse);
+  for (size_t m = 1; m < spatial_dim; ++m) {
+    get(*source_tilde_e) +=
+        extrinsic_curvature.get(0, m) * alpha_tilde_p.get(0, m) +
+        extrinsic_curvature.get(m, 0) * alpha_tilde_p.get(m, 0) -
+        tilde_s_M.get(m) * d_lapse.get(m);
+    for (size_t n = 1; n < spatial_dim; ++n) {
+      get(*source_tilde_e) +=
+          extrinsic_curvature.get(m, n) * alpha_tilde_p.get(m, n);
+    }
+  }
+
+  for (size_t i = 0; i < spatial_dim; ++i) {
+    source_tilde_s->get(i) =
+        -get(tilde_e) * d_lapse.get(i) + get<0>(tilde_s) * d_shift.get(i, 0) +
+        0.5 * get<0, 0>(alpha_tilde_p) * d_spatial_metric.get(i, 0, 0);
+    for (size_t m = 1; m < spatial_dim; ++m) {
+      source_tilde_s->get(i) +=
+          tilde_s.get(m) * d_shift.get(i, m) +
+          0.5 * (alpha_tilde_p.get(0, m) * d_spatial_metric.get(i, 0, m) +
+                 alpha_tilde_p.get(m, 0) * d_spatial_metric.get(i, m, 0));
+      for (size_t n = 1; n < spatial_dim; ++n) {
+        source_tilde_s->get(i) +=
+            0.5 * alpha_tilde_p.get(m, n) * d_spatial_metric.get(i, m, n);
+      }
+    }
+  }
+}
+
+}  // namespace detail
+}  // namespace M1Grey
+}  // namespace RadiationTransport

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp
@@ -1,0 +1,118 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"  // for item_type
+#include "DataStructures/Tensor/TypeAliases.hpp"  // IWYU pragma: keep
+#include "Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"  //  IWYU pragma: keep
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"  // IWYU pragma: keep
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"  // for EXPAND_PACK_LEFT_TO...
+
+// IWYU pragma: no_include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+
+/// \cond
+class DataVector;
+/// \endcond
+
+// IWYU pragma: no_forward_declare Tensor
+// IWYU pragma: no_forward_declare Tags::deriv
+
+namespace RadiationTransport {
+namespace M1Grey {
+
+/// Implementation of the curvature source terms
+/// for the M1 system, for an individual species.
+namespace detail {
+void compute_sources_impl(
+    gsl::not_null<Scalar<DataVector>*> source_tilde_e,
+    gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> source_tilde_s,
+    const Scalar<DataVector>& tilde_e,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& tilde_s,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& tilde_p,
+    const Scalar<DataVector>& lapse,
+    const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
+    const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
+    const tnsr::ijj<DataVector, 3, Frame::Inertial>& d_spatial_metric,
+    const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>&
+        extrinsic_curvature) noexcept;
+}  // namespace detail
+
+/*!
+ * \brief Compute the curvature source terms for the flux-balanced
+ * grey M1 radiation transport.
+ *
+ *
+ * A flux-balanced system has the generic form:
+ * \f[
+ * \partial_t U_i + \partial_m F^m(U_i) = S(U_i)
+ * \f]
+ *
+ * where \f$F^a()\f$ denotes the flux of a conserved variable \f$U_i\f$ and
+ * \f$S()\f$ denotes the source term for the conserved variable.
+ *
+ * For the grey M1 formalism (neglecting coupling to the fluid):
+ * \f{align*}
+ * S({\tilde E}) &= \alpha \tilde P^{ij} K_{ij} - \tilde S^i \partial_i
+ * \alpha,\\ S({\tilde S_i}) &= -\tilde E \partial_i \alpha + \tilde S_k
+ * \partial_i \beta^k
+ * + \frac{1}{2} \alpha \tilde P^{jk} \partial_i \gamma_{jk},
+ * \f}
+ *
+ * where \f${\tilde E}\f$, \f${\tilde S_i}\f$, \f${\tilde P}^{ij}\f$ are the
+ * densitized energy, momentum, and pressure tensor of the neutrinos/photons,
+ * \f$K_{ij}\f$ is the extrinsic curvature, and \f$\alpha\f$, \f$\beta^i\f$,
+ * \f$\gamma_{ij}\f$ are the lapse, shift and 3-metric.
+ *
+ * In the main function, we loop over all neutrino species, and then call
+ * the actual implementation of the curvature source terms.
+ */
+template <typename... NeutrinoSpecies>
+struct ComputeSources {
+  using return_tags =
+      tmpl::list<Tags::TildeE<Frame::Inertial, NeutrinoSpecies>...,
+                 Tags::TildeS<Frame::Inertial, NeutrinoSpecies>...>;
+
+  using argument_tags = tmpl::list<
+      Tags::TildeE<Frame::Inertial, NeutrinoSpecies>...,
+      Tags::TildeS<Frame::Inertial, NeutrinoSpecies>...,
+      Tags::TildeP<Frame::Inertial, NeutrinoSpecies>..., gr::Tags::Lapse<>,
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>, tmpl::size_t<3>,
+                    Frame::Inertial>,
+      ::Tags::deriv<gr::Tags::Shift<3, Frame::Inertial, DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial>,
+      ::Tags::deriv<gr::Tags::SpatialMetric<3, Frame::Inertial, DataVector>,
+                    tmpl::size_t<3>, Frame::Inertial>,
+      gr::Tags::InverseSpatialMetric<3>, gr::Tags::SqrtDetSpatialMetric<>,
+      gr::Tags::ExtrinsicCurvature<3, Frame::Inertial, DataVector>>;
+
+  static void apply(
+      const gsl::not_null<db::item_type<
+          Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>*>... sources_tilde_e,
+      const gsl::not_null<db::item_type<
+          Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>*>... sources_tilde_s,
+      const db::item_type<
+          Tags::TildeE<Frame::Inertial, NeutrinoSpecies>>&... tilde_e,
+      const db::item_type<
+          Tags::TildeS<Frame::Inertial, NeutrinoSpecies>>&... tilde_s,
+      const db::item_type<
+          Tags::TildeP<Frame::Inertial, NeutrinoSpecies>>&... tilde_p,
+      const Scalar<DataVector>& lapse,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& d_lapse,
+      const tnsr::iJ<DataVector, 3, Frame::Inertial>& d_shift,
+      const tnsr::ijj<DataVector, 3, Frame::Inertial>& d_spatial_metric,
+      const tnsr::II<DataVector, 3, Frame::Inertial>& inv_spatial_metric,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>&
+          extrinsic_curvature) noexcept {
+    EXPAND_PACK_LEFT_TO_RIGHT(detail::compute_sources_impl(
+        sources_tilde_e, sources_tilde_s, tilde_e, tilde_s, tilde_p, lapse,
+        d_lapse, d_shift, d_spatial_metric, inv_spatial_metric,
+        extrinsic_curvature));
+  }
+};
+
+}  // namespace M1Grey
+}  // namespace RadiationTransport

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Tags.hpp
@@ -31,12 +31,34 @@ struct TildeE : db::SimpleTag {
 };
 
 /// The densitized momentum density of neutrinos of a given species
-/// \f${\tilde F_i}\f$
+/// \f${\tilde S_i}\f$
 template <typename Fr, class Species>
-struct TildeF : db::SimpleTag {
+struct TildeS : db::SimpleTag {
   using type = tnsr::i<DataVector, 3, Fr>;
   static std::string name() noexcept {
-    return Frame::prefix<Fr>() + "TildeF_" + neutrinos::get_name(Species{});
+    return Frame::prefix<Fr>() + "TildeS_" + neutrinos::get_name(Species{});
+  }
+};
+
+/// The densitized pressure tensor of neutrinos of a given species
+/// \f${\tilde P^{ij}}\f$
+/// computed from \f${\tilde E}\f$, \f${\tilde S_i}\f$ using the M1 closure
+template <typename Fr, class Species>
+struct TildeP : db::SimpleTag {
+  using type = tnsr::II<DataVector, 3, Fr>;
+  static std::string name() noexcept {
+    return Frame::prefix<Fr>() + "TildeP_" + neutrinos::get_name(Species{});
+  }
+};
+
+/// The upper index momentum density of a neutrino species.
+/// This tag does not know the species of neutrinos being used.
+/// \f${\tilde S^i}\f$
+template <typename Fr>
+struct TildeSVector : db::SimpleTag {
+  using type = tnsr::I<DataVector, 3, Fr>;
+  static std::string name() noexcept {
+    return Frame::prefix<Fr>() + "TildeSVector";
   }
 };
 

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_M1Grey")
 
 set(LIBRARY_SOURCES
   Test_M1Closure.cpp
+  Test_Sources.cpp
   Test_Tags.cpp
   )
 
@@ -13,4 +14,5 @@ add_test_library(
   "Evolution/Systems/RadiationTransport/M1Grey/"
   "${LIBRARY_SOURCES}"
   "M1Grey"
+  "Test_Pypp"
   )

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Sources.py
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Sources.py
@@ -1,0 +1,28 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Functions for testing Sources.cpp
+def source_tilde_e(tilde_e,tilde_s,tilde_p,lapse,
+                   d_lapse,d_shift,d_spatial_metric,
+                   inv_spatial_metric,extrinsic_curvature):
+    result = (lapse * np.einsum("ab, ab",tilde_p,extrinsic_curvature) -
+              np.einsum("ab, ab", inv_spatial_metric,
+                       np.outer(tilde_s, d_lapse)))
+    return result
+
+
+def source_tilde_s(tilde_e,tilde_s,tilde_p,lapse,
+                   d_lapse,d_shift,d_spatial_metric,
+                   inv_spatial_metric,extrinsic_curvature):
+    result = (0.5 * lapse *
+              np.einsum("ab, iab", tilde_p, d_spatial_metric) +
+              np.einsum("a, ia", tilde_s, d_shift) -
+              tilde_e * d_lapse)
+    return result
+
+
+# End of functions for testing Sources.cpp
+

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Sources.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Sources.cpp
@@ -1,0 +1,25 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/RadiationTransport/M1Grey/Sources.hpp"
+#include "Evolution/Systems/RadiationTransport/Tags.hpp" // IWYU pragma: keep
+#include "Utilities/Gsl.hpp"
+#include "tests/Unit/Pypp/CheckWithRandomValues.hpp"
+#include "tests/Unit/Pypp/SetupLocalPythonEnvironment.hpp"
+
+SPECTRE_TEST_CASE("Unit.RadiationTransport.M1Grey.Sources", "[Unit][M1Grey]") {
+  pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/RadiationTransport/M1Grey"};
+
+  pypp::check_with_random_values<1>(&RadiationTransport::M1Grey::ComputeSources<
+                                        neutrinos::ElectronNeutrinos<0>>::apply,
+                                    "Sources",
+                                    {"source_tilde_e", "source_tilde_s"},
+                                    {{{0.0, 1.0}}}, DataVector{5});
+}

--- a/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/RadiationTransport/M1Grey/Test_Tags.cpp
@@ -25,7 +25,7 @@ SPECTRE_TEST_CASE("Evolution.Systems.RadiationTransport.M1Grey.Tags",
   CHECK(RadiationTransport::M1Grey::Tags::TildeE<
             Frame::Inertial, neutrinos::ElectronNeutrinos<1> >::name() ==
         "TildeE_ElectronNeutrinos1");
-  CHECK(RadiationTransport::M1Grey::Tags::TildeF<
+  CHECK(RadiationTransport::M1Grey::Tags::TildeS<
             Frame::Grid, neutrinos::ElectronAntiNeutrinos<2> >::name() ==
-        "Grid_TildeF_ElectronAntiNeutrinos2");
+        "Grid_TildeS_ElectronAntiNeutrinos2");
 }


### PR DESCRIPTION
## Proposed changes

Add explicit part of the source terms for M1 evolution of a radiation field.
Replaces PR #1235 

### Types of changes:

- [ ] Bugfix
- [x ] New feature

### Component:

- [ x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).