### PR TITLE
Add function to get collapsed index from mesh

### DIFF
--- a/src/DataStructures/Index.cpp
+++ b/src/DataStructures/Index.cpp
@@ -5,7 +5,6 @@
 
 #include <pup.h>  // IWYU pragma: keep
 
-#include "ErrorHandling/Assert.hpp"
 #include "Parallel/PupStlCpp11.hpp"  // IWYU pragma: keep
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/StdHelpers.hpp"  // IWYU pragma: keep
@@ -14,18 +13,6 @@
 template <size_t Dim>
 void Index<Dim>::pup(PUP::er& p) noexcept {
   p | indices_;
-}
-
-template <size_t N>
-size_t collapsed_index(const Index<N>& index,
-                       const Index<N>& extents) noexcept {
-  size_t result = 0;
-  // note: size_t(-1) == std::numeric_limits<size_t>::max()
-  for (size_t i = N - 1; i < N; i--) {
-    ASSERT(index[i] < extents[i], "Index out of range.");
-    result = index[i] + extents[i] * result;
-  }
-  return result;
 }
 
 template <size_t N>
@@ -47,13 +34,11 @@ bool operator!=(const Index<Dim>& lhs, const Index<Dim>& rhs) noexcept {
 #define GEN_OP(op, dim)                            \
   template bool operator op(const Index<dim>& lhs, \
                             const Index<dim>& rhs) noexcept;
-#define INSTANTIATE(_, data)                                                 \
-  template class Index<DIM(data)>;                                           \
-  GEN_OP(==, DIM(data))                                                      \
-  GEN_OP(!=, DIM(data))                                                      \
-  template size_t collapsed_index(const Index<DIM(data)>& index,             \
-                                  const Index<DIM(data)>& extents) noexcept; \
-  template std::ostream& operator<<(std::ostream& os,                        \
+#define INSTANTIATE(_, data)                          \
+  template class Index<DIM(data)>;                    \
+  GEN_OP(==, DIM(data))                               \
+  GEN_OP(!=, DIM(data))                               \
+  template std::ostream& operator<<(std::ostream& os, \
                                     const Index<DIM(data)>& i);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2, 3, 4))

