### PR TITLE
Allow numerical fluxes to retrieve volume_tags

### DIFF
--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -14,6 +14,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Tags.hpp"  // IWYU pragma: keep
 #include "Utilities/TMPL.hpp"
 

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -91,8 +91,8 @@ struct UnnormalizedFaceNormalCompute
 /// represent ghost elements, the normals should correspond to the normals in
 /// said element, which are inverted with respect to the current element.
 template <size_t VolumeDim, typename Frame>
-struct InterfaceComputeItem<Tags::BoundaryDirectionsExterior<VolumeDim>,
-                            UnnormalizedFaceNormalCompute<VolumeDim, Frame>>
+struct InterfaceCompute<Tags::BoundaryDirectionsExterior<VolumeDim>,
+                        UnnormalizedFaceNormalCompute<VolumeDim, Frame>>
     : db::PrefixTag,
       db::ComputeTag,
       Tags::Interface<Tags::BoundaryDirectionsExterior<VolumeDim>,

--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -29,8 +29,7 @@ template <typename DirectionsTag, typename BaseComputeItem,
           typename... ArgumentTags>
 struct evaluate_compute_item<DirectionsTag, BaseComputeItem,
                              tmpl::list<ArgumentTags...>> {
-  using volume_tags =
-      typename InterfaceHelpers_detail::volume_tags<BaseComputeItem>::type;
+  using volume_tags = get_volume_tags<BaseComputeItem>;
   static_assert(
       tmpl::size<tmpl::list_difference<
               volume_tags, typename BaseComputeItem::argument_tags>>::value ==
@@ -128,8 +127,7 @@ struct InterfaceCompute : Interface<DirectionsTag, Tag>,
   };
   using tag = Tag;
   using forwarded_argument_tags =
-      InterfaceHelpers_detail::interface_compute_item_argument_tags<
-          DirectionsTag, Tag>;
+      InterfaceHelpers_detail::get_interface_argument_tags<Tag, DirectionsTag>;
   using argument_tags =
       tmpl::push_front<forwarded_argument_tags, DirectionsTag>;
 

--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -1,0 +1,255 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/VariablesHelpers.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/IndexToSliceAt.hpp"
+#include "Domain/InterfaceHelpers.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "Domain/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Tags {
+
+namespace Interface_detail {
+
+template <typename DirectionsTag, typename BaseComputeItem,
+          typename ArgumentTags>
+struct evaluate_compute_item;
+
+template <typename DirectionsTag, typename BaseComputeItem,
+          typename... ArgumentTags>
+struct evaluate_compute_item<DirectionsTag, BaseComputeItem,
+                             tmpl::list<ArgumentTags...>> {
+  using volume_tags =
+      typename InterfaceHelpers_detail::volume_tags<BaseComputeItem>::type;
+  static_assert(
+      tmpl::size<tmpl::list_difference<
+              volume_tags, typename BaseComputeItem::argument_tags>>::value ==
+          0,
+      "volume_tags contains tags not in argument_tags");
+
+ private:
+  // Order matters so we mix public/private
+  template <class ComputeItem, bool = db::has_return_type_member_v<ComputeItem>>
+  struct ComputeItemType {
+    using type = std::decay_t<decltype(BaseComputeItem::function(
+        std::declval<typename InterfaceHelpers_detail::unmap_interface_args<
+            tmpl::list_contains_v<volume_tags, ArgumentTags>>::
+                         template f<db::item_type<ArgumentTags>>>()...))>;
+  };
+
+  template <class ComputeItem>
+  struct ComputeItemType<ComputeItem, true> {
+    using type = typename BaseComputeItem::return_type;
+  };
+
+ public:
+  using return_type =
+      std::unordered_map<typename db::item_type<DirectionsTag>::value_type,
+                         typename ComputeItemType<BaseComputeItem>::type>;
+
+  static constexpr void apply(
+      const gsl::not_null<return_type*> result,
+      const db::item_type<DirectionsTag>& directions,
+      const db::item_type<ArgumentTags>&... args) noexcept {
+    apply_helper(
+        std::integral_constant<bool,
+                               db::has_return_type_member_v<BaseComputeItem>>{},
+        result, directions, args...);
+  }
+
+ private:
+  static constexpr void apply_helper(
+      std::false_type /*has_return_type_member*/,
+      const gsl::not_null<return_type*> result,
+      const db::item_type<DirectionsTag>& directions,
+      const db::item_type<ArgumentTags>&... args) noexcept {
+    for (const auto& direction : directions) {
+      (*result)[direction] = BaseComputeItem::function(
+          InterfaceHelpers_detail::unmap_interface_args<tmpl::list_contains_v<
+              volume_tags, ArgumentTags>>::apply(direction, args)...);
+    }
+  }
+
+  static constexpr void apply_helper(
+      std::true_type /*has_return_type_member*/,
+      const gsl::not_null<return_type*> result,
+      const db::item_type<DirectionsTag>& directions,
+      const db::item_type<ArgumentTags>&... args) noexcept {
+    for (const auto& direction : directions) {
+      BaseComputeItem::function(
+          make_not_null(&(*result)[direction]),
+          InterfaceHelpers_detail::unmap_interface_args<tmpl::list_contains_v<
+              volume_tags, ArgumentTags>>::apply(direction, args)...);
+    }
+  }
+};
+
+}  // namespace Interface_detail
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// \brief Derived tag for representing a compute item which acts on Tags on an
+/// interface. Can be retrieved using Tags::Interface<DirectionsTag, Tag>
+///
+/// The contained object will be a map from ::Direction to the item type of
+/// `Tag`, with the set of directions being those produced by `DirectionsTag`.
+/// `Tag::function` will be applied separately to the data on each interface. If
+/// some of the compute item's inputs should be taken from the volume even when
+/// applied on a slice, it may indicate them using `volume_tags`.
+///
+/// If using the base tag mechanism for an interface tag is desired,
+/// then `Tag` can have a `base` type alias pointing to its base
+/// class.  (This requirement is due to the lack of a way to determine
+/// a type's base classes in C++.)
+///
+/// \tparam DirectionsTag the item of Directions
+/// \tparam Tag the tag labeling the item
+template <typename DirectionsTag, typename Tag>
+struct InterfaceComputeItem : Interface<DirectionsTag, Tag>,
+                              db::ComputeTag,
+                              virtual db::PrefixTag {
+  static_assert(db::is_compute_item_v<Tag>,
+                "Cannot use a non compute item as an interface compute item.");
+  // Defining name here prevents an ambiguous function call when using base
+  // tags; Both Interface<Dirs, Tag> and Interface<Dirs, Tag::base> will have a
+  // name function and so cannot be disambiguated.
+  static std::string name() noexcept {
+    return "Interface<" + DirectionsTag::name() + ", " + Tag::name() + ">";
+  };
+  using tag = Tag;
+  using forwarded_argument_tags =
+      InterfaceHelpers_detail::interface_compute_item_argument_tags<
+          DirectionsTag, Tag>;
+  using argument_tags =
+      tmpl::push_front<forwarded_argument_tags, DirectionsTag>;
+
+  using return_type = typename Interface_detail::evaluate_compute_item<
+      DirectionsTag, Tag, forwarded_argument_tags>::return_type;
+  static constexpr auto function =
+      Interface_detail::evaluate_compute_item<DirectionsTag, Tag,
+                                              forwarded_argument_tags>::apply;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// \brief Derived tag for representing a compute item which slices a Tag
+/// containing a `Tensor` or a `Variables` from the volume to an interface.
+/// Retrievable from the DataBox using `Tags::Interface<DirectionsTag, Tag>`
+///
+/// The contained object will be a map from ::Direction to the item
+/// type of `Tag`, with the set of directions being those produced by
+/// `DirectionsTag`.
+///
+/// \requires `Tag` correspond to a `Tensor` or a `Variables`
+///
+/// \tparam DirectionsTag the item of Directions
+/// \tparam Tag the tag labeling the item
+template <typename DirectionsTag, typename Tag>
+struct Slice : Interface<DirectionsTag, Tag>, db::ComputeTag {
+  static constexpr size_t volume_dim =
+      db::item_type<DirectionsTag>::value_type::volume_dim;
+
+  using return_type =
+      std::unordered_map<::Direction<volume_dim>, db::item_type<Tag>>;
+
+  static constexpr void function(
+      const gsl::not_null<
+          std::unordered_map<::Direction<volume_dim>, db::item_type<Tag>>*>
+          sliced_vars,
+      const ::Mesh<volume_dim>& mesh,
+      const std::unordered_set<::Direction<volume_dim>>& directions,
+      const db::item_type<Tag>& variables) noexcept {
+    for (const auto& direction : directions) {
+      data_on_slice(make_not_null(&((*sliced_vars)[direction])), variables,
+                    mesh.extents(), direction.dimension(),
+                    index_to_slice_at(mesh.extents(), direction));
+    }
+  }
+  static std::string name() { return "Interface<" + Tag::name() + ">"; };
+  using argument_tags = tmpl::list<Mesh<volume_dim>, DirectionsTag, Tag>;
+  using volume_tags = tmpl::list<Mesh<volume_dim>, Tag>;
+};
+
+/// \cond
+template <typename DirectionsTag, size_t VolumeDim>
+struct InterfaceComputeItem<DirectionsTag, Direction<VolumeDim>>
+    : db::PrefixTag,
+      db::ComputeTag,
+      Tags::Interface<DirectionsTag, Direction<VolumeDim>> {
+  static std::string name() noexcept { return "Interface"; }
+  using tag = Direction<VolumeDim>;
+  static constexpr auto function(
+      const std::unordered_set<::Direction<VolumeDim>>& directions) noexcept {
+    std::unordered_map<::Direction<VolumeDim>, ::Direction<VolumeDim>> result;
+    for (const auto& d : directions) {
+      result.emplace(d, d);
+    }
+    return result;
+  }
+  using argument_tags = tmpl::list<DirectionsTag>;
+};
+/// \endcond
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationalDomainGroup
+/// Computes the `VolumeDim-1` dimensional mesh on an interface from the volume
+/// mesh. `Tags::InterfaceComputeItem<Dirs, InterfaceMesh<VolumeDim>>` is
+/// retrievable as Tags::Interface<Dirs, Mesh<VolumeDim>>` from the DataBox.
+template <size_t VolumeDim>
+struct InterfaceMesh : db::ComputeTag, Tags::Mesh<VolumeDim - 1> {
+  static constexpr auto function(
+      const ::Direction<VolumeDim>& direction,
+      const ::Mesh<VolumeDim>& volume_mesh) noexcept {
+    return volume_mesh.slice_away(direction.dimension());
+  }
+  using base = Tags::Mesh<VolumeDim - 1>;
+  using argument_tags = tmpl::list<Direction<VolumeDim>, Mesh<VolumeDim>>;
+  using volume_tags = tmpl::list<Mesh<VolumeDim>>;
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup ComputationDomainGroup
+/// Computes the coordinates in the frame `Frame` on the faces defined by
+/// `Direction`. Intended to be prefixed by a `Tags::InterfaceComputeItem` to
+/// define the directions on which to compute the coordinates.
+template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
+struct BoundaryCoordinates : db::ComputeTag,
+                             Tags::Coordinates<VolumeDim, Frame> {
+  static constexpr auto function(
+      const ::Direction<VolumeDim>& direction,
+      const ::Mesh<VolumeDim - 1>& interface_mesh,
+      const ::ElementMap<VolumeDim, Frame>& map) noexcept {
+    return map(interface_logical_coordinates(interface_mesh, direction));
+  }
+  static std::string name() noexcept { return "BoundaryCoordinates"; }
+  using base = Tags::Coordinates<VolumeDim, Frame>;
+  using argument_tags = tmpl::list<Direction<VolumeDim>, Mesh<VolumeDim - 1>,
+                                   ElementMap<VolumeDim, Frame>>;
+  using volume_tags = tmpl::list<ElementMap<VolumeDim, Frame>>;
+};
+
+}  // namespace Tags
+
+namespace db {
+template <typename TagList, typename DirectionsTag, typename VariablesTag>
+struct Subitems<
+    TagList, Tags::InterfaceComputeItem<DirectionsTag, VariablesTag>,
+    Requires<tt::is_a_v<Variables, item_type<VariablesTag, TagList>>>>
+    : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
+
+template <typename TagList, typename DirectionsTag, typename VariablesTag>
+struct Subitems<
+    TagList, Tags::Slice<DirectionsTag, VariablesTag>,
+    Requires<tt::is_a_v<Variables, item_type<VariablesTag, TagList>>>>
+    : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
+}  // namespace db

--- a/src/Domain/InterfaceComputeTags.hpp
+++ b/src/Domain/InterfaceComputeTags.hpp
@@ -115,9 +115,9 @@ struct evaluate_compute_item<DirectionsTag, BaseComputeItem,
 /// \tparam DirectionsTag the item of Directions
 /// \tparam Tag the tag labeling the item
 template <typename DirectionsTag, typename Tag>
-struct InterfaceComputeItem : Interface<DirectionsTag, Tag>,
-                              db::ComputeTag,
-                              virtual db::PrefixTag {
+struct InterfaceCompute : Interface<DirectionsTag, Tag>,
+                          db::ComputeTag,
+                          virtual db::PrefixTag {
   static_assert(db::is_compute_item_v<Tag>,
                 "Cannot use a non compute item as an interface compute item.");
   // Defining name here prevents an ambiguous function call when using base
@@ -182,7 +182,7 @@ struct Slice : Interface<DirectionsTag, Tag>, db::ComputeTag {
 
 /// \cond
 template <typename DirectionsTag, size_t VolumeDim>
-struct InterfaceComputeItem<DirectionsTag, Direction<VolumeDim>>
+struct InterfaceCompute<DirectionsTag, Direction<VolumeDim>>
     : db::PrefixTag,
       db::ComputeTag,
       Tags::Interface<DirectionsTag, Direction<VolumeDim>> {
@@ -203,7 +203,7 @@ struct InterfaceComputeItem<DirectionsTag, Direction<VolumeDim>>
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// Computes the `VolumeDim-1` dimensional mesh on an interface from the volume
-/// mesh. `Tags::InterfaceComputeItem<Dirs, InterfaceMesh<VolumeDim>>` is
+/// mesh. `Tags::InterfaceCompute<Dirs, InterfaceMesh<VolumeDim>>` is
 /// retrievable as Tags::Interface<Dirs, Mesh<VolumeDim>>` from the DataBox.
 template <size_t VolumeDim>
 struct InterfaceMesh : db::ComputeTag, Tags::Mesh<VolumeDim - 1> {
@@ -220,7 +220,7 @@ struct InterfaceMesh : db::ComputeTag, Tags::Mesh<VolumeDim - 1> {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationDomainGroup
 /// Computes the coordinates in the frame `Frame` on the faces defined by
-/// `Direction`. Intended to be prefixed by a `Tags::InterfaceComputeItem` to
+/// `Direction`. Intended to be prefixed by a `Tags::InterfaceCompute` to
 /// define the directions on which to compute the coordinates.
 template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
 struct BoundaryCoordinates : db::ComputeTag,
@@ -243,7 +243,7 @@ struct BoundaryCoordinates : db::ComputeTag,
 namespace db {
 template <typename TagList, typename DirectionsTag, typename VariablesTag>
 struct Subitems<
-    TagList, Tags::InterfaceComputeItem<DirectionsTag, VariablesTag>,
+    TagList, Tags::InterfaceCompute<DirectionsTag, VariablesTag>,
     Requires<tt::is_a_v<Variables, item_type<VariablesTag, TagList>>>>
     : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
 

--- a/src/Domain/InterfaceHelpers.hpp
+++ b/src/Domain/InterfaceHelpers.hpp
@@ -1,0 +1,71 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Domain/Direction.hpp"
+#include "Domain/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace InterfaceHelpers_detail {
+
+// Pull volume_tags from BaseComputeItem, defaulting to an empty list.
+template <typename BaseComputeItem, typename = cpp17::void_t<>>
+struct volume_tags {
+  using type = tmpl::list<>;
+};
+
+template <typename BaseComputeItem>
+struct volume_tags<BaseComputeItem,
+                   cpp17::void_t<typename BaseComputeItem::volume_tags>> {
+  using type = typename BaseComputeItem::volume_tags;
+};
+
+// Add an Interface wrapper to a tag if it is not listed as being
+// taken from the volume.
+template <typename DirectionsTag, typename Tag, typename VolumeTags>
+struct interface_compute_item_argument_tag {
+  using type = tmpl::conditional_t<tmpl::list_contains_v<VolumeTags, Tag>, Tag,
+                                   ::Tags::Interface<DirectionsTag, Tag>>;
+};
+
+// Compute the argument tags for the interface version of a compute item.
+template <typename DirectionsTag, typename BaseComputeItem>
+using interface_compute_item_argument_tags = tmpl::transform<
+    typename BaseComputeItem::argument_tags,
+    interface_compute_item_argument_tag<
+        tmpl::pin<DirectionsTag>, tmpl::_1,
+        tmpl::pin<typename volume_tags<BaseComputeItem>::type>>>;
+
+// Pull the direction's entry from interface arguments, passing volume
+// arguments through unchanged.
+template <bool IsVolumeTag>
+struct unmap_interface_args;
+
+template <>
+struct unmap_interface_args<true> {
+  template <typename T>
+  using f = T;
+
+  template <size_t VolumeDim, typename T>
+  static constexpr const T& apply(const ::Direction<VolumeDim>& /*direction*/,
+                                  const T& arg) noexcept {
+    return arg;
+  }
+};
+
+template <>
+struct unmap_interface_args<false> {
+  template <typename T>
+  using f = typename T::mapped_type;
+
+  template <size_t VolumeDim, typename T>
+  static constexpr decltype(auto) apply(const ::Direction<VolumeDim>& direction,
+                                        const T& arg) noexcept {
+    return arg.at(direction);
+  }
+};
+
+}  // namespace InterfaceHelpers_detail

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -17,13 +17,11 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
-#include "DataStructures/VariablesHelpers.hpp"
+#include "DataStructures/Variables.hpp"
 #include "Domain/Creators/DomainCreator.hpp"  // IWYU pragma: keep
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"
 #include "Domain/ElementMap.hpp"
-#include "Domain/IndexToSliceAt.hpp"
-#include "Domain/LogicalCoordinates.hpp"  // IWYU pragma: keep
 #include "Domain/Mesh.hpp"
 #include "Domain/Side.hpp"
 #include "Options/Options.hpp"
@@ -228,7 +226,6 @@ struct BoundaryDirectionsExterior : db::ComputeTag {
   }
 };
 
-
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
 /// \brief Tag which is either a SimpleTag for quantities on an
@@ -263,134 +260,6 @@ template <typename DirectionsTag, typename Tag>
 struct Interface;
 
 namespace Interface_detail {
-// Pull volume_tags from BaseComputeItem, defaulting to an empty list.
-template <typename BaseComputeItem, typename = cpp17::void_t<>>
-struct volume_tags {
-  using type = tmpl::list<>;
-};
-
-template <typename BaseComputeItem>
-struct volume_tags<BaseComputeItem,
-                   cpp17::void_t<typename BaseComputeItem::volume_tags>> {
-  using type = typename BaseComputeItem::volume_tags;
-};
-
-// Add an Interface wrapper to a tag if it is not listed as being
-// taken from the volume.
-template <typename DirectionsTag, typename Tag, typename VolumeTags>
-struct interface_compute_item_argument_tag {
-  using type = tmpl::conditional_t<tmpl::list_contains_v<VolumeTags, Tag>, Tag,
-                                   Interface<DirectionsTag, Tag>>;
-};
-
-// Compute the argument tags for the interface version of a compute item.
-template <typename DirectionsTag, typename BaseComputeItem>
-using interface_compute_item_argument_tags = tmpl::transform<
-    typename BaseComputeItem::argument_tags,
-    interface_compute_item_argument_tag<
-        tmpl::pin<DirectionsTag>, tmpl::_1,
-        tmpl::pin<typename volume_tags<BaseComputeItem>::type>>>;
-
-// Pull the direction's entry from interface arguments, passing volume
-// arguments through unchanged.
-template <bool IsVolumeTag>
-struct unmap_interface_args;
-
-template <>
-struct unmap_interface_args<true> {
-  template <typename T>
-  using f = T;
-
-  template <size_t VolumeDim, typename T>
-  static constexpr const T& apply(const ::Direction<VolumeDim>& /*direction*/,
-                                  const T& arg) noexcept {
-    return arg;
-  }
-};
-
-template <>
-struct unmap_interface_args<false> {
-  template <typename T>
-  using f = typename T::mapped_type;
-
-  template <size_t VolumeDim, typename T>
-  static constexpr decltype(auto) apply(const ::Direction<VolumeDim>& direction,
-                                        const T& arg) noexcept {
-    return arg.at(direction);
-  }
-};
-
-template <typename DirectionsTag, typename BaseComputeItem,
-          typename ArgumentTags>
-struct evaluate_compute_item;
-
-template <typename DirectionsTag, typename BaseComputeItem,
-          typename... ArgumentTags>
-struct evaluate_compute_item<DirectionsTag, BaseComputeItem,
-                             tmpl::list<ArgumentTags...>> {
-  using volume_tags = typename volume_tags<BaseComputeItem>::type;
-  static_assert(
-      tmpl::size<tmpl::list_difference<
-          volume_tags, typename BaseComputeItem::argument_tags>>::value == 0,
-      "volume_tags contains tags not in argument_tags");
-
- private:
-  // Order matters so we mix public/private
-  template <class ComputeItem, bool = db::has_return_type_member_v<ComputeItem>>
-  struct ComputeItemType {
-    using type = std::decay_t<decltype(BaseComputeItem::function(
-        std::declval<typename unmap_interface_args<
-            tmpl::list_contains_v<volume_tags, ArgumentTags>>::
-                         template f<db::item_type<ArgumentTags>>>()...))>;
-  };
-
-  template <class ComputeItem>
-  struct ComputeItemType<ComputeItem, true> {
-    using type = typename BaseComputeItem::return_type;
-  };
-
- public:
-  using return_type =
-      std::unordered_map<typename db::item_type<DirectionsTag>::value_type,
-                         typename ComputeItemType<BaseComputeItem>::type>;
-
-  static constexpr void apply(
-      const gsl::not_null<return_type*> result,
-      const db::item_type<DirectionsTag>& directions,
-      const db::item_type<ArgumentTags>&... args) noexcept {
-    apply_helper(
-        std::integral_constant<bool,
-                               db::has_return_type_member_v<BaseComputeItem>>{},
-        result, directions, args...);
-  }
-
- private:
-  static constexpr void apply_helper(
-      std::false_type /*has_return_type_member*/,
-      const gsl::not_null<return_type*> result,
-      const db::item_type<DirectionsTag>& directions,
-      const db::item_type<ArgumentTags>&... args) noexcept {
-    for (const auto& direction : directions) {
-      (*result)[direction] = BaseComputeItem::function(
-          unmap_interface_args<tmpl::list_contains_v<
-              volume_tags, ArgumentTags>>::apply(direction, args)...);
-    }
-  }
-
-  static constexpr void apply_helper(
-      std::true_type /*has_return_type_member*/,
-      const gsl::not_null<return_type*> result,
-      const db::item_type<DirectionsTag>& directions,
-      const db::item_type<ArgumentTags>&... args) noexcept {
-    for (const auto& direction : directions) {
-      BaseComputeItem::function(
-          make_not_null(&(*result)[direction]),
-          unmap_interface_args<tmpl::list_contains_v<
-              volume_tags, ArgumentTags>>::apply(direction, args)...);
-    }
-  }
-};
-
 template <typename DirectionsTag, typename Tag, typename = cpp17::void_t<>>
 struct GetBaseTagIfPresent {};
 
@@ -402,53 +271,6 @@ struct GetBaseTagIfPresent<DirectionsTag, Tag,
                 "Tag `base` alias must be a base class of `Tag`.");
 };
 }  // namespace Interface_detail
-
-/// \ingroup DataBoxTagsGroup
-/// \ingroup ComputationalDomainGroup
-/// ::Direction to an interface
-template<size_t VolumeDim>
-struct Direction : db::SimpleTag {
-  static std::string name() noexcept { return "Direction"; }
-  using type = ::Direction<VolumeDim>;
-};
-
-/// \ingroup DataBoxTagsGroup
-/// \ingroup ComputationalDomainGroup
-/// Computes the `VolumeDim-1` dimensional mesh on an interface from the volume
-/// mesh. `Tags::InterfaceComputeItem<Dirs, InterfaceMesh<VolumeDim>>` is
-/// retrievable as Tags::Interface<Dirs, Mesh<VolumeDim>>` from the DataBox.
-template<size_t VolumeDim>
-struct InterfaceMesh : db::ComputeTag, Tags::Mesh<VolumeDim - 1> {
-  static constexpr auto function(
-      const ::Direction<VolumeDim> &direction,
-      const ::Mesh<VolumeDim> &volume_mesh) noexcept {
-    return volume_mesh.slice_away(direction.dimension());
-  }
-  using base = Tags::Mesh<VolumeDim - 1>;
-  using argument_tags = tmpl::list<Direction<VolumeDim>, Mesh<VolumeDim>>;
-  using volume_tags = tmpl::list<Mesh<VolumeDim>>;
-};
-
-/// \ingroup DataBoxTagsGroup
-/// \ingroup ComputationDomainGroup
-/// Computes the coordinates in the frame `Frame` on the faces defined by
-/// `Direction`. Intended to be prefixed by a `Tags::InterfaceComputeItem` to
-/// define the directions on which to compute the coordinates.
-template <size_t VolumeDim, typename Frame = ::Frame::Inertial>
-struct BoundaryCoordinates : db::ComputeTag,
-                             Tags::Coordinates<VolumeDim, Frame> {
-  static constexpr auto function(
-      const ::Direction<VolumeDim> &direction,
-      const ::Mesh<VolumeDim - 1> &interface_mesh,
-      const ::ElementMap<VolumeDim, Frame> &map) noexcept {
-    return map(interface_logical_coordinates(interface_mesh, direction));
-  }
-  static std::string name() noexcept { return "BoundaryCoordinates"; }
-  using base = Tags::Coordinates<VolumeDim, Frame>;
-  using argument_tags = tmpl::list<Direction<VolumeDim>, Mesh<VolumeDim - 1>,
-                                   ElementMap<VolumeDim, Frame>>;
-  using volume_tags = tmpl::list<ElementMap<VolumeDim, Frame>>;
-};
 
 // Virtual inheritance is used here to prevent a compiler warning: Derived class
 // SimpleTag is inaccessible
@@ -466,108 +288,13 @@ struct Interface : virtual db::SimpleTag,
 
 /// \ingroup DataBoxTagsGroup
 /// \ingroup ComputationalDomainGroup
-/// \brief Derived tag for representing a compute item which acts on Tags on an
-/// interface. Can be retrieved using Tags::Interface<DirectionsTag, Tag>
-///
-/// The contained object will be a map from ::Direction to the item type of
-/// `Tag`, with the set of directions being those produced by `DirectionsTag`.
-/// `Tag::function` will be applied separately to the data on each interface. If
-/// some of the compute item's inputs should be taken from the volume even when
-/// applied on a slice, it may indicate them using `volume_tags`.
-///
-/// If using the base tag mechanism for an interface tag is desired,
-/// then `Tag` can have a `base` type alias pointing to its base
-/// class.  (This requirement is due to the lack of a way to determine
-/// a type's base classes in C++.)
-///
-/// \tparam DirectionsTag the item of Directions
-/// \tparam Tag the tag labeling the item
-template <typename DirectionsTag, typename Tag>
-struct InterfaceComputeItem
-    : Interface<DirectionsTag, Tag>,
-      db::ComputeTag,
-      virtual db::PrefixTag {
-  static_assert(db::is_compute_item_v<Tag>,
-                "Cannot use a non compute item as an interface compute item.");
-  // Defining name here prevents an ambiguous function call when using base
-  // tags; Both Interface<Dirs, Tag> and Interface<Dirs, Tag::base> will have a
-  // name function and so cannot be disambiguated.
-  static std::string name() noexcept {
-    return "Interface<" + DirectionsTag::name() + ", " + Tag::name() + ">";
-  };
-  using tag = Tag;
-  using forwarded_argument_tags =
-      Interface_detail::interface_compute_item_argument_tags<DirectionsTag,
-                                                             Tag>;
-  using argument_tags =
-      tmpl::push_front<forwarded_argument_tags, DirectionsTag>;
-
-  using return_type = typename Interface_detail::evaluate_compute_item<
-      DirectionsTag, Tag, forwarded_argument_tags>::return_type;
-  static constexpr auto function =
-      Interface_detail::evaluate_compute_item<DirectionsTag, Tag,
-                                              forwarded_argument_tags>::apply;
+/// ::Direction to an interface
+template <size_t VolumeDim>
+struct Direction : db::SimpleTag {
+  static std::string name() noexcept { return "Direction"; }
+  using type = ::Direction<VolumeDim>;
 };
 
-/// \ingroup DataBoxTagsGroup
-/// \ingroup ComputationalDomainGroup
-/// \brief Derived tag for representing a compute item which slices a Tag
-/// containing a `Tensor` or a `Variables` from the volume to an interface.
-/// Retrievable from the DataBox using `Tags::Interface<DirectionsTag, Tag>`
-///
-/// The contained object will be a map from ::Direction to the item
-/// type of `Tag`, with the set of directions being those produced by
-/// `DirectionsTag`.
-///
-/// \requires `Tag` correspond to a `Tensor` or a `Variables`
-///
-/// \tparam DirectionsTag the item of Directions
-/// \tparam Tag the tag labeling the item
-template <typename DirectionsTag, typename Tag>
-struct Slice : Interface<DirectionsTag, Tag>, db::ComputeTag {
-  static constexpr size_t volume_dim =
-      db::item_type<DirectionsTag>::value_type::volume_dim;
-
-  using return_type =
-      std::unordered_map<::Direction<volume_dim>, db::item_type<Tag>>;
-
-  static constexpr void function(
-      const gsl::not_null<
-          std::unordered_map<::Direction<volume_dim>, db::item_type<Tag>>*>
-          sliced_vars,
-      const ::Mesh<volume_dim>& mesh,
-      const std::unordered_set<::Direction<volume_dim>>& directions,
-      const db::item_type<Tag>& variables) noexcept {
-    for (const auto& direction : directions) {
-      data_on_slice(make_not_null(&((*sliced_vars)[direction])), variables,
-                    mesh.extents(), direction.dimension(),
-                    index_to_slice_at(mesh.extents(), direction));
-    }
-  }
-  static std::string name() { return "Interface<" + Tag::name() + ">"; };
-  using argument_tags = tmpl::list<Mesh<volume_dim>, DirectionsTag, Tag>;
-  using volume_tags = tmpl::list<Mesh<volume_dim>, Tag>;
-};
-
-/// \cond
-template <typename DirectionsTag, size_t VolumeDim>
-struct InterfaceComputeItem<DirectionsTag, Direction<VolumeDim>>
-    : db::PrefixTag,
-      db::ComputeTag,
-      Tags::Interface<DirectionsTag, Direction<VolumeDim>> {
-  static std::string name() noexcept { return "Interface"; }
-  using tag = Direction<VolumeDim>;
-  static constexpr auto function(
-      const std::unordered_set<::Direction<VolumeDim>>& directions) noexcept {
-    std::unordered_map<::Direction<VolumeDim>, ::Direction<VolumeDim>> result;
-    for (const auto& d : directions) {
-      result.emplace(d, d);
-    }
-    return result;
-  }
-  using argument_tags = tmpl::list<DirectionsTag>;
-};
-/// \endcond
 }  // namespace Tags
 
 namespace db {
@@ -634,15 +361,5 @@ struct Subitems<
     Requires<tt::is_a_v<Variables, item_type<VariablesTag, TagList>>>>
     : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {
 };
-template <typename TagList, typename DirectionsTag, typename VariablesTag>
-struct Subitems<
-    TagList, Tags::InterfaceComputeItem<DirectionsTag, VariablesTag>,
-    Requires<tt::is_a_v<Variables, item_type<VariablesTag, TagList>>>>
-    : detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
 
-template <typename TagList, typename DirectionsTag, typename VariablesTag>
-struct Subitems<
-    TagList, Tags::Slice<DirectionsTag, VariablesTag>,
-    Requires<tt::is_a_v<Variables, item_type<VariablesTag, TagList>>>>
-: detail::InterfaceSubitemsImpl<TagList, DirectionsTag, VariablesTag> {};
 }  // namespace db

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -187,6 +187,7 @@ struct VariablesBoundaryData : db::BaseTag {};
 /// The set of directions to neighboring Elements
 template <size_t VolumeDim>
 struct InternalDirections : db::ComputeTag {
+  static constexpr size_t volume_dim = VolumeDim;
   static std::string name() noexcept { return "InternalDirections"; }
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
@@ -205,6 +206,7 @@ struct InternalDirections : db::ComputeTag {
 /// faces.
 template <size_t VolumeDim>
 struct BoundaryDirectionsInterior : db::ComputeTag {
+  static constexpr size_t volume_dim = VolumeDim;
   static std::string name() noexcept { return "BoundaryDirectionsInterior"; }
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {
@@ -219,6 +221,7 @@ struct BoundaryDirectionsInterior : db::ComputeTag {
 /// faces.
 template <size_t VolumeDim>
 struct BoundaryDirectionsExterior : db::ComputeTag {
+  static constexpr size_t volume_dim = VolumeDim;
   static std::string name() noexcept { return "BoundaryDirectionsExterior"; }
   using argument_tags = tmpl::list<Element<VolumeDim>>;
   static constexpr auto function(const ::Element<VolumeDim>& element) noexcept {

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -241,7 +241,7 @@ struct BoundaryDirectionsExterior : db::ComputeTag {
 ///
 /// If a SimpleTag is desired on the interface, then this tag can be added to
 /// the DataBox directly. If a ComputeTag which acts on Tags on the interface is
-/// desired, then the tag should be added using `InterfaceComputeItem`. If a
+/// desired, then the tag should be added using `InterfaceCompute`. If a
 /// ComputeTag which slices a TensorTag or a VariablesTag in the volume to an
 /// Interface is desired, then it should be added using `Slice`. In all cases,
 /// the tag can then be retrieved using `Tags::Interface<DirectionsTag, Tag>`.
@@ -258,7 +258,7 @@ struct BoundaryDirectionsExterior : db::ComputeTag {
 /// \tparam DirectionsTag the item of directions
 /// \tparam Tag the tag labeling the item
 ///
-/// \see InterfaceComputeItem, Slice
+/// \see InterfaceCompute, Slice
 template <typename DirectionsTag, typename Tag>
 struct Interface;
 

--- a/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp
@@ -146,29 +146,30 @@ struct ImposeHomogeneousDirichletBoundaryConditions {
     const auto& normal_dot_numerical_flux_computer =
         get<typename Metavariables::normal_dot_numerical_flux>(cache);
 
+    auto interior_data = DgActions_detail::compute_local_mortar_data(
+        box, normal_dot_numerical_flux_computer,
+        Tags::BoundaryDirectionsInterior<volume_dim>{}, Metavariables{});
+
+    auto exterior_data = DgActions_detail::compute_packaged_data(
+        box, normal_dot_numerical_flux_computer,
+        Tags::BoundaryDirectionsExterior<volume_dim>{}, Metavariables{});
+
     // Store local and packaged data on the mortars
     for (const auto& direction : element.external_boundaries()) {
       const auto mortar_id = std::make_pair(
           direction, ElementId<volume_dim>::external_boundary_id());
 
-      auto interior_data = DgActions_detail::compute_local_mortar_data(
-          box, direction, normal_dot_numerical_flux_computer,
-          Tags::BoundaryDirectionsInterior<volume_dim>{}, Metavariables{});
-
-      auto exterior_data = DgActions_detail::compute_packaged_data(
-          box, direction, normal_dot_numerical_flux_computer,
-          Tags::BoundaryDirectionsExterior<volume_dim>{}, Metavariables{});
-
       db::mutate<Tags::VariablesBoundaryData>(
           make_not_null(&box),
-          [&mortar_id, &temporal_id, &interior_data,
-           &exterior_data ](const gsl::not_null<
-                            db::item_type<Tags::VariablesBoundaryData, DbTags>*>
-                                mortar_data) noexcept {
-            mortar_data->at(mortar_id).local_insert(temporal_id,
-                                                    std::move(interior_data));
-            mortar_data->at(mortar_id).remote_insert(temporal_id,
-                                                     std::move(exterior_data));
+          [
+            &mortar_id, &temporal_id, &direction, &interior_data, &exterior_data
+          ](const gsl::not_null<
+              db::item_type<Tags::VariablesBoundaryData, DbTags>*>
+                mortar_data) noexcept {
+            mortar_data->at(mortar_id).local_insert(
+                temporal_id, std::move(interior_data.at(direction)));
+            mortar_data->at(mortar_id).remote_insert(
+                temporal_id, std::move(exterior_data.at(direction)));
           });
     }
     return std::forward_as_tuple(std::move(box));

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/MinmodTci.hpp
@@ -11,6 +11,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/SliceIterator.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/MinmodHelpers.hpp"
 #include "Evolution/DiscontinuousGalerkin/Limiters/MinmodType.hpp"
 #include "Utilities/Gsl.hpp"

--- a/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
@@ -16,6 +16,7 @@
 #include "Domain/CreateInitialMesh.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Neighbors.hpp"
 #include "Domain/OrientationMap.hpp"

--- a/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
+++ b/src/Evolution/Initialization/DiscontinuousGalerkin.hpp
@@ -134,17 +134,15 @@ struct DiscontinuousGalerkin {
 
     template <typename Tag>
     using interface_compute_tag =
-        ::Tags::InterfaceComputeItem<::Tags::InternalDirections<dim>, Tag>;
+        ::Tags::InterfaceCompute<::Tags::InternalDirections<dim>, Tag>;
 
     template <typename Tag>
     using boundary_interior_compute_tag =
-        ::Tags::InterfaceComputeItem<::Tags::BoundaryDirectionsInterior<dim>,
-                                     Tag>;
+        ::Tags::InterfaceCompute<::Tags::BoundaryDirectionsInterior<dim>, Tag>;
 
     template <typename Tag>
     using boundary_exterior_compute_tag =
-        ::Tags::InterfaceComputeItem<::Tags::BoundaryDirectionsExterior<dim>,
-                                     Tag>;
+        ::Tags::InterfaceCompute<::Tags::BoundaryDirectionsExterior<dim>, Tag>;
 
     using char_speed_tag = typename LocalSystem::char_speeds_tag;
 

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp
@@ -126,27 +126,29 @@ struct ImposeDirichletBoundaryConditions {
     const auto& normal_dot_numerical_flux_computer =
         get<typename Metavariables::normal_dot_numerical_flux>(cache);
 
+    auto interior_data = DgActions_detail::compute_local_mortar_data(
+        *box, normal_dot_numerical_flux_computer,
+        Tags::BoundaryDirectionsInterior<volume_dim>{}, Metavariables{});
+
+    auto exterior_data = DgActions_detail::compute_packaged_data(
+        *box, normal_dot_numerical_flux_computer,
+        Tags::BoundaryDirectionsExterior<volume_dim>{}, Metavariables{});
+
     for (const auto& direction : element.external_boundaries()) {
       const auto mortar_id = std::make_pair(
           direction, ElementId<volume_dim>::external_boundary_id());
 
-      auto interior_data = DgActions_detail::compute_local_mortar_data(
-          *box, direction, normal_dot_numerical_flux_computer,
-          Tags::BoundaryDirectionsInterior<volume_dim>{}, Metavariables{});
-
-      auto exterior_data = DgActions_detail::compute_packaged_data(
-          *box, direction, normal_dot_numerical_flux_computer,
-          Tags::BoundaryDirectionsExterior<volume_dim>{}, Metavariables{});
-
       db::mutate<Tags::VariablesBoundaryData>(
-          box, [&mortar_id, &temporal_id, &interior_data, &exterior_data ](
-                   const gsl::not_null<
-                       db::item_type<Tags::VariablesBoundaryData, DbTags>*>
-                       mortar_data) noexcept {
-            mortar_data->at(mortar_id).local_insert(temporal_id,
-                                                    std::move(interior_data));
-            mortar_data->at(mortar_id).remote_insert(temporal_id,
-                                                     std::move(exterior_data));
+          box,
+          [
+            &mortar_id, &temporal_id, &direction, &interior_data, &exterior_data
+          ](const gsl::not_null<
+              db::item_type<Tags::VariablesBoundaryData, DbTags>*>
+                mortar_data) noexcept {
+            mortar_data->at(mortar_id).local_insert(
+                temporal_id, std::move(interior_data.at(direction)));
+            mortar_data->at(mortar_id).remote_insert(
+                temporal_id, std::move(exterior_data.at(direction)));
           });
     }
   }

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp
@@ -148,22 +148,21 @@ struct InitializeInterfaces {
 
   template <typename ComputeTag, typename Directions>
   struct make_compute_tag {
-    using type = ::Tags::InterfaceComputeItem<Directions, ComputeTag>;
+    using type = ::Tags::InterfaceCompute<Directions, ComputeTag>;
   };
 
   template <typename Directions>
   using face_tags = tmpl::flatten<tmpl::list<
-      Directions,
-      ::Tags::InterfaceComputeItem<Directions, ::Tags::Direction<dim>>,
-      ::Tags::InterfaceComputeItem<Directions, ::Tags::InterfaceMesh<dim>>,
+      Directions, ::Tags::InterfaceCompute<Directions, ::Tags::Direction<dim>>,
+      ::Tags::InterfaceCompute<Directions, ::Tags::InterfaceMesh<dim>>,
       tmpl::transform<SliceTagsToFace,
                       make_slice_tag<tmpl::_1, tmpl::pin<Directions>>>,
-      ::Tags::InterfaceComputeItem<Directions,
-                                   ::Tags::UnnormalizedFaceNormalCompute<dim>>,
-      ::Tags::InterfaceComputeItem<Directions,
-                                   typename System::template magnitude_tag<
-                                       ::Tags::UnnormalizedFaceNormal<dim>>>,
-      ::Tags::InterfaceComputeItem<
+      ::Tags::InterfaceCompute<Directions,
+                               ::Tags::UnnormalizedFaceNormalCompute<dim>>,
+      ::Tags::InterfaceCompute<Directions,
+                               typename System::template magnitude_tag<
+                                   ::Tags::UnnormalizedFaceNormal<dim>>>,
+      ::Tags::InterfaceCompute<
           Directions,
           ::Tags::NormalizedCompute<::Tags::UnnormalizedFaceNormal<dim>>>,
       tmpl::transform<FaceComputeTags,
@@ -171,23 +170,23 @@ struct InitializeInterfaces {
 
   using exterior_face_tags = tmpl::flatten<tmpl::list<
       ::Tags::BoundaryDirectionsExterior<dim>,
-      ::Tags::InterfaceComputeItem<::Tags::BoundaryDirectionsExterior<dim>,
-                                   ::Tags::Direction<dim>>,
-      ::Tags::InterfaceComputeItem<::Tags::BoundaryDirectionsExterior<dim>,
-                                   ::Tags::InterfaceMesh<dim>>,
+      ::Tags::InterfaceCompute<::Tags::BoundaryDirectionsExterior<dim>,
+                               ::Tags::Direction<dim>>,
+      ::Tags::InterfaceCompute<::Tags::BoundaryDirectionsExterior<dim>,
+                               ::Tags::InterfaceMesh<dim>>,
       tmpl::transform<
           SliceTagsToExterior,
           make_slice_tag<tmpl::_1,
                          tmpl::pin<::Tags::BoundaryDirectionsExterior<dim>>>>,
-      ::Tags::InterfaceComputeItem<
+      ::Tags::InterfaceCompute<
           ::Tags::BoundaryDirectionsExterior<dim>,
           ::Tags::BoundaryCoordinates<dim, Frame::Inertial>>,
-      ::Tags::InterfaceComputeItem<::Tags::BoundaryDirectionsExterior<dim>,
-                                   ::Tags::UnnormalizedFaceNormalCompute<dim>>,
-      ::Tags::InterfaceComputeItem<::Tags::BoundaryDirectionsExterior<dim>,
-                                   typename System::template magnitude_tag<
-                                       ::Tags::UnnormalizedFaceNormal<dim>>>,
-      ::Tags::InterfaceComputeItem<
+      ::Tags::InterfaceCompute<::Tags::BoundaryDirectionsExterior<dim>,
+                               ::Tags::UnnormalizedFaceNormalCompute<dim>>,
+      ::Tags::InterfaceCompute<::Tags::BoundaryDirectionsExterior<dim>,
+                               typename System::template magnitude_tag<
+                                   ::Tags::UnnormalizedFaceNormal<dim>>>,
+      ::Tags::InterfaceCompute<
           ::Tags::BoundaryDirectionsExterior<dim>,
           ::Tags::NormalizedCompute<::Tags::UnnormalizedFaceNormal<dim>>>,
       tmpl::transform<

--- a/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp
+++ b/src/ParallelAlgorithms/DiscontinuousGalerkin/InitializeInterfaces.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Tags.hpp"
 #include "ParallelAlgorithms/Initialization/MergeIntoDataBox.hpp"
 #include "Utilities/TMPL.hpp"

--- a/tests/Unit/Domain/CMakeLists.txt
+++ b/tests/Unit/Domain/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LIBRARY_SOURCES
   Test_FaceNormal.cpp
   Test_IndexToSliceAt.cpp
   Test_InitialElementIds.cpp
+  Test_InterfaceHelpers.cpp
   Test_InterfaceItems.cpp
   Test_LogicalCoordinates.cpp
   Test_Mesh.cpp

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -144,16 +144,16 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ComputeItem", "[Unit][Domain]") {
                         Tags::ElementMap<2>>,
       db::AddComputeTags<
           Tags::BoundaryDirectionsExterior<2>,
-          Tags::InterfaceComputeItem<Directions, Tags::Direction<2>>,
-          Tags::InterfaceComputeItem<Directions, Tags::InterfaceMesh<2>>,
-          Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<2>,
-                                     Tags::Direction<2>>,
-          Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<2>,
-                                     Tags::InterfaceMesh<2>>,
-          Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<2>,
-                                     Tags::UnnormalizedFaceNormalCompute<2>>,
-          Tags::InterfaceComputeItem<Directions,
-                                     Tags::UnnormalizedFaceNormalCompute<2>>>>(
+          Tags::InterfaceCompute<Directions, Tags::Direction<2>>,
+          Tags::InterfaceCompute<Directions, Tags::InterfaceMesh<2>>,
+          Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,
+                                 Tags::Direction<2>>,
+          Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,
+                                 Tags::InterfaceMesh<2>>,
+          Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,
+                                 Tags::UnnormalizedFaceNormalCompute<2>>,
+          Tags::InterfaceCompute<Directions,
+                                 Tags::UnnormalizedFaceNormalCompute<2>>>>(
       Element<2>(ElementId<2>(0), {}),
       std::unordered_set<Direction<2>>{Direction<2>::upper_xi(),
                                        Direction<2>::lower_eta()},
@@ -163,7 +163,7 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ComputeItem", "[Unit][Domain]") {
           make_coordinate_map_base<Frame::Logical, Frame::Inertial>(
               CoordinateMaps::Rotation<2>(atan2(4., 3.)))));
 
-  CHECK((Tags::InterfaceComputeItem<
+  CHECK((Tags::InterfaceCompute<
             Tags::BoundaryDirectionsExterior<2>,
             Tags::UnnormalizedFaceNormalCompute<2>>::name()) ==
         "BoundaryDirectionsExterior<UnnormalizedFaceNormal>"s);
@@ -200,18 +200,18 @@ SPECTRE_TEST_CASE("Unit.Domain.FaceNormal.ComputeItem", "[Unit][Domain]") {
       db::AddComputeTags<
           Tags::BoundaryDirectionsExterior<2>,
           Tags::BoundaryDirectionsInterior<2>,
-          Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<2>,
-                                     Tags::Direction<2>>,
-          Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<2>,
-                                     Tags::InterfaceMesh<2>>,
-          Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<2>,
-                                     Tags::UnnormalizedFaceNormalCompute<2>>,
-          Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<2>,
-                                     Tags::Direction<2>>,
-          Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<2>,
-                                     Tags::InterfaceMesh<2>>,
-          Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<2>,
-                                     Tags::UnnormalizedFaceNormalCompute<2>>>>(
+          Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,
+                                 Tags::Direction<2>>,
+          Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,
+                                 Tags::InterfaceMesh<2>>,
+          Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<2>,
+                                 Tags::UnnormalizedFaceNormalCompute<2>>,
+          Tags::InterfaceCompute<Tags::BoundaryDirectionsInterior<2>,
+                                 Tags::Direction<2>>,
+          Tags::InterfaceCompute<Tags::BoundaryDirectionsInterior<2>,
+                                 Tags::InterfaceMesh<2>>,
+          Tags::InterfaceCompute<Tags::BoundaryDirectionsInterior<2>,
+                                 Tags::UnnormalizedFaceNormalCompute<2>>>>(
       Element<2>(ElementId<2>(0), {}),
       Mesh<2>{2, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto},
       ElementMap<2, Frame::Inertial>(

--- a/tests/Unit/Domain/Test_FaceNormal.cpp
+++ b/tests/Unit/Domain/Test_FaceNormal.cpp
@@ -28,6 +28,7 @@
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/OrientationMap.hpp"
 #include "Domain/Side.hpp"

--- a/tests/Unit/Domain/Test_InterfaceHelpers.cpp
+++ b/tests/Unit/Domain/Test_InterfaceHelpers.cpp
@@ -1,0 +1,96 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/Direction.hpp"
+#include "Domain/Element.hpp"
+#include "Domain/ElementId.hpp"
+#include "Domain/InterfaceHelpers.hpp"
+#include "Domain/Neighbors.hpp"
+#include "Domain/Tags.hpp"
+
+namespace {
+struct SomeNumber : db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "SomeNumber"; }
+};
+struct VolumeArgumentBase : db::BaseTag {};
+struct SomeVolumeArgument : VolumeArgumentBase, db::SimpleTag {
+  using type = double;
+  static std::string name() noexcept { return "SomeVolumeArgument"; }
+};
+}  // namespace
+
+template <size_t Dim, typename DirectionsTag>
+void test_interface_apply(
+    const Element<Dim>& element,
+    const std::unordered_map<Direction<Dim>, double>& number_on_interfaces,
+    const std::unordered_map<Direction<Dim>, double>&
+        expected_result_on_interfaces) {
+  // Construct DataBox that holds the test data
+  const auto box =
+      db::create<db::AddSimpleTags<::Tags::Element<Dim>,
+                                   ::Tags::Interface<DirectionsTag, SomeNumber>,
+                                   SomeVolumeArgument>,
+                 db::AddComputeTags<DirectionsTag>>(element,
+                                                    number_on_interfaces, 1.);
+  // Test applying a function to the interface and give an example
+  /// [interface_apply_example]
+  const auto computed_number_on_interfaces =
+      interface_apply<DirectionsTag, tmpl::list<SomeNumber, SomeVolumeArgument>,
+                      tmpl::list<SomeVolumeArgument>>(
+          [](const double& some_number_on_interface,
+             const double& volume_argument, const double factor) noexcept {
+            return factor * some_number_on_interface + volume_argument;
+          },
+          box, 2.);
+  CHECK(computed_number_on_interfaces.size() ==
+        expected_result_on_interfaces.size());
+  for (const auto& direction_and_expected_result :
+       expected_result_on_interfaces) {
+    CHECK(
+        computed_number_on_interfaces.at(direction_and_expected_result.first) ==
+        direction_and_expected_result.second);
+  }
+  /// [interface_apply_example]
+
+  // Test volume base tag
+  const auto computed_numbers_with_base_tag =
+      interface_apply<DirectionsTag, tmpl::list<SomeNumber, VolumeArgumentBase>,
+                      tmpl::list<VolumeArgumentBase>>(
+          [](const double& some_number_on_interface,
+             const double& volume_argument, const double factor) noexcept {
+            return factor * some_number_on_interface + volume_argument;
+          },
+          box, 2.);
+  CHECK(computed_numbers_with_base_tag == computed_number_on_interfaces);
+}
+
+SPECTRE_TEST_CASE("Unit.Domain.InterfaceHelpers", "[Unit][Domain]") {
+  test_interface_apply<1, ::Tags::InternalDirections<1>>(
+      // Reference element has one internal direction:
+      // [ X | ]-> xi
+      {{0, {{{1, 0}}}}, {{Direction<1>::upper_xi(), {{{0, {{{1, 1}}}}}, {}}}}},
+      {{Direction<1>::upper_xi(), 2.}}, {{Direction<1>::upper_xi(), 5.}});
+  test_interface_apply<1, ::Tags::InternalDirections<1>>(
+      // Reference element has no internal directions:
+      // [ X ]-> xi
+      {{0, {{{0, 0}}}}, {}}, {}, {});
+  test_interface_apply<1, ::Tags::BoundaryDirectionsInterior<1>>(
+      // Reference element has two boundary directions:
+      // [ X ]-> xi
+      {{0, {{{0, 0}}}}, {}},
+      {{Direction<1>::lower_xi(), 2.}, {Direction<1>::upper_xi(), 3.}},
+      {{Direction<1>::lower_xi(), 5.}, {Direction<1>::upper_xi(), 7.}});
+  test_interface_apply<2, ::Tags::InternalDirections<2>>(
+      // Reference element has one internal directions:
+      // ^ eta
+      // +-+-+
+      // |X| |
+      // +-+-+> xi
+      {{0, {{{1, 0}, {0, 0}}}},
+       {{Direction<2>::upper_xi(), {{{0, {{{1, 1}, {0, 0}}}}}, {}}}}},
+      {{Direction<2>::upper_xi(), 2.}}, {{Direction<2>::upper_xi(), 5.}});
+}

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -27,6 +27,7 @@
 #include "Domain/Element.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementMap.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Neighbors.hpp"  // IWYU pragma: keep

--- a/tests/Unit/Domain/Test_InterfaceItems.cpp
+++ b/tests/Unit/Domain/Test_InterfaceItems.cpp
@@ -142,26 +142,25 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
           Tags::Interface<templated_directions, TestTags::Double>>,
       db::AddComputeTags<
           internal_directions,
-          Tags::InterfaceComputeItem<internal_directions, Tags::Direction<dim>>,
+          Tags::InterfaceCompute<internal_directions, Tags::Direction<dim>>,
           TestTags::Negate<TestTags::Int>,
-          Tags::InterfaceComputeItem<internal_directions, TestTags::AddThree>,
-          Tags::InterfaceComputeItem<internal_directions,
-                                     TestTags::Negate<TestTags::Double>>,
-          Tags::InterfaceComputeItem<internal_directions,
-                                     TestTags::ComplexComputeItem<dim>>,
-          Tags::InterfaceComputeItem<templated_directions,
-                                     Tags::Direction<dim>>,
-          Tags::InterfaceComputeItem<templated_directions,
-                                     TestTags::Negate<TestTags::Double>>,
+          Tags::InterfaceCompute<internal_directions, TestTags::AddThree>,
+          Tags::InterfaceCompute<internal_directions,
+                                 TestTags::Negate<TestTags::Double>>,
+          Tags::InterfaceCompute<internal_directions,
+                                 TestTags::ComplexComputeItem<dim>>,
+          Tags::InterfaceCompute<templated_directions, Tags::Direction<dim>>,
+          Tags::InterfaceCompute<templated_directions,
+                                 TestTags::Negate<TestTags::Double>>,
           boundary_directions_interior,
-          Tags::InterfaceComputeItem<boundary_directions_interior,
-                                     Tags::Direction<dim>>,
-          Tags::InterfaceComputeItem<boundary_directions_interior,
-                                     TestTags::AddThree>,
-          Tags::InterfaceComputeItem<boundary_directions_interior,
-                                     TestTags::Negate<TestTags::Double>>,
-          Tags::InterfaceComputeItem<boundary_directions_interior,
-                                     TestTags::ComplexComputeItem<dim>>,
+          Tags::InterfaceCompute<boundary_directions_interior,
+                                 Tags::Direction<dim>>,
+          Tags::InterfaceCompute<boundary_directions_interior,
+                                 TestTags::AddThree>,
+          Tags::InterfaceCompute<boundary_directions_interior,
+                                 TestTags::Negate<TestTags::Double>>,
+          Tags::InterfaceCompute<boundary_directions_interior,
+                                 TestTags::ComplexComputeItem<dim>>,
           boundary_directions_exterior>>(
       std::move(element), 5,
       std::unordered_map<Direction<dim>, double>{
@@ -178,17 +177,17 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems", "[Unit][Domain]") {
       std::unordered_map<Direction<dim>, double>{
           {Direction<dim>::upper_xi(), 4.5}});
 
-    CHECK(get<Tags::BoundaryDirectionsInterior<dim>>(box) ==
-          std::unordered_set<Direction<dim>>{Direction<dim>::lower_eta(),
-                                             Direction<dim>::upper_eta(),
-                                             Direction<dim>::lower_zeta()});
+  CHECK(get<Tags::BoundaryDirectionsInterior<dim>>(box) ==
+        std::unordered_set<Direction<dim>>{Direction<dim>::lower_eta(),
+                                           Direction<dim>::upper_eta(),
+                                           Direction<dim>::lower_zeta()});
 
-    CHECK((get<Tags::Interface<internal_directions, Tags::Direction<dim>>>(
-              box)) ==
-          (std::unordered_map<Direction<dim>, Direction<dim>>{
-              {Direction<dim>::lower_xi(), Direction<dim>::lower_xi()},
-              {Direction<dim>::upper_xi(), Direction<dim>::upper_xi()},
-              {Direction<dim>::upper_zeta(), Direction<dim>::upper_zeta()}}));
+  CHECK(
+      (get<Tags::Interface<internal_directions, Tags::Direction<dim>>>(box)) ==
+      (std::unordered_map<Direction<dim>, Direction<dim>>{
+          {Direction<dim>::lower_xi(), Direction<dim>::lower_xi()},
+          {Direction<dim>::upper_xi(), Direction<dim>::upper_xi()},
+          {Direction<dim>::upper_zeta(), Direction<dim>::upper_zeta()}}));
 
   CHECK(get<Tags::BoundaryDirectionsInterior<dim>>(box) ==
         get<Tags::BoundaryDirectionsExterior<dim>>(box));
@@ -361,13 +360,13 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.Subitems", "[Unit][Domain]") {
       db::AddSimpleTags<
           Tags::Mesh<dim>, Tags::Variables<tmpl::list<Var<2>>>, Var<3>,
           Tags::Interface<Dirs, Tags::Variables<tmpl::list<Var<0>>>>>,
-      db::AddComputeTags<
-          Dirs, VarPlusFiveCompute<3>,
-          Tags::InterfaceComputeItem<Dirs, Tags::Direction<dim>>,
-          Tags::InterfaceComputeItem<Dirs, Tags::InterfaceMesh<dim>>,
-          Tags::InterfaceComputeItem<Dirs, Compute<1>>,
-          Tags::Slice<Dirs, Tags::Variables<tmpl::list<Var<2>>>>,
-          Tags::Slice<Dirs, Var<3>>, Tags::Slice<Dirs, VarPlusFive<3>>>>(
+      db::AddComputeTags<Dirs, VarPlusFiveCompute<3>,
+                         Tags::InterfaceCompute<Dirs, Tags::Direction<dim>>,
+                         Tags::InterfaceCompute<Dirs, Tags::InterfaceMesh<dim>>,
+                         Tags::InterfaceCompute<Dirs, Compute<1>>,
+                         Tags::Slice<Dirs, Tags::Variables<tmpl::list<Var<2>>>>,
+                         Tags::Slice<Dirs, Var<3>>,
+                         Tags::Slice<Dirs, VarPlusFive<3>>>>(
       mesh, volume_var, volume_tensor,
       make_interface_variables<0>(boundary_vars_xi, boundary_vars_eta));
 
@@ -447,10 +446,10 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.Slice", "[Unit][Domain]") {
                         Tags::Interface<Dirs, simple_item_tag>>,
       db::AddComputeTags<
           Dirs, sliced_compute_item_tag, VarPlusFiveCompute<4>,
-          Tags::InterfaceComputeItem<Dirs, Tags::Direction<dim>>,
-          Tags::InterfaceComputeItem<Dirs, Tags::InterfaceMesh<dim>>,
-          Tags::InterfaceComputeItem<Dirs, compute_item_tag>,
-          Tags::InterfaceComputeItem<Dirs, Tags::BoundaryCoordinates<dim>>,
+          Tags::InterfaceCompute<Dirs, Tags::Direction<dim>>,
+          Tags::InterfaceCompute<Dirs, Tags::InterfaceMesh<dim>>,
+          Tags::InterfaceCompute<Dirs, compute_item_tag>,
+          Tags::InterfaceCompute<Dirs, Tags::BoundaryCoordinates<dim>>,
           Tags::Slice<Dirs, sliced_compute_item_tag>,
           Tags::Slice<Dirs, sliced_simple_item_tag>, Tags::Slice<Dirs, Var<4>>,
           Tags::Slice<Dirs, VarPlusFive<4>>>>(
@@ -511,11 +510,10 @@ SPECTRE_TEST_CASE("Unit.Domain.InterfaceItems.BaseTags", "[Unit][Domain]") {
         {Direction<2>::lower_xi(), xi_value},
         {Direction<2>::upper_eta(), eta_value}};
   };
-  const auto box =
-      db::create<db::AddSimpleTags<Tags::Interface<Dirs, SimpleDerived>>,
-                 db::AddComputeTags<
-                     Dirs, Tags::InterfaceComputeItem<Dirs, ComputeDerived>>>(
-          interface(4, 5));
+  const auto box = db::create<
+      db::AddSimpleTags<Tags::Interface<Dirs, SimpleDerived>>,
+      db::AddComputeTags<Dirs, Tags::InterfaceCompute<Dirs, ComputeDerived>>>(
+      interface(4, 5));
   CHECK(get<Tags::Interface<Dirs, SimpleBase>>(box) == interface(4, 5));
   CHECK(get<Tags::Interface<Dirs, ComputeBase>>(box) == interface(5.5, 6.5));
 }

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -131,21 +131,21 @@ template <typename Tag>
 using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
 template <typename Tag>
 using interface_compute_tag =
-    Tags::InterfaceComputeItem<Tags::InternalDirections<Dim>, Tag>;
+    Tags::InterfaceCompute<Tags::InternalDirections<Dim>, Tag>;
 
 template <typename Tag>
 using boundary_tag =
     Tags::Interface<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
 template <typename Tag>
 using boundary_compute_tag =
-    Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
+    Tags::InterfaceCompute<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
 
 template <typename Tag>
 using exterior_boundary_tag =
     Tags::Interface<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
 template <typename Tag>
 using exterior_boundary_compute_tag =
-    Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
+    Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
 
 template <typename FluxCommTypes>
 using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_ImposeBoundaryConditions.cpp
@@ -28,6 +28,7 @@
 #include "Domain/ElementIndex.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/DiscontinuousGalerkin/ImposeBoundaryConditions.hpp"  // IWYU pragma: keep

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
@@ -58,14 +58,14 @@ struct ElementArray {
               Initialization::Actions::AddComputeTags<tmpl::list<
                   ::Tags::InternalDirections<Dim>,
                   ::Tags::BoundaryDirectionsInterior<Dim>,
-                  ::Tags::InterfaceComputeItem<::Tags::InternalDirections<Dim>,
-                                               ::Tags::Direction<Dim>>,
-                  ::Tags::InterfaceComputeItem<
+                  ::Tags::InterfaceCompute<::Tags::InternalDirections<Dim>,
+                                           ::Tags::Direction<Dim>>,
+                  ::Tags::InterfaceCompute<
                       ::Tags::BoundaryDirectionsInterior<Dim>,
                       ::Tags::Direction<Dim>>,
-                  ::Tags::InterfaceComputeItem<::Tags::InternalDirections<Dim>,
-                                               ::Tags::InterfaceMesh<Dim>>,
-                  ::Tags::InterfaceComputeItem<
+                  ::Tags::InterfaceCompute<::Tags::InternalDirections<Dim>,
+                                           ::Tags::InterfaceMesh<Dim>>,
+                  ::Tags::InterfaceCompute<
                       ::Tags::BoundaryDirectionsInterior<Dim>,
                       ::Tags::InterfaceMesh<Dim>>>>>>,
 

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_InitializeFluxes.cpp
@@ -22,6 +22,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementIndex.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/SegmentId.hpp"
 #include "Domain/Tags.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -28,6 +28,7 @@
 #include "Domain/ElementIndex.hpp"  // IWYU pragma: keep
 #include "Domain/ElementMap.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Neighbors.hpp"  // IWYU pragma: keep
 #include "Domain/Tags.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ComputeNonconservativeBoundaryFluxes.cpp
@@ -95,7 +95,7 @@ template <typename Tag>
 using interface_tag = Tags::Interface<Tags::InternalDirections<2>, Tag>;
 template <typename Tag>
 using interface_compute_tag =
-    Tags::InterfaceComputeItem<Tags::InternalDirections<2>, Tag>;
+    Tags::InterfaceCompute<Tags::InternalDirections<2>, Tag>;
 
 using n_dot_f_tag = interface_tag<Tags::NormalDotFlux<Tags::Variables<
     tmpl::list<Tags::NormalDotFlux<Var>, Tags::NormalDotFlux<Var2>>>>>;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -131,7 +131,7 @@ template <size_t Dim, typename Tag>
 using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
 template <size_t Dim, typename Tag>
 using interface_compute_tag =
-    Tags::InterfaceComputeItem<Tags::InternalDirections<Dim>, Tag>;
+    Tags::InterfaceCompute<Tags::InternalDirections<Dim>, Tag>;
 
 template <typename FluxCommTypes>
 using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunication.cpp
@@ -34,6 +34,7 @@
 #include "Domain/ElementIndex.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/LogicalCoordinates.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Neighbors.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -124,7 +124,7 @@ template <size_t Dim, typename Tag>
 using interface_tag = Tags::Interface<Tags::InternalDirections<Dim>, Tag>;
 template <size_t Dim, typename Tag>
 using interface_compute_tag =
-    Tags::InterfaceComputeItem<Tags::InternalDirections<Dim>, Tag>;
+    Tags::InterfaceCompute<Tags::InternalDirections<Dim>, Tag>;
 
 template <typename FluxCommTypes>
 using LocalData = typename FluxCommTypes::LocalData;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_FluxCommunicationLts.cpp
@@ -31,6 +31,7 @@
 #include "Domain/ElementIndex.hpp"  // IWYU pragma: keep
 #include "Domain/ElementMap.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Neighbors.hpp"
 #include "Domain/OrientationMapHelpers.hpp"

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -159,14 +159,14 @@ using boundary_tag =
     Tags::Interface<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
 template <typename Tag>
 using boundary_compute_tag =
-    Tags::InterfaceComputeItem<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
+    Tags::InterfaceCompute<Tags::BoundaryDirectionsInterior<Dim>, Tag>;
 
 template <typename Tag>
 using external_boundary_tag =
     Tags::Interface<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
 template <typename Tag>
 using external_boundary_compute_tag =
-    Tags::InterfaceComputeItem<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
+    Tags::InterfaceCompute<Tags::BoundaryDirectionsExterior<Dim>, Tag>;
 
 template <typename FluxCommTypes>
 using mortar_data_tag = typename FluxCommTypes::simple_mortar_data_tag;

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Actions/Test_ImposeBoundaryConditions.cpp
@@ -29,6 +29,7 @@
 #include "Domain/ElementIndex.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/FaceNormal.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Actions/ImposeBoundaryConditions.hpp"

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -65,14 +65,14 @@ struct ElementArray {
               Initialization::Actions::AddComputeTags<tmpl::list<
                   ::Tags::InternalDirections<Dim>,
                   ::Tags::BoundaryDirectionsInterior<Dim>,
-                  ::Tags::InterfaceComputeItem<::Tags::InternalDirections<Dim>,
-                                               ::Tags::Direction<Dim>>,
-                  ::Tags::InterfaceComputeItem<
+                  ::Tags::InterfaceCompute<::Tags::InternalDirections<Dim>,
+                                           ::Tags::Direction<Dim>>,
+                  ::Tags::InterfaceCompute<
                       ::Tags::BoundaryDirectionsInterior<Dim>,
                       ::Tags::Direction<Dim>>,
-                  ::Tags::InterfaceComputeItem<::Tags::InternalDirections<Dim>,
-                                               ::Tags::InterfaceMesh<Dim>>,
-                  ::Tags::InterfaceComputeItem<
+                  ::Tags::InterfaceCompute<::Tags::InternalDirections<Dim>,
+                                           ::Tags::InterfaceMesh<Dim>>,
+                  ::Tags::InterfaceCompute<
                       ::Tags::BoundaryDirectionsInterior<Dim>,
                       ::Tags::InterfaceMesh<Dim>>>>>>,
 

--- a/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
+++ b/tests/Unit/ParallelAlgorithms/DiscontinuousGalerkin/Test_InitializeMortars.cpp
@@ -21,6 +21,7 @@
 #include "Domain/Domain.hpp"
 #include "Domain/ElementId.hpp"
 #include "Domain/ElementIndex.hpp"
+#include "Domain/InterfaceComputeTags.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/SegmentId.hpp"
 #include "Domain/Tags.hpp"


### PR DESCRIPTION
## Proposed changes

_Edited on Sep 4, 2019:_ This PR now creates an `interface` interface from the metafunctions that were in `Domain/Tags.hpp` and uses it to treat numerical fluxes similar to interface compute items.

_Edited on May 31, 2019:_ The linear elasticity system operators need access to the `ConstitutiveRelation` (describing the material properties), which is going to be available through the DataBox once PDALs #1535 are merged. However, all `argument_tags` for the flux operators are currently taken from the element interface. So this PR adds a `volume_tags` typelist that works the same as it does for interface compute items, i.e. it specifies the `argument_tags` that should be taken directly from the DataBox instead of the interface.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).