### PR TITLE
Observer writer registration

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgElementArray.hpp
@@ -8,7 +8,9 @@
 #include "Domain/InitialElementIds.hpp"
 #include "Domain/Tags.hpp"
 #include "Elliptic/DiscontinuousGalerkin/InitializeElement.hpp"
+#include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
+#include "NumericalAlgorithms/LinearSolver/IterationId.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
 #include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
@@ -106,15 +108,17 @@ struct DgElementArray {
       Parallel::CProxy_ConstGlobalCache<Metavariables>& global_cache) noexcept {
     if (next_phase == Metavariables::Phase::RegisterWithObserver) {
       auto& local_cache = *(global_cache.ckLocalBranch());
-      // We currently use a fake temporal id when registering observers but in
-      // the future when we start doing load balancing and elements migrate
-      // around the system they will need to register and unregister themselves
-      // at specific times.
-      const size_t fake_temporal_id = 0;
+      // We currently use an observation_id with a fake time when registering
+      // observers but in the future when we start doing load balancing and
+      // elements migrate around the system they will need to register and
+      // unregister themselves at specific times.
+      const observers::ObservationId observation_id_with_fake_time(
+          LinearSolver::IterationId{},
+          typename Metavariables::element_observation_type{});
       Parallel::simple_action<observers::Actions::RegisterWithObservers<
           observers::TypeOfObservation::ReductionAndVolume>>(
           Parallel::get_parallel_component<DgElementArray>(local_cache),
-          fake_temporal_id);
+          observation_id_with_fake_time);
     }
   }
 };

--- a/src/IO/Observer/Actions.hpp
+++ b/src/IO/Observer/Actions.hpp
@@ -31,7 +31,6 @@ struct RegisterSenderWithSelf {
   template <
       typename DbTagList, typename... InboxTags, typename Metavariables,
       typename ArrayIndex, typename ActionList, typename ParallelComponent,
-      typename TemporalId,
       Requires<tmpl::list_contains_v<
                    DbTagList, observers::Tags::ReductionArrayComponentIds> and
                tmpl::list_contains_v<
@@ -43,7 +42,7 @@ struct RegisterSenderWithSelf {
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/,
-                    const TemporalId& /*temporal_id*/,
+                    const observers::ObservationId& /*observation_id*/,
                     const observers::ArrayComponentId& component_id,
                     const TypeOfObservation& type_of_observation) noexcept {
     const auto register_reduction = [&box, &component_id]() noexcept {
@@ -82,8 +81,8 @@ struct RegisterSenderWithSelf {
         return;
       default:
         ERROR(
-          "Registering an unknown TypeOfObservation. Should be one of "
-          "'Reduction', 'Volume', or 'ReductionAndVolume'");
+            "Registering an unknown TypeOfObservation. Should be one of "
+            "'Reduction', 'Volume', or 'ReductionAndVolume'");
     };
   }
 };
