### PR TITLE
Minmod bugfixes and cleanups

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -52,6 +52,21 @@
   volume         = "193",
 }
 
+@book{Cockburn1999,
+  author     = "Cockburn, Bernardo",
+  editor     = "Barth, Timothy J. and Deconinck, Herman",
+  title      = "Discontinuous Galerkin Methods for Convection-Dominated
+                Problems",
+  bookTitle  = "High-Order Methods for Computational Physics",
+  year       = "1999",
+  publisher  = "Springer Berlin Heidelberg",
+  address    = "Berlin, Heidelberg",
+  pages      = "69-224",
+  isbn       = "978-3-662-03882-6",
+  doi        = "10.1007/978-3-662-03882-6_2",
+  url        = "https://doi.org/10.1007/978-3-662-03882-6_2"
+}
+
 @article{Dedner2002,
   author   = "Dedner, A. and Kemm, F. and Kröner, D. and Munz, C.-D. and
               Schnitzer, T. and Wesenberg, M.",

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
@@ -73,6 +73,10 @@ bool limit_one_tensor(
                      VolumeDim>& volume_and_slice_indices) noexcept {
   // True if the mesh is linear-order in every direction
   const bool mesh_is_linear = (mesh.extents() == Index<VolumeDim>(2));
+  const bool minmod_type_is_linear =
+      (minmod_type != SlopeLimiters::MinmodType::LambdaPiN);
+  const bool using_linear_limiter_on_non_linear_mesh =
+      minmod_type_is_linear and not mesh_is_linear;
 
   const double tvbm_scale = [&tvbm_constant, &element_size ]() noexcept {
     const double max_h =
@@ -231,7 +235,7 @@ bool limit_one_tensor(
     }
 
     linearize(u_lin_buffer, u, mesh);
-    bool this_component_was_limited = false;
+    bool reduce_slope = false;
     auto u_limited_slopes = make_array<VolumeDim>(0.0);
 
     for (size_t d = 0; d < VolumeDim; ++d) {
@@ -253,25 +257,18 @@ bool limit_one_tensor(
           minmod_tvbm(local_slope, max_slope_factor * upper_slope,
                       max_slope_factor * lower_slope, tvbm_scale);
       gsl::at(u_limited_slopes, d) = result.value;
-      if (result.activated or not mesh_is_linear) {
-        this_component_was_limited = true;
+      if (result.activated) {
+        reduce_slope = true;
       }
     }
 
-    // Optimization: if the mesh is linear (so that linearization is a no-op),
-    // and the limiter did not request a reduced slope, then there is no need to
-    // overwite u = u_mean + (new limited slope in x) * x + etc., in the
-    // loop below, so skip it.
-    if (mesh_is_linear and not this_component_was_limited) {
-      continue;
+    if (reduce_slope or using_linear_limiter_on_non_linear_mesh) {
+      u = u_mean;
+      for (size_t d = 0; d < VolumeDim; ++d) {
+        u += logical_coords.get(d) * gsl::at(u_limited_slopes, d);
+      }
+      some_component_was_limited = true;
     }
-
-    u = u_mean;
-    for (size_t d = 0; d < VolumeDim; ++d) {
-      u += logical_coords.get(d) * gsl::at(u_limited_slopes, d);
-    }
-    some_component_was_limited =
-        (some_component_was_limited or this_component_was_limited);
   }
 
   return some_component_was_limited;

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.cpp
@@ -75,11 +75,9 @@ bool limit_one_tensor(
   const bool mesh_is_linear = (mesh.extents() == Index<VolumeDim>(2));
 
   const double tvbm_scale = [&tvbm_constant, &element_size ]() noexcept {
-    double max_h_sqr = 0.0;
-    for (size_t d = 0; d < VolumeDim; ++d) {
-      max_h_sqr = std::max(max_h_sqr, square(gsl::at(element_size, d)));
-    }
-    return tvbm_constant * max_h_sqr;
+    const double max_h =
+        *std::max_element(element_size.begin(), element_size.end());
+    return tvbm_constant * square(max_h);
   }
   ();
 

--- a/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/SlopeLimiters/Minmod.hpp
@@ -8,7 +8,6 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
-#include <string>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
@@ -288,7 +287,7 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
                     const std::array<double, VolumeDim>& element_size,
                     const OrientationMap<VolumeDim>& orientation_map) const
       noexcept {
-    if (disable_for_debugging_) {
+    if (UNLIKELY(disable_for_debugging_)) {
       // Do not initialize packaged_data
       return;
     }
@@ -349,7 +348,7 @@ class Minmod<VolumeDim, tmpl::list<Tags...>> {
           std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>, PackagedData,
           boost::hash<std::pair<Direction<VolumeDim>, ElementId<VolumeDim>>>>&
           neighbor_data) const noexcept {
-    if (disable_for_debugging_) {
+    if (UNLIKELY(disable_for_debugging_)) {
       // Do not modify input tensors
       return false;
     }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -403,22 +403,19 @@ void test_limiter_action_on_quadratic_function(
   const double mean = mean_value(get(input), mesh);
 
   // Steepness test
-  // Because the mesh is higher-than-linear order, the limiter will generally
-  // activate due to linearizing the solution, even in cases where slope is OK.
-  if (minmod.minmod_type() == SlopeLimiters::MinmodType::LambdaPiN) {
-    // However, the LambdaPiN limiter's troubled cell detector will avoid
-    // limiting certain smooth solutions; this avoidance will kick in here if,
-    // max(u_mean - u_left AND u_right - u_mean) < min(difference of means)
-    const double du_left = mean - get(input)[0];
-    const double du_right = get(input)[mesh.extents(0) - 1] - mean;
-    const double du = std::max(du_left, du_right);
-    test_limiter_does_not_activate(input, mean - du - 2.0, mean + du + 2.0);
-    test_limiter_does_not_activate(input, mean - du, mean + du);
+  if (minmod.minmod_type() != SlopeLimiters::MinmodType::LambdaPiN) {
+    // Because the mesh is higher-than-linear order, the limiter will generally
+    // activate to linearize the solution, even in cases where slope is OK.
+    test_limiter_activates(input, mean - 5.0, mean + 5.0,
+                           4.0 * muscl_slope_factor);
+    test_limiter_activates(input, mean - 4.01, mean + 4.01,
+                           4.0 * muscl_slope_factor);
+  } else {
+    // However, the LambdaPiN limiter does not activate purely to linearize the
+    // solution, so in these same cases where the slope is OK, it does nothing.
+    test_limiter_does_not_activate(input, mean - 5.0, mean + 5.0);
+    test_limiter_does_not_activate(input, mean - 4.01, mean + 4.01);
   }
-  test_limiter_activates(input, mean - 5.0, mean + 5.0,
-                         4.0 * muscl_slope_factor);
-  test_limiter_activates(input, mean - 4.01, mean + 4.01,
-                         4.0 * muscl_slope_factor);
   // Cases where slope is too steep and needs to be reduced
   test_limiter_activates(input, mean - 3.99, mean + 3.99,
                          3.99 * muscl_slope_factor);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -3,7 +3,6 @@
 
 #include "tests/Unit/TestingFramework.hpp"
 
-#include <algorithm>
 #include <array>
 #include <boost/functional/hash.hpp>
 #include <cstddef>

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/SlopeLimiters/Test_Minmod.cpp
@@ -16,6 +16,7 @@
 
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Direction.hpp"
 #include "Domain/Element.hpp"
@@ -929,13 +930,10 @@ void test_package_data_work(
                       modified_vector, mesh, element_size, {});
 
   // Should not normally look inside the package, but we do so here for testing.
-  double lhs =
-      get(get<Minmod_detail::to_tensor_double<ScalarTag>>(packaged_data.means));
+  double lhs = get(get<Tags::Mean<ScalarTag>>(packaged_data.means));
   CHECK(lhs == approx(mean_value(get(input_scalar), mesh)));
   for (size_t d = 0; d < VolumeDim; ++d) {
-    lhs = get<Minmod_detail::to_tensor_double<VectorTag<VolumeDim>>>(
-              packaged_data.means)
-              .get(d);
+    lhs = get<Tags::Mean<VectorTag<VolumeDim>>>(packaged_data.means).get(d);
     CHECK(lhs == approx(mean_value(modified_vector.get(d), mesh)));
   }
   CHECK(packaged_data.element_size == element_size);
@@ -943,13 +941,10 @@ void test_package_data_work(
   // Then we test with a reorientation, as if sending the data to another Block
   minmod.package_data(make_not_null(&packaged_data), input_scalar,
                       modified_vector, mesh, element_size, orientation_map);
-  lhs =
-      get(get<Minmod_detail::to_tensor_double<ScalarTag>>(packaged_data.means));
+  lhs = get(get<Tags::Mean<ScalarTag>>(packaged_data.means));
   CHECK(lhs == approx(mean_value(get(input_scalar), mesh)));
   for (size_t d = 0; d < VolumeDim; ++d) {
-    lhs = get<Minmod_detail::to_tensor_double<VectorTag<VolumeDim>>>(
-              packaged_data.means)
-              .get(d);
+    lhs = get<Tags::Mean<VectorTag<VolumeDim>>>(packaged_data.means).get(d);
     CHECK(lhs == approx(mean_value(modified_vector.get(d), mesh)));
   }
   CHECK(packaged_data.element_size ==
@@ -1052,21 +1047,17 @@ SPECTRE_TEST_CASE(
 
   // The scalar we treat as a shock: we want the slope to be reduced
   const auto target_scalar_slope = std::array<double, 1>{{1.2}};
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[0]].means) =
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[0]].means) =
       Scalar<double>(mean - target_scalar_slope[0]);
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[1]].means) =
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[1]].means) =
       Scalar<double>(mean + target_scalar_slope[0]);
 
   // The vector x-component we treat as a smooth function: no limiter action
   const auto target_vector_slope =
       std::array<std::array<double, 1>, 1>{{true_slope}};
-  get<Minmod_detail::to_tensor_double<VectorTag<1>>>(
-      neighbor_data[dir_keys[0]].means) =
+  get<Tags::Mean<VectorTag<1>>>(neighbor_data[dir_keys[0]].means) =
       tnsr::I<double, 1>(mean - 2.0 * true_slope[0]);
-  get<Minmod_detail::to_tensor_double<VectorTag<1>>>(
-      neighbor_data[dir_keys[1]].means) =
+  get<Tags::Mean<VectorTag<1>>>(neighbor_data[dir_keys[1]].means) =
       tnsr::I<double, 1>(mean + 2.0 * true_slope[0]);
 
   test_work(input_scalar, input_vector, neighbor_data, mesh, logical_coords,
@@ -1128,14 +1119,14 @@ SPECTRE_TEST_CASE(
                                         const size_t dim, const int sign) {
     return Scalar<double>(mean + sign * gsl::at(target_scalar_slope, dim));
   };
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[0]].means) = neighbor_scalar_func(0, -1);
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[1]].means) = neighbor_scalar_func(0, 1);
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[2]].means) = neighbor_scalar_func(1, -1);
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[3]].means) = neighbor_scalar_func(1, 1);
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[0]].means) =
+      neighbor_scalar_func(0, -1);
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[1]].means) =
+      neighbor_scalar_func(0, 1);
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[2]].means) =
+      neighbor_scalar_func(1, -1);
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[3]].means) =
+      neighbor_scalar_func(1, 1);
 
   // The vector we treat differently in each component, to check the limiter
   // acts independently on each:
