### PR TITLE
Fix unused variable warning in test

### DIFF
--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
@@ -139,9 +139,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCollocation",
     "Unit.NumericalAlgorithms.Spectral.SwshCollocation.PrecomputationOverrun",
     "[Unit][NumericalAlgorithms]") {
   ERROR_TEST();
-  const Collocation<ComplexRepresentation::RealsThenImags>&
-      precomputed_collocation = precomputed_spherical_harmonic_collocation<
-          ComplexRepresentation::RealsThenImags>(collocation_maximum_l_max + 1);
+  precomputed_spherical_harmonic_collocation<
+      ComplexRepresentation::RealsThenImags>(collocation_maximum_l_max + 1);
   ERROR("Failed to trigger ERROR in an error test");
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