--- a/src/Domain/Mesh.hpp
+++ b/src/Domain/Mesh.hpp
@@ -124,6 +124,18 @@ class Mesh {
   size_t number_of_grid_points() const noexcept { return extents_.product(); }
 
   /*!
+   * \brief Returns the 1-dimensional index corresponding to the `Dim`
+   * dimensional `index`.
+   *
+   * The first dimension varies fastest.
+   *
+   * \see collapsed_index()
+   */
+  size_t storage_index(const Index<Dim>& index) const noexcept {
+    return collapsed_index(index, extents_);
+  }
+
+  /*!
    * \brief The basis chosen in each dimension of the grid.
    */
   const std::array<Spectral::Basis, Dim>& basis() const noexcept {

--- a/tests/Unit/DataStructures/Test_Index.cpp
+++ b/tests/Unit/DataStructures/Test_Index.cpp
@@ -16,6 +16,23 @@
 #include "Utilities/Literals.hpp"
 #include "tests/Unit/TestHelpers.hpp"
 
+namespace {
+template <size_t Dim>
+void test_collapsed_index(const Index<Dim> extents) noexcept {
+  for (IndexIterator<Dim> index_it(extents); index_it; ++index_it) {
+    CAPTURE(*index_it);
+    Index<Dim> index;
+    for (size_t d = 0; d < Dim; ++d) {
+      index[d] = (*index_it)[d];
+    }
+    // Compare the collapsed index of the IndexIterator to the collapsed index
+    // computed by the free function to make sure the two implementations are
+    // consistent.
+    CHECK(index_it.collapsed_index() == collapsed_index(index, extents));
+  }
+}
+}  // namespace
+
 SPECTRE_TEST_CASE("Unit.DataStructures.Index", "[DataStructures][Unit]") {
   Index<0> index_0d;
   CHECK(index_0d.product() == 1);
@@ -93,7 +110,7 @@ SPECTRE_TEST_CASE("Unit.DataStructures.Index", "[DataStructures][Unit]") {
   }
 }
 
-// [[OutputRegex, Index out of range.]]
+// [[OutputRegex, The requested index in the dimension]]
 [[noreturn]] SPECTRE_TEST_CASE("Unit.DataStructures.Index.Assert",
                                "[DataStructures][Unit]") {
   ASSERTION_TEST();

--- a/tests/Unit/Domain/Test_DomainHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainHelpers.cpp
@@ -926,18 +926,6 @@ SPECTRE_TEST_CASE("Unit.Domain.DomainHelpers.VolumeCornerIterator",
   test_vci_3d();
 }
 
-// [[OutputRegex, Index out of range.]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.DomainHelpers.VolumeCornerIterator.Assert", "[Domain][Unit]") {
-  ASSERTION_TEST();
-#ifdef SPECTRE_DEBUG
-  auto extents = Index<3>{4, 4, 4};
-  auto failed_index_with = Index<3>{2, 3, 4};
-  static_cast<void>(VolumeCornerIterator<3>{failed_index_with, extents});
-  ERROR("Failed to trigger ASSERT in an assertion test");
-#endif
-}
-
 namespace {
 void test_fci_1d() {
   FaceCornerIterator<1> fci{Direction<1>::upper_xi()};

--- a/tests/Unit/Domain/Test_Mesh.cpp
+++ b/tests/Unit/Domain/Test_Mesh.cpp
@@ -39,206 +39,213 @@ void test_extents_basis_and_quadrature(
   }
   CHECK(get_output(mesh) == get_output(extents));
 }
-}  // namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
-  SECTION("Uniform LGL mesh") {
-    const Mesh<1> mesh1d_lgl{3, Spectral::Basis::Legendre,
-                             Spectral::Quadrature::GaussLobatto};
-    test_extents_basis_and_quadrature(mesh1d_lgl, {{3}},
-                                      {{Spectral::Basis::Legendre}},
-                                      {{Spectral::Quadrature::GaussLobatto}});
-    const Mesh<2> mesh2d_lgl{3, Spectral::Basis::Legendre,
-                             Spectral::Quadrature::GaussLobatto};
-    test_extents_basis_and_quadrature(
-        mesh2d_lgl, {{3, 3}},
-        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
-        {{Spectral::Quadrature::GaussLobatto,
-          Spectral::Quadrature::GaussLobatto}});
-    const Mesh<3> mesh3d_lgl{3, Spectral::Basis::Legendre,
-                             Spectral::Quadrature::GaussLobatto};
-    test_extents_basis_and_quadrature(
-        mesh3d_lgl, {{3, 3, 3}},
-        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
-          Spectral::Basis::Legendre}},
-        {{Spectral::Quadrature::GaussLobatto,
-          Spectral::Quadrature::GaussLobatto,
-          Spectral::Quadrature::GaussLobatto}});
-  }
+void test_uniform_lgl_mesh() noexcept {
+  INFO("Uniform LGL mesh");
+  const Mesh<1> mesh1d_lgl{3, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto};
+  test_extents_basis_and_quadrature(mesh1d_lgl, {{3}},
+                                    {{Spectral::Basis::Legendre}},
+                                    {{Spectral::Quadrature::GaussLobatto}});
+  const Mesh<2> mesh2d_lgl{3, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto};
+  test_extents_basis_and_quadrature(
+      mesh2d_lgl, {{3, 3}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::GaussLobatto,
+        Spectral::Quadrature::GaussLobatto}});
+  const Mesh<3> mesh3d_lgl{3, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto};
+  test_extents_basis_and_quadrature(
+      mesh3d_lgl, {{3, 3, 3}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+        Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::GaussLobatto,
+        Spectral::Quadrature::GaussLobatto}});
+}
 
