### PR TITLE
Add return-by-ref versions of functions that compute GH vars

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.cpp
@@ -19,6 +19,43 @@
 
 namespace GeneralizedHarmonic {
 template <size_t SpatialDim, typename Frame, typename DataType>
+void phi(const gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> phi,
+         const Scalar<DataType>& lapse,
+         const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+         const tnsr::I<DataType, SpatialDim, Frame>& shift,
+         const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+         const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+         const tnsr::ijj<DataType, SpatialDim, Frame>&
+             deriv_spatial_metric) noexcept {
+  if (UNLIKELY(get_size(get<0, 0, 0>(*phi)) != get_size(get(lapse)))) {
+    *phi = tnsr::iaa<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+  for (size_t k = 0; k < SpatialDim; ++k) {
+    phi->get(k, 0, 0) = -2. * get(lapse) * deriv_lapse.get(k);
+    for (size_t m = 0; m < SpatialDim; ++m) {
+      for (size_t n = 0; n < SpatialDim; ++n) {
+        phi->get(k, 0, 0) +=
+            deriv_spatial_metric.get(k, m, n) * shift.get(m) * shift.get(n) +
+            2. * spatial_metric.get(m, n) * shift.get(m) *
+                deriv_shift.get(k, n);
+      }
+    }
+
+    for (size_t i = 0; i < SpatialDim; ++i) {
+      phi->get(k, 0, i + 1) = 0.;
+      for (size_t m = 0; m < SpatialDim; ++m) {
+        phi->get(k, 0, i + 1) +=
+            deriv_spatial_metric.get(k, m, i) * shift.get(m) +
+            spatial_metric.get(m, i) * deriv_shift.get(k, m);
+      }
+      for (size_t j = i; j < SpatialDim; ++j) {
+        phi->get(k, i + 1, j + 1) = deriv_spatial_metric.get(k, i, j);
+      }
+    }
+  }
+}
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::iaa<DataType, SpatialDim, Frame> phi(
     const Scalar<DataType>& lapse,
     const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
@@ -27,31 +64,56 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept {
-  tnsr::iaa<DataType, SpatialDim, Frame> phi(
-      make_with_value<DataType>(deriv_lapse, 0.));
-  for (size_t k = 0; k < SpatialDim; ++k) {
-    phi.get(k, 0, 0) = -2.0 * get(lapse) * deriv_lapse.get(k);
-    for (size_t m = 0; m < SpatialDim; ++m) {
-      for (size_t n = 0; n < SpatialDim; ++n) {
-        phi.get(k, 0, 0) +=
-            deriv_spatial_metric.get(k, m, n) * shift.get(m) * shift.get(n) +
-            2. * spatial_metric.get(m, n) * shift.get(m) *
-                deriv_shift.get(k, n);
-      }
-    }
+  tnsr::iaa<DataType, SpatialDim, Frame> var_phi{};
+  GeneralizedHarmonic::phi<SpatialDim, Frame, DataType>(
+      make_not_null(&var_phi), lapse, deriv_lapse, shift, deriv_shift,
+      spatial_metric, deriv_spatial_metric);
+  return var_phi;
+}
 
-    for (size_t i = 0; i < SpatialDim; ++i) {
-      for (size_t m = 0; m < SpatialDim; ++m) {
-        phi.get(k, 0, i + 1) +=
-            deriv_spatial_metric.get(k, m, i) * shift.get(m) +
-            spatial_metric.get(m, i) * deriv_shift.get(k, m);
-      }
-      for (size_t j = i; j < SpatialDim; ++j) {
-        phi.get(k, i + 1, j + 1) = deriv_spatial_metric.get(k, i, j);
-      }
+template <size_t SpatialDim, typename Frame, typename DataType>
+void pi(const gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> pi,
+        const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+        const tnsr::I<DataType, SpatialDim, Frame>& shift,
+        const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+        const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+        const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+        const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
+  if (UNLIKELY(get_size(get<0, 0>(*pi)) != get_size(get(lapse)))) {
+    *pi = tnsr::aa<DataType, SpatialDim, Frame>(get_size(get(lapse)));
+  }
+
+  get<0, 0>(*pi) = -2. * get(lapse) * get(dt_lapse);
+
+  for (size_t m = 0; m < SpatialDim; ++m) {
+    for (size_t n = 0; n < SpatialDim; ++n) {
+      get<0, 0>(*pi) +=
+          dt_spatial_metric.get(m, n) * shift.get(m) * shift.get(n) +
+          2. * spatial_metric.get(m, n) * shift.get(m) * dt_shift.get(n);
     }
   }
-  return phi;
+
+  for (size_t i = 0; i < SpatialDim; ++i) {
+    pi->get(0, i + 1) = 0.;
+    for (size_t m = 0; m < SpatialDim; ++m) {
+      pi->get(0, i + 1) += dt_spatial_metric.get(m, i) * shift.get(m) +
+                           spatial_metric.get(m, i) * dt_shift.get(m);
+    }
+    for (size_t j = i; j < SpatialDim; ++j) {
+      pi->get(i + 1, j + 1) = dt_spatial_metric.get(i, j);
+    }
+  }
+  for (size_t mu = 0; mu < SpatialDim + 1; ++mu) {
+    for (size_t nu = mu; nu < SpatialDim + 1; ++nu) {
+      for (size_t i = 0; i < SpatialDim; ++i) {
+        pi->get(mu, nu) -= shift.get(i) * phi.get(i, mu, nu);
+      }
+      // Division by `lapse` here is somewhat more efficient (in Release mode)
+      // than pre-computing `one_over_lapse` outside the loop for DataVectors
+      // of `size` up to `50`. This is why we the next line is as it is.
+      pi->get(mu, nu) /= -get(lapse);
+    }
+  }
 }
 
 template <size_t SpatialDim, typename Frame, typename DataType>
@@ -62,36 +124,10 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept {
-  tnsr::aa<DataType, SpatialDim, Frame> pi{
-      make_with_value<DataType>(lapse, 0.)};
-
-  get<0, 0>(pi) = -2. * get(lapse) * get(dt_lapse);
-
-  for (size_t m = 0; m < SpatialDim; ++m) {
-    for (size_t n = 0; n < SpatialDim; ++n) {
-      get<0, 0>(pi) +=
-          dt_spatial_metric.get(m, n) * shift.get(m) * shift.get(n) +
-          2. * spatial_metric.get(m, n) * shift.get(m) * dt_shift.get(n);
-    }
-  }
-
-  for (size_t i = 0; i < SpatialDim; ++i) {
-    for (size_t m = 0; m < SpatialDim; ++m) {
-      pi.get(0, i + 1) += dt_spatial_metric.get(m, i) * shift.get(m) +
-                          spatial_metric.get(m, i) * dt_shift.get(m);
-    }
-    for (size_t j = i; j < SpatialDim; ++j) {
-      pi.get(i + 1, j + 1) = dt_spatial_metric.get(i, j);
-    }
-  }
-  for (size_t mu = 0; mu < SpatialDim + 1; ++mu) {
-    for (size_t nu = mu; nu < SpatialDim + 1; ++nu) {
-      for (size_t i = 0; i < SpatialDim; ++i) {
-        pi.get(mu, nu) -= shift.get(i) * phi.get(i, mu, nu);
-      }
-      pi.get(mu, nu) /= -get(lapse);
-    }
-  }
+  tnsr::aa<DataType, SpatialDim, Frame> pi{};
+  GeneralizedHarmonic::pi<SpatialDim, Frame, DataType>(
+      make_not_null(&pi), lapse, dt_lapse, shift, dt_shift, spatial_metric,
+      dt_spatial_metric, phi);
   return pi;
 }
 
@@ -696,6 +732,16 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_norm_of_shift(
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
 #define INSTANTIATE(_, data)                                                  \
+  template void GeneralizedHarmonic::phi(                                     \
+      const gsl::not_null<tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>*>    \
+          var_phi,                                                            \
+      const Scalar<DTYPE(data)>& lapse,                                       \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>& deriv_lapse,        \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::iJ<DTYPE(data), DIM(data), FRAME(data)>& deriv_shift,       \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                   \
+          deriv_spatial_metric) noexcept;                                     \
   template tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>                     \
   GeneralizedHarmonic::phi(                                                   \
       const Scalar<DTYPE(data)>& lapse,                                       \
@@ -705,6 +751,15 @@ tnsr::a<DataType, SpatialDim, Frame> spacetime_deriv_of_norm_of_shift(
       const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
       const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&                   \
           deriv_spatial_metric) noexcept;                                     \
+  template void GeneralizedHarmonic::pi(                                      \
+      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>*>     \
+          var_pi,                                                             \
+      const Scalar<DTYPE(data)>& lapse, const Scalar<DTYPE(data)>& dt_lapse,  \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,              \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& dt_shift,           \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& spatial_metric,    \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>& dt_spatial_metric, \
+      const tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>& phi) noexcept;    \
   template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>                      \
   GeneralizedHarmonic::pi(                                                    \
       const Scalar<DTYPE(data)>& lapse, const Scalar<DTYPE(data)>& dt_lapse,  \

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeGhQuantities.hpp
@@ -18,6 +18,7 @@ class not_null;
 /// \endcond
 
 namespace GeneralizedHarmonic {
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the auxiliary variable \f$\Phi_{iab}\f$ used by the
@@ -36,6 +37,16 @@ namespace GeneralizedHarmonic {
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
+void phi(gsl::not_null<tnsr::iaa<DataType, SpatialDim, Frame>*> phi,
+         const Scalar<DataType>& lapse,
+         const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
+         const tnsr::I<DataType, SpatialDim, Frame>& shift,
+         const tnsr::iJ<DataType, SpatialDim, Frame>& deriv_shift,
+         const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+         const tnsr::ijj<DataType, SpatialDim, Frame>&
+             deriv_spatial_metric) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::iaa<DataType, SpatialDim, Frame> phi(
     const Scalar<DataType>& lapse,
     const tnsr::i<DataType, SpatialDim, Frame>& deriv_lapse,
@@ -44,7 +55,9 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ijj<DataType, SpatialDim, Frame>&
         deriv_spatial_metric) noexcept;
+// @}
 
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the conjugate momentum \f$\Pi_{ab}\f$ of the spacetime metric
@@ -66,6 +79,15 @@ tnsr::iaa<DataType, SpatialDim, Frame> phi(
  * \f}
  */
 template <size_t SpatialDim, typename Frame, typename DataType>
+void pi(gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> pi,
+        const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
+        const tnsr::I<DataType, SpatialDim, Frame>& shift,
+        const tnsr::I<DataType, SpatialDim, Frame>& dt_shift,
+        const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
+        const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
+        const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+
+template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::aa<DataType, SpatialDim, Frame> pi(
     const Scalar<DataType>& lapse, const Scalar<DataType>& dt_lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
@@ -73,6 +95,7 @@ tnsr::aa<DataType, SpatialDim, Frame> pi(
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric,
     const tnsr::ii<DataType, SpatialDim, Frame>& dt_spatial_metric,
     const tnsr::iaa<DataType, SpatialDim, Frame>& phi) noexcept;
+// @}
 
 /*!
  * \ingroup GeneralRelativityGroup

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.cpp
@@ -3,39 +3,58 @@
 
 #include "PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp"
 
-#include <cmath>
+#include <cmath>  // IWYU pragma: keep
 
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
+
+// IWYU pragma: no_include <complex>
 
 namespace gr {
 template <size_t Dim, typename Frame, typename DataType>
-tnsr::aa<DataType, Dim, Frame> spacetime_metric(
+void spacetime_metric(
+    const gsl::not_null<tnsr::aa<DataType, Dim, Frame>*> spacetime_metric,
     const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Frame>& shift,
     const tnsr::ii<DataType, Dim, Frame>& spatial_metric) noexcept {
-  auto spacetime_metric =
-      make_with_value<tnsr::aa<DataType, Dim, Frame>>(lapse, 0.);
+  if (UNLIKELY(get_size(get<0, 0>(*spacetime_metric)) !=
+               get_size(get(lapse)))) {
+    *spacetime_metric = tnsr::aa<DataType, Dim, Frame>(get_size(get(lapse)));
+  }
 
-  get<0, 0>(spacetime_metric) = -get(lapse) * get(lapse);
+  get<0, 0>(*spacetime_metric) = -square(get(lapse));
 
   for (size_t m = 0; m < Dim; ++m) {
-    get<0, 0>(spacetime_metric) +=
-        spatial_metric.get(m, m) * shift.get(m) * shift.get(m);
+    get<0, 0>(*spacetime_metric) +=
+        spatial_metric.get(m, m) * square(shift.get(m));
     for (size_t n = 0; n < m; ++n) {
-      get<0, 0>(spacetime_metric) +=
-          2 * spatial_metric.get(m, n) * shift.get(m) * shift.get(n);
+      get<0, 0>(*spacetime_metric) +=
+          2. * spatial_metric.get(m, n) * shift.get(m) * shift.get(n);
     }
   }
 
   for (size_t i = 0; i < Dim; ++i) {
+    spacetime_metric->get(0, i + 1) = 0.;
     for (size_t m = 0; m < Dim; ++m) {
-      spacetime_metric.get(0, i + 1) += spatial_metric.get(m, i) * shift.get(m);
+      spacetime_metric->get(0, i + 1) +=
+          spatial_metric.get(m, i) * shift.get(m);
     }
     for (size_t j = i; j < Dim; ++j) {
-      spacetime_metric.get(i + 1, j + 1) = spatial_metric.get(i, j);
+      spacetime_metric->get(i + 1, j + 1) = spatial_metric.get(i, j);
     }
   }
+}
+
+template <size_t Dim, typename Frame, typename DataType>
+tnsr::aa<DataType, Dim, Frame> spacetime_metric(
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Frame>& shift,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric) noexcept {
+  tnsr::aa<DataType, Dim, Frame> spacetime_metric{};
+  gr::spacetime_metric<Dim, Frame, DataType>(make_not_null(&spacetime_metric),
+                                             lapse, shift, spatial_metric);
   return spacetime_metric;
 }
 
@@ -231,6 +250,13 @@ tnsr::ii<DataType, SpatialDim, Frame> extrinsic_curvature(
 #define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
 
 #define INSTANTIATE(_, data)                                                   \
+  template void gr::spacetime_metric(                                          \
+      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>*>      \
+          spacetime_metric,                                                    \
+      const Scalar<DTYPE(data)>& lapse,                                        \
+      const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,               \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&                     \
+          spatial_metric) noexcept;                                            \
   template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)> gr::spacetime_metric( \
       const Scalar<DTYPE(data)>& lapse,                                        \
       const tnsr::I<DTYPE(data), DIM(data), FRAME(data)>& shift,               \

--- a/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.hpp
@@ -10,10 +10,17 @@
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 
+/// \cond
+namespace gsl {
+template <class T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
 /// \ingroup GeneralRelativityGroup
 /// Holds functions related to general relativity.
 namespace gr {
-
+// @{
 /*!
  * \ingroup GeneralRelativityGroup
  * \brief Computes the spacetime metric from the spatial metric, lapse, and
@@ -27,11 +34,18 @@ namespace gr {
  * where \f$ N, N^i\f$ and \f$ g_{ij}\f$ are the lapse, shift and spatial metric
  * respectively
  */
+template <size_t Dim, typename Frame, typename DataType>
+void spacetime_metric(
+    gsl::not_null<tnsr::aa<DataType, Dim, Frame>*> spacetime_metric,
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, Dim, Frame>& shift,
+    const tnsr::ii<DataType, Dim, Frame>& spatial_metric) noexcept;
+
 template <size_t SpatialDim, typename Frame, typename DataType>
 tnsr::aa<DataType, SpatialDim, Frame> spacetime_metric(
     const Scalar<DataType>& lapse,
     const tnsr::I<DataType, SpatialDim, Frame>& shift,
     const tnsr::ii<DataType, SpatialDim, Frame>& spatial_metric) noexcept;
+// @}
 
 /*!
  * \ingroup GeneralRelativityGroup

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeGhQuantities.cpp
@@ -44,14 +44,28 @@ using Affine3D = domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
 template <size_t Dim, typename DataType>
 void test_compute_phi(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
-      &GeneralizedHarmonic::phi<Dim, Frame::Inertial, DataType>,
+      static_cast<tnsr::iaa<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&,
+          const tnsr::i<DataType, Dim, Frame::Inertial>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iJ<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ijj<DataType, Dim, Frame::Inertial>&)>(
+          &::GeneralizedHarmonic::phi<Dim, Frame::Inertial, DataType>),
       "GeneralRelativity.ComputeGhQuantities", "phi", {{{-10., 10.}}},
       used_for_size);
 }
 template <size_t Dim, typename DataType>
 void test_compute_pi(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
-      &GeneralizedHarmonic::pi<Dim, Frame::Inertial, DataType>,
+      static_cast<tnsr::aa<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&, const Scalar<DataType>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&,
+          const tnsr::iaa<DataType, Dim, Frame::Inertial>&)>(
+          &::GeneralizedHarmonic::pi<Dim, Frame::Inertial, DataType>),
       "GeneralRelativity.ComputeGhQuantities", "pi", {{{-10., 10.}}},
       used_for_size);
 }
@@ -60,7 +74,7 @@ void test_compute_gauge_source(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
       &GeneralizedHarmonic::gauge_source<Dim, Frame::Inertial, DataType>,
       "GeneralRelativity.ComputeGhQuantities", "gauge_source", {{{-10., 10.}}},
-      used_for_size);
+      used_for_size, 1.e-11);
 }
 
 template <size_t Dim, typename T>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -21,7 +21,11 @@ namespace {
 template <size_t Dim, typename DataType>
 void test_compute_spacetime_metric(const DataType& used_for_size) {
   pypp::check_with_random_values<1>(
-      &gr::spacetime_metric<Dim, Frame::Inertial, DataType>,
+      static_cast<tnsr::aa<DataType, Dim, Frame::Inertial> (*)(
+          const Scalar<DataType>&,
+          const tnsr::I<DataType, Dim, Frame::Inertial>&,
+          const tnsr::ii<DataType, Dim, Frame::Inertial>&)>(
+          &gr::spacetime_metric<Dim, Frame::Inertial, DataType>),
       "ComputeSpacetimeQuantities", "spacetime_metric", {{{-10., 10.}}},
       used_for_size);
 }


### PR DESCRIPTION
## Proposed changes

Add return-by-reference versions for functions that compute the generalized harmonic variables `pi`, `phi` and `spacetime_metric`.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
