### PR TITLE
add missing includes in ReductionActions and LinearSolver tests

### DIFF
--- a/src/IO/Observer/ReductionActions.hpp
+++ b/src/IO/Observer/ReductionActions.hpp
@@ -31,6 +31,12 @@
 #include "Utilities/TaggedTuple.hpp"
 
 namespace observers {
+
+/// \cond
+template <class Metavariables>
+struct ObserverWriter;
+/// \endcond
+
 namespace ThreadedActions {
 /// \cond
 struct WriteReductionData;

--- a/src/IO/Observer/Tags.hpp
+++ b/src/IO/Observer/Tags.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
+#include <converse.h>
 #include <cstddef>
-#include <lrtslock.h>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/Parallel/Algorithm.hpp
+++ b/src/Parallel/Algorithm.hpp
@@ -4,10 +4,10 @@
 #pragma once
 
 #include <boost/variant/variant.hpp>
+#include <converse.h>
 #include <cstddef>
 #include <exception>
 #include <initializer_list>
-#include <lrtslock.h>
 #include <ostream>
 #include <pup.h>
 #include <tuple>

--- a/src/Parallel/NodeLock.hpp
+++ b/src/Parallel/NodeLock.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <lrtslock.h>
+#include <converse.h>
 
 #include "Utilities/Gsl.hpp"
 #include "Utilities/NoSuchType.hpp"

--- a/tests/Unit/ActionTesting.hpp
+++ b/tests/Unit/ActionTesting.hpp
@@ -10,10 +10,10 @@
 #include <boost/preprocessor/logical/not.hpp>
 #include <boost/preprocessor/punctuation/comma_if.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
+#include <converse.h>
 #include <cstddef>
 #include <deque>
 #include <exception>
-#include <lrtslock.h>
 #include <memory>
 #include <ostream>
 #include <random>

--- a/tests/Unit/NumericalAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
+++ b/tests/Unit/NumericalAlgorithms/LinearSolver/ResidualMonitorActionsTestHelpers.hpp
@@ -4,13 +4,17 @@
 #pragma once
 
 #include <cmath>
+#include <converse.h>
 #include <string>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
+#include "IO/Observer/ObservationId.hpp"
+#include "IO/Observer/ReductionActions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
+#include "tests/Unit/ActionTesting.hpp"
 
 namespace Parallel {
 template <typename Metavariables>


### PR DESCRIPTION
## Proposed changes

Add missing includes.

This fixed #1396 in my local install.

### Types of changes:

- [x] Bugfix
- [ ] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Further comments

ReductionActions.hpp needs ObserverComponent.hpp for `ObserverWriter`.
Not including "tests/Unit/TestingFramework.hpp" caused the problems when compiling without precompiled headers.