-  SECTION("Explicit choices per dimension") {
-    CHECK(Mesh<0>{}.slice_through() == Mesh<0>{});
-    const Mesh<1> mesh1d{{{2}},
-                         {{Spectral::Basis::Legendre}},
-                         {{Spectral::Quadrature::GaussLobatto}}};
-    test_extents_basis_and_quadrature(mesh1d, {{2}},
-                                      {{Spectral::Basis::Legendre}},
-                                      {{Spectral::Quadrature::GaussLobatto}});
-    CHECK(mesh1d.slice_away(0) == Mesh<0>{});
-    CHECK(mesh1d.slice_through() == Mesh<0>{});
-    CHECK(mesh1d.slice_through(0) == mesh1d);
+void test_explicit_choices_per_dimension() noexcept {
+  INFO("Explicit choices per dimension");
+  CHECK(Mesh<0>{}.slice_through() == Mesh<0>{});
+  const Mesh<1> mesh1d{{{2}},
+                       {{Spectral::Basis::Legendre}},
+                       {{Spectral::Quadrature::GaussLobatto}}};
+  test_extents_basis_and_quadrature(mesh1d, {{2}},
+                                    {{Spectral::Basis::Legendre}},
+                                    {{Spectral::Quadrature::GaussLobatto}});
+  CHECK(mesh1d.slice_away(0) == Mesh<0>{});
+  CHECK(mesh1d.slice_through() == Mesh<0>{});
+  CHECK(mesh1d.slice_through(0) == mesh1d);
 
-    const Mesh<2> mesh2d{
-        {{2, 3}},
-        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
-        {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}}};
-    test_extents_basis_and_quadrature(
-        mesh2d, {{2, 3}},
-        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
-        {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}});
-    CHECK(mesh2d.slice_away(0) == Mesh<1>{3, Spectral::Basis::Legendre,
-                                          Spectral::Quadrature::GaussLobatto});
-    CHECK(mesh2d.slice_away(1) ==
-          Mesh<1>{2, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss});
-    CHECK(mesh2d.slice_through() == Mesh<0>{});
-    CHECK(mesh2d.slice_through(0) == mesh2d.slice_away(1));
-    CHECK(mesh2d.slice_through(1) == mesh2d.slice_away(0));
-    CHECK(mesh2d.slice_through(0, 1) == mesh2d);
-    CHECK(mesh2d.slice_through(1, 0) ==
-          Mesh<2>{{{3, 2}},
-                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
-                  {{Spectral::Quadrature::GaussLobatto,
-                    Spectral::Quadrature::Gauss}}});
+  const Mesh<2> mesh2d{
+      {{2, 3}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}}};
+  test_extents_basis_and_quadrature(
+      mesh2d, {{2, 3}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}});
+  CHECK(mesh2d.slice_away(0) == Mesh<1>{3, Spectral::Basis::Legendre,
+                                        Spectral::Quadrature::GaussLobatto});
+  CHECK(mesh2d.slice_away(1) ==
+        Mesh<1>{2, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss});
+  CHECK(mesh2d.slice_through() == Mesh<0>{});
+  CHECK(mesh2d.slice_through(0) == mesh2d.slice_away(1));
+  CHECK(mesh2d.slice_through(1) == mesh2d.slice_away(0));
+  CHECK(mesh2d.slice_through(0, 1) == mesh2d);
+  CHECK(mesh2d.slice_through(1, 0) ==
+        Mesh<2>{{{3, 2}},
+                {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+                {{Spectral::Quadrature::GaussLobatto,
+                  Spectral::Quadrature::Gauss}}});
 
-    const Mesh<3> mesh3d{
-        {{2, 3, 4}},
-        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
-          Spectral::Basis::Legendre}},
-        {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
-          Spectral::Quadrature::GaussLobatto}}};
-    test_extents_basis_and_quadrature(
-        mesh3d, {{2, 3, 4}},
-        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
-          Spectral::Basis::Legendre}},
-        {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
-          Spectral::Quadrature::GaussLobatto}});
-    CHECK(mesh3d.slice_away(0) ==
-          Mesh<2>{{{3, 4}},
-                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
-                  {{Spectral::Quadrature::Gauss,
-                    Spectral::Quadrature::GaussLobatto}}});
-    CHECK(mesh3d.slice_away(1) == Mesh<2>{{{2, 4}},
-                                          Spectral::Basis::Legendre,
-                                          Spectral::Quadrature::GaussLobatto});
-    CHECK(mesh3d.slice_away(2) ==
-          Mesh<2>{{{2, 3}},
-                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
-                  {{Spectral::Quadrature::GaussLobatto,
-                    Spectral::Quadrature::Gauss}}});
-    CHECK(mesh3d.slice_through() == Mesh<0>{});
-    CHECK(mesh3d.slice_through(0) ==
-          Mesh<1>{2, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto});
-    CHECK(mesh3d.slice_through(1) ==
-          Mesh<1>{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss});
-    CHECK(mesh3d.slice_through(2) ==
-          Mesh<1>{4, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto});
-    CHECK(mesh3d.slice_through(0, 1) == mesh3d.slice_away(2));
-    CHECK(mesh3d.slice_through(0, 2) == mesh3d.slice_away(1));
-    CHECK(mesh3d.slice_through(1, 2) == mesh3d.slice_away(0));
-    CHECK(mesh3d.slice_through(0, 1, 2) == mesh3d);
-    CHECK(mesh3d.slice_through(2, 0, 1) ==
-          Mesh<3>{{{4, 2, 3}},
-                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
-                    Spectral::Basis::Legendre}},
-                  {{Spectral::Quadrature::GaussLobatto,
-                    Spectral::Quadrature::GaussLobatto,
-                    Spectral::Quadrature::Gauss}}});
-  }
+  const Mesh<3> mesh3d{
+      {{2, 3, 4}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+        Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+        Spectral::Quadrature::GaussLobatto}}};
+  test_extents_basis_and_quadrature(
+      mesh3d, {{2, 3, 4}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+        Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+        Spectral::Quadrature::GaussLobatto}});
+  CHECK(mesh3d.slice_away(0) ==
+        Mesh<2>{{{3, 4}},
+                {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+                {{Spectral::Quadrature::Gauss,
+                  Spectral::Quadrature::GaussLobatto}}});
+  CHECK(mesh3d.slice_away(1) == Mesh<2>{{{2, 4}},
+                                        Spectral::Basis::Legendre,
+                                        Spectral::Quadrature::GaussLobatto});
+  CHECK(mesh3d.slice_away(2) ==
+        Mesh<2>{{{2, 3}},
+                {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+                {{Spectral::Quadrature::GaussLobatto,
+                  Spectral::Quadrature::Gauss}}});
+  CHECK(mesh3d.slice_through() == Mesh<0>{});
+  CHECK(mesh3d.slice_through(0) == Mesh<1>{2, Spectral::Basis::Legendre,
+                                           Spectral::Quadrature::GaussLobatto});
+  CHECK(mesh3d.slice_through(1) ==
+        Mesh<1>{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss});
+  CHECK(mesh3d.slice_through(2) == Mesh<1>{4, Spectral::Basis::Legendre,
+                                           Spectral::Quadrature::GaussLobatto});
+  CHECK(mesh3d.slice_through(0, 1) == mesh3d.slice_away(2));
+  CHECK(mesh3d.slice_through(0, 2) == mesh3d.slice_away(1));
+  CHECK(mesh3d.slice_through(1, 2) == mesh3d.slice_away(0));
+  CHECK(mesh3d.slice_through(0, 1, 2) == mesh3d);
+  CHECK(mesh3d.slice_through(2, 0, 1) ==
+        Mesh<3>{{{4, 2, 3}},
+                {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                  Spectral::Basis::Legendre}},
+                {{Spectral::Quadrature::GaussLobatto,
+                  Spectral::Quadrature::GaussLobatto,
+                  Spectral::Quadrature::Gauss}}});
+}
 
