### PR TITLE
Add PrimitiveId data structure

### DIFF
--- a/src/DataStructures/PrimitiveId.hpp
+++ b/src/DataStructures/PrimitiveId.hpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <functional>
+#include <iosfwd>
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+template <typename T>
+struct PrimitiveId {
+  PrimitiveId() = default;
+  PrimitiveId(const T& value) : value_(value){};
+  operator T&() { return value_; }
+  operator T() const { return value_; }
+
+  // To support ObservationId
+  double value() const noexcept { return static_cast<double>(value_); }
+
+  // clang-tidy: google-runtime-references
+  void pup(PUP::er& p) noexcept { p | value_; };  // NOLINT
+
+ private:
+  T value_{};
+};
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const PrimitiveId<T>& id) noexcept {
+  return os << static_cast<T>(id);
+}
+
+template <typename T>
+size_t hash_value(const PrimitiveId<T>& id) noexcept {
+  size_t h = 0;
+  boost::hash_combine(h, static_cast<T>(id));
+  return h;
+}
+
+namespace std {
+template <typename T>
+struct hash<PrimitiveId<T>> {
+  size_t operator()(const PrimitiveId<T>& id) const noexcept {
+    return boost::hash<PrimitiveId<T>>{}(id);
+  }
+};
+}  // namespace std

--- a/tests/Unit/DataStructures/CMakeLists.txt
+++ b/tests/Unit/DataStructures/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBRARY_SOURCES
   Test_LeviCivitaIterator.cpp
   Test_ModalVector.cpp
   Test_OrientVariables.cpp
+  Test_PrimitiveId.cpp
   Test_SliceIterator.cpp
   Test_SpinWeighted.cpp
   Test_StripeIterator.cpp

--- a/tests/Unit/DataStructures/Test_PrimitiveId.cpp
+++ b/tests/Unit/DataStructures/Test_PrimitiveId.cpp
@@ -1,0 +1,30 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "tests/Unit/TestingFramework.hpp"
+
+#include <functional>
+#include <string>
+
+#include "DataStructures/PrimitiveId.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "tests/Unit/TestHelpers.hpp"
+
+SPECTRE_TEST_CASE("Unit.DataStructures.PrimitiveId", "[Unit][DataStructures]") {
+  {
+    const PrimitiveId<size_t> id{2};
+    CHECK(id == 2);
+    using Hash = std::hash<PrimitiveId<size_t>>;
+    CHECK(Hash{}(id) == Hash{}(PrimitiveId<size_t>{2}));
+    CHECK(get_output(id) == "2");
+    check_cmp(PrimitiveId<size_t>{1}, PrimitiveId<size_t>{2});
+  }
+  {
+    const PrimitiveId<double> id{2.};
+    CHECK(id == 2.);
+    using Hash = std::hash<PrimitiveId<double>>;
+    CHECK(Hash{}(id) == Hash{}(PrimitiveId<double>{2.}));
+    CHECK(get_output(id) == "2.0");
+    check_cmp(PrimitiveId<double>{1.}, PrimitiveId<double>{2.});
+  }
+}


### PR DESCRIPTION
## Proposed changes

This data structure wraps a generic type `T` and provides a `value()` member function that allows it to be used by `ObservationId`.
I intend to replace my `LinearSolver::IterationId` with a `PrimitiveId<size_t>` and also use it as the type for the new `NonlinearSolver::Tags::IterationId`, as well as other components of the elliptic solver that need to keep track of a step number, such as AMR and Multigrid cycles.
I understand a `PrimitiveId<double>` is also useful for horizon finding and other components, so I'd appreciate some feedback. Putting this in as a draft PR for now to make sure we agree on the design before finalising this.

### Types of changes:

- [x] New feature

### Component:

- [x] Code

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