@@ -1156,14 +1147,14 @@ SPECTRE_TEST_CASE(
         {{mean + sign * gsl::at(neighbor_vector_slope[0], dim),
           mean + sign * gsl::at(neighbor_vector_slope[1], dim)}}};
   };
-  get<Minmod_detail::to_tensor_double<VectorTag<2>>>(
-      neighbor_data[dir_keys[0]].means) = neighbor_vector_func(0, -1);
-  get<Minmod_detail::to_tensor_double<VectorTag<2>>>(
-      neighbor_data[dir_keys[1]].means) = neighbor_vector_func(0, 1);
-  get<Minmod_detail::to_tensor_double<VectorTag<2>>>(
-      neighbor_data[dir_keys[2]].means) = neighbor_vector_func(1, -1);
-  get<Minmod_detail::to_tensor_double<VectorTag<2>>>(
-      neighbor_data[dir_keys[3]].means) = neighbor_vector_func(1, 1);
+  get<Tags::Mean<VectorTag<2>>>(neighbor_data[dir_keys[0]].means) =
+      neighbor_vector_func(0, -1);
+  get<Tags::Mean<VectorTag<2>>>(neighbor_data[dir_keys[1]].means) =
+      neighbor_vector_func(0, 1);
+  get<Tags::Mean<VectorTag<2>>>(neighbor_data[dir_keys[2]].means) =
+      neighbor_vector_func(1, -1);
+  get<Tags::Mean<VectorTag<2>>>(neighbor_data[dir_keys[3]].means) =
+      neighbor_vector_func(1, 1);
 
   test_work(input_scalar, input_vector, neighbor_data, mesh, logical_coords,
             element_size, target_scalar_slope, target_vector_slope);
