### PR TITLE
Add Swsh::detail::Coefficients wrapper

### DIFF
--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY_SOURCES
     Legendre.cpp
     Projection.cpp
     Spectral.cpp
+    SwshCoefficients.cpp
     SwshCollocation.cpp
     SwshTags.cpp
     )

--- a/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCoefficients.cpp
@@ -1,0 +1,59 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details
+
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+
+#include <array>
+#include <ostream>
+#include <sharp_cxx.h>
+#include <utility>
+
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Utilities/ForceInline.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Spectral {
+namespace Swsh {
+namespace detail {
+Coefficients::Coefficients(const size_t l_max) noexcept : l_max_(l_max) {
+  sharp_alm_info* alm_to_initialize;
+  sharp_make_triangular_alm_info(l_max, l_max, 1, &alm_to_initialize);
+  alm_info_.reset(alm_to_initialize);
+}
+
+namespace {
+template <size_t I>
+const Coefficients& coefficients_cache_impl() noexcept {
+  static const Coefficients precomputed_coefficients{I};
+  return precomputed_coefficients;
+}
+
+template <size_t... Is>
+SPECTRE_ALWAYS_INLINE const Coefficients& precomputed_static_coefficients_impl(
+    const size_t index, std::index_sequence<Is...> /*meta*/) noexcept {
+  if (UNLIKELY(index > collocation_maximum_l_max)) {
+    ERROR("The provided l_max "
+          << index
+          << " is not below the maximum l_max to cache, which is currently "
+          << coefficients_maximum_l_max
+          << ". Either "
+             "construct the Coefficients manually, or consider (with caution) "
+             "increasing `coefficients_maximum_l_max`.");
+  }
+
+  static const std::array<const Coefficients& (*)(), sizeof...(Is)> cache{
+      {&coefficients_cache_impl<Is>...}};
+  return gsl::at(cache, index)();
+}
+
+}  // namespace
+
+const Coefficients& precomputed_coefficients(const size_t l_max) noexcept {
+  return precomputed_static_coefficients_impl(
+      l_max, std::make_index_sequence<coefficients_maximum_l_max>{});
+}
+
+}  // namespace detail
+}  // namespace Swsh
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshCoefficients.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCoefficients.hpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details
+
+#pragma once
+
+#include <cstdlib>
+#include <memory>
+#include <sharp_cxx.h>
+
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+
+namespace Spectral {
+namespace Swsh {
+namespace detail {
+
+constexpr size_t coefficients_maximum_l_max = collocation_maximum_l_max;
+
+struct DestroySharpAlm {
+  void operator()(sharp_alm_info* to_delete) noexcept {
+    sharp_destroy_alm_info(to_delete);
+  }
+};
+// The Coefficients class acts largely as a memory-safe container for a
+// `sharp_alm_info*`, required for use of libsharp transform utilities.
+// The libsharp utilities are currently constructed to only provide user
+// functions with collocation data for spin-weighted functions and
+// derivatives. If and when the libsharp utilities are expanded to provide
+// spin-weighted coefficients as output, this class should be expanded to
+// provide information about the value and storage ordering of those
+// coefficients to user code. This should be implemented as an iterator, as is
+// done in SwshCollocation.hpp.
+class Coefficients {
+ public:
+  explicit Coefficients(size_t l_max) noexcept;
+
+  ~Coefficients() = default;
+  Coefficients() = default;
+  Coefficients(const Coefficients&) = delete;
+  Coefficients(Coefficients&&) = default;
+  Coefficients& operator=(const Coefficients&) = delete;
+  Coefficients& operator=(Coefficients&&) = default;
+  sharp_alm_info* get_sharp_alm_info() const noexcept {
+    return alm_info_.get();
+  }
+
+  size_t l_max() const noexcept { return l_max_; }
+
+ private:
+  std::unique_ptr<sharp_alm_info, DestroySharpAlm> alm_info_;
+  size_t l_max_ = 0;
+};
+
+// Function for obtaining a `Coefficients`, which is a thin wrapper around
+// the libsharp `alm_info`, needed to perform transformations and iterate over
+// coefficients. A lazy static cache is used to avoid repeated computation. See
+// the similar implementation in `SwshCollocation.hpp` for details about the
+// caching mechanism.
+const Coefficients& precomputed_coefficients(size_t l_max) noexcept;
+}  // namespace detail
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_LegendreGaussLobatto.cpp
   Test_Projection.cpp
   Test_Spectral.cpp
+  Test_SwshCoefficients.cpp
   Test_SwshCollocation.cpp
   Test_SwshTags.cpp
   )

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCoefficients.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+#include <sharp_cxx.h>
+
+#include "ErrorHandling/Error.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Spectral {
+namespace Swsh {
+namespace {
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCoefficients",
+                  "[Unit][NumericalAlgorithms]") {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> sdist{8, 64};
+  const size_t l_max = sdist(gen);
+
+  CAPTURE(l_max);
+  const detail::Coefficients& precomputed_coefficients =
+      detail::precomputed_coefficients(l_max);
+
+  const detail::Coefficients& another_precomputed_coefficients =
+      detail::precomputed_coefficients(l_max);
+
+  // checks that the same pointer is in both
+  CHECK(precomputed_coefficients.get_sharp_alm_info() ==
+        another_precomputed_coefficients.get_sharp_alm_info());
+
+  const detail::Coefficients computed_coefficients{l_max};
+
+  CHECK(precomputed_coefficients.l_max() == l_max);
+  CHECK(computed_coefficients.l_max() == l_max);
+
+  sharp_alm_info* manual_sai;
+  sharp_make_triangular_alm_info(l_max, l_max, 1, &manual_sai);
+
+  // check that all of the precomputed coefficients, the directly constructed
+  // coefficients, and the manually created sharp_alm_info* all contain the same
+  // data
+  CHECK(precomputed_coefficients.get_sharp_alm_info()->lmax ==
+        computed_coefficients.get_sharp_alm_info()->lmax);
+  CHECK(precomputed_coefficients.get_sharp_alm_info()->lmax ==
+        manual_sai->lmax);
+  CHECK(precomputed_coefficients.get_sharp_alm_info()->lmax ==
+        computed_coefficients.l_max());
+
+  CHECK(precomputed_coefficients.get_sharp_alm_info()->nm ==
+        computed_coefficients.get_sharp_alm_info()->nm);
+  CHECK(precomputed_coefficients.get_sharp_alm_info()->nm == manual_sai->nm);
+
+  CHECK(precomputed_coefficients.get_sharp_alm_info()->flags ==
+        computed_coefficients.get_sharp_alm_info()->flags);
+  CHECK(precomputed_coefficients.get_sharp_alm_info()->flags ==
+        manual_sai->flags);
+
+  CHECK(precomputed_coefficients.get_sharp_alm_info()->stride ==
+        computed_coefficients.get_sharp_alm_info()->stride);
+  CHECK(precomputed_coefficients.get_sharp_alm_info()->stride ==
+        manual_sai->stride);
+
+  for (size_t m_index = 0;
+       m_index <
+       static_cast<size_t>(precomputed_coefficients.get_sharp_alm_info()->nm);
+       ++m_index) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(precomputed_coefficients.get_sharp_alm_info()->mval[m_index] ==
+          computed_coefficients.get_sharp_alm_info()->mval[m_index]);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(precomputed_coefficients.get_sharp_alm_info()->mval[m_index] ==
+          manual_sai->mval[m_index]);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(precomputed_coefficients.get_sharp_alm_info()->mvstart[m_index] ==
+          computed_coefficients.get_sharp_alm_info()->mvstart[m_index]);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    CHECK(precomputed_coefficients.get_sharp_alm_info()->mvstart[m_index] ==
+          manual_sai->mvstart[m_index]);
+  }
+}
+
+// [[OutputRegex, is not below the maximum l_max]]
+[[noreturn]] SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.Spectral.SwshCoefficients.PrecomputationOverrun",
+    "[Unit][NumericalAlgorithms]") {
+  ERROR_TEST();
+  detail::precomputed_coefficients(detail::coefficients_maximum_l_max + 1);
+  ERROR("Failed to trigger ERROR in an error test");
+}
+}  // namespace
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tools/Iwyu/iwyu.imp
+++ b/tools/Iwyu/iwyu.imp
@@ -45,9 +45,11 @@
   { include: ["<pythonrun.h>", private,
               "<Python.h>", public]},
 
-  { include: ["<sharp_lowlevel.h>", public,
+  { include: ["<sharp_almhelpers.h>", public,
               "<sharp_cxx.h>", public]},
   { include: ["<sharp_geomhelpers.h>", public,
+              "<sharp_cxx.h>", public]},
+  { include: ["<sharp_lowlevel.h>", public,
               "<sharp_cxx.h>", public]},
 
   { include: ["<boost/optional/optional.hpp>", public,


### PR DESCRIPTION
## Proposed changes

Add a wrapper class for libsharp's `sharp_alm_info`, to be used primarily in the libsharp wrapper. It is placed in a detail namespace to emphasized that it is not intended as part of the libsharp wrapper interface.

The implementation details are closely patterned on the `Swsh::Collocation` class provided as a part of the libsharp wrapper interface.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
