### PR TITLE
Add spin-weighted spherical harmonic TransformJob

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -159,6 +159,18 @@
   url      = "https://doi.org/10.1086/374594",
 }
 
+@article{Goldberg1966uu,
+  author         = "Goldberg, J. N. and MacFarlane, A. J. and Newman, E. T.
+                        and Rohrlich, F. and Sudarshan, E. C. G.",
+  title          = "{Spin s spherical harmonics and edth}",
+  journal        = "J. Math. Phys.",
+  volume         = "8",
+  year           = "1967",
+  pages          = "2155",
+  doi            = "10.1063/1.1705135",
+  url            = "https://doi.org/10.1063/1.1705135"
+}
+
 @article{Gundlach1997us,
   author         = "Gundlach, Carsten",
   title          = "Pseudospectral apparent horizon finders: An Efficient

--- a/src/NumericalAlgorithms/Spectral/SwshCoefficients.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCoefficients.hpp
@@ -8,9 +8,114 @@
 #include <sharp_cxx.h>
 
 #include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "Utilities/ForceInline.hpp"
 
 namespace Spectral {
 namespace Swsh {
+
+/// \ingroup SwshGroup
+/// \brief Convenience function for determining the number of spin-weighted
+/// spherical harmonics coefficients that are stored for a given `l_max`
+constexpr SPECTRE_ALWAYS_INLINE size_t
+number_of_swsh_coefficients(const size_t l_max) noexcept {
+  return (l_max + 1) * (l_max + 2) / 2;  // "triangular" representation
+}
+
+/*!
+ * \ingroup SwshGroup
+ * \brief Compute the relative sign change necessary to convert between the
+ * libsharp basis for spin weight `from_spin_weight` to the basis for spin
+ * weight `to_spin_weight`, for the real component coefficients if `real` is
+ * true, otherwise for the imaginary component coefficients. The sign change for
+ * a given coefficient is equivalent to the product of
+ * `sharp_swsh_sign(from_spin, m, real) * sharp_swsh_sign(to_spin, m,
+ * real)`. Due to the form of the signs, it does not end up depending on m (the
+ * m's in the power of \f$-1\f$'s cancel).
+ * For full details of the libsharp sign conventions, see the documentation for
+ * TransformJob.
+ *
+ * \details The sign change is obtained by the
+ * difference between the libsharp convention and the convention which uses:
+ *
+ * \f[
+ * {}_s Y_{\ell m} (\theta, \phi) = (-1)^m \sqrt{\frac{2 l + 1}{4 \pi}}
+ * D^{\ell}{}_{-m s}(\phi, \theta, 0).
+ * \f]
+ *
+ * See \cite Goldberg1966uu
+ */
+constexpr SPECTRE_ALWAYS_INLINE double sharp_swsh_sign_change(
+    const int from_spin_weight, const int to_spin_weight,
+    const bool real) noexcept {
+  if (real) {
+    return (from_spin_weight == 0 ? -1.0 : 1.0) *
+           (from_spin_weight >= 0 ? -1.0 : 1.0) *
+           ((from_spin_weight < 0 and (from_spin_weight % 2 == 0)) ? -1.0
+                                                                   : 1.0) *
+           (to_spin_weight == 0 ? -1.0 : 1.0) *
+           (to_spin_weight >= 0 ? -1.0 : 1.0) *
+           ((to_spin_weight < 0 and (to_spin_weight % 2 == 0)) ? -1.0 : 1.0);
+  }
+  return (from_spin_weight == 0 ? -1.0 : 1.0) *
+         ((from_spin_weight < 0 and (from_spin_weight % 2 == 0)) ? 1.0 : -1.0) *
+         (to_spin_weight == 0 ? -1.0 : 1.0) *
+         ((to_spin_weight < 0 and (to_spin_weight % 2 == 0)) ? 1.0 : -1.0);
+}
+
+/*!
+ * \ingroup SwshGroup
+ * \brief Compute the sign change between the libsharp convention and the set
+ * of spin-weighted spherical harmonics given by the relation to the Wigner
+ * rotation matrices.
+ *
+ * \details The sign change is obtained via the difference between the libsharp
+ * convention and the convention which uses:
+ *
+ * \f[
+ * {}_s Y_{\ell m} (\theta, \phi) = (-1)^m \sqrt{\frac{2 l + 1}{4 \pi}}
+ * D^{\ell}{}_{-m s}(\phi, \theta, 0).
+ * \f]
+ *
+ * See \cite Goldberg1966uu.
+ * The sign change is computed for the real component coefficients if `real` is
+ * true, otherwise for the imaginary component coefficients. For full details on
+ * the sign convention used in libsharp, see the documentation for TransformJob.
+ * This function outputs the \f$\mathrm{sign}(m, s, \mathrm{real})\f$ necessary
+ * to produce the conversion between Goldberg moments and libsharp moments:
+ *
+ * \f{align*}{
+ * {}_s Y_{\ell m}^{\mathrm{real}, \mathrm{sharp}}  =& \mathrm{sign}(m, s,
+ * \mathrm{real=true}) {}_s Y_{\ell m}^{\mathrm{Goldberg}}\\
+ * {}_s Y_{\ell m}^{\mathrm{imag}, \mathrm{sharp}}  =&
+ * \mathrm{sign}(m, s, \mathrm{real=false}) {}_s Y_{\ell
+ * m}^{\mathrm{Goldberg}}.
+ * \f}
+ *
+ * Note that in this equation, the "real" and "imag" superscripts refer to the
+ * set of basis functions used for the decomposition of the real and imaginary
+ * part of the spin-weighted collocation points, not real or imaginary parts of
+ * the basis functions themselves.
+ */
+constexpr SPECTRE_ALWAYS_INLINE double sharp_swsh_sign(
+    const int spin_weight, const int m, const bool real) noexcept {
+  if (real) {
+    if (m >= 0) {
+      return (spin_weight > 0 ? -1.0 : 1.0) *
+             ((spin_weight < 0 and (spin_weight % 2 == 0)) ? -1.0 : 1.0);
+    }
+    return (spin_weight == 0 ? -1.0 : 1.0) *
+           ((spin_weight >= 0 and (m % 2 == 0)) ? -1.0 : 1.0) *
+           (spin_weight < 0 and (m + spin_weight) % 2 == 0 ? -1.0 : 1.0);
+  }
+  if (m >= 0) {
+    return (spin_weight == 0 ? -1.0 : 1.0) *
+           ((spin_weight < 0 and (spin_weight % 2 == 0)) ? 1.0 : -1.0);
+  }
+  return (spin_weight == 0 ? -1.0 : 1.0) *
+         ((spin_weight >= 0 and (m % 2 == 0)) ? -1.0 : 1.0) *
+         ((spin_weight < 0 and (m + spin_weight) % 2 != 0) ? -1.0 : 1.0);
+}
+
 namespace detail {
 
 constexpr size_t coefficients_maximum_l_max = collocation_maximum_l_max;
@@ -29,6 +134,23 @@ struct DestroySharpAlm {
 // provide information about the value and storage ordering of those
 // coefficients to user code. This should be implemented as an iterator, as is
 // done in SwshCollocation.hpp.
+//
+// Note: The libsharp representation of coefficients is altered from the
+// standard mathematical definitions in a nontrivial way. There are a number of
+// important features to the data storage of the coefficients.
+// - they are stored as a set of complex values, but each vector of complex
+//   values is the transform of only the real or imaginary part of the
+//   collocation data
+// - because each vector of complex coefficients is related to the transform of
+//   a set of doubles, only (about) half of the m's are stored (m >= 0), because
+//   the remaining m modes are determinable by conjugation from the positive m
+//   modes, given that they represent the transform of a purely real or purely
+//   imaginary collocation quantity
+// - they are stored in an l-varies-fastest, triangular representation. To be
+//   concrete, for an l_max=2, the order of coefficient storage is (l, m):
+//   [(0, 0), (1, 0), (2, 0), (1, 1), (2, 1), (2, 2)]
+// - due to the restriction of representing only the transform of real
+//   quantities, the m=0 modes always have vanishing imaginary component.
 class Coefficients {
  public:
   explicit Coefficients(size_t l_max) noexcept;

--- a/src/NumericalAlgorithms/Spectral/SwshCollocation.cpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCollocation.cpp
@@ -24,7 +24,7 @@ Collocation<Representation>::Collocation(const size_t l_max) noexcept
   sharp_make_gauss_geom_info(
       l_max_ + 1, 2 * l_max_ + 1, 0.0,
       detail::ComplexDataView<Representation>::stride(),
-      detail::ComplexDataView<Representation>::stride() * (1 * l_max_ + 1),
+      detail::ComplexDataView<Representation>::stride() * (2 * l_max_ + 1),
       &geometry_to_initialize);
   geom_info_.reset(geometry_to_initialize);
 }
@@ -94,7 +94,7 @@ dispatch_to_precomputed_static_collocation_impl(
 }  // namespace
 
 template <ComplexRepresentation Representation>
-const Collocation<Representation>& precomputed_spherical_harmonic_collocation(
+const Collocation<Representation>& precomputed_collocation(
     const size_t l_max) noexcept {
   return dispatch_to_precomputed_static_collocation_impl<Representation>(
       l_max, std::make_index_sequence<collocation_maximum_l_max + 1>{});
@@ -104,9 +104,9 @@ template class Collocation<ComplexRepresentation::Interleaved>;
 template class Collocation<ComplexRepresentation::RealsThenImags>;
 
 template const Collocation<ComplexRepresentation::Interleaved>&
-precomputed_spherical_harmonic_collocation(const size_t l_max) noexcept;
+precomputed_collocation(const size_t l_max) noexcept;
 template const Collocation<ComplexRepresentation::RealsThenImags>&
-precomputed_spherical_harmonic_collocation(const size_t l_max) noexcept;
+precomputed_collocation(const size_t l_max) noexcept;
 
 }  // namespace Swsh
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshCollocation.hpp
@@ -8,10 +8,20 @@
 #include <sharp_cxx.h>
 
 #include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "Utilities/ForceInline.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace Spectral {
 namespace Swsh {
+
+/// \ingroup SwshGroup
+/// \brief Convenience function for determining the number of spin-weighted
+/// spherical harmonic collocation values that are stored for a given `l_max`
+/// for a libsharp-compatible set of collocation points.
+constexpr SPECTRE_ALWAYS_INLINE size_t
+number_of_swsh_collocation_points(const size_t l_max) noexcept {
+  return (l_max + 1) * (2 * l_max + 1);
+}
 
 // In the static caching mechanism, we permit an l_max up to this macro
 // value. Higher l_max values may still be created manually using the
@@ -190,7 +200,7 @@ class Collocation {
 /// generated, it's returned by reference. Otherwise, the new grid is generated
 /// and put in the lookup table before it is returned by reference.
 template <ComplexRepresentation Representation>
-const Collocation<Representation>& precomputed_spherical_harmonic_collocation(
+const Collocation<Representation>& precomputed_collocation(
     size_t l_max) noexcept;
 }  // namespace Swsh
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SwshTransformJob.hpp
+++ b/src/NumericalAlgorithms/Spectral/SwshTransformJob.hpp
@@ -1,0 +1,432 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <sharp_cxx.h>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/Variables.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+// IWYU pragma: no_forward_declare Variables
+// IWYU pragma: no_forward_declare Coefficients
+
+namespace Spectral {
+namespace Swsh {
+
+/*!
+ * \ingroup SwshGroup
+ * \brief A class which gathers all necessary shared structure among several
+ * spin-weighted spherical harmonic transforms and dispatches to libsharp. Each
+ * `TransformJob` represents exactly one spin-weighted transform libsharp
+ * execution call, and one inverse transform libsharp execution call.
+ *
+ *
+ * \details
+ * Template Parameters:
+ * - `Spin`: The spin weight for all of the fields to transform with this job.
+ * - `Representation`: The element of the `ComplexRepresentation` enum which
+ *   parameterizes how the data passed to libsharp will be represented. Two
+ *   options are available:
+ *  - `ComplexRepresentation:Interleaved`: indicates that the real and imaginary
+ *    parts of the collocation values will be passed to libsharp as pointers
+ *    into existing complex data structures, minimizing copies, but maintaining
+ *    a stride of 2 for 'adjacent' real or imaginary values.
+ *  - `ComplexRepresentation::RealsThenImags`: indicates that the real and
+ *    imaginary parts of the collocation values will be passed to libsharp as
+ *    separate contiguous blocks. At current, this introduces both allocations
+ *    and copies.  **optimization note** In the future most of the allocations
+ *    can be aggregated to calling code, which would pass in buffers by
+ *    `not_null` pointers.
+ *
+ *  For performance-sensitive code, both options should be tested, as each
+ *  strategy has trade-offs.
+ * - `TagList`: A `tmpl::list` of Tags to be forward and/or backward transformed
+ *   with the `TransformJob`.
+ *
+ * \note The signs obtained from libsharp transformations must be handled
+ * carefully. (In particular, it does not use the sign convention you will find
+ * in [Wikipedia]
+ * (https://en.wikipedia.org/wiki/Spin-weighted_spherical_harmonics)).
+ * - libsharp deals only with the transformation of real values, so
+ *   transformation of complex values must be done for real and imaginary parts
+ *   separately.
+ * - due to only transforming real components, it stores only the positive
+ *   \f$m\f$ modes (as the rest would be redundant). Therefore, the negative
+ *   \f$m\f$ modes must be inferred from conjugation and further sign changes.
+ * - libsharp only has the capability of transforming positive spin weighted
+ *   quantities. Therefore, additional steps are taken (involving further
+ *   conjugation of the provided data) in order to use those utilities on
+ *   negative spin-weighted quantities. The resulting modes have yet more sign
+ *   changes that must be taken into account.
+ *
+ * The decomposition resulting from the libsharp transform for spin \f$s\f$ and
+ * complex spin-weighted \f${}_s f\f$ can be represented mathematically as:
+ *
+ * \f{align*}{
+ * {}_s f(\theta, \phi) = \sum_{\ell = 0}^{\ell_\mathrm{max}} \Bigg\{&
+ * \left(\sum_{m = 0}^{\ell} a^\mathrm{sharp, real}_{l m} {}_s Y_{\ell
+ * m}^\mathrm{sharp, real}\right) + \left(\sum_{m=1}^{\ell}
+ * \left(a^\mathrm{sharp, real}_{l m}{}\right)^*
+ * {}_s Y_{\ell -m}^\mathrm{sharp, real}\right) \notag\\
+ * &+ i \left[\left(\sum_{m = 0}^{\ell} a^\mathrm{sharp, imag}_{l m} {}_s
+ * Y_{\ell m}^\mathrm{sharp, imag}\right) + \left(\sum_{m=1}^{\ell}
+ * \left(a^\mathrm{sharp, imag}_{l m}{}\right)^* {}_s Y_{\ell -m}^\mathrm{sharp,
+ * imag} \right)\right] \Bigg\},
+ * \f}
+ *
+ * where
+ *
+ * \f{align*}{
+ * {}_s Y_{\ell m}^\mathrm{sharp, real} &=
+ * \begin{cases}
+ * (-1)^{s + 1} {}_s Y_{\ell m}, & \mathrm{for}\; s < 0, m \ge 0 \\
+ * {}_s Y_{\ell m}, & \mathrm{for}\; s = 0, m \ge 0 \\
+ * - {}_s Y_{\ell m}, & \mathrm{for}\; s > 0, m \ge 0 \\
+ * (-1)^{s + m + 1} {}_s Y_{\ell m}, & \mathrm{for}\; s < 0, m < 0 \\
+ * (-1)^{m} {}_s Y_{\ell m}, & \mathrm{for}\; s = 0, m < 0 \\
+ * (-1)^{m + 1} {}_s Y_{\ell m}, & \mathrm{for}\; s > 0, m < 0
+ * \end{cases} \\
+ * &\equiv {}_s S_{\ell m}^{\mathrm{real}} {}_s Y_{\ell m}\\
+ * {}_s Y_{\ell m}^\mathrm{sharp, imag} &=
+ * \begin{cases}
+ * (-1)^{s + 1} {}_s Y_{\ell m}, & \mathrm{for}\; s < 0, m \ge 0 \\
+ * -{}_s Y_{\ell m}, & \mathrm{for}\; s = 0, m \ge 0 \\
+ * {}_s Y_{\ell m}, & \mathrm{for}\; s > 0, m \ge 0 \\
+ * (-1)^{s + m} {}_s Y_{\ell m}, & \mathrm{for}\; s < 0, m < 0 \\
+ * (-1)^{m} {}_s Y_{\ell m}, & \mathrm{for}\; s = 0, m < 0 \\
+ * (-1)^{m + 1} {}_s Y_{\ell m}, & \mathrm{for}\; s > 0, m < 0
+ * \end{cases} \\
+ * &\equiv {}_s S_{\ell m}^{\mathrm{real}} {}_s Y_{\ell m},
+ * \f}
+ *
+ * where the unadorned \f${}_s Y_{\ell m}\f$ on the right-hand-sides follow the
+ * (older) convention of \cite Goldberg1966uu. Note the phase in these
+ * expressions is not completely standardized, so should be checked carefully
+ * whenever coefficient data is directly manipulated.
+ *
+ * For reference, we can compute the relation between Goldberg spin-weighted
+ * moments \f${}_s f_{\ell m}\f$, defined as
+ *
+ * \f[ {}_s f(\theta, \phi) = \sum_{\ell = 0}^{\ell_\mathrm{max}} \sum_{m =
+ * -\ell}^{\ell} {}_s f_{\ell m} {}_s Y_{\ell m}
+ * \f]
+ *
+ * so,
+ * \f[
+ * {}_s f_{\ell m} =
+ * \begin{cases}
+ * a_{\ell m}^{\mathrm{sharp}, \mathrm{real}}  {}_s S_{\ell m}^{\mathrm{real}} +
+ * a_{\ell m}^{\mathrm{sharp}, \mathrm{imag}}  {}_s S_{\ell m}^{\mathrm{imag}} &
+ * \mathrm{for} \; m \ge 0 \\
+ * \left(a_{\ell -m}^{\mathrm{sharp}, \mathrm{real}}\right)^* {}_s S_{\ell
+ * m}^{\mathrm{real}} + \left(a_{\ell -m}^{\mathrm{sharp},
+ * \mathrm{imag}}\right)^* {}_s S_{\ell m}^{\mathrm{imag}} &
+ * \mathrm{for} \; m < 0 \\
+ * \end{cases} \f]
+ *
+ *
+ * The resulting coefficients \f$a_{\ell m}\f$ are stored in a triangular,
+ * \f$\ell\f$-varies-fastest configuration. So, for instance, the first
+ * \f$\ell_\mathrm{max}\f$ entries contain the coefficients for \f$m=0\f$ and
+ * all \f$\ell\f$s, and the next \f$\ell_\mathrm{max} - 1\f$ entries contain the
+ * coefficients for \f$m=1\f$ and \f$1 \le \ell \le \ell_\mathrm{max} \f$, and
+ * so on.
+ */
+template <int Spin, ComplexRepresentation Representation, typename TagList>
+class TransformJob {
+ public:
+  static_assert(cpp17::is_same_v<get_tags_with_spin<Spin, TagList>, TagList>,
+                "All Tags in TagList submitted to TransformJob must have the "
+                "same spin weight as the TransformJob Spin template parameter");
+  using CoefficientTagList = db::wrap_tags_in<Tags::SwshTransform, TagList>;
+  static constexpr int spin = Spin;
+
+  /// \brief Constructor for transform job. Both the `l_max` and
+  /// `number_of_radial_grid_points` must be specified for the transformation to
+  /// appropriately find all of the data in memory and associate it with the
+  /// correct collocation grid.
+  TransformJob(size_t l_max, size_t number_of_radial_grid_points) noexcept;
+
+  /// \brief Helper function for determining the size of allocation necessary to
+  /// store the coefficient data.
+  ///
+  /// \note This size is not the same as the collocation data size, as the
+  /// coefficients are stored in the efficient 'triangular' form noted in the
+  /// documentation for `TransformJob`.
+  constexpr size_t coefficient_output_size() const noexcept {
+    return number_of_swsh_coefficients(l_max_) * number_of_radial_grid_points_;
+  }
+
+  /// \brief Execute the forward spin-weighted spherical harmonic transform
+  /// using libsharp.
+  ///
+  /// \param output A `Variables` which must contain `CoefficientTag<...>`s
+  /// for each of the tags provided via `TagList`. The coefficients will be
+  /// stored appropriately in this Variables.
+  /// \param input A `Variables` which must contain each of the tags provided
+  /// via `TagList`. The collocation points may be temporarily altered
+  /// (conjugated) during the execution of the transform if the `Spin` is
+  /// negative, but are reverted to their original state by the end of the
+  /// function execution.
+  template <typename InputVarsTagList, typename OutputVarsTagList>
+  void execute_transform(
+      gsl::not_null<Variables<OutputVarsTagList>*> output,
+      gsl::not_null<Variables<InputVarsTagList>*> input) const noexcept;
+
+  /// \brief Execute the inverse spin-weighted spherical harmonic transform
+  /// using libsharp.
+  ///
+  /// \param input A `Variables` which must contain `CoefficientTag<...>`s
+  /// for each of the tags provided via `TagList`. The coefficients may be
+  /// temporarily altered (conjugated) during the execution of the transform if
+  /// the `Spin` is negative, but are reverted to their original state by the
+  /// end of the function execution.
+  /// \param output A `Variables` which must contain each of the tags provided
+  /// via `TagList`. The collocation data will be stored appropriately in this
+  /// Variables.
+  template <typename InputVarsTagList, typename OutputVarsTagList>
+  void execute_inverse_transform(
+      gsl::not_null<Variables<OutputVarsTagList>*> output,
+      gsl::not_null<Variables<InputVarsTagList>*> input) const noexcept;
+
+ private:
+  size_t number_of_radial_grid_points_;
+  size_t l_max_;
+  sharp_alm_info* alm_info_;
+  const Collocation<Representation>* collocation_metadata_;
+};
+
+template <int Spin, ComplexRepresentation Representation, typename TagList>
+TransformJob<Spin, Representation, TagList>::TransformJob(
+    const size_t l_max, const size_t number_of_radial_grid_points) noexcept
+    : number_of_radial_grid_points_{number_of_radial_grid_points},
+      l_max_{l_max},
+      collocation_metadata_{&precomputed_collocation<Representation>(l_max_)} {
+  alm_info_ = detail::precomputed_coefficients(l_max_).get_sharp_alm_info();
+}
+
+template <int Spin, ComplexRepresentation Representation, typename TagList>
+template <typename InputVarsTagList, typename OutputVarsTagList>
+void TransformJob<Spin, Representation, TagList>::execute_transform(
+    const gsl::not_null<Variables<OutputVarsTagList>*> output,
+    const gsl::not_null<Variables<InputVarsTagList>*> input) const noexcept {
+  // assemble a list of pointers into the collocation point data. This is
+  // required because libsharp expects pointers to pointers.
+  std::vector<detail::ComplexDataView<Representation>> pre_transform_views;
+  pre_transform_views.reserve(number_of_radial_grid_points_ *
+                              tmpl::size<TagList>::value);
+  std::vector<const double*> pre_transform_collocation_data;
+  pre_transform_collocation_data.reserve(2 * number_of_radial_grid_points_ *
+                                         tmpl::size<TagList>::value);
+
+  // for each Tag and each slice block in the radial direction, construct a
+  // ComplexDataView at the appropriate locations, then retrieve its real
+  // and imaginary data and put it in subsequent slots in the
+  // pre_transform_collocation_data.
+  size_t num_transforms = 0;
+  tmpl::for_each<TagList>([
+    &pre_transform_collocation_data, &pre_transform_views, &num_transforms,
+    &input, this
+  ](auto x) noexcept {
+    using transform_var_tag = typename decltype(x)::type;
+    decltype(auto) input_vector = get(get<transform_var_tag>(*input)).data();
+    for (size_t i = 0; i < number_of_radial_grid_points_; ++i) {
+      pre_transform_views.push_back(detail::ComplexDataView<Representation>{
+          make_not_null(&input_vector), collocation_metadata_->size(),
+          i * collocation_metadata_->size()});
+      pre_transform_collocation_data.push_back(
+          pre_transform_views.back().real_data());
+      // alteration needed because libsharp doesn't support negative spins
+      if (spin < 0) {
+        pre_transform_views.back().conjugate();
+      }
+      pre_transform_collocation_data.push_back(
+          pre_transform_views.back().imag_data());
+      // libsharp considers two arrays per transform when spin is not zero.
+      num_transforms += (spin == 0 ? 2 : 1);
+    }
+  });
+
+  std::vector<std::complex<double>*> post_transform_coefficient_data;
+  post_transform_coefficient_data.reserve(2 * number_of_radial_grid_points_ *
+                                          tmpl::size<TagList>::value);
+
+  // assemble list of locations in the output Variables for the destinations
+  // of the coefficient data
+  tmpl::for_each<CoefficientTagList>([
+    &post_transform_coefficient_data, &output, this
+  ](auto x) noexcept {
+    using coefficient_var_tag = typename decltype(x)::type;
+    decltype(auto) output_vector =
+        get(get<coefficient_var_tag>(*output)).data();
+    for (size_t i = 0; i < number_of_radial_grid_points_; ++i) {
+      // coefficients associated with the real part
+      post_transform_coefficient_data.push_back(
+          output_vector.data() + 2 * i * number_of_swsh_coefficients(l_max_));
+      // coefficients associated with the imaginary part
+      post_transform_coefficient_data.push_back(
+          output_vector.data() +
+          (2 * i + 1) * number_of_swsh_coefficients(l_max_));
+    }
+  });
+
+  sharp_execute(SHARP_MAP2ALM, abs(spin),
+                post_transform_coefficient_data.data(),
+                pre_transform_collocation_data.data(),
+                collocation_metadata_->get_sharp_geom_info(), alm_info_,
+                num_transforms, SHARP_DP, nullptr, nullptr);
+
+  // libsharp only has the ability to transform positive spins, so we have to
+  // perform conjugation to deal with negative spins.
+  if (spin < 0) {
+    // fix the conjugation performed prior to transformation.
+    for (auto& view : pre_transform_views) {
+      view.conjugate();
+    }
+  }
+}
+
+template <int Spin, ComplexRepresentation Representation, typename TagList>
+template <typename InputVarsTagList, typename OutputVarsTagList>
+void TransformJob<Spin, Representation, TagList>::execute_inverse_transform(
+    const gsl::not_null<Variables<OutputVarsTagList>*> output,
+    const gsl::not_null<Variables<InputVarsTagList>*> input) const noexcept {
+  std::vector<std::complex<double>*> pre_transform_coefficient_data;
+  pre_transform_coefficient_data.reserve(2 * number_of_radial_grid_points_ *
+                                         tmpl::size<CoefficientTagList>::value);
+  // assemble list of locations in the input Variables for the locations
+  // of the coefficient data
+  tmpl::for_each<CoefficientTagList>([&pre_transform_coefficient_data, &input,
+                                      this](auto x) {
+    using coefficient_var_tag = typename decltype(x)::type;
+    decltype(auto) input_vector = get(get<coefficient_var_tag>(*input)).data();
+    for (size_t i = 0; i < number_of_radial_grid_points_; ++i) {
+      pre_transform_coefficient_data.push_back(
+          input_vector.data() + 2 * i * number_of_swsh_coefficients(l_max_));
+      pre_transform_coefficient_data.push_back(
+          input_vector.data() +
+          (2 * i + 1) * number_of_swsh_coefficients(l_max_));
+    }
+  });
+
+  std::vector<detail::ComplexDataView<Representation>> post_transform_views;
+  post_transform_views.reserve(number_of_radial_grid_points_ *
+                               tmpl::size<TagList>::value);
+  std::vector<const double*> post_transform_collocation_data;
+  post_transform_collocation_data.reserve(2 * number_of_radial_grid_points_ *
+                                          tmpl::size<TagList>::value);
+
+  // for each tag in `TagList`, construct a ComplexDataView at the
+  // appropriate locations, then retrieve its real and imaginary data and put
+  // it in subsequent slots in the pre_transform_collocation_data
+  size_t num_transforms = 0;
+  tmpl::for_each<TagList>([&post_transform_collocation_data, &num_transforms,
+                           &post_transform_views, &output, this](auto x) {
+    using transform_var_tag = typename decltype(x)::type;
+    decltype(auto) output_vector = get(get<transform_var_tag>(*output)).data();
+    for (size_t i = 0; i < number_of_radial_grid_points_; ++i) {
+      post_transform_views.push_back(detail::ComplexDataView<Representation>{
+          make_not_null(&output_vector), collocation_metadata_->size(),
+          i * collocation_metadata_->size()});
+      post_transform_collocation_data.push_back(
+          post_transform_views.back().real_data());
+      post_transform_collocation_data.push_back(
+          post_transform_views.back().imag_data());
+      // libsharp considers two arrays per transform when spin is not zero.
+      num_transforms += (spin == 0 ? 2 : 1);
+    }
+  });
+
+  sharp_execute(SHARP_ALM2MAP, abs(spin), pre_transform_coefficient_data.data(),
+                post_transform_collocation_data.data(),
+                collocation_metadata_->get_sharp_geom_info(), alm_info_,
+                num_transforms, SHARP_DP, nullptr, nullptr);
+
+  if (spin < 0) {
+    // the conjugate is needed because libsharp doesn't handle negative spins.
+    for (auto& view : post_transform_views) {
+      view.conjugate();
+    }
+  }
+
+  // The inverse transformed collocation data has just been placed in the
+  // memory blocks controlled by the `ComplexDataView`s. Finally, that data
+  // must be flushed back to the Variables.
+  for (auto& view : post_transform_views) {
+    view.copy_back_to_source();
+  }
+}
+
+namespace detail {
+template <typename Job>
+struct transform_job_is_not_empty : std::true_type {};
+
+template <int Spin, ComplexRepresentation Representation>
+struct transform_job_is_not_empty<
+    TransformJob<Spin, Representation, tmpl::list<>>> : std::false_type {};
+
+template <int MinSpin, ComplexRepresentation Representation, typename TagList,
+          typename IndexSequence>
+struct make_swsh_transform_job_list_impl;
+
+template <int MinSpin, ComplexRepresentation Representation, typename TagList,
+          int... Is>
+struct make_swsh_transform_job_list_impl<MinSpin, Representation, TagList,
+                                         std::integer_sequence<int, Is...>> {
+  using type = tmpl::filter<
+      tmpl::list<TransformJob<Is + MinSpin, Representation,
+                              get_tags_with_spin<Is + MinSpin, TagList>>...>,
+      transform_job_is_not_empty<tmpl::_1>>;
+};
+}  // namespace detail
+
+/// \ingroup SpectralGroup
+/// \brief Assemble a `tmpl::list` of `TransformJob` given a list of tags
+/// `TagList` that need to be transformed. The `Representation` is the
+/// `ComplexRepresentation` to use for the transformations.
+///
+/// \details Up to five `TransformJob` will be returned, corresponding to
+/// the possible spin values. Any number of transformations are aggregated into
+/// that set of `TransformJob`s. The number of transforms is up to five because
+/// the libsharp utility only has capability to perform spin-weighted spherical
+/// harmonic transforms for integer spin-weights from -2 to 2.
+///
+/// \snippet Test_SwshTransformJob.cpp make_swsh_transform_job_list
+template <ComplexRepresentation Representation, typename TagList>
+using make_swsh_transform_job_list =
+    typename detail::make_swsh_transform_job_list_impl<
+        -2, Representation, TagList,
+        decltype(std::make_integer_sequence<int, 5>{})>::type;
+
+/// \ingroup SpectralGroup
+/// \brief Assemble a `tmpl::list` of `TransformJob`s given a list of
+/// `Derivative<Tag, Derivative>` that need to be computed. The
+/// `TransformJob`s constructed by this type alias correspond to the
+/// `Tag`s in the list.
+///
+/// \details This is intended as a convenience utility for the first step of a
+/// derivative routine, where one transforms the set of fields for which
+/// derivatives are required.
+///
+/// \snippet Test_SwshTransformJob.cpp make_swsh_transform_from_derivative_tags
+template <ComplexRepresentation Representation, typename DerivativeTagList>
+using make_swsh_transform_job_list_from_derivative_tags =
+    typename detail::make_swsh_transform_job_list_impl<
+        -2, Representation,
+        tmpl::transform<DerivativeTagList,
+                        tmpl::bind<db::remove_tag_prefix, tmpl::_1>>,
+        decltype(std::make_integer_sequence<int, 5>{})>::type;
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBRARY_SOURCES
   Test_SwshCollocation.cpp
   Test_SwshTags.cpp
   Test_SwshTestHelpers.cpp
+  Test_SwshTransformJob.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_Spectral")
 
 set(LIBRARY_SOURCES
+  SwshTestHelpers.cpp
   Test_ChebyshevGauss.cpp
   Test_ChebyshevGaussLobatto.cpp
   Test_ComplexDataView.cpp
@@ -15,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_SwshCoefficients.cpp
   Test_SwshCollocation.cpp
   Test_SwshTags.cpp
+  Test_SwshTestHelpers.cpp
   )
 
 add_test_library(

--- a/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.cpp
@@ -1,0 +1,115 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
+
+#include <boost/math/special_functions/binomial.hpp>
+#include <cmath>
+#include <complex>
+
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"  // IWYU pragma: keep
+
+namespace Spectral {
+namespace Swsh {
+namespace TestHelpers {
+
+double factorial(const size_t arg) noexcept {
+  if (arg <= 1) {
+    return 1.0;
+  }
+  double factorial_result = 1.0;
+  for (size_t product_term = 1; product_term <= arg; ++product_term) {
+    factorial_result *= static_cast<double>(product_term);
+  }
+  return factorial_result;
+}
+
+std::complex<double> spin_weighted_spherical_harmonic(
+    const int s, const int l, const int m, const double theta,
+    const double phi) noexcept {
+  if (l + s < 0 or l - s < 0) {
+    return 0.0;
+  }
+  std::complex<double> swshval = 0.0;
+  for (int r = 0; r <= l - s; ++r) {
+    if (r + s - m >= 0 and l - r + m >= 0) {
+      swshval +=
+          boost::math::binomial_coefficient<double>(
+              static_cast<unsigned>(l - s), static_cast<unsigned>(r)) *
+          boost::math::binomial_coefficient<double>(
+              static_cast<unsigned>(l + s), static_cast<unsigned>(r + s - m)) *
+          ((l - r - s) % 2 == 0 ? 1.0 : -1.0) *
+          pow(cos(theta / 2.0) / sin(theta / 2.0), 2.0 * r + s - m);
+    }
+  }
+  swshval *= (m % 2 == 0 ? 1.0 : -1.0) *
+             sqrt(factorial(static_cast<size_t>(l) + static_cast<size_t>(m)) *
+                  factorial(static_cast<size_t>(l - m)) * (2.0 * l + 1) /
+                  (4.0 * M_PI *
+                   factorial(static_cast<size_t>(l) + static_cast<size_t>(s)) *
+                   factorial(static_cast<size_t>(l - s)))) *
+             (std::complex<double>(cos(m * phi), sin(m * phi))) *
+             pow(sin(theta / 2.0), 2.0 * l);
+  return swshval;
+}
+
+template <>
+std::complex<double> derivative_of_spin_weighted_spherical_harmonic<Tags::Eth>(
+    const int s, const int l, const int m, const double theta,
+    const double phi) noexcept {
+  return sqrt(static_cast<std::complex<double>>((l - s) * (l + s + 1))) *
+         spin_weighted_spherical_harmonic(s + 1, l, m, theta, phi);
+}
+
+template <>
+std::complex<double>
+derivative_of_spin_weighted_spherical_harmonic<Tags::Ethbar>(
+    const int s, const int l, const int m, const double theta,
+    const double phi) noexcept {
+  return -sqrt(static_cast<std::complex<double>>((l + s) * (l - s + 1))) *
+         spin_weighted_spherical_harmonic(s - 1, l, m, theta, phi);
+}
+
+template <>
+std::complex<double>
+derivative_of_spin_weighted_spherical_harmonic<Tags::EthEth>(
+    const int s, const int l, const int m, const double theta,
+    const double phi) noexcept {
+  return sqrt(static_cast<std::complex<double>>((l - s) * (l + s + 1))) *
+         derivative_of_spin_weighted_spherical_harmonic<Tags::Eth>(s + 1, l, m,
+                                                                   theta, phi);
+}
+
+template <>
+std::complex<double>
+derivative_of_spin_weighted_spherical_harmonic<Tags::EthbarEth>(
+    const int s, const int l, const int m, const double theta,
+    const double phi) noexcept {
+  return -sqrt(static_cast<std::complex<double>>((l + s) * (l - s + 1))) *
+         derivative_of_spin_weighted_spherical_harmonic<Tags::Eth>(s - 1, l, m,
+                                                                   theta, phi);
+}
+
+template <>
+std::complex<double>
+derivative_of_spin_weighted_spherical_harmonic<Tags::EthEthbar>(
+    const int s, const int l, const int m, const double theta,
+    const double phi) noexcept {
+  return sqrt(static_cast<std::complex<double>>((l - s) * (l + s + 1))) *
+         derivative_of_spin_weighted_spherical_harmonic<Tags::Ethbar>(
+             s + 1, l, m, theta, phi);
+}
+
+template <>
+std::complex<double>
+derivative_of_spin_weighted_spherical_harmonic<Tags::EthbarEthbar>(
+    const int s, const int l, const int m, const double theta,
+    const double phi) noexcept {
+  return -sqrt(static_cast<std::complex<double>>((l + s) * (l - s + 1))) *
+         derivative_of_spin_weighted_spherical_harmonic<Tags::Ethbar>(
+             s - 1, l, m, theta, phi);
+}
+
+}  // namespace TestHelpers
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp
@@ -1,0 +1,45 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"  // IWYU pragma: keep
+
+namespace Spectral {
+namespace Swsh {
+namespace TestHelpers {
+
+// returns the factorial of the argument as a double so that an approximate
+// value can be given for larger input quantities. Note that the spin-weighted
+// harmonic function requires a factorial of l + m, so harmonics above l~12
+// would be untestable if the factorial only returned size_t's.
+double factorial(size_t arg) noexcept;
+
+// Note that the methods for computing the spin-weighted spherical harmonics and
+// their derivatives below are both 1) poorly optimized (they use many
+// computations per grid point evaluated) and 2) not terribly accurate (the
+// analytic expressions require evaluation of ratios of factorials, losing
+// numerical precision rapidly). However, they are comparatively easy to
+// manually check for correctness, which is critical to offer a reliable measure
+// of the spin-weighted transforms.
+
+// Analytic form for the spin-weighted spherical harmonic function, for testing
+// purposes. The formula is from [Goldberg
+// et. al.](https://aip.scitation.org/doi/10.1063/1.1705135)
+std::complex<double> spin_weighted_spherical_harmonic(int s, int l, int m,
+                                                      double theta,
+                                                      double phi) noexcept;
+
+// Returns the value of the spin-weighted derivative `DerivativeKind` of the
+// spherical harmonic basis function \f${}_s Y_{l m}\f$ at angular location
+// (`theta`, `phi`) using the recurrence identities for spin-weighted
+// derivatives.
+template <typename DerivativeKind>
+std::complex<double> derivative_of_spin_weighted_spherical_harmonic(
+    int s, int l, int m, double theta, double phi) noexcept;
+}  // namespace TestHelpers
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp
@@ -3,10 +3,23 @@
 
 #pragma once
 
+#include <cmath>
 #include <complex>
 #include <cstddef>
+#include <sharp_cxx.h>
 
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
 #include "NumericalAlgorithms/Spectral/SwshTags.hpp"  // IWYU pragma: keep
+#include "Utilities/Gsl.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+/// \cond
+class ComplexDataVector;
+/// \endcond
 
 namespace Spectral {
 namespace Swsh {
@@ -40,6 +53,134 @@ std::complex<double> spin_weighted_spherical_harmonic(int s, int l, int m,
 template <typename DerivativeKind>
 std::complex<double> derivative_of_spin_weighted_spherical_harmonic(
     int s, int l, int m, double theta, double phi) noexcept;
+
+// Performs the generation of spin-weighted coefficients into a supplied
+// ComplexModalVector `to_fill`, passed by pointer. The resulting random
+// coefficients must then be adjusted in two ways:
+// - The modes l < |s| are always zero, so must have zero coefficient to be
+//   compatible with tests
+// - Modes with m=0 obey reality conditions, so must also be adjusted
+// The libsharp coefficient representation is not currently presented as an
+// interface in SpECTRE. However, to help maintain the Swsh library, further
+// notes on the coefficient representation can be found in the comments for the
+// `Coefficients` class in `SwshCoefficients.hpp`.
+template <int Spin, typename Distribution, typename Generator>
+void generate_swsh_modes(const gsl::not_null<ComplexModalVector*> to_fill,
+                         const gsl::not_null<Generator*> generator,
+                         const gsl::not_null<Distribution*> distribution,
+                         const size_t number_of_radial_points,
+                         const size_t l_max) noexcept {
+  fill_with_random_values(to_fill, generator, distribution);
+
+  auto spherical_harmonic_lm =
+      detail::precomputed_coefficients(l_max).get_sharp_alm_info();
+  for (size_t i = 0; i < number_of_radial_points; i++) {
+    // adjust the m = 0 modes for the reality conditions in libsharp
+    for (size_t l = 0; l < l_max + 1; l++) {
+      (*to_fill)[l + 2 * i * number_of_swsh_coefficients(l_max)] =
+          real((*to_fill)[l + i * number_of_swsh_coefficients(l_max)]);
+      (*to_fill)[l + (2 * i + 1) * number_of_swsh_coefficients(l_max)] = imag(
+          (*to_fill)[l + (2 * i + 1) * number_of_swsh_coefficients(l_max)]);
+    }
+    for (size_t m = 0; m < static_cast<size_t>(spherical_harmonic_lm->nm);
+         ++m) {
+      for (size_t l = m; l <= l_max; ++l) {
+        // clang-tidy do not use pointer arithmetic
+        // pointer arithmetic here is unavoidable as we are interacting with
+        // the libsharp structures
+        const auto m_start =
+            static_cast<size_t>(spherical_harmonic_lm->mvstart[m]);  // NOLINT
+        const auto l_stride =
+            static_cast<size_t>(spherical_harmonic_lm->stride);
+        // modes for l < |s| are zero
+        if (static_cast<int>(l) < abs(Spin)) {
+          (*to_fill)[m_start + l * l_stride +
+                     2 * i * number_of_swsh_coefficients(l_max)] = 0.0;
+          (*to_fill)[m_start + l * l_stride +
+                     (2 * i + 1) * number_of_swsh_coefficients(l_max)] = 0.0;
+        }
+      }
+    }
+  }
+}
+
+// Computes a set of collocation points from a set of spin-weighted spherical
+// harmonic coefficients. This function takes care of the nastiness associated
+// with appropriately iterating over the sharp representation of coefficients
+// and storing the result computed from the input `basis_function` evaluated
+// with arguments (size_t s, size_t l, size_t m, double theta, double phi),
+// which is compatible with the above `spin_weighted_spherical_harmonic`
+// and `derivative_of_spin_weighted_spherical_harmonic` functions.
+// This function does not have easy test verification, but acts as an
+// independent computation of the spherical harmonic collocation values, so the
+// agreement (from `Test_SwshTransformJob.cpp`) with the libsharp transform
+// lends credibility to both methods.
+template <int Spin, ComplexRepresentation Representation,
+          typename BasisFunction>
+void swsh_collocation_from_coefficients_and_basis_func(
+    const gsl::not_null<ComplexDataVector*> collocation_data,
+    const gsl::not_null<ComplexModalVector*> coefficient_data,
+    const size_t l_max, const size_t number_of_radial_points,
+    const BasisFunction basis_function) noexcept {
+  auto& spherical_harmonic_collocation =
+      precomputed_collocation<Representation>(l_max);
+  auto spherical_harmonic_lm =
+      detail::precomputed_coefficients(l_max).get_sharp_alm_info();
+
+  for (size_t i = 0; i < number_of_radial_points; ++i) {
+    for (auto j : spherical_harmonic_collocation) {
+      for (size_t m = 0; m < static_cast<size_t>(spherical_harmonic_lm->nm);
+           ++m) {
+        for (size_t l = m; l <= l_max; ++l) {
+          // clang-tidy do not use pointer arithmetic
+          // pointer arithmetic here is unavoidable as we are interacting with
+          // the libsharp structures
+          const auto m_start =
+              static_cast<size_t>(spherical_harmonic_lm->mvstart[m]);  // NOLINT
+          const auto l_stride =
+              static_cast<size_t>(spherical_harmonic_lm->stride);
+          // see the documentation associated with Swsh::TransformJob in
+          // SwshTransformJob.hpp for a detailed explanation of the libsharp
+          // collocation representation, and why there must be four steps with
+          // sign transformations.
+          (*collocation_data)[j.offset +
+                              i * spherical_harmonic_collocation.size()] +=
+              sharp_swsh_sign(Spin, m, true) *
+              (*coefficient_data)[m_start + l * l_stride +
+                                  2 * i * number_of_swsh_coefficients(l_max)] *
+              basis_function(Spin, l, m, j.theta, j.phi);
+
+          if (m != 0) {
+            (*collocation_data)[j.offset +
+                                i * spherical_harmonic_collocation.size()] +=
+                sharp_swsh_sign(Spin, -m, true) *
+                conj((*coefficient_data)
+                         [m_start + l * l_stride +
+                          2 * i * number_of_swsh_coefficients(l_max)]) *
+                basis_function(Spin, l, -m, j.theta, j.phi);
+          }
+          (*collocation_data)[j.offset +
+                              i * spherical_harmonic_collocation.size()] +=
+              sharp_swsh_sign(Spin, m, false) * std::complex<double>(0.0, 1.0) *
+              (*coefficient_data)[m_start + l * l_stride +
+                                  (2 * i + 1) *
+                                      number_of_swsh_coefficients(l_max)] *
+              basis_function(Spin, l, m, j.theta, j.phi);
+          if (m != 0) {
+            (*collocation_data)[j.offset +
+                                i * spherical_harmonic_collocation.size()] +=
+                sharp_swsh_sign(Spin, -m, false) *
+                std::complex<double>(0.0, 1.0) *
+                conj((*coefficient_data)
+                         [m_start + l * l_stride +
+                          (2 * i + 1) * number_of_swsh_coefficients(l_max)]) *
+                basis_function(Spin, l, -m, j.theta, j.phi);
+          }
+        }
+      }
+    }
+  }
+}
 }  // namespace TestHelpers
 }  // namespace Swsh
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshCollocation.cpp
@@ -28,19 +28,19 @@ void test_spherical_harmonic_collocation() noexcept {
   const size_t l_max = sdist(gen);
 
   CAPTURE(l_max);
-  const Collocation<Representation>& precomputed_collocation =
-      precomputed_spherical_harmonic_collocation<Representation>(l_max);
+  const Collocation<Representation>& precomputed_collocation_value =
+      precomputed_collocation<Representation>(l_max);
 
   const Collocation<Representation>& another_precomputed_collocation =
-      precomputed_spherical_harmonic_collocation<Representation>(l_max);
+      precomputed_collocation<Representation>(l_max);
 
   // checks that the same pointer is in both
-  CHECK(precomputed_collocation.get_sharp_geom_info() ==
+  CHECK(precomputed_collocation_value.get_sharp_geom_info() ==
         another_precomputed_collocation.get_sharp_geom_info());
 
   const Collocation<Representation> computed_collocation{l_max};
 
-  CHECK(precomputed_collocation.l_max() == l_max);
+  CHECK(precomputed_collocation_value.l_max() == l_max);
   CHECK(computed_collocation.l_max() == l_max);
 
   const int expected_stride = detail::ComplexDataView<Representation>::stride();
@@ -53,11 +53,11 @@ void test_spherical_harmonic_collocation() noexcept {
 
   // clang-tidy doesn't like the pointer manipulation needed to work with the
   // libsharp types.
-  CHECK(precomputed_collocation  // NOLINT
+  CHECK(precomputed_collocation_value  // NOLINT
             .get_sharp_geom_info()
             ->pair[0]
             .r1.stride == expected_stride);  // NOLINT
-  CHECK(precomputed_collocation              // NOLINT
+  CHECK(precomputed_collocation_value        // NOLINT
             .get_sharp_geom_info()
             ->pair[0]
             .r2.stride == expected_stride);  // NOLINT
@@ -76,10 +76,13 @@ void test_spherical_harmonic_collocation() noexcept {
 
   // check iterator equivalence. The for loop below is also a check of the
   // iterator functionality.
-  CHECK(precomputed_collocation.begin() == precomputed_collocation.cbegin());
-  CHECK(precomputed_collocation.end() == precomputed_collocation.cend());
-  CHECK(precomputed_collocation.begin() != precomputed_collocation.end());
-  for (const auto& collocation_point : precomputed_collocation) {
+  CHECK(precomputed_collocation_value.begin() ==
+        precomputed_collocation_value.cbegin());
+  CHECK(precomputed_collocation_value.end() ==
+        precomputed_collocation_value.cend());
+  CHECK(precomputed_collocation_value.begin() !=
+        precomputed_collocation_value.end());
+  for (const auto& collocation_point : precomputed_collocation_value) {
     CHECK(collocation_point.offset == offset_counter);
     CHECK(collocation_point.theta ==
           computed_collocation.theta(offset_counter));
@@ -139,8 +142,8 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshCollocation",
     "Unit.NumericalAlgorithms.Spectral.SwshCollocation.PrecomputationOverrun",
     "[Unit][NumericalAlgorithms]") {
   ERROR_TEST();
-  precomputed_spherical_harmonic_collocation<
-      ComplexRepresentation::RealsThenImags>(collocation_maximum_l_max + 1);
+  precomputed_collocation<ComplexRepresentation::RealsThenImags>(
+      collocation_maximum_l_max + 1);
   ERROR("Failed to trigger ERROR in an error test");
 }
 }  // namespace

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTestHelpers.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTestHelpers.cpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <random>
+
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Math.hpp"
+#include "tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+namespace Spectral {
+namespace Swsh {
+namespace TestHelpers {
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.SwshTestHelpers",
+                  "[Unit][NumericalAlgorithms]") {
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<double> theta_dist{-M_PI / 2.0, M_PI / 2.0};
+  UniformCustomDistribution<double> phi_dist{0, 2.0 * M_PI};
+  UniformCustomDistribution<size_t> factorial_dist{0, 20};
+
+  size_t test_factorial_value = factorial_dist(gen);
+  CHECK(approx(factorial(test_factorial_value)) ==
+        static_cast<double>(::factorial(test_factorial_value)));
+
+  const double theta_point = theta_dist(gen);
+  const double phi_point = phi_dist(gen);
+  const std::complex<double> expected_swsh_02m2 =
+      sqrt(15.0 / (32.0 * M_PI)) * sin(theta_point) * sin(theta_point) *
+      (std::complex<double>(cos(-2.0 * phi_point), sin(-2.0 * phi_point)));
+
+  const std::complex<double> expected_swsh_110 =
+      sqrt(3.0 / (8.0 * M_PI)) * sin(theta_point);
+
+  const std::complex<double> expected_swsh_111 =
+      -sqrt(3.0 / (16.0 * M_PI)) * (1 - cos(theta_point)) *
+      (std::complex<double>(cos(phi_point), sin(phi_point)));
+
+  CHECK(real(spin_weighted_spherical_harmonic(0, 2, -2, theta_point,
+                                              phi_point)) ==
+        approx(real(expected_swsh_02m2)));
+  CHECK(imag(spin_weighted_spherical_harmonic(0, 2, -2, theta_point,
+                                              phi_point)) ==
+        approx(imag(expected_swsh_02m2)));
+
+  CHECK(
+      real(spin_weighted_spherical_harmonic(1, 1, 0, theta_point, phi_point)) ==
+      approx(real(expected_swsh_110)));
+  CHECK(
+      imag(spin_weighted_spherical_harmonic(1, 1, 0, theta_point, phi_point)) ==
+      approx(imag(expected_swsh_110)));
+
+  CHECK(
+      real(spin_weighted_spherical_harmonic(1, 1, 1, theta_point, phi_point)) ==
+      approx(real(expected_swsh_111)));
+  CHECK(
+      imag(spin_weighted_spherical_harmonic(1, 1, 1, theta_point, phi_point)) ==
+      approx(imag(expected_swsh_111)));
+}
+}  // namespace TestHelpers
+}  // namespace Swsh
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransformJob.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_SwshTransformJob.cpp
@@ -1,0 +1,209 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <string>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"  // IWYU pragma: keep
+#include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"  // IWYU pragma: keep
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/ComplexDataView.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/Spectral/SwshCollocation.hpp"
+#include "NumericalAlgorithms/Spectral/SwshTags.hpp"  // IWYU pragma: keep
+#include "NumericalAlgorithms/Spectral/SwshTransformJob.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits.hpp"
+#include "tests/Unit/NumericalAlgorithms/Spectral/SwshTestHelpers.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+#include "tests/Utilities/MakeWithRandomValues.hpp"
+
+// IWYU pragma: no_forward_declare ComplexModalVector
+// IWYU pragma: no_forward_declare SpinWeighted
+
+namespace Spectral {
+namespace Swsh {
+namespace {
+
+// for storing a computed spin-weighted value during the transform test
+template <int Spin>
+struct TestTag : db::SimpleTag {
+  static std::string name() noexcept { return "TestTag"; }
+  using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
+};
+
+// for storing an expected spin-weighted value during the transform test
+template <int Spin>
+struct ExpectedTestTag : db::SimpleTag {
+  static std::string name() noexcept { return "ExpectedTestTag"; }
+  using type = Scalar<SpinWeighted<ComplexDataVector, Spin>>;
+};
+
+using TestDerivativeTagList =
+    tmpl::list<Tags::Derivative<TestTag<-1>, Tags::Eth>,
+               Tags::Derivative<TestTag<-1>, Tags::EthEthbar>,
+               Tags::Derivative<ExpectedTestTag<-1>, Tags::EthEthbar>,
+               Tags::Derivative<TestTag<2>, Tags::EthbarEthbar>>;
+
+/// [make_swsh_transform_job_list]
+using ExpectedInverseJobs = tmpl::list<
+    TransformJob<
+        -1, ComplexRepresentation::RealsThenImags,
+        tmpl::list<Tags::Derivative<TestTag<-1>, Tags::EthEthbar>,
+                   Tags::Derivative<ExpectedTestTag<-1>, Tags::EthEthbar>>>,
+    TransformJob<0, ComplexRepresentation::RealsThenImags,
+                 tmpl::list<Tags::Derivative<TestTag<-1>, Tags::Eth>,
+                            Tags::Derivative<TestTag<2>, Tags::EthbarEthbar>>>>;
+
+static_assert(
+    cpp17::is_same_v<
+        make_swsh_transform_job_list<ComplexRepresentation::RealsThenImags,
+                                     TestDerivativeTagList>,
+        ExpectedInverseJobs>,
+    "failed testing make_swsh_transform_job_list");
+/// [make_swsh_transform_job_list]
+
+/// [make_swsh_transform_from_derivative_tags]
+using ExpectedJobs =
+    tmpl::list<TransformJob<-1, ComplexRepresentation::Interleaved,
+                            tmpl::list<TestTag<-1>, ExpectedTestTag<-1>>>,
+               TransformJob<2, ComplexRepresentation::Interleaved,
+                            tmpl::list<TestTag<2>>>>;
+
+static_assert(
+    cpp17::is_same_v<
+        make_swsh_transform_job_list_from_derivative_tags<
+            ComplexRepresentation::Interleaved, TestDerivativeTagList>,
+        ExpectedJobs>,
+    "failed testing make_swsh_transform_job_list_from_derivative_tags");
+/// [make_swsh_transform_from_derivative_tags]
+
+static_assert(
+    cpp17::is_same_v<
+        typename tmpl::front<ExpectedInverseJobs>::CoefficientTagList,
+        tmpl::list<
+            Tags::SwshTransform<Tags::Derivative<TestTag<-1>, Tags::EthEthbar>>,
+            Tags::SwshTransform<
+                Tags::Derivative<ExpectedTestTag<-1>, Tags::EthEthbar>>>>,
+    "failed testing TransformJob");
+
+template <ComplexRepresentation Representation, int S>
+void test_transform_and_inverse_transform() noexcept {
+  // generate parameters for the points to transform
+  MAKE_GENERATOR(gen);
+  UniformCustomDistribution<size_t> sdist{2, 7};
+  const size_t l_max = sdist(gen);
+  const size_t number_of_radial_points = 2;
+  UniformCustomDistribution<double> coefficient_distribution{-10.0, 10.0};
+
+  // create the variables for the transformations
+  // The four data structures will be used as:
+  // - `generated_modes`: randomly generated
+  // - `test_collocation`: computed from analytic expressions using the
+  //                       randomly generated coefficients in `generated_modes`
+  // - `transformed_modes`: computed from test_collocation points from forward
+  //                        transform
+  // next, we test the equivalence of the coefficients in test and expected
+  // for the inverse transform test, we use:
+  // - `expected_collocation`: copied from `test_collocation`
+  // - `test_collocation`: computed from an inverse transform of the
+  //                       `transformed_modes`, overwriting the previous data
+  // Finally, we test the equivalence of the `expected_collocation` and
+  // `test_collocation`
+  Variables<tmpl::list<ExpectedTestTag<S>, TestTag<S>>> collocation_data{
+      number_of_radial_points * number_of_swsh_collocation_points(l_max), 0.0};
+  Variables<tmpl::list<Tags::SwshTransform<ExpectedTestTag<S>>,
+                       Tags::SwshTransform<TestTag<S>>>>
+      coefficient_data{
+          number_of_swsh_coefficients(l_max) * 2 * number_of_radial_points,
+          0.0};
+
+  // randomly generate the mode coefficients
+  ComplexModalVector& generated_modes =
+      get(get<Tags::SwshTransform<ExpectedTestTag<S>>>(coefficient_data))
+          .data();
+  TestHelpers::generate_swsh_modes<S>(
+      make_not_null(&generated_modes), make_not_null(&gen),
+      make_not_null(&coefficient_distribution), number_of_radial_points, l_max);
+
+  // fill the expected collocation point data by evaluating the analytic
+  // functions. This is very slow and rough (due to factorial division), but
+  // comparatively simple to formulate.
+  ComplexDataVector& test_collocation =
+      get(get<TestTag<S>>(collocation_data)).data();
+  TestHelpers::swsh_collocation_from_coefficients_and_basis_func<
+      S, Representation>(&test_collocation, &generated_modes, l_max,
+                         number_of_radial_points,
+                         TestHelpers::spin_weighted_spherical_harmonic);
+  // create the forward transformation job and execute
+  using JobTags = tmpl::list<TestTag<S>>;
+  const TransformJob<S, Representation, JobTags> job{l_max,
+                                                     number_of_radial_points};
+  const auto test_collocation_copy = test_collocation;
+  job.execute_transform(make_not_null(&coefficient_data),
+                        make_not_null(&collocation_data));
+
+  // approximation needs to be a little loose to consistently accommodate the
+  // ratios of factorials in the analytic form
+  Approx transform_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e6)
+          .scale(1.0);
+
+  // verify that the collocation points haven't been altered by the
+  // transformation
+  CHECK(test_collocation_copy == test_collocation_copy);
+
+  ComplexDataVector& expected_collocation =
+      get(get<ExpectedTestTag<S>>(collocation_data)).data();
+  expected_collocation = test_collocation;
+
+  const ComplexModalVector& transformed_modes =
+      get(get<Tags::SwshTransform<TestTag<S>>>(coefficient_data)).data();
+  CHECK_ITERABLE_CUSTOM_APPROX(transformed_modes, generated_modes,
+                               transform_approx);
+
+  // create the inverse transformation job and execute
+  using InverseJobTags = tmpl::list<TestTag<S>>;
+  const TransformJob<S, Representation, InverseJobTags> inverse_job{
+      l_max, number_of_radial_points};
+  inverse_job.execute_inverse_transform(make_not_null(&collocation_data),
+                                        make_not_null(&coefficient_data));
+
+  CHECK_ITERABLE_CUSTOM_APPROX(test_collocation, expected_collocation,
+                               transform_approx);
+}
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Transform",
+                  "[Unit][NumericalAlgorithms]") {
+  {
+    INFO("Testing with ComplexRepresentation::Interleaved");
+    test_transform_and_inverse_transform<ComplexRepresentation::Interleaved,
+                                         -2>();
+    test_transform_and_inverse_transform<ComplexRepresentation::Interleaved,
+                                         0>();
+    test_transform_and_inverse_transform<ComplexRepresentation::Interleaved,
+                                         1>();
+  }
+  {
+    INFO("Testing with ComplexRepresentation::RealsThenImags");
+    test_transform_and_inverse_transform<ComplexRepresentation::RealsThenImags,
+                                         -1>();
+    test_transform_and_inverse_transform<ComplexRepresentation::RealsThenImags,
+                                         0>();
+    test_transform_and_inverse_transform<ComplexRepresentation::RealsThenImags,
+                                         2>();
+  }
+}
+}  // namespace
+}  // namespace Swsh
+}  // namespace Spectral


### PR DESCRIPTION
## Proposed changes

Add class for handling the interface with libsharp and perform forward or inverse spin-weighted spherical harmonic transforms. This PR also contains the analytic form for the spin-weighted spherical harmonics in a test helper to verify the results of the transforms. The last two commits are new in this PR, the first is #1383.

### Types of changes:

- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Dependencies
- [x] #1383 