### PR TITLE
InterpolatorReceiveVolumeData now triggers InterpolationTargets.

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp
+++ b/src/NumericalAlgorithms/Interpolation/InterpolatorReceiveVolumeData.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Domain/Mesh.hpp"
 #include "Domain/Tags.hpp"
+#include "NumericalAlgorithms/Interpolation/AddTemporalIdsToInterpolationTarget.hpp"
 #include "NumericalAlgorithms/Interpolation/Tags.hpp"
 #include "NumericalAlgorithms/Interpolation/TryToInterpolate.hpp"
 #include "Parallel/ConstGlobalCache.hpp"
@@ -54,18 +55,21 @@ struct InterpolatorReceiveVolumeData {
       const ElementId<VolumeDim>& element_id, const ::Mesh<VolumeDim>& mesh,
       Variables<typename Metavariables::interpolator_source_vars>&&
           vars) noexcept {
+    bool add_temporal_ids_to_targets = false;
     db::mutate<Tags::VolumeVarsInfo<Metavariables>>(
         make_not_null(&box),
-        [&temporal_id, &element_id, &mesh,
-         &vars ](const gsl::not_null<
-                 db::item_type<Tags::VolumeVarsInfo<Metavariables>>*>
-                     container) noexcept {
+        [
+          &add_temporal_ids_to_targets, &temporal_id, &element_id, &mesh, &vars
+        ](const gsl::not_null<
+            db::item_type<Tags::VolumeVarsInfo<Metavariables>>*>
+              container) noexcept {
           if (container->find(temporal_id) == container->end()) {
+            add_temporal_ids_to_targets = true;
             container->emplace(
                 temporal_id,
-                std::unordered_map<ElementId<VolumeDim>,
-                                   typename Tags::VolumeVarsInfo<
-                                       Metavariables>::Info>{});
+                std::unordered_map<
+                    ElementId<VolumeDim>,
+                    typename Tags::VolumeVarsInfo<Metavariables>::Info>{});
           }
           container->at(temporal_id)
               .emplace(std::make_pair(
@@ -75,12 +79,26 @@ struct InterpolatorReceiveVolumeData {
         });
 
     // Try to interpolate data for all InterpolationTargets.
-    tmpl::for_each<typename Metavariables::interpolation_target_tags>(
-        [&box, &cache, &temporal_id ](auto x) noexcept {
-          using tag = typename decltype(x)::type;
-          try_to_interpolate<tag>(make_not_null(&box), make_not_null(&cache),
-                                  temporal_id);
-        });
+    tmpl::for_each<typename Metavariables::interpolation_target_tags>([
+      &add_temporal_ids_to_targets, &box, &cache, &temporal_id
+    ](auto tag_v) noexcept {
+      using tag = typename decltype(tag_v)::type;
+
+      // The first time (and only the first time) that this interpolator
+      // is called at this temporal_id, tell all the
+      // InterpolationTargets that they will interpolate at this
+      // temporal_id.
+      if (add_temporal_ids_to_targets) {
+        auto& target = Parallel::get_parallel_component<
+            InterpolationTarget<Metavariables, tag>>(cache);
+        Parallel::simple_action<AddTemporalIdsToInterpolationTarget<tag>>(
+            target, std::vector<typename Metavariables::temporal_id::type>{
+                        temporal_id});
+      }
+
+      try_to_interpolate<tag>(make_not_null(&box), make_not_null(&cache),
+                              temporal_id);
+    });
   }
 };
 


### PR DESCRIPTION
Previously it was assumed that some external code would call
AddTemporalIdsToInterpolationTarget for each relevant target.
Now AddTemporalIdsToInterpolationTarget is called by
InterpolatorReceiveVolumeData the first time the latter is
called for a given temporal_id.  This means that whatever
initiates the interpolation needs to now do only one thing
(i.e. call InterpolatorReceiveVolumeData) rather than two things.

### Types of changes:

- [ ] Bugfix
- [x] New feature

### Component:

- [x] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
