### PR TITLE
Modal prefix tag

### DIFF
--- a/src/DataStructures/Tags.hpp
+++ b/src/DataStructures/Tags.hpp
@@ -1,0 +1,31 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tensor/Metafunctions.hpp"
+
+/// \cond
+class DataVector;
+class ModalVector;
+/// \endcond
+
+namespace Tags {
+/// Given the `NodalTag` holding a `Tensor<DataVector, ...>`, swap the
+/// `DataVector` with a `ModalVector`.
+template <typename NodalTag>
+struct Modal : db::SimpleTag, db::PrefixTag {
+  using tag = NodalTag;
+  static_assert(cpp17::is_same_v<typename NodalTag::type::type, DataVector>,
+                "The Modal tag should only be used on tags that hold "
+                "Tensors of DataVectors");
+  using type =
+      TensorMetafunctions::swap_type<ModalVector, typename NodalTag::type>;
+  static std::string name() noexcept {
+    return "Modal(" + NodalTag::name() + ")";
+  }
+};
+}  // namespace Tags

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Test_SliceIterator.cpp
   Test_SpinWeighted.cpp
   Test_StripeIterator.cpp
+  Test_Tags.cpp
   Test_TempBuffer.cpp
   Test_Variables.cpp
   Test_VectorImpl.cpp

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -1040,10 +1040,18 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Variables.extra_reset",
 
 namespace {
 /// [mutate_apply_struct_definition_example]
-struct test_databox_mutate_apply {
+struct TestDataboxMutateApply {
+  // delete copy semantics just to make sure it works. Not necessary in general.
+  TestDataboxMutateApply() = default;
+  TestDataboxMutateApply(const TestDataboxMutateApply&) = delete;
+  TestDataboxMutateApply& operator=(const TestDataboxMutateApply&) = delete;
+  TestDataboxMutateApply(TestDataboxMutateApply&&) = default;
+  TestDataboxMutateApply& operator=(TestDataboxMutateApply&&) = default;
+  ~TestDataboxMutateApply() = default;
+
   static void apply(const gsl::not_null<Scalar<DataVector>*> scalar,
                     const gsl::not_null<tnsr::I<DataVector, 3>*> vector,
-                    const std::string& tag2) {
+                    const std::string& tag2) noexcept {
     scalar->get() *= 2.0;
     get<0>(*vector) *= 3.0;
     get<1>(*vector) *= 4.0;
@@ -1081,7 +1089,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.mutate_apply",
   /// [mutate_apply_struct_example]
   db::mutate_apply<
       tmpl::list<test_databox_tags::ScalarTag, test_databox_tags::VectorTag>,
-      tmpl::list<>>(test_databox_mutate_apply{}, make_not_null(&box),
+      tmpl::list<>>(TestDataboxMutateApply{}, make_not_null(&box),
                     db::get<test_databox_tags::Tag2>(box));
   /// [mutate_apply_struct_example]
   CHECK(approx(db::get<test_databox_tags::ComputeTag0>(box)) == 3.14 * 2.0);

--- a/tests/Unit/DataStructures/Test_Tags.cpp
+++ b/tests/Unit/DataStructures/Test_Tags.cpp
@@ -1,0 +1,51 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Tags.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/TypeTraits.hpp"
+
+class DataVector;
+class ModalVector;
+
+// IWYU pragma: no_forward_declare Tensor
+
+namespace {
+struct ScalarTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+  static std::string name() noexcept { return "Scalar"; }
+};
+
+template <size_t Dim>
+struct VectorTag : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+  static std::string name() noexcept {
+    return "I<" + std::to_string(Dim) + ">";
+  }
+};
+
+void test_modal_tag() noexcept {
+  static_assert(cpp17::is_same_v<typename Tags::Modal<ScalarTag>::type,
+                                 Scalar<ModalVector>>,
+                "Failed testing tags::ModalTag");
+  static_assert(cpp17::is_same_v<typename Tags::Modal<VectorTag<1>>::type,
+                                 tnsr::I<ModalVector, 1>>,
+                "Failed testing tags::ModalTag");
+  static_assert(cpp17::is_same_v<typename Tags::Modal<VectorTag<3>>::type,
+                                 tnsr::I<ModalVector, 3>>,
+                "Failed testing tags::ModalTag");
+  CHECK(Tags::Modal<ScalarTag>::name() == "Modal(Scalar)");
+  CHECK(Tags::Modal<VectorTag<1>>::name() == "Modal(I<1>)");
+  CHECK(Tags::Modal<VectorTag<3>>::name() == "Modal(I<3>)");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.DataStructures.Tags", "[Unit][DataStructures]") {
+  test_modal_tag();
+}


### PR DESCRIPTION
## Proposed changes

- Fixes a bug in DataBox that required closures be copyable when they don't actually need to be
- Add `ModalTag` to swap from a `tnsr` of nodal coefficients to a tensor of modal coefficients.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
