### PR TITLE
Add indefinite integral

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   ApplyMatrices.cpp
   CoefficientTransforms.cpp
   DefiniteIntegral.cpp
+  IndefiniteIntegral.cpp
   Linearize.cpp
   MeanValue.cpp
   )

--- a/src/NumericalAlgorithms/LinearOperators/IndefiniteIntegral.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/IndefiniteIntegral.cpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/LinearOperators/IndefiniteIntegral.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/StripeIterator.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+void indefinite_integral_impl(const gsl::not_null<DataVector*> integral,
+                              const DataVector& integrand,
+                              const Mesh<Dim>& mesh,
+                              const size_t dim) noexcept {
+  if (UNLIKELY(integral->size() != integrand.size())) {
+    *integral = DataVector(integrand.size());
+  }
+  const Mesh<1> mesh_1d{mesh.extents(dim), gsl::at(mesh.basis(), dim),
+                        gsl::at(mesh.quadrature(), dim)};
+  const size_t num_pts = mesh_1d.number_of_grid_points();
+  const Matrix& indefinite_integration_matrix =
+      Spectral::integration_matrix(mesh_1d);
+  for (StripeIterator stripe_it(mesh.extents(), dim); stripe_it; ++stripe_it) {
+    dgemv_('N', num_pts, num_pts, 1.0, indefinite_integration_matrix.data(),
+           num_pts, integrand.data() + stripe_it.offset(),  // NOLINT
+           stripe_it.stride(), 0.0,
+           integral->data() + stripe_it.offset(),  // NOLINT
+           stripe_it.stride());
+  }
+}
+}  // namespace
+
+template <size_t Dim>
+void indefinite_integral(const gsl::not_null<DataVector*> integral,
+                         const DataVector& integrand, const Mesh<Dim>& mesh,
+                         const size_t dim_to_integrate) noexcept {
+  if (UNLIKELY(integral->size() != integrand.size())) {
+    *integral = DataVector(integrand.size());
+  }
+  indefinite_integral_impl(integral, integrand, mesh, dim_to_integrate);
+}
+
+template <size_t Dim>
+DataVector indefinite_integral(const DataVector& integrand,
+                               const Mesh<Dim>& mesh,
+                               const size_t dim_to_integrate) noexcept {
+  DataVector integral{};
+  indefinite_integral(&integral, integrand, mesh, dim_to_integrate);
+  return integral;
+}
+
+#define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(r, data)             \
+  template DataVector indefinite_integral( \
+      const DataVector&, const Mesh<GET_DIM(data)>&, const size_t) noexcept;
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef GET_DIM
+#undef INSTANTIATION