@@ -97,13 +96,13 @@ template <observers::TypeOfObservation TypeOfObservation>
 struct RegisterWithObservers {
   template <typename DbTagList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
-            typename ParallelComponent, typename TemporalId>
+            typename ParallelComponent>
   static void apply(const db::DataBox<DbTagList>& /*box*/,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                     Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& array_index, const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/,
-                    const TemporalId& temporal_id) noexcept {
+                    const observers::ObservationId& observation_id) noexcept {
     auto& observer =
         *Parallel::get_parallel_component<observers::Observer<Metavariables>>(
              cache)
@@ -118,7 +117,7 @@ struct RegisterWithObservers {
     // At that point we won't need the template parameter on the class anymore
     // and everything can be read from an input file.
     Parallel::simple_action<RegisterSenderWithSelf>(
-        observer, temporal_id,
+        observer, observation_id,
         observers::ArrayComponentId(
             std::add_pointer_t<ParallelComponent>{nullptr},
             Parallel::ArrayIndex<std::decay_t<ArrayIndex>>{array_index}),

--- a/src/IO/Observer/Actions.hpp
+++ b/src/IO/Observer/Actions.hpp
@@ -14,15 +14,97 @@
 #include "IO/Observer/Tags.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
+#include "Parallel/Info.hpp"
 #include "Parallel/Invoke.hpp"
 #include "Utilities/TaggedTuple.hpp"
 
 namespace observers {
+
 /*!
  * \ingroup ObserversGroup
  * \brief %Actions used by the observer parallel component
  */
 namespace Actions {
+
+/// \brief Register a class that will call
+/// `observers::ThreadedActions::WriteReductionData` or
+/// `observers::ThreadedActions::ContributeReductionData`.
+///
+/// Should be invoked on ObserverWriter.
+struct RegisterReductionContributorWithObserverWriter {
+ public:
+  template <typename... DbTags, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent, typename... ReductionDatums,
+            Requires<sizeof...(DbTags) != 0> = nullptr>
+  static void apply(db::DataBox<tmpl::list<DbTags...>>& box,
+                    tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
+                    const ArrayIndex& /*array_index*/,
+                    const ActionList /*meta*/,
+                    const ParallelComponent* const /*meta*/,
+                    const observers::ObservationId& observation_id,
+                    const size_t processing_element_or_node,
+                    const bool called_from_other_node = false) noexcept {
+    const auto node_id = static_cast<size_t>(Parallel::my_node());
+    if (not called_from_other_node) {
+      // processing_element_or_node is the processing element of the caller.
+      db::mutate<Tags::ReductionObserversRegistered>(
+          make_not_null(&box),
+          [&cache, &node_id, &observation_id, &processing_element_or_node ](
+              const gsl::not_null<std::unordered_map<size_t, std::set<size_t>>*>
+                  reduction_observers_registered) noexcept {
+            // Currently the only part of the observation_id that is used is the
+            // `observation_type_hash()`. But in the future with load balancing
+            // we will use the full observation_id, and elements will need
+            // to register and unregister themselves at specific times.
+            const size_t hash = observation_id.observation_type_hash();
+
+            if (reduction_observers_registered->count(hash) == 0) {
+              (*reduction_observers_registered)[hash] = std::set<size_t>{};
+
+              // If this is not node 0, call this Action on node 0 to register
+              // the nodes that we expect reductions to be called on.
+              if (node_id != 0) {
+                Parallel::simple_action<
+                    Actions::RegisterReductionContributorWithObserverWriter>(
+                    Parallel::get_parallel_component<
+                        ObserverWriter<Metavariables>>(cache)[0],
+                    observation_id, node_id, true);
+              }
+            }
+
+            // We don't care if we insert the same processing element
+            // more than once. We care only about which processing
+            // elements have registered.
+            reduction_observers_registered->at(hash).insert(
+                processing_element_or_node);
+          });
+    } else if (called_from_other_node) {
+      // processing_element_or_node is the node_id of the caller.
+
+      ASSERT(node_id == 0, "Only node zero, not node "
+                               << node_id
+                               << ", should be called from another node");
+
+      db::mutate<Tags::ReductionObserversRegisteredNodes>(
+          make_not_null(&box),
+          [&processing_element_or_node, &observation_id ](
+              const gsl::not_null<std::unordered_map<size_t, std::set<size_t>>*>
+                  reduction_observers_registered_nodes) noexcept {
+            const size_t hash = observation_id.observation_type_hash();
+
+            if (reduction_observers_registered_nodes->count(hash) == 0) {
+              (*reduction_observers_registered_nodes)[hash] =
+                  std::set<size_t>{};
+            }
+            reduction_observers_registered_nodes->at(hash).insert(
+                processing_element_or_node);
+          });
+    }
+  }
+};
+
 /*!
  * \brief Action that is called on the Observer parallel component to register
  * the parallel component that will send the data to the observer
@@ -38,14 +120,15 @@ struct RegisterSenderWithSelf {
           nullptr>
   static void apply(db::DataBox<DbTagList>& box,
                     const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-                    const Parallel::ConstGlobalCache<Metavariables>& /*cache*/,
+                    Parallel::ConstGlobalCache<Metavariables>& cache,
                     const ArrayIndex& /*array_index*/,
                     const ActionList /*meta*/,
                     const ParallelComponent* const /*meta*/,
-                    const observers::ObservationId& /*observation_id*/,
+                    const observers::ObservationId& observation_id,
                     const observers::ArrayComponentId& component_id,
                     const TypeOfObservation& type_of_observation) noexcept {
-    const auto register_reduction = [&box, &component_id]() noexcept {
+    const auto register_reduction =
+        [&box, &cache, &component_id, &observation_id ]() noexcept {
       db::mutate<observers::Tags::ReductionArrayComponentIds>(
           make_not_null(&box), [&component_id](
                                    const auto array_component_ids) noexcept {
@@ -55,8 +138,16 @@ struct RegisterSenderWithSelf {
                    "with the observers more than once.");
             array_component_ids->insert(component_id);
           });
+      const auto my_proc = static_cast<size_t>(Parallel::my_proc());
+      auto& observer_writer =
+          *Parallel::get_parallel_component<
+               observers::ObserverWriter<Metavariables>>(cache)
+               .ckLocalBranch();
+      Parallel::simple_action<
+          Actions::RegisterReductionContributorWithObserverWriter>(
+          observer_writer, observation_id, my_proc);
     };
-    const auto register_volume = [&box, &component_id]() noexcept {
+    const auto register_volume = [&box, &component_id ]() noexcept {
       db::mutate<observers::Tags::VolumeArrayComponentIds>(
           make_not_null(&box), [&component_id](
                                    const auto array_component_ids) noexcept {

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -77,7 +77,8 @@ struct Initialize {
 template <class Metavariables>
 struct InitializeWriter {
   using simple_tags = tmpl::append<
-      db::AddSimpleTags<Tags::TensorData, Tags::VolumeObserversContributed,
+      db::AddSimpleTags<Tags::TensorData, Tags::VolumeObserversRegistered,
+                        Tags::VolumeObserversContributed,
                         Tags::ReductionObserversRegistered,
                         Tags::ReductionObserversRegisteredNodes,
                         Tags::ReductionObserversContributed, Tags::H5FileLock>,
@@ -105,6 +106,7 @@ struct InitializeWriter {
   static auto helper(tmpl::list<ReductionTags...> /*meta*/) noexcept {
     return std::make_tuple(db::create<simple_tags>(
         db::item_type<Tags::TensorData>{},
+        db::item_type<Tags::VolumeObserversRegistered>{},
         db::item_type<Tags::VolumeObserversContributed>{},
         db::item_type<Tags::ReductionObserversRegistered>{},
         db::item_type<Tags::ReductionObserversRegisteredNodes>{},

--- a/src/IO/Observer/Initialize.hpp
+++ b/src/IO/Observer/Initialize.hpp
@@ -78,6 +78,8 @@ template <class Metavariables>
 struct InitializeWriter {
   using simple_tags = tmpl::append<
       db::AddSimpleTags<Tags::TensorData, Tags::VolumeObserversContributed,
+                        Tags::ReductionObserversRegistered,
+                        Tags::ReductionObserversRegisteredNodes,
                         Tags::ReductionObserversContributed, Tags::H5FileLock>,
       typename Metavariables::observed_reduction_data_tags,
       tmpl::transform<
@@ -104,6 +106,8 @@ struct InitializeWriter {
     return std::make_tuple(db::create<simple_tags>(
         db::item_type<Tags::TensorData>{},
         db::item_type<Tags::VolumeObserversContributed>{},
+        db::item_type<Tags::ReductionObserversRegistered>{},
+        db::item_type<Tags::ReductionObserversRegisteredNodes>{},
         db::item_type<Tags::ReductionObserversContributed>{},
         Parallel::create_lock(), db::item_type<ReductionTags>{}...,
         db::item_type<

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -75,6 +75,15 @@ struct ReductionDataNames : db::SimpleTag {
   using data_tag = ReductionData<ReductionDatums...>;
 };
 
+/// The number of observer components that have registered on each node
+/// for volume output.
+/// The key of the map is the `observation_type_hash` of the `ObservationId`.
+/// The set contains all the processing elements it has registered on.
+struct VolumeObserversRegistered : db::SimpleTag {
+  static std::string name() noexcept { return "VolumeObserversRegistered"; }
+  using type = std::unordered_map<size_t, std::set<size_t>>;
+};
+
 /// The number of observer components that have contributed data at the
 /// observation ids.
 struct VolumeObserversContributed : db::SimpleTag {

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -75,14 +75,6 @@ struct ReductionDataNames : db::SimpleTag {
   using data_tag = ReductionData<ReductionDatums...>;
 };
 
-/// The number of nodes that have contributed to the reduction data so far.
-struct NumberOfNodesContributedToReduction : db::SimpleTag {
-  static std::string name() noexcept {
-    return "NumberOfNodesContributedToReduction";
-  }
-  using type = std::unordered_map<ObservationId, size_t>;
-};
-
 /// The number of observer components that have contributed data at the
 /// observation ids.
 struct VolumeObserversContributed : db::SimpleTag {

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -82,6 +82,30 @@ struct VolumeObserversContributed : db::SimpleTag {
   using type = std::unordered_map<observers::ObservationId, size_t>;
 };
 
+/// The number of observer components that have registered.
+/// The key of the map is the `observation_type_hash` of the `ObservationId`.
+/// The set contains all the processing elements it has registered on.
+///
+/// The idea is to keep track of how many processing elements have
+/// called the registration function (even if some processing elements
+/// call it multiple times).  This number is the number of times the
+/// Observer group will call the local ObserverWriter nodegroup during
+/// a reduction.
+struct ReductionObserversRegistered : db::SimpleTag {
+  static std::string name() noexcept { return "ReductionObserversRegistered"; }
+  using type = std::unordered_map<size_t, std::set<size_t>>;
+};
+
+/// The number of ObserverWriter nodegroups that have registered.
+/// The key of the map is the `observation_type_hash` of the `ObservationId`.
+/// The set contains all the nodes that have been registered.
+struct ReductionObserversRegisteredNodes : db::SimpleTag {
+  static std::string name() noexcept {
+    return "ReductionObserversRegisteredNodes";
+  }
+  using type = std::unordered_map<size_t, std::set<size_t>>;
+};
+
 /// The number of observer components that have contributed data at the
 /// observation ids.
 struct ReductionObserversContributed : db::SimpleTag {

--- a/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolationTarget.hpp
@@ -32,43 +32,37 @@ namespace intrp {
 /// Each InterpolationTarget will communicate with the `Interpolator`.
 ///
 /// `InterpolationTargetTag` must contain the following type aliases:
-/// - vars_to_interpolate_to_target: a `tmpl::list` of tags describing
-///                                  variables to interpolate.  Will be used
-///                                  to construct a `Variables`.
-/// - compute_items_on_source:       a `tmpl::list` of compute items that uses
-///                                  `Metavariables::interpolator_source_vars`
-///                                  as input and computes the `Variables`
-///                                  defined by `vars_to_interpolate_to_target`.
-/// - compute_items_on_target:       a `tmpl::list` of compute items that uses
-///                                 `vars_to_interpolate_to_target` as input.
-/// - compute_target_points:         a `simple_action` of `InterpolationTarget`
-///                                  that computes the target points and
-///                                  sends them to `Interpolators`.
-///                                  It takes a `temporal_id` as an extra
-///                                  argument.  `compute_target_points` can
-///                                  (optionally) have an additional function
+/// - vars_to_interpolate_to_target:
+///      A `tmpl::list` of tags describing variables to interpolate.
+///      Will be used to construct a `Variables`.
+/// - compute_items_on_source:
+///      A `tmpl::list` of compute items that uses
+///      `Metavariables::interpolator_source_vars` as input and computes the
+///      `Variables` defined by `vars_to_interpolate_to_target`.
+/// - compute_items_on_target:
+///      A `tmpl::list` of compute items that uses
+///      `vars_to_interpolate_to_target` as input.
+/// - compute_target_points:
+///      A `simple_action` of `InterpolationTarget`
+///      that computes the target points and sends them to `Interpolators`. It
+///      takes a `temporal_id` as an extra argument. `compute_target_points`
+///      can (optionally) have an additional function
 ///```
 ///   static auto initialize(db::DataBox<DbTags>&&,
 ///                          const Parallel::ConstGlobalCache<Metavariables>&)
 ///                          noexcept;
 ///```
-///                                  that adds arbitrary tags to the `DataBox`
-///                                  when the `InterpolationTarget` is
-///                                  initialized.  If `compute_target_points`
-///                                  has an `initialize` function, it
-///                                  must also have a type alias
-///                                  `initialization_tags`
-///                                  which is a `tmpl::list` of the tags that
-///                                  are added by `initialize`.
-/// - post_interpolation_callback:   a struct with a type alias
-///                                  `const_global_cache_tags` (listing tags
-///                                  that should be read from option parsing),
-///                                  with a type alias `observation_types`
-///                                  (listing any ObservationTypes that the
-///                                  callback will use in constructing
-///                                  ObserverIds to call
-///                             observers::ThreadedActions::WriteReductionData),
-///                                  and with a function
+///      that adds arbitrary tags to the `DataBox` when the
+///      `InterpolationTarget` is initialized.  If `compute_target_points` has
+///      an `initialize` function, it must also have a type alias
+///      `initialization_tags` which is a `tmpl::list` of the tags that are
+///      added by `initialize`.
+/// - post_interpolation_callback:
+///      A struct with a type alias `const_global_cache_tags` (listing tags that
+///      should be read from option parsing), with a type alias
+///      `observation_types` (listing any ObservationTypes that the callback
+///      will use in constructing ObserverIds to call
+///      observers::ThreadedActions::WriteReductionData), and with a function
 ///```
 ///     void apply(const DataBox<DbTags>&,
 ///                const intrp::ConstGlobalCache<Metavariables>&,
@@ -80,25 +74,27 @@ namespace intrp {
 ///                const gsl::not_null<intrp::ConstGlobalCache<Metavariables>*>,
 ///                const Metavariables::temporal_id&) noexcept;
 ///```
-///                            that will be called when interpolation is
-///                            complete.  `DbTags` includes everything in
-///                            `vars_to_interpolate_to_target`, plus everything
-///                            in `compute_items_on_target`.  The second form
-///                            of the `apply` function should return false only
-///                            if it calls another `intrp::Action` that still
-///                            needs the volume data at this temporal_id (such
-///                            as another iteration of the horizon finder).
+///      that will be called when interpolation is complete.  `DbTags` includes
+///      everything in `vars_to_interpolate_to_target`, plus everything in
+///      `compute_items_on_target`.  The second form of the `apply` function
+///      should return false only if it calls another `intrp::Action` that still
+///      needs the volume data at this temporal_id (such as another iteration of
+///      the horizon finder).
 ///
 /// `Metavariables` must contain the following type aliases:
-/// - interpolator_source_vars:   a `tmpl::list` of tags that define a
-///                               `Variables` sent from all `Element`s
-///                               to the local `Interpolator`.
-/// - interpolation_target_tags:  a `tmpl::list` of all
-///                               `InterpolationTargetTag`s.
-/// - temporal_id:                the type held by ::intrp::Tags::TemporalIds.
-/// - domain_frame:               The `::Frame` of the Domain.
+/// - interpolator_source_vars:
+///      A `tmpl::list` of tags that define a `Variables` sent from all
+///      `Element`s to the local `Interpolator`.
+/// - interpolation_target_tags:
+///      A `tmpl::list` of all `InterpolationTargetTag`s.
+/// - temporal_id:
+///      The type held by ::intrp::Tags::TemporalIds.
+/// - domain_frame:
+///      The `::Frame` of the Domain.
+///
 /// `Metavariables` must contain the following static constexpr members:
-/// - size_t domain_dim:    The dimension of the Domain.
+/// - size_t domain_dim:
+///      The dimension of the Domain.
 template <class Metavariables, typename InterpolationTargetTag>
 struct InterpolationTarget {
   using chare_type = ::Parallel::Algorithms::Singleton;

--- a/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/ConjugateGradient/ResidualMonitor.hpp
@@ -6,6 +6,7 @@
 #include "AlgorithmSingleton.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "IO/Observer/Actions.hpp"
 #include "Informer/Tags.hpp"
 #include "Informer/Verbosity.hpp"
 #include "NumericalAlgorithms/LinearSolver/Convergence.hpp"
@@ -60,6 +61,14 @@ struct ResidualMonitor {
         // clang-tidy: std::move of trivially-copyable type
         std::move(verbosity),              // NOLINT
         std::move(convergence_criteria));  // NOLINT
+
+    const auto initial_observation_id = observers::ObservationId(
+        IterationId{}, typename Metavariables::element_observation_type{});
+    Parallel::simple_action<
+        observers::Actions::RegisterSingletonWithObserverWriter>(
+        Parallel::get_parallel_component<ResidualMonitor>(
+            *(global_cache.ckLocalBranch())),
+        initial_observation_id);
   }
 
   static void execute_next_phase(

--- a/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
+++ b/src/NumericalAlgorithms/LinearSolver/Gmres/ResidualMonitor.hpp
@@ -7,6 +7,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DenseMatrix.hpp"
+#include "IO/Observer/Actions.hpp"
 #include "Informer/Tags.hpp"
 #include "Informer/Verbosity.hpp"
 #include "NumericalAlgorithms/LinearSolver/Convergence.hpp"
@@ -61,6 +62,14 @@ struct ResidualMonitor {
         // clang-tidy: std::move of trivially-copyable type
         std::move(verbosity),              // NOLINT
         std::move(convergence_criteria));  // NOLINT
+
+    const auto initial_observation_id = observers::ObservationId(
+        IterationId{}, typename Metavariables::element_observation_type{});
+    Parallel::simple_action<
+        observers::Actions::RegisterSingletonWithObserverWriter>(
+        Parallel::get_parallel_component<ResidualMonitor>(
+            *(global_cache.ckLocalBranch())),
+        initial_observation_id);
   }
 
   static void execute_next_phase(

--- a/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
@@ -203,6 +203,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson.Actions.Observe",
     // observer component by the RegisterWithObservers action.
     runner.invoke_queued_simple_action<obs_component>(0);
     // Invoke the simple_action RegisterReductionContributorWithObserverWriter
+    // and RegisterVolumeContributorWithObserverWriter.
+    runner.invoke_queued_simple_action<obs_writer>(0);
     runner.invoke_queued_simple_action<obs_writer>(0);
   }
 

--- a/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
@@ -26,6 +26,7 @@
 #include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
 #include "IO/Observer/Helpers.hpp"  // IWYU pragma: keep
 #include "IO/Observer/Initialize.hpp"
+#include "IO/Observer/ObservationId.hpp"
 #include "IO/Observer/ObserverComponent.hpp"
 #include "IO/Observer/Tags.hpp"
 #include "IO/Observer/TypeOfObservation.hpp"
@@ -195,7 +196,9 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson.Actions.Observe",
     runner.simple_action<element_comp,
                          observers::Actions::RegisterWithObservers<
                              observers::TypeOfObservation::ReductionAndVolume>>(
-        id, 0);
+        id, observers::ObservationId(
+                LinearSolver::IterationId{},
+                typename Metavariables::element_observation_type{}));
     // Invoke the simple_action RegisterSenderWithSelf that was called on the
     // observer component by the RegisterWithObservers action.
     runner.invoke_queued_simple_action<obs_component>(0);

--- a/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
+++ b/tests/Unit/Elliptic/Systems/Poisson/Actions/Test_Observe.cpp
@@ -202,6 +202,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Poisson.Actions.Observe",
     // Invoke the simple_action RegisterSenderWithSelf that was called on the
     // observer component by the RegisterWithObservers action.
     runner.invoke_queued_simple_action<obs_component>(0);
+    // Invoke the simple_action RegisterReductionContributorWithObserverWriter
+    runner.invoke_queued_simple_action<obs_writer>(0);
   }
 
   const std::string reduction_h5_file_name = reduction_file_name + ".h5";

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -97,6 +97,8 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
     // Invoke the simple_action RegisterSenderWithSelf that was called
     // on the observer component by the RegisterWithObservers action.
     runner.invoke_queued_simple_action<obs_component>(0);
+    // Invoke the simple_action RegisterReductionContributorWithObserverWriter.
+    runner.invoke_queued_simple_action<obs_writer>(0);
   }
 
   const std::string h5_file_name = output_file_prefix + ".h5";

--- a/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_ReductionObserver.cpp
@@ -90,9 +90,12 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
   for (const auto& id : element_ids) {
     runner.simple_action<element_comp,
                          observers::Actions::RegisterWithObservers<
-                             observers::TypeOfObservation::Reduction>>(id, 0);
-    // Invoke the simple_action RegisterSenderWithSelf that was called on the
-    // observer component by the RegisterWithObservers action.
+                             observers::TypeOfObservation::Reduction>>(
+        id, observers::ObservationId(
+                helpers::TimeId{3},
+                typename Metavariables::element_observation_type{}));
+    // Invoke the simple_action RegisterSenderWithSelf that was called
+    // on the observer component by the RegisterWithObservers action.
     runner.invoke_queued_simple_action<obs_component>(0);
   }
 
@@ -129,7 +132,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.ReductionObserver", "[Unit][Observers]") {
             time, typename Metavariables::element_observation_type{}},
         "/element_data", legend, std::move(reduction_data_fakes));
   }
-  // Invke the threaded action 'WriteReductionData' to write reduction data to
+  // Invoke the threaded action 'WriteReductionData' to write reduction data to
   // disk.
   runner.invoke_queued_threaded_action<obs_writer>(0);
 

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -95,6 +95,8 @@ void check_observer_registration() {
           .template get_databox<typename obs_writer::initial_databox>();
   CHECK(db::get<observers::Tags::TensorData>(writer_box).empty());
   CHECK(
+      db::get<observers::Tags::VolumeObserversRegistered>(writer_box).empty());
+  CHECK(
       db::get<observers::Tags::VolumeObserversContributed>(writer_box).empty());
   CHECK(db::get<observers::Tags::ReductionObserversRegistered>(writer_box)
             .empty());
@@ -116,6 +118,10 @@ void check_observer_registration() {
     if (TypeOfObservation != observers::TypeOfObservation::Volume) {
       // Invoke the simple_action
       // RegisterReductionContributorWithObserverWriter.
+      runner.invoke_queued_simple_action<obs_writer>(0);
+    }
+    if (TypeOfObservation != observers::TypeOfObservation::Reduction) {
+      // Invoke the simple_action RegisterVolumeContributorWithObserverWriter.
       runner.invoke_queued_simple_action<obs_writer>(0);
     }
   }
@@ -156,6 +162,15 @@ void check_observer_registration() {
             TimeId(3), typename Metavariables::element_observation_type{})
             .observation_type_hash();
     CHECK(db::get<observers::Tags::ReductionObserversRegistered>(writer_box)
+              .at(hash)
+              .size() == 1);
+  }
+  if (TypeOfObservation != observers::TypeOfObservation::Reduction) {
+    const auto hash =
+        observers::ObservationId(
+            TimeId(3), typename Metavariables::element_observation_type{})
+            .observation_type_hash();
+    CHECK(db::get<observers::Tags::VolumeObserversRegistered>(writer_box)
               .at(hash)
               .size() == 1);
   }

--- a/tests/Unit/IO/Observers/Test_RegisterElements.cpp
+++ b/tests/Unit/IO/Observers/Test_RegisterElements.cpp
@@ -17,6 +17,7 @@
 #include "IO/Observer/Actions.hpp"  // IWYU pragma: keep
 #include "IO/Observer/ArrayComponentId.hpp"
 #include "IO/Observer/Initialize.hpp"         // IWYU pragma: keep
+#include "IO/Observer/ObservationId.hpp"  // IWYU pragma: keep
 #include "IO/Observer/ObserverComponent.hpp"  // IWYU pragma: keep
 #include "IO/Observer/Tags.hpp"               // IWYU pragma: keep
 #include "IO/Observer/TypeOfObservation.hpp"
@@ -89,7 +90,9 @@ void check_observer_registration() {
   for (const auto& id : element_ids) {
     runner.simple_action<
         element_comp,
-        observers::Actions::RegisterWithObservers<TypeOfObservation>>(id, 0);
+        observers::Actions::RegisterWithObservers<TypeOfObservation>>(
+        id, observers::ObservationId(
+                TimeId(3), typename Metavariables::element_observation_type{}));
     // Invoke the simple_action RegisterSenderWithSelf that was called on the
     // observer component by the RegisterWithObservers action.
     runner.invoke_queued_simple_action<obs_component>(0);

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -15,6 +15,7 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
   CHECK(ReductionArrayComponentIds::name() == "ReductionArrayComponentIds");
   CHECK(VolumeArrayComponentIds::name() == "VolumeArrayComponentIds");
   CHECK(TensorData::name() == "TensorData");
+  CHECK(VolumeObserversRegistered::name() == "VolumeObserversRegistered");
   CHECK(VolumeObserversContributed::name() == "VolumeObserversContributed");
   CHECK(H5FileLock::name() == "H5FileLock");
   CHECK(ReductionData<double>::name() == "ReductionData");

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -21,6 +21,9 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
   CHECK(ReductionDataNames<double>::name() == "ReductionDataNames");
   CHECK(ReductionObserversContributed::name() ==
         "ReductionObserversContributed");
+  CHECK(ReductionObserversRegistered::name() == "ReductionObserversRegistered");
+  CHECK(ReductionObserversRegisteredNodes::name() ==
+        "ReductionObserversRegisteredNodes");
   static_assert(
       cpp17::is_same_v<typename ReductionData<double, int, char>::names_tag,
                        ReductionDataNames<double, int, char>>,

--- a/tests/Unit/IO/Observers/Test_Tags.cpp
+++ b/tests/Unit/IO/Observers/Test_Tags.cpp
@@ -19,8 +19,6 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.Tags", "[Unit][Observers]") {
   CHECK(H5FileLock::name() == "H5FileLock");
   CHECK(ReductionData<double>::name() == "ReductionData");
   CHECK(ReductionDataNames<double>::name() == "ReductionDataNames");
-  CHECK(NumberOfNodesContributedToReduction::name() ==
-        "NumberOfNodesContributedToReduction");
   CHECK(ReductionObserversContributed::name() ==
         "ReductionObserversContributed");
   static_assert(

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -95,7 +95,9 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
     runner
         .simple_action<element_comp, observers::Actions::RegisterWithObservers<
                                          observers::TypeOfObservation::Volume>>(
-            id, 0);
+            id,
+            observers::ObservationId(
+                TimeId(3), typename Metavariables::element_observation_type{}));
     // Invoke the simple_action RegisterSenderWithSelf that was called on the
     // observer component by the RegisterWithObservers action.
     runner.invoke_queued_simple_action<obs_component>(0);

--- a/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
+++ b/tests/Unit/IO/Observers/Test_VolumeObserver.cpp
@@ -101,6 +101,8 @@ SPECTRE_TEST_CASE("Unit.IO.Observers.VolumeObserver", "[Unit][Observers]") {
     // Invoke the simple_action RegisterSenderWithSelf that was called on the
     // observer component by the RegisterWithObservers action.
     runner.invoke_queued_simple_action<obs_component>(0);
+    // Invoke the simple_action RegisterVolumeContributorWithObserverWriter.
+    runner.invoke_queued_simple_action<obs_writer>(0);
   }
 
   const std::string h5_file_name = output_file_prefix + "0.h5";


### PR DESCRIPTION
## Proposed changes

All classes that call WriteReductionData, ContributeReductionData, or ContributeVolumeData now register themselves first so that ObserverWriter knows how many calls it will receive.  Previously ObserverWriter assumed it was called once on every processing element on every node. 

There are several commits:

* RegisterObservers now takes an ObservationId and not a TemporalId
* Remove unused Tag from Observers. (this is just a cleanup)
* Add RegisterReductionCallterWithObserverWriter (registration information not used yet)
* Add RegisterSingletonWithObserverWriter (registration information not used yet)
* WriteReductionData now uses registration information. Fixes #1284 and part of #1147
* Add RegisterVolumeCallerWithObserverWriter (registration information not used yet)
* ContributeVolumeDataToWriter now uses registration information. Fixes the rest of #1147

There will still be an upcoming PR (or two) that will enable observing integrals along with volume data and reductions in EvolveValenciaDivClean.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
