### PR TITLE
Clarify direction in which OrientationMap maps

### DIFF
--- a/docs/Tutorials/Orientation.md
+++ b/docs/Tutorials/Orientation.md
@@ -12,15 +12,16 @@ as the logical directions \f$\xi\f$, \f$\eta\f$, and \f$\zeta\f$, where
 \f$\zeta\f$ is the third dimension. In a
 domain with multiple elements, the logical directions are not necessarily
 aligned on the interfaces between two elements, as shown in the figure below.
-As fluxes need to be communicated across the boundaries of adjacent elements,
-there needs to be a system in place that organizes the relative orientations of
-elements with respect to their neighbors. This is handled by OrientationMap.
+As certain operations (e.g. fluxes, limiting) communicate information across
+the boundaries of adjacent elements, there needs to be a class that takes
+into account the relative orientations of elements which neighbor each other.
+This class is OrientationMap.
 
 ### %OrientationMaps between %Blocks
 Each Block in a Domain has a set of BlockNeighbors, which each hold an
 OrientationMap. In this scenario, the Block is referred to as the host, and
 the OrientationMap held by each BlockNeighbor is referred to as "the
-orientation the host Block has with respect to this BlockNeighbor." This is
+orientation the BlockNeighbor has with respect to the host Block." This is
 a convention, so we give an example of constructing and assigning the correct
 OrientationMaps:
 
@@ -176,7 +177,8 @@ Now we know that `Direction<3>::%upper_xi()`
 in Block1 corresponds to `Direction<3>::%lower_zeta().%opposite()` in Block2.
 
 The use of `.%opposite()` is a result of the Directions to a Block face being
-anti-parallel because each Block lies on the opposite side of the shared face.<br>
+anti-parallel because each Block lies on the opposite side of the shared face.
+<br>
 
 The remaining two correspondences are given by the alignment of the shared
 face. It is useful to know the following information:<br>

--- a/src/Domain/BlockNeighbor.hpp
+++ b/src/Domain/BlockNeighbor.hpp
@@ -18,7 +18,7 @@ class er;
 /// \endcond
 
 /// \ingroup ComputationalDomainGroup
-/// Information about the neighbor of a Block in a particular direction.
+/// Information about the neighbor of a host Block in a particular direction.
 ///
 /// \tparam VolumeDim the volume dimension.
 template <size_t VolumeDim>
@@ -26,10 +26,13 @@ class BlockNeighbor {
  public:
   BlockNeighbor() = default;
 
-  /// Construct with the Id and orientation of the neighbor.
+  /// Construct with the Id and orientation of the neighbor relative to the
+  /// host.
   ///
   /// \param id the Id of the neighbor.
-  /// \param orientation the OrientationMap of the neighbor.
+  /// \param orientation This OrientationMap takes objects in the logical
+  /// coordinate frame of the host Block and maps them to the logical
+  /// coordinate frame of the neighbor Block.
   BlockNeighbor(size_t id, OrientationMap<VolumeDim> orientation) noexcept;
   ~BlockNeighbor() = default;
   BlockNeighbor(const BlockNeighbor<VolumeDim>& neighbor) = default;

--- a/src/Domain/Neighbors.hpp
+++ b/src/Domain/Neighbors.hpp
@@ -21,16 +21,19 @@ class ElementId;
 /// \endcond
 
 /// \ingroup ComputationalDomainGroup
-/// Information about the neighbors of an Element in a particular direction.
+/// Information about the neighbors of a host Element in a particular direction.
 ///
 /// \tparam VolumeDim the volume dimension.
 template <size_t VolumeDim>
 class Neighbors {
  public:
-  /// Construct with the ids and orientation of the neighbors.
+  /// Construct with the ids and orientation of the neighbors relative to the
+  /// host.
   ///
   /// \param ids the ids of the neighbors.
-  /// \param orientation the OrientationMap of the neighbors.
+  /// \param orientation This OrientationMap takes objects in the logical
+  /// coordinate frame of the host Element and maps them to the logical
+  /// coordinate frame of the neighbor Element.
   Neighbors(std::unordered_set<ElementId<VolumeDim>> ids,
             OrientationMap<VolumeDim> orientation) noexcept;
 


### PR DESCRIPTION
## Proposed changes

Fix #856 

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
