### PR TITLE
Add ObservationType argument to ObservationId constructor.

### DIFF
--- a/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
+++ b/src/Elliptic/Executables/Poisson/SolvePoissonProblem.hpp
@@ -65,6 +65,9 @@ struct Metavariables {
   // Collect all items to store in the cache.
   using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
 
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::list<Poisson::Actions::Observe, linear_solver>>;
 

--- a/src/Elliptic/Systems/Poisson/Actions/Observe.hpp
+++ b/src/Elliptic/Systems/Poisson/Actions/Observe.hpp
@@ -131,7 +131,9 @@ struct Observe {
              cache)
              .ckLocalBranch();
     Parallel::simple_action<observers::Actions::ContributeVolumeData>(
-        local_observer, observers::ObservationId(iteration_id),
+        local_observer,
+        observers::ObservationId(
+            iteration_id, typename Metavariables::element_observation_type{}),
         std::string{"/element_data"},
         observers::ArrayComponentId(
             std::add_pointer_t<ParallelComponent>{nullptr},
@@ -140,7 +142,9 @@ struct Observe {
 
     // Send data to reduction observer
     Parallel::simple_action<observers::Actions::ContributeReductionData>(
-        local_observer, observers::ObservationId(iteration_id),
+        local_observer,
+        observers::ObservationId(
+            iteration_id, typename Metavariables::element_observation_type{}),
         std::string{"/element_data"},
         std::vector<std::string>{"Iteration", "NumberOfPoints", "L2Error"},
         observed_reduction_data{iteration_id.step_number,

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -75,6 +75,9 @@ struct EvolutionMetavars {
                      local_time_stepping, LtsTimeStepper, TimeStepper>>>;
   using domain_creator_tag = OptionTags::DomainCreator<1, Frame::Inertial>;
 
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::list<Burgers::Actions::Observe>>;
 

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -156,6 +156,9 @@ struct EvolutionMetavars {
 
   using domain_creator_tag = OptionTags::DomainCreator<3, Frame::Inertial>;
 
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   static constexpr OptionString help{
       "Evolve the Valencia formulation of the GRMHD system with divergence "
       "cleaning.\n\n"};

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -79,6 +79,9 @@ struct EvolutionMetavars {
                      local_time_stepping, LtsTimeStepper, TimeStepper>>>;
   using domain_creator_tag = OptionTags::DomainCreator<Dim, Frame::Inertial>;
 
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::list<ScalarWave::Actions::Observe>>;
 

--- a/src/Evolution/Systems/Burgers/Observe.hpp
+++ b/src/Evolution/Systems/Burgers/Observe.hpp
@@ -116,7 +116,9 @@ struct Observe {
                cache)
                .ckLocalBranch();
       Parallel::simple_action<observers::Actions::ContributeVolumeData>(
-          local_observer, observers::ObservationId(time),
+          local_observer,
+          observers::ObservationId(
+              time, typename Metavariables::element_observation_type{}),
           std::string{"/element_data"},
           observers::ArrayComponentId(
               std::add_pointer_t<ParallelComponent>{nullptr},
@@ -125,7 +127,9 @@ struct Observe {
 
       // Send data to reduction observer
       Parallel::simple_action<observers::Actions::ContributeReductionData>(
-          local_observer, observers::ObservationId(time),
+          local_observer,
+          observers::ObservationId(
+              time, typename Metavariables::element_observation_type{}),
           std::string{"/element_data"},
           std::vector<std::string>{"Time", "NumberOfPoints", "UError"},
           reduction_data{

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Observe.hpp
@@ -222,7 +222,9 @@ struct Observe {
                cache)
                .ckLocalBranch();
       Parallel::simple_action<observers::Actions::ContributeVolumeData>(
-          local_observer, observers::ObservationId(time),
+          local_observer,
+          observers::ObservationId(
+              time, typename Metavariables::element_observation_type{}),
           std::string{"/element_data"},
           observers::ArrayComponentId(
               std::add_pointer_t<ParallelComponent>{nullptr},
@@ -231,7 +233,9 @@ struct Observe {
 
       // Send data to reduction observer
       Parallel::simple_action<observers::Actions::ContributeReductionData>(
-          local_observer, observers::ObservationId(time),
+          local_observer,
+          observers::ObservationId(
+              time, typename Metavariables::element_observation_type{}),
           std::string{"/element_data"},
           std::vector<std::string>{
               "Time", "NumberOfPoints", "RestMassDensityError",

--- a/src/Evolution/Systems/ScalarWave/Observe.hpp
+++ b/src/Evolution/Systems/ScalarWave/Observe.hpp
@@ -140,7 +140,9 @@ struct Observe {
                cache)
                .ckLocalBranch();
       Parallel::simple_action<observers::Actions::ContributeVolumeData>(
-          local_observer, observers::ObservationId(time),
+          local_observer,
+          observers::ObservationId(
+              time, typename Metavariables::element_observation_type{}),
           std::string{"/element_data"},
           observers::ArrayComponentId(
               std::add_pointer_t<ParallelComponent>{nullptr},
@@ -149,7 +151,9 @@ struct Observe {
 
       // Send data to reduction observer
       Parallel::simple_action<observers::Actions::ContributeReductionData>(
-          local_observer, observers::ObservationId(time),
+          local_observer,
+          observers::ObservationId(
+              time, typename Metavariables::element_observation_type{}),
           std::string{"/element_data"},
           std::vector<std::string>{"Time", "NumberOfPoints", "PsiError",
                                    "PiError"},

--- a/src/IO/Observer/ObservationId.cpp
+++ b/src/IO/Observer/ObservationId.cpp
@@ -8,6 +8,7 @@
 
 namespace observers {
 void ObservationId::pup(PUP::er& p) noexcept {
+  p | observation_type_hash_;
   p | combined_hash_;
   p | value_;
 }
@@ -21,6 +22,7 @@ bool operator!=(const ObservationId& lhs, const ObservationId& rhs) noexcept {
 }
 
 std::ostream& operator<<(std::ostream& os, const ObservationId& t) noexcept {
-  return os << '(' << t.hash() << ',' << t.value() << ')';
+  return os << '(' << t.observation_type_hash() << ","
+            << t.hash() << ',' << t.value() << ')';
 }
 }  // namespace observers

--- a/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Callbacks/ObserveTimeSeriesOnSurface.hpp
@@ -97,7 +97,11 @@ struct ObserveTimeSeriesOnSurface {
     // We call this on proxy[0] because the 0th element of a NodeGroup is
     // always guaranteed to be present.
     Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(
-        proxy[0], observers::ObservationId(temporal_id.time()),
+        proxy[0],
+        observers::ObservationId(
+            temporal_id.time(),
+            ObserveTimeSeriesOnSurface<TagsToObserve,
+                                       InterpolationTargetTag>{}),
         std::string{"/" + pretty_type::short_name<InterpolationTargetTag>()},
         detail::make_legend(TagsToObserve{}),
         detail::make_reduction_data(box, temporal_id.time().value(),

--- a/src/NumericalAlgorithms/LinearSolver/Observe.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Observe.hpp
@@ -47,8 +47,9 @@ void contribute_to_reduction_observer(
       LinearSolver::Tags::Magnitude,
       db::add_tag_prefix<LinearSolver::Tags::Residual, fields_tag>>;
 
-  const auto observation_id =
-      observers::ObservationId(get<LinearSolver::Tags::IterationId>(box));
+  const auto observation_id = observers::ObservationId(
+      get<LinearSolver::Tags::IterationId>(box),
+      typename Metavariables::element_observation_type{});
   auto& reduction_writer = Parallel::get_parallel_component<
       observers::ObserverWriter<Metavariables>>(cache);
   Parallel::threaded_action<observers::ThreadedActions::WriteReductionData>(

--- a/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
@@ -115,6 +115,9 @@ struct Metavariables {
   using analytic_solution_tag = AnalyticSolutionTag;
   using const_global_cache_tag_list = tmpl::list<analytic_solution_tag>;
 
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   /// [collect_reduction_data_tags]
   using observed_reduction_data_tags = observers::collect_reduction_data_tags<
       tmpl::list<Poisson::Actions::Observe>>;

--- a/tests/Unit/IO/Observers/ObserverHelpers.hpp
+++ b/tests/Unit/IO/Observers/ObserverHelpers.hpp
@@ -74,6 +74,9 @@ struct Metavariables {
                                     observer_writer_component<Metavariables>>;
   using const_global_cache_tag_list = tmpl::list<>;
 
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   /// [make_reduction_data_tags]
   using observed_reduction_data_tags =
       observers::make_reduction_data_tags<tmpl::list<reduction_data>>;

--- a/tests/Unit/IO/Observers/Test_ObservationId.cpp
+++ b/tests/Unit/IO/Observers/Test_ObservationId.cpp
@@ -24,6 +24,10 @@ class DummyTimeId {
   size_t value_;
 };
 size_t hash_value(const DummyTimeId& id) noexcept { return id.value(); }
+
+struct ObservationType1 {};
+struct ObservationType2 {};
+
 }  // namespace observer_testing_detail
 
 namespace std {
@@ -39,34 +43,77 @@ struct hash<observer_testing_detail::DummyTimeId> {
 using DummyTimeId = observer_testing_detail::DummyTimeId;
 namespace observers {
 SPECTRE_TEST_CASE("Unit.IO.Observers.ObservationId", "[Unit][Observers]") {
-  ObservationId id0(DummyTimeId(4));
-  ObservationId id1(DummyTimeId(8));
+  ObservationId id0(DummyTimeId(4),
+                    observer_testing_detail::ObservationType1{});
+  ObservationId id1(DummyTimeId(8),
+                    observer_testing_detail::ObservationType1{});
+  ObservationId id2(DummyTimeId(8),
+                    observer_testing_detail::ObservationType2{});
+  ObservationId id3(DummyTimeId(8), observer_testing_detail::ObservationType2{},
+                    "subtype1");
+  ObservationId id4(DummyTimeId(8), observer_testing_detail::ObservationType2{},
+                    "subtype2");
   CHECK(id0 == id0);
   CHECK(id0.hash() == id0.hash());
-  CHECK(id0 == ObservationId(DummyTimeId(4)));
+  CHECK(id0.observation_type_hash() == id0.observation_type_hash());
+  CHECK(id0 == ObservationId(DummyTimeId(4),
+                             observer_testing_detail::ObservationType1{}));
   CHECK(id0 != id1);
   CHECK(id0.hash() != id1.hash());
+  CHECK(id0.observation_type_hash() == id1.observation_type_hash());
+  CHECK(id1 != id2);
+  CHECK(id1.hash() != id2.hash());
+  CHECK(id1.observation_type_hash() != id2.observation_type_hash());
   CHECK(id0.value() == 4.0);
   CHECK(id1.value() == 8.0);
+  CHECK(id2.value() == 8.0);
+  CHECK(id3 != id0);
+  CHECK(id3 != id1);
+  CHECK(id3 != id2);
+  CHECK(id3.hash() != id2.hash());
+  CHECK(id3.observation_type_hash() != id2.observation_type_hash());
+  CHECK(id3.value() == 8.0);
+  CHECK(id4 != id0);
+  CHECK(id4 != id1);
+  CHECK(id4 != id2);
+  CHECK(id4 != id3);
+  CHECK(id4.hash() != id3.hash());
+  CHECK(id4.observation_type_hash() != id3.observation_type_hash());
+  CHECK(id4.value() == 8.0);
 
-  ObservationId time0(Time(Slab{0.0, 1.0}, 0));
-  ObservationId time1(Time(Slab{0.0, 1.0}, Time::rational_t(1, 2)));
+  ObservationId time0(Time(Slab{0.0, 1.0}, 0),
+                      observer_testing_detail::ObservationType1{});
+  ObservationId time1(Time(Slab{0.0, 1.0}, Time::rational_t(1, 2)),
+                      observer_testing_detail::ObservationType1{});
+  ObservationId time2(Time(Slab{0.0, 1.0}, 0),
+                      observer_testing_detail::ObservationType2{});
   CHECK(time0 != id0);
   CHECK(time0.hash() != id0.hash());
   CHECK(time0 == time0);
   CHECK(time0.hash() == time0.hash());
+  CHECK(time0.observation_type_hash() == time0.observation_type_hash());
   CHECK(time0 != time1);
   CHECK(time0.hash() != time1.hash());
+  CHECK(time0.observation_type_hash() == time1.observation_type_hash());
   CHECK(time0.value() == 0.0);
   CHECK(time1.value() == 0.5);
+  CHECK(time2.value() == 0.0);
+  CHECK(time0 != time2);
+  CHECK(time0.observation_type_hash() != time2.observation_type_hash());
+  CHECK(time0.hash() != time2.hash());
 
-  CHECK(get_output(id0) == std::string(MakeString{} << '(' << id0.hash() << ','
-                                                    << id0.value() << ')'));
+  CHECK(get_output(id0) ==
+        std::string(MakeString{} << '(' << id0.observation_type_hash() << ","
+                                 << id0.hash() << ',' << id0.value() << ')'));
 
   // Test PUP
   test_serialization(id0);
   test_serialization(id1);
+  test_serialization(id2);
+  test_serialization(id3);
+  test_serialization(id4);
   test_serialization(time0);
   test_serialization(time1);
+  test_serialization(time2);
 }
 }  // namespace observers

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -124,8 +124,10 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
         make_fake_reduction_data(array_id, time.value());
     runner.simple_action<obs_component,
                          observers::Actions::ContributeReductionData>(
-        0, observers::ObservationId(time), "/element_data", legend,
-        std::move(reduction_data_fakes));
+        0,
+        observers::ObservationId{
+            time, typename Metavariables::element_observation_type{}},
+        "/element_data", legend, std::move(reduction_data_fakes));
   }
   // Invke the threaded action 'WriteReductionData' to write reduction data to
   // disk.

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -144,7 +144,9 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
         make_fake_volume_data(array_id, MakeString{} << id << '/');
     runner
         .simple_action<obs_component, observers::Actions::ContributeVolumeData>(
-            0, observers::ObservationId(TimeId(3)),
+            0,
+            observers::ObservationId(
+                TimeId(3), typename Metavariables::element_observation_type{}),
             std::string{"/element_data"}, array_id,
             /* get<1> = volume tensor data */
             std::move(std::get<1>(volume_data_fakes)),
@@ -162,7 +164,10 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
     h5::H5File<h5::AccessType::ReadOnly> my_file(h5_file_name);
     auto& volume_file = my_file.get<h5::VolumeData>("/element_data");
 
-    const auto temporal_id = observers::ObservationId(TimeId(3)).hash();
+    const auto temporal_id =
+        observers::ObservationId(
+            TimeId(3), typename Metavariables::element_observation_type{})
+            .hash();
     CHECK(volume_file.list_observation_ids() ==
           std::vector<size_t>{temporal_id});
     const auto grids = volume_file.list_grids(temporal_id);

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ConjugateGradientAlgorithm.cpp
@@ -31,6 +31,9 @@ struct Metavariables {
                    typename linear_solver::component_list>;
   using const_global_cache_tag_list = tmpl::list<>;
 
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_DistributedConjugateGradientAlgorithm.cpp
@@ -33,6 +33,9 @@ struct Metavariables {
                    typename linear_solver::component_list>;
   using const_global_cache_tag_list = tmpl::list<>;
 
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ConjugateGradient/Test_ResidualMonitorActions.cpp
@@ -172,10 +172,12 @@ struct Metavariables {
   using component_list = tmpl::list<MockResidualMonitor<Metavariables>,
                                     MockElementArray<Metavariables>,
                                     MockObserverWriter<Metavariables>>;
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   using system = System;
   using const_global_cache_tag_list = tmpl::list<>;
 };
-
 }  // namespace
 
 SPECTRE_TEST_CASE(
@@ -270,7 +272,9 @@ SPECTRE_TEST_CASE(
     CHECK_FALSE(db::get<CheckConvergedTag>(mock_element_box));
     const auto& mock_observer_writer_box = get_mock_observer_writer_box();
     CHECK(db::get<CheckObservationIdTag>(mock_observer_writer_box) ==
-          observers::ObservationId{LinearSolver::IterationId{0}});
+          observers::ObservationId{
+              LinearSolver::IterationId{0},
+              typename Metavariables::element_observation_type{}});
     CHECK(db::get<CheckSubfileNameTag>(mock_observer_writer_box) ==
           "/linear_residuals");
     CHECK(db::get<CheckReductionNamesTag>(mock_observer_writer_box) ==
@@ -345,7 +349,9 @@ SPECTRE_TEST_CASE(
           get<LinearSolver::Tags::HasConverged>(box));
     const auto& mock_observer_writer_box = get_mock_observer_writer_box();
     CHECK(db::get<CheckObservationIdTag>(mock_observer_writer_box) ==
-          observers::ObservationId{LinearSolver::IterationId{1}});
+          observers::ObservationId{
+              LinearSolver::IterationId{1},
+              typename Metavariables::element_observation_type{}});
     CHECK(db::get<CheckSubfileNameTag>(mock_observer_writer_box) ==
           "/linear_residuals");
     CHECK(db::get<CheckReductionNamesTag>(mock_observer_writer_box) ==

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_DistributedGmresAlgorithm.cpp
@@ -33,6 +33,9 @@ struct Metavariables {
                    typename linear_solver::component_list>;
   using const_global_cache_tag_list = tmpl::list<>;
 
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_GmresAlgorithm.cpp
@@ -31,6 +31,9 @@ struct Metavariables {
                    typename linear_solver::component_list>;
   using const_global_cache_tag_list = tmpl::list<>;
 
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   using observed_reduction_data_tags =
       observers::collect_reduction_data_tags<tmpl::list<linear_solver>>;
 

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/Gmres/Test_ResidualMonitorActions.cpp
@@ -195,6 +195,9 @@ struct Metavariables {
   using component_list = tmpl::list<MockResidualMonitor<Metavariables>,
                                     MockElementArray<Metavariables>,
                                     MockObserverWriter<Metavariables>>;
+  struct ObservationType {};
+  using element_observation_type = ObservationType;
+
   using system = System;
   using const_global_cache_tag_list = tmpl::list<>;
 };
@@ -286,7 +289,9 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
           db::get<LinearSolver::Tags::HasConverged>(box));
     const auto& mock_observer_writer_box = get_mock_observer_writer_box();
     CHECK(db::get<CheckObservationIdTag>(mock_observer_writer_box) ==
-          observers::ObservationId{LinearSolver::IterationId{0}});
+          observers::ObservationId{
+              LinearSolver::IterationId{0},
+              typename Metavariables::element_observation_type{}});
     CHECK(db::get<CheckSubfileNameTag>(mock_observer_writer_box) ==
           "/linear_residuals");
     CHECK(db::get<CheckReductionNamesTag>(mock_observer_writer_box) ==
@@ -384,7 +389,9 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearSolver.Gmres.ResidualMonitorActions",
     CHECK(db::get<CheckValueTag>(mock_element_box) == approx(2.));
     const auto& mock_observer_writer_box = get_mock_observer_writer_box();
     CHECK(db::get<CheckObservationIdTag>(mock_observer_writer_box) ==
-          observers::ObservationId{LinearSolver::IterationId{1}});
+          observers::ObservationId{
+              LinearSolver::IterationId{1},
+              typename Metavariables::element_observation_type{}});
     CHECK(db::get<CheckSubfileNameTag>(mock_observer_writer_box) ==
           "/linear_residuals");
     CHECK(db::get<CheckReductionNamesTag>(mock_observer_writer_box) ==


### PR DESCRIPTION
This allows distinguishing between different classes that are
observing, so that there are no collisions when communicating
to ObserverWriter.  (Changing ObserverWriter will be done in a separate PR).

This is the first of several PRs that will address #1284.
I am adding these as several PRs because some of them (like this one) touch a large number
of files but should be easy to review.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