-  SECTION("Equality") {
-    CHECK(Mesh<1>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} ==
-          Mesh<1>{{{3}},
-                  {{Spectral::Basis::Legendre}},
-                  {{Spectral::Quadrature::GaussLobatto}}});
-    CHECK(Mesh<1>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} !=
-          Mesh<1>{{{2}},
-                  Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto});
-    CHECK(Mesh<1>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} !=
-          Mesh<1>{{{3}},
-                  {{Spectral::Basis::Legendre}},
-                  {{Spectral::Quadrature::Gauss}}});
-    CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} ==
-          Mesh<2>{{{3, 3}},
-                  Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto});
-    CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} ==
-          Mesh<2>{{{3, 3}},
-                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
-                  {{Spectral::Quadrature::GaussLobatto,
-                    Spectral::Quadrature::GaussLobatto}}});
-    CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} !=
-          Mesh<2>{{{3, 2}},
-                  Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto});
-    CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} !=
-          Mesh<2>{{{3, 3}},
-                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
-                  {{Spectral::Quadrature::Gauss,
-                    Spectral::Quadrature::GaussLobatto}}});
-    CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} ==
-          Mesh<3>{{{3, 3, 3}},
-                  Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto});
-    CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} ==
-          Mesh<3>{{{3, 3, 3}},
-                  {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
-                    Spectral::Basis::Legendre}},
-                  {{Spectral::Quadrature::GaussLobatto,
-                    Spectral::Quadrature::GaussLobatto,
-                    Spectral::Quadrature::GaussLobatto}}});
-    CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} !=
-          Mesh<3>{{{3, 2, 3}},
-                  Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto});
-    CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto} !=
-          Mesh<3>{
-              {{3, 3, 3}},
+void test_equality() noexcept {
+  INFO("Equality");
+  CHECK(Mesh<1>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto} ==
+        Mesh<1>{{{3}},
+                {{Spectral::Basis::Legendre}},
+                {{Spectral::Quadrature::GaussLobatto}}});
+  CHECK(Mesh<1>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto} !=
+        Mesh<1>{{{2}},
+                Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto});
+  CHECK(Mesh<1>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto} !=
+        Mesh<1>{{{3}},
+                {{Spectral::Basis::Legendre}},
+                {{Spectral::Quadrature::Gauss}}});
+  CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto} ==
+        Mesh<2>{{{3, 3}},
+                Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto});
+  CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto} ==
+        Mesh<2>{{{3, 3}},
+                {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+                {{Spectral::Quadrature::GaussLobatto,
+                  Spectral::Quadrature::GaussLobatto}}});
+  CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto} !=
+        Mesh<2>{{{3, 2}},
+                Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto});
+  CHECK(Mesh<2>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto} !=
+        Mesh<2>{{{3, 3}},
+                {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+                {{Spectral::Quadrature::Gauss,
+                  Spectral::Quadrature::GaussLobatto}}});
+  CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto} ==
+        Mesh<3>{{{3, 3, 3}},
+                Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto});
+  CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto} ==
+        Mesh<3>{{{3, 3, 3}},
+                {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                  Spectral::Basis::Legendre}},
+                {{Spectral::Quadrature::GaussLobatto,
+                  Spectral::Quadrature::GaussLobatto,
+                  Spectral::Quadrature::GaussLobatto}}});
+  CHECK(Mesh<3>{3, Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto} !=
+        Mesh<3>{{{3, 2, 3}},
+                Spectral::Basis::Legendre,
+                Spectral::Quadrature::GaussLobatto});
+  CHECK(
+      Mesh<3>{3, Spectral::Basis::Legendre,
+              Spectral::Quadrature::GaussLobatto} !=
+      Mesh<3>{{{3, 3, 3}},
               {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
                 Spectral::Basis::Legendre}},
               {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
                 Spectral::Quadrature::GaussLobatto}}});
