### PR TITLE
AddTemporalIdsToInterpolationTarget now ignores old TemporalIds.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp
@@ -24,6 +24,7 @@ namespace Actions {
 /// Uses:
 /// - DataBox:
 ///   - `Tags::TemporalIds<Metavariables>`
+///   - `Tags::CompletedTemporalIds<Metavariables>`
 ///
 /// DataBox changes:
 /// - Adds: nothing
@@ -48,14 +49,36 @@ struct AddTemporalIdsToInterpolationTarget {
     const bool begin_interpolation =
         db::get<Tags::TemporalIds<Metavariables>>(box).empty();
 
-    db::mutate<Tags::TemporalIds<Metavariables>>(
-        make_not_null(&box), [&temporal_ids](
-                                 const gsl::not_null<db::item_type<
-                                     Tags::TemporalIds<Metavariables>>*>
-                                     ids) noexcept {
-          ids->insert(ids->end(), std::make_move_iterator(temporal_ids.begin()),
-                      std::make_move_iterator(temporal_ids.end()));
-        });
+    db::mutate_apply<tmpl::list<Tags::TemporalIds<Metavariables>>,
+                     tmpl::list<Tags::CompletedTemporalIds<Metavariables>>>(
+        [&temporal_ids](
+            const gsl::not_null<
+                db::item_type<Tags::TemporalIds<Metavariables>>*>
+                ids,
+            const db::item_type<Tags::CompletedTemporalIds<Metavariables>>&
+                completed_ids) noexcept {
+          // We allow this Action to be called multiple times with the
+          // same temporal_ids (e.g. from each node of a NodeGroup
+          // ParallelComponent such as Interpolator). If multiple calls
+          // occur, we care only about the first one, and ignore the others.
+          // The first call will often begin interpolation.
+          // So if multiple calls occur, it is possible that some of them
+          // may arrive late, even after interpolation
+          // has been completed on one or more of the temporal_ids (and after
+          // that id has already been removed from `ids`).  If this happens,
+          // we don't want to add the temporal_ids again. For that
+          // reason we keep track of the temporal_ids that we have already
+          // completed interpolation on.  So here we do not add any temporal_ids
+          // that are already present in `ids` or `completed_ids`.
+          for (auto& id : temporal_ids) {
+            if (std::find(completed_ids.begin(), completed_ids.end(), id) ==
+                    completed_ids.end() and
+                std::find(ids->begin(), ids->end(), id) == ids->end()) {
+              ids->push_back(id);
+            }
+          }
+        },
+        make_not_null(&box));
 
     // Begin interpolation if it is not already in progress
     // (i.e. waiting for data), and if there are temporal_ids to
@@ -72,5 +95,5 @@ struct AddTemporalIdsToInterpolationTarget {
     }
   }
 };