--- a/src/NumericalAlgorithms/LinearOperators/IndefiniteIntegral.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/IndefiniteIntegral.hpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+class DataVector;
+template <size_t>
+class Mesh;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+// @{
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Compute the indefinite integral of a function in the
+ * `dim_to_integrate`. Applying a zero boundary condition on each stripe.
+ *
+ * \requires number of points in `integrand` and `mesh` are equal.
+ */
+template <size_t Dim>
+void indefinite_integral(gsl::not_null<DataVector*> integral,
+                         const DataVector& integrand, const Mesh<Dim>& mesh,
+                         size_t dim_to_integrate) noexcept;
+
+template <size_t Dim>
+DataVector indefinite_integral(const DataVector& integrand,
+                               const Mesh<Dim>& mesh,
+                               size_t dim_to_integrate) noexcept;
+// @}

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -25,7 +25,10 @@ namespace Spectral {
 std::ostream& operator<<(std::ostream& os,
                          const Basis& basis) noexcept {
   switch (basis) {
-    case Basis::Legendre: return os << "Legendre";
+    case Basis::Legendre:
+      return os << "Legendre";
+    case Basis::Chebyshev:
+      return os << "Chebyshev";
     default: ERROR("Invalid basis");
   }
 }
@@ -33,8 +36,10 @@ std::ostream& operator<<(std::ostream& os,
 std::ostream& operator<<(std::ostream& os,
                          const Quadrature& quadrature) noexcept {
   switch (quadrature) {
-    case Quadrature::Gauss: return os << "Gauss";
-    case Quadrature::GaussLobatto: return os << "GaussLobatto";
+    case Quadrature::Gauss:
+      return os << "Gauss";
+    case Quadrature::GaussLobatto:
+      return os << "GaussLobatto";
     default: ERROR("Invalid quadrature");
   }
 }
@@ -338,6 +343,23 @@ decltype(auto) get_spectral_quantity_for_mesh(F&& f,
         case Quadrature::GaussLobatto:
           return f(
               std::integral_constant<Basis, Basis::Legendre>{},
+              std::integral_constant<Quadrature, Quadrature::GaussLobatto>{},
+              num_points);
+          break;
+        default:
+          ERROR("Missing quadrature case for spectral quantity");
+      }
+      break;
+    case Basis::Chebyshev:
+      switch (mesh.quadrature(0)) {
+        case Quadrature::Gauss:
+          return f(std::integral_constant<Basis, Basis::Chebyshev>{},
+                   std::integral_constant<Quadrature, Quadrature::Gauss>{},
+                   num_points);
+          break;
+        case Quadrature::GaussLobatto:
+          return f(
+              std::integral_constant<Basis, Basis::Chebyshev>{},
               std::integral_constant<Quadrature, Quadrature::GaussLobatto>{},
               num_points);
           break;

--- a/src/NumericalAlgorithms/Spectral/Spectral.cpp
+++ b/src/NumericalAlgorithms/Spectral/Spectral.cpp
@@ -44,6 +44,9 @@ std::ostream& operator<<(std::ostream& os,
   }
 }
 
+template <Basis BasisType>
+Matrix spectral_indefinite_integral_matrix(size_t num_points) noexcept;
+
 namespace {
 
 // Caching mechanism
@@ -146,6 +149,17 @@ struct DifferentiationMatrixGenerator {
       }
     }
     return diff_matrix;
+  }
+};
+
+template <Basis BasisType, Quadrature QuadratureType>
+struct IntegrationMatrixGenerator {
+  Matrix operator()(const size_t num_points) const noexcept {
+    return Spectral::spectral_to_grid_points_matrix<BasisType, QuadratureType>(
+               num_points) *
+           spectral_indefinite_integral_matrix<BasisType>(num_points) *
+           Spectral::grid_points_to_spectral_matrix<BasisType, QuadratureType>(
+               num_points);
   }
 };
 