-  }
+}
 
-  SECTION("Serialization") {
-    test_serialization(Mesh<1>{3, Spectral::Basis::Legendre,
-                               Spectral::Quadrature::GaussLobatto});
-    test_serialization(Mesh<2>{
-        {{3, 2}},
-        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
-        {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}}});
-    test_serialization(Mesh<3>{
-        {{3, 2, 4}},
-        {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
-          Spectral::Basis::Legendre}},
-        {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
-          Spectral::Quadrature::GaussLobatto}}});
-  }
+void test_serialization() noexcept {
+  INFO("Serialization");
+  test_serialization(Mesh<1>{3, Spectral::Basis::Legendre,
+                             Spectral::Quadrature::GaussLobatto});
+  test_serialization(Mesh<2>{
+      {{3, 2}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}}});
+  test_serialization(
+      Mesh<3>{{{3, 2, 4}},
+              {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                Spectral::Basis::Legendre}},
+              {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+                Spectral::Quadrature::GaussLobatto}}});
+}
 
-  SECTION("Tag") {
-    CHECK(Tags::Mesh<1>::name() == "Mesh");
-    CHECK(Tags::Mesh<2>::name() == "Mesh");
-    CHECK(Tags::Mesh<3>::name() == "Mesh");
-  }
+void test_tags() noexcept {
+  INFO("Tags");
+  CHECK(Tags::Mesh<1>::name() == "Mesh");
+  CHECK(Tags::Mesh<2>::name() == "Mesh");
+  CHECK(Tags::Mesh<3>::name() == "Mesh");
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
+  test_uniform_lgl_mesh();
+  test_explicit_choices_per_dimension();
+  test_equality();
+  test_serialization();
+  test_tags();
 }
 
 // [[OutputRegex, Tried to slice through non-existing dimension]]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.Mesh.SliceThroughNonExistingDimension",