@@ -1245,18 +1236,18 @@ SPECTRE_TEST_CASE(
     // because the center-to-center distance to the neighbor element is 2.0:
     return Scalar<double>(mean + sign * gsl::at(target_scalar_slope, dim));
   };
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[0]].means) = neighbor_scalar_func(0, -1);
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[1]].means) = neighbor_scalar_func(0, 1);
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[2]].means) = neighbor_scalar_func(1, -1);
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[3]].means) = neighbor_scalar_func(1, 1);
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[4]].means) = neighbor_scalar_func(2, -1);
-  get<Minmod_detail::to_tensor_double<ScalarTag>>(
-      neighbor_data[dir_keys[5]].means) = neighbor_scalar_func(2, 1);
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[0]].means) =
+      neighbor_scalar_func(0, -1);
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[1]].means) =
+      neighbor_scalar_func(0, 1);
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[2]].means) =
+      neighbor_scalar_func(1, -1);
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[3]].means) =
+      neighbor_scalar_func(1, 1);
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[4]].means) =
+      neighbor_scalar_func(2, -1);
+  get<Tags::Mean<ScalarTag>>(neighbor_data[dir_keys[5]].means) =
+      neighbor_scalar_func(2, 1);
 
   // The vector we treat differently in each component, to verify that the
   // limiter acts independently on each:
@@ -1286,18 +1277,18 @@ SPECTRE_TEST_CASE(
           mean + sign * gsl::at(neighbor_vector_slope[1], dim),
           mean - 1.1 - dim - sign}}};  // arbitrary, but smaller than mean
   };
-  get<Minmod_detail::to_tensor_double<VectorTag<3>>>(
-      neighbor_data[dir_keys[0]].means) = neighbor_vector_func(0, -1);
-  get<Minmod_detail::to_tensor_double<VectorTag<3>>>(
-      neighbor_data[dir_keys[1]].means) = neighbor_vector_func(0, 1);
-  get<Minmod_detail::to_tensor_double<VectorTag<3>>>(
-      neighbor_data[dir_keys[2]].means) = neighbor_vector_func(1, -1);
-  get<Minmod_detail::to_tensor_double<VectorTag<3>>>(
-      neighbor_data[dir_keys[3]].means) = neighbor_vector_func(1, 1);
-  get<Minmod_detail::to_tensor_double<VectorTag<3>>>(
-      neighbor_data[dir_keys[4]].means) = neighbor_vector_func(2, -1);
-  get<Minmod_detail::to_tensor_double<VectorTag<3>>>(
-      neighbor_data[dir_keys[5]].means) = neighbor_vector_func(2, 1);
+  get<Tags::Mean<VectorTag<3>>>(neighbor_data[dir_keys[0]].means) =
+      neighbor_vector_func(0, -1);
+  get<Tags::Mean<VectorTag<3>>>(neighbor_data[dir_keys[1]].means) =
+      neighbor_vector_func(0, 1);
+  get<Tags::Mean<VectorTag<3>>>(neighbor_data[dir_keys[2]].means) =
+      neighbor_vector_func(1, -1);
+  get<Tags::Mean<VectorTag<3>>>(neighbor_data[dir_keys[3]].means) =
+      neighbor_vector_func(1, 1);
+  get<Tags::Mean<VectorTag<3>>>(neighbor_data[dir_keys[4]].means) =
+      neighbor_vector_func(2, -1);
+  get<Tags::Mean<VectorTag<3>>>(neighbor_data[dir_keys[5]].means) =
+      neighbor_vector_func(2, 1);
 
   test_work(input_scalar, input_vector, neighbor_data, mesh, logical_coords,
             element_size, target_scalar_slope, target_vector_slope);


### PR DESCRIPTION
## Proposed changes

Some bugfixes and cleanups of the Minmod limiter
- Fix error where the LambdaPiN limiter would linearize solutions that did not need their slopes reduced... LambdaPiN should only linearize when the slope is being reduced.
- Update documentation accordingly
- Make small code improvements

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