@@ -264,6 +278,8 @@ const DataVector& quadrature_weights(const size_t num_points) noexcept {
 
 PRECOMPUTED_SPECTRAL_QUANTITY(differentiation_matrix, Matrix,
                               DifferentiationMatrixGenerator)
+PRECOMPUTED_SPECTRAL_QUANTITY(integration_matrix, Matrix,
+                              IntegrationMatrixGenerator)
 PRECOMPUTED_SPECTRAL_QUANTITY(spectral_to_grid_points_matrix, Matrix,
                               SpectralToGridPointsMatrixGenerator)
 PRECOMPUTED_SPECTRAL_QUANTITY(grid_points_to_spectral_matrix, Matrix,
@@ -391,6 +407,7 @@ decltype(auto) get_spectral_quantity_for_mesh(F&& f,
 SPECTRAL_QUANTITY_FOR_MESH(collocation_points, DataVector)
 SPECTRAL_QUANTITY_FOR_MESH(quadrature_weights, DataVector)
 SPECTRAL_QUANTITY_FOR_MESH(differentiation_matrix, Matrix)
+SPECTRAL_QUANTITY_FOR_MESH(integration_matrix, Matrix)
 SPECTRAL_QUANTITY_FOR_MESH(spectral_to_grid_points_matrix, Matrix)
 SPECTRAL_QUANTITY_FOR_MESH(grid_points_to_spectral_matrix, Matrix)
 SPECTRAL_QUANTITY_FOR_MESH(linear_filter_matrix, Matrix)
@@ -424,6 +441,8 @@ Matrix interpolation_matrix(const Mesh<1>& mesh,
   template const Matrix&                                                      \
       Spectral::differentiation_matrix<BASIS(data), QUAD(data)>(              \
           size_t) noexcept;                                                   \
+  template const Matrix&                                                      \
+      Spectral::integration_matrix<BASIS(data), QUAD(data)>(size_t) noexcept; \
   template const Matrix&                                                      \
       Spectral::grid_points_to_spectral_matrix<BASIS(data), QUAD(data)>(      \
           size_t) noexcept;                                                   \

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_CoefficientTransforms.cpp
   Test_DefiniteIntegral.cpp
   Test_Divergence.cpp
+  Test_IndefiniteIntegral.cpp
   Test_Linearize.cpp
   Test_MeanValue.cpp
   Test_PartialDerivatives.cpp

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_CoefficientTransforms.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_CoefficientTransforms.cpp
@@ -139,7 +139,11 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.CoefficientTransforms",
   test_2d<Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>();
   test_3d<Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>();
   test_3d<Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>();
-  // We can't test Chebyshev because our Chebyshev matrices implementation is
-  // incomplete. What appears to be missing is an entry for Chebyshev in the
-  // `get_spectral_quantity_for_mesh` function.
+
+  test_1d<Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>();
+  test_1d<Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss>();
+  test_2d<Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>();
+  test_2d<Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss>();
+  test_3d<Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>();
+  test_3d<Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss>();
 }

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_IndefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_IndefiniteIntegral.cpp
@@ -1,0 +1,98 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/StripeIterator.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/LinearOperators/IndefiniteIntegral.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim, typename T>
+DataVector integrand(const std::array<size_t, Dim>& exponent,
+                     const T& x) noexcept {
+  DataVector integrand(get<0>(x).size(), 1.0);
+  for (size_t d = 0; d < Dim; ++d) {
+    integrand *= pow(x.get(d), gsl::at(exponent, d));
+  }
+  return integrand;
+}
+
+template <size_t Dim, typename T>
+DataVector integral(const std::array<size_t, Dim>& exponent, const T& x,
+                    const Mesh<Dim> mesh, const size_t only_this_dim) noexcept {
+  DataVector integral(get<0>(x).size(), 1.0);
+  for (size_t d = 0; d < Dim; ++d) {
+    if (d == only_this_dim) {
+      integral *= pow(x.get(d), gsl::at(exponent, d) + 1) /
+                  (gsl::at(exponent, d) + 1.0);
+      // Adjust to zero integral on lower boundary.
+      for (StripeIterator stripe_it(mesh.extents(), d); stripe_it;
+           ++stripe_it) {
+        for (size_t count = 1, i = stripe_it.offset() + stripe_it.stride();
+             count < mesh.extents()[d]; ++count, i += stripe_it.stride()) {
+          integral[i] -= integral[stripe_it.offset()];
+        }
+        integral[stripe_it.offset()] = 0.0;
+      }
+    } else {
+      integral *= pow(x.get(d), gsl::at(exponent, d));
+    }
+  }
+  return integral;
+}
+
+template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
+void test_zero_bc() noexcept {
+  const size_t min_pts = 2;
+  REQUIRE(5 <= Spectral::maximum_number_of_points<BasisType>);
+  for (size_t i = min_pts; i < 5; ++i) {
+    Mesh<1> mesh_1d(i, BasisType, QuadratureType);
+    const auto coords_1d = logical_coordinates(mesh_1d);
+    CHECK_ITERABLE_APPROX(
+        indefinite_integral(integrand<1>({{i - 2}}, coords_1d), mesh_1d, 0),
+        integral({{i - 2}}, coords_1d, mesh_1d, 0));
+
+    // 2d and 3d cases
+    for (size_t j = min_pts; j < 5; ++j) {
+      Mesh<2> mesh_2d({{i, j}}, {{BasisType, BasisType}},
+                      {{QuadratureType, QuadratureType}});
+      const auto coords_2d = logical_coordinates(mesh_2d);
+      for (size_t d = 0; d < 2; ++d) {
+        CHECK_ITERABLE_APPROX(
+            indefinite_integral(integrand<2>({{i - 2, j - 2}}, coords_2d),
+                                mesh_2d, d),
+            integral({{i - 2, j - 2}}, coords_2d, mesh_2d, d));
+      }
+
+      // 3d case
+      for (size_t k = min_pts; k < 5; ++k) {
+        Mesh<3> mesh_3d({{i, j, k}}, {{BasisType, BasisType, BasisType}},
+                        {{QuadratureType, QuadratureType, QuadratureType}});
+        const auto coords_3d = logical_coordinates(mesh_3d);
+        for (size_t d = 0; d < 3; ++d) {
+          CHECK_ITERABLE_APPROX(
+              indefinite_integral(
+                  integrand<3>({{i - 2, j - 2, k - 2}}, coords_3d), mesh_3d, d),
+              integral({{i - 2, j - 2, k - 2}}, coords_3d, mesh_3d, d));
+        }
+      }
+    }
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.IndefiniteIntegral",
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+  test_zero_bc<Spectral::Basis::Chebyshev,
+               Spectral::Quadrature::GaussLobatto>();
+  test_zero_bc<Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>();
+}

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_ChebyshevGauss.cpp
   Test_ChebyshevGaussLobatto.cpp
   Test_ComplexDataView.cpp
+  Test_IndefiniteIntegral.cpp
   Test_LegendreGauss.cpp
   Test_LegendreGaussLobatto.cpp
   Test_Projection.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_IndefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_IndefiniteIntegral.cpp
@@ -1,0 +1,74 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/LogicalCoordinates.hpp"
+#include "Domain/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Spectral.hpp"
+#include "Utilities/Blas.hpp"
+
+namespace Spectral {
+namespace {
+DataVector integrate(const DataVector& u, const Mesh<1>& mesh) noexcept {
+  const size_t num_pts = mesh.number_of_grid_points();
+  DataVector result(num_pts, 0.0);
+  const Matrix& indef_int_with_constant = integration_matrix(mesh);
+  dgemv_('N', num_pts, num_pts, 1.0, indef_int_with_constant.data(), num_pts,
+         u.data(), 1, 0.0, result.data(), 1);
+  return result;
+}
+
+template <Basis BasisType, Quadrature QuadratureType>
+void check_integration(const size_t min_pts, const size_t max_pts) noexcept {
+  CAPTURE(BasisType);
+  CAPTURE(QuadratureType);
+  for (size_t num_pts = min_pts; num_pts < max_pts; ++num_pts) {
+    CAPTURE(num_pts);
+    const Mesh<1> mesh{num_pts, BasisType, QuadratureType};
+    const auto logical_coords = logical_coordinates(mesh);
+    DataVector u(num_pts);
+    DataVector u_int_exact(num_pts);
+    // Single term integrals
+    for (size_t i = 0; i < num_pts - 1; ++i) {
+      u = pow(get<0>(logical_coords), i);
+      u_int_exact = 1.0 / (i + 1.0) * pow(get<0>(logical_coords), i + 1);
+      u_int_exact -= 1.0 / (i + 1.0) * pow(-1.0, i + 1);
+      const auto u_int_computed = integrate(u, mesh);
+      CHECK_ITERABLE_APPROX(u_int_exact, u_int_computed);
+    }
+    // Full sum of terms
+    u = 1.0;
+    u_int_exact = get<0>(logical_coords);
+    double u_int_exact_boundary = -1.0;
+    for (size_t i = 1; i < num_pts - 1; ++i) {
+      u += pow(get<0>(logical_coords), i);
+      u_int_exact += 1.0 / (i + 1.0) * pow(get<0>(logical_coords), i + 1);
+      u_int_exact_boundary += 1.0 / (i + 1.0) * pow(-1.0, i + 1);
+    }
+    u_int_exact -= u_int_exact_boundary;
+    const auto u_int_computed = integrate(u, mesh);
+    CHECK_ITERABLE_APPROX(u_int_exact, u_int_computed);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.NumericalAlgoriths.Spectral.IndefiniteIntegral",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  check_integration<Basis::Chebyshev, Quadrature::GaussLobatto>(
+      2, maximum_number_of_points<Basis::Chebyshev>);
+  check_integration<Basis::Chebyshev, Quadrature::Gauss>(
+      2, maximum_number_of_points<Basis::Chebyshev>);
+  check_integration<Basis::Legendre, Quadrature::GaussLobatto>(
+      2, maximum_number_of_points<Basis::Legendre>);
+  check_integration<Basis::Legendre, Quadrature::Gauss>(
+      2, maximum_number_of_points<Basis::Legendre>);
+}
+}  // namespace Spectral


### PR DESCRIPTION
## Proposed changes

- Add tests for coefficient transform with Chebyshev basis
- Add indefinite integration matrix
- Add functions to compute indefinite integrals

Commit order:
1. Enable Chebyshev basis
2. Add coefficient transform tests of Chebyshev
3. Add indefinite integration matrix
4. Add functions to compute indefinite integrals

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