-    "[Domain][Unit]") {
+    "Unit.Domain.Mesh.SliceThroughNonExistingDimension", "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   const Mesh<1> mesh1d{2, Spectral::Basis::Legendre,
@@ -249,9 +256,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
 }
 
 // [[OutputRegex, Tried to slice away non-existing dimension]]
-[[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.Mesh.SliceAwayNonExistingDimension",
-    "[Domain][Unit]") {
+[[noreturn]] SPECTRE_TEST_CASE("Unit.Domain.Mesh.SliceAwayNonExistingDimension",
+                               "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   const Mesh<1> mesh1d{2, Spectral::Basis::Legendre,
@@ -263,8 +269,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Mesh", "[Domain][Unit]") {
 
 // [[OutputRegex, Dimensions to slice through contain duplicates]]
 [[noreturn]] SPECTRE_TEST_CASE(
-    "Unit.Domain.Mesh.SliceThroughDuplicateDimensions",
-    "[Domain][Unit]") {
+    "Unit.Domain.Mesh.SliceThroughDuplicateDimensions", "[Domain][Unit]") {
   ASSERTION_TEST();
 #ifdef SPECTRE_DEBUG
   const Mesh<3> mesh3d{2, Spectral::Basis::Legendre,

--- a/tests/Unit/Domain/Test_Mesh.cpp
+++ b/tests/Unit/Domain/Test_Mesh.cpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "DataStructures/Index.hpp"
+#include "DataStructures/IndexIterator.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
 #include "ErrorHandling/Error.hpp"
@@ -25,6 +26,10 @@ void test_extents_basis_and_quadrature(
     const Mesh<Dim>& mesh, const std::array<size_t, Dim>& extents,
     const std::array<Spectral::Basis, Dim>& basis,
     const std::array<Spectral::Quadrature, Dim>& quadrature) {
+  CAPTURE(Dim);
+  CAPTURE(extents);
+  CAPTURE(basis);
+  CAPTURE(quadrature);
   CHECK(mesh.number_of_grid_points() ==
         std::accumulate(extents.begin(), extents.end(), size_t{1},
                         std::multiplies<size_t>()));
@@ -38,6 +43,14 @@ void test_extents_basis_and_quadrature(
     CHECK(gsl::at(mesh.slices(), d) == mesh.slice_through(d));
   }
   CHECK(get_output(mesh) == get_output(extents));
+  for (IndexIterator<Dim> index_it(mesh.extents()); index_it; ++index_it) {
+    CAPTURE(*index_it);
+    Index<Dim> index{};
+    for (size_t d = 0; d < Dim; ++d) {
+      index[d] = (*index_it)[d];
+    }
+    CHECK(index_it.collapsed_index() == mesh.storage_index(index));
+  }
 }
 
 void test_uniform_lgl_mesh() noexcept {


### PR DESCRIPTION
## Proposed changes

Adds a function to get the collapsed/storage index from the Mesh, which corresponds to the 1D index in the `DataVector`s.

Fixes #862 

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