-} // namespace Actions
-} // namespace intrp
+}  // namespace Actions
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InitializeInterpolationTarget.hpp
@@ -93,6 +93,7 @@ auto make_tuple_of_box(
 /// - Adds:
 ///   - `Tags::IndicesOfFilledInterpPoints`
 ///   - `Tags::TemporalIds<Metavariables>`
+///   - `Tags::CompletedTemporalIds<Metavariables>`
 ///   - `::Tags::Domain<VolumeDim, Frame>`
 ///   - `::Tags::Variables<typename
 ///                   InterpolationTargetTag::vars_to_interpolate_to_target>`
@@ -106,6 +107,7 @@ struct InitializeInterpolationTarget {
   template <typename Metavariables>
   using return_tag_list_initial = tmpl::list<
       Tags::IndicesOfFilledInterpPoints, Tags::TemporalIds<Metavariables>,
+      Tags::CompletedTemporalIds<Metavariables>,
       ::Tags::Domain<Metavariables::domain_dim,
                      typename Metavariables::domain_frame>,
       ::Tags::Variables<
@@ -128,7 +130,9 @@ struct InitializeInterpolationTarget {
     auto box = db::create<
         db::get_items<return_tag_list_initial<Metavariables>>>(
         db::item_type<Tags::IndicesOfFilledInterpPoints>{},
-        db::item_type<Tags::TemporalIds<Metavariables>>{}, std::move(domain),
+        db::item_type<Tags::TemporalIds<Metavariables>>{},
+        db::item_type<Tags::CompletedTemporalIds<Metavariables>>{},
+        std::move(domain),
         db::item_type<::Tags::Variables<
             typename InterpolationTargetTag::vars_to_interpolate_to_target>>{});
 

--- a/src/NumericalAlgorithms/Interpolation/Tags.hpp
+++ b/src/NumericalAlgorithms/Interpolation/Tags.hpp
@@ -40,6 +40,15 @@ struct TemporalIds : db::SimpleTag {
   static std::string name() noexcept { return "TemporalIds"; }
 };
 
+/// `temporal_id`s that we have already interpolated onto.
+///  This is used to prevent problems with multiple late calls to
+///  AddTemporalIdsToInterpolationTarget.
+template <typename Metavariables>
+struct CompletedTemporalIds : db::SimpleTag {
+  using type = std::deque<typename Metavariables::temporal_id::type>;
+  static std::string name() noexcept { return "CompletedTemporalIds"; }
+};
+
 /// Volume variables at all `temporal_id`s for all local `Element`s.
 template <typename Metavariables>
 struct VolumeVarsInfo : db::SimpleTag {
@@ -49,8 +58,7 @@ struct VolumeVarsInfo : db::SimpleTag {
   };
   using type = std::unordered_map<
       typename Metavariables::temporal_id::type,
-      std::unordered_map<
-          ElementId<Metavariables::domain_dim>, Info>>;
+      std::unordered_map<ElementId<Metavariables::domain_dim>, Info>>;
   static std::string name() noexcept { return "VolumeVarsInfo"; }
 };
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_AddTemporalIdsToInterpolationTarget.cpp
@@ -150,6 +150,15 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.InterpolationTarget.AddTemporalIds",
   CHECK(db::get<::intrp::Tags::TemporalIds<metavars>>(box) ==
         std::deque<TimeId>(temporal_ids.begin(), temporal_ids.end()));
 
+  // Add the same temporal_ids again, which should do nothing...
+  runner.simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
+      ::intrp::Actions::AddTemporalIdsToInterpolationTarget<
+          metavars::InterpolationTargetA>>(0, temporal_ids);
+  // ...and check that it indeed did nothing.
+  CHECK(db::get<::intrp::Tags::TemporalIds<metavars>>(box) ==
+        std::deque<TimeId>(temporal_ids.begin(), temporal_ids.end()));
+
   runner.invoke_queued_simple_action<
       mock_interpolation_target<metavars, metavars::InterpolationTargetA>>(0);
 

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_ParallelInterpolator.cpp
@@ -393,5 +393,19 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolator.Integration",
 
   // Check whether test function was called.
   CHECK(num_test_function_calls == 3);
+
+  // Tell one InterpolationTarget that we want to interpolate at the same
+  // temporal_id that we already interpolated at.
+  // This call should be ignored by the InterpolationTarget...
+  runner.simple_action<
+      mock_interpolation_target<metavars, metavars::InterpolationTargetA>,
+      intrp::Actions::AddTemporalIdsToInterpolationTarget<
+          metavars::InterpolationTargetA>>(0, std::vector<TimeId>{temporal_id});
+  // ...so make sure it was ignored by checking that there isn't anything
+  // else in the simple_action queue of the target or the interpolator.
+  CHECK(runner.is_simple_action_queue_empty<
+        mock_interpolation_target<metavars, metavars::InterpolationTargetA>>(
+      0));
+  CHECK(runner.is_simple_action_queue_empty<mock_interpolator<metavars>>(0));
 }
 }  // namespace


### PR DESCRIPTION
Previously it was envisioned that AddTemporalIdsToInterpolationTarget
would be called only once for every TemporalId, by some global mechanism.

But now we want AddTemporalIdsToInterpolationTarget to be called by
an array ParallelComponent (namely DgElementArray), so it will be
called many times (as opposed to only once) for each TemporalId.

This change allows AddTemporalIdsToInterpolationTarget to act as
before on the first call but to ignore duplicate calls, even if
some of the duplicate calls are so late that they arrive after
interpolation has been completed on the relevant TemporalId.

### Types of changes:

- [x] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
